### PR TITLE
fix: append/prepend icon position for switch and checkbox

### DIFF
--- a/src/stylus/components/_selection-controls.styl
+++ b/src/stylus/components/_selection-controls.styl
@@ -108,6 +108,25 @@ theme(selection-control, "input-group--selection-controls")
     label
       left: 76px
 
+.input-group--append-icon
+  &.input-group--selection-controls
+    .input-group__append-icon
+      position: absolute
+      left: 32px
+
+    &.input-group--selection-controls
+      label
+        left: 76px
+
+  &.input-group--prepend-icon
+    &.input-group--selection-controls
+      .input-group__append-icon
+        left: 72px
+
+      &.input-group--selection-controls
+        label
+          left: 112px
+
 .input-group--prepend-icon
   &.radio-group--row
     .icon--selection-control,

--- a/src/stylus/components/_switch.styl
+++ b/src/stylus/components/_switch.styl
@@ -38,11 +38,22 @@ theme(switch, "switch")
   z-index: 0
 
   &.switch
-    min-width: 36px
+    &.input-group--prepend-icon, &.input-group--append-icon
+      label
+        left: 62px
+
+    &.input-group--prepend-icon
+      .input-group--selection-controls__container
+        margin-left: 6px
+
+    &.input-group--append-icon
+      .input-group__append-icon
+        left: 40px
 
     .input-group--selection-controls__container
       color: inherit
       position: relative
+      width: 36px
 
       &[class*="--text"]
         .input-group--selection-controls__ripple--active:after
@@ -66,6 +77,7 @@ theme(switch, "switch")
       transform: translate(-15px, -24px)
       transition: .3s $transition.fast-in-fast-out
       z-index: 1
+      left: 0
 
       &:after
         content: ''


### PR DESCRIPTION
fixes #2418

![localhost-8089- galaxy s5 2](https://user-images.githubusercontent.com/15625235/32698036-dc9763fc-c7cf-11e7-83ef-b7964b7ffd97.png)

### Playground
```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-subheader>append &amp; prepend icon</v-subheader>

      <!-- <v-switch v-model="light" prepend-icon="lightbulb_outline" append-icon="lightbulb_outline"></v-switch> -->
      <v-checkbox v-model="light" prepend-icon="lightbulb_outline" append-icon="lightbulb_outline"></v-checkbox>
      <!-- <v-switch label="test" v-model="light" prepend-icon="lightbulb_outline" append-icon="lightbulb_outline"></v-switch> -->
      <v-checkbox label="test" v-model="light" prepend-icon="lightbulb_outline" append-icon="lightbulb_outline"></v-checkbox>

      <v-subheader>prepend icon</v-subheader>

      <v-switch v-model="light" prepend-icon="lightbulb_outline"></v-switch>
      <v-checkbox v-model="light" prepend-icon="lightbulb_outline"></v-checkbox>
      <v-switch label="test" v-model="light" prepend-icon="lightbulb_outline"></v-switch>
      <v-checkbox label="test" v-model="light" prepend-icon="lightbulb_outline"></v-checkbox>

      <v-subheader>append icon</v-subheader>

      <v-switch v-model="light" append-icon="lightbulb_outline"></v-switch>
      <v-checkbox v-model="light" append-icon="lightbulb_outline"></v-checkbox>
      <v-switch label="test" v-model="light" append-icon="lightbulb_outline"></v-switch>
      <v-checkbox label="test" v-model="light" append-icon="lightbulb_outline"></v-checkbox>

      <v-subheader>no icon</v-subheader>

      <v-switch v-model="light"></v-switch>
      <v-checkbox v-model="light"></v-checkbox>
      <v-switch label="test" v-model="light"></v-switch>
      <v-checkbox label="test" v-model="light"></v-checkbox>

      <v-subheader>alignment check</v-subheader>

      <v-text-field prepend-icon="lightbulb_outline"></v-text-field>
      <v-checkbox v-model="light" prepend-icon="lightbulb_outline" append-icon="lightbulb_outline"></v-checkbox>
      <v-checkbox label="test" v-model="light" prepend-icon="lightbulb_outline" append-icon="lightbulb_outline"></v-checkbox>
      <v-checkbox label="test" v-model="light" prepend-icon="lightbulb_outline"></v-checkbox>
      <v-checkbox label="test" v-model="light" append-icon="lightbulb_outline"></v-checkbox>
      <v-switch label="test" v-model="light" prepend-icon="lightbulb_outline"></v-switch>
      <v-switch label="test" v-model="light" append-icon="lightbulb_outline"></v-switch>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      light: true
    }
  }
}
</script>
```