### PR TITLE
fix: tooltip not initially visible when v-model is true

### DIFF
--- a/src/components/VTooltip/VTooltip.js
+++ b/src/components/VTooltip/VTooltip.js
@@ -126,6 +126,10 @@ export default {
     }
   },
 
+  mounted () {
+    this.value && this.callActivate()
+  },
+
   render (h) {
     const tooltip = h('div', {
       staticClass: 'tooltip__content',


### PR DESCRIPTION
fixes #2000