### PR TITLE
Make sure the input exists

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -158,6 +158,9 @@ export default {
       this.$emit('blur', e)
     },
     focus (e) {
+      if (!this.$refs.input) {
+        return
+      }
       this.isFocused = true
       if (document.activeElement !== this.$refs.input) {
         this.$refs.input.focus()

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -158,9 +158,8 @@ export default {
       this.$emit('blur', e)
     },
     focus (e) {
-      if (!this.$refs.input) {
-        return
-      }
+      if (!this.$refs.input) return
+
       this.isFocused = true
       if (document.activeElement !== this.$refs.input) {
         this.$refs.input.focus()


### PR DESCRIPTION
In some case, the input doesn't exist. For example, in http://owfhx5zzh.bkt.clouddn.com/#/, after logged in, if you refresh the page, the username with autofocus prop doesn't exisit.

Login info for http://owfhx5zzh.bkt.clouddn.com/#/
username: Mario, password: password

The error message got from console if you refresh the page:

> Uncaught TypeError: Cannot read property 'focus' of undefined
>     at s.focus (vendor.3a18aedfd787638103a2.js:6)
>     at s.n [as focus] (vendor.3a18aedfd787638103a2.js:6)
>     at vendor.3a18aedfd787638103a2.js:6
> focus @ vendor.3a18aedfd787638103a2.js:6
> n @ vendor.3a18aedfd787638103a2.js:6
> (anonymous) @ vendor.3a18aedfd787638103a2.js:6