### PR TITLE
fixes #2031

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -231,7 +231,7 @@ export default {
       this.$nextTick(() => this.$refs.input.focus())
     },
     resetSelections (input) {
-      this.selection = input.selectionStart
+      this.selection = input.selectionEnd
       this.lazySelection = 0
 
       for (const char of input.value.substr(0, this.selection)) {

--- a/src/mixins/maskable.js
+++ b/src/mixins/maskable.js
@@ -44,6 +44,9 @@ export default {
       const mask = preDefined || this.mask || ''
 
       return mask.split('')
+    },
+    isAndroid () {
+      return navigator && /android/i.test(navigator.userAgent)
     }
   },
 
@@ -78,7 +81,13 @@ export default {
   methods: {
     setCaretPosition (selection) {
       this.selection = selection
-      this.$refs.input.setSelectionRange(selection, selection)
+      if (this.isAndroid) {
+        window.setTimeout(() => {
+          this.$refs.input.setSelectionRange(selection, selection)
+        }, 1)
+      } else {
+        this.$refs.input.setSelectionRange(selection, selection)
+      }
     },
     updateRange () {
       if (!this.$refs.input) return


### PR DESCRIPTION
Android stores the caret position to later restore it after the component gets rendered. This exhibits a caret bug when we internally change the input text using masks. We need to delay our caret update right after Android is done with it's restoration.