### PR TITLE
Enhancement/v-slider: Added three color props.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:es5": "rimraf es5 && cross-env NODE_ENV=es5 babel src --out-dir es5",
     "build": "rimraf dist && cross-env NODE_ENV=production webpack --config build/config.js --progress --hide-modules",
     "debug-build": "node --inspect --debug-brk build/config.js",
-    "test": "cross-env NODE_ENV=test jest",
+    "test": "cross-env NODE_ENV=test jest --runInBand",
     "lint": "eslint --ext .js,.vue src",
     "precommit": "yarn run lint && yarn test",
     "prepush": "yarn run lint && yarn test"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:es5": "rimraf es5 && cross-env NODE_ENV=es5 babel src --out-dir es5",
     "build": "rimraf dist && cross-env NODE_ENV=production webpack --config build/config.js --progress --hide-modules",
     "debug-build": "node --inspect --debug-brk build/config.js",
-    "test": "cross-env NODE_ENV=test jest --runInBand",
+    "test": "cross-env NODE_ENV=test jest",
     "lint": "eslint --ext .js,.vue src",
     "precommit": "yarn run lint && yarn test",
     "prepush": "yarn run lint && yarn test"

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -35,10 +35,22 @@ export default {
       type: [Number, String],
       default: null
     },
+    thumbColor: {
+      type: String,
+      default: null
+    },
     thumbLabel: Boolean,
     value: [Number, String],
     vertical: Boolean,
-    snap: Boolean
+    snap: Boolean,
+    trackColor: {
+      type: String,
+      default: null
+    },
+    trackFillColor: {
+      type: String,
+      default: null
+    }
   },
 
   computed: {
@@ -215,7 +227,7 @@ export default {
             }
           ]
         }, [
-          h('div', { 'class': 'slider__thumb--label' }, [
+          h('div', { 'class': ['slider__thumb--label', this.thumbColor] }, [
             h('span', {}, parseInt(this.inputValue))
           ])
         ])
@@ -223,7 +235,7 @@ export default {
     },
     genThumbContainer (h) {
       const children = []
-      children.push(h('div', { 'class': 'slider__thumb' }))
+      children.push(h('div', { 'class': ['slider__thumb', this.thumbColor] }))
 
       this.thumbLabel && children.push(this.genThumbLabel(h))
 
@@ -257,11 +269,11 @@ export default {
     genTrackContainer (h) {
       const children = [
         h('div', {
-          'class': 'slider__track',
+          'class': ['slider__track', this.trackColor],
           style: this.trackStyles
         }),
         h('div', {
-          'class': 'slider__track-fill',
+          'class': ['slider__track-fill', this.trackFillColor],
           style: this.trackFillStyles
         })
       ]


### PR DESCRIPTION
Added three new properties to v-slider component: track-color, track-fill-color and thumb-color. Works similar to the color-front property for the v-progress-linear component.

thumb-color also changes the thumb-label color to match the thumb-color.

Usage:
```
    <v-slider
      v-model="progress"
      track-color="pink"
      track-fill-color="green"
      thumb-color="purple"
      label="Dev Slider"
      thumb-label
    ></v-slider>
```