### PR TITLE
check if menu exists before setting listIndex

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -280,7 +280,7 @@ export default {
       this.$refs.menu.listIndex = -1
 
       this.searchValue && this.$nextTick(() => {
-        this.$refs.menu.listIndex = 0
+        this.$refs.menu && (this.$refs.menu.listIndex = 0)
       })
 
       this.genSelectedItems()
@@ -317,7 +317,7 @@ export default {
       this.$refs.menu.listIndex = null
 
       this.$nextTick(() => {
-        this.$refs.menu.listIndex = val ? 0 : -1
+        this.$refs.menu && (this.$refs.menu.listIndex = val ? 0 : -1)
       })
     },
     selectedItems () {
@@ -568,7 +568,7 @@ export default {
           this.$refs.input
         ) this.$refs.input.focus()
         else this.$el.focus()
-        this.$refs.menu.listIndex = savedIndex
+        this.$refs.menu && (this.$refs.menu.listIndex = savedIndex)
       })
     },
     showMenuItems () {


### PR DESCRIPTION
`listIndex` is set in `$nextTick`, meanwhile menu can be removed so before setting `listIndex` we should make sure that `this.$refs.menu` exists
Fixes #1943 

Edit: #1943 is fixed in line 571 https://github.com/vuetifyjs/vuetify/pull/1958/files#diff-ebb3da5567a5b11ea831789469bcc709L571, but I've added check also in 2 more places