### PR TITLE
Update _tables.styl

### DIFF
--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -59,6 +59,10 @@ table
       color: rgba(#000, .87)
       font-size: 13px
     
+    &:last-child tr:last-child td
+      height: 56px
+      padding-bottom: 8px
+    
   .input-group--selection-controls
     margin: 0
     


### PR DESCRIPTION
Last table row should have extra bottom padding resulting in a height of 56px
tbody:last-child ensures that the padding and height is only applied if the the tbody is the last element in the table. If there's a tfoot element, the tbody is no longer last-child and its last row is not affected.

https://material.io/guidelines/components/data-tables.html#data-tables-specs
https://storage.googleapis.com/material-design/publish/material_v_11/assets/0B3mOPoJlxiFhV25CdGNXYzA4cXM/components_datatables_structure_basictable.png