### PR TITLE
Allow a route-link to have a download attribute

### DIFF
--- a/src/mixins/route-link.js
+++ b/src/mixins/route-link.js
@@ -10,7 +10,8 @@ export default {
     ripple: Boolean,
     router: Boolean,
     tag: String,
-    target: String
+    target: String,
+    download: String
   },
 
   methods: {
@@ -51,6 +52,12 @@ export default {
         if (tag === 'a') {
           data.attrs.href = options || 'javascript:;'
           if (this.target) data.attrs.target = this.target
+
+          if (this.download === 'true') {
+            data.attrs.download = ''
+          } else if (this.download) {
+            data.attrs.download = this.download
+          }
         }
 
         data.on = { click: this.click }


### PR DESCRIPTION
Pretty self-explanatory. I needed to use a `<v-list-title>` to link to a file and download it instead of opening it in a new tab or the current window.

This prop can be used like this:
```
<v-list-tile href="file.pdf" download='true'>
    <v-list-tile-title>Download</v-list-tile-title>
</v-list-tile>
```
The above will generate something like:
`<a href="file.pdf" download>Download</a>`

You can also pass in a string you want the file download's file name to be (only works on same-origin urls per HTML5 spec, if the domain is not same-origin, it will just ignore your string and use the file name the file was originally called). You would use it like this:
```
<v-list-tile href="file.pdf" download='fileName'>
    <v-list-tile-title>Download</v-list-tile-title>
</v-list-tile>
```
And it would generate something like this:
`<a href="file.pdf" download="fileName">Download</a>`