### PR TITLE
Use download prop on route-link

### DIFF
--- a/src/mixins/route-link.js
+++ b/src/mixins/route-link.js
@@ -10,7 +10,8 @@ export default {
     ripple: Boolean,
     router: Boolean,
     tag: String,
-    target: String
+    target: String,
+    download: String
   },
 
   methods: {
@@ -52,11 +53,7 @@ export default {
           data.attrs.href = options || 'javascript:;'
           if (this.target) data.attrs.target = this.target
 
-          if (this.$vnode.data.attrs.download === 'true') {
-            data.attrs.download = ''
-          } else if (this.$vnode.data.attrs.download) {
-            data.attrs.download = this.$vnode.data.attrs.download
-          }
+          data.attrs.download = this.download
         }
 
         data.on = { click: this.click }

--- a/src/mixins/route-link.js
+++ b/src/mixins/route-link.js
@@ -10,7 +10,8 @@ export default {
     ripple: Boolean,
     router: Boolean,
     tag: String,
-    target: String
+    target: String,
+    download: String
   },
 
   methods: {
@@ -51,6 +52,12 @@ export default {
         if (tag === 'a') {
           data.attrs.href = options || 'javascript:;'
           if (this.target) data.attrs.target = this.target
+
+          if (this.download === 'true') {
+            data.attrs.download = ''
+          } else if (this.download) {
+            data.attrs.download = this.download
+          }
         }
 
         data.on = { click: this.click }

--- a/src/mixins/route-link.js
+++ b/src/mixins/route-link.js
@@ -10,8 +10,7 @@ export default {
     ripple: Boolean,
     router: Boolean,
     tag: String,
-    target: String,
-    download: String
+    target: String
   },
 
   methods: {
@@ -53,10 +52,10 @@ export default {
           data.attrs.href = options || 'javascript:;'
           if (this.target) data.attrs.target = this.target
 
-          if (this.download === 'true') {
+          if (this.$vnode.data.attrs.download === 'true') {
             data.attrs.download = ''
-          } else if (this.download) {
-            data.attrs.download = this.download
+          } else if (this.$vnode.data.attrs.download) {
+            data.attrs.download = this.$vnode.data.attrs.download
           }
         }
 


### PR DESCRIPTION
Any component that uses route-link can now take a `download` prop. It can have a value, or just be the attribute. If a value is given, and the URL is same-origin, the value will be used for the file name (can still be changed by the user). If no value is given, the file name of the file being downloaded will be used.