### PR TITLE
Pass v-text-field name to domsProps

### DIFF
--- a/src/components/forms/TextField.js
+++ b/src/components/forms/TextField.js
@@ -151,7 +151,8 @@ export default {
           disabled: this.disabled,
           required: this.required,
           value: this.lazyValue,
-          autofucus: this.autofocus
+          autofucus: this.autofocus,
+          name: this.name
         },
         attrs: {
           tabindex: this.tabindex,


### PR DESCRIPTION
Necessary for using plugins such as vee-validate with vuetify.