### PR TITLE
Bug 0.15 - Fix labels on selection-controls to be clickable

### DIFF
--- a/src/stylus/components/_selection-controls.styl
+++ b/src/stylus/components/_selection-controls.styl
@@ -59,7 +59,7 @@ theme(selection-control, "input-group--selection-controls")
       margin: auto
 
 /** Label */
-.input-group--selection-controls label
+.input-group.input-group--selection-controls label
   pointer-events: inherit
   cursor: pointer
   pointer-events: auto


### PR DESCRIPTION
The selector on selection controls label wasn't right so pointer-events were disabled and the z-index was too low.  Fixed selector so it applies the right styles.