### PR TITLE
v-data-table: adds header 'class' parameter

### DIFF
--- a/src/components/VDataTable/VDataTable.spec.js
+++ b/src/components/VDataTable/VDataTable.spec.js
@@ -11,9 +11,9 @@ test('VDataTable.vue', () => {
           sortBy: 'col1'
         },
         headers: [
-          { text: 'First Column', value: 'col1' },
+          { text: 'First Column', value: 'col1', class: 'a-string' },
           { text: 'Second Column', value: 'col2', sortable: false },
-          { text: 'Third Column', value: 'col3' }
+          { text: 'Third Column', value: 'col3', class: ['an', 'array'] }
         ],
         items: [
           { other: 1, col1: 'foo', col2: 'a', col3: 1 },

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -11,7 +11,7 @@ exports[`VDataTable.vue should match a snapshot 1`] = `
             aria-label="First Column: Sorted ascending. Activate to sort descending."
             aria-sort="ascending"
             tabindex="0"
-            class="column sortable active asc text-xs-right"
+            class="column sortable active asc text-xs-right a-string"
         >
           <i aria-hidden="true"
              class="material-icons icon"
@@ -33,7 +33,7 @@ exports[`VDataTable.vue should match a snapshot 1`] = `
             aria-label="Third Column: Not sorted. Activate to sort ascending."
             aria-sort="none"
             tabindex="0"
-            class="column sortable text-xs-right"
+            class="column sortable text-xs-right an array"
         >
           <i aria-hidden="true"
              class="material-icons icon"

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -59,6 +59,11 @@ export default {
       }
 
       classes.push(`text-xs-${header.align || 'right'}`)
+      if (Array.isArray(header.class)) {
+        classes.push(...header.class)
+      } else if (header.class) {
+        classes.push(header.class)
+      }
       data.class = classes
 
       return [data, children]


### PR DESCRIPTION
Fixes #1548
Accepts strings and arrays:

```js
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name',
            class: 'some-class' // or ['some-class', 'other-class']
          },
          { text: 'Calories', value: 'calories' },
```