### PR TITLE
fix(speed-dial): Allow any element inside the activator button

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -142,24 +142,27 @@ theme(button, "btn")
     &:after
       border-radius: 50%
 
-    .icon
-      &:not(:only-of-type):last-of-type
-        opacity: 0
-        position: absolute
-        transform: rotate(-45deg)
-        left: calc(50% - 12px)
-        top: calc(50% - 12px)
+    .btn__content
+      :not(:only-child)
+        transition: $primary-transition
+
+        &:last-child
+          opacity: 0
+          position: absolute
+          transform: rotate(-45deg)
+          left: calc(50% - 12px)
+          top: calc(50% - 12px)
 
     &.btn--active
-      .icon
-        &:not(:only-of-type)
-          &:first-of-type
+      .btn__content
+        :not(:only-child)
+          &:first-child
             opacity: 0
             transform: rotate(45deg)
             left: 'calc(50% - %s)' % (24 / 2)
             top: 'calc(50% - %s)' % (24 / 2)
 
-          &:last-of-type
+          &:last-child
             opacity: 1
             transform: none
 
@@ -258,14 +261,14 @@ theme(button, "btn")
   &--small
     font-size: $button-small-font-size
     height: $button-small-height
-    
+
     .btn__content
       padding: $button-small-padding
 
   &--large
     font-size: $button-large-font-size
     height: $button-large-height
-    
+
     .btn__content
       padding: $button-large-padding
 


### PR DESCRIPTION
 - Uses `:last-child` instead of `.icon:last-of-type` to allow non-icon elements

Fixes #1318

Playground.vue:
```html
<template>
  <boilerplate>
    <v-card>
      <v-card-text>
        <v-speed-dial
          v-model="fab"
        >
          <v-btn
            slot="activator"
            fab
            hover
            v-model="fab"
          >
            <v-avatar>
              <img src="https://unsplash.it/200/200/?random" alt="">
            </v-avatar>
            <v-icon>close</v-icon>
          </v-btn>
          <v-btn
            fab
            dark
            small
            color="green"
          >
            <v-icon>edit</v-icon>
          </v-btn>
          <v-btn
            fab
            dark
            small
            color="indigo"
          >
            <v-icon>add</v-icon>
          </v-btn>
          <v-btn
            fab
            dark
            small
            color="red"
          >
            <v-icon>delete</v-icon>
          </v-btn>
        </v-speed-dial>
      </v-card-text>
    </v-card>
  </boilerplate>
</template>

<script>
export default {
  data: () => ({
    fab: false
  })
}
</script>
```