### PR TITLE
chore: Add .env file to hold dev server config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+HOST=localhost
+PORT=8080

--- a/build/webpack.dev.config.js
+++ b/build/webpack.dev.config.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const merge = require('webpack-merge')
 const baseWebpackConfig = require('./webpack.base.config')
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint --ext .js,.vue src",
     "preparecommitmsg": "node dev/prepare-commit-message.js",
     "precommit": "yarn run lint && yarn test",
-    "prepush": "yarn run lint && yarn test"
+    "prepush": "yarn run lint && yarn test",
+    "prepare": "git update-index --skip-worktree .env"
   },
   "description": "Vue.js 2 Semantic Component Framework",
   "devDependencies": {
@@ -49,6 +50,7 @@
     "css-loader": "^0.28.7",
     "css-mqpacker": "^6.0.1",
     "cssnano": "^3.10.0",
+    "dotenv": "^4.0.0",
     "eslint": "^4.6.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-config-vue": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,6 +1940,10 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"


### PR DESCRIPTION
Allows the dev server host and port to be changed without messing around with environment variables

Changes to the .env file will be ignored thanks to the `prepare` script in package.json