### PR TITLE
fix: added missing exports

### DIFF
--- a/src/components/VCard/index.js
+++ b/src/components/VCard/index.js
@@ -3,18 +3,18 @@ import VCard from './VCard'
 import VCardMedia from './VCardMedia'
 import VCardTitle from './VCardTitle'
 
-export { VCard, VCardMedia, VCardTitle }
+const VCardActions = createSimpleFunctional('card__actions')
+const VCardText = createSimpleFunctional('card__text')
+
+export { VCard, VCardMedia, VCardTitle, VCardActions, VCardText }
 
 /* istanbul ignore next */
 VCard.install = function install (Vue) {
-  const VCardActions = createSimpleFunctional('card__actions')
-  const VCardText = createSimpleFunctional('card__text')
-
   Vue.component(VCard.name, VCard)
   Vue.component(VCardMedia.name, VCardMedia)
   Vue.component(VCardTitle.name, VCardTitle)
-  Vue.component('v-card-actions', VCardActions)
-  Vue.component('v-card-text', VCardText)
+  Vue.component(VCardActions.name, VCardActions)
+  Vue.component(VCardText.name, VCardText)
 }
 
 export default VCard

--- a/src/components/VDataTable/index.js
+++ b/src/components/VDataTable/index.js
@@ -5,13 +5,15 @@ import {
 import VDataTable from './VDataTable'
 import VEditDialog from './VEditDialog'
 
+const VTableOverflow = createSimpleFunctional('table__overflow')
+
+export { VDataTable, VEditDialog, VTableOverflow }
+
 /* istanbul ignore next */
 VDataTable.install = function install (Vue) {
-  const VTableOverflow = createSimpleFunctional('table__overflow')
-
   Vue.component(VDataTable.name, VDataTable)
   Vue.component(VEditDialog.name, VEditDialog)
-  Vue.component('v-table-overflow', VTableOverflow)
+  Vue.component(VTableOverflow.name, VTableOverflow)
 }
 
 export default VDataTable

--- a/src/components/VExpansionPanel/index.js
+++ b/src/components/VExpansionPanel/index.js
@@ -1,6 +1,8 @@
 import VExpansionPanel from './VExpansionPanel'
 import VExpansionPanelContent from './VExpansionPanelContent'
 
+export { VExpansionPanel, VExpansionPanelContent }
+
 /* istanbul ignore next */
 VExpansionPanel.install = function install (Vue) {
   Vue.component(VExpansionPanel.name, VExpansionPanel)

--- a/src/components/VGrid/index.js
+++ b/src/components/VGrid/index.js
@@ -6,12 +6,14 @@ import VContainer from './VContainer'
 import VFlex from './VFlex'
 import VLayout from './VLayout'
 
-export const VSpacer = createSimpleFunctional('spacer')
+const VSpacer = createSimpleFunctional('spacer')
+
 export {
   VContainer,
   VContent,
   VFlex,
-  VLayout
+  VLayout,
+  VSpacer
 }
 
 const VGrid = {}

--- a/src/components/VList/index.js
+++ b/src/components/VList/index.js
@@ -18,11 +18,11 @@ VList.install = function install (Vue) {
   Vue.component(VListGroup.name, VListGroup)
   Vue.component(VListTile.name, VListTile)
   Vue.component(VListTileAction.name, VListTileAction)
-  Vue.component('v-list-tile-action-text', VListTileActionText)
-  Vue.component('v-list-tile-avatar', VListTileAvatar)
-  Vue.component('v-list-tile-content', VListTileContent)
-  Vue.component('v-list-tile-sub-title', VListTileSubTitle)
-  Vue.component('v-list-tile-title', VListTileTitle)
+  Vue.component(VListTileActionText.name, VListTileActionText)
+  Vue.component(VListTileAvatar.name, VListTileAvatar)
+  Vue.component(VListTileContent.name, VListTileContent)
+  Vue.component(VListTileSubTitle.name, VListTileSubTitle)
+  Vue.component(VListTileTitle.name, VListTileTitle)
 }
 
 export default VList

--- a/src/components/VStepper/index.js
+++ b/src/components/VStepper/index.js
@@ -3,11 +3,13 @@ import VStepper from './VStepper'
 import VStepperStep from './VStepperStep'
 import VStepperContent from './VStepperContent'
 
+const VStepperHeader = createSimpleFunctional('stepper__header')
+const VStepperItems = createSimpleFunctional('stepper__items')
+
+export { VStepper, VStepperContent, VStepperStep, VStepperHeader, VStepperItems }
+
 /* istanbul ignore next */
 VStepper.install = function install (Vue) {
-  const VStepperHeader = createSimpleFunctional('stepper__header')
-  const VStepperItems = createSimpleFunctional('stepper__items')
-
   Vue.component(VStepper.name, VStepper)
   Vue.component(VStepperContent.name, VStepperContent)
   Vue.component(VStepperStep.name, VStepperStep)

--- a/src/components/VTabs/index.js
+++ b/src/components/VTabs/index.js
@@ -5,6 +5,8 @@ import VTabsItem from './VTabsItem'
 import VTabsItems from './VTabsItems'
 import VTabsSlider from './VTabsSlider'
 
+export { VTabs, VTabsBar, VTabsContent, VTabsItem, VTabsItems, VTabsSlider }
+
 /* istanbul ignore next */
 VTabs.install = function install (Vue) {
   Vue.component(VTabs.name, VTabs)

--- a/src/components/VToolbar/index.js
+++ b/src/components/VToolbar/index.js
@@ -5,16 +5,17 @@ import {
 import VToolbar from './VToolbar'
 import VToolbarSideIcon from './VToolbarSideIcon'
 
-export { VToolbar, VToolbarSideIcon }
-export const VToolbarTitle = createSimpleFunctional('toolbar__title')
-export const VToolbarItems = createSimpleFunctional('toolbar__items')
+const VToolbarTitle = createSimpleFunctional('toolbar__title')
+const VToolbarItems = createSimpleFunctional('toolbar__items')
+
+export { VToolbar, VToolbarSideIcon, VToolbarTitle, VToolbarItems }
 
 /* istanbul ignore next */
 VToolbar.install = function install (Vue) {
-  Vue.component('v-toolbar', VToolbar)
-  Vue.component('v-toolbar-items', VToolbarItems)
-  Vue.component('v-toolbar-title', VToolbarTitle)
-  Vue.component('v-toolbar-side-icon', VToolbarSideIcon)
+  Vue.component(VToolbar.name, VToolbar)
+  Vue.component(VToolbarItems.name, VToolbarItems)
+  Vue.component(VToolbarTitle.name, VToolbarTitle)
+  Vue.component(VToolbarSideIcon.name, VToolbarSideIcon)
 }
 
 export default VToolbar


### PR DESCRIPTION
When importing a-la-carte components in SFCs, the install function is
not used, which means that we were missing some components that were not
explicitly exported.

closes #2472