### PR TITLE
feat: inherit checkbox/text color of selected item from v-select

### DIFF
--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -37,7 +37,7 @@ exports[`VSelect should render buttons correctly when using items array with seg
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link list__tile--active"
+                 class="list__tile list__tile--link primary--text"
               >
                 <div class="list__tile__content">
                   <div class="list__tile__title">
@@ -97,7 +97,7 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link list__tile--active"
+                 class="list__tile list__tile--link primary--text"
               >
                 <div class="list__tile__content">
                   <div class="list__tile__title">

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -33,13 +33,13 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link list__tile--active"
+                 class="list__tile list__tile--link primary--text"
               >
                 <div class="list__tile__action list__tile__action--select-multi">
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="true"
-                       class="input-group input-group--dirty checkbox input-group--selection-controls input-group--active"
+                       class="input-group input-group--dirty checkbox input-group--selection-controls input-group--active primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control fade-transition-leave fade-transition-leave-active">
@@ -74,7 +74,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls"
+                       class="input-group checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control">
@@ -150,7 +150,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls"
+                       class="input-group checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control icon--checkbox fade-transition-leave fade-transition-leave-active"
@@ -187,7 +187,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls"
+                       class="input-group checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control">
@@ -260,7 +260,7 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link list__tile--active"
+                 class="list__tile list__tile--link primary--text"
               >
                 <div class="list__tile__content">
                   <div class="list__tile__title">

--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -258,6 +258,10 @@ export default {
         data.props.disabled = disabled
       }
 
+      if (this.color && this.addTextColorClassChecks) {
+        data.props.activeClass = Object.keys(this.addTextColorClassChecks({})).join(' ')
+      }
+
       if (this.$scopedSlots.item) {
         return this.$createElement('v-list-tile', data,
           [this.$scopedSlots.item({ parent: this, item })]
@@ -282,7 +286,12 @@ export default {
       }
 
       return this.$createElement('v-list-tile-action', data, [
-        this.$createElement('v-checkbox', { props: { inputValue: active } })
+        this.$createElement('v-checkbox', {
+          props: {
+            color: this.color,
+            inputValue: active
+          }
+        })
       ])
     },
     genContent (item) {


### PR DESCRIPTION
This commit changes also the default colors of list tiles from teal
(checkbox) and primary/accent (text) to primary (default color of select),
so it may need a discussion

see #2174

### Playground.vue:
```vue
<template>
  <v-app>
    <main>
      <v-content>
        <v-container>
          <v-select v-bind:items="items" color="green lighten-2" v-model="select" label="Select" single-line item-text="state" item-value="abbr" return-object></v-select>
          <v-select v-bind:items="items" color="green lighten-2" multiple v-model="select2" label="Select" single-line item-text="state" item-value="abbr" return-object></v-select>
          <v-select v-bind:items="items" v-model="select" label="Select" single-line item-text="state" item-value="abbr" return-object></v-select>
          <v-select v-bind:items="items" multiple v-model="select2" label="Select" single-line item-text="state" item-value="abbr" return-object></v-select>
        </v-container>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data () {
    return {
      select: { state: 'Florida', abbr: 'FL' },
      select2: [{ state: 'Florida', abbr: 'FL' }],
      items: [
        { state: 'Florida', abbr: 'FL' },
        { state: 'Georgia', abbr: 'GA' },
        { state: 'Nebraska', abbr: 'NE' },
        { state: 'California', abbr: 'CA' },
        { state: 'New York', abbr: 'NY' }
      ]
    }
  }
}
</script>
```

`<v-select color="green lighten-2">`
![image](https://user-images.githubusercontent.com/15625235/31585090-a77aed2e-b1e5-11e7-926a-b706238fcdd4.png)

`<v-select>` (no `color` prop)
![image](https://user-images.githubusercontent.com/15625235/31585092-c93d1b94-b1e5-11e7-882e-0006622efb23.png)
