### PR TITLE
Bugfix: Changing VDataTable mixin to reset expanded value to object instead o…

### DIFF
--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -79,7 +79,7 @@ export default {
       data.attrs.tabIndex = 0
       data.on = {
         click: () => {
-          this.expanded = []
+          this.expanded = {}
           this.sort(header.value)
         },
         keydown: e => {


### PR DESCRIPTION
Clicking a VDataTable header triggers a reset of the expanded property.  The functionality requires an object, but this mixin sets it to an array. I believe this was missed in a previous bugfix.

The problematic code causes VDataTable numeric string item-key values to create an array the size of the item-key value. What we want is an object with an item-key to bool mapping.  This change is tested and working.