### PR TITLE
Add small-only and fix all the -only display breakpoints

### DIFF
--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -43,12 +43,13 @@ $container-max-widths := {
 // ============================================================
 $display-breakpoints := {
   xs-only: "only screen and (max-width: %s)" % ($grid-breakpoints.sm - 1)
+  sm-only: "only screen and (min-width: %s) and (max-width: %s)" % ($grid-breakpoints.sm ($grid-breakpoints.md  - 1))
   sm-and-down: "only screen and (max-width: %s)" % ($grid-breakpoints.md - 1)
   sm-and-up: "only screen and (min-width: (%s))" % $grid-breakpoints.sm
-  md-only: "only screen and (min-width: %s) and (max-width: %s)" % $grid-breakpoints.md ($grid-breakpoints.lg  - 1)
+  md-only: "only screen and (min-width: %s) and (max-width: %s)" % ($grid-breakpoints.md ($grid-breakpoints.lg  - 1))
   md-and-down: "only screen and (max-width: %s )" % ($grid-breakpoints.lg - 1)
   md-and-up: "only screen and (min-width: %s)" % $grid-breakpoints.md
-  lg-only: "only screen and (min-width: %s) and (max-width: %s)" % $grid-breakpoints.lg ($grid-breakpoints.xl - 1)
+  lg-only: "only screen and (min-width: %s) and (max-width: %s)" % ($grid-breakpoints.lg ($grid-breakpoints.xl - 1))
   lg-and-down: "only screen and (max-width: (%s - 1))" % $grid-breakpoints.xl
   lg-and-up: "only screen and (min-width: %s)" % $grid-breakpoints.lg
   xl-only: "only screen and (min-width: %s)" % $grid-breakpoints.xl


### PR DESCRIPTION
This is to fix issue #944, which will make the all the hidden-{size}-only classes work.