### PR TITLE
Force click-outside to respond to clicks on body

### DIFF
--- a/src/directives/click-outside.js
+++ b/src/directives/click-outside.js
@@ -17,7 +17,7 @@ export default {
 
   bind (el, binding, v) {
     v.context.$vuetify.load(() => {
-      const outside = document.querySelector('[data-app]')
+      const outside = document.body
       const click = e => directive(e, el, binding, v)
       outside && outside.addEventListener('click', click, false)
       el._clickOutside = click
@@ -25,7 +25,7 @@ export default {
   },
 
   unbind (el) {
-    const outside = document.querySelector('[data-app]')
+    const outside = document.body
     outside && outside.removeEventListener('click', el._clickOutside, false)
   }
 }


### PR DESCRIPTION
This fixes issues with the `click-outside` directive that are caused when `[data-app]` is not the outermost container of the page for those that are using Vuetify in an isolated portion of their site.