### PR TITLE
Fixed dialog bug when not using activator slot

### DIFF
--- a/src/components/dialogs/Dialog.js
+++ b/src/components/dialogs/Dialog.js
@@ -114,7 +114,7 @@ export default {
     return h('div', {
       'class': 'dialog__container',
       style: {
-        display: this.fullWidth ? 'block' : 'inline-block'
+        display: !this.$slots.activator && 'none' || this.fullWidth ? 'block' : 'inline-block'
       }
     }, children)
   }


### PR DESCRIPTION
Fixed bug where dialog__container created empty space when not using an activator slot