### PR TITLE
Add prefix to component names

### DIFF
--- a/src/components/alerts/Alert.js
+++ b/src/components/alerts/Alert.js
@@ -2,7 +2,7 @@ import Toggleable from '../../mixins/toggleable'
 import Contextualable from '../../mixins/contextualable'
 
 export default {
-  name: 'alert',
+  name: 'v-alert',
 
   mixins: [Contextualable, Toggleable],
 

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -1,6 +1,8 @@
 export default {
   functional: true,
 
+  name: 'v-app',
+
   props: {
     light: {
       type: Boolean,

--- a/src/components/app/AppBar.js
+++ b/src/components/app/AppBar.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'app-bar',
+  name: 'v-app-bar',
 
   render (h) {
     return h('v-toolbar')

--- a/src/components/bottom-nav/BottomNav.js
+++ b/src/components/bottom-nav/BottomNav.js
@@ -1,6 +1,8 @@
   export default {
     functional: true,
 
+    name: 'v-bottom-nav',
+
     props: {
       absolute: Boolean,
       shift: Boolean,

--- a/src/components/breadcrumbs/Breadcrumbs.js
+++ b/src/components/breadcrumbs/Breadcrumbs.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'breadcrumbs',
+  name: 'v-breadcrumbs',
 
   provide () {
     return {

--- a/src/components/breadcrumbs/BreadcrumbsItem.js
+++ b/src/components/breadcrumbs/BreadcrumbsItem.js
@@ -1,7 +1,7 @@
 import GenerateRouteLink from '../../mixins/route-link'
 
 export default {
-  name: 'breadcrumbs-item',
+  name: 'v-breadcrumbs-item',
 
   mixins: [GenerateRouteLink],
 

--- a/src/components/buttons/Button.js
+++ b/src/components/buttons/Button.js
@@ -4,7 +4,7 @@ import Schemable from '../../mixins/schemable'
 import GenerateRouteLink from '../../mixins/route-link'
 
 export default {
-  name: 'btn',
+  name: 'v-btn',
 
   mixins: [Contextualable, GenerateRouteLink, Schemable, Toggleable],
 

--- a/src/components/buttons/ButtonToggle.vue
+++ b/src/components/buttons/ButtonToggle.vue
@@ -18,7 +18,7 @@
 
 <script>
   export default {
-    name: 'button-toggle',
+    name: 'v-button-toggle',
 
     model: {
       prop: 'inputValue',

--- a/src/components/buttons/FAB.js
+++ b/src/components/buttons/FAB.js
@@ -4,7 +4,7 @@ import Schemable from '../../mixins/schemable'
 import Toggleable from '../../mixins/toggleable'
 
 export default {
-  name: 'fab',
+  name: 'v-fab',
 
   mixins: [Contextualable, GenerateRouteLink, Schemable, Toggleable],
 

--- a/src/components/cards/Card.js
+++ b/src/components/cards/Card.js
@@ -1,7 +1,7 @@
 export default {
   functional: true,
 
-  name: 'card',
+  name: 'v-card',
 
   props: {
     flat: Boolean,

--- a/src/components/cards/CardRow.js
+++ b/src/components/cards/CardRow.js
@@ -1,6 +1,8 @@
 export default {
   functional: true,
 
+  name: 'v-card-row',
+
   props: {
     actions: Boolean,
     height: {

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -25,7 +25,7 @@
   import Bootable from '../../mixins/bootable'
 
   export default {
-    name: 'carousel',
+    name: 'v-carousel',
 
     mixins: [Bootable],
 

--- a/src/components/carousel/CarouselItem.vue
+++ b/src/components/carousel/CarouselItem.vue
@@ -13,7 +13,7 @@
 
 <script>
   export default {
-    name: 'carousel-item',
+    name: 'v-carousel-item',
 
     data () {
       return {

--- a/src/components/chips/Chip.js
+++ b/src/components/chips/Chip.js
@@ -1,7 +1,7 @@
 import Toggleable from '../../mixins/toggleable'
 
 export default {
-  name: 'chip',
+  name: 'v-chip',
 
   mixins: [Toggleable],
 

--- a/src/components/dialogs/Dialog.js
+++ b/src/components/dialogs/Dialog.js
@@ -4,7 +4,7 @@ import Overlayable from '../../mixins/overlayable'
 import Toggleable from '../../mixins/toggleable'
 
 export default {
-  name: 'dialog',
+  name: 'v-dialog',
 
   mixins: [Bootable, Detachable, Overlayable, Toggleable],
 

--- a/src/components/dividers/index.js
+++ b/src/components/dividers/index.js
@@ -1,6 +1,8 @@
 const Divider = {
   functional: true,
 
+  name: 'v-divider',
+
   props: {
     dark: Boolean,
     inset: Boolean,

--- a/src/components/expansion-panel/ExpansionPanel.js
+++ b/src/components/expansion-panel/ExpansionPanel.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'expansion-panel',
+  name: 'v-expansion-panel',
 
   props: {
     expand: Boolean

--- a/src/components/expansion-panel/ExpansionPanelContent.vue
+++ b/src/components/expansion-panel/ExpansionPanelContent.vue
@@ -28,7 +28,7 @@
   import Toggleable from '../../mixins/toggleable'
 
   export default {
-    name: 'expansion-panel-content',
+    name: 'v-expansion-panel-content',
 
     mixins: [Expand, Toggleable],
 
@@ -52,7 +52,7 @@
 
     methods: {
       closeConditional (e) {
-        return this.$parent.$el.contains(e.target) && 
+        return this.$parent.$el.contains(e.target) &&
           !this.$parent.expand &&
           !this.$el.contains(e.target)
       },

--- a/src/components/footer/index.js
+++ b/src/components/footer/index.js
@@ -1,6 +1,8 @@
 const Footer = {
   functional: true,
 
+  name: 'v-footer',
+
   props: {
     absolute: Boolean,
     fixed: Boolean

--- a/src/components/forms/Checkbox.js
+++ b/src/components/forms/Checkbox.js
@@ -1,7 +1,7 @@
 import Checkbox from '../../mixins/checkbox'
 
 export default {
-  name: 'checkbox',
+  name: 'v-checkbox',
 
   mixins: [Checkbox],
 

--- a/src/components/forms/Radio.js
+++ b/src/components/forms/Radio.js
@@ -2,7 +2,7 @@ import Contextualable from '../../mixins/contextualable'
 import Input from '../../mixins/input'
 
 export default {
-  name: 'radio',
+  name: 'v-radio',
 
   mixins: [Contextualable, Input],
 

--- a/src/components/forms/Switch.js
+++ b/src/components/forms/Switch.js
@@ -1,7 +1,7 @@
 import Checkbox from '../../mixins/checkbox'
 
 export default {
-  name: 'switch',
+  name: 'v-switch',
 
   mixins: [Checkbox],
 

--- a/src/components/forms/TextField.js
+++ b/src/components/forms/TextField.js
@@ -1,7 +1,7 @@
 import Input from '../../mixins/input'
 
 export default {
-  name: 'text-field',
+  name: 'v-text-field',
 
   mixins: [Input],
 

--- a/src/components/grid/index.js
+++ b/src/components/grid/index.js
@@ -3,6 +3,8 @@ import { createSimpleFunctional } from '../../util/helpers'
 const Flex = {
   functional: true,
 
+  name: 'v-flex',
+
   render: (h, { data, children }) => {
     data.staticClass = data.staticClass ? `flex ${data.staticClass}` : 'flex'
     data.staticClass += ` ${Object.keys(data.attrs).join(' ')}`
@@ -14,6 +16,8 @@ const Flex = {
 
 const Layout = {
   functional: true,
+
+  name: 'v-layout',
 
   render: (h, { data, children }) => {
     data.staticClass = data.staticClass ? `layout ${data.staticClass}` : 'layout'
@@ -29,6 +33,8 @@ const Layout = {
 
 const Container = {
   functional: true,
+
+  name: 'v-container',
 
   props: {
     fluid: Boolean

--- a/src/components/icons/Icon.js
+++ b/src/components/icons/Icon.js
@@ -3,6 +3,8 @@ import Schemable from '../../mixins/schemable'
 export default {
   functional: true,
 
+  name: 'v-icon',
+
   mixins: [Schemable],
 
   props: {

--- a/src/components/lists/List.js
+++ b/src/components/lists/List.js
@@ -1,7 +1,7 @@
 import Schemable from '../../mixins/schemable'
 
 export default {
-  name: 'list',
+  name: 'v-list',
 
   provide () {
     return {

--- a/src/components/lists/ListGroup.js
+++ b/src/components/lists/ListGroup.js
@@ -2,7 +2,7 @@ import Expand from '../../mixins/expand-transition'
 import Toggleable from '../../mixins/toggleable'
 
 export default {
-  name: 'list-group',
+  name: 'v-list-group',
 
   inject: ['listClick', 'listClose'],
 

--- a/src/components/lists/ListTile.js
+++ b/src/components/lists/ListTile.js
@@ -2,7 +2,7 @@ import GenerateRouteLink from '../../mixins/route-link'
 import Toggleable from '../../mixins/toggleable'
 
 export default {
-  name: 'list-tile',
+  name: 'v-list-tile',
 
   mixins: [GenerateRouteLink, Toggleable],
 

--- a/src/components/lists/ListTileAction.js
+++ b/src/components/lists/ListTileAction.js
@@ -1,7 +1,7 @@
 export default {
   functional: true,
 
-  name: 'list-tile-action',
+  name: 'v-list-tile-action',
 
   render (h, context) {
     const data = {

--- a/src/components/menus/Menu.js
+++ b/src/components/menus/Menu.js
@@ -7,7 +7,7 @@ import Toggleable from '../../mixins/toggleable'
 import Keyable from './mixins/keyable'
 
 export default {
-  name: 'menu',
+  name: 'v-menu',
 
   mixins: [
     Activator,

--- a/src/components/navigation-drawer/NavigationDrawer.js
+++ b/src/components/navigation-drawer/NavigationDrawer.js
@@ -2,7 +2,7 @@ import Overlayable from '../../mixins/overlayable'
 import Schemable from '../../mixins/schemable'
 
 export default {
-  name: 'navigation-drawer',
+  name: 'v-navigation-drawer',
 
   mixins: [Overlayable, Schemable],
 

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -37,7 +37,7 @@
 
 <script>
   export default {
-    name: 'pagination',
+    name: 'v-pagination',
 
     props: {
       circle: Boolean,

--- a/src/components/parallax/Parallax.vue
+++ b/src/components/parallax/Parallax.vue
@@ -18,7 +18,7 @@
   import Translatable from '../../mixins/translatable'
 
   export default {
-    name: 'parallax',
+    name: 'v-parallax',
 
     mixins: [Translatable],
 

--- a/src/components/pickers/DatePicker.js
+++ b/src/components/pickers/DatePicker.js
@@ -7,7 +7,7 @@ import Picker from '../../mixins/picker'
 const defaultDateFormat = val => new Date(val).toISOString().substr(0, 10)
 
 export default {
-  name: 'date-picker',
+  name: 'v-date-picker',
 
   mixins: [DateTitle, DateHeader, DateTable, DateYears, Picker],
 

--- a/src/components/pickers/TimePicker.js
+++ b/src/components/pickers/TimePicker.js
@@ -3,7 +3,7 @@ import TimeTitle from './mixins/time-title'
 import TimeBody from './mixins/time-body'
 
 export default {
-  name: 'time-picker',
+  name: 'v-time-picker',
 
   mixins: [Picker, TimeBody, TimeTitle],
 

--- a/src/components/progress/ProgressCircular.vue
+++ b/src/components/progress/ProgressCircular.vue
@@ -38,7 +38,7 @@
 
 <script>
   export default {
-    name: 'progress-circular',
+    name: 'v-progress-circular',
 
     props: {
       button: Boolean,

--- a/src/components/progress/ProgressLinear.vue
+++ b/src/components/progress/ProgressLinear.vue
@@ -17,7 +17,7 @@
 
 <script>
   export default {
-    name: 'progress',
+    name: 'v-progress',
 
     props: {
       active: {

--- a/src/components/selects/Select.js
+++ b/src/components/selects/Select.js
@@ -3,7 +3,7 @@ import Generators from './mixins/generators'
 import Autocomplete from './mixins/autocomplete'
 
 export default {
-  name: 'select',
+  name: 'v-select',
 
   mixins: [Autocomplete, Input, Generators],
 

--- a/src/components/sliders/Slider.js
+++ b/src/components/sliders/Slider.js
@@ -2,7 +2,7 @@ import Input from '../../mixins/input'
 import { addOnceEventListener } from '../../util/helpers'
 
 export default {
-  name: 'slider',
+  name: 'v-slider',
 
   mixins: [Input],
 

--- a/src/components/snackbars/Snackbar.js
+++ b/src/components/snackbars/Snackbar.js
@@ -2,7 +2,7 @@ import Toggleable from '../../mixins/toggleable'
 import Contextualable from '../../mixins/contextualable'
 
 export default {
-  name: 'snackbar',
+  name: 'v-snackbar',
 
   mixins: [Contextualable, Toggleable],
 

--- a/src/components/steppers/Stepper.js
+++ b/src/components/steppers/Stepper.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'stepper',
+  name: 'v-stepper',
 
   provide () {
     return {

--- a/src/components/steppers/StepperContent.js
+++ b/src/components/steppers/StepperContent.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'stepper-content',
+  name: 'v-stepper-content',
 
   data () {
     return {

--- a/src/components/steppers/StepperStep.js
+++ b/src/components/steppers/StepperStep.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'stepper-step',
+  name: 'v-stepper-step',
 
   inject: ['stepClick'],
 

--- a/src/components/subheaders/index.js
+++ b/src/components/subheaders/index.js
@@ -1,6 +1,8 @@
 const Subheader = {
   functional: true,
 
+  name: 'v-subheader',
+
   props: {
     inset: Boolean
   },

--- a/src/components/tables/DataTable.js
+++ b/src/components/tables/DataTable.js
@@ -5,7 +5,7 @@ import Progress from './mixins/progress'
 import { getObjectValueByPath } from '../../util/helpers'
 
 export default {
-  name: 'datatable',
+  name: 'v-datatable',
 
   mixins: [Head, Body, Foot, Progress],
 

--- a/src/components/tables/EditDialog.js
+++ b/src/components/tables/EditDialog.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'edit-dialog',
+  name: 'v-edit-dialog',
 
   data () {
     return {

--- a/src/components/tabs/Tabs.js
+++ b/src/components/tabs/Tabs.js
@@ -1,7 +1,7 @@
 import Bootable from '../../mixins/bootable'
 
 export default {
-  name: 'tabs',
+  name: 'v-tabs',
 
   provide () {
     return {

--- a/src/components/tabs/TabsBar.js
+++ b/src/components/tabs/TabsBar.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'tabs-bar',
+  name: 'v-tabs-bar',
 
   props: {
     mobile: Boolean

--- a/src/components/tabs/TabsContent.js
+++ b/src/components/tabs/TabsContent.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'tabs-content',
+  name: 'v-tabs-content',
 
   data () {
     return {

--- a/src/components/tabs/TabsItem.js
+++ b/src/components/tabs/TabsItem.js
@@ -1,7 +1,7 @@
 import GenerateRouteLink from '../../mixins/route-link'
 
 export default {
-  name: 'tabs-item',
+  name: 'v-tabs-item',
 
   inject: ['slider', 'tabClick'],
 

--- a/src/components/tabs/index.js
+++ b/src/components/tabs/index.js
@@ -9,7 +9,7 @@ import TabsBar from './TabsBar'
 const TabsSlider = createSimpleFunctional('tabs__slider', 'li')
 
 const TabsItems = {
-  name: 'tabs-items',
+  name: 'v-tabs-items',
 
   render (h) {
     return h('div', { 'class': { 'tabs__items': true }}, [this.$slots.default])

--- a/src/components/toolbar/Toolbar.js
+++ b/src/components/toolbar/Toolbar.js
@@ -1,6 +1,8 @@
 import Schemable from '../../mixins/schemable'
 
 export default {
+  name: 'v-toolbar',
+
   mixins: [Schemable],
 
   props: {

--- a/src/components/toolbar/ToolbarItem.js
+++ b/src/components/toolbar/ToolbarItem.js
@@ -1,7 +1,7 @@
 import GenerateRouteLink from '../../mixins/route-link'
 
 export default {
-  name: 'toolbar-item',
+  name: 'v-toolbar-item',
 
   mixins: [GenerateRouteLink],
 


### PR DESCRIPTION
Having the component's name the same as its tag allows JetBrains IDEs to autocomplete components and their properties while typing. This has the slight side-effect of adding a `V` to the front of the names in vue-devtools (`TabsBar` => `VTabsBar`, `Btn` => `VBtn`).

Most functional components are generated with the `createSimpleFunctional` helper, and could not have names added, all others are listed below. 

Functional components with existing names: 
 - Card
 - ListTileAction

Functional components with added names: 
 - App
 - BottomNav
 - CardRow
 - Divider
 - Footer
 - Flex
 - Layout
 - Container
 - Icon
 - Subheader
 - TabsItems