### PR TITLE
fix for #1304

### DIFF
--- a/src/components/VSelect/mixins/generators.js
+++ b/src/components/VSelect/mixins/generators.js
@@ -115,7 +115,12 @@ export default {
       })
 
       if (!children.length) {
-        children.push(this.genTile(this.noDataText, true))
+        const noDataItem = {
+          text: this.noDataText,
+          value: this.noDataValue
+        }
+
+        children.push(this.genTile(noDataItem, !this.noDataClickable))
       }
 
       return this.$createElement('v-card', [

--- a/src/mixins/filterable.js
+++ b/src/mixins/filterable.js
@@ -3,6 +3,14 @@ export default {
     noDataText: {
       type: String,
       default: 'No data available'
+    },
+    noDataValue: {
+      type: String,
+      default: 'NO_DATA'
+    },
+    noDataClickable: {
+      type: Boolean,
+      default: false
     }
   }
 }


### PR DESCRIPTION
This fix is intended to solve 2 issues:
1. The "noDataText" tile isnt clickable, and that is hardcoded. Instead it should look for a prop "no-data-clickable" which is by default false for its "disabled" state.
2. Instead of hardcoded value for "noDataText" (which is language specific) when generating the noDataText tile the value can be set to any string, using the prop no-data-value