### PR TITLE
fix(layout): fix layout regression from #2298

### DIFF
--- a/src/components/VApp/VApp.js
+++ b/src/components/VApp/VApp.js
@@ -59,6 +59,8 @@ export default {
       }]
     }
 
-    return h('div', data, this.$slots.default)
+    const app = h('div', data, this.$slots.default)
+
+    return h('div', { staticClass: 'application--wrap' }, [app])
   }
 }

--- a/src/components/VApp/VApp.spec.js
+++ b/src/components/VApp/VApp.spec.js
@@ -2,18 +2,17 @@ import VApp from '~components/VApp'
 import { test } from '~util/testing'
 
 test('VApp.js', ({ mount }) => {
-  it('should have an application class', () => {
+  it('should match a snapshot', () => {
     const wrapper = mount(VApp)
 
-    expect(wrapper.hasClass('application')).toBe(true)
     expect(wrapper.html()).toMatchSnapshot()
   })
 
   it('should have data-app attribute', () => {
     const wrapper = mount(VApp)
+    const app = wrapper.find('.application')[0]
 
-    expect(wrapper.getAttribute('data-app')).toBe('true')
-    expect(wrapper.html()).toMatchSnapshot()
+    expect(app.getAttribute('data-app')).toBe('true')
   })
 
   it('should allow a custom id', () => {
@@ -22,8 +21,9 @@ test('VApp.js', ({ mount }) => {
         id: 'inspire'
       }
     })
+    const app = wrapper.find('.application')[0]
 
-    expect(wrapper.getAttribute('id')).toBe('inspire')
+    expect(app.getAttribute('id')).toBe('inspire')
     expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/src/components/VApp/__snapshots__/VApp.spec.js.snap
+++ b/src/components/VApp/__snapshots__/VApp.spec.js.snap
@@ -2,30 +2,24 @@
 
 exports[`VApp.js should allow a custom id 1`] = `
 
-<div data-app="true"
-     class="application application--light"
-     id="inspire"
->
+<div class="application--wrap">
+  <div data-app="true"
+       class="application application--light"
+       id="inspire"
+  >
+  </div>
 </div>
 
 `;
 
-exports[`VApp.js should have an application class 1`] = `
+exports[`VApp.js should match a snapshot 1`] = `
 
-<div data-app="true"
-     class="application application--light"
-     id="app"
->
-</div>
-
-`;
-
-exports[`VApp.js should have data-app attribute 1`] = `
-
-<div data-app="true"
-     class="application application--light"
-     id="app"
->
+<div class="application--wrap">
+  <div data-app="true"
+       class="application application--light"
+       id="app"
+  >
+  </div>
 </div>
 
 `;

--- a/src/components/VGrid/VContent.js
+++ b/src/components/VGrid/VContent.js
@@ -3,6 +3,13 @@ require('../../stylus/components/_content.styl')
 export default {
   name: 'v-content',
 
+  props: {
+    tag: {
+      type: String,
+      default: 'main'
+    }
+  },
+
   computed: {
     styles () {
       const {
@@ -31,6 +38,10 @@ export default {
       style: this.styles
     }
 
-    return h('main', data, this.$slots.default)
+    return h('div', {
+      staticClass: 'content--wrap'
+    }, [
+      h(this.tag, data, this.$slots.default)
+    ])
   }
 }

--- a/src/stylus/components/_app.styl
+++ b/src/stylus/components/_app.styl
@@ -4,14 +4,12 @@
 .application
   -webkit-backface-visibility: hidden
   display: flex
-  min-height: 100vh
   flex-direction: column
 
   // TODO: Deprecate
   > main:not(.content)
     flex: 1 0 auto
     display: flex
-    flex-direction: column
 
 application($material)
   background: $material.background

--- a/src/stylus/components/_app.styl
+++ b/src/stylus/components/_app.styl
@@ -2,9 +2,14 @@
 @import '../theme'
 
 .application
-  -webkit-backface-visibility: hidden
+  flex: 1 1 auto
+  backface-visibility: hidden
   display: flex
   flex-direction: column
+  min-height: 100vh
+
+  &--wrap
+    display: flex
 
   // TODO: Deprecate
   > main:not(.content)

--- a/src/stylus/components/_content.styl
+++ b/src/stylus/components/_content.styl
@@ -3,7 +3,6 @@
 .content
   flex: 1 1 auto
   max-width: 100%
-  min-height: 100vh
   transition: .3s padding $transition.swing
   will-change: padding
 

--- a/src/stylus/components/_content.styl
+++ b/src/stylus/components/_content.styl
@@ -1,7 +1,12 @@
 @import '../bootstrap'
 
 .content
-  flex: 1 0 auto
+  flex: 1 1 auto
   max-width: 100%
+  min-height: 100vh
   transition: .3s padding $transition.swing
   will-change: padding
+
+  &--wrap
+    flex: 1 0 auto
+    display: flex

--- a/src/stylus/elements/_global.styl
+++ b/src/stylus/elements/_global.styl
@@ -1,9 +1,3 @@
-html, body
-  height: 100%
-  min-height: 100%
-  position: relative
-  width: 100%
-
 html
   font-size: $font-size-root
   text-rendering: optimizeLegibility


### PR DESCRIPTION
0.16.9: https://codepen.io/anon/pen/NaQJbG?editors=1010
0.17 beta: https://codepen.io/anon/pen/xXvBEW?editors=1010 - This works in firefox and edge which is really weird as it's typically the other way around. 

This has been broken in IE for a while too, here's a pen with babel and 0.16.1: https://codepen.io/anon/pen/XevGwP?editors=1010

 - Added a prop to set the `v-content` tag
 - Reverted back to having a wrapper around `.content` due to flexbugs #3 and #11, but it's generated automatically now
 - Removed height and min-height from `body, html` and added `min-height` to `.application`, with a flex row wrapper to prevent flexbugs #3

Throw whatever you can at this, I tried what I could think of and it holds up so far. 