### PR TITLE
enhancement/carousel

### DIFF
--- a/src/components/VCarousel/VCarousel.js
+++ b/src/components/VCarousel/VCarousel.js
@@ -36,11 +36,12 @@ export default {
       type: Boolean,
       default: true
     },
-    hideControls: Boolean,
-    icon: {
+    delimiterIcon: {
       type: String,
       default: 'fiber_manual_record'
     },
+    hideControls: Boolean,
+    hideDelimiters: Boolean,
     interval: {
       type: [Number, String],
       default: 6000,
@@ -90,7 +91,7 @@ export default {
   },
 
   methods: {
-    genControls () {
+    genDelimiters () {
       return this.$createElement('div', {
         staticClass: 'carousel__controls'
       }, this.genItems())
@@ -125,7 +126,7 @@ export default {
           },
           key: index,
           on: { click: this.select.bind(this, index) }
-        }, [this.$createElement(VIcon, this.icon)])
+        }, [this.$createElement(VIcon, this.delimiterIcon)])
       })
     },
     restartTimeout () {
@@ -174,9 +175,9 @@ export default {
         }
       }]
     }, [
-      this.genIcon('left', this.leftControlIcon, this.prev),
-      this.genIcon('right', this.rightControlIcon, this.next),
-      this.hideControls ? null : this.genControls(),
+      this.hideControls ? null : this.genIcon('left', this.leftControlIcon, this.prev),
+      this.hideControls ? null : this.genIcon('right', this.rightControlIcon, this.next),
+      this.hideDelimiters ? null : this.genDelimiters(),
       this.$slots.default
     ])
   }

--- a/src/components/VCarousel/VCarousel.js
+++ b/src/components/VCarousel/VCarousel.js
@@ -15,6 +15,13 @@ export default {
 
   directives: { Touch },
 
+  provide () {
+    return {
+      register: this.register,
+      unregister: this.unregister
+    }
+  },
+
   data () {
     return {
       inputValue: null,
@@ -54,14 +61,10 @@ export default {
     inputValue () {
       // Evaluate items when inputValue changes to account for
       // dynamic changing of children
-      this.items = this.$children.filter(i => {
-        return i.$el.classList && i.$el.classList.contains('carousel__item')
-      })
 
-      this.items.forEach(i => i.open(
-        this.items[this.inputValue]._uid,
-        this.reverse
-      ))
+      this.items.forEach(i => {
+        i.open(this.items[this.inputValue].uid, this.reverse)
+      })
 
       this.$emit('input', this.inputValue)
       this.restartTimeout()
@@ -151,6 +154,12 @@ export default {
       if (!this.cycle) return
 
       this.slideTimeout = setTimeout(() => this.next(), this.interval > 0 ? this.interval : 6000)
+    },
+    register (uid, open) {
+      this.items.push({ uid, open })
+    },
+    unregister (uid) {
+      this.items = this.items.filter(i => i.uid !== uid)
     }
   },
 

--- a/src/components/VCarousel/VCarousel.spec.js
+++ b/src/components/VCarousel/VCarousel.spec.js
@@ -1,100 +1,112 @@
-import VCarousel from '~components/VCarousel'
+import VCarousel from './VCarousel'
 import VCarouselItem from './VCarouselItem'
 import { test } from '~util/testing'
+import Vue from 'vue'
+
+const create = (props = {}, slots = 3) => Vue.component('zxc', {
+  functional: true,
+  render (h) {
+    const items = []
+    for (let i = 0; i < slots; i++) {
+      items.push(h(VCarouselItem, { props: { src: `${i + 1}` } }))
+    }
+    return h(VCarousel, { props }, items)
+  }
+})
 
 test('VCarousel.js', ({ mount }) => {
-  it('should render component and match snapshot', () => {
+  it('should render component and match snapshot', async () => {
     const wrapper = mount(VCarousel)
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with image cycling off and match snapshot', () => {
+  it('should render component with image cycling off and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
         cycle: false
       }
     })
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom icon and match snapshot', () => {
-    const wrapper = mount(VCarousel, {
-      propsData: {
-        icon: 'stop'
-      }
+  it('should render component with custom icon and match snapshot', async () => {
+    const component = create({
+      delimiterIcon: 'stop'
     })
+    const wrapper = mount(component)
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom duration between image cycles and match snapshot', () => {
+  it('should render component with custom duration between image cycles and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
         interval: 1000
       }
     })
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom left control icon and match snapshot', () => {
+  it('should render component with custom left control icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
         leftControlIcon: 'stop'
       }
     })
+    await wrapper.vm.$nextTick()
 
+    expect(wrapper.find('.carousel__left .icon')[0].text()).toBe('stop')
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component without left control icon and match snapshot', () => {
+  it('should render component without left control icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
         leftControlIcon: false
       }
     })
+    await wrapper.vm.$nextTick()
 
+    expect(wrapper.contains('.carousel__left')).toBe(false)
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom right control icon and match snapshot', () => {
+  it('should render component with custom right control icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
         rightControlIcon: 'stop'
       }
     })
+    await wrapper.vm.$nextTick()
 
+    expect(wrapper.find('.carousel__right .icon')[0].text()).toBe('stop')
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component without right control icon and match snapshot', () => {
+  it('should render component without right control icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
         rightControlIcon: false
       }
     })
+    await wrapper.vm.$nextTick()
 
+    expect(wrapper.contains('.carousel__right')).toBe(false)
     expect(wrapper.html()).toMatchSnapshot()
   })
 
   it('should render component with selected active item', async () => {
-    const vm = mount(VCarousel).vm
-    const wrapper = mount(VCarousel, {
-      propsData: {
-        value: 1
-      },
-      slots: {
-        default: [1, 2, 3].map(i => {
-          return {
-            vNode: vm.$createElement(VCarouselItem, { attrs: { src: i.toString() } })
-          }
-        })
-      }
-    })
-
+    const component = create({ value: 1 })
+    const wrapper = mount(component)
     await wrapper.vm.$nextTick()
+
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -124,5 +136,14 @@ test('VCarousel.js', ({ mount }) => {
     })
 
     expect([].concat(...input.mock.calls)).toEqual([1, 2, 0])
+  })
+
+  it('should render component without delimiters', async () => {
+    const component = create({ hideDelimiters: true })
+    const wrapper = mount(component)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.contains('carousel__controls')).toBe(false)
+    expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/src/components/VCarousel/VCarouselItem.js
+++ b/src/components/VCarousel/VCarouselItem.js
@@ -1,5 +1,5 @@
 const injectWarning = () => {
-  return () => console.warn('The v-carousel-item omponent is not meant to be used outside of a v-carousel.')
+  return () => console.warn('The v-carousel-item component is not meant to be used outside of a v-carousel.')
 }
 
 export default {

--- a/src/components/VCarousel/VCarouselItem.js
+++ b/src/components/VCarousel/VCarouselItem.js
@@ -1,5 +1,18 @@
+const injectWarning = () => {
+  return () => console.warn('The v-carousel-item omponent is not meant to be used outside of a v-carousel.')
+}
+
 export default {
   name: 'v-carousel-item',
+
+  inject: {
+    register: {
+      default: injectWarning
+    },
+    unregister: {
+      default: injectWarning
+    }
+  },
 
   data () {
     return {
@@ -42,6 +55,14 @@ export default {
       this.active = this._uid === id
       this.reverse = reverse
     }
+  },
+
+  mounted () {
+    this.register(this._uid, this.open)
+  },
+
+  beforeDestroy () {
+    this.unregister(this._uid, this.open)
   },
 
   render (h) {

--- a/src/components/VCarousel/VCarouselItem.spec.js
+++ b/src/components/VCarousel/VCarouselItem.spec.js
@@ -1,9 +1,20 @@
-import { mount } from 'avoriaz'
+import { test } from '~util/testing'
 import { VCarouselItem } from '~components/VCarousel'
 
 const imageSrc = 'https://vuetifyjs.com/static/doc-images/cards/sunshine.jpg'
+const warning = 'The v-carousel-item component is not meant to be used outside of a v-carousel.'
 
-describe('VCarouselItem.js', () => {
+test('VCarouselItem.js', ({ mount }) => {
+  it('should throw warning when not used inside v-carousel', () => {
+    const wrapper = mount(VCarouselItem, {
+      propsData: {
+        src: imageSrc
+      }
+    })
+
+    expect(warning).toHaveBeenTipped()
+  })
+
   it('should render component and match snapshot', () => {
     const wrapper = mount(VCarouselItem, {
       propsData: {
@@ -12,27 +23,6 @@ describe('VCarouselItem.js', () => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-  })
-
-  it('should render component with custom transition and match snapshot', () => {
-    const wrapper = mount(VCarouselItem, {
-      propsData: {
-        src: imageSrc,
-        transition: 'slide-y-transition'
-      }
-    })
-
-    expect(wrapper.html()).toMatchSnapshot()
-  })
-
-  it('should render component with custom reverse transition and match snapshot', () => {
-    const wrapper = mount(VCarouselItem, {
-      propsData: {
-        src: imageSrc,
-        'reverse-ransition': 'slide-y-reverse-transition'
-      }
-    })
-
-    expect(wrapper.html()).toMatchSnapshot()
+    expect(warning).toHaveBeenTipped()
   })
 })

--- a/src/components/VCarousel/__snapshots__/VCarousel.spec.js.snap
+++ b/src/components/VCarousel/__snapshots__/VCarousel.spec.js.snap
@@ -100,6 +100,51 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
     </button>
   </div>
   <div class="carousel__controls">
+    <button type="button"
+            class="btn btn--icon theme--dark carousel__controls__item carousel__controls__item--active"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="material-icons icon"
+        >
+          stop
+        </i>
+      </div>
+    </button>
+    <button type="button"
+            class="btn btn--icon theme--dark carousel__controls__item"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="material-icons icon"
+        >
+          stop
+        </i>
+      </div>
+    </button>
+    <button type="button"
+            class="btn btn--icon theme--dark carousel__controls__item"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="material-icons icon"
+        >
+          stop
+        </i>
+      </div>
+    </button>
+  </div>
+  <div class="carousel__item tab-transition-enter tab-transition-enter-active"
+       style="background-image: url(1);"
+  >
+  </div>
+  <div class="carousel__item"
+       style="background-image: url(2); display: none;"
+  >
+  </div>
+  <div class="carousel__item"
+       style="background-image: url(3); display: none;"
+  >
   </div>
 </div>
 
@@ -280,6 +325,51 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
   </div>
   <div class="carousel__item tab-transition-enter tab-transition-enter-active"
        style="background-image: url(2);"
+  >
+  </div>
+  <div class="carousel__item"
+       style="background-image: url(3); display: none;"
+  >
+  </div>
+</div>
+
+`;
+
+exports[`VCarousel.js should render component without delimiters 1`] = `
+
+<div class="carousel">
+  <div class="carousel__left">
+    <button type="button"
+            class="btn btn--icon theme--dark"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="material-icons icon"
+        >
+          chevron_left
+        </i>
+      </div>
+    </button>
+  </div>
+  <div class="carousel__right">
+    <button type="button"
+            class="btn btn--icon theme--dark"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="material-icons icon"
+        >
+          chevron_right
+        </i>
+      </div>
+    </button>
+  </div>
+  <div class="carousel__item tab-transition-enter tab-transition-enter-active"
+       style="background-image: url(1);"
+  >
+  </div>
+  <div class="carousel__item"
+       style="background-image: url(2); display: none;"
   >
   </div>
   <div class="carousel__item"

--- a/src/components/VCarousel/__snapshots__/VCarouselItem.spec.js.snap
+++ b/src/components/VCarousel/__snapshots__/VCarouselItem.spec.js.snap
@@ -8,21 +8,3 @@ exports[`VCarouselItem.js should render component and match snapshot 1`] = `
 </div>
 
 `;
-
-exports[`VCarouselItem.js should render component with custom reverse transition and match snapshot 1`] = `
-
-<div class="carousel__item"
-     style="background-image: url(https://vuetifyjs.com/static/doc-images/cards/sunshine.jpg); display: none;"
->
-</div>
-
-`;
-
-exports[`VCarouselItem.js should render component with custom transition and match snapshot 1`] = `
-
-<div class="carousel__item"
-     style="background-image: url(https://vuetifyjs.com/static/doc-images/cards/sunshine.jpg); display: none;"
->
-</div>
-
-`;

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -139,7 +139,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
          style="display: inline-block;"
     >
       <div class="menu__content menu__content--select menuable__content__active"
-           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 10; display: none; z-index: 10;"
+           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 8; display: none; z-index: 8;"
       >
         <div class="card"
              style="height: auto;"
@@ -327,7 +327,7 @@ exports[`VSelect should be clearable with prop, dirty and single select 2`] = `
          style="display: inline-block;"
     >
       <div class="menu__content menu__content--select menuable__content__active"
-           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 10; display: none; z-index: 10;"
+           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 8; display: none; z-index: 8;"
       >
         <div class="card"
              style="height: auto;"


### PR DESCRIPTION
Fixes #1971 

Includes breaking changes:

- `icon` prop is now `delimiter-icon`
- `hide-controls` now hides navigation controls, not delimiters
- `hide-delimiters` prop added for hiding delimiters

Docs update here https://github.com/vuetifyjs/docs/pull/302