### PR TITLE
feature(v-tabs-bar): add touchless prop

### DIFF
--- a/src/components/VTabs/VTabsBar.js
+++ b/src/components/VTabs/VTabsBar.js
@@ -43,6 +43,10 @@ export default {
     }
   },
 
+  props: {
+    touchless: Boolean
+  },
+
   computed: {
     classes () {
       return {
@@ -97,6 +101,20 @@ export default {
         ref: 'container'
       }, this.$slots.default)
     },
+    genDirectives () {
+      const directives = []
+
+      !this.touchless && directives.push({
+        name: 'touch',
+        value: {
+          start: this.start,
+          move: this.move,
+          end: this.end
+        }
+      })
+
+      return directives
+    },
     genIcon (direction) {
       const capitalize = direction.charAt(0).toUpperCase() + direction.slice(1)
       return this.$createElement(VIcon, {
@@ -110,14 +128,7 @@ export default {
     genWrapper () {
       return this.$createElement('div', {
         class: this.wrapperClasses,
-        directives: [{
-          name: 'touch',
-          value: {
-            start: this.start,
-            move: this.move,
-            end: this.end
-          }
-        }]
+        directives: this.genDirectives()
       }, [this.genContainer()])
     },
     start (e) {


### PR DESCRIPTION
Feature request by @johnleider in the Discord server

<img width="298" alt="image" src="https://user-images.githubusercontent.com/2415829/33712338-eb31ab72-dafb-11e7-9b04-9628550a554f.png">

Looks like [the touch directive](https://github.com/vuetifyjs/vuetify/blob/bd0ce95/src/components/VTabs/VTabsBar.js#L114) is in `v-tabs-bar` and not `v-tabs-content`, so this PR assumes that was just a typo in chat