### PR TITLE
support typescript class constructor

### DIFF
--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -93,7 +93,7 @@ export function getObjectValueByPath (obj, path) {
   const a = path.split('.')
   for (var i = 0, n = a.length; i < n; ++i) {
     var k = a[i]
-    if (obj.constructor === Object && k in obj) {
+    if (obj instanceof Object && k in obj) {
       obj = obj[k]
     } else {
       return


### PR DESCRIPTION
For objects with a constructor like:
`var MyClass = (function () {
	function MyClass(foo, bar) {
		this.foo = foo;
		this.bar = bar;
	}
	return MyClass;
}());`
Condition (`obj.constructor === Object`) fails.