### PR TITLE
fix: picker header color in dark theme

### DIFF
--- a/src/components/VApp/VApp.js
+++ b/src/components/VApp/VApp.js
@@ -40,13 +40,13 @@ export default {
   },
 
   mounted () {
-    this.$vuetify.theme.type = this.type
+    this.$vuetify.dark = this.dark
     window.addEventListener('load', this.runCallbacks)
   },
 
   watch: {
-    type () {
-      this.$vuetify.theme.type = this.type
+    dark () {
+      this.$vuetify.dark = this.dark
     }
   },
 

--- a/src/components/VApp/mixins/app-theme.js
+++ b/src/components/VApp/mixins/app-theme.js
@@ -4,33 +4,22 @@ export default {
   }),
 
   watch: {
-    type () {
-      this.applyType()
-    },
     '$vuetify.theme': {
       deep: true,
       handler () {
-        this.applyType()
+        this.applyTheme()
       }
     }
   },
 
   mounted () {
     this.genStyle()
-    this.genThemeClasses()
-    this.applyType()
+    this.applyTheme()
   },
 
   methods: {
-    applyType () {
-      this.genThemeClasses()
-      this.$vuetify.theme.type = this.type
-    },
-    genThemeClasses () {
-      this.updateTheme(this.genTheme())
-    },
-    genTheme () {
-      return this.genColors(this.$vuetify.theme)
+    applyTheme () {
+      this.style.innerHTML = this.genColors(this.$vuetify.theme)
     },
     genColors (theme) {
       return Object.keys(theme).map(key => {
@@ -53,9 +42,6 @@ export default {
       style.type = 'text/css'
       document.head.appendChild(style)
       this.style = style
-    },
-    updateTheme (classes) {
-      this.style.innerHTML = classes
     }
   }
 }

--- a/src/components/Vuetify/index.js
+++ b/src/components/Vuetify/index.js
@@ -11,6 +11,7 @@ const Vuetify = {
     const $vuetify = { load }
     Vue.util.defineReactive($vuetify, 'breakpoint', {})
     Vue.util.defineReactive($vuetify, 'application', application)
+    Vue.util.defineReactive($vuetify, 'dark', false)
     Vue.util.defineReactive($vuetify, 'theme', theme(opts.theme))
     Vue.util.defineReactive($vuetify, 'touchSupport', false)
 

--- a/src/mixins/picker.js
+++ b/src/mixins/picker.js
@@ -25,7 +25,7 @@ export default {
 
   computed: {
     titleColor () {
-      const darkTheme = this.dark || (!this.light && this.$vuetify.theme.type === 'dark')
+      const darkTheme = this.dark || (!this.light && this.$vuetify.dark)
       const defaultTitleColor = darkTheme ? null : 'primary'
       return this.headerColor || this.color || defaultTitleColor
     }


### PR DESCRIPTION
### Playground
```vue
<template>
  <v-app id="inspire" :dark="dark">
    <v-content>
      <v-container>

        <v-checkbox label="Dark" v-model="dark"></v-checkbox>
        <v-text-field label="Primary color" :value="$vuetify.theme.primary" @input="$vuetify.theme.primary = $event"></v-text-field>
        <v-date-picker></v-date-picker>

      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    dark: false
  })
}
</script>
```