### PR TITLE
add lint to test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "cross-env TARGET=dev webpack --config build/config.js --progress --hide-modules --watch",
     "build": "rimraf dist && cross-env NODE_ENV=production node build/build.js --progress --hide-modules",
-    "test": "cross-env NODE_ENV=test jest --no-cache",
+    "test": "npm run lint && cross-env NODE_ENV=test jest --no-cache",
     "lint": "eslint --ext .js,.vue src --ignore-pattern=*/util/testing.js"
   },
   "description": "Vue.js 2 Semantic Component Framework",


### PR DESCRIPTION
Not more pull request with lint errors.
One command npm run test

see example: https://github.com/vuejs/vue/blob/dev/package.json#L26

This must be merged after the current lint errors are adjusted, that is why it fails