### PR TITLE
Register nav-drawer watchers only if needed

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -8,6 +8,11 @@ import ClickOutside from '../../directives/click-outside'
 import Resize from '../../directives/resize'
 import Touch from '../../directives/touch'
 
+const watchers = {
+  unwatchRoute: Function,
+  unwatchResize: Function
+}
+
 export default {
   name: 'v-navigation-drawer',
 
@@ -136,11 +141,6 @@ export default {
   },
 
   watch: {
-    $route () {
-      if (this.reactsToRoute) {
-        this.isActive = !this.closeConditional()
-      }
-    },
     isActive (val) {
       this.$emit('input', val)
 
@@ -194,6 +194,7 @@ export default {
 
   beforeMount () {
     this.checkIfMobile()
+    this.registerWatchers()
 
     if (this.permanent) {
       this.isActive = true
@@ -210,11 +211,16 @@ export default {
     if (this.app) {
       this.$vuetify.application[this.right ? 'right' : 'left'] = 0
     }
+
+    this.unregisterWatchers()
   },
 
   methods: {
     calculateTouchArea () {
-      if (!this.$el.parentNode) return
+      if (!this.$el.parentNode) {
+        return
+      }
+
       const parentRect = this.$el.parentNode.getBoundingClientRect()
 
       this.touchArea = {
@@ -223,9 +229,9 @@ export default {
       }
     },
     checkIfMobile () {
-      if (this.permanent ||
-        this.temporary
-      ) return
+      if (this.permanent || this.temporary) {
+        return
+      }
 
       this.isMobile = window.innerWidth < parseInt(this.mobileBreakPoint, 10)
     },
@@ -259,6 +265,12 @@ export default {
     onResize () {
       this.checkIfMobile()
     },
+    registerWatchers () {
+      if (this.reactsToRoute) {
+        watchers.unwatchRoute = this.$watch('$route',
+          () => this.isActive = !this.closeConditional())
+      }
+    },
     swipeRight (e) {
       if (this.isActive && !this.right) return
       this.calculateTouchArea()
@@ -288,6 +300,11 @@ export default {
       }
 
       this.removeOverlay()
+    },
+    unregisterWatchers () {
+      for (var watcher in watchers) {
+        watchers[watcher]()
+      }
     },
     updateApplication () {
       if (!this.app) return


### PR DESCRIPTION
The watcher was being registered whether its functionality was disabled or not via component's props.
So I created a registerWatchers method (and its counterpart for unregistering), which can be used for opt-in functionality.
More watchers can be moved to this implementation in the future