### PR TITLE
fix(drawer): set correct content padding when temporary is toggled

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -172,7 +172,13 @@ export default {
     permanent (val) {
       // If enabling prop
       // enable the drawer
-      if (val) this.isActive = true
+      if (val) {
+        this.isActive = true
+        this.isMobile = false
+      } else {
+        this.checkIfMobile()
+      }
+      this.updateApplication()
     },
     right (val, prev) {
       // When the value changes
@@ -186,6 +192,7 @@ export default {
     },
     temporary (val) {
       this.tryOverlay()
+      this.updateApplication()
     },
     value (val) {
       if (this.permanent) return

--- a/src/components/VNavigationDrawer/VNavigationDrawer.spec.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.spec.js
@@ -119,4 +119,33 @@ test('VNavigationDrawer', () => {
 
     expect(wrapper.vm.isActive).toBe(true)
   })
+
+  it('should update content padding when temporary state is changed', async () => {
+    const wrapper = mount(VNavigationDrawer, { propsData: {
+      app: true
+    }})
+
+    expect(wrapper.vm.$vuetify.application.left).toBe(300)
+
+    wrapper.setProps({ temporary: true })
+    expect(wrapper.vm.$vuetify.application.left).toBe(0)
+
+    wrapper.setProps({ temporary: false })
+    expect(wrapper.vm.$vuetify.application.left).toBe(300)
+  })
+
+  it('should update content padding when permanent state is changed', async () => {
+    await resizeWindow(800)
+    const wrapper = mount(VNavigationDrawer, { propsData: {
+      app: true
+    }})
+
+    expect(wrapper.vm.$vuetify.application.left).toBe(0)
+
+    wrapper.setProps({ permanent: true })
+    expect(wrapper.vm.$vuetify.application.left).toBe(300)
+
+    wrapper.setProps({ permanent: false })
+    expect(wrapper.vm.$vuetify.application.left).toBe(0)
+  })
 })


### PR DESCRIPTION
I want to refactor this whole thing to be less messy, but this fixes it for now. 