### PR TITLE
fixes TAB key in selects

### DIFF
--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -58,39 +58,51 @@ export default {
         i, this.searchValue, this.getText(i))
       )
     },
+    getCurrentTag () {
+      return this.filteredItems.length && this.$refs.menu.listIndex >= 0
+        ? this.filteredItems[this.$refs.menu.listIndex]
+        : this.searchValue
+    },
     onTabDown (e) {
       if (this.tags) {
-        const newItem = this.filteredItems.length && this.$refs.menu.listIndex >= 0
-          ? this.filteredItems[this.$refs.menu.listIndex]
-          : this.searchValue
+        const newItem = this.getCurrentTag()
+
         if (newItem) {
           e.preventDefault()
           this.addTag(newItem)
         } else {
           this.blur()
         }
+
         return
       }
 
-      if (!this.menuIsActive || !this.isAutocomplete || this.$refs.menu.listIndex === -1) {
+      if (!this.menuIsActive ||
+        !this.isAutocomplete ||
+        this.$refs.menu.listIndex === -1) {
         this.blur()
         return
       }
 
-      if (this.menuIsActive && this.filteredItems.length && this.$refs.menu.listIndex > -1) {
+      if (this.menuIsActive &&
+        this.filteredItems.length &&
+        this.$refs.menu.listIndex > -1) {
         e.preventDefault()
-        this.$refs.menu.tiles[this.$refs.menu.listIndex].click()
+        if (this.$refs.menu.tiles[this.$refs.menu.listIndex]) {
+          this.$refs.menu.tiles[this.$refs.menu.listIndex].click()
+        }
+
         return
       }
 
-      if (this.menuIsActive) {
-        this.blur()
-        return
-      }
+      if (this.menuIsActive) this.blur()
     },
     onEscDown (e) {
       e.preventDefault()
       this.menuIsActive = false
+    },
+    onEnterDown () {
+      this.addTag(this.getCurrentTag())
     },
     onKeyDown (e) {
       // If enter, space, up, or down is pressed, open menu
@@ -120,12 +132,7 @@ export default {
       if (!this.tags || !this.searchValue) return
 
       // Enter
-      if (e.keyCode === 13) {
-        const newItem = this.filteredItems.length && this.$refs.menu.listIndex >= 0
-          ? this.filteredItems[this.$refs.menu.listIndex]
-          : this.searchValue
-        this.addTag(newItem)
-      }
+      if (e.keyCode === 13) return this.onEnterDown()
 
       // Left arrow
       if (e.keyCode === 37 && this.$refs.input.selectionStart === 0 && this.selectedItems.length) {

--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -58,6 +58,20 @@ export default {
         i, this.searchValue, this.getText(i))
       )
     },
+    onTabDown (e) {
+      if (!this.menuIsActive || !this.isAutocomplete || (!this.searchValue && this.$refs.menu.listIndex === -1)) {
+        this.blur()
+      } else if (this.menuIsActive && this.searchValue && this.$refs.menu.listIndex > -1) {
+        e.preventDefault()
+        this.$refs.menu.tiles[this.$refs.menu.listIndex].click()
+      } else if (this.menuIsActive) {
+        this.blur()
+      }
+    },
+    onEscDown (e) {
+      e.preventDefault()
+      this.menuIsActive = false
+    },
     onKeyDown (e) {
       // If enter, space, up, or down is pressed, open menu
       if (!this.menuIsActive && [13, 32, 38, 40].includes(e.keyCode)) {
@@ -65,15 +79,11 @@ export default {
         return this.showMenuItems()
       }
 
-      // If escape or tab with no search, blur
-      if (e.keyCode === 27 || e.keyCode === 9 && !this.searchValue) {
-        return this.blur()
-      }
+      // If escape deactivate the menu
+      if (e.keyCode === 27) return this.onEscDown(e)
 
-      // Tab shouldn't switch inputs
-      if (e.keyCode === 9) {
-        this.tags ? e.preventDefault() : this.blur()
-      }
+      // If tab - select item or close menu
+      if (e.keyCode === 9) return this.onTabDown(e)
 
       if (!this.isAutocomplete ||
         ![32].includes(e.keyCode) // space

--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -59,13 +59,33 @@ export default {
       )
     },
     onTabDown (e) {
-      if (!this.menuIsActive || !this.isAutocomplete || (!this.searchValue && this.$refs.menu.listIndex === -1)) {
+      if (this.tags) {
+        const newItem = this.filteredItems.length && this.$refs.menu.listIndex >= 0
+          ? this.filteredItems[this.$refs.menu.listIndex]
+          : this.searchValue
+        if (newItem) {
+          e.preventDefault()
+          this.addTag(newItem)
+        } else {
+          this.blur()
+        }
+        return
+      }
+
+      if (!this.menuIsActive || !this.isAutocomplete || this.$refs.menu.listIndex === -1) {
         this.blur()
-      } else if (this.menuIsActive && this.searchValue && this.$refs.menu.listIndex > -1) {
+        return
+      }
+
+      if (this.menuIsActive && this.filteredItems.length && this.$refs.menu.listIndex > -1) {
         e.preventDefault()
         this.$refs.menu.tiles[this.$refs.menu.listIndex].click()
-      } else if (this.menuIsActive) {
+        return
+      }
+
+      if (this.menuIsActive) {
         this.blur()
+        return
       }
     },
     onEscDown (e) {
@@ -99,8 +119,8 @@ export default {
 
       if (!this.tags || !this.searchValue) return
 
-      // Tab, enter
-      if ([9, 13].includes(e.keyCode)) {
+      // Enter
+      if (e.keyCode === 13) {
         const newItem = this.filteredItems.length && this.$refs.menu.listIndex >= 0
           ? this.filteredItems[this.$refs.menu.listIndex]
           : this.searchValue


### PR DESCRIPTION
fixes #2094

### Playground
```vue
<template>
  <v-app id="inspire">
    <main>
      <v-content>
        <v-container>
          <p style="font-size: 2em">Click the "Open dialog" button, click the select, type "I", press TAB</p>
          <v-btn @click="dialog = true">Open dialog</v-btn><v-btn @click="select = null">Clear value</v-btn>
          <v-dialog v-model="dialog">
            <v-card>
              <v-card-text>
                <v-select :items="items" chips tags v-model="select1" label="chips tags"></v-select>
                <v-select :items="items" tags v-model="select1" label="tags"></v-select>
                <v-select :items="items" tags multiple v-model="select1" label="tags multiple"></v-select>
                <v-select :items="items" v-model="select2" label="default select"></v-select>
                <v-select :items="items" v-model="select2" autocomplete label="autocomplete"></v-select>
                <v-select :items="items" v-model="select1" multiple label="multiple"></v-select>
                <v-select :items="items" v-model="select1" multiple autocomplete label="multiple"></v-select>
              </v-card-text>
            </v-card>
          </v-dialog>
        </v-container>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      items: ['Item', 'Meti'],
      dialog: false,
      select1: [],
      select2: null
    };
  }
};
</script>
```