### PR TITLE
Improving margin/gutters

### DIFF
--- a/src/stylus/generic/_grid.styl
+++ b/src/stylus/generic/_grid.styl
@@ -2,46 +2,68 @@
   margin-right: auto
   margin-left: auto
   flex-basis: 100%
-  padding: $grid-gutters.lg
+
+  @media $display-breakpoints.xs-only
+    padding: $grid-gutters.xs
+  @media $display-breakpoints.sm-only
+    padding: $grid-gutters.sm
+  @media $display-breakpoints.md-only
+    padding: $grid-gutters.md
+  @media $display-breakpoints.lg-only
+    padding: $grid-gutters.lg
+  @media $display-breakpoints.xl-only
+    padding: $grid-gutters.xl
+
 
   for size, width in $container-max-widths
     @media only screen and (min-width: width)
       max-width: width
-  
-  @media $display-breakpoints.xs-only
-    padding: $grid-gutters.xl
 
   &.fluid
     max-width: 100%
     width: 100%
-  
+
   &.fill-height
     align-items: center
     display: flex
-    
+
     .layout
       height: 100%
       flex: 1 1 auto
-  
+
   &.grid-list
     for $size, $gutter in $grid-gutters
       &-{$size}
         padding: $gutter
-        
+
         > .layout
           margin: -($gutter / 2)
-          
+
           > .flex
             padding: ($gutter / 2)
 
 .layout
   display: flex
-  margin-right: -($grid-gutters.md / 2)
-  margin-left: -($grid-gutters.md / 2)
+
+  @media $display-breakpoints.xs-only
+    margin-right: -($grid-gutters.xs / 2)
+    margin-left: -($grid-gutters.xs / 2)
+  @media $display-breakpoints.sm-only
+    margin-right: -($grid-gutters.sm / 2)
+    margin-left: -($grid-gutters.sm / 2)
+  @media $display-breakpoints.md-only
+    margin-right: -($grid-gutters.md / 2)
+    margin-left: -($grid-gutters.md / 2)
+  @media $display-breakpoints.lg-only
+    margin-right: -($grid-gutters.lg / 2)
+    margin-left: -($grid-gutters.lg / 2)
+  @media $display-breakpoints.xl-only
+    margin-right: -($grid-gutters.xl / 2)
+    margin-left: -($grid-gutters.xl / 2)
 
   &.row, &.column
     flex: 0 1 auto
-    
+
     &.grow
       flex-grow: 1
 
@@ -53,7 +75,7 @@
 
   &.column
     flex-direction: column
-    
+
     &.reverse
       flex-direction: column-reverse
 
@@ -66,18 +88,32 @@
 
   .flex
     flex: 1 1 auto
-    padding-right: ($grid-gutters.md / 2)
-    padding-left: ($grid-gutters.md / 2)
+
+    @media $display-breakpoints.xs-only
+      padding-left: ($grid-gutters.xs / 2)
+      padding-right: ($grid-gutters.xs / 2)
+    @media $display-breakpoints.sm-only
+      padding-left: ($grid-gutters.sm / 2)
+      padding-right: ($grid-gutters.sm / 2)
+    @media $display-breakpoints.md-only
+      padding-left: ($grid-gutters.md / 2)
+      padding-right: ($grid-gutters.md / 2)
+    @media $display-breakpoints.lg-only
+      padding-left: ($grid-gutters.lg / 2)
+      padding-right: ($grid-gutters.lg / 2)
+    @media $display-breakpoints.xl-only
+      padding-left: ($grid-gutters.xl / 2)
+      padding-right: ($grid-gutters.xl / 2)
 
   for size, width in $grid-breakpoints
     @media all and (min-width: width)
-      &.row-{size} 
-        flex-direction: row   
+      &.row-{size}
+        flex-direction: row
 
       &.column-{size}
         flex-direction: column
 
-      &.child-flex-{size} > *   
+      &.child-flex-{size} > *
         flex: 1
 
       for n in (1..$grid-columns)
@@ -95,29 +131,29 @@
 .align
   &-start
     align-items: flex-start
-  
+
   &-end
     align-items: flex-end
-    
+
   &-center
     align-items: center
-    
+
   &-baseline
     align-items: baseline
-    
+
 .justify
   &-start
     justify-content: flex-start
-    
+
   &-end
     justify-content: flex-end
-    
+
   &-center
     justify-content: center
-    
+
   &-space-around
     justify-content: space-around
-  
+
   &-space-between
     justify-content: space-between
 
@@ -129,9 +165,9 @@
 
 .fill-height
   height: 100%
-  
+
 .show-overflow
   overflow: visible !important
-  
+
 .flexbox
   display: flex

--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -12,15 +12,23 @@ $material-left-padding := 16px
 $material-right-padding := 16px
 
 // Grid
+// For optimal user experience, material design user interfaces should adapt layouts for the following breakpoint widths: 480, 600, 840, 960, 1280, 1440, and 1600dp.
+// https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints
 // ============================================================
 $grid-breakpoints := {
   xs: 0
+  // xs 480
   sm: 600px
+  // sm 840
+  // sm 960
   md: 1024px
+  // md 1280
   lg: (1440px - 16px) // Desktop gets a 16dp reduction
-  xl: (1920px - 16px) // https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints
+  // lg 1600
+  xl: (1920px - 16px)
 }
 
+// Margins and gutters can be 8, 16, 24, or 40dp wide.
 $grid-gutter = 8px
 $grid-columns := 12
 $grid-gutters := {

--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -24,11 +24,11 @@ $grid-breakpoints := {
 $grid-gutter = 8px
 $grid-columns := 12
 $grid-gutters := {
-  xs: ($grid-gutter / 4)
-  sm: ($grid-gutter / 2)
-  md: $grid-gutter
-  lg: ($grid-gutter * 2)
-  xl: ($grid-gutter * 3)
+  xs: ($grid-gutter)
+  sm: ($grid-gutter * 2)
+  md: ($grid-gutter * 3)
+  lg: ($grid-gutter * 3)
+  xl: ($grid-gutter * 5)
 }
 
 $container-max-widths := {


### PR DESCRIPTION
This PR includes what should be a non-controversial non-breaking improvement to padding. 

That said, in the docs examples, there are some examples where columns don't have column classes. Some issues could arise there. Maybe I don't understand the intention for the system there.

When using the negative margin trick for the grid, it is important that all direct children of the layout rows have padding to compensate. Some of the docs examples don't do they, they just add gutters/margin manually using `ma-1` for example. 

For example, the way bootstrap deals with this is to say "Content should be placed within columns, and only columns may be immediate children of rows." Not that their word is gospel -- just an example. 

I also added some notes on some MD spec breakpoints we are missing. I can tell you the missing sm and md breakpoints are sorely needed. If you look at the new homepage, there's a wiiiide gap between 1024 and 1440. At 1420 window width the page content looks way too small. 

