### PR TITLE
enhancement/data-table-footer

### DIFF
--- a/src/components/tables/VDataTable.js
+++ b/src/components/tables/VDataTable.js
@@ -298,7 +298,7 @@ export default {
         this.genTHead(),
         this.genTProgress(),
         this.genTBody(),
-        this.hideActions ? null : this.genTFoot()
+        this.genTFoot()
       ])
     ])
   }

--- a/src/components/tables/mixins/foot.js
+++ b/src/components/tables/mixins/foot.js
@@ -99,7 +99,8 @@ export default {
         ]))
       }
 
-      return this.$createElement('tfoot', [children])
+      if (!children.length) return null     
+      return this.$createElement('tfoot', children)
     }
   }
 }

--- a/src/components/tables/mixins/foot.js
+++ b/src/components/tables/mixins/foot.js
@@ -81,13 +81,25 @@ export default {
       ])]
     },
     genTFoot () {
-      return this.$createElement('tfoot', [
-        this.genTR([
+      const children = []
+
+      if (this.$slots.footer) {
+        const footer = this.$slots.footer
+        const needsTableRow = footer.length && footer[0].tag === 'td'
+        const row = !needsTableRow ? footer : this.genTR(this.$slots.footer)
+
+        children.push(row)
+      }
+
+      if (!this.hideActions) {
+        children.push(this.genTR([
           this.$createElement('td', {
             attrs: { colspan: '100%' }
           }, this.genActions())
-        ])
-      ])
+        ]))
+      }
+
+      return this.$createElement('tfoot', [children])
     }
   }
 }

--- a/src/components/tables/mixins/foot.js
+++ b/src/components/tables/mixins/foot.js
@@ -99,7 +99,7 @@ export default {
         ]))
       }
 
-      if (!children.length) return null     
+      if (!children.length) return null
       return this.$createElement('tfoot', children)
     }
   }

--- a/src/stylus/components/_datatables.styl
+++ b/src/stylus/components/_datatables.styl
@@ -59,6 +59,7 @@
 
     .input-group--select
       margin: 13px 0 13px 34px
+      padding: 0
       position: initial
 
       .input-group__selections__comma

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -36,7 +36,7 @@ table.table
 
       > div
         width: 100%
-        
+
     &:last-of-type
       border-bottom: 1px solid rgba($material-theme.fg-color, $material-theme.divider-percent)
 
@@ -73,6 +73,13 @@ table.table
         left: 50%
         transform: translate3d(-50%, -50%, 0)
   tfoot
+    tr:not(:last-child)
+      height: 48px
+
+      &:not(:only-child)
+        td
+          padding: 0 24px
+
     tr
       height: 56px
       border-top: 1px solid rgba($material-theme.fg-color, $material-theme.divider-percent)


### PR DESCRIPTION
See https://github.com/vuetifyjs/vuetify/issues/1172

Added `footer` slot. Works the same way as `items` slot in that you can either supply one or more `<tr>` tags, or one or more `<td>` tags which will be wrapped internally in a `<tr>` tag.