### PR TITLE
removes id attribute from tab content element

### DIFF
--- a/src/components/VTabs/VTabsContent.js
+++ b/src/components/VTabs/VTabsContent.js
@@ -65,7 +65,6 @@ export default {
   render (h) {
     const div = h('div', {
       'class': 'tabs__content',
-      domProps: { id: this.id },
       directives: [{
         name: 'show',
         value: this.isActive


### PR DESCRIPTION
It looks like the "id" dom attribute is not used and can be removed. This solves the problem of duplicated **id**s (html document can have only 1 element with specified id) and allows to create the following code:

```html
<div>
      <v-tabs dark>
        <v-tabs-bar>
          <v-tabs-item href="one">One</v-tabs-item>
          <v-tabs-item href="two">Two</v-tabs-item>
        </v-tabs-bar>
        <v-tabs-items>
          <v-tabs-content id="one">One</v-tabs-content>
          <v-tabs-content id="two">Two</v-tabs-content>
        </v-tabs-items>
      </v-tabs>
</div>
<div>
      <v-tabs dark>
        <v-tabs-bar>
          <v-tabs-item href="one">One</v-tabs-item>
          <v-tabs-item href="two">Two</v-tabs-item>
        </v-tabs-bar>
        <v-tabs-items>
          <v-tabs-content id="one">One</v-tabs-content>
          <v-tabs-content id="two">Two</v-tabs-content>
        </v-tabs-items>
      </v-tabs>
</div>
```

Note that the **'#'** in `href` prop is also not required - that makes the tabs api cleaner and less confusing