### PR TITLE
fixed bug with unchecked property read

### DIFF
--- a/src/components/VList/VListTile.js
+++ b/src/components/VList/VListTile.js
@@ -43,7 +43,7 @@ export default {
   },
 
   render (h) {
-    const isRouteLink = this.active && (this.href || this.to || this.$listeners.click)
+    const isRouteLink = this.active && this.isLink
     const { tag, data } = isRouteLink ? this.generateRouteLink() : {
       tag: this.tag || 'div',
       data: {


### PR DESCRIPTION
Can be seen on dev docs. The v-list holding the version select throws an error since there is no check to see if `$listeners` actually exists before trying to access `.click`. I simply reused existing isLink computed prop instead.