### PR TITLE
Add new debug-build script, and add vuetify.css without nano to dev playground

### DIFF
--- a/build/webpack.dev.config.js
+++ b/build/webpack.dev.config.js
@@ -1,6 +1,7 @@
-const merge = require('webpack-merge')
+﻿const merge = require('webpack-merge')
 const baseWebpackConfig = require('./webpack.base.config')
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 // Helpers
 const resolve = file => require('path').resolve(__dirname, file)
@@ -30,7 +31,9 @@ module.exports = merge(baseWebpackConfig, {
       },
       {
         test: /\.styl$/,
-        loaders: ['css-loader', 'postcss-loader', 'stylus-loader'],
+        use: ExtractTextPlugin.extract({
+          use: ['css-loader', 'postcss-loader', 'stylus-loader']
+        }),
         exclude: /node_modules/
       }
     ]
@@ -40,5 +43,8 @@ module.exports = merge(baseWebpackConfig, {
   },
   devServer: {
     contentBase: resolve('../dev')
-  }
+  },
+  plugins: [
+    new ExtractTextPlugin('vuetify.css')
+  ]
 })

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --config build/webpack.dev.config.js --open --hot",
     "build": "rimraf dist && cross-env NODE_ENV=production node build/build.js --progress --hide-modules",
+    "debug-build": "node --inspect --debug-brk build/build.js",
     "test": "cross-env NODE_ENV=test jest --no-cache --coverage --verbose",
     "test-no-coverage": "cross-env NODE_ENV=test jest --no-cache --verbose",
     "lint": "eslint --ext .js,.vue src --ignore-pattern=*/util/testing.js"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,15 +1,15 @@
-const precss = require('precss')
+﻿const precss = require('precss')
 const autoprefixer = require('autoprefixer')
 const mqpacker = require('css-mqpacker')
 const cssnano = require('cssnano')
 
-module.exports = {
+module.exports = (ctx) => ({
   plugins: [
     precss(),
     autoprefixer({
       browsers: ['ie >= 11', 'safari >= 9', 'last 2 versions', '> 1%']
     }),
     mqpacker(),
-    cssnano()
+    ctx.env === "production" ? cssnano() : null
   ]
-}
+})


### PR DESCRIPTION
debug-build script is useful for debugging webpack configs.
Extracting the css without nano makes diagnosing css issues easier.