### PR TITLE
Fixed right margin of vertical .stepper__content

### DIFF
--- a/src/stylus/components/_steppers.styl
+++ b/src/stylus/components/_steppers.styl
@@ -178,7 +178,7 @@ theme(stepper, "stepper")
     padding-bottom: 36px
 
     .stepper__content
-      margin: -8px 0 -16px 36px
+      margin: -8px -36px -16px 36px
       padding: 16px 60px 16px 23px
       width: auto
 


### PR DESCRIPTION
https://github.com/vuetifyjs/vuetify/blob/0887f9a20e2ed9e82aa8de83c4c971df15333ce1/src/stylus/components/_steppers.styl#L181

The proper line should be:
`margin: -8px -36px -16px 36px;`

See the image from [Mobile steppers](https://material.io/guidelines/components/steppers.html#steppers-specs) section of the Material Design spec. However, it is not explicitly specified in writing.

The empty space on the right looks noticeably wasted on extra small display, making the content looks overly shrunken.