### PR TITLE
fixes #2086

### DIFF
--- a/src/stylus/components/_chips.styl
+++ b/src/stylus/components/_chips.styl
@@ -4,7 +4,7 @@
 chip($material)
   background: $material.chips.background
   color: $material.chips.color
-      
+
   &__close
     color: $material.icons.active
 
@@ -55,7 +55,7 @@ theme(chip, "chip")
   &--label
     border-radius: $chip-label-border-radius
 
-  &--outline
+  &.chip--outline
     background: $chip-outline-background
     border: 1px solid transparent
     color: $chip-outline-color


### PR DESCRIPTION
Fixes #2086

```css
.red--text.text--darken-1 {
    color: #e53935!important;
}
```

overridden chip's

```css
.chip--outline {
    background: transparent!important;
}
```

because of highter specificity

PR changes `.chip--outline` to `.chip.chip--outline`