### PR TITLE
Fix VProgressCircular's error in a-la-carte import

### DIFF
--- a/src/components/VProgressCircular/VProgressCircular.js
+++ b/src/components/VProgressCircular/VProgressCircular.js
@@ -12,7 +12,7 @@ export default {
 
     fill: {
       type: String,
-      default: () => this.indeterminate ? 'none' : 'transparent'
+      default() { return this.indeterminate ? 'none' : 'transparent'; }
     },
 
     indeterminate: Boolean,

--- a/src/components/VProgressCircular/VProgressCircular.js
+++ b/src/components/VProgressCircular/VProgressCircular.js
@@ -12,7 +12,7 @@ export default {
 
     fill: {
       type: String,
-      default() { return this.indeterminate ? 'none' : 'transparent'; }
+      default () { return this.indeterminate ? 'none' : 'transparent' }
     },
 
     indeterminate: Boolean,


### PR DESCRIPTION
Fix a case where importing VProgressCircular to declare as app local component triggers the arrow function behavior (`this` will be undefined).