### PR TITLE
fix: only apply button hover style when supported

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -57,7 +57,6 @@ theme(button, "btn")
 /** Content */
 .btn
   &--active,
-  &:hover,
   &:focus
     .btn__content:before
       background-color: currentColor
@@ -74,6 +73,11 @@ theme(button, "btn")
     padding: $button-padding
     transition: $primary-transition
     white-space: nowrap
+
+  @media not all and (hover: none)
+    &:hover
+      .btn__content:before
+        background-color: currentColor
 
 /** Icons */
 .btn .btn__content .icon
@@ -126,7 +130,7 @@ theme(button, "btn")
     width: $button-floating-width
     padding: 0
     elevation(6)
-    
+
     &.btn--fixed,
     &.btn--absolute
       z-index: 4


### PR DESCRIPTION
fixes #2178

```
<template>
  <v-app>

    <v-toolbar app>
      <v-spacer></v-spacer>
      <v-btn icon @click="">
        <v-icon>favorite</v-icon>
      </v-btn>
    </v-toolbar>

  </v-app>
</template>
```