### PR TITLE
Make v-form validation great again

### DIFF
--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -80,15 +80,11 @@ export default {
       }
     },
     validate () {
-      const errors = this.getInputs().reduce((errors, child) => {
-        const error = !child.validate(true)
-        return errors || error
-      }, false)
-
-      return !errors
+      return this.getInputs().every(i => i.validate(true))
     },
     reset () {
       this.getInputs().forEach((input) => input.reset())
+      this.errorBag = {}
     }
   },
 

--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -35,9 +35,19 @@ export default {
 
   methods: {
     getInputs () {
-      return this.$children.filter(child => {
-        return typeof child.errorBucket !== 'undefined'
-      })
+      const results = []
+
+      const filter = el => typeof el.errorBucket !== 'undefined'
+
+      const search = (children) => {
+        for (const child of children) {
+          filter(child) ? results.push(child) : search(child.$children)
+        }
+      }
+
+      search(this.$children)
+
+      return results
     },
     validate () {
       const errors = this.getInputs().reduce((errors, child) => {

--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -84,7 +84,7 @@ export default {
     },
     reset () {
       this.getInputs().forEach((input) => input.reset())
-      this.errorBag = {}
+      Object.keys(this.errorBag).forEach(key => this.$delete(this.errorBag, key))
     }
   },
 

--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -17,13 +17,7 @@ export default {
   watch: {
     errorBag: {
       handler () {
-        const keys = Object.keys(this.errorBag)
-        if (keys.length < this.inputs.length) return false
-
-        const errors = keys.reduce((errors, key) => {
-          errors = errors || this.errorBag[key]
-          return errors
-        }, false)
+        const errors = Object.values(this.errorBag).includes(true)
 
         this.$emit('input', !errors)
 

--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -37,17 +37,19 @@ export default {
     getInputs () {
       const results = []
 
-      const filter = el => typeof el.errorBucket !== 'undefined'
-
-      const search = (children) => {
+      const search = (children, depth = 0) => {
         for (const child of children) {
-          filter(child) ? results.push(child) : search(child.$children)
+          if (child.errorBucket !== undefined) {
+            results.push(child)
+          } else {
+            search(child.$children, depth + 1)
+          }
         }
+        if (depth === 0) return results
       }
 
-      search(this.$children)
+      return search(this.$children)
 
-      return results
     },
     validate () {
       const errors = this.getInputs().reduce((errors, child) => {

--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -49,22 +49,20 @@ export default {
 
       if (inputs.length < this.inputs.length) {
         // Something was removed, we don't want it in the errorBag any more
-        const newUids = inputs.map(i => i._uid)
-
-        const removed = this.inputs.filter(i => !newUids.includes(i))
+        const removed = this.inputs.filter(i => !inputs.includes(i))
 
         for (const input of removed) {
-          this.$delete(this.errorBag, input)
+          this.$delete(this.errorBag, input._uid)
           this.$delete(this.inputs, this.inputs.indexOf(input))
         }
       }
 
       for (const child of inputs) {
-        if (this.inputs.includes(child._uid)) {
+        if (this.inputs.includes(child)) {
           continue // We already know about this input
         }
 
-        this.inputs.push(child._uid)
+        this.inputs.push(child)
 
         // Only start watching inputs if we need to
         child.$watch('shouldValidate', (val) => {
@@ -80,10 +78,10 @@ export default {
       }
     },
     validate () {
-      return this.getInputs().every(i => i.validate(true))
+      return !this.inputs.filter(input => input.validate(true)).length
     },
     reset () {
-      this.getInputs().forEach((input) => input.reset())
+      this.inputs.forEach((input) => input.reset())
       Object.keys(this.errorBag).forEach(key => this.$delete(this.errorBag, key))
     }
   },

--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -45,16 +45,13 @@ export default {
 
       return search(this.$children)
     },
-    watchInputs (inputs) {
-      inputs === undefined && (inputs = this.getInputs())
-
+    watchInputs (inputs = this.getInputs()) {
       for (const child of inputs) {
         if (this.inputs.includes(child)) {
           continue // We already know about this input
         }
 
         this.inputs.push(child)
-
         this.watchChild(child)
       }
     },
@@ -78,11 +75,14 @@ export default {
       })
     },
     validate () {
-      return !this.inputs.filter(input => input.validate(true)).length
+      const errors = this.inputs.filter(input => !input.validate(true)).length
+      return !errors
     },
     reset () {
       this.inputs.forEach((input) => input.reset())
-      Object.keys(this.errorBag).forEach(key => this.$delete(this.errorBag, key))
+      if (this.lazyValidation) {
+        Object.keys(this.errorBag).forEach(key => this.$delete(this.errorBag, key))
+      }
     }
   },
 


### PR DESCRIPTION
Form validation (`<v-form v-model="valid">`) is kinda useless right now: 
 - It only works on immediate children, so nested components such as date pickers don't count
 - `valid` only changes when every single form field has been updated, whether they require validation or not. This makes optional fields impossible without having to call `form.validate()`
 - If a field is dynamically added to the form (with `v-if` or similar), it doesn't *ever* count towards validation, even if `form.validate()` is called
 - If a field is dynamically removed from the form and is invalid, the form will remain in an invalid state, even if `form.reset()` or `form.validate()` is called

This PR fixes all these issues, making validation of [forms like this](https://codepen.io/anon/pen/VzRKEW?editors=1010) or [this](https://codepen.io/nelxaz/pen/xLemZB?editors=1010#0) possible. 
 - Deeply nested children will be included in the validation
 - `valid` will change after every update. `form.validate()` can still be called to check overall form validity and force validation errors to display on untouched invalid fields
 - A new boolean prop `lazy-validation` is added that only takes into account touched fields when determining overall validity (this is the same as it is currently) - so `form.reset()` will result in `valid` being `true`
 - Dynamically added fields will work the same way as static ones
 - Dynamically removed fields will be removed from consideration, so if an invalid field is removed from an otherwise valid form, `valid` should now be `true`