### PR TITLE
Add support multiple tr in a table

### DIFF
--- a/src/components/buttons/ButtonDropdown.vue
+++ b/src/components/buttons/ButtonDropdown.vue
@@ -27,7 +27,7 @@
         append-icon="arrow_drop_down"
       )
       v-list
-        v-list-item(v-for="(option, index) in options")
+        v-list-item(v-for="(option, index) in options", v-bind:key="index")
           v-list-tile(
             v-bind:class="{ 'list__tile--active': inputValue === option }"
             v-on:click.native="e => updateValue(e, option)"

--- a/src/components/buttons/ButtonToggle.vue
+++ b/src/components/buttons/ButtonToggle.vue
@@ -5,6 +5,7 @@
   )
     v-btn(
       v-for="(option, index) in options"
+      v-bind:key="index"
       v-on:click.native.stop="updateValue(option)"
       v-bind:data-selected="isSelected(option)"
       v-bind:data-index="index"

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -14,6 +14,7 @@
         icon
         v-bind:class="{ 'carousel__controls__item--active': index === current }"
         v-for="(item, index) in items"
+        v-bind:key="index"
         v-on:click.native.stop="select(index)"
       )
         v-icon {{ icon }}

--- a/src/components/tables/DataTable.js
+++ b/src/components/tables/DataTable.js
@@ -208,7 +208,11 @@ export default {
       }
     },
     genTR (children, data = {}) {
-      return this.$createElement('tr', data, children)
+      if (children[0].tag === 'tr') {
+        return children.map(c => this.$createElement('tr', data, c.children))
+      } else {
+        return this.$createElement('tr', data, children)
+      }
     },
     toggle (value) {
       const selected = Object.assign({}, this.selected)


### PR DESCRIPTION
Currently,  the table can only show tds inside.
```
<template slot="items" scope="scope">
    <td class="text-xs-right">{{ scope.item.first_name }}</td>
    <td class="text-xs-right">{{ scope.item.last_name }}</td>
</template>
```
But sometimes, I need a table support collapse, like it below:

```
<template slot="items" scope="scope">
  <tr>
    <td class="text-xs-right">{{ scope.item.first_name }}</td>
    <td class="text-xs-right">{{ scope.item.last_name }}</td>
  </tr>
  <tr v-if="scope.item.expand">
    <td class="text-xs-right">{{ scope.item.info }}</td>
    <td class="text-xs-right">{{ scope.item.info2 }}</td>
  </tr>
</template>
```


So this PR can help support this feature.