### PR TITLE
Skip randomly failing VDatePicker test

### DIFF
--- a/src/components/VDatePicker/VDatePicker.spec.js
+++ b/src/components/VDatePicker/VDatePicker.spec.js
@@ -96,9 +96,10 @@ test('VDatePicker.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  // TODO: This fails in different ways for multiple people
   // Avoriaz/Jsdom (?) doesn't fully support date formatting using locale
   // This should be tested in browser env
-  it('should match snapshot with locale', () => {
+  it.skip('should match snapshot with locale', () => {
     const wrapper = mount(VDatePicker, {
       propsData: {
         value: '2013-05-07',


### PR DESCRIPTION
I've had a couple of people ask me why their fresh copy of the dev branch is failing tests, and it's always been this one. 

@bdeo had this:
```diff
      >
        <div class="picker__title">
          <div class="picker--date__title-year">
    -       2013
    +       ۱۳۹۲ ه.ش.
          </div>
```

@bkpratt84 had this:
```diff
    @@ -5,11 +5,11 @@
          <div class="picker--date__title-year">
            2013
          </div>
          <div class="picker--date__title-date active">
            <div>
    -         M05 7, Tue
    +         Tue, May 7
            </div>
          </div>
        </div>
        <div class="picker__body">
          <div class="picker--date__header">
    @@ -23,11 +23,11 @@
                  </i>
                </div>
              </button>
              <div class="picker--date__header-selector-date">
                <strong>
    -             2013 M05
    +             May 2013
                </strong>
              </div>
              <button type="button"
                      class="btn btn--icon btn--raised"
              >
```