### PR TITLE
fix(drawer): only update layout when isActive changes

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -148,6 +148,8 @@ export default {
         this.tryOverlay()
         this.$el.scrollTop = 0
       }
+
+      this.updateApplication()
     },
     /**
      * When mobile changes, adjust
@@ -307,8 +309,6 @@ export default {
   },
 
   render (h) {
-    this.updateApplication()
-
     const data = {
       'class': this.classes,
       style: this.styles,


### PR DESCRIPTION
Due to the Vue bug with slots forcing re-render, having
updateApplication in the render function causes buggy behaviour with
multiple drawers on the same side.

Fixes #2512

Playground.vue:
```html
<template>
  <v-app id="inspire">
    <v-navigation-drawer fixed app v-model="drawer">
      first
    </v-navigation-drawer>
    <v-navigation-drawer fixed app v-model="drawer2">
      second
    </v-navigation-drawer>
    <v-toolbar app fixed flat>
      <v-toolbar-side-icon @click="toggleDrawer"/>
      <v-toolbar-title>test</v-toolbar-title>
    </v-toolbar>

    <v-content>
      <v-container fluid>
        <v-card>
          <v-card-text>
            <v-btn @click="toggleDrawer">Toggle main</v-btn>
            <v-btn @click="toggleDrawer2">Toggle 2</v-btn>
          </v-card-text>
        </v-card>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      drawer: false,
      drawer2: false
    }),
    methods: {
      toggleDrawer () {
        this.drawer2 = false
        this.$nextTick(() => this.drawer = !this.drawer)
      },
      toggleDrawer2 () {
        this.drawer = false
        this.$nextTick(() => this.drawer2 = !this.drawer2)
      }
    }
  }
</script>
```