### PR TITLE
Added 'ripple' prop to v-checkbox

### DIFF
--- a/src/components/selection-controls/VCheckbox.js
+++ b/src/components/selection-controls/VCheckbox.js
@@ -24,7 +24,11 @@ export default {
   },
 
   props: {
-    indeterminate: Boolean
+    indeterminate: Boolean,
+    ripple: {
+      type: [Boolean, Object],
+      default: true
+    }
   },
 
   computed: {
@@ -56,17 +60,17 @@ export default {
       }, this.icon)
     ])
 
-    const ripple = h('div', {
+    const rippleEl = h('div', {
       'class': 'input-group--selection-controls__ripple',
       on: Object.assign({}, {
         click: this.toggle
       }, this.$listeners),
       directives: [{
         name: 'ripple',
-        value: { center: true }
+        value: this.ripple ? { center: true } : false
       }]
     })
 
-    return this.genInputGroup([transition, ripple])
+    return this.genInputGroup([transition, rippleEl])
   }
 }

--- a/src/components/selection-controls/VCheckbox.js
+++ b/src/components/selection-controls/VCheckbox.js
@@ -27,7 +27,7 @@ export default {
     indeterminate: Boolean,
     ripple: {
       type: [Boolean, Object],
-      default: true
+      default: () => ({ center: true })
     }
   },
 
@@ -60,17 +60,17 @@ export default {
       }, this.icon)
     ])
 
-    const rippleEl = h('div', {
+    const ripple = h('div', {
       'class': 'input-group--selection-controls__ripple',
       on: Object.assign({}, {
         click: this.toggle
       }, this.$listeners),
       directives: [{
         name: 'ripple',
-        value: this.ripple ? { center: true } : false
+        value: this.ripple
       }]
     })
 
-    return this.genInputGroup([transition, rippleEl])
+    return this.genInputGroup([transition, ripple])
   }
 }


### PR DESCRIPTION
As discussed in the chat, this adds a ripple prop to the checkbox component. Ripple can therefore be disabled with:

````
<v-checkbox :ripple="false"></v-checkbox>
````

This prop would also be nice for Radios and Switches. However, this would require a bigger code change. 