### PR TITLE
Fixed icon button's flex shrinking problem

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -69,6 +69,7 @@
     height: $button-height
     width: $button-height
     min-width: 0
+    flex-shrink: 0
 
     .btn__content
       height: $button-height


### PR DESCRIPTION
Set the flex-shrink property of the .btn--icon class to 0, to preserve its round shape even when the screen shrinks too low. Currently the button takes oval shape.

![image](https://user-images.githubusercontent.com/5291103/27982780-de73b2cc-6382-11e7-8ed0-b2f28727c656.png)
