### PR TITLE
Allow any data type in button values

### DIFF
--- a/src/components/VBtn/VBtn.vue
+++ b/src/components/VBtn/VBtn.vue
@@ -41,7 +41,8 @@
       type: {
         type: String,
         default: 'button'
-      }
+      },
+      value: null
     },
 
     computed: {
@@ -124,6 +125,10 @@
 
       tag === 'button' && (data.attrs.type = this.type)
       this.loading && children.push(this.genLoader())
+
+      if (typeof this.value !== 'undefined') {
+        data.attrs.value = (typeof this.value === 'object') ? JSON.stringify(this.value) : this.value
+      }
 
       return h(tag, data, children)
     }

--- a/src/components/VBtnToggle/__snapshots__/VBtnToggle.spec.js.snap
+++ b/src/components/VBtnToggle/__snapshots__/VBtnToggle.spec.js.snap
@@ -184,8 +184,8 @@ exports[`VBtnToggle.vue should use button value attribute if available 1`] = `
 
 <div class="btn-toggle btn-toggle--selected">
   <button type="button"
-          class="btn btn--flat"
           value="left"
+          class="btn btn--flat"
   >
     <div class="btn__content">
       <i class="material-icons icon">
@@ -194,8 +194,8 @@ exports[`VBtnToggle.vue should use button value attribute if available 1`] = `
     </div>
   </button>
   <button type="button"
-          class="btn btn--flat btn--active"
           value="center"
+          class="btn btn--flat btn--active"
           data-selected="true"
           data-only-child="true"
   >
@@ -206,8 +206,8 @@ exports[`VBtnToggle.vue should use button value attribute if available 1`] = `
     </div>
   </button>
   <button type="button"
-          class="btn btn--flat"
           value="right"
+          class="btn btn--flat"
   >
     <div class="btn__content">
       <i class="material-icons icon">

--- a/src/mixins/button-group.js
+++ b/src/mixins/button-group.js
@@ -8,47 +8,45 @@ export default {
 
   methods: {
     getValue (i) {
-      return ('value' in this.buttons[i]) && !!this.buttons[i].value
-        ? this.buttons[i].value
-        : i
+      return this.buttons[i].value == null ? i : this.buttons[i].value
     },
     update () {
       const selected = []
 
-      this.buttons
-        .forEach((elm, i) => {
-          // Fix for testing, dataset does not exist on elm?
-          if (!elm.dataset) elm.dataset = {}
+      this.buttons.forEach((button, i) => {
+        const elm = button.$el
 
-          elm.removeAttribute('data-only-child')
+        // Fix for testing, dataset does not exist on elm?
+        if (!elm.dataset) elm.dataset = {}
 
-          if (this.isSelected(i)) {
-            elm.setAttribute('data-selected', true)
-            elm.classList.add('btn--active')
-            selected.push(i)
-          } else {
-            elm.removeAttribute('data-selected')
-            elm.classList.remove('btn--active')
-          }
+        elm.removeAttribute('data-only-child')
 
-          elm.dataset.index = i
-        })
+        if (this.isSelected(i)) {
+          elm.setAttribute('data-selected', true)
+          elm.classList.add('btn--active')
+          selected.push(i)
+        } else {
+          elm.removeAttribute('data-selected')
+          elm.classList.remove('btn--active')
+        }
+
+        elm.dataset.index = i
+      })
 
       if (selected.length === 1) {
-        this.buttons[selected[0]].setAttribute('data-only-child', true)
+        this.buttons[selected[0]].$el.setAttribute('data-only-child', true)
       }
     }
   },
 
   mounted () {
-    const options = { passive: true }
     this.$vuetify.load(() => {
-      this.buttons = this.$slots.default
-        .filter(vnode => vnode.tag !== undefined)
-        .map((vnode, i) => {
+      this.buttons = this.$children
+        .filter(button => button.$vnode.tag !== undefined)
+        .map((button, i) => {
           this.listeners.push(this.updateValue.bind(this, i))
-          vnode.elm.addEventListener('click', this.listeners[i], options)
-          return vnode.elm
+          button.$on('click', this.listeners[i])
+          return button
         })
 
       this.update()
@@ -56,8 +54,8 @@ export default {
   },
 
   beforeDestroy () {
-    this.buttons.forEach((elm, i) => {
-      elm.removeEventListener('click', this.listeners[i])
+    this.buttons.forEach((button, i) => {
+      button.$off('click', this.listeners[i])
     })
   }
 }

--- a/src/mixins/button-group.js
+++ b/src/mixins/button-group.js
@@ -8,30 +8,40 @@ export default {
 
   methods: {
     getValue (i) {
-      return this.buttons[i].value == null ? i : this.buttons[i].value
+      if (this.buttons[i].value != null) {
+        return this.buttons[i].value
+      }
+
+      // Fix for testing, this should always be false in the browser
+      if (this.buttons[i].$el.value != null && this.buttons[i].$el.value !== '') {
+        return this.buttons[i].$el.value
+      }
+
+      return i
     },
     update () {
       const selected = []
 
-      this.buttons.forEach((button, i) => {
-        const elm = button.$el
+      this.buttons
+        .forEach((button, i) => {
+          const elm = button.$el
 
-        // Fix for testing, dataset does not exist on elm?
-        if (!elm.dataset) elm.dataset = {}
+          // Fix for testing, dataset does not exist on elm?
+          if (!elm.dataset) elm.dataset = {}
 
-        elm.removeAttribute('data-only-child')
+          elm.removeAttribute('data-only-child')
 
-        if (this.isSelected(i)) {
-          elm.setAttribute('data-selected', true)
-          elm.classList.add('btn--active')
-          selected.push(i)
-        } else {
-          elm.removeAttribute('data-selected')
-          elm.classList.remove('btn--active')
-        }
+          if (this.isSelected(i)) {
+            elm.setAttribute('data-selected', true)
+            elm.classList.add('btn--active')
+            selected.push(i)
+          } else {
+            elm.removeAttribute('data-selected')
+            elm.classList.remove('btn--active')
+          }
 
-        elm.dataset.index = i
-      })
+          elm.dataset.index = i
+        })
 
       if (selected.length === 1) {
         this.buttons[selected[0]].$el.setAttribute('data-only-child', true)
@@ -42,12 +52,11 @@ export default {
   mounted () {
     this.$vuetify.load(() => {
       this.buttons = this.$children
-        .filter(button => button.$vnode.tag !== undefined)
-        .map((button, i) => {
-          this.listeners.push(this.updateValue.bind(this, i))
-          button.$on('click', this.listeners[i])
-          return button
-        })
+
+      this.buttons.forEach((button, i) => {
+        this.listeners.push(this.updateValue.bind(this, i))
+        button.$on('click', this.listeners[i])
+      })
 
       this.update()
     })


### PR DESCRIPTION
This PR adds a `value` prop to `v-btn` that lets you store any type of data on it. This allows `v-btn-toggle` to toggle anything instead of just strings, it also fixes the bug where the button's index is returned if its value is `false`

Sample codepen: https://codepen.io/anon/pen/RZmPgx?editors=1010

Fixes #1596