### PR TITLE
removes hover styles for links and buttons

### DIFF
--- a/src/stylus/components/_app.styl
+++ b/src/stylus/components/_app.styl
@@ -18,9 +18,4 @@ application($material)
   a
     color: $material.text.link
 
-    &:hover,
-    &:focus,
-    &:active
-      color: $material.text.link-hover
-
 app(application)

--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -337,8 +337,3 @@ theme(button, "btn")
   &.warning,
   &.info
     color: $material-dark.text.primary
-
-    &:hover,
-    &:focus,
-    &:active
-      color: $material-dark.text.primary


### PR DESCRIPTION
Fixes #2105 

Reverting to 0.16.1 version where links didn't have hover styles at all. This removes also hover styles from breadcrumbs (which are just links) and buttons (hence no need to override it in _buttons.styl) and navigation links

In 0.16.1 afair breadcrumbs had their own hover styles but they also didn't play well with dark theme



