### PR TITLE
delay adding click-outside event handler until after v-app has been mounted

### DIFF
--- a/src/directives/click-outside.js
+++ b/src/directives/click-outside.js
@@ -14,11 +14,11 @@ function directive (e, el, binding, v) {
 
 export default {
   bind (el, binding, v) {
-    const click = e => directive(e, el, binding, v)
-
-    document.querySelector('[data-app]').addEventListener('click', click, false)
-
-    el._clickOutside = click
+    v.context.$vuetify.load(() => {
+      const click = e => directive(e, el, binding, v)
+      document.querySelector('[data-app]').addEventListener('click', click, false)
+      el._clickOutside = click
+    })
   },
 
   unbind (el) {


### PR DESCRIPTION
as discussed on gitter. the bind() method of a directive can run before the component it's in has been mounted and added to the DOM, so install the click event handler after that.