### PR TITLE
Fix support dark theme

### DIFF
--- a/src/components/subheaders/VSubheader.js
+++ b/src/components/subheaders/VSubheader.js
@@ -13,7 +13,7 @@ export default {
     data.staticClass = (`subheader ${data.staticClass || ''}`).trim()
 
     if (props.inset) data.staticClass += ' subheader--inset'
-    if (!props.dark) data.staticClass += ' theme--light'
+    if (props.light) data.staticClass += ' theme--light'
     if (props.dark) data.staticClass += ' theme--dark'
 
     return h('li', data, children)


### PR DESCRIPTION
Fix by analogy with the `<v-divider>`
[VDivider.js#L17](https://github.com/vuetifyjs/vuetify/blob/16515c3ebb9734218ef3d833b6c5cc56a7cc65c7/src/components/dividers/VDivider.js#L17)
