### PR TITLE
Option to set v-data-table header width

### DIFF
--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -49,6 +49,7 @@ export default {
         attrs: {
           role: 'columnheader',
           scope: 'col',
+          width: header.width || null,
           'aria-label': header[this.headerText] || '',
           'aria-sort': 'none'
         }


### PR DESCRIPTION
This PR will allow to set the header width in % or px, for example:

```
headers: [
  { text: 'Dessert (100g serving)', value: 'name', width: '20%'},
  { text: 'Calories', value: 'calories', width: '50%' },
  { text: 'Fat (g)', value: 'fat' },
  { text: 'Carbs (g)', value: 'carbs', width: '200px' },
],
```

Fixes #1856 