### PR TITLE
Make toggleable's prop a boolean

### DIFF
--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -33,7 +33,7 @@ export default {
           offsetOverflow: this.isAutocomplete,
           openOnClick: false,
           value: this.menuIsActive &&
-            this.computedItems.length &&
+            !!this.computedItems.length &&
             (!this.tags || this.tags && this.filteredItems.length > 0),
           zIndex: this.menuZIndex
         },

--- a/src/mixins/toggleable.js
+++ b/src/mixins/toggleable.js
@@ -3,7 +3,7 @@ export function factory (prop = 'value', event = 'input') {
     model: { prop, event },
 
     props: {
-      [prop]: { required: false }
+      [prop]: Boolean
     },
 
     data () {


### PR DESCRIPTION
This was changed in 1d4e6e9e7cb07b4bad76593a01e283ade8ffc418, but we couldn't think of a proper use case for this so it makes more sense to keep it strict