### PR TITLE
Close drawer in mobil after change route

### DIFF
--- a/src/components/navigation-drawer/VNavigationDrawer.js
+++ b/src/components/navigation-drawer/VNavigationDrawer.js
@@ -66,7 +66,7 @@ export default {
 
   watch: {
     $route () {
-      if (!this.disableRouteWatcher) {
+      if (!this.disableRouteWatcher || this.isMobile) {
         this.isActive = !this.closeConditional()
       }
     },


### PR DESCRIPTION
1. In mobil drawer is alway close
![selection_005](https://user-images.githubusercontent.com/451862/28486871-d1a1f75a-6e4c-11e7-9a2a-d7b26d29a8c8.png)

2. Open drawer for select one option

![selection_003](https://user-images.githubusercontent.com/451862/28486848-9b2e7d60-6e4c-11e7-9c4c-244e136934f1.png)

3. Option is selected
![selection_004](https://user-images.githubusercontent.com/451862/28486879-e50f761e-6e4c-11e7-8c1d-02cea3f5317a.png)

But the drawer no close automatic after select option

