### PR TITLE
VSelect - check for destroyed race condition

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -356,6 +356,8 @@ export default {
     this.genSelectedItems()
 
     this.$vuetify.load(() => {
+      // Check again, could have been destroyed by the time this runs
+      if (this._isDestroyed) return
       this.content = this.$refs.menu.$refs.content
     })
   },


### PR DESCRIPTION
Resolves:
Uncaught TypeError: Cannot read property '$refs' of undefined

Reproduction:
https://codepen.io/jayblanchard/pen/ZXqjBB?editors=1010
