### PR TITLE
Use auto margins for centered tabs instead of justify-content.

### DIFF
--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -20,7 +20,10 @@
       
   &--centered
     .tabs__container
-      justify-content: center
+      > li:first-of-type
+        margin-left: auto
+      > li:last-of-type
+        margin-right: auto
       
   &--icons
     .tabs__tabs


### PR DESCRIPTION
**The problem:**
Centered tabs using `justify-content: center` has a known problem with flexbox where items will go outside their container.  

**To repeat the problem:**
1. Check out this full page codepen here: http://codepen.io/prograhammer/full/PprezM/
2. Switch to a mobile view (ie. iPhone 6) and notice the first tab gets cut off. 

**The fix:**
We can use auto margins on first and last tab, instead of `justify-content: center`. You can see the fix working in this jsFiddle: https://jsfiddle.net/s9wxL055/