### PR TITLE
feat: add support for float values in slider

### DIFF
--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -191,13 +191,29 @@ export default {
       }
     },
     onKeyDown (e) {
+      if (![33, 34, 35, 36, 37, 39].includes(e.keyCode)) return
+
+      e.preventDefault()
+      const step = this.stepNumeric || 1
+      const steps = (this.max - this.min) / step
       if (e.keyCode === 37 || e.keyCode === 39) {
+        // Left/right
         this.keyPressed += 1
 
-        const direction = e.keyCode === 37 && -1 || e.keyCode === 39 && 1 || 0
-        const multiplier = e.shiftKey && 3 || e.ctrlKey && 2 || 1
+        const direction = e.keyCode === 37 ? -1 : 1
+        const multiplier = e.shiftKey ? 3 : (e.ctrlKey ? 2 : 1)
 
-        this.inputValue = this.inputValue + (direction * this.stepNumeric * multiplier)
+        this.inputValue = this.inputValue + direction * step * multiplier
+      } else if (e.keyCode === 36) {
+        // Home
+        this.inputValue = parseFloat(this.min)
+      } else if (e.keyCode === 35) {
+        // End
+        this.inputValue = parseFloat(this.max)
+      } else if (e.keyCode === 33 || e.keyCode === 34) {
+        // Page up/down
+        const direction = e.keyCode === 34 ? -1 : 1
+        this.inputValue = this.inputValue - direction * step * (steps > 100 ? steps / 10 : 10)
       }
     },
     onKeyUp (e) {

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -36,19 +36,19 @@ export default {
     },
     step: {
       type: [Number, String],
-      default: null
+      default: 1
     },
+    ticks: Boolean,
     thumbColor: {
       type: String,
       default: null
     },
     thumbLabel: Boolean,
-    value: [Number, String],
-    snap: Boolean,
     trackColor: {
       type: String,
       default: null
-    }
+    },
+    value: [Number, String]
   },
 
   computed: {
@@ -58,21 +58,24 @@ export default {
         'input-group--active': this.isActive,
         'input-group--dirty': this.inputWidth > 0,
         'input-group--disabled': this.disabled,
-        'input-group--ticks': !this.disabled && this.step
+        'input-group--ticks': !this.disabled && this.stepNumeric && this.ticks
       }
+    },
+    stepNumeric () {
+      return this.step > 0 ? parseFloat(this.step) : 0
     },
     inputValue: {
       get () {
         return this.value
       },
       set (val) {
-        const { min, max, step, snap } = this
-        val = val < min && min || val > max && max || val
+        const { min, max, stepNumeric } = this
+        val = Math.min(Math.max(val, min), max)
 
         // Round value to ensure the
         // entire slider range can
         // be selected with step
-        const value = snap ? Math.round(val / step) * step : Math.round(val)
+        const value = stepNumeric ? (Math.round(val / stepNumeric) * stepNumeric) : val
         this.lazyValue = value
 
         if (value !== this.value) {
@@ -81,7 +84,7 @@ export default {
       }
     },
     interval () {
-      return 100 / (this.max - this.min) * this.step
+      return 100 / (this.max - this.min) * this.stepNumeric
     },
     thumbContainerClasses () {
       return {
@@ -119,17 +122,12 @@ export default {
       }
     },
     numTicks () {
-      return parseInt((this.max - this.min) / this.step)
+      return Math.ceil((this.max - this.min) / this.stepNumeric)
     },
     inputWidth () {
-      let val = this.inputValue
-      if (this.snap) {
-        val = Math.round(val / this.step) * this.step
-      }
+      const val = this.stepNumeric ? (Math.round(this.inputValue / this.stepNumeric) * this.stepNumeric) : this.inputValue
 
-      val = (val - this.min) / (this.max - this.min) * 100
-
-      return val < 0.15 ? 0 : val
+      return (val - this.min) / (this.max - this.min) * 100
     }
   },
 
@@ -138,13 +136,13 @@ export default {
       this.isFocused = val
     },
     min (val) {
-      val > this.inputValue && this.$emit('input', val)
+      val > this.inputValue && this.$emit('input', parseFloat(val))
     },
     max (val) {
-      val < this.inputValue && this.$emit('input', val)
+      val < this.inputValue && this.$emit('input', parseFloat(val))
     },
     value (val) {
-      this.inputValue = val
+      this.inputValue = parseFloat(val)
     }
   },
 
@@ -186,12 +184,10 @@ export default {
         width: trackWidth
       } = this.$refs.track.getBoundingClientRect()
       const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
-      const left = (
-        ((clientX - offsetLeft) / trackWidth) * 100
-      )
+      const left = Math.min(Math.max((clientX - offsetLeft) / trackWidth, 0), 1)
 
-      if (left >= 0 && left <= 100) {
-        this.inputValue = parseInt(this.min, 10) + ((left / 100) * (this.max - this.min))
+      if (clientX >= offsetLeft - 8 && clientX <= offsetLeft + trackWidth + 8) {
+        this.inputValue = parseFloat(this.min) + left * (this.max - this.min)
       }
     },
     onKeyDown (e) {
@@ -200,9 +196,8 @@ export default {
 
         const direction = e.keyCode === 37 && -1 || e.keyCode === 39 && 1 || 0
         const multiplier = e.shiftKey && 3 || e.ctrlKey && 2 || 1
-        const amount = this.snap && this.step || 1
 
-        this.inputValue = this.inputValue + (direction * amount * multiplier)
+        this.inputValue = this.inputValue + (direction * this.stepNumeric * multiplier)
       }
     },
     onKeyUp (e) {
@@ -227,10 +222,21 @@ export default {
           ]
         }, [
           h('div', { 'class': ['slider__thumb--label', this.thumbColor || this.color] }, [
-            h('span', {}, parseInt(this.inputValue))
+            h('span', {}, this.formatThumbValue(this.inputValue))
           ])
         ])
       ])
+    },
+    formatThumbValue () {
+      if (!this.stepNumeric) {
+        return this.inputValue
+      }
+
+      // Format input value using the same number
+      // of decimals places as in the step prop
+      const trimmedStep = this.step.toString().trim()
+      const decimals = trimmedStep.indexOf('.') > -1 ? (trimmedStep.length - trimmedStep.indexOf('.') - 1) : 0
+      return this.inputValue.toFixed(decimals)
     },
     genThumbContainer (h) {
       const children = []
@@ -288,7 +294,7 @@ export default {
     const children = []
 
     children.push(this.genTrackContainer(h))
-    this.step && children.push(this.genSteps(h))
+    this.step && this.ticks && children.push(this.genSteps(h))
     children.push(this.genThumbContainer(h))
 
     const slider = h('div', { 'class': 'slider' }, children)

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -69,13 +69,13 @@ export default {
         return this.value
       },
       set (val) {
-        const { min, max, stepNumeric } = this
+        const { min, max } = this
         val = Math.min(Math.max(val, min), max)
 
         // Round value to ensure the
         // entire slider range can
         // be selected with step
-        const value = stepNumeric ? (Math.round(val / stepNumeric) * stepNumeric) : val
+        const value = this.roundValue(val)
         this.lazyValue = value
 
         if (value !== this.value) {
@@ -125,9 +125,7 @@ export default {
       return Math.ceil((this.max - this.min) / this.stepNumeric)
     },
     inputWidth () {
-      const val = this.stepNumeric ? (Math.round(this.inputValue / this.stepNumeric) * this.stepNumeric) : this.inputValue
-
-      return (val - this.min) / (this.max - this.min) * 100
+      return (this.roundValue(this.inputValue) - this.min) / (this.max - this.min) * 100
     }
   },
 
@@ -238,21 +236,21 @@ export default {
           ]
         }, [
           h('div', { 'class': ['slider__thumb--label', this.thumbColor || this.color] }, [
-            h('span', {}, this.formatThumbValue(this.inputValue))
+            h('span', {}, this.inputValue)
           ])
         ])
       ])
     },
-    formatThumbValue () {
+    roundValue (value) {
       if (!this.stepNumeric) {
-        return this.inputValue
+        return value
       }
 
       // Format input value using the same number
       // of decimals places as in the step prop
       const trimmedStep = this.step.toString().trim()
       const decimals = trimmedStep.indexOf('.') > -1 ? (trimmedStep.length - trimmedStep.indexOf('.') - 1) : 0
-      return this.inputValue.toFixed(decimals)
+      return 1 * (Math.round(value / this.stepNumeric) * this.stepNumeric).toFixed(decimals)
     },
     genThumbContainer (h) {
       const children = []

--- a/src/stylus/components/_sliders.styl
+++ b/src/stylus/components/_sliders.styl
@@ -180,8 +180,6 @@ theme(slider, "input-group--slider")
     left: 0
     height: 2px
     width: 100%
-
-  &__ticks-container
     top: 50%
     overflow: hidden
 


### PR DESCRIPTION
fixes #1914

### API changes
- removes `snap` prop
- adds `ticks` prop - for displaying ticks (if `step` > 0)
- `step` - default value changed to 1, if `step` > 0 then slider value rounds to the closest possible value (same behaviour as with `snap` prop before this PR)

### Playground
```vue
<template>
  <v-app>
    <main>
      <v-content>
        <v-container style="margin-bottom: 100%">
          <h5>{{s0}}</h5>
          <v-slider label="Defaults" v-model="s0" thumb-label></v-slider>
          <h5>{{s1}}</h5>
          <v-slider label="Max = 1000" v-model="s1" max="1000" thumb-label></v-slider>
          <h5>{{s2}}</h5>
          <v-slider label="Step = 0" step="0" v-model="s2" thumb-label></v-slider>
          <h5>{{s2}}</h5>
          <v-slider label="Step = null" :step="null" v-model="s2" thumb-label></v-slider>
          <h5>{{s2}}</h5>
          <v-slider label="Step = ''" step="" v-model="s2" thumb-label></v-slider>
          <h5>{{s3}}</h5>
          <v-slider label="Step = 0.3, max = 3, ticks" step="0.3" max="3" ticks v-model="s3" thumb-label></v-slider>
          <h5>{{s4}}</h5>
          <v-slider label="Step = 0.1, min = -1, max = 1" step="0.1" min="-1" max="1" v-model="s4" thumb-label></v-slider>
        </v-container>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    s0: 0,
    s1: 0,
    s2: 0,
    s3: 0,
    s4: 0
  })
};
</script>
```