### PR TITLE
Allow component as row in datatable

### DIFF
--- a/src/components/tables/mixins/body.js
+++ b/src/components/tables/mixins/body.js
@@ -22,10 +22,10 @@ export default {
 
           const row = this.$scopedSlots.items(props)
 
-          if (row.length && row[0].tag === 'tr') {
-            return row
-          } else {
+          if (row.length && row[0].tag === 'td') {
             return this.genTR(row, { attrs: { active: this.isSelected(item) } })
+          } else {
+            return row
           }
         })
       }


### PR DESCRIPTION
With this change, it's possible to use component in datatable body such as:

```
<v-data-table
  v-bind:headers="headers"
  v-bind:items="items"
>
  <template slot="items" scope="props">
    <foo-row :bar="props.item"></foo-row>
  </template>
</v-data-table>
```

BTW I think it would be better if `<tr>` were required (explicit is better than implicit).