### PR TITLE
fix(v-select) Initial items passed via prop should be cached too

### DIFF
--- a/src/components/VSelect/VSelect-autocomplete.spec.js
+++ b/src/components/VSelect/VSelect-autocomplete.spec.js
@@ -252,6 +252,24 @@ test('VSelect - autocomplete', () => {
     expect('Application is missing <v-app> component.').toHaveBeenTipped()
   })
 
+  it('should cache items passed via prop', async () => {
+    const wrapper = mount(VSelect, {
+      attachToDocument: true,
+      propsData: {
+        autocomplete: true,
+        cacheItems: true,
+        items: [1, 2, 3, 4]
+      }
+    })
+
+    expect(wrapper.vm.computedItems).toHaveLength(4)
+
+    wrapper.setProps({ items: [5] })
+    expect(wrapper.vm.computedItems).toHaveLength(5)
+
+    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+  })
+
   it('should allow changing of browser autocomplete', () => {
     const wrapper = mount(VSelect, {
       attachToDocument: true,

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -79,7 +79,7 @@ export default {
 
   data () {
     return {
-      cachedItems: [],
+      cachedItems: this.cacheItems ? this.items : [],
       content: {},
       defaultColor: 'primary',
       inputValue: (this.multiple || this.tags) && !this.value ? [] : this.value,


### PR DESCRIPTION
Hi everyone! It's my first contribution to vuetify.

First :items passed via prop to v-select aren't cached with :cacheItems flag, but I think it's should.

You can check provided tests to better understand what I mean.