### PR TITLE
fix: escape item text in select menu

### DIFF
--- a/src/components/VSelect/VSelect.spec.js
+++ b/src/components/VSelect/VSelect.spec.js
@@ -204,4 +204,22 @@ test('VSelect', () => {
 
     expect('Application is missing <v-app> component.').toHaveBeenTipped()
   })
+
+  it('should escape items in menu', async () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        autocomplete: true,
+        items: ['<strong>foo</strong>']
+      }
+    })
+
+    const tileTitle = wrapper.find('.list__tile__title')[0]
+    expect(tileTitle.html()).toMatchSnapshot()
+
+    wrapper.setProps({ searchInput: 'str' })
+    await wrapper.vm.$nextTick()
+    expect(tileTitle.html()).toMatchSnapshot()
+
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
 })

--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VSelect should escape items in menu 1`] = `
+
+<div class="list__tile__title">
+  &lt;strong&gt;foo&lt;/strong&gt;
+</div>
+
+`;
+
+exports[`VSelect should escape items in menu 2`] = `
+
+<div class="list__tile__title">
+  &lt;
+  <span class="list__tile__mask">
+    str
+  </span>
+  ong&gt;foo&lt;/strong&gt;
+</div>
+
+`;
+
 exports[`VSelect should render buttons correctly when using items array with segmented prop 1`] = `
 
 <div tabindex="0"

--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -1,3 +1,5 @@
+import { escapeHTML } from '../../../util/helpers'
+
 /**
  * Select autocomplete
  *
@@ -31,21 +33,21 @@ export default {
       )
     },
     genFiltered (text) {
+      text = (text || '').toString()
+
       if (!this.isAutocomplete ||
         !this.searchValue ||
         this.filteredItems.length < 1
-      ) return text
-
-      text = (text || '').toString()
+      ) return escapeHTML(text)
 
       const { start, middle, end } = this.getMaskedCharacters(text)
 
-      return `${start}${this.genHighlight(middle)}${end}`
+      return `${escapeHTML(start)}${this.genHighlight(middle)}${escapeHTML(end)}`
     },
     genHighlight (text) {
-      if (this.isNotFiltering) return text
+      if (this.isNotFiltering) return escapeHTML(text)
 
-      return `<span class="list__tile__mask">${text}</span>`
+      return `<span class="list__tile__mask">${escapeHTML(text)}</span>`
     },
     getMaskedCharacters (text) {
       const searchValue = (this.searchValue || '').toString().toLowerCase()

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -123,3 +123,12 @@ export function getZIndex (el) {
 
   return zi
 }
+
+const tagsToReplace = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;'
+}
+export function escapeHTML (str) {
+  return str.replace(/[&<>]/g, tag => tagsToReplace[tag] || tag)
+}


### PR DESCRIPTION
```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-container>
        <v-select label="Your favorite hobbies" clearable :items="chips" v-model="x1"></v-select>
        <v-select label="Your favorite hobbies" autocomplete clearable :items="chips" v-model="x2"></v-select>
        <v-select label="Your favorite hobbies" tags clearable :items="chips" v-model="x3"></v-select>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      chips: ["Progamming<strong>xx</strong>", "Playing video games", "Watching", "Sleeping"],
      x1: null,
      x2: null,
      x3: null
    }
  }
};
</script>
```