### PR TITLE
fix(v-pagination): change keys to use array index

### DIFF
--- a/src/components/VPagination/VPagination.js
+++ b/src/components/VPagination/VPagination.js
@@ -145,8 +145,8 @@ export default {
       }, [i])
     },
     genItems (h) {
-      return this.items.map((i) => {
-        return h('li', { key: i }, [
+      return this.items.map((i, index) => {
+        return h('li', { key: index }, [
           isNaN(i) && h('span', { class: 'pagination__more' }, [i]) || this.genItem(h, i)
         ])
       })


### PR DESCRIPTION
This PR fixes #2707 by changing the pagination items to use their array index as `key` instead of their string value.

Managed to find reproduction steps and cause of bug on `1.0.0-alpha1`. The bug was introduced in #2630 ([line diff](https://github.com/vuetifyjs/vuetify/pull/2630/commits/c80d13fff56a658d059a6126faf06339f3958651#diff-79ad00af4d60169a3e20640b9456f6bcR149)). The bug occurs when the `<v-pagination>` has a length larger than what it can fit on-screen. When you scroll to the right, there are 2 `...`, one at the beginning and one at the end, and using them as keys causes the duplicate key error.

* It starts off fine: `[1] [2] [3] [4] [...] [97] [98] [99] [100]`.
* But when scrolling right: `[1] [...] [49] [50] [51] [52] [...] [100]`.

Normally I wouldn't use array indexes as keys, but scanning through the array to check for other `...` feels kinda wasteful, and duplicating the range check that creates the double `...` would add confusion if anyone ever decides to modify the range check. However, I'm open to any better ways of fixing this.