### PR TITLE
Fixes styling issues with box and solo text-fields

### DIFF
--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -16,11 +16,11 @@ input-group($material)
   &.input-group--textarea:not(.input-group--full-width)
     .input-group__input
       border: 2px solid $material.text.secondary
-      
+
   .input-group__append-icon
     padding: 0 6px
     transition: .3s $transition.ease-in-out
-    
+
   .input-group__append-icon,
   .input-group__prepend-icon
     user-select: none
@@ -170,7 +170,7 @@ theme(input-group, "input-group")
     elevation(2)
 
     label
-      top: 7px
+      top: 9px
       padding-left: 16px
       transform: none !important
 

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -220,3 +220,12 @@ theme(textfield, "input-group--text-field")
       &.input-group--dirty
         label
           transform: translate3d(0, -10px, 0) scale(0.75)
+  // Icons
+  &.input-group--prepend-icon
+    .input-group__details
+      &:before, &:after
+        margin-left: 56px
+        max-width: calc(100% - 56px)
+
+    label
+      left: 56px

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -177,7 +177,7 @@ theme(textfield, "input-group--text-field")
     cursor: pointer
 
   label
-    left: 24px
+    left: 16px
 
   .input-group__input
     align-items: flex-end
@@ -186,7 +186,7 @@ theme(textfield, "input-group--text-field")
     min-height: 56px
 
   .input-group__details
-    padding: 8px 24px 0
+    padding: 8px 16px 0
 
     &:before,
     &:after
@@ -209,8 +209,8 @@ theme(textfield, "input-group--text-field")
 
     &:not(.input-group--multi-line)
       .input-group__input
-        padding-left: 24px
-        padding-right: 24px
+        padding-left: 16px
+        padding-right: 16px
 
       label
         top: calc(50% - 16px)


### PR DESCRIPTION
fixes issue #1638, also makes box text field matching the MD specs

Before and after:
![image](https://user-images.githubusercontent.com/15625235/30237805-f809f99c-9539-11e7-9fb0-59c8c0ffaf54.png)
![image](https://user-images.githubusercontent.com/15625235/30237843-2c4b71da-953b-11e7-9df6-8bfa401b0ae6.png)



Solo input label (vertical align issue) - before:
![solo-before](https://user-images.githubusercontent.com/15625235/30237802-d8ab46b4-9539-11e7-99d7-6cdf8332f94f.gif)

Solo input label (vertical align issue) - after:
![solo-after](https://user-images.githubusercontent.com/15625235/30237803-daf40532-9539-11e7-8492-f405de6f846c.gif)

Playground.vue for screenshots:
```vue
<template>
  <div id="app">
    <v-app id="inspire" class="pa-4">
      <v-text-field :error-messages="['Wrong icon position!']" box label="Box field"></v-text-field>
      <v-text-field hint="Am I OK?" persistent-hint box label="Box field"></v-text-field>
      <v-text-field solo label="Solo field"></v-text-field>
      <v-text-field prepend-icon="check" label="Normal field"></v-text-field>
      <v-text-field prepend-icon="check" :error-messages="['Wrong icon position!']" box label="Box field"></v-text-field>
      <v-text-field prepend-icon="check" solo label="Solo field"></v-text-field>
      <v-text-field append-icon="close" label="Normal field"></v-text-field>
      <v-text-field append-icon="close" :error-messages="['Wrong icon position!']" box label="Box field"></v-text-field>
      <v-text-field append-icon="close" solo label="Solo field - label"></v-text-field>
      <v-text-field append-icon="close" solo placeholder="Solo field - placeholder"></v-text-field>
    </v-app>
  </div>
</template>

<script>
export default {
}
</script>

```