### PR TITLE
Fix #1571 - Delete VForm $listeners.input before render

### DIFF
--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -73,6 +73,7 @@ export default {
   },
 
   render (h) {
+    this.$listeners && delete this.$listeners.input
     return h('form', {
       attrs: this.$attrs,
       on: this.$listeners


### PR DESCRIPTION
This fix will prevent any `input` event listeners from being passed to VForm's internal form element. I'll write a test case for this too if I can figure out how jest works. 