### PR TITLE
fix babel warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "autoprefixer": "^6.6.0",
     "avoriaz": "^2.4.2",
-    "babel": "^6.23.0",
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.1.1",
     "babel-jest": "^20.0.3",


### PR DESCRIPTION
warning babel@6.23.0: In 6.x, the babel package has been deprecated in favor of babel-cli. Check https://opencollective.com/babel to support the Babel maintainers
