### PR TITLE
VSelect -  Re-evaluate selection when items changes

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -250,6 +250,8 @@ export default {
       this.searchValue && this.$nextTick(() => {
         this.$refs.menu.listIndex = 0
       })
+
+      this.genSelectedItems()
     },
     menuIsActive (val) {
       if (!val) return
@@ -430,9 +432,7 @@ export default {
 
       return typeof value === 'undefined' ? item : value
     },
-    genSelectedItems (val) {
-      val = val || this.inputValue
-
+    genSelectedItems (val = this.inputValue) {
       // If we are using tags, don't filter results
       if (this.tags) return (this.selectedItems = val)
 

--- a/src/components/VSelect/VSelect.spec.js
+++ b/src/components/VSelect/VSelect.spec.js
@@ -342,4 +342,42 @@ test('VSelect.js', ({ mount, shallow }) => {
     expect(wrapper.vm.computedItems).toHaveLength(1)
     expect('Application is missing <v-app> component.').toHaveBeenTipped()
   })
+
+  it('should display a default value', async () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        value: 'foo',
+        items: ['foo']
+      }
+    })
+
+    expect(wrapper.vm.selectedItems).toEqual(['foo'])
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
+
+  it('should not display a default value that is not in items', async () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        value: 'foo',
+        items: ['bar']
+      }
+    })
+
+    expect(wrapper.vm.selectedItems).toHaveLength(0)
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
+
+  it('should update the displayed value when items changes', async () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        value: 1,
+        items: []
+      }
+    })
+
+    wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
+    expect(wrapper.vm.selectedItems).toContainEqual({ text: 'foo', value: 1 })
+
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
 })


### PR DESCRIPTION
Fixes #1743 

`selectedItems` should probably be a computed property instead of data, but I don't feel like wading through that much spaghetti today. 