### PR TITLE
fallback for date formating in android firefox

### DIFF
--- a/src/components/VDatePicker/VDatePicker.vue
+++ b/src/components/VDatePicker/VDatePicker.vue
@@ -13,7 +13,8 @@
   import Touch from '../../directives/touch'
 
   const defaultDateFormat = val => new Date(val).toISOString().substr(0, 10)
-  const supportsLocaleFormat = ('toLocaleString' in Date.prototype) && new Date(2000, 0, 15).toLocaleDateString('en', { day: 'numeric' }) == '15'
+  const supportsLocaleFormat = ('toLocaleDateString' in Date.prototype)
+    && new Date(2000, 0, 15).toLocaleDateString('en', { day: 'numeric' }) == '15'
 
   export default {
     name: 'v-date-picker',
@@ -183,7 +184,12 @@
       date.setDate(date.getDate() - date.getDay() + parseInt(this.firstDayOfWeek))
 
       createRange(7).forEach(index => {
-        const narrow = this.supportsLocaleFormat ? date.toLocaleDateString(this.locale, { weekday: 'narrow' }) : ['S', 'M', 'T', 'W', 'T', 'F', 'S'][(index + parseInt(this.firstDayOfWeek)) % 7]
+        let narrow
+        if (this.supportsLocaleFormat) {
+          narrow = date.toLocaleDateString(this.locale, { weekday: 'narrow' })
+        } else {
+          narrow = ['S', 'M', 'T', 'W', 'T', 'F', 'S'][(index + parseInt(this.firstDayOfWeek)) % 7]
+        }
         this.narrowDays.push(narrow)
 
         date.setDate(date.getDate() + 1)

--- a/src/components/VDatePicker/VDatePicker.vue
+++ b/src/components/VDatePicker/VDatePicker.vue
@@ -13,6 +13,7 @@
   import Touch from '../../directives/touch'
 
   const defaultDateFormat = val => new Date(val).toISOString().substr(0, 10)
+  const supportsLocaleFormat = ('toLocaleString' in Date.prototype) && new Date(2000, 0, 15).toLocaleDateString('en', { day: 'numeric' }) == '15'
 
   export default {
     name: 'v-date-picker',
@@ -72,6 +73,7 @@
     },
 
     computed: {
+      supportsLocaleFormat: () => supportsLocaleFormat,
       firstAllowedDate () {
         const date = new Date()
         date.setHours(12, 0, 0, 0)
@@ -180,8 +182,8 @@
       const date = new Date()
       date.setDate(date.getDate() - date.getDay() + parseInt(this.firstDayOfWeek))
 
-      createRange(7).forEach(() => {
-        const narrow = date.toLocaleString(this.locale, { weekday: 'narrow' })
+      createRange(7).forEach(index => {
+        const narrow = this.supportsLocaleFormat ? date.toLocaleDateString(this.locale, { weekday: 'narrow' }) : ['S', 'M', 'T', 'W', 'T', 'F', 'S'][(index + parseInt(this.firstDayOfWeek)) % 7]
         this.narrowDays.push(narrow)
 
         date.setDate(date.getDate() + 1)

--- a/src/components/VDatePicker/VDatePicker.vue
+++ b/src/components/VDatePicker/VDatePicker.vue
@@ -13,8 +13,6 @@
   import Touch from '../../directives/touch'
 
   const defaultDateFormat = val => new Date(val).toISOString().substr(0, 10)
-  const supportsLocaleFormat = ('toLocaleDateString' in Date.prototype)
-    && new Date(2000, 0, 15).toLocaleDateString('en', { day: 'numeric' }) == '15'
 
   export default {
     name: 'v-date-picker',
@@ -74,7 +72,10 @@
     },
 
     computed: {
-      supportsLocaleFormat: () => supportsLocaleFormat,
+      supportsLocaleFormat() {
+        return ('toLocaleDateString' in Date.prototype)
+          && new Date(2000, 0, 15).toLocaleDateString('en', { day: 'numeric' }) == '15'
+      },
       firstAllowedDate () {
         const date = new Date()
         date.setHours(12, 0, 0, 0)

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -26,6 +26,18 @@ export default {
 
       // Workaround for #1409
       date.setHours(1)
+
+      let buttonText
+      if (typeof this.headerDateFormat === 'function') {
+        buttonText = this.headerDateFormat(date)
+      } else if (this.supportsLocaleFormat) {
+        buttonText = date.toLocaleDateString(this.locale, this.headerDateFormat)
+      } else {
+        buttonText = date.getFullYear() + '/'
+        if (date.getMonth() < 9) buttonText += '0'
+        buttonText += (1 + date.getMonth())
+      }
+
       const header = this.$createElement('div', {
         'class': 'picker--date__header-selector-date'
       }, [
@@ -34,8 +46,7 @@ export default {
         }, [
           this.$createElement('strong', {
             key: this.tableMonth
-          }, typeof this.headerDateFormat === 'function' ? this.headerDateFormat(date) : date.toLocaleString(this.locale, this.headerDateFormat))
-        ])
+          }, buttonText)])
       ])
 
       return this.$createElement('div', {

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -64,7 +64,9 @@ export default {
 
       for (let i = 1; i <= length; i++) {
         const date = new Date(this.tableYear, this.tableMonth, i, 12, 0, 0, 0)
-        const buttonText = this.supportsLocaleFormat ? date.toLocaleDateString(this.locale, { day: 'numeric' }) : i
+        const buttonText = this.supportsLocaleFormat
+          ? date.toLocaleDateString(this.locale, { day: 'numeric' })
+          : i
         rows.push(this.$createElement('td', [
           this.$createElement('button', {
             'class': {

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -64,6 +64,7 @@ export default {
 
       for (let i = 1; i <= length; i++) {
         const date = new Date(this.tableYear, this.tableMonth, i, 12, 0, 0, 0)
+        const buttonText = this.supportsLocaleFormat ? date.toLocaleDateString(this.locale, { day: 'numeric' }) : i
         rows.push(this.$createElement('td', [
           this.$createElement('button', {
             'class': {
@@ -77,7 +78,7 @@ export default {
               type: 'button'
             },
             domProps: {
-              innerHTML: '<span class="btn__content">' + date.toLocaleDateString(this.locale, { day: 'numeric' }) + '</span>'
+              innerHTML: `<span class="btn__content">${buttonText}</span>`
             },
             on: {
               click: () => {

--- a/src/components/VDatePicker/mixins/date-title.js
+++ b/src/components/VDatePicker/mixins/date-title.js
@@ -16,7 +16,15 @@ export default {
       // Workaround for #1409
       date.setHours(1)
 
-      date = typeof this.titleDateFormat === 'function' ? this.titleDateFormat(date) : date.toLocaleString(this.locale, this.titleDateFormat)
+      if (typeof this.titleDateFormat === 'function') {
+        date = this.titleDateFormat(date)
+      } else if (this.supportsLocaleFormat) {
+        date = date.toLocaleDateString(this.locale, this.titleDateFormat)
+      } else if ('toLocaleDateString' in Date.prototype) {
+        date = date.toLocaleDateString(this.locale)
+      } else {
+        date = date.toISOString().substr(0, 10)
+      }
 
       if (this.landscape) {
         if (date.indexOf(',') > -1) date = date.replace(',', ',<br>')
@@ -50,7 +58,7 @@ export default {
             }
           }
         }, [
-          new Date(this.year, this.month, this.day, 12).toLocaleDateString(this.locale, { year: 'numeric' }),
+          this.supportsLocaleFormat ? new Date(this.year, this.month, this.day, 12).toLocaleDateString(this.locale, { year: 'numeric' }) : this.year,
           this.genYearIcon()
         ]),
         this.$createElement('div', {

--- a/src/components/VDatePicker/mixins/date-title.js
+++ b/src/components/VDatePicker/mixins/date-title.js
@@ -43,6 +43,7 @@ export default {
         })
       ])
 
+      const titleDate = new Date(this.year, this.month, this.day, 12)
       return this.$createElement('div', {
         'class': 'picker__title'
       }, [
@@ -58,7 +59,9 @@ export default {
             }
           }
         }, [
-          this.supportsLocaleFormat ? new Date(this.year, this.month, this.day, 12).toLocaleDateString(this.locale, { year: 'numeric' }) : this.year,
+          this.supportsLocaleFormat
+            ? titleDate.toLocaleDateString(this.locale, { year: 'numeric' })
+            : this.year,
           this.genYearIcon()
         ]),
         this.$createElement('div', {

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -9,7 +9,11 @@ export default {
     genYearItems () {
       const children = []
       for (let i = this.year + 100, length = this.year - 100; i > length; i--) {
-        const buttonText = this.supportsLocaleFormat ? new Date(i, this.month, this.day, 12).toLocaleDateString(this.locale, { year: 'numeric' }) : i
+        const date = new Date(i, this.month, this.day, 12)
+        const buttonText = this.supportsLocaleFormat
+          ? date.toLocaleDateString(this.locale, { year: 'numeric' })
+          : i
+
         children.push(this.$createElement('li', {
           'class': {
             active: this.year === i

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -9,6 +9,7 @@ export default {
     genYearItems () {
       const children = []
       for (let i = this.year + 100, length = this.year - 100; i > length; i--) {
+        const buttonText = this.supportsLocaleFormat ? new Date(i, this.month, this.day, 12).toLocaleDateString(this.locale, { year: 'numeric' }) : i
         children.push(this.$createElement('li', {
           'class': {
             active: this.year === i
@@ -26,7 +27,7 @@ export default {
               this.isSelected = false
             }
           }
-        }, new Date(i, this.month, this.day, 12).toLocaleString(this.locale, { year: 'numeric' })))
+        }, buttonText))
       }
       return children
     }


### PR DESCRIPTION
Fix (fallback) for #1655

Date picker in firefox android:
![image](https://user-images.githubusercontent.com/15625235/30250719-c890757c-9653-11e7-93c4-9756d4ff0c1e.png)

With farsi locale:
![image](https://user-images.githubusercontent.com/15625235/30250727-ebbb6eee-9653-11e7-8e58-c2fa365b9649.png)
