### PR TITLE
fixes mouse cursor on disabled menu/select

### DIFF
--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -6,11 +6,11 @@
   vertical-align: middle
 
   &--disabled
-    cursor: not-allowed
+    cursor: default
 
     .menu__activator,
     .menu__activator > *
-      cursor: not-allowed
+      cursor: default
       pointer-events: none
 
   &__activator

--- a/src/stylus/components/_select.styl
+++ b/src/stylus/components/_select.styl
@@ -27,7 +27,7 @@
     cursor: pointer
 
   &.input-group--disabled
-    cursor: not-allowed
+    cursor: default
     pointer-events: none
 
 .input-group--select


### PR DESCRIPTION
Disabled menu has "not-allowed" cursor on activator, other disabled elements (text fields or disabled dialog) have default cursor
This PR changed not-allowed cursor to default so that it is same for all disabled elements

Example of disabled menu (left) and dialog (right)
https://codepen.io/anon/pen/RLPOQj