### PR TITLE
Cannot add property blur, object is not extensible

### DIFF
--- a/src/components/VTextField/VTextField.vue
+++ b/src/components/VTextField/VTextField.vue
@@ -164,7 +164,7 @@
             tabindex: this.tabindex,
             'aria-label': (!this.$attrs || !this.$attrs.id) && this.label // Label `for` will be set if we have an id
           },
-          on: Object.assign(listeners, {
+          on: Object.assign({}, listeners, {
             blur: this.blur,
             input: this.onInput,
             focus: this.focus


### PR DESCRIPTION
I can't reproduce it in Playground.vue or jsfiddle, error shows only in codepen, but this change should fix it (didn't check in codepen, just run tests and they all passed)