### PR TITLE
avoid activation of text selection controls in mobile Firefox

### DIFF
--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -196,9 +196,11 @@ theme(textfield, "input-group--text-field")
     border-radius: 4px 4px 0 0
     cursor: pointer
     min-height: 56px
+    user-select: none
 
   .input-group__details
     padding: 8px 16px 0
+    user-select: none
 
     &:before,
     &:after


### PR DESCRIPTION
This only fixes the css for text-fields for bug https://github.com/vuetifyjs/vuetify/issues/2239. Is it more appropriate to add these code to individual component css or make a global declaration for .input-group__details and .input-group__input.
```
.input-group__details, .input-group__input
  user-select: none
```