### PR TITLE
IE11 progress circular issue

### DIFF
--- a/src/stylus/components/_progress-circular.styl
+++ b/src/stylus/components/_progress-circular.styl
@@ -22,7 +22,7 @@
     .progress-circular__overlay
       animation: $progress-circular-rotate-dash
       stroke-linecap: round
-      stroke-dasharray: 1,200
+      stroke-dasharray: 80,200
       stroke-dashoffset: 0px
 
   &__underlay


### PR DESCRIPTION
IE11 doesn't support SVG CSS Transitions and Animation, this PR provides fallback and changes the default layout of progress keeping only rotating animation

https://stackoverflow.com/questions/33812303/svg-animation-is-not-working-on-ie11

This PR makes circular indeterminate progress look like in this codepen

https://codepen.io/anon/pen/Yxaqdd