### PR TITLE
CarouselItem: new boolean prop "img"

### DIFF
--- a/src/components/carousel/CarouselItem.vue
+++ b/src/components/carousel/CarouselItem.vue
@@ -6,8 +6,13 @@
       class="slider__item"
       v-bind:class="{ 'reverse': reverse }"
       v-bind:style="styles"
+      v-bind:img="img"
       v-show="active"
     )
+      img(
+        v-if="img"
+        v-bind:src="src"
+        )
       slot
 </template>
 
@@ -28,6 +33,11 @@
         required: true
       },
 
+      img: {
+        type: Boolean,
+        default: false
+      },
+
       transition: {
         type: String,
         default: 'v-tab-transition'
@@ -46,7 +56,7 @@
 
       styles () {
         return {
-          backgroundImage: `url(${this.src})`
+          backgroundImage: this.img ? null : `url(${this.src})`
         }
       }
     },


### PR DESCRIPTION
Hi, this is my first ever commit and pull request to an official repo in GitHub.
I don't know what the etiquette and I don't consider myself THE developer so feel free to merge/modify/ignore/whatever this commit :)

I just noticed that on mobile devices the carousel item content doesn't scale well(if at all) when loaded as a background image. I fiddled with it locally when inside an <img> and it looked ok to me. The Vuetify CSS sets 500px height for the carousel slider div, but custom CSS rules are always viable and with <img> tag I thimk there are more possibilities.

Also for Carousel component **cycle** prop is _true_ by default, docs say _false_ so you may want to update the docs for that one as well. 

Thanks,
Daniel