### PR TITLE
fix(v-tooltip): increased flex width of tooltip

### DIFF
--- a/src/stylus/components/_tooltips.styl
+++ b/src/stylus/components/_tooltips.styl
@@ -2,6 +2,10 @@
 
 .tooltip
   position: relative
+  // When wrapping selection-controls make
+  // sure tooltip spans the entire length
+  // https://github.com/vuetifyjs/vuetify/issues/2171
+  flex: 1 1 auto
 
   &__content
     background: $grey.darken-2


### PR DESCRIPTION
Fixed a bug where when wrapping a **selection-control** component with a `v-tooltip` would cause the
tooltip to not flex the available space, causing a text overflow

fixes #2171