### PR TITLE
Tooltip shouldn't close dependents

### DIFF
--- a/src/components/VTooltip/VTooltip.js
+++ b/src/components/VTooltip/VTooltip.js
@@ -14,7 +14,8 @@ export default {
   mixins: [Colorable, Delayable, Dependent, Detachable, Menuable, Toggleable],
 
   data: () => ({
-    calculatedMinWidth: 0
+    calculatedMinWidth: 0,
+    closeDependents: false
   }),
 
   props: {


### PR DESCRIPTION
Reproduction:
https://codepen.io/jayblanchard/pen/WZJvRG?editors=1010

Hover over button, click to show menu, move mouse onto menu, tooltip goes away and takes menu with it.

I can't think of a scenario where a tooltip should be responsible for closing dependent elements.  So maybe a larger question is, should VTooltip actually implement Dependent mixin at all?