### PR TITLE
ButtonToggle mandatory prop

### DIFF
--- a/src/components/buttons/ButtonToggle.vue
+++ b/src/components/buttons/ButtonToggle.vue
@@ -4,29 +4,29 @@
     v-bind:class="classes"
   )
     v-btn(
-      v-for="(option, index) in options"
-      v-on:click.native.stop="updateValue(option)"
-      v-bind:data-selected="isSelected(option)"
+      v-for="(item, index) in items"
+      v-bind:key="index"
+      v-on:click.native.stop="updateValue(item)"
+      v-bind:data-selected="isSelected(item)"
       v-bind:data-index="index"
-      v-bind:data-only-child="isSelected(option) && (!multiple || inputValue.length === 1)"
+      v-bind:data-only-child="isSelected(item) && (!multiple || inputValue.length === 1)"
       flat
     )
-      span(v-if="option.text" v-text="option.text")
-      v-icon(v-if="option.icon") {{ option.icon }}
+      span(v-if="item.text" v-text="item.text")
+      v-icon(v-if="item.icon") {{ item.icon }}
 </template>
 
 <script>
   export default {
     name: 'button-toggle',
 
-    data () {
-      return {
-        inputValue: this.value
-      }
+    model: {
+      prop: 'inputValue',
+      event: 'change'
     },
 
     props: {
-      options: {
+      items: {
         type: Array,
         default: () => []
       },
@@ -38,7 +38,7 @@
         value: false
       },
 
-      value: {
+      inputValue: {
         required: false
       }
     },
@@ -48,12 +48,6 @@
         return {
           'btn-toggle--selected': this.inputValue && !this.multiple || this.inputValue && this.inputValue.length > 0
         }
-      }
-    },
-
-    watch: {
-      value () {
-        this.inputValue = this.value
       }
     },
 
@@ -69,7 +63,7 @@
       updateValue (item) {
         if (!this.multiple) {
           if (this.mandatory && this.inputValue === item.value) return
-          return this.$emit('input', this.inputValue === item.value ? null : item.value)
+          return this.$emit('change', this.inputValue === item.value ? null : item.value)
         }
 
         const items = this.inputValue.slice()
@@ -81,7 +75,7 @@
           items.push(item.value)
         }
 
-        this.$emit('input', items)
+        this.$emit('change', items)
       }
     }
   }

--- a/src/components/buttons/ButtonToggle.vue
+++ b/src/components/buttons/ButtonToggle.vue
@@ -33,6 +33,11 @@
 
       multiple: Boolean,
 
+      mandatory: {
+        type: Boolean,
+        value: false
+      },
+
       value: {
         required: false
       }
@@ -63,6 +68,7 @@
 
       updateValue (item) {
         if (!this.multiple) {
+          if (this.mandatory && this.inputValue === item.value) return
           return this.$emit('input', this.inputValue === item.value ? null : item.value)
         }
 
@@ -70,7 +76,7 @@
 
         const i = items.indexOf(item.value)
         if (i !== -1) {
-          items.splice(i, 1)
+          items.length > 1 && !this.mandatory && items.splice(i, 1)
         } else {
           items.push(item.value)
         }

--- a/test/unit/specs/ButtonToggle.spec.js
+++ b/test/unit/specs/ButtonToggle.spec.js
@@ -26,70 +26,70 @@ describe('ButtonToggle.vue', () => {
   it('should not allow empty value when mandatory prop is used', () => {
     const wrapper = mount(ButtonToggle, {
       propsData: {
-        value: 1,
-        options: toggle_text,
+        inputValue: 1,
+        items: toggle_text,
         mandatory: true
       }
     })
 
-    const input = jest.fn()
-    wrapper.instance().$on('input', input)
+    const change = jest.fn()
+    wrapper.instance().$on('change', change)
 
     wrapper.instance().updateValue(toggle_text[0])
 
-    expect(input).not.toBeCalled()
+    expect(change).not.toBeCalled()
   })
 
   it('should allow new value when mandatory prop is used', () => {
     const wrapper = mount(ButtonToggle, {
       propsData: {
-        value: 1,
-        options: toggle_text,
+        inputValue: 1,
+        items: toggle_text,
         mandatory: true
       }
     })
 
-    const input = jest.fn()
-    wrapper.instance().$on('input', input)
+    const change = jest.fn()
+    wrapper.instance().$on('change', change)
 
     wrapper.instance().updateValue(toggle_text[1])
 
-    expect(input).toBeCalledWith(2)
+    expect(change).toBeCalledWith(2)
   })
 
   it('should not allow empty value when mandatory prop is used with multiple prop', () => {
     const wrapper = mount(ButtonToggle, {
       propsData: {
-        value: [1],
-        options: toggle_text,
+        inputValue: [1],
+        items: toggle_text,
         mandatory: true,
         multiple: true
       }
     })
 
-    const input = jest.fn()
-    wrapper.instance().$on('input', input)
+    const change = jest.fn()
+    wrapper.instance().$on('change', change)
 
     wrapper.instance().updateValue(toggle_text[0])
 
-    expect(input).toBeCalledWith([1])
+    expect(change).toBeCalledWith([1])
   })
 
   it('should allow new value when mandatory prop is used with multiple prop', () => {
     const wrapper = mount(ButtonToggle, {
       propsData: {
-        value: [1],
-        options: toggle_text,
+        inputValue: [1],
+        items: toggle_text,
         mandatory: true,
         multiple: true
       }
     })
 
-    const input = jest.fn()
-    wrapper.instance().$on('input', input)
+    const change = jest.fn()
+    wrapper.instance().$on('change', change)
 
     wrapper.instance().updateValue(toggle_text[1])
 
-    expect(input).toBeCalledWith([1, 2])
+    expect(change).toBeCalledWith([1, 2])
   })
 })

--- a/test/unit/specs/ButtonToggle.spec.js
+++ b/test/unit/specs/ButtonToggle.spec.js
@@ -1,0 +1,95 @@
+import { mount } from 'avoriaz'
+import { createRenderer } from 'vue-server-renderer'
+import Vue from 'vue/dist/vue.common'
+import ButtonToggle from 'src/components/buttons/ButtonToggle'
+import Button from 'src/components/buttons/Button'
+import Icon from 'src/components/icons/Icon'
+import ripple from 'src/directives/ripple'
+
+ButtonToggle.components = {
+  'v-icon': Icon,
+  'v-btn': Button
+}
+
+Button.directives = {
+  ripple
+}
+
+const toggle_text = [
+  { text: 'Left', value: 1 },
+  { text: 'Center', value: 2 },
+  { text: 'Right', value: 3 },
+  { text: 'Justify', value: 4 },
+]
+
+describe('ButtonToggle.vue', () => {
+  it('should not allow empty value when mandatory prop is used', () => {
+    const wrapper = mount(ButtonToggle, {
+      propsData: {
+        value: 1,
+        options: toggle_text,
+        mandatory: true
+      }
+    })
+
+    const input = jest.fn()
+    wrapper.instance().$on('input', input)
+
+    wrapper.instance().updateValue(toggle_text[0])
+
+    expect(input).not.toBeCalled()
+  })
+
+  it('should allow new value when mandatory prop is used', () => {
+    const wrapper = mount(ButtonToggle, {
+      propsData: {
+        value: 1,
+        options: toggle_text,
+        mandatory: true
+      }
+    })
+
+    const input = jest.fn()
+    wrapper.instance().$on('input', input)
+
+    wrapper.instance().updateValue(toggle_text[1])
+
+    expect(input).toBeCalledWith(2)
+  })
+
+  it('should not allow empty value when mandatory prop is used with multiple prop', () => {
+    const wrapper = mount(ButtonToggle, {
+      propsData: {
+        value: [1],
+        options: toggle_text,
+        mandatory: true,
+        multiple: true
+      }
+    })
+
+    const input = jest.fn()
+    wrapper.instance().$on('input', input)
+
+    wrapper.instance().updateValue(toggle_text[0])
+
+    expect(input).toBeCalledWith([1])
+  })
+
+  it('should allow new value when mandatory prop is used with multiple prop', () => {
+    const wrapper = mount(ButtonToggle, {
+      propsData: {
+        value: [1],
+        options: toggle_text,
+        mandatory: true,
+        multiple: true
+      }
+    })
+
+    const input = jest.fn()
+    wrapper.instance().$on('input', input)
+
+    wrapper.instance().updateValue(toggle_text[1])
+
+    expect(input).toBeCalledWith([1, 2])
+  })
+})


### PR DESCRIPTION
Added mandatory prop to ButtonToggle. With it activated, you are unable to deselect all buttons. At least one button will always be active.

Can be seen in the updated example https://github.com/vuetifyjs/docs/pull/82