### PR TITLE
Fix/2146

### DIFF
--- a/src/directives/click-outside.js
+++ b/src/directives/click-outside.js
@@ -54,14 +54,18 @@ export default {
   bind (el, binding, v) {
     v.context.$vuetify.load(() => {
       const onClick = e => directive(e, el, binding, v)
-      // Use capturing event so we avoid being blocked by 
-      // stopPropagation in bubbling phase
-      document.addEventListener('click', onClick, true)
+      // iOS does not recognize click events on document
+      // or body, this is the entire purpose of the v-app
+      // component and [data-app], stop removing this
+      const app = document.querySelector('[data-app]') ||
+        document.body // This is only for unit tests
+      app.addEventListener('click', onClick, true)
       el._clickOutside = onClick
     })
   },
 
   unbind (el) {
-    document.removeEventListener('click', el._clickOutside, true)
+    const app = document.querySelector('[data-app]')
+    app && app.removeEventListener('click', el._clickOutside, true)
   }
 }

--- a/src/directives/click-outside.js
+++ b/src/directives/click-outside.js
@@ -65,7 +65,8 @@ export default {
   },
 
   unbind (el) {
-    const app = document.querySelector('[data-app]')
+    const app = document.querySelector('[data-app]') ||
+      document.body // This is only for unit tests
     app && app.removeEventListener('click', el._clickOutside, true)
   }
 }

--- a/src/mixins/dependent.js
+++ b/src/mixins/dependent.js
@@ -27,6 +27,7 @@ export default {
     },
     getOpenDependentElements () {
       const result = []
+
       for (const dependent of this.getOpenDependents()) {
         result.push(...dependent.getClickableDependentElements())
       }

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -6,7 +6,7 @@ export default {
       overlay: null,
       overlayOffset: 0,
       overlayTimeout: null,
-      overlayTransitionDuration: 500
+      overlayTransitionDuration: 500 + 150 // transition + delay
     }
   },
 
@@ -37,21 +37,22 @@ export default {
       this.overlay.className = 'overlay'
 
       if (this.absolute) this.overlay.className += ' overlay--absolute'
-      if (this.activeZIndex !== undefined) this.overlay.style.zIndex = this.activeZIndex - 1
 
       this.hideScroll()
 
-      if (this.absolute) {
-        // Required for IE11
-        const parent = this.$el.parentNode
-        parent.insertBefore(this.overlay, parent.firstChild)
-      } else {
-        document.querySelector('[data-app]').appendChild(this.overlay)
-      }
+      const parent = this.absolute
+        ? this.$el.parentNode
+        : document.querySelector('[data-app]')
+
+      parent.insertBefore(this.overlay, parent.firstChild)
 
       this.overlay.clientHeight // Force repaint
       requestAnimationFrame(() => {
         this.overlay.className += ' overlay--active'
+
+        if (this.activeZIndex !== undefined) {
+          this.overlay.style.zIndex = this.activeZIndex - 1
+        }
       })
 
       return true

--- a/src/mixins/stackable.js
+++ b/src/mixins/stackable.js
@@ -13,28 +13,33 @@ export default {
   computed: {
     activeZIndex () {
       const content = this.stackElement || this.$refs.content
-      if (!this.isActive) {
-        // Return current zindex if not active
+      // Return current zindex if not active
+      if (!this.isActive) return getZIndex(content)
 
-        return getZIndex(content)
-      }
-      // Return max current z-index (excluding self) + 2 (2 to leave room for an overlay below, if needed)
-
-      return this.getMaxZIndex((this.stackExclude || (() => [content]))()) + 2
+      // Return max current z-index (excluding self) + 2
+      // (2 to leave room for an overlay below, if needed)
+      return this.getMaxZIndex(this.stackExclude || [content]) + 2
     }
   },
   methods: {
     getMaxZIndex (exclude = []) {
       const base = this.stackBase || this.$el
-      // start with lowest allowed z-index or z-index of base component's element, whichever is greater
+      // start with lowest allowed z-index or z-index of
+      // base component's element, whichever is greater
       const zis = [this.stackMinZIndex, getZIndex(base)]
       // get z-index for all active dialogs
-      const activeElements = document.getElementsByClassName(this.stackClass)
-      for (const activeElement of activeElements) {
+      const activeElements = [...document.getElementsByClassName(this.stackClass)]
+
+      // Changed to forEach due to
+      // Symbol iterator bug with
+      // Edge when there are 0
+      // active elements
+      // https://github.com/vuetifyjs/vuetify/issues/2146
+      activeElements.forEach(activeElement => {
         if (!exclude.includes(activeElement)) {
           zis.push(getZIndex(activeElement))
         }
-      }
+      })
 
       return Math.max(...zis)
     }

--- a/src/mixins/stackable.js
+++ b/src/mixins/stackable.js
@@ -24,22 +24,20 @@ export default {
   methods: {
     getMaxZIndex (exclude = []) {
       const base = this.stackBase || this.$el
-      // start with lowest allowed z-index or z-index of
+      // Start with lowest allowed z-index or z-index of
       // base component's element, whichever is greater
       const zis = [this.stackMinZIndex, getZIndex(base)]
-      // get z-index for all active dialogs
+      // Convert the NodeList to an array to
+      // prevent an Edge bug with Symbol.iterator
+      // https://github.com/vuetifyjs/vuetify/issues/2146
       const activeElements = [...document.getElementsByClassName(this.stackClass)]
 
-      // Changed to forEach due to
-      // Symbol iterator bug with
-      // Edge when there are 0
-      // active elements
-      // https://github.com/vuetifyjs/vuetify/issues/2146
-      activeElements.forEach(activeElement => {
+      // Get z-index for all active dialogs
+      for (const activeElement of activeElements) {
         if (!exclude.includes(activeElement)) {
           zis.push(getZIndex(activeElement))
         }
-      })
+      }
 
       return Math.max(...zis)
     }

--- a/src/stylus/components/_overlay.styl
+++ b/src/stylus/components/_overlay.styl
@@ -7,6 +7,12 @@
   right: 0
   bottom: 0
   pointer-events: none
+  // The overlay has a dynamically set
+  // z-index, we want the transition
+  // timing to affect its changing
+  // https://github.com/vuetifyjs/vuetify/issues/2146
+  transition: .5s $transition.swing
+  // This is the standard index
   z-index: 5
 
   &--absolute
@@ -22,7 +28,12 @@
     position: absolute
     right: 0
     top: 0
-    transition: .5s ease
+    transition: inherit
+    // Delay the transition to avoid a
+    // rendering bug that is visible
+    // within Edge and Firefox
+    // https://github.com/vuetifyjs/vuetify/issues/2146
+    transition-delay: 150ms
     width: 100%
 
   &--active


### PR DESCRIPTION
Fixes #2146

Handles edge case where the Edge browser is unable to iterate an empty HTMLElementList, causing a fatal Symbol.iterator.

Also fixed a bug where the #1932 PR removed the logic that bound click events to `v-app`. This caused an issue on iOS devices not firing **click-outside** events.