### PR TITLE
Add z-index stacking order to vDialog and associated overlays

### DIFF
--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -55,9 +55,6 @@ export default {
         'dialog--content--active': this.isActive
       }
     },
-    overlayZIndex () {
-      return this.activeZIndex - 1
-    },
     activeZIndex () {
       if (!this.isActive) return 0
       var excludeEl = this.$refs.content

--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -7,6 +7,8 @@ import Toggleable from '../../mixins/toggleable'
 
 import ClickOutside from '../../directives/click-outside'
 
+import { getZIndex } from '../../util/helpers'
+
 export default {
   name: 'v-dialog',
 
@@ -46,6 +48,30 @@ export default {
         'dialog--stacked-actions': this.stackedActions && !this.fullscreen,
         'dialog--scrollable': this.scrollable
       }
+    },
+    contentClasses () {
+      return {
+        'dialog__content': true,
+        'dialog--content--active': this.isActive
+      }
+    },
+    overlayZIndex () {
+      return this.activeZIndex - 1
+    },
+    activeZIndex () {
+      if (!this.isActive) return 0
+      var excludeEl = this.$refs.content
+      // start with lowest allowed z-index (5)
+      var zis = [5]
+      // get z-index for all active dialogs
+      var activeDialogs = document.getElementsByClassName('dialog--content--active')
+      for (let i = 0, l = activeDialogs.length; i < l; i += 1) {
+        if (excludeEl !== activeDialogs[i]) {
+          zis.push(getZIndex(activeDialogs[i]))
+        }
+      }
+      // Return max current z-index + 2 (overlay will be this z-index - 1)
+      return Math.max(...zis) + 2
     }
   },
 
@@ -113,7 +139,10 @@ export default {
     )])
 
     children.push(h('div', {
-      'class': 'dialog__content',
+      'class': this.contentClasses,
+      style: {
+        zIndex: this.activeZIndex
+      },
       ref: 'content'
     }, [dialog]))
 

--- a/src/components/VDialog/__snapshots__/VDialog.spec.js.snap
+++ b/src/components/VDialog/__snapshots__/VDialog.spec.js.snap
@@ -5,7 +5,9 @@ exports[`VDialog.js should render a disabled component and match snapshot 1`] = 
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog"
          style="width: 290px; display: none;"
     >
@@ -20,7 +22,9 @@ exports[`VDialog.js should render a fullscreen component and match snapshot 1`] 
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog dialog--fullscreen"
          style="display: none;"
     >
@@ -35,7 +39,9 @@ exports[`VDialog.js should render a lazy component and match snapshot 1`] = `
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog"
          style="width: 290px; display: none;"
     >
@@ -50,7 +56,9 @@ exports[`VDialog.js should render a persistent component and match snapshot 1`] 
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog dialog--persistent"
          style="width: 290px; display: none;"
     >
@@ -65,7 +73,9 @@ exports[`VDialog.js should render a scrollable component and match snapshot 1`] 
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog dialog--scrollable"
          style="width: 290px; display: none;"
     >
@@ -80,7 +90,9 @@ exports[`VDialog.js should render component and match snapshot 1`] = `
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog"
          style="width: 290px; display: none;"
     >
@@ -95,7 +107,9 @@ exports[`VDialog.js should render component with custom origin and match snapsho
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog"
          style="width: 290px; display: none;"
     >
@@ -110,7 +124,9 @@ exports[`VDialog.js should render component with custom transition and match sna
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog"
          style="width: 290px; display: none;"
     >
@@ -125,7 +141,9 @@ exports[`VDialog.js should render component with custom width and match snapshot
 <div class="dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content">
+  <div class="dialog__content"
+       style="z-index: 0;"
+  >
     <div class="dialog"
          style="width: 100px; display: none;"
     >

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -35,13 +35,15 @@ export default {
 
       this.overlay = document.createElement('div')
       this.overlay.className = 'overlay'
-      this.overlay.onclick = () => {
+      this.overlay.onclick = (e) => {
         if (this.permanent) return
         else if (!this.persistent) this.isActive = false
         else if (this.isMobile) this.isActive = false
+        if (this.overlayZIndex !== undefined) e.stopPropagation()
       }
 
       if (this.absolute) this.overlay.className += ' overlay--absolute'
+      if (this.overlayZIndex !== undefined) this.overlay.style.zIndex = this.overlayZIndex - 1
 
       this.hideScroll()
 

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -39,11 +39,11 @@ export default {
         if (this.permanent) return
         else if (!this.persistent) this.isActive = false
         else if (this.isMobile) this.isActive = false
-        if (this.overlayZIndex !== undefined) e.stopPropagation()
+        if (this.activeZIndex !== undefined) e.stopPropagation()
       }
 
       if (this.absolute) this.overlay.className += ' overlay--absolute'
-      if (this.overlayZIndex !== undefined) this.overlay.style.zIndex = this.overlayZIndex - 1
+      if (this.activeZIndex !== undefined) this.overlay.style.zIndex = this.activeZIndex - 1
 
       this.hideScroll()
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -115,3 +115,9 @@ export function getObjectValueByPath (obj, path) {
 export function createRange (length) {
   return [...Array.from({ length }, (v, k) => k)]
 }
+
+export function getZIndex (el) {
+  var zi = document.defaultView.getComputedStyle(el).getPropertyValue('z-index')
+  if (isNaN(zi)) return getZIndex(el.parentNode)
+  return zi
+}


### PR DESCRIPTION
Sets z-index on dialogs and associated overlays allowing multiple open dialogs to be stacked based on when the dialog was last set active, not when it was added to the dom.

Also stops propagation of click event on overlay if overlay is used by dialog, stopping the dismissal of all open dialogs if the overlay for one dialog is clicked.

Removes need for #1918