### PR TITLE
Partially fix #2133: Double Jeopardy, one input should be tested invalid against only one rule

### DIFF
--- a/src/mixins/validatable.js
+++ b/src/mixins/validatable.js
@@ -104,7 +104,7 @@ export default {
 
       this.errorBucket = []
 
-      this.rules.forEach(rule => {
+      return this.valid = this.rules.every(rule => {
         const valid = typeof rule === 'function' ? rule(value) : rule
 
         if (valid !== true && !['string', 'boolean'].includes(typeof valid)) {
@@ -113,12 +113,11 @@ export default {
 
         if (valid !== true) {
           this.errorBucket.push(valid)
+          return false
         }
+
+        return true
       })
-
-      this.valid = this.errorBucket.length === 0
-
-      return this.valid
     }
   }
 }


### PR DESCRIPTION
One input should be tested invalid against only one rule.
If a rule tells that the input is invalid, other rules should be ignored for testing.