### PR TITLE
add support for sorting nested properties

### DIFF
--- a/src/components/tables/DataTable.js
+++ b/src/components/tables/DataTable.js
@@ -2,6 +2,7 @@ import Head from './mixins/head'
 import Body from './mixins/body'
 import Foot from './mixins/foot'
 import Progress from './mixins/progress'
+import { getObjectValueByPath } from '../../util/helpers'
 
 export default {
   name: 'datatable',
@@ -125,8 +126,8 @@ export default {
       }
 
       items = items.sort((a, b) => {
-        const sortA = a[this.sorting]
-        const sortB = b[this.sorting]
+        const sortA = getObjectValueByPath(a, this.sorting)
+        const sortB = getObjectValueByPath(b, this.sorting)
 
         if (this.desc) {
           if (sortA < sortB) return 1

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -97,3 +97,19 @@ export function debounce (func, threshold, execAsap) {
   }
 }
 
+export function getObjectValueByPath (obj, path) {
+  // credit: http://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-with-string-key#comment55278413_6491621
+  if (!path || path.constructor !== String) return
+  path = path.replace(/\[(\w+)\]/g, '.$1') // convert indexes to properties
+  path = path.replace(/^\./, '')           // strip a leading dot
+  let a = path.split('.')
+  for (var i = 0, n = a.length; i < n; ++i) {
+    var k = a[i]
+    if (obj.constructor === Object && k in obj) {
+      obj = obj[k]
+    } else {
+      return
+    }
+  }
+  return obj
+}


### PR DESCRIPTION
Right now, when setting up the headers and their corresponding values, a key of the v-model is specified. That key is only valid for plain objects.

For example, in an object like `{a: 1, b: 2, c: {d:3, e: e}}` I can only access `a` and `b`.
This PR will allow the dev to setup headers like this:
```
addressHeaders: [
  {text: 'Header label', value: 'obj.nested.value'},
]
```