### PR TITLE
fix(VDataTable): customFilter function now only filters on header values

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -96,7 +96,7 @@ export default {
     },
     customFilter: {
       type: Function,
-      default: (items, headers, search, filter) => {
+      default: (items, search, filter, headers) => {
         search = search.toString().toLowerCase()
         const props = headers.map(h => h.value)
 
@@ -222,7 +222,7 @@ export default {
         this.search !== null
 
       if (hasSearch) {
-        items = this.customFilter(items, this.headers, this.search, this.filter)
+        items = this.customFilter(items, this.search, this.filter, this.headers)
         this.searchLength = items.length
       }
 

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -96,11 +96,11 @@ export default {
     },
     customFilter: {
       type: Function,
-      default: (items, search, filter) => {
+      default: (items, headers, search, filter) => {
         search = search.toString().toLowerCase()
-        return items.filter(i => (
-          Object.keys(i).some(j => filter(i[j], search))
-        ))
+        const props = headers.map(h => h.value)
+
+        return items.filter(item => props.some(prop => filter(getObjectValueByPath(item, prop), search)))
       }
     },
     customSort: {
@@ -222,7 +222,7 @@ export default {
         this.search !== null
 
       if (hasSearch) {
-        items = this.customFilter(items, this.search, this.filter)
+        items = this.customFilter(items, this.headers, this.search, this.filter)
         this.searchLength = items.length
       }
 

--- a/src/components/VDataTable/VDataTable.spec.js
+++ b/src/components/VDataTable/VDataTable.spec.js
@@ -24,6 +24,21 @@ test('VDataTable.vue', () => {
     }
   }
 
+  function dataTableTestDataFilter () {
+    return {
+      propsData: {
+        headers: [
+          { text: 'First Column', value: 'first' },
+          { text: 'Second Column', value: 'second.first' },
+          { text: 'Third Column', value: 'third.first.second' }
+        ],
+        items: [
+          { other: 1, first: 'foo', second: { first: 'bar' }, third: { first: { second: 'baz', third: 'outside' } }, fourth: 'outside' }
+        ]
+      }
+    }
+  }
+
   // TODO: This doesn't actually test anything
   it.skip('should be able to filter null and undefined values', async () => {
     const data = dataTableTestData()
@@ -48,16 +63,18 @@ test('VDataTable.vue', () => {
     const data = dataTableTestData()
     const wrapper = mount(VDataTable, data)
 
-    let headers = wrapper.find('thead:first-of-type > tr:first-of-type > th')
+    const headers = wrapper.find('thead:first-of-type > tr:first-of-type > th')
 
     expect(
       headers.map(h => h.getAttribute('aria-sort'))
     ).toEqual(['ascending', 'none', 'none'])
 
-    wrapper.setProps({ pagination: {
-      sortBy: 'col3',
-      descending: false
-    }})
+    wrapper.setProps({
+      pagination: {
+        sortBy: 'col3',
+        descending: false
+      }
+    })
 
     expect(
       headers.map(h => h.getAttribute('aria-sort'))
@@ -95,6 +112,22 @@ test('VDataTable.vue', () => {
     wrapper.vm.sort(0)
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.defaultPagination.descending).toBe(false)
+
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
+
+  it('should only filter on data specified in headers', async () => {
+    const wrapper = mount(VDataTable, dataTableTestDataFilter())
+
+    expect(wrapper.instance().filteredItems.length).toBe(1)
+    wrapper.setProps({
+      search: 'outside'
+    })
+    expect(wrapper.instance().filteredItems.length).toBe(0)
+    wrapper.setProps({
+      search: 'baz'
+    })
+    expect(wrapper.instance().filteredItems.length).toBe(1)
 
     expect('Application is missing <v-app> component.').toHaveBeenTipped()
   })


### PR DESCRIPTION
Previously customFilter would search through the entire object passed to
items, including properties not displayed in actual table. This change
limits customFilter to only searching properties used in columns.

Fixed #1045

Docs update in https://github.com/vuetifyjs/docs/pull/312