### PR TITLE
v-select multiple prop toggling fix

### DIFF
--- a/src/components/VSelect/VSelect.vue
+++ b/src/components/VSelect/VSelect.vue
@@ -177,6 +177,9 @@
           this.$nextTick(this.$refs.menu.updateDimensions)
         }
       },
+      multiple (val) {
+        this.inputValue = val ? [] : null
+      },
       isActive (val) {
         this.isBooted = true
         this.lastItem += !val ? 20 : 0


### PR DESCRIPTION
This small PR fixes an error occurring after the 'multiple' prop is dynamically changed and a new value is selected.
It just sets the input value to an empty array or null depending on the multiple prop value.