### PR TITLE
normalize mixin import

### DIFF
--- a/src/mixins/selectable.js
+++ b/src/mixins/selectable.js
@@ -1,4 +1,4 @@
-import Colorable from '~mixins/colorable'
+import Colorable from './colorable'
 import Input from './input'
 
 export default {


### PR DESCRIPTION
This will allow the mixin to be used within other projects without hard-coding webpack alias.