### PR TITLE
fix: auto height of data table expanded row

### DIFF
--- a/src/components/transitions/row-expand-transition.js
+++ b/src/components/transitions/row-expand-transition.js
@@ -7,18 +7,15 @@ export default {
     addOnceEventListener(el, 'transitionend', done)
 
     // Get height that is to be scrolled
-    const height = el.dataset.height || el.clientHeight
-    el.dataset.height = height
     el.style.overflow = 'hidden'
     el.style.height = 0
     el.td.style['border-bottom'] = '1px solid rgba(0,0,0,0.12)'
 
-    setTimeout(() => {
-      el.dataset.height = el.style.height = `${el.scrollHeight}px`
-    }, 50)
+    setTimeout(() => el.style.height = `${el.scrollHeight}px`, 0)
   },
   afterEnter (el) {
     el.style.overflow = null
+    el.style.height = null
   },
   leave (el, done) {
     // Remove initial transition
@@ -26,7 +23,7 @@ export default {
 
     // Set height before we transition to 0
     el.style.overflow = 'hidden'
-    el.style.height = `${el.dataset.height}px`
+    el.style.height = `${el.offsetHeight}px`
 
     setTimeout(() => {
       el.style.height = 0

--- a/src/components/transitions/row-expand-transition.js
+++ b/src/components/transitions/row-expand-transition.js
@@ -11,7 +11,7 @@ export default {
     el.style.height = 0
     el.td.style['border-bottom'] = '1px solid rgba(0,0,0,0.12)'
 
-    setTimeout(() => el.style.height = `${el.scrollHeight}px`, 0)
+    setTimeout(() => (el.style.height = `${el.scrollHeight}px`), 0)
   },
   afterEnter (el) {
     el.style.overflow = null
@@ -25,9 +25,7 @@ export default {
     el.style.overflow = 'hidden'
     el.style.height = `${el.offsetHeight}px`
 
-    setTimeout(() => {
-      el.style.height = 0
-    }, 50)
+    setTimeout(() => (el.style.height = 0), 50)
   },
   afterLeave (el) {
     el.td.style['border-bottom'] = null


### PR DESCRIPTION
Expanded row height doesn't change automaticly when content's height changes

 ### Playground
```vue
<template>
  <v-app>
   <main>
      <v-content>
        <v-container fluid>
            <v-data-table v-bind:headers="headers" v-bind:items="items" v-bind:search="search" item-key="ID">
              <template slot="items" slot-scope="props" no-data-text>
                <td>
                  <v-btn dark block color="green" @click="props.expanded = !props.expanded">Expand row</v-btn>
                </td>
              </template>
              <template slot="expand" slot-scope="props">
                <v-tabs v-model="tab" dark centered>
                 <v-tabs-bar>
                   <v-tabs-item href="one">
                     One
                   </v-tabs-item>
                   <v-tabs-item href="two">
                     Two
                   </v-tabs-item>
                 </v-tabs-bar>
                 <v-tabs-items>
                   <v-tabs-content id="one">
                     <div style="height: 100px; background: #888" class="headline white--text">I'm 100px tall</div>
                   </v-tabs-content>
                   <v-tabs-content id="two">
                     <div style="height: 300px; background: #888" class="headline white--text">I'm 300px tall</div>
                   </v-tabs-content>
                 </v-tabs-items>
                </v-tabs>
  				    </template>
            </v-data-table>
        </v-container>
      </v-content>
    </main>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      search: "" /*Table*/,
      height: 100,
      tab: null,
      headers: [{ text: "App #", value: "appNum", sortable: false }],
      items: [
        {
          value: true,
          ID: 1,
          appNum: "60000045"
        }
      ]
    };
  }
};
</script>
```