### PR TITLE
Added focus highlight to select component

### DIFF
--- a/src/components/forms/Select.vue
+++ b/src/components/forms/Select.vue
@@ -13,7 +13,7 @@
       v-bind:name="name"
       v-bind:multiple="multiple"
       v-on:blur="updateValue"
-      v-on:click="focused = true"
+      v-on:focus="focus"
       v-on:input="updateValue"
       ref="select"
     )
@@ -111,6 +111,10 @@
     },
 
     methods: {
+      focus () {
+        this.focused = true
+      },
+
       updateValue () {
         if (this.multiple) {
           this.$emit('input', this.$refs.options.filter(i => i.selected).map(i => i.value))

--- a/src/components/forms/Select.vue
+++ b/src/components/forms/Select.vue
@@ -85,6 +85,7 @@
     computed: {
       classes () {
         return {
+          'input-group--focused': this.focused,
           'input-group--dirty': true
         }
       }

--- a/src/components/forms/Select.vue
+++ b/src/components/forms/Select.vue
@@ -122,6 +122,8 @@
         } else {
           this.$emit('input', this.$refs.select.value)
         }
+
+        this.focused = false
       }
     }
   }

--- a/src/components/forms/Select.vue
+++ b/src/components/forms/Select.vue
@@ -19,7 +19,7 @@
     )
       option(
         value=''
-        v-bind:selected="!multiple"
+        v-bind:selected="!multiple && !this.value"
         v-bind:disabled="defaultDisabled"
         v-text="defaultText"
       )
@@ -85,8 +85,8 @@
     computed: {
       classes () {
         return {
-          'input-group--focused': this.focused,
-          'input-group--dirty': true
+          'input-group--dirty': true,
+          'input-group--focused': this.focused
         }
       }
     },
@@ -116,14 +116,16 @@
         this.focused = true
       },
 
-      updateValue () {
+      updateValue (evt) {
         if (this.multiple) {
           this.$emit('input', this.$refs.options.filter(i => i.selected).map(i => i.value))
         } else {
           this.$emit('input', this.$refs.select.value)
         }
 
-        this.focused = false
+        if (evt.type !== 'input') {
+          this.focused = false
+        }
       }
     }
   }


### PR DESCRIPTION
Don't know if this was done by design, but the select component was missing the focus highlight transition that text input has. 

It made it hard to know which input field was active when using tab to switch between them, so I added the effect.