### PR TITLE
Rippleable (VCheckbox, VRadio, VSwitch) ripple prop with tests

### DIFF
--- a/src/components/VCheckbox/VCheckbox.js
+++ b/src/components/VCheckbox/VCheckbox.js
@@ -73,7 +73,7 @@ export default {
           'icon--checkbox': this.icon === 'check_box'
         },
         key: this.icon,
-        on: Object.assign({}, {
+        on: Object.assign({
           click: this.toggle
         }, this.$listeners)
       }, this.icon)

--- a/src/components/VCheckbox/VCheckbox.js
+++ b/src/components/VCheckbox/VCheckbox.js
@@ -72,7 +72,10 @@ export default {
         'class': {
           'icon--checkbox': this.icon === 'check_box'
         },
-        key: this.icon
+        key: this.icon,
+        on: Object.assign({}, {
+          click: this.toggle
+        }, this.$listeners)
       }, this.icon)
     ])
 
@@ -87,6 +90,8 @@ export default {
       }
     }
 
-    return this.genInputGroup([transition, this.genRipple()], data)
+    const ripple = this.ripple ? this.genRipple() : null
+
+    return this.genInputGroup([transition, ripple], data)
   }
 }

--- a/src/components/VCheckbox/VCheckbox.spec.js
+++ b/src/components/VCheckbox/VCheckbox.spec.js
@@ -180,4 +180,29 @@ test('VCheckbox.js', () => {
 
     expect(ripple.getAttribute('data-ripple')).toBe('false')
   })
+
+  it('should not render ripple when ripple prop is false', () => {
+    const wrapper = mount(VCheckbox, {
+      propsData: {
+        inputValue: false,
+        ripple: false
+      }
+    })
+
+    const ripple = wrapper.find('.input-group--selection-controls__ripple')
+
+    expect(ripple.length).toBe(0)
+  })
+
+  it('should render ripple with data attribute when ripple prop is true', () => {
+    const wrapper = mount(VCheckbox, {
+      propsData: {
+        ripple: true
+      }
+    })
+
+    const ripple = wrapper.find('.input-group--selection-controls__ripple')[0]
+
+    expect(ripple.getAttribute('data-ripple')).toBe('true')
+  })
 })

--- a/src/components/VRadioGroup/VRadio.js
+++ b/src/components/VRadioGroup/VRadio.js
@@ -145,7 +145,7 @@ export default {
           'icon--radio': this.isActive
         },
         key: this.icon,
-        on: Object.assign({}, {
+        on: Object.assign({
           click: this.toggle
         }, this.$listeners)
       }, this.icon)

--- a/src/components/VRadioGroup/VRadio.js
+++ b/src/components/VRadioGroup/VRadio.js
@@ -144,10 +144,15 @@ export default {
         'class': {
           'icon--radio': this.isActive
         },
-        key: this.icon
+        key: this.icon,
+        on: Object.assign({}, {
+          click: this.toggle
+        }, this.$listeners)
       }, this.icon)
     ])
 
-    return this.genWrapper([transition, this.genRipple()])
+    const ripple = this.ripple ? this.genRipple() : null
+
+    return this.genWrapper([transition, ripple])
   }
 }

--- a/src/components/VRadioGroup/VRadio.spec.js
+++ b/src/components/VRadioGroup/VRadio.spec.js
@@ -127,4 +127,44 @@ test('VRadio.vue', ({ mount }) => {
 
     expect('immediate parent of v-radio-group').toHaveBeenTipped()
   })
+
+  it('should not render ripple when ripple prop is false', () => {
+    const wrapper = mount(VRadio, {
+      propsData: {
+        ripple: false
+      },
+      provide: {
+        name: () => 'name',
+        registerChild: () => {},
+        unregisterChild: () => {},
+        isMandatory: () => false
+      }
+    })
+
+    const ripple = wrapper.find('.input-group--selection-controls__ripple')
+
+    expect(ripple.length).toBe(0)
+
+    expect('immediate parent of v-radio-group').toHaveBeenTipped()
+  })
+
+  it('should render ripple with data attribute when ripple prop is true', () => {
+    const wrapper = mount(VRadio, {
+      propsData: {
+        ripple: true
+      },
+      provide: {
+        name: () => 'name',
+        registerChild: () => {},
+        unregisterChild: () => {},
+        isMandatory: () => false
+      }
+    })
+
+    const ripple = wrapper.find('.input-group--selection-controls__ripple')[0]
+
+    expect(ripple.getAttribute('data-ripple')).toBe('true')
+
+    expect('immediate parent of v-radio-group').toHaveBeenTipped()
+  })
 })

--- a/src/components/VSwitch/VSwitch.spec.js
+++ b/src/components/VSwitch/VSwitch.spec.js
@@ -1,0 +1,22 @@
+import { test } from '~util/testing'
+import { mount } from 'avoriaz'
+import VSwitch from '~components/VSwitch'
+
+test('VSwitch.js', () => {
+  it('should set ripple data attribute based on ripple prop state', () => {
+    const wrapper = mount(VSwitch, {
+      propsData: {
+        inputValue: false,
+        ripple: false
+      }
+    })
+
+    const ripple = wrapper.find('.input-group--selection-controls__ripple')[0]
+
+    expect(ripple.getAttribute('data-ripple')).toBe('false')
+
+    wrapper.setProps({ ripple: true })
+
+    expect(ripple.getAttribute('data-ripple')).toBe('true')
+  })
+})

--- a/src/mixins/rippleable.js
+++ b/src/mixins/rippleable.js
@@ -15,7 +15,7 @@ export default {
     genRipple () {
       return this.$createElement('div', {
         'class': this.rippleClasses || 'input-group--selection-controls__ripple',
-        on: Object.assign({}, {
+        on: Object.assign({
           click: this.toggle
         }, this.$listeners),
         directives: [{

--- a/src/mixins/rippleable.js
+++ b/src/mixins/rippleable.js
@@ -4,6 +4,13 @@ import Ripple from '../directives/ripple'
 export default {
   directives: { Ripple },
 
+  props: {
+    ripple: {
+      type: [Boolean, Object],
+      default: true
+    }
+  },
+
   methods: {
     genRipple () {
       return this.$createElement('div', {
@@ -13,7 +20,7 @@ export default {
         }, this.$listeners),
         directives: [{
           name: 'ripple',
-          value: !this.disabled && { center: true }
+          value: this.ripple && !this.disabled && { center: true }
         }]
       })
     }


### PR DESCRIPTION
VSwitch has to render ripple always, currently, due to the switch knob being part of the ripple styles.