### PR TITLE
Fix cursor position in masked inputs on android

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -231,7 +231,7 @@ export default {
       this.$nextTick(() => this.$refs.input.focus())
     },
     resetSelections (input) {
-      this.selection = input.selectionStart
+      this.selection = input.selectionEnd
       this.lazySelection = 0
 
       for (const char of input.value.substr(0, this.selection)) {

--- a/src/mixins/maskable.js
+++ b/src/mixins/maskable.js
@@ -78,7 +78,9 @@ export default {
   methods: {
     setCaretPosition (selection) {
       this.selection = selection
-      this.$refs.input.setSelectionRange(selection, selection)
+      window.setTimeout(() => {
+        this.$refs.input.setSelectionRange(selection, selection)
+      }, 0)
     },
     updateRange () {
       if (!this.$refs.input) return


### PR DESCRIPTION
Android chrome selects the last entered character, so we should use
selectionEnd instead of selectionStart.
It also has a slight delay before deselecting the character, so a
timeout of 0 is set to ensure the correct update order.

Better than #2049
Fixes #2031