### PR TITLE
Little change on Vue version checking for easier maintenance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 ﻿require('./stylus/main.styl')
 
+import { devDependencies } from '../package.json'
 import Components from './components'
 import * as Directives from './directives'
 import Load from './util/load'
@@ -20,8 +21,9 @@ function plugin (Vue) {
 }
 
 function checkVueVersion () {
-  if (!semver.satisfies(window.Vue.version, '>=2.4.0')) {
-    console.error('Vuetify requires Vue version >= 2.4.0')
+  const vueDep = devDependencies.vue.replace('^', '')
+  if (!semver.satisfies(window.Vue.version, `>=${vueDep}`)) {
+    console.warn(`Vuetify requires Vue version >= ${vueDep}`)
   }
 }
 


### PR DESCRIPTION
The current implementation is a bit hard-coded and implies changing the vue version in that file at every vue version change.

Also, changed the `console.error` to `console.warn` since some features would also be ok with earlier vue versions.

Don't know if it's really useful but it seems a little easier to maintain this way.