### PR TITLE
fix: Fixed select blur in Edge

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -181,7 +181,7 @@ export default {
      * @return {Number}
      */
     currentRange () {
-      return (this.selectedItem || '').length
+      return this.getText(this.selectedItem || '').length
     },
     filteredItems () {
       // If we are not actively filtering

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -175,6 +175,14 @@ export default {
     computedItems () {
       return this.filterDuplicates(this.cachedItems.concat(this.items))
     },
+    /**
+     * The range of the current input text
+     * 
+     * @return {Number}
+     */
+    currentRange () {
+      return (this.selectedItem || '').length
+    },
     filteredItems () {
       // If we are not actively filtering
       // Show all available items
@@ -264,17 +272,14 @@ export default {
       })
     },
     isFocused (val) {
-      // Always ensure caret is
-      // in correct position
+      // When focusing the input
+      // re-set the caret position
       if (this.isAutocomplete &&
         !this.mask &&
-        !this.isMultiple
+        !this.isMultiple &&
+        val
       ) {
-        const len = (this.selectedItem || '').length
-
-        requestAnimationFrame(() => {
-          this.$refs.input.setSelectionRange(len, len)
-        })
+        this.setCaretPosition(this.currentRange)
       }
     },
     items (val) {
@@ -580,8 +585,12 @@ export default {
       const savedIndex = this.$refs.menu.listIndex
       this.$refs.menu.listIndex = -1
 
+      // After selecting an item
+      // refocus the input and
+      // reset the caret pos
       this.$nextTick(() => {
         this.focus()
+        this.setCaretPosition(this.currentRange)
         this.$refs.menu && (this.$refs.menu.listIndex = savedIndex)
       })
     },


### PR DESCRIPTION
Fixed a bug where when trying to blur a `v-select` component it would immediately refocus when using
the Edge browser

fixes #2152