### PR TITLE
fix build command on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "dist/vuetify.js",
   "scripts": {
     "dev": "cross-env TARGET=dev webpack --config build/config.js --progress --hide-modules",
-    "build": "cross-env rimraf dist && NODE_ENV=production node build/build.js --progress --hide-modules",
+    "build": "rimraf dist && cross-env NODE_ENV=production node build/build.js --progress --hide-modules",
     "unit": "cross-env BABEL_ENV=test karma start test/unit/karma.conf.js --single-run",
     "e2e": "node test/e2e/runner.js",
     "test": "npm run unit && npm run e2e",


### PR DESCRIPTION
`npm run dev` caused an error on my windows. Now, it works on both of windows cmd and bash.