### PR TITLE
fix/2514 stepper editable hover icon

### DIFF
--- a/src/stylus/components/_steppers.styl
+++ b/src/stylus/components/_steppers.styl
@@ -35,7 +35,7 @@ stepper($material)
         color: $material.stepper.completed
 
     &--inactive
-      &.stepper__step--editable
+      &.stepper__step--editable:not(.stepper__step--error)
         &:hover
           .stepper__step__step
             background: $material.stepper.hover
@@ -47,7 +47,7 @@ stepper($material)
       color: rgba($material.fg-color, $material.secondary-text-percent)
 
   &--non-linear
-    .stepper__step:not(.stepper__step--complete)
+    .stepper__step:not(.stepper__step--complete):not(.stepper__step--error)
       .stepper__label
         color: rgba($material.fg-color, $material.secondary-text-percent)
 


### PR DESCRIPTION
Removes step background on icon when step is editable and/or non-linear.

Fixes #2514