### PR TITLE
colorable alerts

### DIFF
--- a/src/components/VAlert/VAlert.js
+++ b/src/components/VAlert/VAlert.js
@@ -17,7 +17,6 @@ export default {
 
   props: {
     dismissible: Boolean,
-    hideIcon: Boolean,
     icon: String
   },
 
@@ -27,22 +26,16 @@ export default {
         'alert--dismissible': this.dismissible,
         [this.color || 'error']: true
       }
-    },
-
-    mdIcon () {
-      switch (true) {
-        case !!this.icon: return this.icon
-      }
     }
   },
 
   render (h) {
     const children = [h('div', this.$slots.default)]
 
-    if (!this.hideIcon && this.mdIcon) {
+    if (this.icon) {
       children.unshift(h('v-icon', {
         'class': 'alert__icon'
-      }, this.mdIcon))
+      }, this.icon))
     }
 
     if (this.dismissible) {

--- a/src/components/VAlert/VAlert.js
+++ b/src/components/VAlert/VAlert.js
@@ -2,7 +2,7 @@ require('../../stylus/components/_alerts.styl')
 
 import VIcon from '../VIcon'
 
-import Contextualable from '../../mixins/contextualable'
+import Colorable from '../../mixins/colorable'
 import Toggleable from '../../mixins/toggleable'
 import Transitionable from '../../mixins/transitionable'
 
@@ -13,7 +13,7 @@ export default {
     VIcon
   },
 
-  mixins: [Contextualable, Toggleable, Transitionable],
+  mixins: [Colorable, Toggleable, Transitionable],
 
   props: {
     dismissible: Boolean,
@@ -24,24 +24,14 @@ export default {
   computed: {
     classes () {
       return {
-        'alert': true,
         'alert--dismissible': this.dismissible,
-        'error': this.error,
-        'info': this.info,
-        'primary': this.primary,
-        'secondary': this.secondary,
-        'success': this.success,
-        'warning': this.warning
+        [this.color || 'error']: true
       }
     },
 
     mdIcon () {
       switch (true) {
         case !!this.icon: return this.icon
-        case this.error: return 'warning'
-        case this.info: return 'info'
-        case this.success: return 'check_circle'
-        case this.warning: return 'priority_high'
       }
     }
   },
@@ -72,6 +62,7 @@ export default {
     }
 
     const alert = h('div', {
+      staticClass: 'alert',
       'class': this.classes,
       directives: [{
         name: 'show',

--- a/src/components/VAlert/VAlert.spec.js
+++ b/src/components/VAlert/VAlert.spec.js
@@ -50,11 +50,7 @@ test('VAlert.vue', ({ mount }) => {
   })
 
   it('should have no icon', () => {
-    const wrapper = mount(VAlert, {
-      propsData: {
-        hideIcon: true
-      }
-    })
+    const wrapper = mount(VAlert)
 
     expect(wrapper.contains('.icon')).toBe(false)
   })

--- a/src/components/VAlert/__snapshots__/VAlert.spec.js.snap
+++ b/src/components/VAlert/__snapshots__/VAlert.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`VAlert.vue should be closed by default 1`] = `
 
-<div class="alert"
+<div class="alert error"
      style="display: none;"
 >
   <div>
@@ -13,7 +13,7 @@ exports[`VAlert.vue should be closed by default 1`] = `
 
 exports[`VAlert.vue should be dismissible 1`] = `
 
-<div class="alert alert--dismissible"
+<div class="alert alert--dismissible error"
      style="display: none;"
 >
   <div>
@@ -31,7 +31,7 @@ exports[`VAlert.vue should be dismissible 1`] = `
 
 exports[`VAlert.vue should have a close icon 1`] = `
 
-<div class="alert alert--dismissible"
+<div class="alert alert--dismissible error"
      style="display: none;"
 >
   <div>


### PR DESCRIPTION
In 0.15 icon depended on the context (`<a-alert error>` had an `warning` icon etc), should it still depend on the color in `colorable` version? This would made transition from 0.15 to 0.16 a bit easier (just `primary` => `color="primary"` etc, no need to specify icon for every alert), but it's not semantic - color is color, not the context

I've also set the default color to `error`, so just `<v-alert>Error</v-alert>` could work.

In future versions there could be some global settings that sets the default icon for contextual colors

Docs: https://github.com/vuetifyjs/docs/pull/260