### PR TITLE
fix: Hide text field in blurred autocomplete v-selects

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -274,6 +274,7 @@ export default {
 
         requestAnimationFrame(() => {
           this.$refs.input.setSelectionRange(len, len)
+          this.shouldBreak && (this.$refs.input.scrollLeft = this.$refs.input.scrollWidth)
         })
       }
     },

--- a/src/stylus/components/_select.styl
+++ b/src/stylus/components/_select.styl
@@ -4,7 +4,7 @@
   // TODO: revisit this
   .input-group--select__autocomplete
     display: block
-    padding-bottom: 1px
+    height: 0px
 
     &--index
       opacity: 0 !important
@@ -18,6 +18,7 @@
   &.input-group--focused
     .input-group--select__autocomplete
       display: inline-block
+      padding-bottom: 1px
       height: 30px
       opacity: 1
 
@@ -42,7 +43,7 @@
     &__comma
       display: inline-flex
       font-size: 16px
-      padding-right: 4px
+      padding: 3px 4px 3px 0
 
       &--active
         color: inherit
@@ -57,6 +58,10 @@
   &.input-group--autocomplete.input-group--search-focused
     .input-group__selections__comma
       display: none
+
+.input-group--autocomplete
+  .input-group__selections
+    cursor: text
 
 
 .input-group


### PR DESCRIPTION
The extra padding on input-group__selections__comma is to prevent a jump
in line height when the element is focused

 - Also scroll to the end when focusing autocomplete selects that have
   overflow

Fixes #1691