### PR TITLE
Allow flat/raised style options for v-expansion-panel

### DIFF
--- a/src/components/VExpansionPanel/VExpansionPanel.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.js
@@ -18,7 +18,9 @@ export default {
     expand: Boolean,
     focusable: Boolean,
     inset: Boolean,
-    popout: Boolean
+    popout: Boolean,
+    raised: Boolean,
+    flat: Boolean
   },
 
   methods: {
@@ -48,6 +50,8 @@ export default {
         'expansion-panel--focusable': this.focusable,
         'expansion-panel--popout': this.popout,
         'expansion-panel--inset': this.inset,
+        'expansion-panel--raised': this.raised,
+        'expansion-panel--flat': this.flat,
         ...this.themeClasses
       }
     }, this.$slots.default)

--- a/src/stylus/components/_expansion-panel.styl
+++ b/src/stylus/components/_expansion-panel.styl
@@ -28,6 +28,12 @@ theme(expansion-panel, "expansion-panel")
   width: 100%
   elevation(2)
 
+  &--raised
+    elevation(3)
+
+  &--flat
+    elevation(0)
+
   &__container
     flex: 1 0 100%
     outline: none
@@ -38,7 +44,7 @@ theme(expansion-panel, "expansion-panel")
 
     .header__icon
       margin-left: auto
-      
+
       .icon
         // Edge rendering issue TODO: revisit later
         transition: none
@@ -75,7 +81,7 @@ theme(expansion-panel, "expansion-panel")
   &--popout, &--inset
     .expansion-panel__container
       max-width: 95%
-  
+
   &--popout
     .expansion-panel__container--active
       max-width: 100%


### PR DESCRIPTION
Like some other components (like v-card) v-expansion-panel should have flat/raised style options to modify the component elevation.