### PR TITLE
Set a default id for all inputs

### DIFF
--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -23,6 +23,10 @@ export default {
     },
     hint: String,
     hideDetails: Boolean,
+    id: {
+      type: [String, Number],
+      default: this._uid
+    },
     label: String,
     persistentHint: Boolean,
     placeholder: String,


### PR DESCRIPTION
First I believe the vue uid is unique to each instance of a component so it should work as dom id.
Second this will allow the creation of the inputs label to automatically have something to tie the label too. 
Should the id be spec compliant and start with a `_`?
Should the check on whether this an id be removed from line 112?