### PR TITLE
fixes disabled textfield colors #1472

### DIFF
--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -26,6 +26,10 @@ input-group($material)
     label
       color: $material.text.secondary
 
+    &.input-group--disabled
+      label
+        color: $material.text.disabled
+
     .input-group__details:before
       background-color: $material.input-bottom-line
 
@@ -54,10 +58,6 @@ input-group($material)
           background-color: $material.dividers
 
   &.input-group--disabled
-    input,
-    // textarea
-      color: $material.text.secondary
-
     .input-group__details:before
       background-color: transparent
       background-image: linear-gradient(
@@ -69,7 +69,7 @@ input-group($material)
 
   .input-group--text-field
     &__prefix, &__suffix
-      color: $material.text.secondary
+      color: $material.text.disabled
 
 theme(input-group, "input-group")
 

--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -69,7 +69,11 @@ input-group($material)
 
   .input-group--text-field
     &__prefix, &__suffix
-      color: $material.text.disabled
+      color: $material.text.secondary
+
+    &.input-group--disabled
+      &__prefix, &__suffix
+        color: $material.text.disabled
 
 theme(input-group, "input-group")
 


### PR DESCRIPTION
It still doesn't match MD specs in 100%, but at least it uses `$theme.text.disabled` color instead of `$theme.text.secondary` for disabled label/value

`$material-light.text.disabled` is defined as `rgba(#000, .38)` instead of `rgba(#000, .42)`, I didn't change it