### PR TITLE
fix(chip): Move chip__content in front of background

### DIFF
--- a/src/stylus/components/_chips.styl
+++ b/src/stylus/components/_chips.styl
@@ -33,6 +33,7 @@ theme(chip, "chip")
     padding: $chip-padding
     vertical-align: middle
     white-space: nowrap
+    z-index: 1
 
   &--removable
     .chip__content
@@ -66,6 +67,7 @@ theme(chip, "chip")
         position: absolute
         transition: inherit
         width: 100%
+        pointer-events: none
 
   &--label
     border-radius: $chip-label-border-radius
@@ -94,6 +96,7 @@ theme(chip, "chip")
     margin-left: 4px
     margin-right: -2px
     transition: none !important
+    user-select: none
 
     &:hover
       opacity: .8


### PR DESCRIPTION
Fixes #2501

Also prevents images and text from darkening when chips are selected