### PR TITLE
Fix/navigation drawer active states

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -218,10 +218,7 @@ export default {
     },
     genDirectives () {
       const directives = [
-        {
-          name: 'click-outside',
-          value: this.closeConditional
-        },
+        { name: 'click-outside', value: this.closeConditional },
         {
           name: 'resize',
           value: {

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -21,7 +21,7 @@ export default {
 
   data () {
     return {
-      isActive: this.value,
+      isActive: !!this.value,
       isBooted: false,
       isMobile: false,
       touchArea: {
@@ -35,7 +35,7 @@ export default {
     absolute: Boolean,
     clipped: Boolean,
     disableRouteWatcher: Boolean,
-    enableResizeWatcher: Boolean,
+    disableResizeWatcher: Boolean,
     height: String,
     floating: Boolean,
     miniVariant: Boolean,
@@ -167,13 +167,13 @@ export default {
 
   methods: {
     init () {
-      if (this.value != null) this.isActive = this.value
-      else if (this.permanent) this.isActive = true
-      else if (this.isMobile) this.isActive = false
-      else if (!this.value &&
-        (this.persistent || this.temporary)
-      ) this.isActive = false
-      else this.isActive = true
+      if (this.permanent) {
+        this.isActive = true
+      } else if (this.value == null) {
+        this.onResize()
+      } else {
+        this.isActive = this.value
+      }
 
       setTimeout(() => (this.isBooted = true), 0)
     },
@@ -200,7 +200,11 @@ export default {
         },
         {
           name: 'resize',
-          value: this.onResize
+          value: {
+            debounce: 200,
+            quiet: true,
+            value: this.onResize
+          }
         }
       ]
 
@@ -216,7 +220,7 @@ export default {
       return directives
     },
     onResize () {
-      if (!this.enableResizeWatcher ||
+      if (this.disableResizeWatcher ||
         this.permanent ||
         this.temporary
       ) return

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -128,22 +128,20 @@ export default {
       this.tryOverlay()
       this.$el.scrollTop = 0
     },
-    /**
-     * When mobile changes, adjust
-     * the active state only when
-     * there has been a previous
-     * value
-     */
-    isMobile (val, prev) {
+    isMobile (val) {
       // This skips normal functionality
       // when the drawer first boots up
-      if (prev == null) return
+      // or the drawer is temporary
+      if (!this.isBooted ||
+        this.temporary ||
+        this.disableResizeWatcher
+      ) return
 
-      !val && !this.isActive && this.removeOverlay()
+      this.isActive = !val
 
-      if (prev != null && !this.temporary) {
-        this.isActive = !val
-      }
+      // When resizing small to large
+      // remove the overlay
+      if (!val) this.removeOverlay()
     },
     permanent (val) {
       // If we are removing prop
@@ -189,13 +187,13 @@ export default {
 
   methods: {
     init () {
-      this.checkIfMobile()
+      this.onResize()
 
       if (this.permanent && !this.isMobile) {
         this.isActive = true
       } else if (this.value != null) {
         this.isActive = this.value
-      } else {
+      } else if (!this.temporary) {
         this.isActive = !this.isMobile
       }
 
@@ -209,9 +207,6 @@ export default {
         left: parentRect.left + 50,
         right: parentRect.right - 50
       }
-    },
-    checkIfMobile () {
-      this.isMobile = window.innerWidth < parseInt(this.mobileBreakPoint, 10)
     },
     closeConditional () {
       return this.isMobile || this.temporary
@@ -241,9 +236,7 @@ export default {
       return directives
     },
     onResize () {
-      if (this.disableResizeWatcher) return
-
-      this.checkIfMobile()
+      this.isMobile = window.innerWidth < parseInt(this.mobileBreakPoint, 10)
     },
     swipeRight (e) {
       if (this.isActive && !this.right) return
@@ -266,7 +259,10 @@ export default {
       else if (!this.right && this.isActive) this.isActive = false
     },
     tryOverlay () {
-      if (this.showOverlay && this.isActive) {
+      if (this.showOverlay &&
+        this.isActive &&
+        (this.temporary || this.isMobile)
+      ) {
         return this.genOverlay()
       }
 

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -21,9 +21,9 @@ export default {
 
   data () {
     return {
-      isActive: !!this.value,
+      isActive: false,
       isBooted: false,
-      isMobile: false,
+      isMobile: null,
       touchArea: {
         left: 0,
         right: 0
@@ -37,6 +37,7 @@ export default {
     disableRouteWatcher: Boolean,
     disableResizeWatcher: Boolean,
     height: String,
+    fixed: Boolean,
     floating: Boolean,
     miniVariant: Boolean,
     miniVariantWidth: {
@@ -48,7 +49,6 @@ export default {
       default: 1264
     },
     permanent: Boolean,
-    persistent: Boolean,
     right: Boolean,
     temporary: Boolean,
     touchless: Boolean,
@@ -74,13 +74,12 @@ export default {
         'navigation-drawer--absolute': this.absolute,
         'navigation-drawer--clipped': this.clipped,
         'navigation-drawer--close': !this.isBooted || !this.isActive,
+        'navigation-drawer--fixed': this.fixed,
         'navigation-drawer--floating': this.floating,
         'navigation-drawer--is-booted': this.isBooted,
         'navigation-drawer--is-mobile': this.isMobile,
         'navigation-drawer--mini-variant': this.miniVariant,
         'navigation-drawer--open': this.isActive && this.isBooted,
-        'navigation-drawer--permanent': this.permanent,
-        'navigation-drawer--persistent': this.persistent,
         'navigation-drawer--right': this.right,
         'navigation-drawer--temporary': this.temporary,
         'theme--dark': this.dark,
@@ -105,8 +104,7 @@ export default {
         : this.$vuetify.application.bottom
     },
     showOverlay () {
-      return !this.permanent &&
-        this.isActive &&
+      return this.isActive &&
         (this.temporary || this.isMobile)
     },
     styles () {
@@ -127,17 +125,36 @@ export default {
     },
     isActive (val) {
       this.$emit('input', val)
-      this.showOverlay &&
-        val &&
-        this.genOverlay() ||
-        this.removeOverlay()
+      this.tryOverlay()
       this.$el.scrollTop = 0
     },
-    isMobile (val) {
-      !val && this.removeOverlay()
+    /**
+     * When mobile changes, adjust
+     * the active state only when
+     * there has been a previous
+     * value
+     */
+    isMobile (val, prev) {
+      // This skips normal functionality
+      // when the drawer first boots up
+      if (prev == null) return
+
+      !val && !this.isActive && this.removeOverlay()
+
+      if (prev != null && !this.temporary) {
+        this.isActive = !val
+      }
     },
     permanent (val) {
-      this.$emit('input', val)
+      // If we are removing prop
+      // reset active to match
+      // current value
+      if (!val) return (this.isActive = this.value)
+
+      // We are enabling prop
+      // set its state to match
+      // viewport size
+      this.isActive = !this.isMobile
     },
     right (val, prev) {
       // When the value changes
@@ -149,8 +166,13 @@ export default {
 
       this.updateApplication()
     },
+    temporary (val) {
+      if (!val) return
+
+      this.tryOverlay()
+    },
     value (val) {
-      if (this.permanent) return
+      if (this.permanent && !this.isMobile) return
       if (val !== this.isActive) this.isActive = val
     }
   },
@@ -167,12 +189,14 @@ export default {
 
   methods: {
     init () {
-      if (this.permanent) {
+      this.checkIfMobile()
+
+      if (this.permanent && !this.isMobile) {
         this.isActive = true
-      } else if (this.value == null) {
-        this.onResize()
-      } else {
+      } else if (this.value != null) {
         this.isActive = this.value
+      } else {
+        this.isActive = !this.isMobile
       }
 
       setTimeout(() => (this.isBooted = true), 0)
@@ -190,7 +214,7 @@ export default {
       this.isMobile = window.innerWidth < parseInt(this.mobileBreakPoint, 10)
     },
     closeConditional () {
-      return !this.permanent && (this.temporary || this.isMobile)
+      return this.isMobile || this.temporary
     },
     genDirectives () {
       const directives = [
@@ -220,14 +244,9 @@ export default {
       return directives
     },
     onResize () {
-      if (this.disableResizeWatcher ||
-        this.permanent ||
-        this.temporary
-      ) return
+      if (this.disableResizeWatcher) return
 
       this.checkIfMobile()
-
-      this.isActive = !this.isMobile
     },
     swipeRight (e) {
       if (this.isActive && !this.right) return
@@ -249,14 +268,19 @@ export default {
       ) this.isActive = true
       else if (!this.right && this.isActive) this.isActive = false
     },
+    tryOverlay () {
+      if (this.showOverlay && this.isActive) {
+        return this.genOverlay()
+      }
+
+      this.removeOverlay()
+    },
     updateApplication () {
       if (!this.app) return
 
       const width = !this.isActive ||
-        !this.isBooted ||
-        this.temporary ||
-        !this.permanent &&
-        this.$vuetify.breakpoint.width < parseInt(this.mobileBreakPoint, 10)
+        this.isMobile ||
+        this.temporary
         ? 0
         : this.calculatedWidth
 

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -128,20 +128,22 @@ export default {
       this.tryOverlay()
       this.$el.scrollTop = 0
     },
-    isMobile (val) {
+    /**
+     * When mobile changes, adjust
+     * the active state only when
+     * there has been a previous
+     * value
+     */
+    isMobile (val, prev) {
       // This skips normal functionality
       // when the drawer first boots up
-      // or the drawer is temporary
-      if (!this.isBooted ||
-        this.temporary ||
-        this.disableResizeWatcher
-      ) return
+      if (prev == null) return
 
-      this.isActive = !val
+      !val && !this.isActive && this.removeOverlay()
 
-      // When resizing small to large
-      // remove the overlay
-      if (!val) this.removeOverlay()
+      if (prev != null && !this.temporary) {
+        this.isActive = !val
+      }
     },
     permanent (val) {
       // If we are removing prop
@@ -187,13 +189,13 @@ export default {
 
   methods: {
     init () {
-      this.onResize()
+      this.checkIfMobile()
 
       if (this.permanent && !this.isMobile) {
         this.isActive = true
       } else if (this.value != null) {
         this.isActive = this.value
-      } else if (!this.temporary) {
+      } else {
         this.isActive = !this.isMobile
       }
 
@@ -207,6 +209,9 @@ export default {
         left: parentRect.left + 50,
         right: parentRect.right - 50
       }
+    },
+    checkIfMobile () {
+      this.isMobile = window.innerWidth < parseInt(this.mobileBreakPoint, 10)
     },
     closeConditional () {
       return this.isMobile || this.temporary
@@ -236,7 +241,9 @@ export default {
       return directives
     },
     onResize () {
-      this.isMobile = window.innerWidth < parseInt(this.mobileBreakPoint, 10)
+      if (this.disableResizeWatcher) return
+
+      this.checkIfMobile()
     },
     swipeRight (e) {
       if (this.isActive && !this.right) return
@@ -259,10 +266,7 @@ export default {
       else if (!this.right && this.isActive) this.isActive = false
     },
     tryOverlay () {
-      if (this.showOverlay &&
-        this.isActive &&
-        (this.temporary || this.isMobile)
-      ) {
+      if (this.showOverlay && this.isActive) {
         return this.genOverlay()
       }
 

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -139,7 +139,7 @@ export default {
       // when the drawer first boots up
       if (prev == null) return
 
-      !val && !this.isActive && this.removeOverlay()
+      !val && this.isActive && this.removeOverlay()
 
       if (prev != null && !this.temporary) {
         this.isActive = !val

--- a/src/components/VNavigationDrawer/VNavigationDrawer.spec.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.spec.js
@@ -39,10 +39,10 @@ test('VNavigationDrawer.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom enableResizeWatcher and match snapshot', () => {
+  it('should render component with custom disableResizeWatcher and match snapshot', () => {
     const wrapper = mount(VNavigationDrawer, {
       propsData: {
-        enableResizeWatcher: true
+        disableResizeWatcher: true
       }
     })
 
@@ -149,17 +149,24 @@ test('VNavigationDrawer.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should match value if resize-watcher is not enabled', async () => {
+  it('should match value if value is true or false', async () => {
     const wrapper = mount(VNavigationDrawer, {
       attachToDocument: true,
       propsData: {
-        permanent: true,
         value: false
+      }
+    })
+
+    const wrapper2 = mount(VNavigationDrawer, {
+      attachToDocument: true,
+      propsData: {
+        value: true
       }
     })
 
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.isActive).toBe(false)
+    expect(wrapper2.vm.isActive).toBe(true)
   })
 })

--- a/src/components/VNavigationDrawer/__snapshots__/VNavigationDrawer.spec.js.snap
+++ b/src/components/VNavigationDrawer/__snapshots__/VNavigationDrawer.spec.js.snap
@@ -101,7 +101,7 @@ exports[`VNavigationDrawer.js should render component with custom mobileBreakPoi
 
 exports[`VNavigationDrawer.js should render component with custom permanent and match snapshot 1`] = `
 
-<aside class="navigation-drawer navigation-drawer--close navigation-drawer--permanent"
+<aside class="navigation-drawer navigation-drawer--close"
        style="height: 100%; margin-top: 0px; max-height: calc(100% - 100%px); width: 300px;"
 >
   <div class="navigation-drawer__border">
@@ -112,7 +112,7 @@ exports[`VNavigationDrawer.js should render component with custom permanent and 
 
 exports[`VNavigationDrawer.js should render component with custom persistent and match snapshot 1`] = `
 
-<aside class="navigation-drawer navigation-drawer--close navigation-drawer--persistent"
+<aside class="navigation-drawer navigation-drawer--close"
        style="height: 100%; margin-top: 0px; max-height: calc(100% - 100%px); width: 300px;"
 >
   <div class="navigation-drawer__border">

--- a/src/components/VNavigationDrawer/__snapshots__/VNavigationDrawer.spec.js.snap
+++ b/src/components/VNavigationDrawer/__snapshots__/VNavigationDrawer.spec.js.snap
@@ -33,7 +33,7 @@ exports[`VNavigationDrawer.js should render component with custom clipped and ma
 
 `;
 
-exports[`VNavigationDrawer.js should render component with custom disableRouteWatcher and match snapshot 1`] = `
+exports[`VNavigationDrawer.js should render component with custom disableResizeWatcher and match snapshot 1`] = `
 
 <aside class="navigation-drawer navigation-drawer--close"
        style="height: 100%; margin-top: 0px; max-height: calc(100% - 100%px); width: 300px;"
@@ -44,7 +44,7 @@ exports[`VNavigationDrawer.js should render component with custom disableRouteWa
 
 `;
 
-exports[`VNavigationDrawer.js should render component with custom enableResizeWatcher and match snapshot 1`] = `
+exports[`VNavigationDrawer.js should render component with custom disableRouteWatcher and match snapshot 1`] = `
 
 <aside class="navigation-drawer navigation-drawer--close"
        style="height: 100%; margin-top: 0px; max-height: calc(100% - 100%px); width: 300px;"

--- a/src/directives/resize.js
+++ b/src/directives/resize.js
@@ -1,13 +1,15 @@
 function inserted (el, binding) {
   let cb = binding.value
   let debounce = 200
+  let callOnLoad = true
 
   if (typeof binding.value !== 'function') {
     cb = binding.value.value
-    debounce = binding.value.debounce
+    debounce = binding.value.debounce || debounce
+    callOnLoad = binding.value.quiet != null ? false : callOnLoad
   }
 
-  let debounceTimeout = setTimeout(cb, debounce)
+  let debounceTimeout = null
   const onResize = () => {
     clearTimeout(debounceTimeout)
     debounceTimeout = setTimeout(cb, debounce)
@@ -16,7 +18,7 @@ function inserted (el, binding) {
   window.addEventListener('resize', onResize, { passive: true })
   el._onResize = onResize
 
-  onResize()
+  callOnLoad && onResize()
 }
 
 function unbind (el, binding) {

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -44,7 +44,7 @@ export default {
         ? this.$el.parentNode
         : document.querySelector('[data-app]')
 
-      parent.insertBefore(this.overlay, parent.firstChild)
+      parent && parent.insertBefore(this.overlay, parent.firstChild)
 
       this.overlay.clientHeight // Force repaint
       requestAnimationFrame(() => {

--- a/src/stylus/components/_app.styl
+++ b/src/stylus/components/_app.styl
@@ -11,6 +11,7 @@
     flex-direction: column
     min-height: 100vh
     max-width: 100%
+    position: relative
 
     // TODO: Deprecate
     > main:not(.content)

--- a/src/stylus/components/_navigation-drawer.styl
+++ b/src/stylus/components/_navigation-drawer.styl
@@ -40,7 +40,6 @@ theme(navigation-drawer, "navigation-drawer")
   -webkit-overflow-scrolling: touch
   padding: 0 0 100px
   pointer-events: auto
-  position: fixed
   transition: .3s $transition.swing
   top: 0
   left: 0
@@ -59,7 +58,7 @@ theme(navigation-drawer, "navigation-drawer")
       left: 0
       right: initial
 
-  &--close:not(.navigation--permanent)
+  &--close
     &.navigation-drawer:not(.navigation-drawer--right)
       transform: translateX(-100%)
 
@@ -76,6 +75,9 @@ theme(navigation-drawer, "navigation-drawer")
 
   &--absolute
     position: absolute
+    
+  &--fixed
+    position: fixed
 
   &--floating:after
     display: none
@@ -97,7 +99,8 @@ theme(navigation-drawer, "navigation-drawer")
     .list--group
       display: none !important
 
-  &--temporary, &--is-mobile:not(.navigation-drawer--permanent)
+  &--temporary,
+  &--is-mobile
     z-index: 6
 
     &:not(.navigation-drawer--close)


### PR DESCRIPTION
Resolves complicated states with the **permanent**, **temporary** and **persistent** props.

- removed **persistent**
- a provided explicit boolean value will always determine initial state
- a provided null/undefined value will cause the system to determine initial state
 - permanent will always open by default and not toggle on desktop, regardless of value
 - temporary will always be closed by default
 - no props will open on desktop by default