### PR TITLE
Comply with the Datatable specs

### DIFF
--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -25,7 +25,7 @@ table.table
 
     th
       color: rgba($material-theme.text-color, $material-theme.secondary-text-percent)
-      font-weight: 600
+      font-weight: 500
       font-size: 12px
       transition: .3s $transition.swing
       white-space: nowrap
@@ -46,16 +46,16 @@ table.table
       will-change: background
 
       &[active]
-        background: #f5f5f5
+        background: $grey.lighten-4
 
       &:hover
-        background: rgba($material-theme.fg-color, $material-theme.divider-percent)
+        background: $grey.lighten-3
 
     td, th
       height: 48px
 
     td
-      font-weight: 500
+      font-weight: 400
       font-size: 13px
 
   .input-group--selection-controls


### PR DESCRIPTION
According to the [specs](https://material.io/guidelines/components/data-tables.html#data-tables-structure)

Table content (table.table tbody td) should be 13sp Roboto Regular
Column headers (table.table thead th) should be 12sp Roboto Medium
Hover background Grey 200 (#EEEEEE)
Selected row background Grey 100 (#F5F5F5)