### PR TITLE
fix(chips): prevent changing the size of an element in outline mode

### DIFF
--- a/src/stylus/components/_chips.styl
+++ b/src/stylus/components/_chips.styl
@@ -20,6 +20,7 @@ theme(chip, "chip")
 .chip
   align-items: center
   border-radius: $chip-border-radius
+  border: 1px solid transparent
   color: $chip-label-color
   cursor: default
   display: inline-flex
@@ -57,7 +58,6 @@ theme(chip, "chip")
 
   &.chip--outline
     background: $chip-outline-background
-    border: 1px solid transparent
     color: $chip-outline-color
 
   &--small


### PR DESCRIPTION
When the state of the element changes (normal / outline), the adjacent elements begin to shift by 2px due to the addition of border