### PR TITLE
refactor(registrable): namespaced methods to not collide

### DIFF
--- a/src/components/VCarousel/VCarousel.js
+++ b/src/components/VCarousel/VCarousel.js
@@ -12,7 +12,7 @@ import Touch from '../../directives/touch'
 export default {
   name: 'v-carousel',
 
-  mixins: [Bootable, Themeable, RegistrableProvide],
+  mixins: [Bootable, Themeable, RegistrableProvide('carousel')],
 
   directives: { Touch },
 

--- a/src/components/VCarousel/VCarouselItem.js
+++ b/src/components/VCarousel/VCarouselItem.js
@@ -3,7 +3,7 @@ import { inject as RegistrableInject } from '../../mixins/registrable'
 export default {
   name: 'v-carousel-item',
 
-  mixins: [RegistrableInject('v-carousel-item', 'v-carousel')],
+  mixins: [RegistrableInject('carousel', 'v-carousel-item', 'v-carousel')],
 
   data () {
     return {
@@ -49,11 +49,11 @@ export default {
   },
 
   mounted () {
-    this.register(this._uid, this.open)
+    this.carousel.register(this._uid, this.open)
   },
 
   beforeDestroy () {
-    this.unregister(this._uid, this.open)
+    this.carousel.unregister(this._uid, this.open)
   },
 
   render (h) {

--- a/src/mixins/registrable.js
+++ b/src/mixins/registrable.js
@@ -2,28 +2,32 @@ function generateWarning (child, parent) {
   return () => console.warn(`[Vuetify] Warn: The ${child} component must be used inside a ${parent}.`)
 }
 
-export function inject (child, parent) {
+export function inject (namespace, child, parent) {
   return {
     inject: {
-      register: {
-        default: () => generateWarning(child, parent)
-      },
-      unregister: {
-        default: () => generateWarning(child, parent)
+      [namespace]: {
+        default: {
+          register: generateWarning(child, parent),
+          unregister: generateWarning(child, parent)
+        }
       }
     }
   }
 }
 
-export const provide = {
-  methods: {
-    register: null,
-    unregister: null
-  },
-  provide () {
-    return {
-      register: this.register,
-      unregister: this.unregister
+export function provide (namespace) {
+  return {
+    methods: {
+      register: null,
+      unregister: null
+    },
+    provide () {
+      return {
+        [namespace]: {
+          register: this.register,
+          unregister: this.unregister
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Puts registrable methods in a namespace to avoid collisions