### PR TITLE
Allow the use of computed classes on v-avatar

### DIFF
--- a/src/components/avatars/index.js
+++ b/src/components/avatars/index.js
@@ -4,7 +4,7 @@ const Avatar = {
   render (h, context) {
     const children = context.children
     const data = {
-      'class': `avatar ${context.data.staticClass || ''}`
+      'class': `avatar ${context.data.staticClass || ''} ${context.data.class || ''}`
     }
 
     return h('div', data, children)


### PR DESCRIPTION
Currently computed classes get ignored on v-avatar