### PR TITLE
fixes button icon colors

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -5,9 +5,6 @@
 button($material)
   color: $material.text.primary
 
-  .icon
-    color: $material.text.primary
-
   &.btn--disabled
     color: $material.buttons.disabled !important
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/15625235/31307220-9d7e5ce6-ab89-11e7-94e4-8eaf096f4edb.png)

and after
![image](https://user-images.githubusercontent.com/15625235/31307223-a0bd2eb4-ab89-11e7-8bf3-a5aaaeaa4faf.png)

with this playground

```vue
<template>
  <v-app id="inspire">
    <main>
      <v-content>
        No theme<br>
        <v-btn href="/" color="primary"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" flat color="primary"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" flat><v-icon>block</v-icon>Button</v-btn>
        <v-divider></v-divider>
        Dark theme<br>
        <v-btn href="/" dark color="primary"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" dark flat color="primary"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" dark><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" dark flat><v-icon>block</v-icon>Button</v-btn>
        <v-divider></v-divider>
        Light theme<br>
        <v-btn href="/" light color="primary"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" light flat color="primary"><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" light><v-icon>block</v-icon>Button</v-btn>
        <v-btn href="/" light flat><v-icon>block</v-icon>Button</v-btn>
      </v-content>
    </main>
  </v-app>
</template>
```