### PR TITLE
fix: trigger swipe events only for proper swiping angle

### DIFF
--- a/src/directives/touch.js
+++ b/src/directives/touch.js
@@ -28,19 +28,20 @@ const touchmove = (event, wrapper) => {
 
 const handleGesture = (wrapper) => {
   const { touchstartX, touchendX, touchstartY, touchendY } = wrapper
+  const dirRatio = 0.5
   wrapper.offsetX = touchendX - touchstartX
   wrapper.offsetY = touchendY - touchstartY
 
-  if (touchendX < touchstartX) {
+  if (touchendX < touchstartX && Math.abs(wrapper.offsetY / wrapper.offsetX) < dirRatio) {
     wrapper.left && wrapper.left(wrapper)
   }
-  if (touchendX > touchstartX) {
+  if (touchendX > touchstartX && Math.abs(wrapper.offsetY / wrapper.offsetX) < dirRatio) {
     wrapper.right && wrapper.right(wrapper)
   }
-  if (touchendY < touchstartY) {
+  if (touchendY < touchstartY && Math.abs(wrapper.offsetX / wrapper.offsetY) < dirRatio) {
     wrapper.up && wrapper.up(wrapper)
   }
-  if (touchendY > touchstartY) {
+  if (touchendY > touchstartY && Math.abs(wrapper.offsetX / wrapper.offsetY) < dirRatio) {
     wrapper.down && wrapper.down(wrapper)
   }
 }

--- a/src/directives/touch.js
+++ b/src/directives/touch.js
@@ -32,17 +32,14 @@ const handleGesture = (wrapper) => {
   wrapper.offsetX = touchendX - touchstartX
   wrapper.offsetY = touchendY - touchstartY
 
-  if (touchendX < touchstartX && Math.abs(wrapper.offsetY / wrapper.offsetX) < dirRatio) {
-    wrapper.left && wrapper.left(wrapper)
+  if (Math.abs(wrapper.offsetY) < dirRatio * Math.abs(wrapper.offsetX)) {
+    wrapper.left && (touchendX < touchstartX) && wrapper.left(wrapper)
+    wrapper.right && (touchendX > touchstartX) && wrapper.right(wrapper)
   }
-  if (touchendX > touchstartX && Math.abs(wrapper.offsetY / wrapper.offsetX) < dirRatio) {
-    wrapper.right && wrapper.right(wrapper)
-  }
-  if (touchendY < touchstartY && Math.abs(wrapper.offsetX / wrapper.offsetY) < dirRatio) {
-    wrapper.up && wrapper.up(wrapper)
-  }
-  if (touchendY > touchstartY && Math.abs(wrapper.offsetX / wrapper.offsetY) < dirRatio) {
-    wrapper.down && wrapper.down(wrapper)
+
+  if (Math.abs(wrapper.offsetX) < dirRatio * Math.abs(wrapper.offsetY)) {
+    wrapper.up && (touchendY < touchstartY) && wrapper.up(wrapper)
+    wrapper.down && (touchendY > touchstartY) && wrapper.down(wrapper)
   }
 }
 

--- a/src/directives/touch.js
+++ b/src/directives/touch.js
@@ -29,17 +29,18 @@ const touchmove = (event, wrapper) => {
 const handleGesture = (wrapper) => {
   const { touchstartX, touchendX, touchstartY, touchendY } = wrapper
   const dirRatio = 0.5
+  const minDistance = 16
   wrapper.offsetX = touchendX - touchstartX
   wrapper.offsetY = touchendY - touchstartY
 
   if (Math.abs(wrapper.offsetY) < dirRatio * Math.abs(wrapper.offsetX)) {
-    wrapper.left && (touchendX < touchstartX) && wrapper.left(wrapper)
-    wrapper.right && (touchendX > touchstartX) && wrapper.right(wrapper)
+    wrapper.left && (touchendX < touchstartX - minDistance) && wrapper.left(wrapper)
+    wrapper.right && (touchendX > touchstartX + minDistance) && wrapper.right(wrapper)
   }
 
   if (Math.abs(wrapper.offsetX) < dirRatio * Math.abs(wrapper.offsetY)) {
-    wrapper.up && (touchendY < touchstartY) && wrapper.up(wrapper)
-    wrapper.down && (touchendY > touchstartY) && wrapper.down(wrapper)
+    wrapper.up && (touchendY < touchstartY - minDistance) && wrapper.up(wrapper)
+    wrapper.down && (touchendY > touchstartY + minDistance) && wrapper.down(wrapper)
   }
 }
 


### PR DESCRIPTION
Swipe event should be triggered only where there is no doubt that user
wants to swipe in the specified direction

fixes #2125