### PR TITLE
Handle up/down arrow key events on VSelect

### DIFF
--- a/src/components/VSelect/VSelect.spec.js
+++ b/src/components/VSelect/VSelect.spec.js
@@ -85,4 +85,48 @@ test('VSelect.js', ({ mount, shallow }) => {
     expect(wrapper.vm.filteredItems[0]).toBe('foo')
     expect('Application is missing <v-app> component.').toHaveBeenTipped()
   })
+
+  const down = document.createEvent('HTMLEvents')
+  down.initEvent('keydown', true, true)
+  down.keyCode = 40
+
+  const up = new Event('keydown')
+  up.initEvent('keydown', true, true)
+  up.keyCode = 38
+
+  it('should handle keydown up/down arrow', () => {
+    const wrapper = mount(VSelect, {
+      attachToDocument: true,
+      propsData: {
+        value: null,
+        items: [0, 1, 2]
+      }
+    })
+
+    const change = jest.fn()
+    wrapper.instance().$on('change', change)
+
+    wrapper.instance().$el.dispatchEvent(up)
+    expect(change).not.toHaveBeenCalled()
+    wrapper.instance().$el.dispatchEvent(down)
+    expect(change).toHaveBeenLastCalledWith(0)
+    wrapper.instance().$el.dispatchEvent(down)
+    expect(change).toHaveBeenLastCalledWith(1)
+    wrapper.instance().$el.dispatchEvent(down)
+    expect(change).toHaveBeenLastCalledWith(2)
+
+    change.mockReset()
+    wrapper.instance().$el.dispatchEvent(down)
+    expect(change).not.toHaveBeenCalled()
+    wrapper.instance().$el.dispatchEvent(up)
+    expect(change).toHaveBeenLastCalledWith(1)
+    wrapper.instance().$el.dispatchEvent(up)
+    expect(change).toHaveBeenLastCalledWith(0)
+
+    change.mockReset()
+    wrapper.instance().$el.dispatchEvent(up)
+    expect(change).not.toHaveBeenCalled()
+
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
 })

--- a/src/components/VSelect/VSelect.vue
+++ b/src/components/VSelect/VSelect.vue
@@ -329,7 +329,21 @@
           click: () => {
             if (!this.isActive) this.isActive = true
           },
-          keydown: this.onKeyDown // Located in mixins/autocomplete.js
+          keydown: (e) => {
+            if (!this.isActive &&
+                !this.multiple &&
+                !this.autocomplete &&
+                [38, 40].includes(e.keyCode)) {
+              const i = this.items.findIndex((i) => {
+                return this.getValue(i) === this.getValue(this.inputValue)
+              }) + e.keyCode - 39
+              if (i >= 0 && i < this.items.length) {
+                this.$emit('change', this.inputValue = this.items[i])
+              }
+            } else {
+              this.onKeyDown(e) // Located in mixins/autocomplete.js
+            }
+          }
         }
       })
     }


### PR DESCRIPTION
This change allows the up and down arrow keys to select the next and previous items respectively when the v-select input box is focused but the menu is not open. If the value is not set, then the down arrow key selects the first item and the up arrow does nothing.