### PR TITLE
fix: TypeScript import error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,4 +5,4 @@ declare class Vuetify {
   static install: PluginFunction<never>
 }
 
-export = Vuetify
+export default Vuetify


### PR DESCRIPTION
TypeScript require ‘export default class’ when using es2015 module. It can't be 'export = class'  .