### PR TITLE
Fixes #1218 - change triggered on blur

### DIFF
--- a/src/components/text-fields/VTextField.js
+++ b/src/components/text-fields/VTextField.js
@@ -142,9 +142,9 @@ export default {
       this.inputValue = e.target.value
       this.multiLine && this.autoGrow && this.calculateInputHeight()
     },
-    onChange (e) {
+    onChange () {
       if (this.originalValue !== this.inputValue) {
-        this.$emit('change', e)
+        this.$emit('change', this.inputValue)
       }
     },
     blur (e) {

--- a/src/components/text-fields/VTextField.js
+++ b/src/components/text-fields/VTextField.js
@@ -106,10 +106,8 @@ export default {
   },
 
   watch: {
-    focused (val) {
+    focused () {
       this.hasFocused = true
-
-      !val && this.$emit('change', this.lazyValue)
     },
     value () {
       this.lazyValue = this.value

--- a/src/components/text-fields/VTextField.js
+++ b/src/components/text-fields/VTextField.js
@@ -10,6 +10,7 @@ export default {
   data () {
     return {
       hasFocused: false,
+      originalValue: null,
       inputHeight: null
     }
   },
@@ -106,8 +107,11 @@ export default {
   },
 
   watch: {
-    focused () {
+    focused (val) {
       this.hasFocused = true
+      if (val) {
+        this.originalValue = this.inputValue
+      }
     },
     value () {
       this.lazyValue = this.value
@@ -137,6 +141,11 @@ export default {
     onInput (e) {
       this.inputValue = e.target.value
       this.multiLine && this.autoGrow && this.calculateInputHeight()
+    },
+    onChange (e) {
+      if (this.originalValue !== this.inputValue) {
+        this.$emit('change', e)
+      }
     },
     blur (e) {
       this.validate()
@@ -177,6 +186,7 @@ export default {
           ...this.$listeners,
           blur: this.blur,
           input: this.onInput,
+          change: this.onChange,
           focus: this.focus
         },
         ref: 'input'


### PR DESCRIPTION
First commit removes emitting 'change' event on blur. Now the 'change' event is emitted only when input.value changes. However it emits the event object instead of input value (as it should do according to documentation). It also emits event when value after applying modifiers has not changed - i.e. when trailing spaces were added to the value of the text field with "trim" modifier. Input element fires the 'change' event, but the effective value (input.value.trim()) doesn't change

Second commit fixes the last issue, and the 3rd commit fixes the emitted value (input value instead of event object)

Playground.vue for testing:

```
<template>
    <v-container>
        <v-text-field v-model.trim="value" label="Input" @change="change($event)"></v-text-field>
        <p>Type 'abc' then blur, 'change' event should be emitted. Then add some spaces at the end and blur - change event should not be emitted</p>
    </v-container>
</template>


<script>
    export default {
        data: () => ({value: ''}),
        methods: {
            change: e => console.log('Event emitted', e)
        }
    }
</script>
```