### PR TITLE
Fix for default Google Chrome outline on sortable table headers

### DIFF
--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -60,6 +60,7 @@ table.table
 
       &.sortable
         pointer-events: auto
+        outline: none
 
       > div
         width: 100%


### PR DESCRIPTION
This change will prevent the default Google Chrome outline (-webkit-focus-ring-color auto 5px;) being applied to the sortable table headers.