### PR TITLE
add `hideHeaders` prop

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -61,6 +61,7 @@ export default {
       default: 'text'
     },
     hideActions: Boolean,
+    hideHeaders: Boolean,
     mustSort: Boolean,
     noResultsText: {
       type: String,


### PR DESCRIPTION
Gives an option to have a header-less data-table