### PR TITLE
fix: don't open autocomplete menu when focused or cleared

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -536,8 +536,7 @@ export default {
       this.inputValue = inputValue
       this.searchValue = null
       this.$emit('change', inputValue)
-      this.genSelectedItems()
-      setTimeout(this.showMenu, 0)
+      this.$nextTick(this.focus)
     },
     showMenu () {
       this.showMenuItems()
@@ -627,21 +626,11 @@ export default {
     if (!this.isAutocomplete) {
       data.on = this.genListeners()
       data.directives = this.genDirectives()
-    } else {
+    } else if (!this.disabled && !this.readonly) {
+      // Workaround for clicking autocomplete
+      // if click does not target the input
       data.on = {
-        click: () => {
-          if (this.disabled || this.readonly) return
-
-          // Workaround for clicking select
-          // when using autocomplete
-          // and click doesn't target the input
-          setTimeout(() => {
-            if (this.menuIsActive) return
-
-            this.focus()
-            this.menuIsActive = true
-          }, 100)
-        }
+        click: this.focus
       }
     }
 

--- a/src/components/VSelect/VSelect2.spec.js
+++ b/src/components/VSelect/VSelect2.spec.js
@@ -69,7 +69,7 @@ test('VSelect', () => {
     expect(wrapper.html()).toMatchSnapshot()
 
     clear.trigger('click')
-    await new Promise(resolve => setTimeout(resolve, 5))
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.inputValue).toBe(null)
     expect(wrapper.html()).toMatchSnapshot()
 
@@ -96,7 +96,7 @@ test('VSelect', () => {
     expect(wrapper.html()).toMatchSnapshot()
 
     clear.trigger('click')
-    await new Promise(resolve => setTimeout(resolve, 5))
+    await wrapper.vm.$nextTick()
     expect(change).toHaveBeenCalledWith([])
     expect(wrapper.html()).toMatchSnapshot()
 

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -125,7 +125,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--text"
+     class="input-group input-group--focused input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -140,8 +140,8 @@ exports[`VSelect should be clearable with prop, dirty and multi select 2`] = `
     <div class="menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select menuable__content__active"
-           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 10; display: none; z-index: 10;"
+      <div class="menu__content menu__content--select"
+           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
       >
         <div class="card"
              style="height: auto;"
@@ -319,7 +319,7 @@ exports[`VSelect should be clearable with prop, dirty and single select 2`] = `
 
 <div tabindex="0"
      role="combobox"
-     class="input-group input-group--append-icon input-group--text-field input-group--select primary--text"
+     class="input-group input-group--focused input-group--append-icon input-group--text-field input-group--select primary--text"
 >
   <div class="input-group__input">
     <div class="input-group__selections"
@@ -334,8 +334,8 @@ exports[`VSelect should be clearable with prop, dirty and single select 2`] = `
     <div class="menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select menuable__content__active"
-           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 10; display: none; z-index: 10;"
+      <div class="menu__content menu__content--select"
+           style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
       >
         <div class="card"
              style="height: auto;"


### PR DESCRIPTION
fixes #2339

### Playground
```vue
<template>
  <v-app id="inspire">
    <v-container fluid>
      <input style="border: 1px solid red; padding: 1em; width: 100%">
      <v-select label="v0" clearable :items="['abc', 'def']" v-model="v0"></v-select>
      <v-select label="v1" clearable combobox :items="['abc', 'def']" v-model="v1"></v-select>
      <v-select label="v2" clearable tags :items="['abc', 'def']" v-model="v2"></v-select>
      <v-select label="v3" clearable autocomplete :items="['abc', 'def']" v-model="v3"></v-select>
      <v-select label="v4" clearable autocomplete multiple :items="['abc', 'def']" v-model="v4"></v-select>
      <input style="border: 1px solid red; padding: 1em; width: 100%">
    </v-container>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    v0: 'abc',
    v1: 'abc',
    v2: ['abc'],
    v3: 'abc',
    v4: ['abc']
  })
}
</script>
```