### PR TITLE
Display fixed toolbars in front of "default" toolbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://vuetifyjs.com" target="_blank"><img width="100"src="https://vuetifyjs.com/public/v.png"></a></p>
+<p align="center"><a href="https://vuetifyjs.com" target="_blank"><img width="100"src="https://image.ibb.co/cZg23Q/v.png"></a></p>
 <p align="center">Vuetify for Vue.js</p>
 <p align="center">
   <a href="https://www.npmjs.com/package/vuetify"><img src="https://img.shields.io/npm/dt/vuetify.svg" alt="Downloads"></a>

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@
     <img width="300px" src="https://vuetifyjs.com/static/doc-images/browser-stack.svg">
   </a>
   <br><br>
-  <a href="https://www.cloudflare.com" target="_blank">
-    <img height="60px" src="https://vuetifyjs.com/static/doc-images/cloudflare.svg">
-  </a>
-  <br><br>
 </p>
 <p align="center">
   <strong>Looking for Vue.js jobs? Check out <a href="https://vuejobs.com/?ref=vuetify" target="_blank">vuejobs.com</a></strong>

--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -3,7 +3,6 @@
   transition: .3s $transition.swing
   width: 100%
   will-change: padding-left
-  z-index: 2
   elevation(4)
     
   .input-group--solo
@@ -93,6 +92,7 @@
     
   &--fixed
     position: fixed
+    z-index: 2
 
   &--fixed, &--absolute
     top: 0


### PR DESCRIPTION
"Default" toolbars are displayed in front of fixed toolbars if the toolbar is scrolled.
This PR fixes this and sets the `z-index` only for fixed toolbars.

As I had no time to test this, this PR is more like a issue with a proposed solution.