### PR TITLE
setSelectionRange refactoring

### DIFF
--- a/src/mixins/maskable.js
+++ b/src/mixins/maskable.js
@@ -63,24 +63,30 @@ export default {
         isMaskDelimiter(oldText[i]) || position++
       }
 
-      this.selection = 0
+      let selection = 0
       for (const char of newText) {
         isMaskDelimiter(char) || position--
-        this.selection++
+        selection++
         if (position <= 0) break
       }
 
+      this.selection = selection
+    },
+
+    selection () {
       this.$refs.input.setSelectionRange(this.selection, this.selection)
     }
   },
 
   methods: {
-    findRange () {
+    updateRange () {
       const newValue = this.$refs.input.value
+      let selection = this.selection
 
-      while (isMaskDelimiter(newValue.substr(this.selection - 1, 1))) {
-        this.selection++
+      while (isMaskDelimiter(newValue.substr(selection - 1, 1))) {
+        selection++
       }
+      this.selection = selection
     },
     maskText (text) {
       if (!this.mask) return text
@@ -101,9 +107,7 @@ export default {
 
         this.$refs.input.value = this.maskText(this.lazyValue)
 
-        if (!this.deleting) this.findRange()
-
-        this.$refs.input.setSelectionRange(this.selection, this.selection)
+        if (!this.deleting) this.updateRange()
       })
     }
   }

--- a/src/mixins/maskable.js
+++ b/src/mixins/maskable.js
@@ -73,8 +73,8 @@ export default {
       this.selection = selection
     },
 
-    selection () {
-      this.$refs.input.setSelectionRange(this.selection, this.selection)
+    selection (val) {
+      this.$refs.input.setSelectionRange(val, val)
     }
   },
 


### PR DESCRIPTION
fix proposal for #1910

Maybe the current code is not WET, but at least a bit humid, especially when you notice that `input.setSelectionRange()` always comes in pair with `this.selection = ...`, so this is my proposal to keep it together.
Maybe `this.selection` should be synchronized somehow with input selection, now there's a bunch of issues when changes the caret position and continues typing

