### PR TITLE
Prevent scrolling in firefox when a dialog is open

### DIFF
--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -160,17 +160,14 @@ export default {
       if (this.$vuetify.breakpoint.mdAndDown) {
         document.documentElement.classList.add('overflow-y-hidden')
       } else {
-        window.addEventListener('mousewheel', this.scrollListener)
+        window.addEventListener('wheel', this.scrollListener)
         window.addEventListener('keydown', this.scrollListener)
       }
     },
     showScroll () {
-      if (this.$vuetify.breakpoint.mdAndDown) {
-        document.documentElement.classList.remove('overflow-y-hidden')
-      } else {
-        window.removeEventListener('mousewheel', this.scrollListener)
-        window.removeEventListener('keydown', this.scrollListener)
-      }
+      document.documentElement.classList.remove('overflow-y-hidden')
+      window.removeEventListener('wheel', this.scrollListener)
+      window.removeEventListener('keydown', this.scrollListener)
     }
   }
 }

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -79,6 +79,10 @@ export default {
         this.overlayTimeout = null
       }, this.overlayTransitionDuration)
     },
+    /**
+     * @param {Event} e
+     * @returns void
+     */
     scrollListener (e) {
       if (e.type === 'keydown') {
         const up = [38, 33]
@@ -97,7 +101,55 @@ export default {
         (e.type !== 'keydown' && e.target === document.body) ||
         this.checkPath(e)) e.preventDefault()
     },
+    hasScrollbar (el) {
+      const style = window.getComputedStyle(el)
+      return ['auto', 'scroll'].includes(style['overflow-y']) && el.scrollHeight > el.clientHeight
+    },
+    shouldScroll (el, delta) {
+      if (el.scrollTop === 0 && delta < 0) return true
+      return el.scrollTop + el.clientHeight === el.scrollHeight && delta > 0
+    },
+    isInside (el, parent) {
+      if (el === parent) {
+        return true
+      } else if (el === null || el === document.body) {
+        return false
+      } else {
+        return this.isInside(el.parentNode, parent)
+      }
+    },
+    /**
+     * @param {Event} e
+     * @returns boolean
+     */
+    checkPath (e) {
+      const path = e.path || this.composedPath(e)
+      const delta = e.deltaY || -e.wheelDelta
+
+      if (e.type === 'keydown' && path[0] === document.body) {
+        const dialog = this.$refs.dialog
+        const selected = window.getSelection().anchorNode
+        if (this.hasScrollbar(dialog) && this.isInside(selected, dialog)) {
+          return this.shouldScroll(dialog, delta)
+        }
+        return true
+      }
+
+      for (const el of path) {
+        if ([document, document.documentElement, this.$refs.content].includes(el)) return true
+        if (this.hasScrollbar(el)) return this.shouldScroll(el, delta)
+      }
+
+      return true
+    },
+    /**
+     * Polyfill for Event.prototype.composedPath
+     * @param {Event} e
+     * @returns Element[]
+     */
     composedPath (e) {
+      if (e.composedPath) return e.composedPath()
+
       const path = []
       let el = e.target
 
@@ -113,48 +165,6 @@ export default {
 
         el = el.parentElement
       }
-    },
-    hasScrollbar (el) {
-      const style = window.getComputedStyle(el)
-      return ['auto', 'scroll'].includes(style['overflow-y'])
-    },
-    shouldScroll (el, delta) {
-      if (el.scrollTop === 0 && delta < 0) return true
-      else if (el.scrollTop + el.clientHeight === el.scrollHeight && delta > 0) return true
-      else return false
-    },
-    isInside (el, parent) {
-      if (el === parent) {
-        return true
-      } else if (el === null || el === document.body) {
-        return false
-      } else {
-        return this.isInside(el.parentNode, parent)
-      }
-    },
-    checkPath (e) {
-      const path = e.path || this.composedPath(e)
-      const delta = e.deltaY || -e.wheelDelta
-
-      if (e.type === 'keydown' && path[0] === document.body) {
-        const dialog = this.$refs.content.querySelector('.dialog')
-        const selected = window.getSelection().anchorNode
-        if (this.hasScrollbar(dialog) && this.isInside(selected, dialog)) {
-          return this.shouldScroll(dialog, delta)
-        }
-        return true
-      }
-
-      for (let i = 0; i < path.length; i++) {
-        const el = path[i]
-
-        if (el === document) return true
-        else if (this.hasScrollbar(el)) {
-          return this.shouldScroll(el, delta)
-        } else if (el === this.$refs.content) return true
-      }
-
-      return true
     },
     hideScroll () {
       if (this.$vuetify.breakpoint.mdAndDown) {

--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -50,3 +50,4 @@
 
     .card__text
       overflow-y: auto
+      backface-visibility: hidden


### PR DESCRIPTION
`mousewheel` is non-standard, it should be `wheel` instead. 

#### Confirmed working in:
 - [x] Firefox 55
 - [x] Chrome 61
 - [x] IE 11
 - [x] Edge 14

In unrelated news, I've discovered that firefox is absolutely terrible and I have no idea why anyone still uses it. 

Fixes #1816
Fixes #1725

Related to #1457