### PR TITLE
feat: add disabled prop for tooltips

### DIFF
--- a/src/components/VTooltip/VTooltip.js
+++ b/src/components/VTooltip/VTooltip.js
@@ -23,6 +23,7 @@ export default {
       type: [Number, String],
       default: 0
     },
+    disabled: Boolean,
     fixed: {
       type: Boolean,
       default: true

--- a/src/components/VTooltip/VTooltip.js
+++ b/src/components/VTooltip/VTooltip.js
@@ -147,7 +147,7 @@ export default {
         }
       }, [tooltip]),
       h('span', {
-        on: {
+        on: this.disabled ? {} : {
           mouseenter: () => {
             this.runDelay('open', () => (this.isActive = true))
           },


### PR DESCRIPTION
Currently there is no way to programmaticaly disable tooltip

fixes #2002