### PR TITLE
Re-validate inputs on reset

### DIFF
--- a/src/mixins/validatable.js
+++ b/src/mixins/validatable.js
@@ -96,6 +96,7 @@ export default {
       this.$nextTick(() => {
         this.shouldValidate = false
         this.hasFocused = false
+        this.validate()
       })
     },
     validate (force = false, value) {


### PR DESCRIPTION
Fixes #1626

Also happens to fix the same issue for text fields that have `validate-on-blur`