### PR TITLE
Issue1235

### DIFF
--- a/src/components/breadcrumbs/VBreadcrumbsItem.js
+++ b/src/components/breadcrumbs/VBreadcrumbsItem.js
@@ -16,13 +16,13 @@ export default {
 
   computed: {
     classes () {
-      const classes =  {
+      const classes = {
         'breadcrumbs__item': true
       }
 
       classes[this.activeClass] = this.disabled
 
-      return classes;
+      return classes
     }
   },
 

--- a/src/components/breadcrumbs/VBreadcrumbsItem.js
+++ b/src/components/breadcrumbs/VBreadcrumbsItem.js
@@ -10,16 +10,19 @@ export default {
   props: {
     activeClass: {
       type: String,
-      default: 'breadcrumbs__item--active'
+      default: 'breadcrumbs__item--disabled'
     }
   },
 
   computed: {
     classes () {
-      return {
-        'breadcrumbs__item': true,
-        'breadcrumbs__item--disabled': this.disabled
+      const classes =  {
+        'breadcrumbs__item': true
       }
+
+      classes[this.activeClass] = this.disabled
+
+      return classes;
     }
   },
 

--- a/src/components/lists/VListTile.js
+++ b/src/components/lists/VListTile.js
@@ -23,12 +23,15 @@ export default {
 
   computed: {
     classes () {
-      return {
+      const classes = {
         'list__tile': true,
-        'list__tile--active': this.isActive,
         'list__tile--avatar': this.avatar,
         'list__tile--disabled': this.disabled
       }
+
+      classes[this.activeClass] = this.isActive
+
+      return classes
     }
   },
 

--- a/src/components/tabs/VTabsItem.js
+++ b/src/components/tabs/VTabsItem.js
@@ -9,8 +9,7 @@ export default {
 
   data () {
     return {
-      isActive: false,
-      defaultActiveClass: 'tabs__item--active'
+      isActive: false
     }
   },
 
@@ -23,11 +22,14 @@ export default {
 
   computed: {
     classes () {
-      return {
+      const classes = {
         'tabs__item': true,
-        'tabs__item--active': !this.to && this.isActive,
         'tabs__item--disabled': this.disabled
       }
+
+      classes[this.activeClass] = !this.to && this.isActive
+
+      return classes
     },
     action () {
       const to = this.to || this.href


### PR DESCRIPTION
`activeClass` was being received as prop, but was not being used in computed classes function. 

Question: I noticed vBreadCrumbsItem also receives active class, but does nothing with it. However I think with breadcrumbs,  when a breadcrumb is 'active' it is actually 'disabled'. What should happen there? I took a shot at what I think the intended logic is there. Let me know if it makes sense. 