### PR TITLE
[WIP] fix: take closest ancestor's theme into account (for enhancement/theme branch)

### DIFF
--- a/src/components/VAlert/__snapshots__/VAlert.spec.js.snap
+++ b/src/components/VAlert/__snapshots__/VAlert.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`VAlert.vue should be closed by default 1`] = `
 
-<div class="alert error--light"
+<div class="alert error"
      style="display: none;"
 >
   <div>
@@ -13,7 +13,7 @@ exports[`VAlert.vue should be closed by default 1`] = `
 
 exports[`VAlert.vue should be dismissible 1`] = `
 
-<div class="alert alert--dismissible error--light"
+<div class="alert alert--dismissible error"
      style="display: none;"
 >
   <div>
@@ -31,7 +31,7 @@ exports[`VAlert.vue should be dismissible 1`] = `
 
 exports[`VAlert.vue should have a close icon 1`] = `
 
-<div class="alert alert--dismissible error--light"
+<div class="alert alert--dismissible error"
      style="display: none;"
 >
   <div>

--- a/src/components/VApp/mixins/app-theme.js
+++ b/src/components/VApp/mixins/app-theme.js
@@ -37,11 +37,19 @@ export default {
         )
       }).join('')
     },
+    genRules (key, color, suffix = '') {
+      return [
+        `.application--${color} .${key}${suffix}`,
+        `.application .theme--${color} .${key}${suffix}`,
+        `.application.application--light .theme--${color}.${key}${suffix}`,
+        `.application.application--dark .theme--${color}.${key}${suffix}`
+      ].join(',')
+    },
     genBackgroundColor (key, value, color) {
-      return `.${key}--${color}{background-color:${value}!important;border-color:${value}!important}`
+      return `${this.genRules(key, color)}{background-color:${value}!important;border-color:${value}!important}`
     },
     genTextColor (key, value, color) {
-      return `.${key}--${color}--text{color:${value}!important}`
+      return `${this.genRules(key, color, '--text')}{color:${value}!important}`
     },
     genStyle () {
       const style = document.createElement('style')

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -68,7 +68,7 @@ exports[`VDataTable.vue should match a snapshot 1`] = `
               <div tabindex="0"
                    aria-label="Rows per page:"
                    role="combobox"
-                   class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--light--text"
+                   class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
               >
                 <div class="input-group__input">
                   <div class="input-group__selections"

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.spec.js.snap
@@ -30,7 +30,7 @@ exports[`VDatePicker.js should match snapshot with allowed dates 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             May 2013
           </strong>
         </div>
@@ -139,7 +139,7 @@ exports[`VDatePicker.js should match snapshot with allowed dates 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active accent--light"
+                      class="btn btn--raised btn--icon btn--active accent"
               >
                 <span class="btn__content">
                   7
@@ -412,7 +412,7 @@ exports[`VDatePicker.js should match snapshot with allowed dates and pick-month 
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             2013
           </strong>
         </div>
@@ -472,7 +472,7 @@ exports[`VDatePicker.js should match snapshot with allowed dates and pick-month 
             </td>
             <td>
               <button type="button"
-                      class="btn btn--active accent--light"
+                      class="btn btn--active accent"
               >
                 <span class="btn__content">
                   May
@@ -585,7 +585,7 @@ exports[`VDatePicker.js should match snapshot with colored date picker 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="primary--light--text">
+          <strong class="primary--text">
             November 2005
           </strong>
         </div>
@@ -636,7 +636,7 @@ exports[`VDatePicker.js should match snapshot with colored date picker 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active primary--light"
+                      class="btn btn--raised btn--icon btn--active primary"
               >
                 <span class="btn__content">
                   1
@@ -1327,7 +1327,7 @@ exports[`VDatePicker.js should match snapshot with colored month picker 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="primary--light--text">
+          <strong class="primary--text">
             2005
           </strong>
         </div>
@@ -1445,7 +1445,7 @@ exports[`VDatePicker.js should match snapshot with colored month picker 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--active primary--light"
+                      class="btn btn--active primary"
               >
                 <span class="btn__content">
                   Nov
@@ -1673,7 +1673,7 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--dark--text">
+          <strong class="accent--text">
             May 2013
           </strong>
         </div>
@@ -1782,7 +1782,7 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active theme--dark accent--dark"
+                      class="btn btn--raised btn--icon btn--active theme--dark accent"
               >
                 <span class="btn__content">
                   7
@@ -2055,7 +2055,7 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             May 2013
           </strong>
         </div>
@@ -2164,7 +2164,7 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active accent--light"
+                      class="btn btn--raised btn--icon btn--active accent"
               >
                 <span class="btn__content">
                   7
@@ -2437,7 +2437,7 @@ exports[`VDatePicker.js should match snapshot with first day of week 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             May 2013
           </strong>
         </div>
@@ -2542,7 +2542,7 @@ exports[`VDatePicker.js should match snapshot with first day of week 1`] = `
           <tr>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active accent--light"
+                      class="btn btn--raised btn--icon btn--active accent"
               >
                 <span class="btn__content">
                   7
@@ -3194,7 +3194,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             2005
           </strong>
         </div>
@@ -3312,7 +3312,7 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
             </td>
             <td>
               <button type="button"
-                      class="btn btn--active accent--light"
+                      class="btn btn--active accent"
               >
                 <span class="btn__content">
                   11, en-us
@@ -3357,7 +3357,7 @@ exports[`VDatePicker.js should match snapshot with no title 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             May 2013
           </strong>
         </div>
@@ -3466,7 +3466,7 @@ exports[`VDatePicker.js should match snapshot with no title 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active accent--light"
+                      class="btn btn--raised btn--icon btn--active accent"
               >
                 <span class="btn__content">
                   7
@@ -3739,7 +3739,7 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             2013
           </strong>
         </div>
@@ -3799,7 +3799,7 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
             </td>
             <td>
               <button type="button"
-                      class="btn btn--active accent--light"
+                      class="btn btn--active accent"
               >
                 <span class="btn__content">
                   May
@@ -3912,7 +3912,7 @@ exports[`VDatePicker.js should match snapshot with title/header formatting funct
           </div>
         </button>
         <div class="picker--date__header-selector-date">
-          <strong class="accent--light--text">
+          <strong class="accent--text">
             2005-11, en-us
           </strong>
         </div>
@@ -3963,7 +3963,7 @@ exports[`VDatePicker.js should match snapshot with title/header formatting funct
             </td>
             <td>
               <button type="button"
-                      class="btn btn--raised btn--icon btn--active accent--light"
+                      class="btn btn--raised btn--icon btn--active accent"
               >
                 <span class="btn__content">
                   1

--- a/src/components/VProgressLinear/__snapshots__/VProgressLinear.spec.js.snap
+++ b/src/components/VProgressLinear/__snapshots__/VProgressLinear.spec.js.snap
@@ -11,7 +11,7 @@ exports[`VProgressLinear.js should render component and match snapshot 1`] = `
   </div>
   <div class="progress-linear__bar">
     <!---->
-    <div class="progress-linear__bar__determinate primary--light"
+    <div class="progress-linear__bar__determinate primary"
          style="width: 33%;"
     >
     </div>
@@ -33,7 +33,7 @@ exports[`VProgressLinear.js should render component with buffer value and match 
        style="width: 80%;"
   >
     <!---->
-    <div class="progress-linear__bar__determinate primary--light"
+    <div class="progress-linear__bar__determinate primary"
          style="width: 41.25%;"
     >
     </div>
@@ -55,7 +55,7 @@ exports[`VProgressLinear.js should render component with buffer value and value 
        style="width: 80%;"
   >
     <!---->
-    <div class="progress-linear__bar__determinate primary--light"
+    <div class="progress-linear__bar__determinate primary"
          style="width: 112.5%;"
     >
     </div>
@@ -155,9 +155,9 @@ exports[`VProgressLinear.js should render indeterminate progress and match snaps
   </div>
   <div class="progress-linear__bar">
     <div class="progress-linear__bar__indeterminate progress-linear__bar__indeterminate--active">
-      <div class="progress-linear__bar__indeterminate long primary--light">
+      <div class="progress-linear__bar__indeterminate long primary">
       </div>
-      <div class="progress-linear__bar__indeterminate short primary--light">
+      <div class="progress-linear__bar__indeterminate short primary">
       </div>
     </div>
     <!---->
@@ -177,9 +177,9 @@ exports[`VProgressLinear.js should render indeterminate progress with query prop
   </div>
   <div class="progress-linear__bar">
     <div class="progress-linear__bar__indeterminate progress-linear__bar__indeterminate--active">
-      <div class="progress-linear__bar__indeterminate long primary--light">
+      <div class="progress-linear__bar__indeterminate long primary">
       </div>
-      <div class="progress-linear__bar__indeterminate short primary--light">
+      <div class="progress-linear__bar__indeterminate short primary">
       </div>
     </div>
     <!---->

--- a/src/components/VRadioGroup/__snapshots__/VRadio.spec.js.snap
+++ b/src/components/VRadioGroup/__snapshots__/VRadio.spec.js.snap
@@ -4,7 +4,7 @@ exports[`VRadio.vue should not render aria-label attribute with no label value o
 
 <div role="radio"
      aria-checked="false"
-     class="input-group input-group--selection-controls radio accent--light--text"
+     class="input-group input-group--selection-controls radio accent--text"
 >
   <label>
   </label>
@@ -30,7 +30,7 @@ exports[`VRadio.vue should render aria-label attribute with label value on input
 <div role="radio"
      aria-checked="false"
      aria-label="Test"
-     class="input-group input-group--selection-controls radio accent--light--text"
+     class="input-group input-group--selection-controls radio accent--text"
 >
   <label>
     Test
@@ -56,7 +56,7 @@ exports[`VRadio.vue should render proper input name 1`] = `
 
 <div role="radio"
      aria-checked="false"
-     class="input-group input-group--selection-controls radio accent--light--text"
+     class="input-group input-group--selection-controls radio accent--text"
 >
   <label>
   </label>
@@ -81,7 +81,7 @@ exports[`VRadio.vue should render role and aria-checked attributes on input grou
 
 <div role="radio"
      aria-checked="true"
-     class="input-group input-group--active input-group--selection-controls radio accent--light--text"
+     class="input-group input-group--active input-group--selection-controls radio accent--text"
 >
   <label>
   </label>

--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -4,7 +4,7 @@ exports[`VSelect should render buttons correctly when using items array with seg
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--segmented input-group--single-line primary--light--text"
+     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--segmented input-group--single-line primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -39,7 +39,7 @@ exports[`VSelect should render buttons correctly when using items array with seg
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link primary--light--text"
+                 class="list__tile list__tile--link primary--text"
                  data-ripple="true"
               >
                 <div class="list__tile__content">
@@ -71,7 +71,7 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--segmented input-group--single-line primary--light--text"
+     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--segmented input-group--single-line primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -101,7 +101,7 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link primary--light--text"
+                 class="list__tile list__tile--link primary--text"
                  data-ripple="true"
               >
                 <div class="list__tile__content">

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -4,7 +4,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--light--text"
+     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -34,14 +34,14 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link primary--light--text"
+                 class="list__tile list__tile--link primary--text"
                  data-ripple="true"
               >
                 <div class="list__tile__action list__tile__action--select-multi">
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="true"
-                       class="input-group input-group--dirty checkbox input-group--selection-controls input-group--active primary--light--text"
+                       class="input-group input-group--dirty checkbox input-group--selection-controls input-group--active primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control fade-transition-leave fade-transition-leave-active">
@@ -79,7 +79,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls primary--light--text"
+                       class="input-group checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control">
@@ -125,7 +125,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--light--text"
+     class="input-group input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -159,7 +159,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls primary--light--text"
+                       class="input-group checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control icon--checkbox fade-transition-leave fade-transition-leave-active"
@@ -199,7 +199,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls primary--light--text"
+                       class="input-group checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i class="material-icons icon icon--selection-control">
@@ -245,7 +245,7 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select primary--light--text"
+     class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -275,7 +275,7 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
           >
             <li>
               <a href="javascript:;"
-                 class="list__tile list__tile--link primary--light--text"
+                 class="list__tile list__tile--link primary--text"
                  data-ripple="true"
               >
                 <div class="list__tile__content">
@@ -319,7 +319,7 @@ exports[`VSelect should be clearable with prop, dirty and single select 2`] = `
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--append-icon input-group--text-field input-group--select primary--light--text"
+     class="input-group input-group--append-icon input-group--text-field input-group--select primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"

--- a/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
+++ b/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`VTextField.js should not display counter when set to false 1`] = `
 
-<div class="input-group input-group--text-field primary--light--text">
+<div class="input-group input-group--text-field primary--text">
   <div class="input-group__input">
     <input tabindex="0"
            type="text"
@@ -21,7 +21,7 @@ exports[`VTextField.js should not display counter when set to false 1`] = `
 
 exports[`VTextField.js should not display counter when set to false 2`] = `
 
-<div class="input-group input-group--text-field primary--light--text">
+<div class="input-group input-group--text-field primary--text">
   <div class="input-group__input">
     <input tabindex="0"
            type="text"
@@ -37,7 +37,7 @@ exports[`VTextField.js should not display counter when set to false 2`] = `
 
 exports[`VTextField.js should render component and match snapshot 1`] = `
 
-<div class="input-group input-group--text-field primary--light--text">
+<div class="input-group input-group--text-field primary--text">
   <div class="input-group__input">
     <input tabindex="0"
            type="text"
@@ -53,7 +53,7 @@ exports[`VTextField.js should render component and match snapshot 1`] = `
 
 exports[`VTextField.js should render component with async loading and custom progress and match snapshot 1`] = `
 
-<div class="input-group input-group--async-loading input-group--text-field primary--light--text">
+<div class="input-group input-group--async-loading input-group--text-field primary--text">
   <div class="input-group__input">
     <input tabindex="0"
            type="text"
@@ -86,7 +86,7 @@ exports[`VTextField.js should render component with async loading and custom pro
 
 exports[`VTextField.js should render component with async loading and match snapshot 1`] = `
 
-<div class="input-group input-group--async-loading input-group--text-field primary--light--text">
+<div class="input-group input-group--async-loading input-group--text-field primary--text">
   <div class="input-group__input">
     <input tabindex="0"
            type="text"
@@ -102,9 +102,9 @@ exports[`VTextField.js should render component with async loading and match snap
       </div>
       <div class="progress-linear__bar">
         <div class="progress-linear__bar__indeterminate progress-linear__bar__indeterminate--active">
-          <div class="progress-linear__bar__indeterminate long primary--light">
+          <div class="progress-linear__bar__indeterminate long primary">
           </div>
-          <div class="progress-linear__bar__indeterminate short primary--light">
+          <div class="progress-linear__bar__indeterminate short primary">
           </div>
         </div>
         <!---->

--- a/src/components/VTimePicker/__snapshots__/VTimePicker.spec.js.snap
+++ b/src/components/VTimePicker/__snapshots__/VTimePicker.spec.js.snap
@@ -26,7 +26,7 @@ exports[`VTimePicker.js should accept a date object for a value 1`] = `
   </div>
   <div class="picker__body">
     <div class="picker--time__clock">
-      <div class="picker--time__clock-hand hour accent--light">
+      <div class="picker--time__clock-hand hour accent">
       </div>
       <span class>
         <span>
@@ -83,7 +83,7 @@ exports[`VTimePicker.js should accept a date object for a value 1`] = `
           11
         </span>
       </span>
-      <span class="active accent--light">
+      <span class="active accent">
         <span>
           12
         </span>
@@ -120,7 +120,7 @@ exports[`VTimePicker.js should accept a value 1`] = `
   </div>
   <div class="picker__body">
     <div class="picker--time__clock">
-      <div class="picker--time__clock-hand hour accent--light">
+      <div class="picker--time__clock-hand hour accent">
       </div>
       <span class>
         <span>
@@ -162,7 +162,7 @@ exports[`VTimePicker.js should accept a value 1`] = `
           8
         </span>
       </span>
-      <span class="active accent--light">
+      <span class="active accent">
         <span>
           9
         </span>
@@ -214,7 +214,7 @@ exports[`VTimePicker.js should change am/pm when updated from model 1`] = `
   </div>
   <div class="picker__body">
     <div class="picker--time__clock">
-      <div class="picker--time__clock-hand hour accent--light">
+      <div class="picker--time__clock-hand hour accent">
       </div>
       <span class>
         <span>
@@ -256,7 +256,7 @@ exports[`VTimePicker.js should change am/pm when updated from model 1`] = `
           8
         </span>
       </span>
-      <span class="active accent--light">
+      <span class="active accent">
         <span>
           9
         </span>
@@ -308,7 +308,7 @@ exports[`VTimePicker.js should render colored time picker 1`] = `
   </div>
   <div class="picker__body">
     <div class="picker--time__clock">
-      <div class="picker--time__clock-hand hour primary--light">
+      <div class="picker--time__clock-hand hour primary">
       </div>
       <span class>
         <span>
@@ -350,7 +350,7 @@ exports[`VTimePicker.js should render colored time picker 1`] = `
           8
         </span>
       </span>
-      <span class="active primary--light">
+      <span class="active primary">
         <span>
           9
         </span>

--- a/src/components/Vuetify/mixins/theme.js
+++ b/src/components/Vuetify/mixins/theme.js
@@ -1,5 +1,5 @@
 const LIGHT_THEME_DEFAULTS = {
-  primary: 'red',
+  primary: '#1976D2',
   secondary: '#424242',
   accent: '#82B1FF',
   error: '#FF5252',
@@ -8,15 +8,7 @@ const LIGHT_THEME_DEFAULTS = {
   warning: '#FFC107'
 }
 
-const DARK_THEME_DEFAULTS = {
-  primary: 'green',
-  secondary: '#424242',
-  accent: '#82B1FF',
-  error: '#FF5252',
-  info: '#2196F3',
-  success: '#4CAF50',
-  warning: '#FFC107'
-}
+const DARK_THEME_DEFAULTS = LIGHT_THEME_DEFAULTS
 
 export default function (opts) {
   const dark = opts.theme && opts.theme.dark

--- a/src/components/Vuetify/mixins/theme.js
+++ b/src/components/Vuetify/mixins/theme.js
@@ -1,5 +1,5 @@
 const LIGHT_THEME_DEFAULTS = {
-  primary: '#1976D2',
+  primary: 'red',
   secondary: '#424242',
   accent: '#82B1FF',
   error: '#FF5252',
@@ -8,7 +8,15 @@ const LIGHT_THEME_DEFAULTS = {
   warning: '#FFC107'
 }
 
-const DARK_THEME_DEFAULTS = LIGHT_THEME_DEFAULTS
+const DARK_THEME_DEFAULTS = {
+  primary: 'green',
+  secondary: '#424242',
+  accent: '#82B1FF',
+  error: '#FF5252',
+  info: '#2196F3',
+  success: '#4CAF50',
+  warning: '#FFC107'
+}
 
 export default function (opts) {
   const dark = opts.theme && opts.theme.dark

--- a/src/mixins/colorable.js
+++ b/src/mixins/colorable.js
@@ -16,22 +16,9 @@ export default {
   },
 
   methods: {
-    _genAppendedClass (color) {
-      if (![
-        'primary',
-        'secondary',
-        'accent',
-        'error',
-        'info',
-        'success',
-        'warning'
-      ].includes(color)) return color
-
-      return `${color}--${this.dark ? 'dark' : 'light'}`
-    },
     addBackgroundColorClassChecks (classes = {}, prop = 'computedColor') {
       if (prop && this[prop]) {
-        classes[this._genAppendedClass(this[prop])] = true
+        classes[this[prop]] = true
       }
 
       return classes
@@ -40,7 +27,7 @@ export default {
       if (prop && this[prop]) {
         const parts = this[prop].trim().split(' ')
 
-        let color = `${this._genAppendedClass(parts[0])}--text`
+        let color = `${parts[0]}--text`
 
         if (parts.length > 1) color += ' text--' + parts[1]
 


### PR DESCRIPTION
Following code (`app-theme.js`):
```js
genBackgroundColor (key, value, color) {
    return `.${key}--${color}{background-color:${value}!important;border-color:${value}!important}`
}

```
combined with this (`colorable.js/_getAppendedClass()`):

```js
return `${color}--${this.dark ? 'dark' : 'light'}`
```

assumes that the color depends only on the `v-app` theme and won't behave as expected when there's a dark themed component inside light themed application.

PR #2223  uses the theme which is based on component theme or closest ancestor theme or application theme (in this order), I think it could be possible to use the same functionality in the theming branch. In order to do this two changes are necessary:

1. remove `_getAppendedClass`, so that `color="primary"` will result in adding `primary` class instead of `primary--light` or `primary--dark`
2. in the `genBackgroundColor` add rules similar to `theme.styl` from #2223, instead of adding

```css
.error--light { background: ERROR_COLOR_FOR_LIGHT_THEME }
.error--dark { background: ERROR_COLOR_FOR_DARK_THEME }
```

we should add

```css
.application--light .error
.application .theme--light .error,
.application.application--light .theme--light.error,
.application.application--dark .theme--light.error { background: ERROR_COLOR_FOR_LIGHT_THEME }
.application--dark .error
.application .theme--dark .error,
.application.application--light .theme--dark.error,
.application.application--dark .theme--dark.error { background: ERROR_COLOR_FOR_DARK_THEME }
```

This is what this PR does

### Note
I guess the rules could be simplified a bit if `v-app` will have the `theme--*` class applied instead of `application--*`, didn't check it though, but I haven't found any other usage of `application--*` classes except the theming function in stylus

### Playground
Set different primary colors for dark/light theme and you'll see that the button color depends on the toolbar theme instead of the app theme
```vue
<template>
  <v-app id="inspire" :dark="dark">
    <main>
      <v-content>
        <v-toolbar :dark="tdark" :light="!tdark">
          <v-btn color="primary">
            <v-icon>block</v-icon> Button</v-btn>
        </v-toolbar>
        <v-checkbox v-model="dark" label="Dark app"></v-checkbox>
        <v-checkbox v-model="tdark" label="Dark toolbar"></v-checkbox>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data: () => ({ dark: true, tdark: true })
}
</script>
```

