### PR TITLE
fixes #1263 - emit event on drawer toggle

### DIFF
--- a/src/components/navigation-drawer/VNavigationDrawer.js
+++ b/src/components/navigation-drawer/VNavigationDrawer.js
@@ -94,11 +94,12 @@ export default {
 
   mounted () {
     this.$vuetify.load(this.init)
-    this.$el.addEventListener('transitionend', this.onTransitionend)
+    this.$el.addEventListener('transitionend', this.onTransitionend, false)
   },
 
-  destroyed () {
-    this.$el.removeEventListener('transitionend', this.onTransitionend)
+  beforeDestroy () {
+    this.$el &&
+      this.$el.removeEventListener('transitionend', this.onTransitionend, false)
   },
 
   methods: {

--- a/src/components/navigation-drawer/VNavigationDrawer.js
+++ b/src/components/navigation-drawer/VNavigationDrawer.js
@@ -94,6 +94,11 @@ export default {
 
   mounted () {
     this.$vuetify.load(this.init)
+    this.$el.addEventListener('transitionend', this.onTransitionend)
+  },
+
+  destroyed () {
+    this.$el.removeEventListener('transitionend', this.onTransitionend)
   },
 
   methods: {
@@ -125,6 +130,13 @@ export default {
         this.checkIfMobile()
         this.isActive = !this.isMobile
       }, 200)
+    },
+    onTransitionend (e) {
+      if (e.target === this.$el &&
+        (e.propertyName === 'width' ||
+          (e.propertyName === 'transform' && this.persistent))) {
+        this.$emit('toggle')
+      }
     },
     swipeRight (e) {
       if (this.isActive && !this.right) return


### PR DESCRIPTION
Playground.vue for testing - switching on/off left drawer (persistent) should write 'toggle' in console after end of transition, same for changing mini variant, for right (temporary) drawer no event should be emitted:

```
<template>
    <v-app>
        <v-navigation-drawer @toggle="toggle()" persistent :mini-variant="mini" v-model="drawer">
            <v-btn @click="mini = !mini" icon>
                <v-icon v-if="mini">chevron_right</v-icon>
                <v-icon v-else>chevron_left</v-icon>
            </v-btn>
        </v-navigation-drawer>

        <v-toolbar>
            <v-toolbar-side-icon @click.native.stop="drawer = !drawer"></v-toolbar-side-icon>
            <v-spacer></v-spacer>
            <v-toolbar-side-icon @click.native.stop="temporary = !temporary"></v-toolbar-side-icon>
        </v-toolbar>

        <main>
            <v-navigation-drawer @toggle="toggle()" temporary v-model="temporary" right></v-navigation-drawer>
        </main>
    </v-app>
</template>

<script>
    export default {
        data() {
            return {
                drawer: true,
                temporary: false,
                mini: false,
            };
        },
        methods: {
            toggle() {
                console.log('toggle');
            },
        },
    };
</script>
``` 

