### PR TITLE
fix/2271 table header border

### DIFF
--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -7,7 +7,9 @@ table($material)
   color: $material.text.primary
 
   thead
-    border-bottom: 1px solid rgba($material.fg-color, $material.divider-percent)
+    tr
+      &:first-child
+        border-bottom: 1px solid rgba($material.fg-color, $material.divider-percent)
 
     th
       color: rgba($material.text-color, $material.secondary-text-percent)


### PR DESCRIPTION
This is the problem with border on `thead`element.
When we remove border from `thead` and place it on `tr` inside `thead` it renders good.
I have placed this on first row because of the possible problems with datatable progress row.
Possible problems are if someone uses multiple rows inside header slot.
In that case, custom css would be required.

Other solution is to set top border on first row of `tbody`.
It would also show on headerless table though unless we add some class to distinguish headerless table from normal one.

Fixes #2271 