### PR TITLE
Fix: Show no-data text on non-autocomplete selects

### DIFF
--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -41,9 +41,7 @@ export default {
           offsetOverflow: this.isAutocomplete,
           openOnClick: false,
           value: this.menuIsActive &&
-            this.computedItems.length &&
-            (!this.tags || this.filteredItems.length > 0) &&
-            (!this.combobox || this.filteredItems.length > 0),
+            (!this.isAutocomplete || this.filteredItems.length),
           zIndex: this.menuZIndex
         },
         on: {


### PR DESCRIPTION
See #2081
Reverts c89ac1034f720d2483fb331412b6331f3f24fdf0