### PR TITLE
Add border color classes

### DIFF
--- a/src/stylus/tools/_colors.styl
+++ b/src/stylus/tools/_colors.styl
@@ -9,6 +9,9 @@ global-color(color_name, color_value)
   .{color_name}--after
     &:after
       background: color_value !important
+          
+  .{color_name}--border
+    border-color color_value !important
       
 global-color-accent(color_name, color_value)
   .{color_name}
@@ -23,3 +26,7 @@ global-color-accent(color_name, color_value)
   .{color_name}--text
     &.text--{color_type}
       color: color_value !important
+  
+  .{color_name}--border
+    &.border--{color_type}
+      border-color: color_value !important


### PR DESCRIPTION
As classes for color text, now there are classes for the color border. It can be used for the theming of the border. For example, for the block-quotes:
```html
<blockquote> Default blockquote.</blockquote>
<blockquote class="red--border border--lighten-4"> .red--border.border--lighten-4 </blockquote>
<blockquote class="red--border border--darken-4"> .red--border .border--darken-4 </blockquote>
```
![image](https://cloud.githubusercontent.com/assets/1662812/24801520/41430920-1bad-11e7-8630-fc6b4016216d.png)
