### PR TITLE
Fix v-ripple with no expression should be enabled.

### DIFF
--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -79,8 +79,12 @@ const ripple = {
   }
 }
 
+function isRippleEnabled (binding) {
+  return typeof binding.value === 'undefined' || !!binding.value
+}
+
 function directive (el, binding) {
-  el.setAttribute(RippleDataAttribute, !!binding.value)
+  el.setAttribute(RippleDataAttribute, isRippleEnabled(binding))
 
   if ('ontouchstart' in window) {
     el.addEventListener('touchend', () => ripple.hide(el), false)
@@ -109,7 +113,7 @@ function update (el, binding) {
     return
   }
 
-  el.setAttribute(RippleDataAttribute, !!binding.value)
+  el.setAttribute(RippleDataAttribute, isRippleEnabled(binding))
 }
 
 export default {

--- a/src/directives/ripple.spec.js
+++ b/src/directives/ripple.spec.js
@@ -25,50 +25,6 @@ test('VRipple', () => {
     expect(div.getAttribute('data-ripple')).toBe('true')
   })
 
-  it('Ripple with true value should render data attribute true', () => {
-    const testComponent = Vue.component('test', {
-      directives: {
-        Ripple
-      },
-      render (h){
-        const data = {
-          directives: [{
-            name: 'ripple',
-            value: true
-          }]
-        }
-        return h('div', data)
-      }
-    })
-
-    const wrapper = mount(testComponent)
-
-    const div = wrapper.find('div')[0]
-    expect(div.getAttribute('data-ripple')).toBe('true')
-  })
-
-  it('Ripple with false value should render data attribute false', () => {
-    const testComponent = Vue.component('test', {
-      directives: {
-        Ripple
-      },
-      render (h){
-        const data = {
-          directives: [{
-            name: 'ripple',
-            value: false
-          }]
-        }
-        return h('div', data)
-      }
-    })
-
-    const wrapper = mount(testComponent)
-
-    const div = wrapper.find('div')[0]
-    expect(div.getAttribute('data-ripple')).toBe('false')
-  })
-
   it('Ripple should update data attribute reactively', () => {
     const testComponent = Vue.component('test', {
       directives: {

--- a/src/directives/ripple.spec.js
+++ b/src/directives/ripple.spec.js
@@ -1,0 +1,111 @@
+import Vue from 'vue'
+import { test } from '~util/testing'
+import { mount } from 'avoriaz'
+import Ripple from '~directives/ripple'
+
+test('VRipple', () => {
+  it('Ripple with no value should render data attribute true', () => {
+    const testComponent = Vue.component('test', {
+      directives: {
+        Ripple
+      },
+      render (h){
+        const data = {
+          directives: [{
+            name: 'ripple'
+          }]
+        }
+        return h('div', data)
+      }
+    })
+
+    const wrapper = mount(testComponent)
+
+    const div = wrapper.find('div')[0]
+    expect(div.getAttribute('data-ripple')).toBe('true')
+  })
+
+  it('Ripple with true value should render data attribute true', () => {
+    const testComponent = Vue.component('test', {
+      directives: {
+        Ripple
+      },
+      render (h){
+        const data = {
+          directives: [{
+            name: 'ripple',
+            value: true
+          }]
+        }
+        return h('div', data)
+      }
+    })
+
+    const wrapper = mount(testComponent)
+
+    const div = wrapper.find('div')[0]
+    expect(div.getAttribute('data-ripple')).toBe('true')
+  })
+
+  it('Ripple with false value should render data attribute false', () => {
+    const testComponent = Vue.component('test', {
+      directives: {
+        Ripple
+      },
+      render (h){
+        const data = {
+          directives: [{
+            name: 'ripple',
+            value: false
+          }]
+        }
+        return h('div', data)
+      }
+    })
+
+    const wrapper = mount(testComponent)
+
+    const div = wrapper.find('div')[0]
+    expect(div.getAttribute('data-ripple')).toBe('false')
+  })
+
+  it('Ripple should update data attribute reactively', () => {
+    const testComponent = Vue.component('test', {
+      directives: {
+        Ripple
+      },
+      props: {
+        ripple: Boolean,
+        default: false
+      },
+      render (h){
+        const data = {
+          directives: [{
+            name: 'ripple',
+            value: this.ripple
+          }]
+        }
+        return h('div', data)
+      }
+    })
+
+    const wrapper = mount(testComponent, {
+      propsData: {
+        ripple: true
+      }
+    })
+
+    wrapper.vm.$nextTick()
+
+    const div = wrapper.find('div')[0]
+    expect(div.getAttribute('data-ripple')).toBe('true')
+
+    wrapper.setProps({ ripple: false })
+
+    expect(div.getAttribute('data-ripple')).toBe('false')
+
+    wrapper.setProps({ ripple: true })
+
+    expect(div.getAttribute('data-ripple')).toBe('true')
+  })
+})

--- a/src/directives/ripple.spec.js
+++ b/src/directives/ripple.spec.js
@@ -95,17 +95,13 @@ test('VRipple', () => {
       }
     })
 
-    wrapper.vm.$nextTick()
-
     const div = wrapper.find('div')[0]
     expect(div.getAttribute('data-ripple')).toBe('true')
 
     wrapper.setProps({ ripple: false })
-
     expect(div.getAttribute('data-ripple')).toBe('false')
 
     wrapper.setProps({ ripple: true })
-
     expect(div.getAttribute('data-ripple')).toBe('true')
   })
 })


### PR DESCRIPTION
```<div v-ripple>Test</div>```  should have ripple.  Ripple reactivity fix broke this use case.