### PR TITLE
Allow download attribute on any component that uses route-link mixin

### DIFF
--- a/src/mixins/route-link.js
+++ b/src/mixins/route-link.js
@@ -10,7 +10,8 @@ export default {
     ripple: Boolean,
     router: Boolean,
     tag: String,
-    target: String
+    target: String,
+    download: String
   },
 
   methods: {
@@ -51,6 +52,12 @@ export default {
         if (tag === 'a') {
           data.attrs.href = options || 'javascript:;'
           if (this.target) data.attrs.target = this.target
+
+          if (this.download === 'true') {
+            data.attrs.download = ''
+          } else if (this.download) {
+            data.attrs.download = this.download
+          }
         }
 
         data.on = { click: this.click }

--- a/src/mixins/route-link.js
+++ b/src/mixins/route-link.js
@@ -10,8 +10,7 @@ export default {
     ripple: Boolean,
     router: Boolean,
     tag: String,
-    target: String,
-    download: String
+    target: String
   },
 
   methods: {
@@ -53,10 +52,10 @@ export default {
           data.attrs.href = options || 'javascript:;'
           if (this.target) data.attrs.target = this.target
 
-          if (this.download === 'true') {
+          if (this.$vnode.data.attrs.download === 'true') {
             data.attrs.download = ''
-          } else if (this.download) {
-            data.attrs.download = this.download
+          } else if (this.$vnode.data.attrs.download) {
+            data.attrs.download = this.$vnode.data.attrs.download
           }
         }
 


### PR DESCRIPTION
Updated version of #837

Instead of using a prop on route-link mixin, this will just look at the attributes on the tag that's wrapping route-link. So basically it's an optional prop.

It works on any component that uses route-link. For example, on a button, you would do this:
```
      <v-btn
        dark
        flat
        tag="a"
        href="/file.pdf"
        download
      >button text
      </v-btn>
```