### PR TITLE
Enhancement/absolute menus

### DIFF
--- a/src/components/VDataIterator/VDataIterator.spec.js
+++ b/src/components/VDataIterator/VDataIterator.spec.js
@@ -32,7 +32,7 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
     const content = wrapper.find('.data-iterator div div')[0]
     expect(content.element.textContent).toBe('No matching records found')
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot - hideActions and no footer slot', () => {
@@ -51,7 +51,7 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
     const wrapper = mount(VDataIterator, data)
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot - no data', () => {
@@ -64,7 +64,7 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
     const content = wrapper.find('.data-iterator div div')[0]
     expect(content.element.textContent).toBe('No data available')
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot - with data', () => {
@@ -93,7 +93,7 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
     const wrapper = mount(component)
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should pass attrs, class and props to content', () => {
@@ -134,7 +134,7 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
     expect(button.hasClass('btn--block')).toBe(true)
     expect(button.hasClass('test__class')).toBe(true)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not filter items if search is empty', async () => {
@@ -144,6 +144,6 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.instance().filteredItems).toHaveLength(data.propsData.items.length)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -13,6 +13,7 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
       <div class="data-iterator__actions__select">
         Items per page:
         <div tabindex="0"
+             data-uid="15"
              aria-label="Items per page:"
              role="combobox"
              class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
@@ -161,6 +162,7 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
       <div class="data-iterator__actions__select">
         Items per page:
         <div tabindex="0"
+             data-uid="27"
              aria-label="Items per page:"
              role="combobox"
              class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
@@ -300,6 +302,7 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
       <div class="data-iterator__actions__select">
         Items per page:
         <div tabindex="0"
+             data-uid="1"
              aria-label="Items per page:"
              role="combobox"
              class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
@@ -443,6 +446,7 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
       <div class="data-iterator__actions__select">
         Items per page:
         <div tabindex="0"
+             data-uid="41"
              aria-label="Items per page:"
              role="combobox"
              class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"

--- a/src/components/VDataTable/VDataTable.spec.js
+++ b/src/components/VDataTable/VDataTable.spec.js
@@ -50,7 +50,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     pagination.descending = true
 
     expect(wrapper.vm.$props.pagination.descending).toBe(true)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot - no matching results', () => {
@@ -63,7 +63,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     const content = wrapper.find('table.datatable tbody > tr > td')[0]
     expect(content.element.textContent).toBe('No matching records found')
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot - no data', () => {
@@ -76,7 +76,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     const content = wrapper.find('table.datatable tbody > tr > td')[0]
     expect(content.element.textContent).toBe('No data available')
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot - with data', () => {
@@ -104,7 +104,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     const wrapper = mount(component)
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match a snapshot with single rows-per-page-items', () => {
@@ -122,7 +122,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     const wrapper = mount(VDataTable, data)
 
     expect(wrapper.find('tbody td')[0].html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match display no-results-text when no results', () => {
@@ -132,7 +132,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     const wrapper = mount(VDataTable, data)
 
     expect(wrapper.find('tbody td')[0].html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render aria-sort attribute on column headers', async () => {
@@ -156,7 +156,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
       headers.map(h => h.getAttribute('aria-sort'))
     ).toEqual(['none', 'none', 'ascending'])
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should match not allow a null sort', async () => {
@@ -189,7 +189,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.defaultPagination.descending).toBe(false)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a progress with headers slot', () => {
@@ -211,7 +211,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     }))
 
     expect(wrapper.find('.datatable__progress')).toHaveLength(1)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should only filter on data specified in headers', async () => {
@@ -227,7 +227,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     })
     expect(wrapper.instance().filteredItems).toHaveLength(1)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not filter items if search is empty', async () => {
@@ -237,6 +237,6 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.instance().filteredItems).toHaveLength(data.propsData.items.length)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -68,6 +68,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
             <div class="datatable__actions__select">
               Rows per page:
               <div tabindex="0"
+                   data-uid="13"
                    aria-label="Rows per page:"
                    role="combobox"
                    class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
@@ -263,6 +264,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
             <div class="datatable__actions__select">
               Rows per page:
               <div tabindex="0"
+                   data-uid="1"
                    aria-label="Rows per page:"
                    role="combobox"
                    class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
@@ -460,6 +462,7 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
             <div class="datatable__actions__select">
               Rows per page:
               <div tabindex="0"
+                   data-uid="27"
                    aria-label="Rows per page:"
                    role="combobox"
                    class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"

--- a/src/components/VDialog/VDialog.spec.js
+++ b/src/components/VDialog/VDialog.spec.js
@@ -6,7 +6,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     const wrapper = mount(VDialog)
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a disabled component and match snapshot', () => {
@@ -17,7 +17,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a persistent component and match snapshot', () => {
@@ -28,7 +28,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a fullscreen component and match snapshot', () => {
@@ -39,7 +39,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a lazy component and match snapshot', () => {
@@ -50,7 +50,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a scrollable component and match snapshot', () => {
@@ -61,7 +61,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom origin and match snapshot', () => {
@@ -72,7 +72,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom width (max-width) and match snapshot', () => {
@@ -83,7 +83,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom transition and match snapshot', () => {
@@ -94,7 +94,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should open dialog on activator click', async () => {
@@ -113,7 +113,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(input).toBeCalledWith(true)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('not should open disabed dialog on activator click', async () => {
@@ -135,7 +135,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(input).not.toBeCalled()
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('not change state on v-model update', async () => {
@@ -162,7 +162,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isActive).toBe(false)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should emit keydown event', async () => {
@@ -182,6 +182,6 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     window.dispatchEvent(new Event('keydown'))
     expect(keydown).toBeCalled()
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VMenu/VMenu.js
+++ b/src/components/VMenu/VMenu.js
@@ -80,7 +80,9 @@ export default {
 
   computed: {
     calculatedLeft () {
-      return `${this.calcXOverflow(this.computedLeft)}px`
+      if (!this.auto) return this.calcLeft()
+
+      return `${this.calcXOverflow(this.calcLeftAuto())}px`
     },
     calculatedMaxHeight () {
       return this.auto
@@ -117,9 +119,9 @@ export default {
       )}px`
     },
     calculatedTop () {
-      const top = this.auto ? this.calcTopAuto : this.calcTop
+      if (!this.auto || this.absolute) return this.calcTop()
 
-      return `${this.calcYOverflow(top())}px`
+      return `${this.calcYOverflow(this.calcTopAuto())}px`
     },
     styles () {
       return {

--- a/src/components/VMenu/VMenu.js
+++ b/src/components/VMenu/VMenu.js
@@ -80,10 +80,7 @@ export default {
 
   computed: {
     calculatedLeft () {
-      let left = this.calcLeft
-      if (this.auto) left = this.calcLeftAuto
-
-      return `${this.calcXOverflow(left())}px`
+      return `${this.calcXOverflow(this.computedLeft)}px`
     },
     calculatedMaxHeight () {
       return this.auto

--- a/src/components/VMenu/VMenu.spec.js
+++ b/src/components/VMenu/VMenu.spec.js
@@ -25,7 +25,7 @@ test('VMenu.js', ({ mount }) => {
 
     expect(input).toBeCalledWith(true)
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom top and match snapshot', () => {
@@ -36,7 +36,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom bottom and match snapshot', () => {
@@ -47,7 +47,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom left and match snapshot', () => {
@@ -58,7 +58,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom right and match snapshot', () => {
@@ -69,7 +69,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom fullWidth and match snapshot', () => {
@@ -80,7 +80,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom auto and match snapshot', () => {
@@ -91,7 +91,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom offsetX and match snapshot', () => {
@@ -102,7 +102,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom offsetY and match snapshot', () => {
@@ -113,7 +113,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom disabled and match snapshot', () => {
@@ -124,7 +124,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom maxHeight and match snapshot', () => {
@@ -135,7 +135,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom nudgeTop and match snapshot', () => {
@@ -146,7 +146,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom nudgeBottom and match snapshot', () => {
@@ -157,7 +157,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom nudgeLeft and match snapshot', () => {
@@ -168,7 +168,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom nudgeRight and match snapshot', () => {
@@ -179,7 +179,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom nudgeWidth and match snapshot', () => {
@@ -190,7 +190,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom openOnClick and match snapshot', () => {
@@ -201,7 +201,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom openOnHover and match snapshot', () => {
@@ -212,7 +212,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom lazy and match snapshot', () => {
@@ -223,7 +223,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom closeOnClick and match snapshot', () => {
@@ -234,7 +234,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom closeOnContentClick and match snapshot', () => {
@@ -245,7 +245,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom activator and match snapshot', () => {
@@ -256,7 +256,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom origin and match snapshot', () => {
@@ -267,7 +267,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom transition and match snapshot', () => {
@@ -278,7 +278,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom positionX and match snapshot', () => {
@@ -289,7 +289,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom positionY and match snapshot', () => {
@@ -300,7 +300,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom positionAbsolutely and match snapshot', () => {
@@ -311,7 +311,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom maxWidth and match snapshot', () => {
@@ -322,7 +322,7 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom minWidth and match snapshot', () => {
@@ -333,6 +333,6 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VMenu/mixins/menu-generators.js
+++ b/src/components/VMenu/mixins/menu-generators.js
@@ -59,9 +59,14 @@ export default {
 
     genContent () {
       const options = {
+        staticClass: 'menu__content',
         'class': [
-          (`menu__content ${this.contentClass}`).trim(),
-          { 'menuable__content__active': this.isActive }
+          {
+            [this.contentClass.trim()]: true,
+            'menuable__content__active': this.isActive,
+            'theme--dark': this.dark,
+            'theme--light': this.light
+          }
         ],
         style: this.styles,
         directives: this.genDirectives(),

--- a/src/components/VMenu/mixins/menu-generators.js
+++ b/src/components/VMenu/mixins/menu-generators.js
@@ -60,14 +60,12 @@ export default {
     genContent () {
       const options = {
         staticClass: 'menu__content',
-        'class': [
-          {
-            [this.contentClass.trim()]: true,
-            'menuable__content__active': this.isActive,
-            'theme--dark': this.dark,
-            'theme--light': this.light
-          }
-        ],
+        'class': {
+          [this.contentClass.trim()]: true,
+          'menuable__content__active': this.isActive,
+          'theme--dark': this.dark,
+          'theme--light': this.light
+        },
         style: this.styles,
         directives: this.genDirectives(),
         ref: 'content',

--- a/src/components/VMenu/mixins/menu-position.js
+++ b/src/components/VMenu/mixins/menu-position.js
@@ -26,20 +26,18 @@ export default {
       this.$refs.content.scrollTop = scrollTop
     },
     calcLeftAuto () {
-      const a = this.dimensions.activator
+      if (this.isAbsolute) return 0
 
-      return parseInt(a.left - this.defaultOffset * 2)
+      return parseInt(this.dimensions.activator.left - this.defaultOffset * 2)
     },
     calcTopAuto () {
-      if (!this.hasActivator) return this.calcTop()
-
       const selectedIndex = Array.from(this.tiles)
         .findIndex(n => n.classList.contains('list__tile--active'))
 
       if (selectedIndex === -1) {
         this.selectedIndex = null
 
-        return this.calcTop()
+        return this.computedTop
       }
 
       this.selectedIndex = selectedIndex
@@ -63,7 +61,7 @@ export default {
       offsetPadding--
 
       return (
-        this.calcTop() +
+        this.computedTop +
         offsetPadding -
         (actingIndex * (this.defaultOffset * 6))
       )

--- a/src/components/VSelect/VSelect-autocomplete.spec.js
+++ b/src/components/VSelect/VSelect-autocomplete.spec.js
@@ -13,7 +13,7 @@ test('VSelect - autocomplete', ({ mount }) => {
 
     expect(wrapper.vm.$refs.input.tabIndex).toBe(-1)
     expect(wrapper.vm.$el.tabIndex).toBe(-1)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should have explicit tabindex passed through when autocomplete', () => {
@@ -27,7 +27,7 @@ test('VSelect - autocomplete', ({ mount }) => {
 
     expect(wrapper.vm.$refs.input.tabIndex).toBe(10)
     expect(wrapper.vm.$el.tabIndex).toBe(-1)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should have explicit tabindex passed through when not autocomplete', () => {
@@ -40,7 +40,7 @@ test('VSelect - autocomplete', ({ mount }) => {
 
     expect(wrapper.vm.$refs.input.tabIndex).toBe(-1)
     expect(wrapper.vm.$el.tabIndex).toBe(10)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should emit search input changes', async () => {
@@ -63,7 +63,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     await new Promise(resolve => setTimeout(resolve, 1))
 
     expect(update).toBeCalledWith('test')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should filter autocomplete search results', () => {
@@ -78,7 +78,7 @@ test('VSelect - autocomplete', ({ mount }) => {
 
     expect(wrapper.vm.filteredItems).toHaveLength(1)
     expect(wrapper.vm.filteredItems[0]).toBe('foo')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should filter numeric primitives', () => {
@@ -93,7 +93,7 @@ test('VSelect - autocomplete', ({ mount }) => {
 
     expect(wrapper.vm.filteredItems).toHaveLength(1)
     expect(wrapper.vm.filteredItems[0]).toBe(1)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should activate when search changes and not active', async () => {
@@ -112,7 +112,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.isActive).toBe(true)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should set searchValue to null when deactivated', async () => {
@@ -132,7 +132,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.searchValue).toBe(null)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render role=combobox correctly when autocomplete', async () => {
@@ -148,7 +148,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     const input = wrapper.find('input')[0]
     expect(input.getAttribute('role')).toBe('combobox')
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render role=combobox correctly when not autocomplete)', async () => {
@@ -157,7 +157,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     const inputGroup = wrapper.find('.input-group--select')[0]
     expect(inputGroup.element.getAttribute('role')).toBe('combobox')
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not duplicate items after items update when caching is turned on', async () => {
@@ -176,7 +176,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     expect(wrapper.vm.computedItems).toHaveLength(1)
     wrapper.setProps({ items: [{ id: 1, text: 'A' }] })
     expect(wrapper.vm.computedItems).toHaveLength(1)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not display list with no items and autocomplete', async () => {
@@ -194,7 +194,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.menuIsActive).toBe(false)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should cache items', async () => {
@@ -216,7 +216,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     wrapper.setProps({ items: ['bar'] })
     expect(wrapper.vm.computedItems).toHaveLength(3)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should cache items passed via prop', async () => {
@@ -234,7 +234,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     wrapper.setProps({ items: [5] })
     expect(wrapper.vm.computedItems).toHaveLength(5)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should allow changing of browser autocomplete', () => {
@@ -249,7 +249,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     const input = wrapper.find('input')[0]
 
     expect(input.getAttribute('autocomplete')).toBe('off')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should show input when focused and autocomplete', async () => {
@@ -268,7 +268,7 @@ test('VSelect - autocomplete', ({ mount }) => {
     await wrapper.vm.$nextTick()
     expect(input.hasStyle('display', 'block'))
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not filter text with no items', async () => {
@@ -286,6 +286,6 @@ test('VSelect - autocomplete', ({ mount }) => {
     const tile = wrapper.find('.list__tile__title')[0]
 
     expect(tile.text()).toBe('No data available')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VSelect/VSelect-combobox.spec.js
+++ b/src/components/VSelect/VSelect-combobox.spec.js
@@ -28,7 +28,7 @@ test('VSelect - combobox', ({ mount }) => {
     await wrapper.vm.$nextTick()
 
     expect(change).toHaveBeenCalledWith('foo')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should evaluate the range of an integer', async () => {
@@ -46,7 +46,7 @@ test('VSelect - combobox', ({ mount }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.currentRange).toBe(1)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not use search input when blurring', async () => {
@@ -74,6 +74,6 @@ test('VSelect - combobox', ({ mount }) => {
     list.trigger('click')
     await wrapper.vm.$nextTick()
     expect(event).toBeCalledWith(12)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VSelect/VSelect-tags.spec.js
+++ b/src/components/VSelect/VSelect-tags.spec.js
@@ -32,7 +32,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(change).toHaveBeenCalledWith(['foo'])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should change selectedIndex with keyboard', async () => {
@@ -55,7 +55,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
       expect(wrapper.vm.selectedIndex).toBe(index)
     }
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should delete a tagged item when selected and backspace/delete is pressed', async () => {
@@ -87,7 +87,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     expect(change).toHaveBeenCalledWith([])
     expect(wrapper.vm.selectedIndex).toBe(-1)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should add a tag on tab using the first suggestion', async () => {
@@ -116,7 +116,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(change).toBeCalledWith(['bar'])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should add a tag on tab using the current searchValue', async () => {
@@ -152,7 +152,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(change).toBeCalledWith(['bar', 'it'])
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should add a tag on enter using the current searchValue', async () => {
@@ -183,7 +183,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(change).toBeCalledWith(['ba'])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should add a tag on left arrow and select the previous tag', async () => {
@@ -211,7 +211,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
 
     expect(change).toBeCalledWith(['foo', 'b'])
     expect(wrapper.vm.selectedIndex).toBe(0)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should remove a duplicate tag and add it to the end', async () => {
@@ -237,7 +237,7 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(change).toBeCalledWith(['bar', 'foo'])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should add tag with valid search value on blur', async () => {
@@ -265,6 +265,6 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick() // Second tick processes change after tag added
 
     expect(change).toBeCalledWith(['bar'])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -289,6 +289,7 @@ export default {
     const data = {
       attrs: {
         tabindex: this.isAutocomplete || this.disabled ? -1 : this.tabindex,
+        'data-uid': this._uid,
         ...(this.isAutocomplete ? null : this.$attrs),
         role: this.isAutocomplete ? null : 'combobox'
       }

--- a/src/components/VSelect/VSelect.spec.js
+++ b/src/components/VSelect/VSelect.spec.js
@@ -18,7 +18,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     wrapper.vm.selectItem(item)
 
     expect(change).toBeCalledWith([0])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should be in an error state', async () => {
@@ -37,7 +37,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.hasError).toBe(true)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should disable list items', () => {
@@ -54,7 +54,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     const item = wrapper.find('li')[0]
 
     expect(item.element.getAttribute('disabled')).toBe('disabled')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should warn when using incorrect item together with segmented prop', async () => {
@@ -74,7 +74,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     await wrapper.vm.$nextTick()
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
     expect('items must contain both a text and callback property').toHaveBeenTipped()
   })
 
@@ -95,7 +95,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render buttons correctly when using slot with segmented prop', async () => {
@@ -129,7 +129,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not close menu when using multiple prop', async () => {
@@ -156,7 +156,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(blur).not.toBeCalled()
     expect(wrapper.vm.isActive).toBe(true)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render aria-hidden=true on arrow icon', async () => {
@@ -164,7 +164,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     const icon = wrapper.find('.input-group__append-icon')[0]
     expect(icon.hasAttribute('aria-hidden')).toBe(true)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should display a default value', async () => {
@@ -176,7 +176,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.vm.selectedItems).toEqual(['foo'])
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not display a default value that is not in items', async () => {
@@ -188,7 +188,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.vm.selectedItems).toHaveLength(0)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should update the displayed value when items changes', async () => {
@@ -202,7 +202,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
     expect(wrapper.vm.selectedItems).toContainEqual({ text: 'foo', value: 1 })
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render select menu with content class', async () => {
@@ -217,7 +217,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     const menu = wrapper.find('.menu__content')[0]
     expect(menu.element.classList).toContain('menu-class')
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should have deletable chips', async () => {
@@ -237,7 +237,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(!!chip).toBe(true)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should escape items in menu', async () => {
@@ -255,7 +255,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(tileTitle.html()).toMatchSnapshot()
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should have the proper nudge', async () => {
@@ -289,6 +289,6 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.vm.nudgeTop).toBe(2)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VSelect/VSelect2.spec.js
+++ b/src/components/VSelect/VSelect2.spec.js
@@ -22,7 +22,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
       await wrapper.vm.$nextTick()
     }
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should clear input value', async () => {
@@ -49,7 +49,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.vm.inputValue).toBe(null)
     expect(input).toHaveBeenCalledWith(null)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should be clearable with prop, dirty and single select', async () => {
@@ -74,7 +74,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(wrapper.vm.inputValue).toBe(null)
     expect(wrapper.vm.menuIsVisible).toBe(false)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should be clearable with prop, dirty and multi select', async () => {
@@ -101,7 +101,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(change).toHaveBeenCalledWith([])
     expect(wrapper.vm.menuIsVisible).toBe(false)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should prepropulate selectedItems', () => {
@@ -132,7 +132,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(wrapper.vm.selectedItems).toHaveLength(1)
     expect(wrapper2.vm.selectedItems).toHaveLength(2)
     expect(wrapper3.vm.selectedItems).toHaveLength(0)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should show input with placeholder and not dirty', async () => {
@@ -144,7 +144,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.find('input')[0].hasStyle('display', 'block'))
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not show input with placeholder and dirty', async () => {
@@ -158,7 +158,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.find('input')[0].hasStyle('display', 'none'))
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   // #1704
@@ -180,7 +180,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     const selections = wrapper.find('.input-group__selections__comma')
 
     expect(selections.length).toBeGreaterThan(0)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   // Discovered when working on #1704
@@ -204,7 +204,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     item.trigger('click')
 
     expect(wrapper.vm.selectedItems).toHaveLength(0)
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should open menu when arrow is clicked', async () => {
@@ -222,7 +222,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     arrow.trigger('click')
     expect(wrapper.vm.menuIsActive).toBe(true)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should open menu when cleared with open-on-clear', async () => {
@@ -242,7 +242,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.vm.menuIsActive).toBe(true)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should not rotate icon if menu is not open', async () => {
@@ -266,6 +266,6 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(wrapper.vm.menuIsVisible).toBe(true)
     expect(wrapper.hasClass('input-group--open')).toBe(true)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -23,6 +23,7 @@ exports[`VSelect should escape items in menu 2`] = `
 exports[`VSelect should render buttons correctly when using items array with segmented prop 1`] = `
 
 <div tabindex="0"
+     data-uid="34"
      role="combobox"
      class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--segmented input-group--single-line primary--text"
 >
@@ -87,6 +88,7 @@ exports[`VSelect should render buttons correctly when using items array with seg
 exports[`VSelect should render buttons correctly when using slot with segmented prop 1`] = `
 
 <div tabindex="0"
+     data-uid="44"
      role="combobox"
      class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--segmented input-group--single-line primary--text"
 >

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
 
 <div tabindex="0"
+     data-uid="24"
      role="combobox"
      class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select input-group--multiple primary--text"
 >
@@ -125,6 +126,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
 exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
 
 <div tabindex="0"
+     data-uid="16"
      role="combobox"
      class="input-group input-group--dirty input-group--append-icon input-group--text-field input-group--select primary--text"
 >

--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -13,17 +13,21 @@ export default {
       const data = {
         ref: 'menu',
         props: {
+          absolute: this.absolute,
           activator: this.$el,
           auto: this.auto,
           closeOnClick: false,
           closeOnContentClick: !this.isMultiple,
           contentClass: this.computedContentClass,
+          dark: this.dark,
           disabled: this.disabled,
+          light: this.light,
           maxHeight: this.maxHeight,
           nudgeTop: this.nudgeTop,
           offsetY: this.shouldOffset,
           offsetOverflow: this.isAutocomplete,
           openOnClick: false,
+          target: this.absolute ? `[data-uid="${this._uid}"]` : undefined,
           value: this.menuIsVisible,
           zIndex: this.menuZIndex
         },

--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -13,9 +13,9 @@ export default {
       const data = {
         ref: 'menu',
         props: {
-          absolute: this.absolute,
           activator: this.$el,
           auto: this.auto,
+          attach: this.attach && `[data-uid="${this._uid}"]`,
           closeOnClick: false,
           closeOnContentClick: !this.isMultiple,
           contentClass: this.computedContentClass,
@@ -27,7 +27,6 @@ export default {
           offsetY: this.shouldOffset,
           offsetOverflow: this.isAutocomplete,
           openOnClick: false,
-          target: this.absolute ? `[data-uid="${this._uid}"]` : undefined,
           value: this.menuIsVisible,
           zIndex: this.menuZIndex
         },

--- a/src/components/VSelect/mixins/select-props.js
+++ b/src/components/VSelect/mixins/select-props.js
@@ -1,5 +1,6 @@
 export default {
   props: {
+    absolute: Boolean,
     appendIcon: {
       type: String,
       default: 'arrow_drop_down'

--- a/src/components/VSelect/mixins/select-props.js
+++ b/src/components/VSelect/mixins/select-props.js
@@ -1,11 +1,11 @@
 export default {
   props: {
-    absolute: Boolean,
     appendIcon: {
       type: String,
       default: 'arrow_drop_down'
     },
     appendIconCb: Function,
+    attach: Boolean,
     auto: Boolean,
     autocomplete: Boolean,
     browserAutocomplete: {

--- a/src/components/VTooltip/VTooltip.spec.js
+++ b/src/components/VTooltip/VTooltip.spec.js
@@ -21,7 +21,7 @@ test('VTooltip.js', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with value=true and match snapshot', async () => {
@@ -37,7 +37,7 @@ test('VTooltip.js', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.data().isActive).toBe(true)
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with zIndex prop and match snapshot', async () => {
@@ -48,7 +48,7 @@ test('VTooltip.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should display tooltip after mouseenter and hide after mouseleave', async () => {
@@ -82,6 +82,6 @@ test('VTooltip.js', ({ mount, compileToFunctions }) => {
     expect(setTimeout.mock.calls[1][1]).toBe(321)
     expect(cb).toBeCalledWith(false)
 
-    expect('Application is missing <v-app> component.').toHaveBeenTipped()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 })

--- a/src/mixins/detachable.js
+++ b/src/mixins/detachable.js
@@ -4,8 +4,13 @@ export default {
   mixins: [Bootable],
 
   props: {
+    absolute: Boolean,
     contentClass: {
       default: ''
+    },
+    target: {
+      type: String,
+      default: '[data-app]'
     }
   },
 
@@ -24,9 +29,9 @@ export default {
 
   methods: {
     initDetach () {
-      if (this._isDestroyed) return
+      if (this._isDestroyed || this.absolute) return
 
-      const app = document.querySelector('[data-app]')
+      const app = document.querySelector(this.target)
 
       if (!app) {
         return console.warn('Application is missing <v-app> component.')

--- a/src/mixins/detachable.js
+++ b/src/mixins/detachable.js
@@ -9,7 +9,6 @@ export default {
       default: ''
     },
     target: {
-      type: String,
       default: '[data-app]'
     }
   },
@@ -29,16 +28,20 @@ export default {
 
   methods: {
     initDetach () {
-      if (this._isDestroyed || this.absolute) return
+      if (this._isDestroyed ||
+        !this.$refs.content ||
+        // Leave menu in place if absolute
+        // and dev has not changed target
+        (this.absolute && this.target === '[data-app]')
+      ) return
 
-      const app = document.querySelector(this.target)
+      const app = typeof this.target === 'string'
+        ? document.querySelector(this.target)
+        : this.target
 
       if (!app) {
-        return console.warn('Application is missing <v-app> component.')
+        return console.warn(`Unable to locate target ${this.target}`)
       }
-
-      // If child has already been removed, bail
-      if (!this.$refs.content) return
 
       app.insertBefore(
         this.$refs.content,

--- a/src/mixins/detachable.js
+++ b/src/mixins/detachable.js
@@ -1,15 +1,24 @@
 import Bootable from './bootable'
 
+function validateAttachTarget (val) {
+  const type = typeof val
+
+  if (type === 'boolean' || type === 'string') return true
+
+  return val.nodeType === Node.ELEMENT_NODE
+}
+
 export default {
   mixins: [Bootable],
 
   props: {
-    attach: Boolean,
+    attach: {
+      type: [Boolean, String, Object],
+      default: false,
+      validator: validateAttachTarget
+    },
     contentClass: {
       default: ''
-    },
-    target: {
-      default: '[data-app]'
     }
   },
 
@@ -32,20 +41,29 @@ export default {
         !this.$refs.content ||
         // Leave menu in place if attached
         // and dev has not changed target
-        (this.attach && this.target === '[data-app]')
+        this.attach === '' || // If used as a boolean prop (<v-menu attach>)
+        this.attach === true // If bound to a boolean (<v-menu :attach="true">)
       ) return
 
-      const app = typeof this.target === 'string'
-        ? document.querySelector(this.target)
-        : this.target
-
-      if (!app) {
-        return console.warn(`Unable to locate target ${this.target}`)
+      let target
+      if (this.attach === false) {
+        // Default, detach to app
+        target = document.querySelector('[data-app]')
+      } else if (typeof this.attach === 'string') {
+        // CSS selector
+        target = document.querySelector(this.attach)
+      } else {
+        // DOM Element
+        target = this.attach
       }
 
-      app.insertBefore(
+      if (!target) {
+        return console.warn(`Unable to locate target ${this.attach || '[data-app]'}`)
+      }
+
+      target.insertBefore(
         this.$refs.content,
-        app.firstChild
+        target.firstChild
       )
     }
   }

--- a/src/mixins/detachable.js
+++ b/src/mixins/detachable.js
@@ -4,7 +4,7 @@ export default {
   mixins: [Bootable],
 
   props: {
-    absolute: Boolean,
+    attach: Boolean,
     contentClass: {
       default: ''
     },
@@ -30,9 +30,9 @@ export default {
     initDetach () {
       if (this._isDestroyed ||
         !this.$refs.content ||
-        // Leave menu in place if absolute
+        // Leave menu in place if attached
         // and dev has not changed target
-        (this.absolute && this.target === '[data-app]')
+        (this.attach && this.target === '[data-app]')
       ) return
 
       const app = typeof this.target === 'string'

--- a/src/mixins/menuable.js
+++ b/src/mixins/menuable.js
@@ -104,7 +104,7 @@ export default {
       if (this.isAttached) {
         left += this.left ? -a.width : 0
       } else {
-        left += this.left ? a.left - minWidth : a.left
+        left += this.left ? a.left - (minWidth - a.width) : a.left
       }
 
       if (this.offsetX) left += this.left ? -a.width : a.width

--- a/src/mixins/menuable.js
+++ b/src/mixins/menuable.js
@@ -49,7 +49,7 @@ export default {
   props: {
     activator: {
       default: null,
-      validate: val => {
+      validator: val => {
         return ['string', 'object'].includes(typeof val)
       }
     },
@@ -101,7 +101,7 @@ export default {
       const minWidth = a.width < c.width ? c.width : a.width
       let left = 0
 
-      if (this.isAbsolute) {
+      if (this.isAttached) {
         left += this.left ? -a.width : 0
       } else {
         left += this.left ? a.left - minWidth : a.left
@@ -118,7 +118,7 @@ export default {
       const c = this.dimensions.content
       let top = 0
 
-      if (!this.isAbsolute) {
+      if (!this.isAttached) {
         top = this.top ? a.bottom - c.height : a.top
         top += this.pageYOffset
       }
@@ -132,8 +132,8 @@ export default {
     hasActivator () {
       return !!this.$slots.activator || this.activator
     },
-    isAbsolute () {
-      return this.absolute || this.target !== '[data-app]'
+    isAttached () {
+      return this.attach || this.target !== '[data-app]'
     }
   },
 
@@ -167,13 +167,13 @@ export default {
     },
     activate () {},
     calcLeft () {
-      return `${this.isAbsolute
+      return `${this.isAttached
         ? this.computedLeft
         : this.calcXOverflow(this.computedLeft)
       }px`
     },
     calcTop () {
-      return `${this.isAbsolute
+      return `${this.isAttached
         ? this.computedTop
         : this.calcYOverflow(this.computedTop)
       }px`

--- a/src/mixins/menuable.js
+++ b/src/mixins/menuable.js
@@ -133,7 +133,7 @@ export default {
       return !!this.$slots.activator || this.activator
     },
     isAttached () {
-      return this.attach || this.target !== '[data-app]'
+      return this.attach !== false
     }
   },
 

--- a/src/mixins/menuable.spec.js
+++ b/src/mixins/menuable.spec.js
@@ -1,0 +1,34 @@
+import { test } from '~util/testing'
+import Menuable from '~mixins/menuable'
+import VBtn from '~components/VBtn'
+
+test('menuable.js', ({ mount }) => {
+  it('should bind custom activator', () => {
+    const wrapper = mount({
+      mixins: [Menuable],
+      render: h => h('div')
+    }, {
+      attachToDocument: true,
+      propsData: {
+        activator: 'body'
+      }
+    })
+
+    expect(wrapper.vm.getActivator()).toBeTruthy()
+  })
+
+  it('should update dimensions when activated', async () => {
+    const sneakPeek = jest.fn()
+    const wrapper = mount({
+      mixins: [Menuable],
+      methods: {
+        sneakPeek
+      },
+      render: h => h('div')
+    })
+
+    wrapper.vm.updateDimensions()
+    await wrapper.vm.$nextTick()
+    expect(sneakPeek).toHaveBeenCalled()
+  })
+})

--- a/src/mixins/stackable.js
+++ b/src/mixins/stackable.js
@@ -11,14 +11,24 @@ export default {
     }
   },
   computed: {
+    /**
+     * Currently active z-index
+     * 
+     * @return {number}
+     */
     activeZIndex () {
       const content = this.stackElement || this.$refs.content
       // Return current zindex if not active
-      if (!this.isActive) return getZIndex(content)
+
+      const index = !this.isActive
+        ? getZIndex(content)
+        : this.getMaxZIndex(this.stackExclude || [content]) + 2
+
+      if (index == null) return index
 
       // Return max current z-index (excluding self) + 2
       // (2 to leave room for an overlay below, if needed)
-      return this.getMaxZIndex(this.stackExclude || [content]) + 2
+      return parseInt(index)
     }
   },
   methods: {

--- a/src/stylus/components/_lists.styl
+++ b/src/stylus/components/_lists.styl
@@ -4,6 +4,7 @@
 /* Themes */
 list($material)
   background: $material.cards
+  color: $material.text.primary
 
   .list__tile__sub-title
     color: $material.text.secondary

--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -2,6 +2,7 @@
 
 .menu
   display: inline-block
+  margin: $button-margin
   position: relative
   vertical-align: middle
 

--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -20,6 +20,9 @@
 
     input[readonly]
       cursor: pointer
+      
+    > *
+      margin: 0
 
   &__content
     position: absolute

--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -65,13 +65,13 @@ theme(toolbar, "toolbar")
     
     .menu
       height: 100%
+      margin: 0
 
     > .menu .menu__activator
       height: 100%
 
       .btn
         height: 100%
-        margin: 0
 
     > .btn
       height: 100%


### PR DESCRIPTION
Added new **absolute** prop (want to change, need ideas) that will keep the `v-menu` content within its container (unless specified different from **[data-app]**). Added ability to specify a detachable target, defaults to **[data-app]**.

@Phlow2001 has proposed the prop name of **attach** which I like.

fixes #2202
fixes #1300
fixes #795