### PR TITLE
Allow to disable min-width on content element.

### DIFF
--- a/src/components/menus/Menu.js
+++ b/src/components/menus/Menu.js
@@ -127,20 +127,22 @@ export default {
       type: Boolean,
       default: false
     },
-    disableContentMinWidth: {
-      type: Boolean,
-      default: false
+    minWidth: {
+      type: Number,
+      default: null
     }
   },
 
   computed: {
-    minWidth () {
-      return this.dimensions.activator.width + this.nudgeWidth + (this.auto ? 16 : 0)
+    calculatedMinWidth () {
+      return this.minWidth !== null
+        ? this.minWidth
+        : this.dimensions.activator.width + this.nudgeWidth + (this.auto ? 16 : 0)
     },
     styles () {
       return {
         maxHeight: this.auto ? '200px' : isNaN(this.maxHeight) ? this.maxHeight : `${this.maxHeight}px`,
-        minWidth: this.disableContentMinWidth ? 0 : `${this.minWidth}px`,
+        minWidth: `${this.calculatedMinWidth}px`,
         top: `${this.calcTop()}px`,
         left: `${this.calcLeft()}px`
       }

--- a/src/components/menus/Menu.js
+++ b/src/components/menus/Menu.js
@@ -126,6 +126,10 @@ export default {
     positionAbsolutely: {
       type: Boolean,
       default: false
+    },
+    disableContentMinWidth: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -136,7 +140,7 @@ export default {
     styles () {
       return {
         maxHeight: this.auto ? '200px' : isNaN(this.maxHeight) ? this.maxHeight : `${this.maxHeight}px`,
-        minWidth: `${this.minWidth}px`,
+        minWidth: this.disableContentMinWidth ? 0 : `${this.minWidth}px`,
         top: `${this.calcTop()}px`,
         left: `${this.calcLeft()}px`
       }

--- a/src/components/menus/mixins/position.js
+++ b/src/components/menus/mixins/position.js
@@ -60,10 +60,9 @@ export default {
       if (this.nudgeLeft) left += this.nudgeLeft
       if (this.nudgeRight) left -= this.nudgeRight
 
-      const totalWidth = left + this.minWidth - this.window.innerWidth
+      const totalWidth = left + this.calculatedMinWidth - this.window.innerWidth
 
       if (totalWidth > 0) left -= (totalWidth + 24) // give a little extra space
-
       return left
     },
     calcTop (force) {


### PR DESCRIPTION
There are cases when the width of `activator` element of Menu component is wider than the needed width of `content` element. For example, Date picker `content` is 290px wide, but if the `activator` is wider, then by setting `min-width` style on `content`, unneeded white space appears right to the Date picker.

Here is a CodePen to show the issue - https://codepen.io/anon/pen/bReKmX. Click on the input field and see the extra white space on the right of the Date picker.

I have added a new prop for Menu element - `disableContentMinWidth`, which sets the `min-width` style of the `content` to `0` if set to `true`.