### PR TITLE
fix(menuable): Enforce the check that $refs.content exist in sneakPeek

### DIFF
--- a/src/mixins/menuable.js
+++ b/src/mixins/menuable.js
@@ -266,7 +266,7 @@ export default {
       requestAnimationFrame(() => {
         const el = this.$refs.content
 
-        if (this.isShown(el)) return cb()
+        if (!el || this.isShown(el)) return cb()
 
         el.style.display = 'inline-block'
         cb()
@@ -277,7 +277,7 @@ export default {
       requestAnimationFrame(() => (this.isContentActive = true))
     },
     isShown (el) {
-      return !!el && el.style.display !== 'none'
+      return el.style.display !== 'none'
     },
     updateDimensions () {
       const dimensions = {}


### PR DESCRIPTION
If `$refs.content` is removed between `sneakPeek` being called and the animation frame fires, it becomes undefined in the callback.

Then it results with a `Uncaught TypeError: Cannot read property 'style' of undefined`

This fix ensure that $refs.content exists.

===
Thanks Kael for the help to debug it :-)