### PR TITLE
Add outline support to Alert component

### DIFF
--- a/src/components/VAlert/VAlert.js
+++ b/src/components/VAlert/VAlert.js
@@ -18,6 +18,7 @@ export default {
   props: {
     dismissible: Boolean,
     icon: String,
+    outline: Boolean,
     type: {
       type: String,
       validator (val) {
@@ -38,10 +39,12 @@ export default {
   computed: {
     classes () {
       const colorProp = (this.type && !this.color) ? 'type' : 'computedColor'
-
-      return this.addBackgroundColorClassChecks({
-        'alert--dismissible': this.dismissible
-      }, colorProp)
+      const classes = {
+        'alert--dismissible': this.dismissible,
+        'alert--outline': this.outline
+      }
+      return this.outline ? this.addTextColorClassChecks(classes, colorProp)
+        : this.addBackgroundColorClassChecks(classes, colorProp)
     },
     computedIcon () {
       if (this.icon || !this.type) return this.icon

--- a/src/components/VAlert/VAlert.js
+++ b/src/components/VAlert/VAlert.js
@@ -43,6 +43,7 @@ export default {
         'alert--dismissible': this.dismissible,
         'alert--outline': this.outline
       }
+      
       return this.outline ? this.addTextColorClassChecks(classes, colorProp)
         : this.addBackgroundColorClassChecks(classes, colorProp)
     },

--- a/src/components/VAlert/VAlert.js
+++ b/src/components/VAlert/VAlert.js
@@ -43,7 +43,7 @@ export default {
         'alert--dismissible': this.dismissible,
         'alert--outline': this.outline
       }
-      
+
       return this.outline ? this.addTextColorClassChecks(classes, colorProp)
         : this.addBackgroundColorClassChecks(classes, colorProp)
     },

--- a/src/stylus/components/_alerts.styl
+++ b/src/stylus/components/_alerts.styl
@@ -18,7 +18,7 @@
     color: $alert-icon-color
     font-size: $alert-icon-font-size
   &--outline .icon
-    color: currentColor !important
+    color: inherit !important
 
   &__icon
     margin-right: $alert-padding

--- a/src/stylus/components/_alerts.styl
+++ b/src/stylus/components/_alerts.styl
@@ -17,6 +17,8 @@
     align-self: center
     color: $alert-icon-color
     font-size: $alert-icon-font-size
+  &--outline .icon
+    color: currentColor !important
 
   &__icon
     margin-right: $alert-padding
@@ -47,3 +49,5 @@
 // with modifier (for example "red lighten-2")
 .alert.alert
   border-color: $material-light.dividers !important
+  &--outline
+    border: $alert-outline-border-width $alert-outline-border-style currentColor !important

--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -135,6 +135,8 @@ $alert-icon-color := rgba($material-light.fg-color, .3)
 $alert-icon-font-size := 24px
 $alert-padding := 16px
 $alert-margin := $spacers.one.y auto
+$alert-outline-border-width := 1px
+$alert-outline-border-style := solid
 
 // Badges
 $badge-border-radius := 50%


### PR DESCRIPTION
The button component supports an outline display mode and users may want to display alerts this way for certain designs.

Docs PR: https://github.com/vuetifyjs/docs/pull/353

![screenshot_20171030_144202](https://user-images.githubusercontent.com/19727675/32171382-957f8de0-bd80-11e7-8632-d4342458fb8a.png)



