### PR TITLE
fix: proper unbinding of touch events

### DIFF
--- a/src/directives/touch.js
+++ b/src/directives/touch.js
@@ -68,9 +68,14 @@ function inserted (el, { value }) {
 
   // Needed to pass unit tests
   if (!target) return
-  target.addEventListener('touchstart', e => touchstart(e, wrapper), options)
-  target.addEventListener('touchend', e => touchend(e, wrapper), options)
-  target.addEventListener('touchmove', e => touchmove(e, wrapper), options)
+
+  target._touchstartHandler = e => touchstart(e, wrapper)
+  target._touchendHandler = e => touchend(e, wrapper)
+  target._touchmoveHandler = e => touchmove(e, wrapper)
+
+  target.addEventListener('touchstart', target._touchstartHandler, options)
+  target.addEventListener('touchend', target._touchendHandler, options)
+  target.addEventListener('touchmove', target._touchmoveHandler, options)
 }
 
 function unbind (el, { value }) {
@@ -78,9 +83,9 @@ function unbind (el, { value }) {
 
   if (!target) return
 
-  target.removeEventListener('touchstart', touchstart)
-  target.removeEventListener('touchend', touchend)
-  target.removeEventListener('touchmove', touchmove)
+  target.removeEventListener('touchstart', target._touchstartHandler)
+  target.removeEventListener('touchend', target._touchendHandler)
+  target.removeEventListener('touchmove', target._touchmoveHandler)
 }
 
 export default {


### PR DESCRIPTION
fixes #2248

### Playground
```vue
<template>
  <v-app>
    <v-navigation-drawer v-model="drawer1" temporary :touchless="touchless1"></v-navigation-drawer>
    <v-navigation-drawer v-model="drawer2" temporary :touchless="touchless2" right></v-navigation-drawer>
    <v-toolbar app flat>
      <v-btn class="white--text" :color="touchless1 ? 'error' : 'success'" @click="touchless1 = !touchless1">{{ touchless1 ? 'OFF' : 'ON' }}</v-btn>
      <v-spacer></v-spacer>
      <v-btn class="white--text" :color="touchless2 ? 'error' : 'success'" @click="touchless2 = !touchless2">{{ touchless2 ? 'OFF' : 'ON' }}</v-btn>
    </v-toolbar>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    drawer1: false,
    drawer2: false,
    touchless1: false,
    touchless2: true
  })
};
</script>
```