### PR TITLE
Add TypeScript definitions for Vuetify plugin and createSimpleTransition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import './src/util/helpers'
 import { PluginFunction } from 'vue'
 
 declare class Vuetify {
-    static install: PluginFunction<never>
+  static install: PluginFunction<never>
 }
 
 export = Vuetify

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+import './src/util/helpers'
+import { PluginFunction } from 'vue'
+
+declare class Vuetify {
+    static install: PluginFunction<never>
+}
+
+export = Vuetify

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "homepage": "http://vuetifyjs.com",
   "main": "dist/vuetify.js",
+  "types": "index.d.ts",
   "scripts": {
     "dev": "cross-env TARGET=dev webpack --config build/config.js --progress --hide-modules --watch",
     "build": "rimraf dist && cross-env NODE_ENV=production node build/build.js --progress --hide-modules",

--- a/src/util/helpers.d.ts
+++ b/src/util/helpers.d.ts
@@ -1,0 +1,5 @@
+declare module 'vuetify/src/util/helpers' {
+    import { FunctionalComponentOptions } from 'vue'
+
+    export function createSimpleTransition(name: string): FunctionalComponentOptions
+}

--- a/src/util/helpers.d.ts
+++ b/src/util/helpers.d.ts
@@ -1,5 +1,21 @@
 declare module 'vuetify/src/util/helpers' {
-    import { FunctionalComponentOptions } from 'vue'
+    import { FunctionalComponentOptions, VNodeDirective } from 'vue'
 
-    export function createSimpleTransition(name: string): FunctionalComponentOptions
+    export function createSimpleFunctional(c: string, el: string): FunctionalComponentOptions
+    export function createSimpleTransition(name: string, origin: string, mode: string): FunctionalComponentOptions
+    
+    export interface EventHandlersDict {
+        [event: string]: Function
+    }
+    export function createJavaScriptTransition(name: string, functions: EventHandlersDict, css: boolean, mode: string): FunctionalComponentOptions
+    
+    export interface BindingConfig {
+        arg: VNodeDirective['arg'],
+        modifiers: VNodeDirective['modifiers'],
+        value: VNodeDirective['value']
+    }
+    export function directiveConfig(binding: BindingConfig, defaults: object): VNodeDirective
+    export function addOnceEventListener(el: EventTarget, event: string, cb: () => void): void
+    export function getObjectValueByPath(obj: object, path: string): any
+    export function createRange(length: number): Array<number>
 }

--- a/src/util/helpers.d.ts
+++ b/src/util/helpers.d.ts
@@ -1,21 +1,21 @@
 declare module 'vuetify/src/util/helpers' {
-    import { FunctionalComponentOptions, VNodeDirective } from 'vue'
+  import { FunctionalComponentOptions, VNodeDirective } from 'vue'
 
-    export function createSimpleFunctional(c: string, el: string): FunctionalComponentOptions
-    export function createSimpleTransition(name: string, origin: string, mode: string): FunctionalComponentOptions
-    
-    export interface EventHandlersDict {
-        [event: string]: Function
-    }
-    export function createJavaScriptTransition(name: string, functions: EventHandlersDict, css: boolean, mode: string): FunctionalComponentOptions
-    
-    export interface BindingConfig {
-        arg: VNodeDirective['arg'],
-        modifiers: VNodeDirective['modifiers'],
-        value: VNodeDirective['value']
-    }
-    export function directiveConfig(binding: BindingConfig, defaults: object): VNodeDirective
-    export function addOnceEventListener(el: EventTarget, event: string, cb: () => void): void
-    export function getObjectValueByPath(obj: object, path: string): any
-    export function createRange(length: number): Array<number>
+  export function createSimpleFunctional(c: string, el: string): FunctionalComponentOptions
+  export function createSimpleTransition(name: string, origin: string, mode: string): FunctionalComponentOptions
+
+  export interface EventHandlersDict {
+    [event: string]: Function
+  }
+  export function createJavaScriptTransition(name: string, functions: EventHandlersDict, css: boolean, mode: string): FunctionalComponentOptions
+
+  export interface BindingConfig {
+    arg: VNodeDirective['arg'],
+    modifiers: VNodeDirective['modifiers'],
+    value: VNodeDirective['value']
+  }
+  export function directiveConfig(binding: BindingConfig, defaults: object): VNodeDirective
+  export function addOnceEventListener(el: EventTarget, event: string, cb: () => void): void
+  export function getObjectValueByPath(obj: object, path: string): any
+  export function createRange(length: number): Array<number>
 }


### PR DESCRIPTION
If you're writing a Vue app with TypeScript and you write `Vue.use(Vuetify)`, TypeScript throws an error because the Vuetify module hasn't been declared.

This pull request includes a tiny TypeScript definition file for the Vuetify plugin and one for the `createSimpleTransition` method as documented here: https://vuetifyjs.com/motion/transitions

I believe this covers the entire documented API surface area of Vuetify imports in a TypeScript application.