### PR TITLE
Fixes date picker locale formatting (fixes #1649)

### DIFF
--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -77,7 +77,7 @@ export default {
               type: 'button'
             },
             domProps: {
-              innerHTML: `<span class="btn__content">${i}</span>`
+              innerHTML: '<span class="btn__content">' + date.toLocaleDateString(this.locale, { day: 'numeric' }) + '</span>'
             },
             on: {
               click: () => {

--- a/src/components/VDatePicker/mixins/date-title.js
+++ b/src/components/VDatePicker/mixins/date-title.js
@@ -50,7 +50,7 @@ export default {
             }
           }
         }, [
-          this.year,
+          new Date(this.year, this.month, this.day, 12).toLocaleDateString(this.locale, { year: 'numeric' }),
           this.genYearIcon()
         ]),
         this.$createElement('div', {

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -26,7 +26,7 @@ export default {
               this.isSelected = false
             }
           }
-        }, i))
+        }, new Date(i, this.month, this.day, 12).toLocaleString(this.locale, { year: 'numeric' })))
       }
       return children
     }


### PR DESCRIPTION
No tests for this PR as avoriaz/jsdom (?) doesn't support locale formatting for years/days (only months are displayed as "M01" instead of "January")

This PR is ready for 0.15.3 (no need to wait for month picker integration)

Before:
![image](https://user-images.githubusercontent.com/15625235/30248341-120d6cf6-9626-11e7-984d-344a2cc5d551.png)

After:
![image](https://user-images.githubusercontent.com/15625235/30248336-0371a7c0-9626-11e7-9797-6da116fc6553.png)
