### PR TITLE
Switch input group transition group to transition

### DIFF
--- a/src/components/VRadioGroup/__snapshots__/VRadioGroup.spec.js.snap
+++ b/src/components/VRadioGroup/__snapshots__/VRadioGroup.spec.js.snap
@@ -37,8 +37,6 @@ exports[`VRadioGroup.vue should be in error when v-radio-group is 1`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -81,8 +79,6 @@ exports[`VRadioGroup.vue should be in error when v-radio-group is 2`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -96,8 +92,6 @@ exports[`VRadioGroup.vue should render role on radio group 1`] = `
   <div class="input-group__input">
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 

--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -78,8 +78,6 @@ exports[`VSelect should render buttons correctly when using items array with seg
     </i>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -138,8 +136,6 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
     </i>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -59,8 +59,6 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                       </div>
                     </div>
                     <div class="input-group__details">
-                      <div class="input-group__messages">
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -94,8 +92,6 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                       </div>
                     </div>
                     <div class="input-group__details">
-                      <div class="input-group__messages">
-                      </div>
                     </div>
                   </div>
                 </div>
@@ -118,8 +114,6 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
     </i>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -189,8 +183,6 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
     </i>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 

--- a/src/components/VSlider/__snapshots__/VSlider.spec.js.snap
+++ b/src/components/VSlider/__snapshots__/VSlider.spec.js.snap
@@ -23,8 +23,6 @@ exports[`Vslider.vue should be focused when active 1`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -51,8 +49,6 @@ exports[`Vslider.vue should match a snapshot 1`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 

--- a/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
+++ b/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
@@ -9,8 +9,6 @@ exports[`VTextField.js should not display counter when set to false 1`] = `
     >
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
     <div class="input-group__counter">
       0 / 25
     </div>
@@ -28,8 +26,6 @@ exports[`VTextField.js should not display counter when set to false 2`] = `
     >
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -44,8 +40,6 @@ exports[`VTextField.js should render component and match snapshot 1`] = `
     >
   </div>
   <div class="input-group__details">
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -77,8 +71,6 @@ exports[`VTextField.js should render component with async loading and custom pro
         <!---->
       </div>
     </div>
-    <div class="input-group__messages">
-    </div>
   </div>
 </div>
 
@@ -109,8 +101,6 @@ exports[`VTextField.js should render component with async loading and match snap
         </div>
         <!---->
       </div>
-    </div>
-    <div class="input-group__messages">
     </div>
   </div>
 </div>

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -81,7 +81,7 @@ export default {
       }, this.$slots.label || this.label)
     },
     genMessages () {
-      let messages = []
+      let messages = null
 
       if ((this.hint &&
             this.isFocused ||
@@ -94,18 +94,19 @@ export default {
         messages = [this.genError(this.validations[0])]
       }
 
-      return this.$createElement('transition-group', {
-        'class': 'input-group__messages',
+      if (!messages || !messages.length) {
+        return null
+      }
+
+      return this.$createElement('transition', {
         props: {
-          tag: 'div',
           name: 'slide-y-transition'
         }
       }, messages)
     },
     genHint () {
       return this.$createElement('div', {
-        'class': 'input-group__hint',
-        key: this.hint,
+        'class': 'input-group__messages input-group__hint',
         domProps: { innerHTML: this.hint }
       })
     },
@@ -113,8 +114,7 @@ export default {
       return this.$createElement(
         'div',
         {
-          'class': 'input-group__error',
-          key: error
+          'class': 'input-group__messages input-group__error'
         },
         error
       )

--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -288,7 +288,7 @@ theme(input-group, "input-group")
 
 /** Error */
 .input-group
-  .input-group__error
+  &__error
     color: inherit
     flex: 1 0
     transition: .3s $transition.fast-in-fast-out


### PR DESCRIPTION
- Optimized away the array and don't bother rendering the transition if no children
- Combined input-group__messages into hint and error content gen.  (Could look at getting rid of this class altogether in the future maybe)
- Consistency fix in .styl
- Snapshots updated