### PR TITLE
performance: Remove 3d transform hack (and a few other things)

### DIFF
--- a/src/components/VParallax/VParallax.js
+++ b/src/components/VParallax/VParallax.js
@@ -28,7 +28,7 @@ export default {
       return {
         display: 'block',
         opacity: this.isBooted ? 1 : 0,
-        transform: `translate3d(-50%, ${this.jumbotron ? 0 : this.parallax + 'px'}, 0)`
+        transform: `translate(-50%, ${this.jumbotron ? 0 : this.parallax + 'px'})`
       }
     }
   },

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -101,7 +101,7 @@ export default {
     },
     tickContainerStyles () {
       return {
-        transform: `translate3d(0, -50%, 0)`
+        transform: `translate(0, -50%)`
       }
     },
     trackPadding () {

--- a/src/stylus/components/_bottom-navs.styl
+++ b/src/stylus/components/_bottom-navs.styl
@@ -8,7 +8,7 @@
   height: 56px
   justify-content: center
   position: fixed
-  transform: translate3d(0, 60px, 0)
+  transform: translate(0, 60px)
   transition: all .4s $transition.swing
   width: 100%
   z-index: 4
@@ -17,7 +17,7 @@
     position: absolute
 
   &--active
-    transform: translate3d(0, 0, 0)
+    transform: translate(0, 0)
 
   .btn
     background: transparent !important
@@ -38,7 +38,7 @@
       flex-direction: column-reverse
       height: 56px
       font-size: 12px
-      transform: scale3d(1, 1, 1) translate3d(0, 0, 0)
+      transform: scale(1, 1) translate(0, 0)
       white-space: nowrap
       will-change: font-size
 
@@ -80,7 +80,7 @@
 .bottom-nav--shift
   .btn:not(.btn--active) .btn__content
     .icon
-      transform: scale3d(1, 1, 1) translate3d(0, 10px, 0)
+      transform: scale(1, 1) translate(0, 10px)
 
     span
       color: transparent

--- a/src/stylus/components/_cards.styl
+++ b/src/stylus/components/_cards.styl
@@ -12,7 +12,6 @@ theme(card, "card")
   display: block
   border-radius: $card-border-radius
   min-width: 0
-  position: relative
   text-decoration: none
   elevation(2)
 

--- a/src/stylus/components/_cards.styl
+++ b/src/stylus/components/_cards.styl
@@ -12,6 +12,7 @@ theme(card, "card")
   display: block
   border-radius: $card-border-radius
   min-width: 0
+  position: relative
   text-decoration: none
   elevation(2)
 

--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -107,7 +107,6 @@ theme(input-group, "input-group")
     pointer-events: none
     text-align: left
     text-overflow: ellipsis
-    transform: translate3d(0, 0, 0)
     transform-origin: top left
     transition: .4s $transition.fast-in-fast-out
     white-space: nowrap
@@ -160,9 +159,6 @@ theme(input-group, "input-group")
   // Single Line
   &.input-group--single-line,
   &.input-group--solo
-    label
-      transform: translate3d(0,0,0)
-
     &.input-group--dirty
       label
         display: none

--- a/src/stylus/components/_navigation-drawer.styl
+++ b/src/stylus/components/_navigation-drawer.styl
@@ -61,10 +61,10 @@ theme(navigation-drawer, "navigation-drawer")
 
   &--close:not(.navigation--permanent)
     &.navigation-drawer:not(.navigation-drawer--right)
-      transform: translate3d(-100%, 0, 0)
+      transform: translateX(-100%)
 
     &.navigation-drawer--right
-      transform: translate3d(100%, 0, 0)
+      transform: translateX(100%)
 
   &--right
     left: auto

--- a/src/stylus/components/_parallax.styl
+++ b/src/stylus/components/_parallax.styl
@@ -12,6 +12,7 @@
     right: 0
     bottom: 0
     z-index: 1
+    contain: strict
 
   &__image
     position: absolute
@@ -21,6 +22,7 @@
     min-height: 100%
     display: none
     transform: translate(-50%, 0)
+    will-change: transform
     transition: .3s opacity $transition.swing
     z-index: 1
 

--- a/src/stylus/components/_parallax.styl
+++ b/src/stylus/components/_parallax.styl
@@ -20,7 +20,7 @@
     min-width: 100%
     min-height: 100%
     display: none
-    transform: translate3d(-50%, 0, 0)
+    transform: translate(-50%, 0)
     transition: .3s opacity $transition.swing
     z-index: 1
 

--- a/src/stylus/components/_progress-circular.styl
+++ b/src/stylus/components/_progress-circular.styl
@@ -38,7 +38,7 @@
     position: absolute
     top: 50%
     left: 50%
-    transform: translate3d(-50%, -50%, 0)
+    transform: translate(-50%, -50%)
 
   @keyframes progress-circular-dash
     0%

--- a/src/stylus/components/_selection-controls.styl
+++ b/src/stylus/components/_selection-controls.styl
@@ -27,7 +27,7 @@ theme(selection-control, "input-group--selection-controls")
 .input-group--tab-focused .input-group:focus
   .input-group--selection-controls__ripple
     &:before
-      transform: translate3d(-50%, -50%, 0) scale(1)
+      transform: translate(-50%, -50%) scale(1)
       opacity: $ripple-animation-visible-opacity
 
 /** Input */
@@ -66,9 +66,7 @@ theme(selection-control, "input-group--selection-controls")
 
 /** Label */
 .input-group.input-group--selection-controls label
-  pointer-events: inherit
   cursor: pointer
-  pointer-events: auto
   position: absolute
   left: 32px
   user-select: none
@@ -81,7 +79,7 @@ theme(selection-control, "input-group--selection-controls")
   width: 48px
   cursor: pointer
   position: absolute
-  transform: translate3d(-12px, -50%, 0)
+  transform: translate(-12px, -50%)
   transform-origin: center center
   top: 50%
   left: 0
@@ -95,7 +93,7 @@ theme(selection-control, "input-group--selection-controls")
     border-radius: 50%
     left: 50%
     top: 50%
-    transform: translate3d(-50%, -50%, 0) scale(.3)
+    transform: translate(-50%, -50%) scale(.3)
     opacity: 0
     transition: $ripple-animation-transition
     transform-origin: center center

--- a/src/stylus/components/_sliders.styl
+++ b/src/stylus/components/_sliders.styl
@@ -216,7 +216,7 @@ theme(slider, "input-group--slider")
     transition: .3s ease-in-out
 
     span
-      transform: rotate(-45deg) translateZ(0)
+      transform: rotate(-45deg)
 
   &__track,
   &__track-fill

--- a/src/stylus/components/_snackbars.styl
+++ b/src/stylus/components/_snackbars.styl
@@ -15,12 +15,12 @@
   &--top
     top: 0
     left: 50%
-    transform: translate3d(-50%, 0, 0) translateZ(0)
+    transform: translate(-50%, 0)
 
   &--bottom
     bottom: 48px
     left: 50%
-    transform: translate3d(-50%, 0, 0) translateZ(0)
+    transform: translate(-50%, 0)
 
   &--left
     left: 8px

--- a/src/stylus/components/_switch.styl
+++ b/src/stylus/components/_switch.styl
@@ -63,7 +63,7 @@ theme(switch, "switch")
         opacity: .5
 
     .input-group--selection-controls__ripple
-      transform: translate3d(-15px, -24px, 0)
+      transform: translate(-15px, -24px)
       transition: .3s $transition.fast-in-fast-out
       z-index: 1
 
@@ -76,12 +76,12 @@ theme(switch, "switch")
         border-radius: 50%
         top: 50%
         left: 50%
-        transform: translate3d(-50%, -50%, 0)
+        transform: translate(-50%, -50%)
         height: 20px
         elevation(4)
 
       &--active
-        transform: translate3d(2px, -24px, 0)
+        transform: translate(2px, -24px)
 
     label
       padding-left: 14px

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -89,7 +89,7 @@ table.table
 
       .input-group--selection-controls__ripple
         left: 50%
-        transform: translate3d(-50%, -50%, 0)
+        transform: translate(-50%, -50%)
   tfoot
     tr:not(:last-child)
       height: 48px

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -127,25 +127,25 @@ theme(textfield, "input-group--text-field")
 
       &:not(.input-group--textarea)
         label
-          transform: translate3d(0, -18px, 0) scale(.75)
+          transform: translate(0, -18px) scale(.75)
 
       &:not(.input-group--full-width).input-group--textarea
         label
-          transform: translate3d(0, -8px, 0) scale(.75)
+          transform: translate(0, -8px) scale(.75)
 
       &.input-group--text-field-box
         label
-          transform: translate3d(0, -10px, 0) scale(.75)
+          transform: translate(0, -10px) scale(.75)
 
   &.input-group--dirty
     &.input-group--select,
     &:not(.input-group--textarea)
       label
-        transform: translate3d(0, -18px, 0) scale(.75)
+        transform: translate(0, -18px) scale(.75)
 
     &:not(.input-group--full-width).input-group--textarea
       label
-        transform: translate3d(0, -8px, 0) scale(.75)
+        transform: translate(0, -8px) scale(.75)
 
   // Multi Line
   &.input-group--multi-line
@@ -231,7 +231,7 @@ theme(textfield, "input-group--text-field")
       &.input-group--focused,
       &.input-group--dirty
         label
-          transform: translate3d(0, -10px, 0) scale(0.75)
+          transform: translate(0, -10px) scale(0.75)
   // Icons
   &.input-group--prepend-icon
     .input-group__details

--- a/src/stylus/components/_time-picker.styl
+++ b/src/stylus/components/_time-picker.styl
@@ -114,7 +114,7 @@ theme(date-picker, "picker--time")
       position: absolute
       top: -3%
       left: 50%
-      transform: translate3d(-50%, -50%, 0)
+      transform: translate(-50%, -50%)
 
     &:after
       content: ''
@@ -127,7 +127,7 @@ theme(date-picker, "picker--time")
       border-style: solid
       border-color: inherit
       background-color: inherit
-      transform: translate3d(calc(-50%, - 1px), -50%, 0)
+      transform: translate(calc(-50%, - 1px), -50%)
 
   > span
     align-items: center
@@ -155,7 +155,7 @@ theme(date-picker, "picker--time")
       left: 50%
       height: 14px
       width: 14px
-      transform: translate3d(-50%, -50%, 0)
+      transform: translate(-50%, -50%)
 
     &:after, &:before
       height: $time-picker-number-font-size * 2.5

--- a/src/stylus/generic/_transitions.styl
+++ b/src/stylus/generic/_transitions.styl
@@ -8,21 +8,21 @@
 
 .carousel-transition
   &-enter
-    transform: translate3d(100%, 0, 0)
+    transform: translate(100%, 0)
 
   &-leave, &-leave-to
     position: absolute
     top: 0
-    transform: translate3d(-100%, 0, 0)
+    transform: translate(-100%, 0)
 
 .carousel-reverse-transition
   &-enter
-    transform: translate3d(-100%, 0, 0)
+    transform: translate(-100%, 0)
 
   &-leave, &-leave-to
     position: absolute
     top: 0
-    transform: translate3d(100%, 0, 0)
+    transform: translate(100%, 0)
 
 .dialog-transition
   &-enter, &-leave-to


### PR DESCRIPTION
The over-use of 3d transforms was causing massive memory leaks on complex pages. This PR replaces them all with 2d transforms instead. 

This is **very heavy-handed**, there are probably some cases where a new compositing layer was actually needed. If any of these *were* needed, they should be added back in with the proper methods instead - `backface-visibility` or `will-change` 

Other things that managed to sneak in:
 - ~~Removed `position: relative` from `v-card`, it was also causing memory issues~~ **REVERTED**, this broke bottom-nav in cards
 - Removed two redundant `pointer-events` declarations from `.input-group--selection-controls label`

The first commit is all that's really needed to fix this codepen: https://codepen.io/anon/pen/WXbjjz?editors=1000