### PR TITLE
Add directive clickOutside, fixed lint error.

### DIFF
--- a/src/components/menus/VMenu.js
+++ b/src/components/menus/VMenu.js
@@ -21,6 +21,10 @@ export default {
     Toggleable
   ],
 
+  directives: {
+    clickOutside
+  },
+
   data () {
     return {
       autoIndex: null,


### PR DESCRIPTION
This is used in the line: https://github.com/vuetifyjs/vuetify/blob/dev/src/components/menus/VMenu.js#L220