### PR TITLE
fix: remove extra padding from text field hint with prepended icon

### DIFF
--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -107,10 +107,6 @@ theme(textfield, "input-group--text-field")
       min-width: 40px
       transition: .3s $transition.fast-in-fast-out
 
-    .input-group__messages
-      margin-right: auto
-      padding-left: 40px
-
     .input-group__details
       margin-left: auto
       max-width: calc(100% - 40px)


### PR DESCRIPTION
Regression from aba924a

See #2063, #895
Fixes #2517