### PR TITLE
Add `disable-initial-sort` prop to VDataTable

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -138,6 +138,10 @@ export default {
         })
       }
     },
+    defaultSort: {
+      type: Boolean,
+      default: true,
+    },
     value: {
       type: Array,
       default: () => []
@@ -314,7 +318,7 @@ export default {
       !('sortable' in h) || h.sortable)
     )
 
-    this.defaultPagination.sortBy = firstSortable
+    this.defaultPagination.sortBy = this.defaultSort && firstSortable
       ? firstSortable.value
       : null
 

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -140,7 +140,7 @@ export default {
     },
     defaultSort: {
       type: Boolean,
-      default: true,
+      default: true
     },
     value: {
       type: Array,

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -62,6 +62,7 @@ export default {
     },
     hideActions: Boolean,
     hideHeaders: Boolean,
+    disableInitialSort: Boolean,
     mustSort: Boolean,
     noResultsText: {
       type: String,
@@ -137,10 +138,6 @@ export default {
           return 0
         })
       }
-    },
-    defaultSort: {
-      type: Boolean,
-      default: true
     },
     value: {
       type: Array,
@@ -318,7 +315,7 @@ export default {
       !('sortable' in h) || h.sortable)
     )
 
-    this.defaultPagination.sortBy = this.defaultSort && firstSortable
+    this.defaultPagination.sortBy = !this.disableInitialSort && firstSortable
       ? firstSortable.value
       : null
 


### PR DESCRIPTION
* Added a new `default-sort` prop to DataTable, which defaults to `true` (no breaking behavior)
* Use new prop to help determine the initial value for `defaultPagination.sortBy`, if any.

_Closes #2366_ 