### PR TITLE
pagination was synced even when nothing has changed

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -260,7 +260,9 @@ export default {
       const updatedPagination = Object.assign({}, pagination, val)
 
       if (this.pagination) {
-        this.$emit('update:pagination', updatedPagination)
+        if (JSON.stringify(updatedPagination) !== JSON.stringify(pagination)) {
+          this.$emit('update:pagination', updatedPagination)
+        }
       } else {
         this.defaultPagination = updatedPagination
       }


### PR DESCRIPTION
### Original codepen
API was called twice on init
https://codepen.io/anon/pen/yzVPvm?editors=1010

### Playground.vue for tests
`console.log` should be called once
```vue
<template>
  <v-app id="inspire">
    <v-data-table :items="[]" :pagination.sync="pagination">
    </v-data-table>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    pagination: {}
  }),
  watch: {
    pagination: {
      handler() {
        console.log(Array.from(arguments).map(JSON.stringify))
      },
    }
  }
}
</script>
```