### PR TITLE
toISOString() ignores timezone offset

### DIFF
--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -15,7 +15,12 @@ import VIcon from '../VIcon'
 
 import Touch from '../../directives/touch'
 
-const createDefaultDateFormat = type => date => new Date(date).toISOString().substr(0, { date: 10, month: 7, year: 4 }[type])
+const createDefaultDateFormat = type => date => {
+  date = new Date(date)
+  const tzOffset = date.getTimezoneOffset() * 60000
+  const localDate = new Date(date.getTime() - tzOffset)
+  return localDate.toISOString().substr(0, { date: 10, month: 7, year: 4 }[type])
+}
 
 export default {
   name: 'v-date-picker',


### PR DESCRIPTION
fixes #1939

Based on https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset