### PR TITLE
Revert "Fix v-btn modifier triggering twice"

### DIFF
--- a/src/mixins/routable.js
+++ b/src/mixins/routable.js
@@ -25,9 +25,7 @@ export default {
     generateRouteLink () {
       let exact = this.exact
       let tag
-      const normalizedListeners = Object.keys(this.$listeners).map(event => (
-        { [event.replace(/[&!~]/g, '')]: this.$listeners[event] }
-      ))
+
       const data = {
         attrs: { disabled: this.disabled },
         class: this.classes,
@@ -36,10 +34,12 @@ export default {
           name: 'ripple',
           value: this.ripple || false
         }],
-        on: Object.assign(normalizedListeners, {
+        on: {
+          ...(this.$listeners || {}),
           click: this.click
-        })
+        }
       }
+
       if (typeof this.exact === 'undefined') {
         exact = this.to === '/' ||
           (this.to === Object(this.to) && this.to.path === '/')


### PR DESCRIPTION
After merging this, a few scenarios came up that have convinced me otherwise of this change. The use-case can be handled with the .native modifier, which I now believe would be the correct way to handle this. Arbitrarily stripping events feels like a bad practice.

Reverts vuetifyjs/vuetify#2487