### PR TITLE
fixes icon colors in v-tabs-content

### DIFF
--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -12,9 +12,9 @@ tabs($material)
     &.tabs__item--disabled
       color: $material.buttons.disabled
 
-  .icon--left,
-  .icon--right
-    color: $material.icons.active
+    .icon--left,
+    .icon--right
+      color: $material.icons.active
 
 theme(tabs, "tabs")
 


### PR DESCRIPTION
https://codepen.io/anon/pen/bobYZZ

Icons with left/right prop located in `v-tabs-content` have wrong color, probably the lines below:

```styl
    .icon--left,
    .icon--right
      color: $material.icons.active
```

were supposed to affect only icons in `v-tabs-item`, but affected icons in `v-tabs-content` as well