### PR TITLE
feat: selects input value when focusing autocomplete

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -288,7 +288,6 @@ export default {
         !this.isMultiple &&
         val
       ) {
-        this.setCaretPosition(this.currentRange)
         this.shouldBreak && this.$nextTick(() => {
           this.$refs.input.scrollLeft = this.$refs.input.scrollWidth
         })
@@ -440,7 +439,7 @@ export default {
 
       if (this.$refs.input && this.isAutocomplete) {
         this.$refs.input.focus()
-        setTimeout(() => this.$refs.input.select(), 20)
+        this.$nextTick(() => this.$refs.input.select())
       } else {
         this.$el.focus()
       }

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -280,19 +280,6 @@ export default {
         }
       })
     },
-    isFocused (val) {
-      // When focusing the input
-      // re-set the caret position
-      if (this.isAutocomplete &&
-        !this.mask &&
-        !this.isMultiple &&
-        val
-      ) {
-        this.shouldBreak && this.$nextTick(() => {
-          this.$refs.input.scrollLeft = this.$refs.input.scrollWidth
-        })
-      }
-    },
     items (val) {
       if (this.cacheItems) {
         this.cachedItems = this.filterDuplicates(this.cachedItems.concat(val))
@@ -439,7 +426,12 @@ export default {
 
       if (this.$refs.input && this.isAutocomplete) {
         this.$refs.input.focus()
-        this.$nextTick(() => this.$refs.input.select())
+        this.$nextTick(() => {
+          this.$refs.input.select()
+          this.shouldBreak && (
+            this.$refs.input.scrollLeft = this.$refs.input.scrollWidth
+          )
+        })
       } else {
         this.$el.focus()
       }

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -364,6 +364,10 @@ export default {
     // to avoid a unnecessary label transition
     this.genSelectedItems()
 
+    if (this.isAutocomplete) {
+      this.lazySearch = this.getText(this.selectedItem)
+    }
+
     this.content = this.$refs.menu.$refs.content
   },
 
@@ -436,6 +440,7 @@ export default {
 
       if (this.$refs.input && this.isAutocomplete) {
         this.$refs.input.focus()
+        setTimeout(() => this.$refs.input.select(), 20)
       } else {
         this.$el.focus()
       }

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -350,10 +350,6 @@ export default {
     // to avoid a unnecessary label transition
     this.genSelectedItems()
 
-    if (this.isAutocomplete) {
-      this.lazySearch = this.getText(this.selectedItem)
-    }
-
     this.content = this.$refs.menu.$refs.content
   },
 


### PR DESCRIPTION
fixes #2255

### Playground
```vue
<template>
  <v-app id="inspire">
    <v-container fluid>
      <input style="border: 1px solid red; padding: 1em; width: 100%">
      <v-select combobox :items="['abc', 'def']" v-model="v1"></v-select>
      <v-select tags :items="['abc', 'def']" v-model="v2"></v-select>
      <v-select autocomplete :items="['abc', 'def']" v-model="v3"></v-select>
      <v-select autocomplete multiple :items="['abc', 'def']" v-model="v4"></v-select>
      <input style="border: 1px solid red; padding: 1em; width: 100%">
    </v-container>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    v1: 'test',
    v2: ['abc'],
    v3: 'abc',
    v4: ['abc']
  })
}
</script>
```