### PR TITLE
exclude nested forms from validation

### DIFF
--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -34,6 +34,9 @@ export default {
 
       const search = (children, depth = 0) => {
         for (const child of children) {
+          if (child.$options.name === 'v-form') {
+            continue
+          }
           if (child.errorBucket !== undefined) {
             results.push(child)
           } else {


### PR DESCRIPTION
If a v-form contains a v-dialog which in turn contains another v-form, then it breaks the validation of the outer form, since inputs of the inner form affect the outer one.

Is this an acceptable solution to the issue?