### PR TITLE
Auto adjust scrollable dialog's height based on content

### DIFF
--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -53,7 +53,7 @@
       .card
         display: flex
         flex: 1 1 auto
-        flex-flow: column
+        flex-direction: column
         
         .card__title
         .card__actions

--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -46,8 +46,19 @@
         padding 0 !important
 
   &--scrollable
+    display: flex
     overflow: hidden
-
-    .card__text
-      overflow-y: auto
-      backface-visibility: hidden
+    
+    >
+      .card
+        display: flex
+        flex: 1 1 auto
+        flex-flow: column
+        
+        .card__title
+        .card__actions
+          flex: 1 0 auto
+      
+        .card__text
+          overflow-y: auto
+          backface-visibility: hidden

--- a/src/stylus/components/_dividers.styl
+++ b/src/stylus/components/_dividers.styl
@@ -9,7 +9,7 @@ theme(divider, "divider")
 .divider
   border: none
   display: block
-  height: 1px
+  min-height: 1px
   flex: 1
   width: 100%
 

--- a/src/stylus/components/_dividers.styl
+++ b/src/stylus/components/_dividers.styl
@@ -9,6 +9,7 @@ theme(divider, "divider")
 .divider
   border: none
   display: block
+  height: 1px
   min-height: 1px
   flex: 1
   width: 100%


### PR DESCRIPTION
Currently, on scrollable dialogs, you need to set `v-card-text`'s height for it to properly show its contents. Also, where `v-card-text`'s height is too high, it will hide `v-card-actions`. This PR will auto adjust `v-card-text`'s height based on content and it will not hide `v-card-actions`.