### PR TITLE
round input value instead of floor

### DIFF
--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -74,7 +74,7 @@ export default {
         }
         */
 
-        const value = snap ? Math.round(val / step) * step : parseInt(val)
+        const value = snap ? Math.round(val / step) * step : Math.round(val)
         this.lazyValue = value
 
         if (value !== this.value) {


### PR DESCRIPTION
It was not possible to set the max value with this codepen https://codepen.io/anon/pen/boLmqq

This PR uses `Math.round` instead of `parseInt`, so if the new value calculated in `onMouseMove` is for example 4.56 then the slider value will be set to 5, before it was set to 4