### PR TITLE
fix: (VExpansionPanel) use component name instead

### DIFF
--- a/src/components/VExpansionPanel/VExpansionPanel.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.js
@@ -26,7 +26,7 @@ export default {
       return this.$children.filter(c => {
         if (!c.$options) return
 
-        return c.$options._componentTag === 'v-expansion-panel-content'
+        return c.$options.name === 'v-expansion-panel-content'
       })
     },
     panelClick (uid) {


### PR DESCRIPTION
If we would register component locally like this:

```js
import VExpansionPanel from 'vuetify/es5/components/VExpansionPanel/VExpansionPanel'

export default {
  name: 'my-component',
  components: {
    'expansion-panel-with-my-name': VExpansionPanel
  }
}
```
The component would be named as  'expansion-panel-with-my-name'. But $options._componentTag would be equal to 'expansion-panel-with-my-name' and toogle would not work, but $options.name will still have a name equal to 'v-expansion-panel-content' and toogle work as expected.