### PR TITLE
Sort data tables on first sortable column by default

### DIFF
--- a/src/components/tables/DataTable.js
+++ b/src/components/tables/DataTable.js
@@ -95,6 +95,7 @@ export default {
       }
 
       items = items.sort((a, b) => {
+        this.sorting = !this.sorting ? this.headers.find(h => !('sortable' in h) || h.sortable).value : this.sorting
         const sortA = a[this.sorting]
         const sortB = b[this.sorting]
 


### PR DESCRIPTION
In my opinion data tables should be sorted on their first sortable column by default. Not sure if what I've done is the best way to do it though