### PR TITLE
Check v-select checkbox even if the item is disabled

### DIFF
--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -262,7 +262,7 @@ export default {
       }
 
       return this.$createElement('v-list-tile', data,
-        [this.genAction(item, active && !disabled), this.genContent(item)]
+        [this.genAction(item, active), this.genContent(item)]
       )
     },
     genAction (item, active) {


### PR DESCRIPTION
Checkboxes in disabled list-tiles are already styled differently, so there's no
reason to uncheck them too

Fixes #2113

![image](https://user-images.githubusercontent.com/16421948/31425993-43a354ac-aead-11e7-9714-e8222b88b3af.png)
