### PR TITLE
[WIP] fix: take closest ancestor's theme into account

### DIFF
--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -6,9 +6,6 @@ toolbar($material)
   background-color: $material.app-bar
   color: $material.text.primary
 
-  .btn:not(.btn--disabled)
-    color: $material.icons.active
-
 theme(toolbar, "toolbar")
 
 .toolbar
@@ -21,7 +18,7 @@ theme(toolbar, "toolbar")
   .input-group--solo
     .input-group__details
       display: none
-      
+
   .input-group--single-line:not(.input-group--solo)
     padding: 0
 
@@ -65,7 +62,7 @@ theme(toolbar, "toolbar")
     height: 100%
     max-width: 100%
     padding: 0
-    
+
     .menu
       height: 100%
 
@@ -120,7 +117,7 @@ theme(toolbar, "toolbar")
     display: inline-flex
     margin: 16px
     width: auto
-  
+
   &--clipped
     z-index: 3
 

--- a/src/stylus/theme.styl
+++ b/src/stylus/theme.styl
@@ -12,13 +12,15 @@ theme($component, $name)
   dark($component, $name)
 
 light($component, $name)
-  .application--light .{$name}
-    $component($material-light)
-  .application .theme--light.{$name}
+  .application--light .{$name},
+  .application .theme--light .{$name},
+  .application.application--light .theme--light.{$name},
+  .application.application--dark .theme--light.{$name}
     $component($material-light)
 
 dark($component, $name)
-  .application--dark .{$name}
-    $component($material-dark)
-  .application .theme--dark.{$name}
+  .application--dark .{$name},
+  .application .theme--dark .{$name},
+  .application.application--light .theme--dark.{$name},
+  .application.application--dark .theme--dark.{$name}
     $component($material-dark)


### PR DESCRIPTION
fixes #2210

That's a quite big change, it's purpose is to use  the theme based on the app theme or closest ancestor's theme or component's theme, now Vuetify checks only app/component's theme and ignores the container's theme. Example:

```
v-app dark
  v-card light
    v-button
```

In the current version the button will match to `.application--dark .btn` rule
In the new version it will match to `.application--dark .btn` and `.application .theme--light .btn` rules, the latter will be applied as it takes precedence over the first one

```
v-app dark
  v-card light
    v-button dark
```
In the current version the button will match to `.application--dark .btn` and `.application ,theme--dark` rules
In the new version it will match to `.application--dark .btn`, `.application .theme--light .btn` and `.application.application--dark .theme--dark.btn` - the last one will be applied (has the highest specificity).
The second example explains why the following lines are required and why they look how they look (they must have the proper css specificity):
```diff
+  .application.application--light .theme--light.{$name},
+  .application.application--dark .theme--light.{$name}
```
Without it the light theme (from light v-card) would be applied

### Note
I guess the rules could be simplified a bit if `v-app` will have the `theme--*` class applied instead of `application--*`, didn't check it though, but I haven't found any other usage of `application--*` classes except the theming function in stylus

### Playground
```vue
<template>
  <v-app id="inspire" :dark="dark">
    <main>
      <v-content>
        <v-checkbox v-model="dark" label="Dark app"></v-checkbox>
        <v-checkbox v-model="tdark" label="Dark toolbar"></v-checkbox>
        <v-toolbar :dark="tdark" :light="!tdark">
          <v-toolbar-side-icon></v-toolbar-side-icon>
          <v-toolbar-title class="mr-5">Title</v-toolbar-title>
          Light:
          <v-btn light><v-icon>block</v-icon> Button</v-btn>
          <v-btn light disabled><v-icon>block</v-icon> Button</v-btn>
          Dark:
          <v-btn dark><v-icon>block</v-icon> Button</v-btn>
          <v-btn dark disabled><v-icon>block</v-icon> Button</v-btn>
          No theme:
          <v-btn><v-icon>block</v-icon> Button</v-btn>
          <v-btn disabled><v-icon>block</v-icon> Button</v-btn>
        </v-toolbar>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data: () => ({ dark: true, tdark: true })
}
</script>
```