### PR TITLE
Accessibility and testing changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
-build/*.js
+﻿build/*.js
 src/stylus/*.styl
+src/util/testing.js
+src/util/to-have-been-warned.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-.DS_Store
+﻿.DS_Store
 node_modules/
 .vscode/
 npm-debug.log
 .idea/
 coverage/
 Playground.vue
+.vs/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug-build": "node --inspect --debug-brk build/build.js",
     "test": "cross-env NODE_ENV=test jest --no-cache --verbose",
     "test-coverage": "cross-env NODE_ENV=test jest --no-cache --coverage --verbose",
-    "lint": "eslint --ext .js,.vue src --ignore-pattern=*/util/testing.js"
+    "lint": "eslint --ext .js,.vue src"
   },
   "description": "Vue.js 2 Semantic Component Framework",
   "devDependencies": {

--- a/src/components/icons/VIcon.spec.js
+++ b/src/components/icons/VIcon.spec.js
@@ -1,4 +1,4 @@
-import VIcon from '~components/icons/VIcon'
+﻿import VIcon from '~components/icons/VIcon'
 import { test } from '~util/testing'
 
 test('VIcon.js', ({ mount, functionalContext }) => {
@@ -13,7 +13,7 @@ test('VIcon.js', ({ mount, functionalContext }) => {
     const context = functionalContext({ props: { mdi: true } }, 'add')
     mount(VIcon, context)
 
-    expect(console.warn).toBeCalled()
+    expect("'fa' and 'mdi' will be deprecated").toHaveBeenTipped()
   })
 
   it('should still render correctly when using deprecated prop mdi', () => {
@@ -23,13 +23,15 @@ test('VIcon.js', ({ mount, functionalContext }) => {
     expect(wrapper.hasClass('mdi')).toBe(true)
     expect(wrapper.hasClass('mdi-add')).toBe(true)
     expect(wrapper.text()).toBe('')
+
+    expect("'fa' and 'mdi' will be deprecated").toHaveBeenTipped()
   })
 
   it('should throw warning when using deprecated prop fa', () => {
     const context = functionalContext({ props: { fa: true } }, 'add')
     mount(VIcon, context)
 
-    expect(console.warn).toBeCalled()
+    expect("'fa' and 'mdi' will be deprecated").toHaveBeenTipped()
   })
 
   it('should still render correctly when using deprecated prop fa', () => {
@@ -39,6 +41,8 @@ test('VIcon.js', ({ mount, functionalContext }) => {
     expect(wrapper.hasClass('fa')).toBe(true)
     expect(wrapper.hasClass('fa-add')).toBe(true)
     expect(wrapper.text()).toBe('')
+
+    expect("'fa' and 'mdi' will be deprecated").toHaveBeenTipped()
   })
 
   it('should allow third-party icons when using <icon>- prefix', () => {

--- a/src/components/selection-controls/VCheckbox.js
+++ b/src/components/selection-controls/VCheckbox.js
@@ -1,4 +1,4 @@
-import Selectable from '~mixins/selectable'
+﻿import Selectable from '~mixins/selectable'
 import Ripple from '~directives/ripple'
 import { VFadeTransition } from '~components/transitions'
 import VIcon from '~components/icons/VIcon'
@@ -19,7 +19,7 @@ export default {
 
   data () {
     return {
-      inputDeterminate: this.indeterminate
+      inputIndeterminate: this.indeterminate
     }
   },
 
@@ -36,7 +36,7 @@ export default {
       })
     },
     icon () {
-      if (this.inputDeterminate) {
+      if (this.inputIndeterminate) {
         return 'indeterminate_check_box'
       } else if (this.isActive) {
         return 'check_box'
@@ -67,6 +67,14 @@ export default {
       }]
     })
 
-    return this.genInputGroup([transition, ripple])
+    const data = {
+      attrs: {
+        role: 'checkbox',
+        'aria-checked': this.inputIndeterminate && 'mixed' || this.isActive && 'true' || 'false',
+        'aria-label': this.label
+      }
+    }
+
+    return this.genInputGroup([transition, ripple], data)
   }
 }

--- a/src/components/selection-controls/VCheckbox.spec.js
+++ b/src/components/selection-controls/VCheckbox.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+﻿import { test } from '~util/testing'
 import VCheckbox from '~components/selection-controls/VCheckbox'
 
 test('VCheckbox.js', ({ mount }) => {
@@ -52,7 +52,8 @@ test('VCheckbox.js', ({ mount }) => {
       propsData: {
         label: 'Label',
         value: null
-      }
+      },
+      attrs: {}
     })
 
     const label = wrapper.find('label')[0]
@@ -60,5 +61,50 @@ test('VCheckbox.js', ({ mount }) => {
     label.trigger('click')
 
     expect(change).toBeCalled()
+    expect('$attrs is readonly').toHaveBeenWarned()
+  })
+
+  it('should render role and aria-checked attributes on input group', () => {
+    const wrapper = mount(VCheckbox, {
+      propsData: {
+        inputValue: false
+      }
+    })
+
+    let inputGroup = wrapper.find('.input-group')[0]
+    expect(inputGroup.hasAttribute('role', 'checkbox')).toBe(true)
+    expect(inputGroup.hasAttribute('aria-checked', 'false')).toBe(true)
+
+    wrapper.setProps({ 'inputValue': true })
+    inputGroup = wrapper.find('.input-group')[0]
+    expect(inputGroup.hasAttribute('aria-checked', 'true')).toBe(true)
+
+    wrapper.setProps({ 'indeterminate': true })
+    inputGroup = wrapper.find('.input-group')[0]
+    expect(inputGroup.hasAttribute('aria-checked', 'mixed')).toBe(true)
+  })
+
+  it('should render aria-label attribute with label value on input group', () => {
+    const wrapper = mount(VCheckbox, {
+      propsData: {
+        label: 'Test'
+      },
+      attrs: {}
+    })
+
+    let inputGroup = wrapper.find('.input-group')[0]
+    expect(inputGroup.hasAttribute('aria-label', 'Test')).toBe(true)
+    expect(`$attrs is readonly`).toHaveBeenWarned()
+  })
+
+  it('should not render aria-label attribute with no label value on input group', () => {
+    const wrapper = mount(VCheckbox, {
+      propsData: {
+        label: null
+      }
+    })
+
+    let inputGroup = wrapper.find('.input-group')[0]
+    expect(inputGroup.element.getAttribute('aria-label')).toBeFalsy()
   })
 })

--- a/src/components/selection-controls/VCheckbox.spec.js
+++ b/src/components/selection-controls/VCheckbox.spec.js
@@ -92,7 +92,7 @@ test('VCheckbox.js', ({ mount }) => {
       attrs: {}
     })
 
-    let inputGroup = wrapper.find('.input-group')[0]
+    const inputGroup = wrapper.find('.input-group')[0]
     expect(inputGroup.hasAttribute('aria-label', 'Test')).toBe(true)
     expect(`$attrs is readonly`).toHaveBeenWarned()
   })
@@ -104,7 +104,7 @@ test('VCheckbox.js', ({ mount }) => {
       }
     })
 
-    let inputGroup = wrapper.find('.input-group')[0]
+    const inputGroup = wrapper.find('.input-group')[0]
     expect(inputGroup.element.getAttribute('aria-label')).toBeFalsy()
   })
 })

--- a/src/components/tables/VDataTable.spec.js
+++ b/src/components/tables/VDataTable.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+﻿import { test } from '~util/testing'
 import VDataTable from './VDataTable'
 
 test('VDataTable.js', ({ mount }) => {
@@ -26,7 +26,7 @@ test('VDataTable.js', ({ mount }) => {
 
     pagination.descending = true
 
-    expect(wrapper.propsData().pagination.descending).toBe(true)
+    expect(wrapper.vm.$props.pagination.descending).toBe(true)
     // Also expect tests to not crash :)
   })
 })

--- a/src/components/text-fields/VTextField.js
+++ b/src/components/text-fields/VTextField.js
@@ -1,4 +1,4 @@
-import Input from '~mixins/input'
+﻿import Input from '~mixins/input'
 
 export default {
   name: 'v-text-field',
@@ -175,7 +175,8 @@ export default {
         },
         attrs: {
           ...this.$attrs,
-          tabindex: this.tabindex
+          tabindex: this.tabindex,
+          'aria-label': !this.$attrs.id && this.label // Label `for` will be set if we have an id
         },
         on: {
           ...this.$listeners,

--- a/src/components/text-fields/VTextField.spec.js
+++ b/src/components/text-fields/VTextField.spec.js
@@ -1,4 +1,4 @@
-import { mount } from 'avoriaz'
+﻿import { mount } from 'avoriaz'
 import { test } from '~util/testing'
 import VTextField from '~components/text-fields/VTextField'
 
@@ -7,7 +7,7 @@ test('VTextField.js', () => {
     const keyup = jest.fn()
     const component = {
       render (h) {
-        return h(VTextField, { on: { keyUp: keyup }, props: { download: '' } })
+        return h(VTextField, { on: { keyUp: keyup }, props: { download: '' }, attrs: {} })
       }
     }
     const wrapper = mount(component)
@@ -16,5 +16,46 @@ test('VTextField.js', () => {
     input.trigger('keyUp', { keyCode: 65 })
 
     expect(keyup).toBeCalled()
+  })
+
+  it('should render aria-label attribute on text field element with label value and no id', () => {
+    const wrapper = mount(VTextField, {
+      propsData: {
+        label: 'Test'
+      },
+      attrs: {}
+    })
+
+    let inputGroup = wrapper.find('input')[0]
+    expect(inputGroup.hasAttribute('aria-label', 'Test')).toBe(true)
+    expect(`$attrs is readonly`).toHaveBeenWarned()
+  })
+
+  it('should not render aria-label attribute on text field element with no label value or id', () => {
+    const wrapper = mount(VTextField, {
+      propsData: {
+        label: null
+      },
+      attrs: {}
+    })
+
+    let inputGroup = wrapper.find('input')[0]
+    expect(inputGroup.element.getAttribute('aria-label')).toBeFalsy()
+    expect(`$attrs is readonly`).toHaveBeenWarned()
+  })
+
+  it('should not render aria-label attribute on text field element with id', () => {
+    const wrapper = mount(VTextField, {
+      propsData: {
+        label: 'Test'
+      },
+      attrs: {
+        id: 'Test'
+      }
+    })
+
+    let inputGroup = wrapper.find('input')[0]
+    expect(inputGroup.element.getAttribute('aria-label')).toBeFalsy()
+    expect(`$attrs is readonly`).toHaveBeenWarned()
   })
 })

--- a/src/components/text-fields/VTextField.spec.js
+++ b/src/components/text-fields/VTextField.spec.js
@@ -26,7 +26,7 @@ test('VTextField.js', () => {
       attrs: {}
     })
 
-    let inputGroup = wrapper.find('input')[0]
+    const inputGroup = wrapper.find('input')[0]
     expect(inputGroup.hasAttribute('aria-label', 'Test')).toBe(true)
     expect(`$attrs is readonly`).toHaveBeenWarned()
   })
@@ -39,7 +39,7 @@ test('VTextField.js', () => {
       attrs: {}
     })
 
-    let inputGroup = wrapper.find('input')[0]
+    const inputGroup = wrapper.find('input')[0]
     expect(inputGroup.element.getAttribute('aria-label')).toBeFalsy()
     expect(`$attrs is readonly`).toHaveBeenWarned()
   })
@@ -54,7 +54,7 @@ test('VTextField.js', () => {
       }
     })
 
-    let inputGroup = wrapper.find('input')[0]
+    const inputGroup = wrapper.find('input')[0]
     expect(inputGroup.element.getAttribute('aria-label')).toBeFalsy()
     expect(`$attrs is readonly`).toHaveBeenWarned()
   })

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -103,11 +103,11 @@ export default {
 
   methods: {
     genLabel () {
-      const data = {}
-
-      if (this.$attrs.id) data.attrs = { for: this.$attrs.id }
-
-      return this.$createElement('label', data, this.$slots.label || this.label)
+      return this.$createElement('label', {
+        attrs: {
+          for: this.$attrs.id
+        }
+      }, this.$slots.label || this.label)
     },
     genMessages () {
       let messages = []

--- a/src/mixins/selectable.js
+++ b/src/mixins/selectable.js
@@ -1,4 +1,4 @@
-import Colorable from './colorable'
+﻿import Colorable from './colorable'
 import Input from './input'
 
 export default {
@@ -34,14 +34,17 @@ export default {
 
   watch: {
     indeterminate (val) {
-      this.inputDeterminate = val
+      this.inputIndeterminate = val
     }
   },
 
   methods: {
     genLabel () {
       return this.$createElement('label', {
-        on: { click: this.toggle }
+        on: { click: this.toggle },
+        attrs: {
+          for: this.$attrs.id
+        }
       }, this.$slots.label || this.label)
     },
     toggle () {

--- a/src/util/testing.js
+++ b/src/util/testing.js
@@ -1,10 +1,12 @@
-import Vue from 'vue'
+﻿import Vue from 'vue'
 import load from '~util/load'
 import * as Directives from '~directives'
 import { mount, shallow } from 'avoriaz'
+import toHaveBeenWarnedInit from '~util/to-have-been-warned'
 
 export function test(name, cb) {
-  global.console.warn = jest.fn()
+  toHaveBeenWarnedInit()
+
   Vue.prototype.$vuetify = { load }
 
   Object.keys(Directives).forEach(key => {
@@ -32,7 +34,6 @@ export function functionalContext(context = {}, children = []) {
     children
   }
 }
-
 
 //requestAnimationFrame polyfill | Milos Djakonovic ( @Miloshio ) | MIT | https://github.com/milosdjakonovic/requestAnimationFrame-polyfill
 export function rafPolyfill(w) {

--- a/src/util/to-have-been-warned.js
+++ b/src/util/to-have-been-warned.js
@@ -1,0 +1,86 @@
+﻿// From Vue, slightly modified
+
+function noop() { }
+
+if (typeof console === 'undefined') {
+  window.console = {
+    warn: noop,
+    error: noop
+  }
+}
+
+// avoid info messages during test
+console.info = noop
+
+let asserted
+
+function createCompareFn (spy) {
+  const hasWarned = msg => {
+    var count = spy.calls.count()
+    var args
+    while (count--) {
+      args = spy.calls.argsFor(count)
+      if (args.some(containsMsg)) {
+        return true
+      }
+    }
+
+    function containsMsg (arg) {
+      return arg.toString().indexOf(msg) > -1
+    }
+  }
+
+  return {
+    compare: msg => {
+      asserted = asserted.concat(msg)
+      var warned = Array.isArray(msg)
+        ? msg.some(hasWarned)
+        : hasWarned(msg)
+      return {
+        pass: warned,
+        message: warned
+          ? 'Expected message "' + msg + '" not to have been warned'
+          : 'Expected message "' + msg + '" to have been warned'
+      }
+    }
+  }
+}
+
+function toHaveBeenWarnedInit() {
+  // define custom matcher for warnings
+  beforeEach(() => {
+    asserted = []
+    spyOn(console, 'warn')
+    spyOn(console, 'error')
+    jasmine.addMatchers({
+      toHaveBeenWarned: () => createCompareFn(console.error),
+      toHaveBeenTipped: () => createCompareFn(console.warn)
+    })
+  })
+
+  afterEach(done => {
+    const warned = msg => asserted.some(assertedMsg => msg.toString().indexOf(assertedMsg) > -1)
+    let count = console.error.calls.count()
+    let args
+    while (count--) {
+      args = console.error.calls.argsFor(count)
+      if (!warned(args[0])) {
+        done.fail(`Unexpected console.error message: ${args[0]}`)
+        return
+      }
+    }
+
+    const tipped = msg => asserted.some(assertedMsg => msg.toString().indexOf(assertedMsg) > -1)
+    count = console.warn.calls.count()
+    while (count--) {
+      args = console.warn.calls.argsFor(count)
+      if (!tipped(args[0])) {
+        done.fail(`Unexpected console.warn message: ${args[0]}`)
+        return
+      }
+    }
+    done()
+  })
+}
+
+export default toHaveBeenWarnedInit


### PR DESCRIPTION
Accessibility changes to VTextField and VCheckbox.  Removed console.warn mock in favor of spy's and new expect() matchers, toHaveBeenWarned and toHaveBeenTipped, with failure on unexpected console.error and console.warn messages.  Compensating changes where console.warn was being asserted.
