### PR TITLE
fix(text-field): update lazyValue when bound value is changed by keydown

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -117,8 +117,7 @@ export default {
       }
     },
     value (val) {
-      if (this.internalChange) this.internalChange = false
-      else if (this.mask) {
+      if (this.mask && !this.internalChange) {
         const masked = this.maskText(this.unmaskText(val))
         this.lazyValue = this.unmaskText(masked)
 
@@ -128,6 +127,8 @@ export default {
           this.$emit('input', this.lazyValue)
         })
       } else this.lazyValue = val
+
+      if (this.internalChange) this.internalChange = false
 
       !this.validateOnBlur && this.validate()
       this.shouldAutoGrow && this.calculateInputHeight()


### PR DESCRIPTION
This whole function is a mess and I have no idea what's actually going on here, @azaars is going to have to take a look too. 

Fixes #2498

 - What is `internalChange` for?
 - What should *really* be happening when it is `true` or `false`?
 - Is there a better way to determine `internalChange` that doesn't involve keypress events or anything like that?

From azaars on discord:
> Well, as far as I could remember, the internalChange is there to avoid unnecessary overhead processing in watched.value
which is more needed if the input is externally changed