### PR TITLE
fix for #1117

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -111,6 +111,7 @@
     .btn__content
       flex: 0 0 auto
       padding: 0
+	  margin: 0
 
       .icon
         color: inherit


### PR DESCRIPTION
Overwrite the buttons default margin definition which is only needed for non-circular buttons.