### PR TITLE
fix(v-checkbox): label overflow now readable

### DIFF
--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -173,10 +173,6 @@ export default {
         }
       }, data)
 
-      if (this.$slots.label || this.label) {
-        children.push(this.genLabel())
-      }
-
       wrapperChildren.push(input)
 
       if (this.prependIcon) {
@@ -195,6 +191,10 @@ export default {
           'class': 'input-group__input'
         }, wrapperChildren)
       )
+
+      if (this.$slots.label || this.label) {
+        children.push(this.genLabel())
+      }
 
       !this.hideDetails && detailsChildren.push(this.genMessages())
 

--- a/src/stylus/components/_selection-controls.styl
+++ b/src/stylus/components/_selection-controls.styl
@@ -116,3 +116,17 @@ theme(selection-control, "input-group--selection-controls")
 
     label
       left: 52px
+
+/** Flow checkbox labels */
+.input-group
+  &.checkbox
+    .input-group__input
+      display: flex
+      flex: 0 0 38px
+      align-self: flex-start
+
+    label
+      white-space: normal
+      left: 0
+      position: relative
+      height: inherit


### PR DESCRIPTION
Just saw the reply from @KaelWD and the codepen workaround for #2686. I tried to come up with a fix for it and found a different way, not sure if its worth the pull request though. First time looking into the internals of vuetify and the element creation (oh and flexbox). Please close if inappropriate!