### PR TITLE
support font awesome 5 icons

### DIFF
--- a/src/components/VIcon/VIcon.js
+++ b/src/components/VIcon/VIcon.js
@@ -59,7 +59,11 @@ export default {
 
     let iconType = 'material-icons'
     const thirdPartyIcon = iconName.indexOf('-') > -1
-    if (thirdPartyIcon) iconType = iconName.slice(0, iconName.indexOf('-'))
+
+    if (thirdPartyIcon) {
+      iconType = iconName.slice(0, iconName.indexOf('-'))
+      if (['fas', 'far', 'fal', 'fab'].some(val => iconType.includes(val))) iconType = ''
+    }
 
     data.staticClass = (`${iconType} icon ${data.staticClass || ''}`).trim()
     data.attrs = data.attrs || {}

--- a/src/components/VIcon/VIcon.spec.js
+++ b/src/components/VIcon/VIcon.spec.js
@@ -78,6 +78,14 @@ test('VIcon.js', ({ mount, compileToFunctions }) => {
     expect(wrapper.element.className).toBe('fa icon fa-add')
   })
 
+  it('should support font awesome 5 icons when using <icon>- prefix', () => {
+    const context = functionalContext({ props: {} }, 'fab fa-facebook')
+    const wrapper = mount(VIcon, context)
+
+    expect(wrapper.text()).toBe('')
+    expect(wrapper.element.className).toBe('icon fab fa-facebook')
+  })
+
   it('should allow the use of v-text', () => {
     const wrapper = mount(VIcon, functionalContext({
       domProps: { textContent: 'fa-home' }


### PR DESCRIPTION
Font Awesome 5 introduces new type of icons, like regular, light, brands and logos. When using these icons, each prefix name is different. For example, when using `facebook` icon, the class name should be `fab fa-facebook` instead of `fa fa-facebook`.

Currently, when using font awesome 5 icons and the icon is not solid type(solid is default type, prefix with `fa`), the icon class name is incorrect. This pull request add the function that support font awesome 5 icons.

Icon class name comparison:

| icon | before | after |
|-----|---------|---------|
| fa-check | fa icon fa-check| fa icon fa-check |
| far-check | far icon far-check | far icon fa-check |
| fab-facebook | fab icon fab-facebook | fab icon fa-facebook |

