### PR TITLE
Fixes the focus shadow appearing above the Chip in Firefox 56

### DIFF
--- a/src/stylus/components/_chips.styl
+++ b/src/stylus/components/_chips.styl
@@ -68,6 +68,7 @@ theme(chip, "chip")
         transition: inherit
         width: 100%
         pointer-events: none
+        top: 0
 
   &--label
     border-radius: $chip-label-border-radius


### PR DESCRIPTION
When clicking on a chip the box shadow appears well outside of the chip.  Add the top: 0 to the :focus::active puts the box shadow in the correct place in both Chrome and Firefox.

#2539 is the issue report for this fix.


Reproduction link: https://codepen.io/drw112/pen/wPPGgV