### PR TITLE
fix(application): abstracting applicationable functionality

### DIFF
--- a/src/components/VBottomNav/VBottomNav.js
+++ b/src/components/VBottomNav/VBottomNav.js
@@ -1,3 +1,4 @@
+// Styles
 require('../../stylus/components/_bottom-navs.styl')
 
 // Mixins
@@ -9,36 +10,42 @@ export default {
   name: 'v-bottom-nav',
 
   mixins: [
-    Applicationable,
+    Applicationable('bottom', [
+      'height',
+      'value'
+    ]),
     ButtonGroup,
     Colorable
   ],
 
-  data: () => ({
-    defaultColor: 'primary'
-  }),
-
   props: {
-    absolute: Boolean,
     active: [Number, String],
+    height: {
+      default: 48,
+      type: [Number, String],
+      validator: v => !isNaN(parseInt(v))
+    },
     shift: Boolean,
     value: { required: false }
   },
 
   watch: {
-    active () {
-      this.update()
+    active (val) {
+      this.updateValue(val)
     }
   },
 
   computed: {
     classes () {
       return {
-        'bottom-nav': true,
         'bottom-nav--absolute': this.absolute,
+        'bottom-nav--fixed': this.fixed || this.app,
         'bottom-nav--shift': this.shift,
         'bottom-nav--active': this.value
       }
+    },
+    computedHeight () {
+      return parseInt(this.height)
     }
   },
 
@@ -47,20 +54,30 @@ export default {
       const item = this.getValue(i)
       return this.active === item
     },
+    /**
+     * Update the application layout
+     * 
+     * @return {integer}
+     */
     updateApplication () {
-      if (!this.app) return
-
-      this.$vuetify.application.bottom = this.$el.clientHeight
+      return !this.value
+        ? 0
+        : this.computedHeight
     },
     updateValue (i) {
       const item = this.getValue(i)
+
       this.$emit('update:active', item)
     }
   },
 
   render (h) {
     return h('div', {
+      staticClass: 'bottom-nav',
       class: this.addBackgroundColorClassChecks(this.classes),
+      style: {
+        height: `${parseInt(this.computedHeight)}px`
+      },
       ref: 'content'
     }, this.$slots.default)
   }

--- a/src/components/VBottomNav/VBottomNav.js
+++ b/src/components/VBottomNav/VBottomNav.js
@@ -56,8 +56,8 @@ export default {
     },
     /**
      * Update the application layout
-     * 
-     * @return {integer}
+     *
+     * @return {number}
      */
     updateApplication () {
       return !this.value

--- a/src/components/VBottomNav/VBottomNav.spec.js
+++ b/src/components/VBottomNav/VBottomNav.spec.js
@@ -70,4 +70,34 @@ test('VBottomNav.js', ({ mount }) => {
     btn.trigger('click')
     expect(change).toBeCalledWith(0)
   })
+
+  it('should set the application bottom', () => {
+    const wrapper = mount(VBottomNav, {
+      propsData: {
+        app: true,
+        height: 80,
+        value: true
+      },
+      slots: {
+        default: [VBtn, VBtn]
+      }
+    })
+
+    expect(wrapper.vm.$vuetify.application.bottom).toBe(80)
+  })
+
+  it('should emit update when active changes', async () => {
+    const update = jest.fn()
+    const wrapper = mount(VBottomNav, {
+      slots: {
+        default: [VBtn, VBtn]
+      }
+    })
+
+    wrapper.vm.$on('update:active', update)
+    await wrapper.vm.$nextTick()
+    wrapper.setProps({ active: 1 })
+    await wrapper.vm.$nextTick()
+    expect(update).toBeCalledWith(1)
+  })
 })

--- a/src/components/VBottomNav/__snapshots__/VBottomNav.spec.js.snap
+++ b/src/components/VBottomNav/__snapshots__/VBottomNav.spec.js.snap
@@ -2,7 +2,9 @@
 
 exports[`VBottomNav.js should be hidden with a false value 1`] = `
 
-<div class="bottom-nav primary">
+<div class="bottom-nav"
+     style="height: 48px;"
+>
   <button type="button"
           class="btn"
           data-ripple="true"
@@ -23,7 +25,9 @@ exports[`VBottomNav.js should be hidden with a false value 1`] = `
 
 exports[`VBottomNav.js should be visible with a true value 1`] = `
 
-<div class="bottom-nav bottom-nav--active primary">
+<div class="bottom-nav bottom-nav--active"
+     style="height: 48px;"
+>
   <button type="button"
           class="btn"
           data-ripple="true"
@@ -44,7 +48,9 @@ exports[`VBottomNav.js should be visible with a true value 1`] = `
 
 exports[`VBottomNav.js should have a bottom-nav class 1`] = `
 
-<div class="bottom-nav primary">
+<div class="bottom-nav"
+     style="height: 48px;"
+>
   <button type="button"
           class="btn"
           data-ripple="true"
@@ -65,7 +71,9 @@ exports[`VBottomNav.js should have a bottom-nav class 1`] = `
 
 exports[`VBottomNav.js should have prop classes 1`] = `
 
-<div class="bottom-nav bottom-nav--absolute bottom-nav--shift primary">
+<div class="bottom-nav bottom-nav--absolute bottom-nav--shift"
+     style="height: 48px;"
+>
   <button type="button"
           class="btn"
           data-ripple="true"

--- a/src/components/VFooter/VFooter.js
+++ b/src/components/VFooter/VFooter.js
@@ -69,8 +69,8 @@ export default {
   methods: {
     /**
      * Update the application layout
-     * 
-     * @return {integer}
+     *
+     * @return {number}
      */
     updateApplication () {
       return this.computedHeight

--- a/src/components/VFooter/VFooter.js
+++ b/src/components/VFooter/VFooter.js
@@ -1,5 +1,7 @@
+// Styles
 require('../../stylus/components/_footer.styl')
 
+// Mixins
 import Applicationable from '../../mixins/applicationable'
 import Colorable from '../../mixins/colorable'
 import Themeable from '../../mixins/themeable'
@@ -7,59 +9,85 @@ import Themeable from '../../mixins/themeable'
 export default {
   name: 'v-footer',
 
-  mixins: [Applicationable, Colorable, Themeable],
+  mixins: [
+    Applicationable('footer', [
+      'height'
+    ]),
+    Colorable,
+    Themeable
+  ],
 
   props: {
-    absolute: Boolean,
-    fixed: Boolean
+    height: {
+      default: 32,
+      type: [Number, String],
+      validator: v => !isNaN(parseInt(v))
+    },
+    inset: Boolean
   },
 
   computed: {
-    paddingLeft () {
-      return this.fixed || !this.app
+    computedHeight () {
+      return parseInt(this.height)
+    },
+    computedMarginBottom () {
+      if (!this.app) return
+
+      return this.$vuetify.application.bottom
+    },
+    computedPaddingLeft () {
+      return !this.app || !this.inset
         ? 0
         : this.$vuetify.application.left
     },
-    paddingRight () {
-      return this.fixed || !this.app
+    computedPaddingRight () {
+      return !this.app
         ? 0
         : this.$vuetify.application.right
-    }
-  },
+    },
+    styles () {
+      const styles = {
+        height: `${this.computedHeight}px`
+      }
 
-  destroyed () {
-    if (this.app) this.$vuetify.application.bottom = 0
+      if (this.computedPaddingLeft) {
+        styles.paddingLeft = `${this.computedPaddingLeft}px`
+      }
+
+      if (this.computedPaddingRight) {
+        styles.paddingRight = `${this.computedPaddingRight}px`
+      }
+
+      if (this.computedMarginBottom) {
+        styles.marginBottom = `${this.computedMarginBottom}px`
+      }
+
+      return styles
+    }
   },
 
   methods: {
+    /**
+     * Update the application layout
+     * 
+     * @return {integer}
+     */
     updateApplication () {
-      if (!this.app) return
-
-      this.$vuetify.application.bottom = this.fixed
-        ? this.$el && this.$el.clientHeight
-        : 0
+      return this.computedHeight
     }
   },
 
-  mounted () {
-    this.updateApplication()
-  },
-
   render (h) {
-    this.updateApplication()
-
     const data = {
       staticClass: 'footer',
       'class': this.addBackgroundColorClassChecks({
         'footer--absolute': this.absolute,
-        'footer--fixed': this.fixed,
+        'footer--fixed': !this.absolute && (this.app || this.fixed),
+        'footer--inset': this.inset,
         'theme--dark': this.dark,
         'theme--light': this.light
       }),
-      style: {
-        paddingLeft: `${this.paddingLeft}px`,
-        paddingRight: `${this.paddingRight}px`
-      },
+      style: this.styles,
       ref: 'content'
     }
 

--- a/src/components/VFooter/VFooter.spec.js
+++ b/src/components/VFooter/VFooter.spec.js
@@ -48,6 +48,7 @@ test('VFooter.js', ({ mount, functionalContext }) => {
     })
 
     expect(wrapper.element.classList).toContain('footer--absolute')
+    wrapper.setProps({ absolute: false })
     expect(wrapper.element.classList).toContain('footer--fixed')
   })
 
@@ -65,5 +66,33 @@ test('VFooter.js', ({ mount, functionalContext }) => {
     wrapper.vm.$vuetify.application.right  = 30
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should have margin bottom', async () => {
+    const wrapper = mount(VFooter, {
+      propsData: {
+        app: true,
+        height: 60
+      }
+    })
+
+    expect(wrapper.vm.$vuetify.application.footer).toBe(60)
+    wrapper.vm.$vuetify.application.bottom = 30
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.$vuetify.application.bottom).toBe(30)
+  })
+
+  it('should have padding left when using inset', async () => {
+    const wrapper = mount(VFooter, {
+      propsData: {
+        app: true,
+        inset: true
+      }
+    })
+
+    wrapper.vm.$vuetify.application.left = 300
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.computedPaddingLeft).toBe(300)
   })
 })

--- a/src/components/VFooter/__snapshots__/VFooter.spec.js.snap
+++ b/src/components/VFooter/__snapshots__/VFooter.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`VFooter.js should get the right padding with app prop 1`] = `
 
 <footer class="footer footer--absolute"
-        style="padding-left: 0px; padding-right: 0px;"
+        style="height: 32px;"
 >
 </footer>
 
@@ -12,7 +12,7 @@ exports[`VFooter.js should get the right padding with app prop 1`] = `
 exports[`VFooter.js should get the right padding with app prop 2`] = `
 
 <footer class="footer footer--absolute"
-        style="padding-left: 20px; padding-right: 30px;"
+        style="height: 32px; padding-right: 30px;"
 >
 </footer>
 

--- a/src/components/VGrid/VContent.js
+++ b/src/components/VGrid/VContent.js
@@ -24,13 +24,13 @@ export default {
     },
     styles () {
       const {
-        bar, top, right, bottom, left
+        bar, top, right, footer, bottom, left
       } = this.$vuetify.application
 
       return {
         paddingTop: `${top + bar}px`,
         paddingRight: `${right}px`,
-        paddingBottom: `${bottom}px`,
+        paddingBottom: `${footer + bottom}px`,
         paddingLeft: `${left}px`
       }
     }

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -75,7 +75,7 @@ export default {
      * value from a dynamic
      * property. Called from
      * applicationable.js
-     * 
+     *
      * @return {string}
      */
     applicationProperty () {
@@ -269,7 +269,7 @@ export default {
     /**
      * Sets state before mount to avoid
      * entry transitions in SSR
-     * 
+     *
      * @return {void}
      */
     init () {
@@ -315,8 +315,8 @@ export default {
     },
     /**
      * Update the application layout
-     * 
-     * @return {integer}
+     *
+     * @return {number}
      */
     updateApplication () {
       return !this.isActive ||

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -15,7 +15,11 @@ export default {
   name: 'v-navigation-drawer',
 
   mixins: [
-    Applicationable,
+    Applicationable(null, [
+      'miniVariant',
+      'right',
+      'width'
+    ]),
     Overlayable,
     SSRBootable,
     Themeable
@@ -27,23 +31,22 @@ export default {
     Touch
   },
 
-  data () {
-    return {
-      isActive: false,
-      touchArea: {
-        left: 0,
-        right: 0
-      }
+  data: () => ({
+    isActive: false,
+    touchArea: {
+      left: 0,
+      right: 0
     }
-  },
+  }),
 
   props: {
-    absolute: Boolean,
     clipped: Boolean,
     disableRouteWatcher: Boolean,
     disableResizeWatcher: Boolean,
-    height: String,
-    fixed: Boolean,
+    height: {
+      type: [Number, String],
+      default: '100%'
+    },
     floating: Boolean,
     miniVariant: Boolean,
     miniVariantWidth: {
@@ -67,8 +70,19 @@ export default {
   },
 
   computed: {
+    /**
+     * Used for setting an app
+     * value from a dynamic
+     * property. Called from
+     * applicationable.js
+     * 
+     * @return {string}
+     */
+    applicationProperty () {
+      return this.right ? 'right' : 'left'
+    },
     calculatedHeight () {
-      return this.height || '100%'
+      return isNaN(this.height) ? this.height : `${this.height}px`
     },
     calculatedTransform () {
       if (this.isActive) return 0
@@ -88,7 +102,7 @@ export default {
         'navigation-drawer--absolute': this.absolute,
         'navigation-drawer--clipped': this.clipped,
         'navigation-drawer--close': !this.isActive,
-        'navigation-drawer--fixed': this.fixed,
+        'navigation-drawer--fixed': this.fixed || this.app,
         'navigation-drawer--floating': this.floating,
         'navigation-drawer--is-booted': this.isBooted,
         'navigation-drawer--is-mobile': this.isMobile,
@@ -146,13 +160,21 @@ export default {
         (this.temporary || this.isMobile)
     },
     styles () {
-      return {
+      const styles = {
         height: this.calculatedHeight,
-        marginTop: `${this.marginTop}px`,
         maxHeight: `calc(100% - ${this.maxHeight}px)`,
-        transform: `translateX(${this.calculatedTransform}px)`,
         width: `${this.calculatedWidth}px`
       }
+
+      if (this.marginTop) {
+        styles.marginTop = `${this.marginTop}px`
+      }
+
+      if (this.calculatedTransform) {
+        styles.transform = `translateX(${this.calculatedTransform}px)`
+      }
+
+      return styles
     }
   },
 
@@ -170,7 +192,7 @@ export default {
         this.$el && (this.$el.scrollTop = 0)
       }
 
-      this.updateApplication()
+      this.callUpdate()
     },
     /**
      * When mobile changes, adjust
@@ -190,10 +212,7 @@ export default {
       ) return
 
       this.isActive = !val
-      this.updateApplication()
-    },
-    miniVariant () {
-      this.updateApplication()
+      this.callUpdate()
     },
     permanent (val) {
       // If enabling prop
@@ -201,21 +220,11 @@ export default {
       if (val) {
         this.isActive = true
       }
-      this.updateApplication()
+      this.callUpdate()
     },
-    right (val, prev) {
-      // When the value changes
-      // reset previous direction
-      if (prev != null) {
-        const dir = val ? 'left' : 'right'
-        this.$vuetify.application[dir] = 0
-      }
-
-      this.updateApplication()
-    },
-    temporary (val) {
+    temporary () {
       this.tryOverlay()
-      this.updateApplication()
+      this.callUpdate()
     },
     value (val) {
       if (this.permanent) return
@@ -226,12 +235,6 @@ export default {
 
   beforeMount () {
     this.init()
-  },
-
-  destroyed () {
-    if (this.app) {
-      this.$vuetify.application[this.right ? 'right' : 'left'] = 0
-    }
   },
 
   methods: {
@@ -310,20 +313,17 @@ export default {
 
       this.removeOverlay()
     },
+    /**
+     * Update the application layout
+     * 
+     * @return {integer}
+     */
     updateApplication () {
-      if (!this.app) return
-
-      const width = !this.isActive ||
+      return !this.isActive ||
         this.temporary ||
         this.isMobile
         ? 0
         : this.calculatedWidth
-
-      if (this.right) {
-        this.$vuetify.application.right = width
-      } else {
-        this.$vuetify.application.left = width
-      }
     }
   },
 

--- a/src/components/VSystemBar/VSystemBar.js
+++ b/src/components/VSystemBar/VSystemBar.js
@@ -44,6 +44,11 @@ export default {
   },
 
   methods: {
+    /**
+     * Update the application layout
+     *
+     * @return {number}
+     */
     updateApplication () {
       return this.computedHeight
     }

--- a/src/components/VSystemBar/VSystemBar.js
+++ b/src/components/VSystemBar/VSystemBar.js
@@ -7,12 +7,20 @@ import Themeable from '../../mixins/themeable'
 export default {
   name: 'v-system-bar',
 
-  mixins: [Applicationable, Colorable, Themeable],
+  mixins: [
+    Applicationable('bar', [
+      'height',
+      'window'
+    ]),
+    Colorable,
+    Themeable
+  ],
 
   props: {
-    absolute: Boolean,
-    fixed: Boolean,
-    height: [Number, String],
+    height: {
+      type: [Number, String],
+      validator: v => !isNaN(parseInt(v))
+    },
     lightsOut: Boolean,
     status: Boolean,
     window: Boolean
@@ -23,7 +31,7 @@ export default {
       return this.addBackgroundColorClassChecks(Object.assign({
         'system-bar--lights-out': this.lightsOut,
         'system-bar--absolute': this.absolute,
-        'system-bar--fixed': this.fixed,
+        'system-bar--fixed': this.fixed || this.app,
         'system-bar--status': this.status,
         'system-bar--window': this.window
       }, this.themeClasses))
@@ -35,33 +43,10 @@ export default {
     }
   },
 
-  watch: {
-    absolute () {
-      this.updateApplication()
-    },
-    fixed () {
-      this.updateApplication()
-    },
-    height () {
-      this.updateApplication()
-    },
-    window () {
-      this.updateApplication()
-    }
-  },
-
   methods: {
     updateApplication () {
-      if (this.app) {
-        this.$vuetify.application.bar = (this.fixed || this.absolute)
-          ? this.computedHeight
-          : 0
-      }
+      return this.computedHeight
     }
-  },
-
-  destroyed () {
-    if (this.app) this.$vuetify.application.bar = 0
   },
 
   render (h) {

--- a/src/components/VSystemBar/VSystemBar.spec.js
+++ b/src/components/VSystemBar/VSystemBar.spec.js
@@ -40,18 +40,6 @@ test('VSystemBar.vue', ({ mount }) => {
       }
     })
 
-    expect(wrapper.vm.$vuetify.application.bar).toBe(0)
-
-    wrapper.setProps({
-      fixed: false,
-      absolute: true
-    })
-    expect(wrapper.vm.$vuetify.application.bar).toBe(24)
-
-    wrapper.setProps({
-      fixed: true,
-      absolute: false
-    })
     expect(wrapper.vm.$vuetify.application.bar).toBe(24)
 
     wrapper.setProps({
@@ -63,5 +51,15 @@ test('VSystemBar.vue', ({ mount }) => {
       height: 90
     })
     expect(wrapper.vm.$vuetify.application.bar).toBe(90)
+  })
+
+  it('should warn for improper height', () => {
+    const wrapper = mount(VSystemBar, {
+      propsData: {
+        height: 'foo'
+      }
+    })
+
+    expect('custom validator check failed for prop "height"').toHaveBeenWarned()
   })
 })

--- a/src/components/VToolbar/VToolbar.js
+++ b/src/components/VToolbar/VToolbar.js
@@ -199,8 +199,8 @@ export default {
     },
     /**
      * Update the application layout
-     * 
-     * @return {integer}
+     *
+     * @return {number}
      */
     updateApplication () {
       return this.invertedScroll

--- a/src/components/VToolbar/VToolbar.js
+++ b/src/components/VToolbar/VToolbar.js
@@ -1,19 +1,31 @@
+// Styles
 require('../../stylus/components/_toolbar.styl')
 
+// Mixins
 import Applicationable from '../../mixins/applicationable'
 import Colorable from '../../mixins/colorable'
 import Themeable from '../../mixins/themeable'
 import SSRBootable from '../../mixins/ssr-bootable'
 
+// Directives
+import Scroll from '../../directives/scroll'
+
 export default {
   name: 'v-toolbar',
 
   mixins: [
-    Applicationable,
+    Applicationable('top', [
+      'clippedLeft',
+      'clippedRight',
+      'height',
+      'invertedScroll'
+    ]),
     Colorable,
     SSRBootable,
     Themeable
   ],
+
+  directives: { Scroll },
 
   data: () => ({
     activeTimeout: null,
@@ -33,17 +45,21 @@ export default {
   }),
 
   props: {
-    absolute: Boolean,
     card: Boolean,
     clippedLeft: Boolean,
     clippedRight: Boolean,
     dense: Boolean,
     extended: Boolean,
-    extensionHeight: [Number, String],
-    fixed: Boolean,
+    extensionHeight: {
+      type: [Number, String],
+      validator: v => !isNaN(parseInt(v))
+    },
     flat: Boolean,
     floating: Boolean,
-    height: [Number, String],
+    height: {
+      type: [Number, String],
+      validator: v => !isNaN(parseInt(v))
+    },
     invertedScroll: Boolean,
     manualScroll: {
       type: Boolean,
@@ -98,7 +114,7 @@ export default {
         'toolbar--clipped': this.clippedLeft || this.clippedRight,
         'toolbar--dense': this.dense,
         'toolbar--extended': this.isExtended,
-        'toolbar--fixed': this.fixed,
+        'toolbar--fixed': this.fixed || this.app,
         'toolbar--floating': this.floating,
         'toolbar--is-booted': this.isBooted,
         'toolbar--prominent': this.prominent,
@@ -106,19 +122,19 @@ export default {
         'theme--light': this.light
       })
     },
-    paddingLeft () {
+    computedPaddingLeft () {
       if (!this.app || this.clippedLeft) return 0
 
       return this.$vuetify.application.left
     },
-    paddingRight () {
+    computedPaddingRight () {
       if (!this.app || this.clippedRight) return 0
 
       return this.$vuetify.application.right
     },
     isActive () {
       if (!this.scrollOffScreen) return true
-      if (this.manualScroll) return this.manualScroll
+      if (this.manualScroll != null) return !this.manualScroll
 
       return this.invertedScroll
         ? this.currentScroll > this.scrollThreshold
@@ -137,8 +153,8 @@ export default {
       }
 
       if (this.app) {
-        style.paddingRight = `${this.paddingRight}px`
-        style.paddingLeft = `${this.paddingLeft}px`
+        style.paddingRight = `${this.computedPaddingRight}px`
+        style.paddingLeft = `${this.computedPaddingLeft}px`
       }
 
       return style
@@ -160,23 +176,7 @@ export default {
           this.isActiveProxy = val
         }, 20)
       }
-    },
-    clippedLeft (val) {
-      this.updateApplication()
-    },
-    height (val) {
-      this.updateApplication()
-    },
-    clippedRight (val) {
-      this.updateApplication()
-    },
-    invertedScroll () {
-      this.updateApplication()
     }
-  },
-
-  destroyed () {
-    if (this.app) this.$vuetify.application.top -= this.computedHeight
   },
 
   methods: {
@@ -197,12 +197,13 @@ export default {
 
       this.previousScroll = this.currentScroll
     },
+    /**
+     * Update the application layout
+     * 
+     * @return {integer}
+     */
     updateApplication () {
-      if (!this.app) return
-
-      this.$vuetify.application.top = (!this.fixed &&
-        !this.absolute) ||
-        this.invertedScroll
+      return this.invertedScroll
         ? 0
         : this.computedHeight
     }

--- a/src/components/VToolbar/VToolbar.spec.js
+++ b/src/components/VToolbar/VToolbar.spec.js
@@ -2,6 +2,13 @@ import Vue from 'vue'
 import { test } from '~util/testing'
 import VToolbar from '~components/VToolbar'
 
+const scrollWindow = y => {
+  global.pageYOffset = y
+  global.dispatchEvent(new Event('scroll'))
+
+  return new Promise(resolve => setTimeout(resolve, 200))
+}
+
 test('VToolbar.vue', ({ mount }) => {
   it('should render a colored toolbar', () => {
     const wrapper = mount(VToolbar, {
@@ -42,17 +49,17 @@ test('VToolbar.vue', ({ mount }) => {
     wrapper.vm.$vuetify.application.right = 84
 
     wrapper.setProps({ app: false, clippedLeft: false, clippedRight: false })
-    expect(wrapper.vm.paddingLeft).toBe(0)
-    expect(wrapper.vm.paddingRight).toBe(0)
+    expect(wrapper.vm.computedPaddingLeft).toBe(0)
+    expect(wrapper.vm.computedPaddingRight).toBe(0)
     wrapper.setProps({ app: false, clippedLeft: true, clippedRight: true })
-    expect(wrapper.vm.paddingLeft).toBe(0)
-    expect(wrapper.vm.paddingRight).toBe(0)
+    expect(wrapper.vm.computedPaddingLeft).toBe(0)
+    expect(wrapper.vm.computedPaddingRight).toBe(0)
     wrapper.setProps({ app: true, clippedLeft: false, clippedRight: false })
-    expect(wrapper.vm.paddingLeft).toBe(42)
-    expect(wrapper.vm.paddingRight).toBe(84)
+    expect(wrapper.vm.computedPaddingLeft).toBe(42)
+    expect(wrapper.vm.computedPaddingRight).toBe(84)
     wrapper.setProps({ app: true, clippedLeft: true, clippedRight: true })
-    expect(wrapper.vm.paddingLeft).toBe(0)
-    expect(wrapper.vm.paddingRight).toBe(0)
+    expect(wrapper.vm.computedPaddingLeft).toBe(0)
+    expect(wrapper.vm.computedPaddingRight).toBe(0)
   })
 
   it('should calculate application top', async () => {
@@ -121,5 +128,40 @@ test('VToolbar.vue', ({ mount }) => {
 
     Vue.set(wrapper.vm.$vuetify.application, 'bar', 24)
     expect(wrapper.vm.computedMarginTop).toBe(24)
+  })
+
+  it('should set active based on manual scroll', async () => {
+    const wrapper = mount(VToolbar, {
+      propsData: {
+        scrollOffScreen: true
+      }
+    })
+
+    expect(wrapper.vm.isActive).toBe(true)
+    wrapper.setProps({ manualScroll: true })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(wrapper.vm.isActiveProxy).toBe(false)
+  })
+
+  it.skip('should set a custom target', async () => {
+    const wrapper = mount(VToolbar, {
+      propsData: {
+        target: 'body'
+      }
+    })
+
+    wrapper.vm.onScroll()
+    expect(wrapper.vm.target).toBe('body')
+  })
+
+  it.skip('should set isScrollingUp', async () => {
+    const wrapper = mount(VToolbar)
+
+    await scrollWindow(100)
+    expect(wrapper.vm.isScrollingUp).toBe(false)
+    await scrollWindow(0)
+    expect(wrapper.vm.isScrollingUp).toBe(true)
   })
 })

--- a/src/components/Vuetify/mixins/application.js
+++ b/src/components/Vuetify/mixins/application.js
@@ -1,7 +1,8 @@
 export default {
   bar: 0,
-  top: 0,
   bottom: 0,
+  footer: 0,
   left: 0,
-  right: 0
+  right: 0,
+  top: 0
 }

--- a/src/mixins/applicationable.js
+++ b/src/mixins/applicationable.js
@@ -1,15 +1,51 @@
-export default {
-  props: {
-    app: Boolean
-  },
+export default function applicationable (value, events = []) {
+  return {
+    props: {
+      absolute: Boolean,
+      app: Boolean,
+      fixed: Boolean
+    },
 
-  watch: {
-    app () {
-      this.updateApplication()
+    computed: {
+      applicationProperty () {
+        return value
+      }
+    },
+
+    watch: {
+      // If previous value was app
+      // reset the provided prop
+      app (x, prev) {
+        prev
+          ? this.removeApplication()
+          : this.callUpdate()
+      }
+    },
+
+    created () {
+      for (let i = 0, length = events.length; i < length; i++) {
+        this.$watch(events[i], this.callUpdate)
+      }
+    },
+
+    mounted () {
+      this.callUpdate()
+    },
+
+    destroyed () {
+      this.app && this.removeApplication()
+    },
+
+    methods: {
+      callUpdate () {
+        if (!this.app) return
+
+        this.$vuetify.application[this.applicationProperty] = this.updateApplication()
+      },
+      removeApplication () {
+        this.$vuetify.application[this.applicationProperty] = 0
+      },
+      updateApplication: () => {}
     }
-  },
-
-  mounted () {
-    this.updateApplication()
   }
 }

--- a/src/mixins/applicationable.spec.js
+++ b/src/mixins/applicationable.spec.js
@@ -6,23 +6,99 @@ test('applicationable.js', ({ mount }) => {
   it('should update application on mount', async () => {
     const updateApplication = jest.fn()
     const wrapper = mount({
-      mixins: [ Applicationable ],
-      methods: { updateApplication },
-      render: h => h('div')
-    })
-
-    expect(updateApplication.mock.calls).toHaveLength(1)
-  })
-
-  it('should update application on app prop change', async () => {
-    const updateApplication = jest.fn()
-    const wrapper = mount({
-      mixins: [ Applicationable ],
+      mixins: [ Applicationable() ],
       methods: { updateApplication },
       render: h => h('div')
     })
 
     wrapper.setProps({ app: true })
+    await wrapper.vm.$nextTick()
+    expect(updateApplication.mock.calls).toHaveLength(1)
+  })
+
+  it('should update application on app prop change', async () => {
+    const updateApplication = jest.fn()
+    const removeApplication = jest.fn()
+    const wrapper = mount({
+      mixins: [ Applicationable() ],
+      methods: { updateApplication, removeApplication },
+      render: h => h('div')
+    })
+
+    wrapper.setProps({ app: true })
+    await wrapper.vm.$nextTick()
+    wrapper.setProps({ app: false })
+    await wrapper.vm.$nextTick()
+    wrapper.setProps({ app: true })
+    await wrapper.vm.$nextTick()
     expect(updateApplication.mock.calls).toHaveLength(2)
+    expect(removeApplication.mock.calls).toHaveLength(1)
+  })
+
+  it('should bind watchers passed through factory', () => {
+    const wrapper = mount({
+      data: () => ({
+        foo: 1,
+        bar: 2
+      }),
+      mixins: [ Applicationable(null, ['foo', 'bar']) ],
+      render: h => h('div')
+    })
+
+    expect(wrapper.vm._watchers.length).toBe(5)
+  })
+
+  it('should call to remove application on destroy', async () => {
+    const removeApplication = jest.fn()
+    const wrapper = mount({
+      mixins: [ Applicationable() ],
+      methods: { removeApplication },
+      render: h => h('div')
+    })
+
+    wrapper.setProps({ app: true })
+    wrapper.destroy()
+    await wrapper.vm.$nextTick()
+    expect(removeApplication.mock.calls).toHaveLength(1)
+  })
+
+  it('should update application with dynamic property', async () => {
+    const wrapper = mount({
+      mixins: [ Applicationable() ],
+      computed: {
+        applicationProperty () {
+          return 'top'
+        }
+      },
+      methods: {
+        updateApplication () {
+          return 30
+        }
+      },
+      render: h => h('div')
+    })
+
+    wrapper.setProps({ app: true })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.$vuetify.application.top).toBe(30)
+  })
+
+  it('should remove designated value from application', async () => {
+    const wrapper = mount({
+      mixins: [ Applicationable('footer') ],
+      methods: {
+        updateApplication () {
+          return 30
+        }
+      },
+      render: h => h('div')
+    })
+
+    wrapper.setProps({ app: true })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.$vuetify.application.footer).toBe(30)
+    wrapper.vm.removeApplication()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.$vuetify.application.footer).toBe(0)
   })
 })

--- a/src/stylus/components/_bottom-navs.styl
+++ b/src/stylus/components/_bottom-navs.styl
@@ -1,12 +1,16 @@
 @import '../bootstrap'
+@import '../theme'
+
+bottom-nav($material)
+  background-color: $material.cards
+
+theme(bottom-nav, "bottom-nav")
 
 .bottom-nav
   bottom: 0
   box-shadow: 0 3px 14px 2px rgba(#000, .12)
   display: flex
-  height: 56px
   justify-content: center
-  position: fixed
   transform: translate(0, 60px)
   transition: all .4s $transition.swing
   width: 100%
@@ -17,6 +21,9 @@
 
   &--active
     transform: translate(0, 0)
+  
+  &--fixed
+    position: fixed
 
   .btn
     background: transparent !important
@@ -35,7 +42,7 @@
     .btn__content
       height: 100%
       flex-direction: column-reverse
-      height: 56px
+      height: inherit
       font-size: 12px
       transform: scale(1, 1) translate(0, 0)
       white-space: nowrap

--- a/src/stylus/components/_footer.styl
+++ b/src/stylus/components/_footer.styl
@@ -13,28 +13,19 @@ theme(footer, "footer")
   min-height: $footer-height
   transition: .2s $transition.fast-out-slow-in
 
-  &--absolute, &--fixed
+  &--absolute,
+  &--fixed
     bottom: 0
     left: 0
     width: 100%
     z-index: 3
+    
+  &--inset
+    z-index: 2
 
   &--absolute
     position: absolute
 
   &--fixed
     position: fixed
-
-  > *:first-child
-    margin-left: $grid-gutters.md
-
-  > *:last-child
-    margin-right: $grid-gutters.md
-
-  @media $display-breakpoints.xs-only
-    > *:first-child
-      margin-left: $grid-gutters.lg
-
-    > *:last-child
-      margin-right: $grid-gutters.lg
 

--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -21,9 +21,6 @@
     input[readonly]
       cursor: pointer
 
-    .toolbar__side-icon
-      margin: 0
-
   &__content
     position: absolute
     display: inline-block


### PR DESCRIPTION
Turned applicationable into a factory function, added ability to have a `v-bottom-nav` and `v-footer`. Using the **app** prop now automatically adds **fixed** as we will not support any other behavior. Added **height** prop to `v-bottom-nav`, `v-footer`, and `v-system-bar`. Add tons of new tests. Added missing directive **scroll** in `v-toolbar`. Normalized property names in layout files. Added **inset** prop to `v-footer`. Updated style declarations to be lazy.

fixes #2679