### PR TITLE
Added positionX/Y props to menu

### DIFF
--- a/src/components/menus/Menu.js
+++ b/src/components/menus/Menu.js
@@ -100,6 +100,14 @@ export default {
     transition: {
       type: String,
       default: 'v-menu-transition'
+    },
+    positionX: {
+      type: Number,
+      default: 0
+    },
+    positionY: {
+      type: Number,
+      default: 0
     }
   },
 
@@ -114,6 +122,9 @@ export default {
         top: `${this.calcTop()}px`,
         left: `${this.calcLeft()}px`
       }
+    },
+    hasActivator () {
+      return !!this.$refs.activator
     }
   },
 

--- a/src/components/menus/mixins/activator.js
+++ b/src/components/menus/mixins/activator.js
@@ -9,16 +9,19 @@ export default {
     activatorClickHandler (e) {
       if (!this.closeOnClick) e.stopPropagation()
       if (this.disabled) return
-      else if (this.openOnClick && !this.isActive) this.isActive = true
-      else if (this.closeOnClick && this.isActive) this.isActive = false
+      else if (this.openOnClick && !this.isActive) {
+        this.isActive = true
+        this.absoluteX = e.clientX
+        this.absoluteY = e.clientY
+      } else if (this.closeOnClick && this.isActive) this.isActive = false
     },
-    addActivatorEvents (activator = null) {
-      if (!activator) return
-      activator.addEventListener('click', this.activatorClickHandler)
+    mouseEnterHandler (e) {
+      if (this.disabled) return
+      this.isActive = true
     },
-    removeActivatorEvents (activator = null) {
-      if (!activator) return
-      activator.removeEventListener('click', this.activatorClickHandler)
+    mouseLeaveHandler (e) {
+      if (this.insideContent) return
+      this.isActive = false
     }
   }
 }

--- a/src/components/menus/mixins/generators.js
+++ b/src/components/menus/mixins/generators.js
@@ -3,12 +3,21 @@ export default {
     genActivator () {
       if (!this.$slots.activator) return null
 
-      return this.$createElement('div', {
+      const options = {
         'class': 'menu__activator',
         ref: 'activator',
         slot: 'activator',
-        on: { click: this.activatorClickHandler }
-      }, this.$slots.activator)
+        on: {}
+      }
+
+      if (this.openOnHover) {
+        options.on['mouseenter'] = this.mouseEnterHandler
+        options.on['mouseleave'] = this.mouseLeaveHandler
+      } else if (this.openOnClick) {
+        options.on['click'] = this.activatorClickHandler
+      }
+
+      return this.$createElement('div', options, this.$slots.activator)
     },
 
     genTransition () {
@@ -30,6 +39,13 @@ export default {
           click: e => {
             e.stopPropagation()
             if (this.closeOnContentClick) this.isActive = false
+          },
+          mouseenter: e => {
+            this.insideContent = true
+          },
+          mouseleave: e => {
+            this.insideContent = false
+            this.openOnHover && this.mouseLeaveHandler()
           }
         }
       }, [this.lazy && this.isBooted || !this.lazy ? this.$slots.default : null])

--- a/src/components/menus/mixins/position.js
+++ b/src/components/menus/mixins/position.js
@@ -83,10 +83,22 @@ export default {
       cb()
       el.style.display = currentDisplay
     },
+    absolutePosition () {
+      return {
+        offsetTop: 0,
+        scrollHeight: 0,
+        top: this.positionY,
+        bottom: this.positionY,
+        left: this.positionX,
+        right: this.positionX,
+        height: 0,
+        width: 0
+      }
+    },
     updateDimensions () {
       this.sneakPeek(() => {
         this.dimensions = {
-          activator: this.measure(this.getActivator()),
+          activator: this.hasActivator ? this.measure(this.getActivator()) : this.absolutePosition(),
           content: this.measure(this.$refs.content)
         }
       })

--- a/src/components/menus/mixins/position.js
+++ b/src/components/menus/mixins/position.js
@@ -91,10 +91,10 @@ export default {
       return {
         offsetTop: 0,
         scrollHeight: 0,
-        top: this.positionY,
-        bottom: this.positionY,
-        left: this.positionX,
-        right: this.positionX,
+        top: this.positionY !== null ? this.positionY : this.absoluteY,
+        bottom: this.positionY !== null ? this.positionY : this.absoluteY,
+        left: this.positionX !== null ? this.positionX : this.absoluteX,
+        right: this.positionX !== null ? this.positionX : this.absoluteX,
         height: 0,
         width: 0
       }
@@ -102,7 +102,8 @@ export default {
     updateDimensions () {
       this.sneakPeek(() => {
         this.dimensions = {
-          activator: this.hasActivator ? this.measure(this.getActivator()) : this.absolutePosition(),
+          activator: !this.hasActivator || this.positionAbsolutely
+            ? this.absolutePosition() : this.measure(this.getActivator()),
           content: this.measure(this.$refs.content)
         }
       })


### PR DESCRIPTION
Allows one to use the menu without an activator by manually positioning it using `position-x` and `position-y` props. Example can be seen in PR to docs.