### PR TITLE
fix/2617 wrapped expansion panel

### DIFF
--- a/src/components/VExpansionPanel/VExpansionPanel.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.js
@@ -24,8 +24,8 @@ export default {
   methods: {
     getChildren () {
       return this.$children.reduce((toggleables, child) => {
-        const component = child.$children[0] || child;
-        const options = component.$options;
+        const component = child.$children[0] || child
+        const options = component.$options
         if (options && options.name === 'v-expansion-panel-content') {
           toggleables.push(component)
         }

--- a/src/components/VExpansionPanel/VExpansionPanel.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.js
@@ -23,11 +23,15 @@ export default {
 
   methods: {
     getChildren () {
-      return this.$children.filter(c => {
-        if (!c.$options) return
+      return this.$children.reduce((toggleables, child) => {
+        const component = child.$children[0] || child;
+        const options = component.$options;
+        if (options && options.name === 'v-expansion-panel-content') {
+          toggleables.push(component)
+        }
 
-        return c.$options.name === 'v-expansion-panel-content'
-      })
+        return toggleables
+      }, [])
     },
     panelClick (uid) {
       if (!this.expand) {


### PR DESCRIPTION
Not sure if this should even be handled, but in the issue reported problem is that even though DOM seems like same, virtual dom is not and vue is wrapping (as expected) expansion panel inside panel wrapper component.

I have created small fix/hack to deal with this.

Anyways, this part of the code should be refactored.
Do not like the part where name is compared `c.$options.name === 'v-expansion-panel-content'`. Maybe it is better to check for existence of toggle method, or something like that.

Fixes #2617 