### PR TITLE
Add menu--disabled class for disabled v-menu

### DIFF
--- a/src/components/VMenu/VMenu.vue
+++ b/src/components/VMenu/VMenu.vue
@@ -229,7 +229,10 @@
       })
 
       const data = {
-        'class': 'menu',
+        staticClass: 'menu',
+        class: {
+          'menu--disabled': this.disabled,
+        },
         style: {
           display: this.fullWidth ? 'block' : 'inline-block'
         },

--- a/src/components/VMenu/__snapshots__/VMenu.spec.js.snap
+++ b/src/components/VMenu/__snapshots__/VMenu.spec.js.snap
@@ -67,7 +67,7 @@ exports[`VMenu.js should render component with custom closeOnContentClick and ma
 
 exports[`VMenu.js should render component with custom disabled and match snapshot 1`] = `
 
-<div class="menu"
+<div class="menu menu--disabled"
      style="display: inline-block;"
 >
   <div class="menu__content"


### PR DESCRIPTION
There was a "cursor: not-allowed" for .menu--disabled, but the menu--disabled class was not added to the disabled menu

I'm only not sure if it shouldn't be "cursor: default" to be consistent with disabled buttons, text fields etc
