### PR TITLE
fix(v-navigation-drawer): revert lazy styles

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -162,16 +162,10 @@ export default {
     styles () {
       const styles = {
         height: this.calculatedHeight,
+        marginTop: `${this.marginTop}px`,
         maxHeight: `calc(100% - ${this.maxHeight}px)`,
+        transform: `translateX(${this.calculatedTransform}px)`,
         width: `${this.calculatedWidth}px`
-      }
-
-      if (this.marginTop) {
-        styles.marginTop = `${this.marginTop}px`
-      }
-
-      if (this.calculatedTransform) {
-        styles.transform = `translateX(${this.calculatedTransform}px)`
       }
 
       return styles


### PR DESCRIPTION
On `dev` branch, PR #2703 seems to have broken initial render of `<v-navigation-drawer>`.

Before the PR, if `v-model` is set to null, it would automatically expand the navigation drawer on desktop.

After the PR, if `v-model` is set to null, it internally sets `this.isActive` in `.init()`, but it never removes the `transform` property, leading to an "invisible" navigation drawer. The body (highlighted yellow) has been shifted as if the drawer was there, but the drawer is still transformed out of the viewport (its initial render state).

<img width="1277" alt="navdrawer" src="https://user-images.githubusercontent.com/2415829/33599425-fafc6cf6-d95a-11e7-862a-4b28fcb0091d.png">

After some _experimenting_ with the [dark application layout example](https://github.com/vuetifyjs/docs/blob/dev/examples/layouts/dark.vue), it seems the change in behavior was due to the [lazy styling introduced in #2703](https://github.com/vuetifyjs/vuetify/pull/2703/files#diff-442cd2fee6d6530f74d8b9af1cd62d56R162). **Vue doesn't seem to be clearing the `transition` style if it is undefined in `data.style`**. Setting it to `null`or `translateX(0px)` (pre-PR behavior) makes the drawer render properly again.

I'm not too familiar with how style objects work in Vue, so having someone else confirm the issue and fix would be nice.