### PR TITLE
operate on strings instead of Date objects

### DIFF
--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -50,7 +50,6 @@ export default {
       currentMonth: null,
       currentYear: null,
       isReversing: false,
-      narrowDays: [],
       originalDate: this.value,
       tableDate: this.sanitizeDateString(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`, this.type === 'month' ? 'year' : 'month'),
       yearFormat: createNativeLocaleFormatter({ year: 'numeric' }, 'year')
@@ -103,6 +102,17 @@ export default {
       } catch (e) {
         return 'UTC'
       }
+    },
+    weekDays () {
+      const first = parseInt(this.firstDayOfWeek, 10)
+      if (!this.supportsLocaleFormat) {
+        return createRange(7).map(i => ['S', 'M', 'T', 'W', 'T', 'F', 'S'][(i + first) % 7])
+      }
+
+      const date = new Date('2000-01-07 GMT+0')
+      const day = date.getUTCDate() - date.getUTCDay() + first
+      const format = { weekday: 'narrow', timeZone: 'UTC' }
+      return createRange(7).map(i => new Date(`2000-01-${day + i} GMT+0`).toLocaleDateString(this.locale, format))
     },
     supportsLocaleFormat () {
       return ('toLocaleDateString' in Date.prototype) &&
@@ -234,9 +244,6 @@ export default {
       } else if (val === 'year') {
         this.activePicker = 'YEAR'
       }
-    },
-    firstDayOfWeek () {
-      this.getWeekDays()
     }
   },
 
@@ -253,17 +260,6 @@ export default {
     cancel () {
       this.inputDate = this.originalDate
       if (this.$parent && this.$parent.isActive) this.$parent.isActive = false
-    },
-    getWeekDays () {
-      const first = parseInt(this.firstDayOfWeek, 10)
-      if (this.supportsLocaleFormat) {
-        const date = new Date('2000-01-07 GMT+0')
-        const day = date.getUTCDate() - date.getUTCDay() + first
-        const format = { weekday: 'narrow', timeZone: 'UTC' }
-        this.narrowDays = createRange(7).map(i => new Date(`2000-01-${day + i} GMT+0`).toLocaleDateString(this.locale, format))
-      } else {
-        this.narrowDays = createRange(7).map(i => ['S', 'M', 'T', 'W', 'T', 'F', 'S'][(i + first) % 7])
-      }
     },
     isAllowed (date) {
       if (!this.allowedDates) return true
@@ -346,7 +342,6 @@ export default {
   },
 
   created () {
-    this.getWeekDays()
     this.tableDate = this.inputDate
   },
 

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -339,11 +339,9 @@ export default {
       return pickerBodyChildren
     },
     sanitizeDateString (dateString, type) {
-      const [year, month, date] = dateString.trim().split(' ')[0].split('-')
-      const dateObject = new Date(`${year}-${month || 1}-${date || 1} GMT+0`)
-      const pad = n => n < 10 ? `0${n}` : `${n}`
-      const sanitizedFullString = `${dateObject.getUTCFullYear()}-${pad(dateObject.getUTCMonth() + 1)}-${pad(dateObject.getUTCDate())}`
-      return sanitizedFullString.substr(0, { date: 10, month: 7, year: 4 }[type])
+      const [year, month, date] = dateString.split('-')
+      const pad = n => (n * 1 < 10) ? `0${n * 1}` : `${n}`
+      return `${year}-${pad(month)}-${pad(date)}`.substr(0, { date: 10, month: 7, year: 4 }[type])
     }
   },
 

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -260,7 +260,7 @@ export default {
         this.tableDate = this.type === 'month' ? `${this.year}` : `${this.year}-${this.month + 1}`
       }
     },
-    type (val, old) {
+    type (val) {
       if (val === 'month' && this.activePicker === 'DATE') {
         this.activePicker = 'MONTH'
       } else if (val === 'year') {

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -215,7 +215,8 @@ export default {
       }, 100)
     },
     tableDate (val, prev) {
-      this.isReversing = val < prev
+      const sanitizeType = this.type === 'month' ? 'year' : 'month'
+      this.isReversing = this.sanitizeDateString(val, sanitizeType) < this.sanitizeDateString(prev, sanitizeType)
     },
     value (val) {
       if (val) {

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -52,7 +52,7 @@ export default {
       isReversing: false,
       narrowDays: [],
       originalDate: this.value,
-      tableDate: this.sanitizeDateString(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`, this.type),
+      tableDate: this.sanitizeDateString(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`, this.type === 'month' ? 'year' : 'month'),
       yearFormat: createNativeLocaleFormatter({ year: 'numeric' }, 'year')
     }
   },
@@ -224,7 +224,9 @@ export default {
       this.isReversing = val < prev
     },
     value (val) {
-      if (val) this.tableDate = this.inputDate
+      if (val) {
+        this.tableDate = this.sanitizeDateString(this.inputDate, this.type === 'month' ? 'year' : 'month')
+      }
     },
     type (val) {
       if (val === 'month' && this.activePicker === 'DATE') {
@@ -315,12 +317,21 @@ export default {
         pickerBodyChildren.push(this.genTable([
           this.dateGenTHead(),
           this.dateGenTBody()
-        ], value => this.tableDate = this.sanitizeDateString(`${this.tableYear}-${this.tableMonth + value + 1}`, 'month')))
+        ], value => {
+          const newMonth = this.tableMonth + value
+          if (newMonth === 12) {
+            this.tableDate = this.sanitizeDateString(`${this.tableYear + 1}-01`, 'month')
+          } else if (newMonth === -1) {
+            this.tableDate = this.sanitizeDateString(`${this.tableYear - 1}-12`, 'month')
+          } else {
+            this.tableDate = this.sanitizeDateString(`${this.tableYear}-${newMonth + 1}`, 'month')
+          }
+        }))
       } else if (this.activePicker === 'MONTH') {
         pickerBodyChildren.push(h('div', { staticClass: 'picker--date__header' }, [this.genSelector()]))
         pickerBodyChildren.push(this.genTable([
           this.monthGenTBody()
-        ], value => this.tableDate = this.sanitizeDateString(`${this.tableYear}`, 'year')))
+        ], value => this.tableDate = this.sanitizeDateString(`${this.tableYear + value}`, 'year')))
       } else if (this.activePicker === 'YEAR') {
         pickerBodyChildren.push(this.genYears())
       }

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -91,18 +91,6 @@ export default {
   },
 
   computed: {
-    timeZone () {
-      try {
-        const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-        new Date('2000-01-15').toLocaleDateString('en', {
-          day: 'numeric',
-          timeZone
-        })
-        return timeZone
-      } catch (e) {
-        return 'UTC'
-      }
-    },
     weekDays () {
       const first = parseInt(this.firstDayOfWeek, 10)
       if (!Date.prototype.toLocaleDateString) {

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -15,6 +15,8 @@ import VIcon from '../VIcon'
 
 import Touch from '../../directives/touch'
 
+const pad = n => (n * 1 < 10) ? `0${n * 1}` : `${n}`
+
 /**
  * Creates the formatting function that uses Date::toLocaleDateString or returns date
  * in ISO format if toLocaleDateString is not supported by the browser
@@ -28,12 +30,11 @@ const createNativeLocaleFormatter = (format, fallbackType) => (dateString, local
   const [year, month, date] = dateString.trim().split(' ')[0].split('-')
 
   if (Date.prototype.toLocaleDateString) {
-    const dateObject = new Date(`${year}-${month || 1}-${date || 1} GMT+0`)
+    const dateObject = new Date(`${year}-${pad(month || 1)}-${pad(date || 1)}T00:00:00+00:00`)
     return dateObject.toLocaleDateString(locale, Object.assign(format, {
       timeZone: 'UTC'
     }))
   } else {
-    const pad = n => n < 10 ? `0${n}` : `${n}`
     const isoString = `${year * 1}-${pad(month || 1)}-${pad(date || 1)}`
     const formats = {
       date: { start: 0, length: 10 },
@@ -130,10 +131,10 @@ export default {
       }
 
       // Operates on UTC time zone to get the names of the week days
-      const date = new Date('2000-01-07 GMT+0')
+      const date = new Date('2000-01-07T00:00:00+00:00')
       const day = date.getUTCDate() - date.getUTCDay() + first
       const format = { weekday: 'narrow', timeZone: 'UTC' }
-      return createRange(7).map(i => new Date(`2000-01-${day + i} GMT+0`).toLocaleDateString(this.locale, format))
+      return createRange(7).map(i => new Date(`2000-01-${pad(day + i)}T00:00:00+00:00`).toLocaleDateString(this.locale, format))
     },
     firstAllowedDate () {
       const now = new Date()
@@ -205,8 +206,6 @@ export default {
       return this.isReversing ? 'tab-reverse-transition' : 'tab-transition'
     },
     titleText () {
-      const pad = n => n < 10 ? `0${n}` : `${n}`
-
       // Current date in ISO 8601 format (with leading zero)
       const date = this.type === 'month'
         ? `${this.year}-${pad(this.month + 1)}`
@@ -354,7 +353,6 @@ export default {
     // 'YYYY-MM' if 'month' and 'YYYY-MM-DD' if 'date'
     sanitizeDateString (dateString, type) {
       const [year, month, date] = dateString.split('-')
-      const pad = n => (n * 1 < 10) ? `0${n * 1}` : `${n}`
       return `${year}-${pad(month)}-${pad(date)}`.substr(0, { date: 10, month: 7, year: 4 }[type])
     },
     // For month = 12 it sets the tableDate to January next year

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -141,7 +141,7 @@ export default {
       const month = now.getMonth()
 
       if (this.allowedDates) {
-        for (let date = 1; date <= 31; date++) {
+        for (let date = now.getDate(); date <= 31; date++) {
           const dateString = `${year}-${month + 1}-${date}`
           if (isNaN(new Date(dateString).getDate())) break
 
@@ -159,7 +159,7 @@ export default {
       const year = now.getFullYear()
 
       if (this.allowedDates) {
-        for (let month = 0; month < 12; month++) {
+        for (let month = now.getMonth(); month < 12; month++) {
           const dateString = `${year}-${month + 1}`
           const sanitizedDateString = this.sanitizeDateString(dateString, 'month')
           if (this.isAllowed(sanitizedDateString)) {

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -3,12 +3,12 @@ require('../../stylus/components/_date-picker.styl')
 
 import { createRange } from '../../util/helpers'
 
-import Picker from '../../mixins/picker'
 import DateYears from './mixins/date-years'
 import DateTitle from './mixins/date-title'
 import DateHeader from './mixins/date-header'
 import DateTable from './mixins/date-table'
 import MonthTable from './mixins/month-table'
+import Picker from '../../mixins/picker'
 import VBtn from '../VBtn'
 import VCard from '../VCard'
 import VIcon from '../VIcon'
@@ -36,46 +36,18 @@ export default {
 
   data () {
     return {
-      tableDate: new Date(),
-      originalDate: this.value,
+      activePicker: this.type.toUpperCase(),
       currentDay: null,
       currentMonth: null,
       currentYear: null,
       isReversing: false,
       narrowDays: [],
-      activePicker: this.type.toUpperCase()
+      originalDate: this.value,
+      tableDate: new Date()
     }
   },
 
   props: {
-    locale: {
-      type: String,
-      default: 'en-us'
-    },
-    type: {
-      type: String,
-      default: 'date',
-      validator: type => ['date', 'month'/*, 'year'*/].includes(type)
-    },
-    dateFormat: {
-      type: Function,
-      default: null
-    },
-    titleDateFormat: {
-      type: [Object, Function],
-      default: null
-    },
-    headerDateFormat: {
-      type: [Object, Function],
-      default: () => ({ month: 'long', year: 'numeric' })
-    },
-    monthFormat: {
-      type: [Object, Function],
-      default: () => ({ month: 'short' })
-    },
-    formattedValue: {
-      required: false
-    },
     allowedDates: {
       type: [Array, Object, Function],
       default: () => (null)
@@ -84,6 +56,28 @@ export default {
       type: [String, Number],
       default: 0
     },
+    headerDateFormat: {
+      type: [Object, Function],
+      default: () => ({ month: 'long', year: 'numeric' })
+    },
+    locale: {
+      type: String,
+      default: 'en-us'
+    },
+    monthFormat: {
+      type: [Object, Function],
+      default: () => ({ month: 'short' })
+    },
+    titleDateFormat: {
+      type: [Object, Function],
+      default: null
+    },
+    type: {
+      type: String,
+      default: 'date',
+      validator: type => ['date', 'month'/*, 'year'*/].includes(type)
+    },
+    value: String,
     yearIcon: String
   },
 
@@ -147,7 +141,6 @@ export default {
         const date = this.makeDate(value)
         const pickerDateFormat = createDefaultDateFormat(this.type)
         this.$emit('input', date == null ? this.originalDate : pickerDateFormat(date))
-        this.$emit('update:formattedValue', (this.dateFormat || pickerDateFormat)(date == null ? (this.makeDate(this.originalDate) || this.firstAllowedDate) : date))
       }
     },
     day () {

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -105,7 +105,7 @@ export default {
     },
     weekDays () {
       const first = parseInt(this.firstDayOfWeek, 10)
-      if (!this.supportsLocaleFormat) {
+      if (!Date.prototype.toLocaleDateString) {
         return createRange(7).map(i => ['S', 'M', 'T', 'W', 'T', 'F', 'S'][(i + first) % 7])
       }
 
@@ -113,13 +113,6 @@ export default {
       const day = date.getUTCDate() - date.getUTCDay() + first
       const format = { weekday: 'narrow', timeZone: 'UTC' }
       return createRange(7).map(i => new Date(`2000-01-${day + i} GMT+0`).toLocaleDateString(this.locale, format))
-    },
-    supportsLocaleFormat () {
-      return ('toLocaleDateString' in Date.prototype) &&
-        new Date('2000-01-15').toLocaleDateString('en', {
-          day: 'numeric',
-          timeZone: 'UTC'
-        }) === '15'
     },
     firstAllowedDate () {
       const now = new Date()

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -17,15 +17,15 @@ import Touch from '../../directives/touch'
 
 const createNativeLocaleFormatter = (format, fallbackType) => (dateString, locale) => {
   const [year, month, date] = dateString.trim().split(' ')[0].split('-')
-  const dateObject = new Date(`${year}-${month || 1}-${date || 1} GMT+0`)
 
-  if (dateObject.toLocaleDateString) {
+  if (Date.prototype.toLocaleDateString) {
+    const dateObject = new Date(`${year}-${month || 1}-${date || 1} GMT+0`)
     return dateObject.toLocaleDateString(locale, Object.assign(format, {
       timeZone: 'UTC'
     }))
   } else {
     const pad = n => n < 10 ? `0${n}` : `${n}`
-    const isoString = `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`
+    const isoString = `${year * 1}-${pad(month * 1)}-${pad(date * 1)}`
     return isoString.substr(0, { date: 10, month: 7, year: 4 }[fallbackType])
   }
 }

--- a/src/components/VDatePicker/VDatePicker.spec.js
+++ b/src/components/VDatePicker/VDatePicker.spec.js
@@ -111,7 +111,7 @@ test('VDatePicker.js', ({ mount }) => {
   })
 
   it('should match snapshot with title/header formatting functions', () => {
-    const dateFormat = date => `${date.getFullYear() * 2} ${persianMonths[11 - date.getMonth()]}`
+    const dateFormat = (date, locale) => date + ', ' + locale
     const wrapper = mount(VDatePicker, {
       propsData: {
         value: '2005-11-01',
@@ -128,8 +128,8 @@ test('VDatePicker.js', ({ mount }) => {
       propsData: {
         value: '2005-11-01',
         type: 'month',
-        monthFormat: date => {
-          return persianMonths[11 - date.getMonth()]
+        monthFormat: (date, locale) => {
+          return date.split('-')[1] + ', ' + locale
         }
       }
     })

--- a/src/components/VDatePicker/VDatePicker.spec.js
+++ b/src/components/VDatePicker/VDatePicker.spec.js
@@ -2,8 +2,6 @@ import VDatePicker from '~components/VDatePicker'
 import { test } from '~util/testing'
 import { mount } from 'avoriaz'
 
-const persianMonths = ['حمل', 'ثور', 'جوزا', 'سرطان',' اسد', 'سنبله' ,'میزان' ,'عقرب' ,'قوس', 'جدی' ,'دلو', 'حوت']
-
 test('VDatePicker.js', ({ mount }) => {
   it('should display the correct date in title and header', () => {
     const wrapper = mount(VDatePicker, {

--- a/src/components/VDatePicker/VDatePicker.spec.js
+++ b/src/components/VDatePicker/VDatePicker.spec.js
@@ -8,7 +8,7 @@ test('VDatePicker.js', ({ mount }) => {
   it('should display the correct date in title and header', () => {
     const wrapper = mount(VDatePicker, {
       propsData: {
-        value: new Date('November 1 2005')
+        value: '2005-11-01',
       }
     })
 
@@ -114,7 +114,7 @@ test('VDatePicker.js', ({ mount }) => {
     const dateFormat = date => `${date.getFullYear() * 2} ${persianMonths[11 - date.getMonth()]}`
     const wrapper = mount(VDatePicker, {
       propsData: {
-        value: new Date('November 1 2005'),
+        value: '2005-11-01',
         headerDateFormat: dateFormat,
         titleDateFormat: dateFormat
       }
@@ -126,7 +126,7 @@ test('VDatePicker.js', ({ mount }) => {
   it('should match snapshot with month formatting functions', () => {
     const wrapper = mount(VDatePicker, {
       propsData: {
-        value: new Date('November 1 2005'),
+        value: '2005-11-01',
         type: 'month',
         monthFormat: date => {
           return persianMonths[11 - date.getMonth()]

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.spec.js.snap
@@ -2113,7 +2113,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  حوت
+                  01, en-us
                 </span>
               </button>
             </td>
@@ -2122,7 +2122,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  دلو
+                  02, en-us
                 </span>
               </button>
             </td>
@@ -2131,36 +2131,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  جدی
-                </span>
-              </button>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <button type="button"
-                      class="btn btn--date-picker btn--flat"
-              >
-                <span class="btn__content">
-                  قوس
-                </span>
-              </button>
-            </td>
-            <td>
-              <button type="button"
-                      class="btn btn--date-picker btn--flat"
-              >
-                <span class="btn__content">
-                  عقرب
-                </span>
-              </button>
-            </td>
-            <td>
-              <button type="button"
-                      class="btn btn--date-picker btn--flat"
-              >
-                <span class="btn__content">
-                  میزان
+                  03, en-us
                 </span>
               </button>
             </td>
@@ -2171,7 +2142,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  سنبله
+                  04, en-us
                 </span>
               </button>
             </td>
@@ -2180,7 +2151,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  اسد
+                  05, en-us
                 </span>
               </button>
             </td>
@@ -2189,7 +2160,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  سرطان
+                  06, en-us
                 </span>
               </button>
             </td>
@@ -2200,7 +2171,36 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  جوزا
+                  07, en-us
+                </span>
+              </button>
+            </td>
+            <td>
+              <button type="button"
+                      class="btn btn--date-picker btn--flat"
+              >
+                <span class="btn__content">
+                  08, en-us
+                </span>
+              </button>
+            </td>
+            <td>
+              <button type="button"
+                      class="btn btn--date-picker btn--flat"
+              >
+                <span class="btn__content">
+                  09, en-us
+                </span>
+              </button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <button type="button"
+                      class="btn btn--date-picker btn--flat"
+              >
+                <span class="btn__content">
+                  10, en-us
                 </span>
               </button>
             </td>
@@ -2209,7 +2209,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--raised btn--flat btn--active"
               >
                 <span class="btn__content">
-                  ثور
+                  11, en-us
                 </span>
               </button>
             </td>
@@ -2218,7 +2218,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
                       class="btn btn--date-picker btn--flat"
               >
                 <span class="btn__content">
-                  حمل
+                  12, en-us
                 </span>
               </button>
             </td>
@@ -2781,7 +2781,7 @@ exports[`VDatePicker.js should match snapshot with title/header formatting funct
     </div>
     <div class="picker--date__title-date active">
       <div>
-        4010 ثور
+        2005-11-01, en-us
       </div>
     </div>
   </div>
@@ -2799,7 +2799,7 @@ exports[`VDatePicker.js should match snapshot with title/header formatting funct
         </button>
         <div class="picker--date__header-selector-date">
           <strong>
-            4010 ثور
+            2005-11, en-us
           </strong>
         </div>
         <button type="button"

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -18,7 +18,7 @@ export default {
                 this.tableDate = this.sanitizeDateString(`${this.tableYear}-${change + 1}`, 'month')
               }
             } else if (this.activePicker === 'MONTH') {
-              this.tableDate = this.sanitizeDateString(`${change}-${this.tableMonth + 1}`, 'month')
+              this.tableDate = this.sanitizeDateString(`${change}`, 'month')
             }
           }
         }

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -38,25 +38,14 @@ export default {
 
     genSelector () {
       const keyValue = this.activePicker === 'DATE' ? this.tableMonth : this.tableYear
-      const selectorDate = this.normalizeDate(this.tableYear, this.tableMonth)
-
-      let selectorText = ''
-      if (typeof this.headerDateFormat === 'function' && this.activePicker === 'DATE') {
-        selectorText = this.headerDateFormat(selectorDate, this.activePicker)
-      } else if (this.supportsLocaleFormat) {
-        const format = this.activePicker === 'DATE'
-          ? this.headerDateFormat
-          : { year: 'numeric' }
-        selectorText = selectorDate.toLocaleDateString(this.locale, Object.assign(format, {
-          timeZone: this.timeZone
-        }))
-      } else if (this.activePicker === 'DATE') {
-        selectorText = selectorDate.getFullYear() + '/'
-        if (selectorDate.getMonth() < 9) selectorText += '0'
-        selectorText += (1 + selectorDate.getMonth())
-      } else if (this.activePicker === 'MONTH') {
-        selectorText = selectorDate.getFullYear()
-      }
+      const pad = n => n < 10 ? `0${n}` : `${n}`
+      const selectorText = this.activePicker === 'DATE'
+        ? this.headerDateFormat(`${this.tableYear}-${pad(this.tableMonth + 1)}`, this.locale)
+        : Date.prototype.toLocaleDateString
+          ? new Date(`${this.tableYear}-01-01 GMT+0`).toLocaleDateString(this.locale, {
+            year: 'numeric',
+            timeZone: 'UTC'
+          }) : this.tableYear
 
       return this.$createElement('div', {
         'class': 'picker--date__header-selector'

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -10,15 +10,9 @@ export default {
           click: e => {
             e.stopPropagation()
             if (this.activePicker === 'DATE') {
-              if (change === 12) {
-                this.tableDate = this.sanitizeDateString(`${this.tableYear + 1}-1`, 'month')
-              } else if (change === -1) {
-                this.tableDate = this.sanitizeDateString(`${this.tableYear - 1}-12`, 'month')
-              } else {
-                this.tableDate = this.sanitizeDateString(`${this.tableYear}-${change + 1}`, 'month')
-              }
+              this.updateTableMonth(change)
             } else if (this.activePicker === 'MONTH') {
-              this.tableDate = this.sanitizeDateString(`${change}`, 'year')
+              this.tableDate = `${change}`
             }
           }
         }

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -18,7 +18,7 @@ export default {
                 this.tableDate = this.sanitizeDateString(`${this.tableYear}-${change + 1}`, 'month')
               }
             } else if (this.activePicker === 'MONTH') {
-              this.tableDate = this.sanitizeDateString(`${change}`, 'month')
+              this.tableDate = this.sanitizeDateString(`${change}`, 'year')
             }
           }
         }
@@ -44,9 +44,8 @@ export default {
 
     genSelector () {
       const keyValue = this.activePicker === 'DATE' ? this.tableMonth : this.tableYear
-      const pad = n => n < 10 ? `0${n}` : `${n}`
       const selectorText = this.activePicker === 'DATE'
-        ? this.headerDateFormat(`${this.tableYear}-${pad(this.tableMonth + 1)}`, this.locale)
+        ? this.headerDateFormat(`${this.tableYear}-${this.tableMonth + 1}`, this.locale)
         : Date.prototype.toLocaleDateString
           ? new Date(`${this.tableYear}-01-01 GMT+0`).toLocaleDateString(this.locale, {
             year: 'numeric',

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -38,13 +38,14 @@ export default {
 
     genSelector () {
       const keyValue = this.activePicker === 'DATE' ? this.tableMonth : this.tableYear
+      // Generates the text of the button switching the active picker in the table header.
+      // For date picker it uses headerDateFormat formatting function (defined by dev or
+      // default). For month picker it uses Date::toLocaleDateString to get the year
+      // in the current locale or just a year numeric value if Date::toLocaleDateString
+      // is not supported
       const selectorText = this.activePicker === 'DATE'
         ? this.headerDateFormat(`${this.tableYear}-${this.tableMonth + 1}`, this.locale)
-        : Date.prototype.toLocaleDateString
-          ? new Date(`${this.tableYear}-01-01 GMT+0`).toLocaleDateString(this.locale, {
-            year: 'numeric',
-            timeZone: 'UTC'
-          }) : this.tableYear
+        : this.yearFormat(`${this.tableYear}`, this.locale)
 
       return this.$createElement('div', {
         'class': 'picker--date__header-selector'

--- a/src/components/VDatePicker/mixins/date-header.js
+++ b/src/components/VDatePicker/mixins/date-header.js
@@ -10,9 +10,15 @@ export default {
           click: e => {
             e.stopPropagation()
             if (this.activePicker === 'DATE') {
-              this.tableDate = this.normalizeDate(this.tableYear, change)
+              if (change === 12) {
+                this.tableDate = this.sanitizeDateString(`${this.tableYear + 1}-1`, 'month')
+              } else if (change === -1) {
+                this.tableDate = this.sanitizeDateString(`${this.tableYear - 1}-12`, 'month')
+              } else {
+                this.tableDate = this.sanitizeDateString(`${this.tableYear}-${change + 1}`, 'month')
+              }
             } else if (this.activePicker === 'MONTH') {
-              this.tableDate = this.normalizeDate(change, this.tableMonth)
+              this.tableDate = this.sanitizeDateString(`${change}-${this.tableMonth + 1}`, 'month')
             }
           }
         }

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -25,7 +25,7 @@ export default {
       this.$nextTick(() => (this.autosave && this.save()))
     },
     dateGenButtonText (day) {
-      return this.supportsLocaleFormat
+      return Date.prototype.toLocaleDateString
         ? new Date(`${this.tableYear}-${this.tableMonth + 1}-${day} GMT+0`).toLocaleDateString(this.locale, {
           day: 'numeric',
           timeZone: 'UTC'

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -36,13 +36,17 @@ export default {
 
       return this.$createElement('td', [button])
     },
+    // Returns number of the days from the firstDayOfWeek to the first day of the current month
+    weekDaysBeforeFirstDayOfTheMonth () {
+      const firstDayOfTheMonth = new Date(`${this.tableYear}-${this.tableMonth + 1}-01 GMT+0`)
+      const weekDay = firstDayOfTheMonth.getUTCDay()
+      return (weekDay - parseInt(this.firstDayOfWeek) + 7) % 7
+    },
     dateGenTBody () {
       const children = []
       const daysInMonth = new Date(this.tableYear, this.tableMonth + 1, 0).getDate()
       let rows = []
-
-      // Use UTC time zone to get the position of the first day of the month relative to the first day of the week
-      const day = (new Date(`${this.tableYear}-${this.tableMonth + 1}-01 GMT+0`).getUTCDay() - parseInt(this.firstDayOfWeek) + 7) % 7
+      const day = this.weekDaysBeforeFirstDayOfTheMonth()
 
       for (let i = 0; i < day; i++) {
         rows.push(this.$createElement('td'))

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -8,27 +8,27 @@ export default {
       if (e.deltaY < 0) month++
       else month--
 
-      this.tableDate = this.normalizeDate(this.tableYear, month)
+      this.tableDate = this.sanitizeDateString(`${this.tableYear}-${month + 1}`, 'month')
     },
     dateGenTHead () {
       const days = this.narrowDays.map(day => this.$createElement('th', day))
       return this.$createElement('thead', this.dateGenTR(days))
     },
     dateClick (day) {
-      this.inputDate = this.normalizeDate(this.tableYear, this.tableMonth, day)
+      this.inputDate = this.sanitizeDateString(`${this.tableYear}-${this.tableMonth + 1}-${day}`, 'date')
       this.$nextTick(() => (this.autosave && this.save()))
     },
-    dateGenButtonText (date, day) {
+    dateGenButtonText (day) {
       return this.supportsLocaleFormat
-        ? date.toLocaleDateString(this.locale, {
+        ? new Date(`${this.tableYear}-${this.tableMonth + 1}-${day} GMT+0`).toLocaleDateString(this.locale, {
           day: 'numeric',
-          timeZone: this.timeZone
+          timeZone: 'UTC'
         })
         : day
     },
     dateGenTD (day) {
-      const date = this.normalizeDate(this.tableYear, this.tableMonth, day)
-      const buttonText = this.dateGenButtonText(date, day)
+      const date = this.sanitizeDateString(`${this.tableYear}-${this.tableMonth + 1}-${day}`, 'date')
+      const buttonText = this.dateGenButtonText(day)
       const button = this.$createElement('button', {
         staticClass: 'btn btn--date-picker btn--floating btn--small btn--flat',
         'class': {
@@ -51,9 +51,9 @@ export default {
     },
     dateGenTBody () {
       const children = []
-      const daysInMonth = this.normalizeDate(this.tableYear, this.tableMonth + 1, 0).getDate()
+      const daysInMonth = new Date(this.tableYear, this.tableMonth + 1, 0).getDate()
       let rows = []
-      const day = (this.normalizeDate(this.tableYear, this.tableMonth).getDay() - parseInt(this.firstDayOfWeek) + 7) % 7
+      const day = (new Date(`${this.tableYear}-${this.tableMonth + 1}-01 GMT+0`).getUTCDay() - parseInt(this.firstDayOfWeek) + 7) % 7
 
       for (let i = 0; i < day; i++) {
         rows.push(this.$createElement('td'))

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -38,7 +38,8 @@ export default {
     },
     // Returns number of the days from the firstDayOfWeek to the first day of the current month
     weekDaysBeforeFirstDayOfTheMonth () {
-      const firstDayOfTheMonth = new Date(`${this.tableYear}-${this.tableMonth + 1}-01 GMT+0`)
+      const pad = n => (n * 1 < 10) ? `0${n * 1}` : `${n}`
+      const firstDayOfTheMonth = new Date(`${this.tableYear}-${pad(this.tableMonth + 1)}-01T00:00:00+00:00`)
       const weekDay = firstDayOfTheMonth.getUTCDay()
       return (weekDay - parseInt(this.firstDayOfWeek) + 7) % 7
     },

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -3,18 +3,7 @@ export default {
     dateWheelScroll (e) {
       e.preventDefault()
 
-      let month = this.tableMonth
-
-      if (e.deltaY < 0) month++
-      else month--
-
-      if (month === 12) {
-        this.tableDate = this.sanitizeDateString(`${this.tableYear + 1}-01`, 'month')
-      } else if (month === -1) {
-        this.tableDate = this.sanitizeDateString(`${this.tableYear - 1}-12`, 'month')
-      } else {
-        this.tableDate = this.sanitizeDateString(`${this.tableYear}-${month + 1}`, 'month')
-      }
+      this.updateTableMonth(e.deltaY < 0 ? this.tableMonth + 1 : this.tableMonth - 1)
     },
     dateGenTHead () {
       const days = this.weekDays.map(day => this.$createElement('th', day))

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -17,7 +17,7 @@ export default {
       }
     },
     dateGenTHead () {
-      const days = this.narrowDays.map(day => this.$createElement('th', day))
+      const days = this.weekDays.map(day => this.$createElement('th', day))
       return this.$createElement('thead', this.dateGenTR(days))
     },
     dateClick (day) {

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -13,17 +13,9 @@ export default {
       this.inputDate = this.sanitizeDateString(`${this.tableYear}-${this.tableMonth + 1}-${day}`, 'date')
       this.$nextTick(() => (this.autosave && this.save()))
     },
-    dateGenButtonText (day) {
-      return Date.prototype.toLocaleDateString
-        ? new Date(`${this.tableYear}-${this.tableMonth + 1}-${day} GMT+0`).toLocaleDateString(this.locale, {
-          day: 'numeric',
-          timeZone: 'UTC'
-        })
-        : day
-    },
     dateGenTD (day) {
       const date = this.sanitizeDateString(`${this.tableYear}-${this.tableMonth + 1}-${day}`, 'date')
-      const buttonText = this.dateGenButtonText(day)
+      const buttonText = this.dayFormat(date, this.locale)
       const button = this.$createElement('button', {
         staticClass: 'btn btn--date-picker btn--floating btn--small btn--flat',
         'class': {
@@ -48,6 +40,8 @@ export default {
       const children = []
       const daysInMonth = new Date(this.tableYear, this.tableMonth + 1, 0).getDate()
       let rows = []
+
+      // Use UTC time zone to get the position of the first day of the month relative to the first day of the week
       const day = (new Date(`${this.tableYear}-${this.tableMonth + 1}-01 GMT+0`).getUTCDay() - parseInt(this.firstDayOfWeek) + 7) % 7
 
       for (let i = 0; i < day; i++) {

--- a/src/components/VDatePicker/mixins/date-table.js
+++ b/src/components/VDatePicker/mixins/date-table.js
@@ -8,7 +8,13 @@ export default {
       if (e.deltaY < 0) month++
       else month--
 
-      this.tableDate = this.sanitizeDateString(`${this.tableYear}-${month + 1}`, 'month')
+      if (month === 12) {
+        this.tableDate = this.sanitizeDateString(`${this.tableYear + 1}-01`, 'month')
+      } else if (month === -1) {
+        this.tableDate = this.sanitizeDateString(`${this.tableYear - 1}-12`, 'month')
+      } else {
+        this.tableDate = this.sanitizeDateString(`${this.tableYear}-${month + 1}`, 'month')
+      }
     },
     dateGenTHead () {
       const days = this.narrowDays.map(day => this.$createElement('th', day))

--- a/src/components/VDatePicker/mixins/date-title.js
+++ b/src/components/VDatePicker/mixins/date-title.js
@@ -12,7 +12,6 @@ export default {
     },
 
     getYearBtn () {
-      const titleDate = this.normalizeDate(this.year, this.month, this.day)
       return this.$createElement('div', {
         'class': {
           'picker--date__title-year': true,
@@ -25,12 +24,7 @@ export default {
           }
         }
       }, [
-        this.supportsLocaleFormat
-          ? titleDate.toLocaleDateString(this.locale, {
-            year: 'numeric',
-            timeZone: this.timeZone
-          })
-          : this.year,
+        this.yearFormat(`${this.year}`, this.locale),
         this.genYearIcon()
       ])
     },

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -20,7 +20,7 @@ export default {
       const children = []
       for (let year = this.year + 100, length = this.year - 100; year > length; year--) {
         const date = new Date(`${year}-1-1 GMT+0`)
-        const buttonText = this.supportsLocaleFormat
+        const buttonText = Date.prototype.toLocaleDateString
           ? date.toLocaleDateString(this.locale, {
             year: 'numeric',
             timeZone: this.timeZone

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -8,7 +8,7 @@ export default {
       }, this.genYearItems())
     },
     yearClick (year) {
-      this.inputDate = this.normalizeDate(year, this.tableMonth, this.day)
+      this.inputDate = this.sanitizeDateString(`${year}-${this.tableMonth + 1}-${this.day}`, this.type)
 
       if (this.type === 'year') {
         this.$nextTick(() => (this.autosave && this.save()))
@@ -19,7 +19,7 @@ export default {
     genYearItems () {
       const children = []
       for (let year = this.year + 100, length = this.year - 100; year > length; year--) {
-        const date = this.normalizeDate(year, this.month, this.day)
+        const date = new Date(`${year}-1-1 GMT+0`)
         const buttonText = this.supportsLocaleFormat
           ? date.toLocaleDateString(this.locale, {
             year: 'numeric',

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -19,13 +19,7 @@ export default {
     genYearItems () {
       const children = []
       for (let year = this.year + 100, length = this.year - 100; year > length; year--) {
-        const date = new Date(`${year}-1-1 GMT+0`)
-        const buttonText = Date.prototype.toLocaleDateString
-          ? date.toLocaleDateString(this.locale, {
-            year: 'numeric',
-            timeZone: 'UTC'
-          })
-          : year
+        const buttonText = this.yearFormat(`${year}`, this.locale)
 
         children.push(this.$createElement('li', {
           'class': {

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -23,7 +23,7 @@ export default {
         const buttonText = Date.prototype.toLocaleDateString
           ? date.toLocaleDateString(this.locale, {
             year: 'numeric',
-            timeZone: this.timeZone
+            timeZone: 'UTC'
           })
           : year
 

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -8,6 +8,7 @@ export default {
       }, this.genYearItems())
     },
     yearClick (year) {
+      // Updates inputDate setting 'YYYY-MM' or 'YYYY-MM-DD' format, depending on the picker type
       this.inputDate = this.sanitizeDateString(`${year}-${this.tableMonth + 1}-${this.day}`, this.type)
 
       if (this.type === 'year') {

--- a/src/components/VDatePicker/mixins/date-years.js
+++ b/src/components/VDatePicker/mixins/date-years.js
@@ -8,12 +8,14 @@ export default {
       }, this.genYearItems())
     },
     yearClick (year) {
-      // Updates inputDate setting 'YYYY-MM' or 'YYYY-MM-DD' format, depending on the picker type
-      this.inputDate = this.sanitizeDateString(`${year}-${this.tableMonth + 1}-${this.day}`, this.type)
-
       if (this.type === 'year') {
+        this.inputDate = `${year}`
         this.$nextTick(() => (this.autosave && this.save()))
+      } else if (this.type === 'month') {
+        this.inputDate = this.sanitizeDateString(`${year}-${this.month + 1}`, 'month')
+        this.activePicker = 'MONTH'
       } else {
+        this.inputDate = this.sanitizeDateString(`${year}-${this.tableMonth + 1}-${this.day}`, 'date')
         this.activePicker = 'MONTH'
       }
     },

--- a/src/components/VDatePicker/mixins/month-table.js
+++ b/src/components/VDatePicker/mixins/month-table.js
@@ -19,21 +19,9 @@ export default {
       }
     },
     monthGenTD (month) {
-      const date = this.normalizeDate(this.tableYear, month)
-      let monthName
-
-      if (typeof this.monthFormat === 'function') {
-        monthName = this.monthFormat(date)
-      } else if (this.supportsLocaleFormat) {
-        monthName = date.toLocaleDateString(this.locale, Object.assign(this.monthFormat, {
-          timeZone: this.timeZone
-        }))
-      } else {
-        monthName = date.getMonth() + 1
-        if (monthName < 10) {
-          monthName = `0${monthName}`
-        }
-      }
+      const pad = n => n < 10 ? `0${n}` : `${n}`
+      const date = `${this.tableYear}-${pad(month + 1)}`
+      const monthName = this.monthFormat(date, this.locale)
 
       return this.$createElement('td', [
         this.$createElement('button', {

--- a/src/components/VDatePicker/mixins/month-table.js
+++ b/src/components/VDatePicker/mixins/month-table.js
@@ -8,10 +8,13 @@ export default {
       if (e.deltaY < 0) year++
       else year--
 
-      this.tableDate = this.normalizeDate(year)
+      this.tableDate = this.sanitizeDateString(year, 'year')
     },
     monthClick (month) {
-      this.inputDate = this.normalizeDate(this.tableYear, month, this.day)
+      this.inputDate = this.type === 'date'
+        ? this.sanitizeDateString(`${this.tableYear}-${month + 1}-${this.day}`, this.type)
+        : this.sanitizeDateString(`${this.tableYear}-${month + 1}`, this.type)
+
       if (this.type === 'date') {
         this.activePicker = 'DATE'
       } else {

--- a/src/components/VDatePicker/mixins/month-table.js
+++ b/src/components/VDatePicker/mixins/month-table.js
@@ -23,7 +23,7 @@ export default {
       }
     },
     monthGenTD (month) {
-      const pad = n => n < 10 ? `0${n}` : `${n}`
+      const pad = n => (n * 1 < 10) ? `0${n * 1}` : `${n}`
       const date = `${this.tableYear}-${pad(month + 1)}`
       const monthName = this.monthFormat(date, this.locale)
 

--- a/src/components/VDatePicker/mixins/month-table.js
+++ b/src/components/VDatePicker/mixins/month-table.js
@@ -11,6 +11,7 @@ export default {
       this.tableDate = `${year}`
     },
     monthClick (month) {
+      // Updates inputDate setting 'YYYY-MM' or 'YYYY-MM-DD' format, depending on the picker type
       this.inputDate = this.type === 'date'
         ? this.sanitizeDateString(`${this.tableYear}-${month + 1}-${this.day}`, this.type)
         : this.sanitizeDateString(`${this.tableYear}-${month + 1}`, this.type)

--- a/src/components/VDatePicker/mixins/month-table.js
+++ b/src/components/VDatePicker/mixins/month-table.js
@@ -8,7 +8,7 @@ export default {
       if (e.deltaY < 0) year++
       else year--
 
-      this.tableDate = this.sanitizeDateString(year, 'year')
+      this.tableDate = this.sanitizeDateString(`${year}`, 'year')
     },
     monthClick (month) {
       this.inputDate = this.type === 'date'

--- a/src/components/VDatePicker/mixins/month-table.js
+++ b/src/components/VDatePicker/mixins/month-table.js
@@ -8,7 +8,7 @@ export default {
       if (e.deltaY < 0) year++
       else year--
 
-      this.tableDate = this.sanitizeDateString(`${year}`, 'year')
+      this.tableDate = `${year}`
     },
     monthClick (month) {
       this.inputDate = this.type === 'date'


### PR DESCRIPTION
Besides solving the problem with time zones on Chrome/OSX it also introduces few minor breaking changes:

- removes `dateFormat` and `formattedValue` props - setting `dateFormat` prop only to send a function to Vuetify, call it and get the result back doesn't make sense to me, dev can just run the formatting function by himself on the model
- all input/output values are strings, `value`, `allowedDates` etc must be strings in `YYYY-MM-DD` or `YYYY-MM` format

Fixes #2022 
Fixes #2173