### PR TITLE
Hide native icons on inputs for the Edge browser

### DIFF
--- a/src/stylus/elements/_global.styl
+++ b/src/stylus/elements/_global.styl
@@ -25,3 +25,7 @@ main
 
 a
   color: $theme.primary
+
+::-ms-clear
+::-ms-reveal
+  display: none


### PR DESCRIPTION
This resolve https://github.com/vuetifyjs/vuetify/issues/537