### PR TITLE
[Vue 2.4.3] Cannot add property blur, object is not extensible

### DIFF
--- a/src/components/VTextField/VTextField.vue
+++ b/src/components/VTextField/VTextField.vue
@@ -164,7 +164,7 @@
             tabindex: this.tabindex,
             'aria-label': (!this.$attrs || !this.$attrs.id) && this.label // Label `for` will be set if we have an id
           },
-          on: Object.assign(listeners, {
+          on: Object.assign({}, listeners, {
             blur: this.blur,
             input: this.onInput,
             focus: this.focus


### PR DESCRIPTION
Fixes #1712
All tests passed with Vue 2.4.3