### PR TITLE
Selects have long bottom margin/distance

### DIFF
--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -1,5 +1,5 @@
 .menu
-  display: block
+  display: inline
   
   &--disabled
     cursor: not-allowed

--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -1,5 +1,5 @@
 .menu
-  display: inline-block
+  display: block
   
   &--disabled
     cursor: not-allowed


### PR DESCRIPTION
Selects have a longer bottom margin/distance compared to other inputs. Can be observed here http://codepen.io/anon/pen/gmoZEj

Left and right columns to compare, right shows this fix