### PR TITLE
fixes cursor on readonly input in menu activator

### DIFF
--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -18,6 +18,9 @@
     cursor: pointer
     position: relative
 
+    input[readonly]
+      cursor: pointer
+
     .toolbar__side-icon
       margin: 0
 
@@ -30,7 +33,7 @@
     overflow-x: hidden
     transition: .3s $transition.swing
     elevation(8)
-    
+
     &--active
       pointer-events: none
 


### PR DESCRIPTION
If menu activator contains readonly input then cursor is set to default instead of pointer, it's visible for example in "#3 Date pickers - In dialog and menu" - https://codepen.io/anon/pen/WEYZvx


Playground.vue

```
<template>
  <v-app>
    <v-menu>
      <v-text-field slot="activator" label="Input" readonly></v-text-field>
      <v-card><v-card-text>Hello world!</v-card-text></v-card>
    </v-menu>
  </v-app>
</template>

<script>
export default {
  data: () => ({date:null})
}
</script>

```