### PR TITLE
date picker 's first-day-of-week props is not working properly. for :first-day-of-week="6"

### DIFF
--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -56,7 +56,7 @@ export default {
       ).getDate()
 
       let day = new Date(this.tableYear, this.tableMonth).getDay()
-      day = day < 1 ? 6 : day - parseInt(this.firstDayOfWeek)
+      day = (day + 7 - parseInt(this.firstDayOfWeek)) % 7
 
       for (let i = 0; i < day; i++) {
         rows.push(this.$createElement('td'))


### PR DESCRIPTION
It's already fixed in month picker PR - https://github.com/vuetifyjs/vuetify/pull/1435/files#diff-57ddfb4d0c97aefae512d6e644ca4447R52

Playground.vue
```vue
<template>
<div id="app">
  <v-app id="inspire">
    <v-layout row>
      <v-date-picker :key="f" v-for="f in 7"
        :first-day-of-week="f - 1"
        v-model="picker"
      ></v-date-picker>
    </v-layout>
  </v-app>
</div></template>

<script>
export default {
  data () {
    return {
      picker: '2017-09-11'
    }
  },
}
</script>
```

![image](https://user-images.githubusercontent.com/15625235/30275827-f9b459ca-9702-11e7-81a9-f66b50d8e5be.png)
