### PR TITLE
defaultPagination.sortBy isn't initialized

### DIFF
--- a/src/components/VDataTable/VDataTable.vue
+++ b/src/components/VDataTable/VDataTable.vue
@@ -33,9 +33,10 @@
         all: false,
         searchLength: 0,
         defaultPagination: {
+          descending: false,
           page: 1,
           rowsPerPage: 5,
-          descending: false,
+          sortBy: null,
           totalItems: 0
         }
       }


### PR DESCRIPTION
customSort() receives an index set to undefined (and checks against null) then it doesn't
return items but try to sort them.

https://github.com/stephane/vuetify/blob/0912ccdd41e1efc106560a31286ecb12660796a4/src/components/VDataTable/VDataTable.vue#L100

BTW Do you think it would an improvement to rename `index` argument to `sortBy`? 
