### PR TITLE
Comply with the specs

### DIFF
--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -55,7 +55,7 @@ table.table
       height: 48px
 
     td
-      font-weight: 300
+      font-weight: 400
       font-size: 13px
 
   .input-group--selection-controls

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -25,7 +25,7 @@ table.table
 
     th
       color: rgba($material-theme.text-color, $material-theme.secondary-text-percent)
-      font-weight: 600
+      font-weight: 500
       font-size: 12px
       transition: .3s $transition.swing
       white-space: nowrap
@@ -55,7 +55,7 @@ table.table
       height: 48px
 
     td
-      font-weight: 500
+      font-weight: 300
       font-size: 13px
 
   .input-group--selection-controls


### PR DESCRIPTION
According to the [specs](https://material.io/guidelines/components/data-tables.html#data-tables-structure)

Table content (table.table tbody td) should be 13sp Roboto Regular
Column headers (rule table.table thead th) should be 12sp Roboto Medium