### PR TITLE
Remove CSS Blur

### DIFF
--- a/src/stylus/components/_overlay.styl
+++ b/src/stylus/components/_overlay.styl
@@ -14,7 +14,6 @@
     background-color: rgba(33, 33, 33, 1)
     bottom: 0
     content: ''
-    filter: blur(10%)
     height: 100%
     left: 0
     opacity: 0


### PR DESCRIPTION
Hi,

The overlay menu, is a bit sluggish on low power device, I notice it's a bit better without (the barely noticeable) blur effect.

Since the 10% of blur is slightly noticeable, removing it, seems not a big loss, but on mobile (like a Nexus 5) make the animation more smooth.

I hope this little deletion will be merge.