### PR TITLE
Fixed the bug where the caret position is not properly watched.

### DIFF
--- a/src/mixins/maskable.js
+++ b/src/mixins/maskable.js
@@ -58,27 +58,28 @@ export default {
       const oldText = this.$refs.input.value || ''
       const newText = this.maskText(this.lazyValue || '')
       let position = 0
+      let selection = this.selection
 
-      for (const char of oldText.substr(0, this.selection)) {
+      for (const char of oldText.substr(0, selection)) {
         isMaskDelimiter(char) || position++
       }
 
-      let selection = 0
+      selection = 0
       for (const char of newText) {
         isMaskDelimiter(char) || position--
         selection++
         if (position <= 0) break
       }
 
-      this.selection = selection
-    },
-
-    selection (val) {
-      this.$refs.input.setSelectionRange(val, val)
+      this.setCaretPosition(selection)
     }
   },
 
   methods: {
+    setCaretPosition (selection) {
+      this.selection = selection
+      this.$refs.input.setSelectionRange(selection, selection)
+    },
     updateRange () {
       const newValue = this.$refs.input.value
       let selection = this.selection
@@ -86,7 +87,7 @@ export default {
       while (isMaskDelimiter(newValue.substr(selection - 1, 1))) {
         selection++
       }
-      this.selection = selection
+      this.setCaretPosition(selection)
     },
     maskText (text) {
       if (!this.mask) return text
@@ -107,7 +108,7 @@ export default {
 
         this.$refs.input.value = this.maskText(this.lazyValue)
 
-        if (!this.deleting) this.updateRange()
+        this.deleting ? this.setCaretPosition(this.selection) : this.updateRange()
       })
     }
   }


### PR DESCRIPTION
Fixed the bug where the `selection()` is not called at certain situations when the caret position changes. The actual caret position will be moved to the end of input field particularly when the mask changes dynamically, and it should be re-positioned to the value of `this.selection`. However, because `this.selection` is observed (watched) as unchanged, `selection()` is not called to fix the caret position.