### PR TITLE
Added getValues method to v-form

### DIFF
--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -45,6 +45,16 @@ export default {
 
       return search(this.$children)
     },
+    getValues () {
+      const results = {}
+
+      this.getInputs().forEach((input) => {
+        const name = input.$attrs.name
+        if (name) results[name] = input.value
+      })
+
+      return results
+    },
     watchInputs (inputs = this.getInputs()) {
       for (const child of inputs) {
         if (this.inputs.includes(child)) {


### PR DESCRIPTION
Added a helpful method to v-form which returns an object of the inputs names and values like this:
`{ name: value }`
for example, on something like this:
```
<v-form v-model="valid" ref="form">
    <v-text-field label="Email" name="email" v-model="email" type="text" :rules="[(v) => !!v || 'Email is required']"
        required>
    </v-text-field>
    <v-text-field label="Password" name="password" v-model="password" type="password" :rules="[(v) => !!v || 'Password is required']"
        required>
    </v-text-field>
</v-form>
```
You can simply pass in your params like this instead of having to list them one by one
```
ApiCall(url, { params: this.$refs.form.getValues() })
```
which is equivalent to 
```
ApiCall(url, { params: {
   email: this.email
   password: this.password
} })
```
Saves a bit of typing, especially on large forms