### PR TITLE
feat: hideSelected prop for v-select

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -94,6 +94,7 @@ export default {
       default: 200
     },
     editable: Boolean,
+    hideSelected: Boolean,
     items: {
       type: Array,
       default: () => []

--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -201,7 +201,11 @@ export default {
       }, `${this.getText(item)}${comma ? ', ' : ''}`)
     },
     genList () {
-      const children = this.filteredItems.map(o => {
+      const visibleItems = this.hideSelected ? this.filteredItems.filter(o => {
+        return (this.selectedItems || []).indexOf(o) === -1
+      }) : this.filteredItems
+
+      const children = visibleItems.map(o => {
         if (o.header) return this.genHeader(o)
         if (o.divider) return this.genDivider(o)
         else return this.genTile(o)
@@ -271,7 +275,7 @@ export default {
       )
     },
     genAction (item, active) {
-      if (!this.isMultiple) return null
+      if (!this.isMultiple || this.hideSelected) return null
 
       const data = {
         staticClass: 'list__tile__action--select-multi',


### PR DESCRIPTION
With hide-selected prop items that are selected are not listed
in the menu (and there is also no need to display checkbox on
in the menu)

### Playground
```vue
<template>
  <v-app id="inspire">
    <main>
      <v-content>
        <v-container>
          <p style="font-size: 2em">Click the "Open dialog" button, click the select, type "I", press TAB</p>
          <v-btn @click="dialog = true">Open dialog</v-btn><v-btn @click="select = null">Clear value</v-btn>
          <v-checkbox label="Hide selected" v-model="hide"></v-checkbox>
          <v-dialog v-model="dialog">
            <v-card>
              <v-card-text>
                <v-select :items="items" chips tags v-model="select1" label="chips tags" :hide-selected="hide"></v-select>
                <v-select :items="items" tags v-model="select1" label="tags" :hide-selected="hide"></v-select>
                <v-select :items="items" tags multiple v-model="select1" label="tags multiple" :hide-selected="hide"></v-select>
                <v-select :items="items" v-model="select2" label="default select" :hide-selected="hide"></v-select>
                <v-select :items="items" v-model="select2" autocomplete label="autocomplete" :hide-selected="hide"></v-select>
                <v-select :items="items" v-model="select1" multiple label="multiple" :hide-selected="hide"></v-select>
                <v-select :items="items" v-model="select1" multiple autocomplete label="multiple" :hide-selected="hide"></v-select>
              </v-card-text>
            </v-card>
          </v-dialog>
        </v-container>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      hide: true,
      items: ['abc', 'def', 'ghi', 'jkl', 'mno', 'pqr', 'stu', 'vwy'],
      dialog: false,
      select1: [],
      select2: null
    };
  }
};
</script>
```