### PR TITLE
Fix btn--floating overlapping toolbar--fixed

### DIFF
--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -103,7 +103,7 @@ theme(toolbar, "toolbar")
 
   &--fixed
     position: fixed
-    z-index: 2
+    z-index: 5
 
   &--fixed, &--absolute
     top: 0


### PR DESCRIPTION
When scrolling down in a page containing a btn--floating (z-index = 4) with a toolbar--fixed (z-index = 2). The button icon overlaps the toolbar