### PR TITLE
fix/2558 v-btn icon padding

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -102,7 +102,9 @@ theme(button, "btn")
     min-width: 0
 
     .btn__content
-      padding: 0
+      // overwrite size padding when using `icon` prop together
+      // with one of size props (`small`, `large`)
+      padding: 0 !important
 
       &:before
         border-radius: 50%


### PR DESCRIPTION
Fixes #2558

Ignore size props (`small`, `large`) padding when
using it together with `icon` prop.

