### PR TITLE
Improved toolbar behavior

### DIFF
--- a/src/components/toolbar/Toolbar.js
+++ b/src/components/toolbar/Toolbar.js
@@ -25,14 +25,11 @@ export default {
         'toolbar--fixed': this.fixed,
         'toolbar--floating': this.floating,
         'toolbar--prominent': this.prominent,
-        'toolbar--extended': this.isExtended(),
+        'toolbar--extended': this.isExtended,
         'theme--dark': this.dark,
         'theme--light': this.light
       }
-    }
-  },
-
-  methods: {
+    },
     isExtended () {
       return this.$slots.extension || this.extended
     }
@@ -48,7 +45,7 @@ export default {
       'class': 'toolbar__content'
     }, this.$slots.default))
 
-    if (this.isExtended()) {
+    if (this.isExtended) {
       children.push(h('div', {
         'class': 'toolbar__extension'
       }, this.$slots.extension))

--- a/src/components/toolbar/Toolbar.js
+++ b/src/components/toolbar/Toolbar.js
@@ -25,9 +25,16 @@ export default {
         'toolbar--fixed': this.fixed,
         'toolbar--floating': this.floating,
         'toolbar--prominent': this.prominent,
+        'toolbar--extended': this.isExtended(),
         'theme--dark': this.dark,
         'theme--light': this.light
       }
+    }
+  },
+
+  methods: {
+    isExtended () {
+      return this.$slots.extension || this.extended
     }
   },
 
@@ -41,9 +48,7 @@ export default {
       'class': 'toolbar__content'
     }, this.$slots.default))
 
-    if (this.$slots.extension ||
-      this.extended
-    ) {
+    if (this.isExtended()) {
       children.push(h('div', {
         'class': 'toolbar__extension'
       }, this.$slots.extension))

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -35,11 +35,11 @@ export default {
 
       if (this.absolute) {
         // Required for IE11
-        this.$el.parentNode.insertBefore(overlay, this.$el.parentNode.firstChild)
+        this.$el.parentNode.insertBefore(this.overlay, this.$el.parentNode.firstChild)
       } else {
         document.querySelector('[data-app]').appendChild(this.overlay)
       }
-        
+
       this.overlay.clientHeight // Force repaint
       requestAnimationFrame(() => {
         this.overlay.className += ' overlay--active'

--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -98,9 +98,45 @@
     top: 0
     left: 0
 
+  &--absolute
+    z-index 2
+
+    + main
+      padding-top: 0
+
+  &--fixed
     + main
       padding-top: $toolbar-height
-      
+
+    @media all and (max-width: $grid-breakpoints.lg) and (orientation: landscape)
+      + main
+        padding-top: $toolbar-mobile-landscape-height
+
+    &.toolbar--extended
+      + main
+          padding-top: $toolbar-height + $toolbar-extension-height
+
+      &.toolbar--dense
+        + main
+          padding-top: $toolbar-mobile-landscape-height * 2
+
+      &.toolbar--prominent
+        + main
+          padding-top: $toolbar-height * 2
+
+      @media all and (max-width: $grid-breakpoints.lg) and (orientation: landscape)
+        + main
+            padding-top: $toolbar-mobile-landscape-height * 2
+
+    &.toolbar--dense
+      + main
+        padding-top: $toolbar-mobile-landscape-height
+
+    &.toolbar--prominent
+      + main
+        padding-top: $toolbar-height
+
+
   &--floating
     display: inline-flex
     margin: 16px


### PR DESCRIPTION
Better `<main>` section responsibility depends on toolbar state.

now css rule `padding-top` of  folowing `<main>`  take into consideration toolbar modifiers:

* toolbar-fixed
* toolbar-extended
* toolbar-dense
* toolbar-prominent

in all combinations

[old behavior](https://codepen.io/anon/pen/RgEeBy)
[new behavior](https://codepen.io/anon/pen/BZvqwO)
 
