### PR TITLE
Disallow focusing of VSelect when disabled attribute is present.

### DIFF
--- a/src/components/VSelect/VSelect.vue
+++ b/src/components/VSelect/VSelect.vue
@@ -69,6 +69,7 @@
         type: Number,
         default: 200
       },
+      disabled: Boolean,
       items: {
         type: Array,
         default: () => []
@@ -198,6 +199,10 @@
       searchValue (val) {
         if (val && !this.isActive) this.isActive = true
         this.$refs.menu.listIndex = -1
+      },
+      disabled (val) {
+        val && this.blur()
+        this.internalTabIndex = -val
       }
     },
 


### PR DESCRIPTION
This change removes the ability to tab to a `v-select` if it's disabled and blurs the field when it becomes disabled.