### PR TITLE
Pagination separation

### DIFF
--- a/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -99,39 +99,41 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
           </div>
         </div>
       </div>
-      <div class="data-iterator__actions__pagination">
-        1-3 of 3
+      <div class="data-iterator__actions__range-controls">
+        <div class="data-iterator__actions__pagination">
+          1-3 of 3
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>
@@ -248,39 +250,41 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
           </div>
         </div>
       </div>
-      <div class="data-iterator__actions__pagination">
-        –
+      <div class="data-iterator__actions__range-controls">
+        <div class="data-iterator__actions__pagination">
+          –
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>
@@ -388,39 +392,41 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
           </div>
         </div>
       </div>
-      <div class="data-iterator__actions__pagination">
-        –
+      <div class="data-iterator__actions__range-controls">
+        <div class="data-iterator__actions__pagination">
+          –
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>
@@ -532,39 +538,41 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
           </div>
         </div>
       </div>
-      <div class="data-iterator__actions__pagination">
-        1-3 of 3
+      <div class="data-iterator__actions__range-controls">
+        <div class="data-iterator__actions__pagination">
+          1-3 of 3
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -27,6 +27,7 @@ export default {
   data () {
     return {
       actionsClasses: 'datatable__actions',
+      actionsRangeControlsClasses: 'datatable__actions__range-controls',
       actionsSelectClasses: 'datatable__actions__select',
       actionsPaginationClasses: 'datatable__actions__pagination'
     }

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -97,7 +97,7 @@ export default {
   },
 
   render (h) {
-    return h('v-table-overflow', {}, [
+    const tableOverflow = h('v-table-overflow', {}, [
       h('table', {
         'class': this.classes
       }, [
@@ -105,6 +105,11 @@ export default {
         this.genTBody(),
         this.genTFoot()
       ])
+    ])
+
+    return h('div', [
+      tableOverflow,
+      this.genActionsFooter()
     ])
   }
 }

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -155,39 +155,41 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
           </div>
         </div>
       </div>
-      <div class="datatable__actions__pagination">
-        –
+      <div class="datatable__actions__range-controls">
+        <div class="datatable__actions__pagination">
+          –
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>
@@ -349,39 +351,41 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
           </div>
         </div>
       </div>
-      <div class="datatable__actions__pagination">
-        –
+      <div class="datatable__actions__range-controls">
+        <div class="datatable__actions__pagination">
+          –
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>
@@ -545,39 +549,41 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
           </div>
         </div>
       </div>
-      <div class="datatable__actions__pagination">
-        1-3 of 3
+      <div class="datatable__actions__range-controls">
+        <div class="datatable__actions__pagination">
+          1-3 of 3
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>
@@ -643,38 +649,40 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
   </div>
   <div class="datatable table">
     <div class="datatable__actions">
-      <div class="datatable__actions__pagination">
-        1-1 of 3
+      <div class="datatable__actions__range-controls">
+        <div class="datatable__actions__pagination">
+          1-1 of 3
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button type="button"
+                class="btn btn--flat btn--icon"
+                data-ripple="true"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 24px;"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
       </div>
-      <button disabled="disabled"
-              type="button"
-              class="btn btn--disabled btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Previous page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_left
-          </i>
-        </div>
-      </button>
-      <button type="button"
-              class="btn btn--flat btn--icon"
-              data-ripple="true"
-              aria-label="Next page"
-      >
-        <div class="btn__content">
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 24px;"
-          >
-            chevron_right
-          </i>
-        </div>
-      </button>
     </div>
   </div>
 </div>

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -2,689 +2,681 @@
 
 exports[`VDataTable.vue should match a snapshot - no data 1`] = `
 
-<div class="table__overflow">
-  <table class="datatable table">
-    <thead>
-      <tr>
-        <th role="columnheader"
-            scope="col"
-            aria-label="First Column: Sorted ascending. Activate to sort descending."
-            aria-sort="ascending"
-            tabindex="0"
-            class="column sortable active asc text-xs-right a-string"
-        >
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 16px;"
+<div>
+  <div class="table__overflow">
+    <table class="datatable table">
+      <thead>
+        <tr>
+          <th role="columnheader"
+              scope="col"
+              aria-label="First Column: Sorted ascending. Activate to sort descending."
+              aria-sort="ascending"
+              tabindex="0"
+              class="column sortable active asc text-xs-right a-string"
           >
-            arrow_upward
-          </i>
-          First Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Second Column: Not sorted."
-            aria-sort="none"
-            class="column text-xs-right"
-        >
-          Second Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Third Column: Not sorted. Activate to sort ascending."
-            aria-sort="none"
-            tabindex="0"
-            class="column sortable text-xs-right an array"
-        >
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 16px;"
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            First Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Second Column: Not sorted."
+              aria-sort="none"
+              class="column text-xs-right"
           >
-            arrow_upward
-          </i>
-          Third Column
-        </th>
-      </tr>
-      <tr class="datatable__progress">
-        <th colspan="100%"
-            class="column"
+            Second Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Third Column: Not sorted. Activate to sort ascending."
+              aria-sort="none"
+              tabindex="0"
+              class="column sortable text-xs-right an array"
+          >
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            Third Column
+          </th>
+        </tr>
+        <tr class="datatable__progress">
+          <th colspan="100%"
+              class="column"
+          >
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td colspan="100%"
+              class="text-xs-center"
+          >
+            No data available
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="datatable table">
+    <div class="datatable__actions">
+      <div class="datatable__actions__select">
+        Rows per page:
+        <div tabindex="0"
+             data-uid="13"
+             aria-label="Rows per page:"
+             role="combobox"
+             class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
         >
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td colspan="100%"
-            class="text-xs-center"
-        >
-          No data available
-        </td>
-      </tr>
-    </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="100%">
-          <div class="datatable__actions">
-            <div class="datatable__actions__select">
-              Rows per page:
-              <div tabindex="0"
-                   data-uid="13"
-                   aria-label="Rows per page:"
-                   role="combobox"
-                   class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
+          <div class="input-group__input">
+            <div class="input-group__selections"
+                 style="overflow: hidden;"
+            >
+              <input aria-label="Rows per page:"
+                     disabled="disabled"
+                     tabindex="-1"
+                     class="input-group--select__autocomplete"
+                     style="display: none;"
               >
-                <div class="input-group__input">
-                  <div class="input-group__selections"
-                       style="overflow: hidden;"
-                  >
-                    <input aria-label="Rows per page:"
-                           disabled="disabled"
-                           tabindex="-1"
-                           class="input-group--select__autocomplete"
-                           style="display: none;"
-                    >
-                  </div>
-                  <div class="menu"
-                       style="display: inline-block;"
-                  >
-                    <div class="menu__content menu__content--select menu__content--auto"
-                         style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
-                    >
-                      <div class="card"
-                           style="height: auto;"
-                           data-ripple="false"
+            </div>
+            <div class="menu"
+                 style="display: inline-block;"
+            >
+              <div class="menu__content menu__content--select menu__content--auto"
+                   style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
+              >
+                <div class="card"
+                     style="height: auto;"
+                     data-ripple="false"
+                >
+                  <ul class="list">
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
                       >
-                        <ul class="list">
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  5
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  10
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  25
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  All
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                  <i aria-hidden="true"
-                     class="material-icons icon input-group__append-icon input-group__icon-cb"
-                     style="font-size: 24px;"
-                  >
-                    arrow_drop_down
-                  </i>
-                </div>
-                <div class="input-group__details">
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            5
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            10
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            25
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            All
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>
-            <div class="datatable__actions__pagination">
-              –
-            </div>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Previous page"
+            <i aria-hidden="true"
+               class="material-icons icon input-group__append-icon input-group__icon-cb"
+               style="font-size: 24px;"
             >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_left
-                </i>
-              </div>
-            </button>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Next page"
-            >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_right
-                </i>
-              </div>
-            </button>
+              arrow_drop_down
+            </i>
           </div>
-        </td>
-      </tr>
-    </tfoot>
-  </table>
+          <div class="input-group__details">
+          </div>
+        </div>
+      </div>
+      <div class="datatable__actions__pagination">
+        –
+      </div>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Previous page"
+      >
+        <div class="btn__content">
+          <i aria-hidden="true"
+             class="material-icons icon"
+             style="font-size: 24px;"
+          >
+            chevron_left
+          </i>
+        </div>
+      </button>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Next page"
+      >
+        <div class="btn__content">
+          <i aria-hidden="true"
+             class="material-icons icon"
+             style="font-size: 24px;"
+          >
+            chevron_right
+          </i>
+        </div>
+      </button>
+    </div>
+  </div>
 </div>
 
 `;
 
 exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
 
-<div class="table__overflow">
-  <table class="datatable table">
-    <thead>
-      <tr>
-        <th role="columnheader"
-            scope="col"
-            aria-label="First Column: Sorted ascending. Activate to sort descending."
-            aria-sort="ascending"
-            tabindex="0"
-            class="column sortable active asc text-xs-right a-string"
-        >
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 16px;"
+<div>
+  <div class="table__overflow">
+    <table class="datatable table">
+      <thead>
+        <tr>
+          <th role="columnheader"
+              scope="col"
+              aria-label="First Column: Sorted ascending. Activate to sort descending."
+              aria-sort="ascending"
+              tabindex="0"
+              class="column sortable active asc text-xs-right a-string"
           >
-            arrow_upward
-          </i>
-          First Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Second Column: Not sorted."
-            aria-sort="none"
-            class="column text-xs-right"
-        >
-          Second Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Third Column: Not sorted. Activate to sort ascending."
-            aria-sort="none"
-            tabindex="0"
-            class="column sortable text-xs-right an array"
-        >
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 16px;"
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            First Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Second Column: Not sorted."
+              aria-sort="none"
+              class="column text-xs-right"
           >
-            arrow_upward
-          </i>
-          Third Column
-        </th>
-      </tr>
-      <tr class="datatable__progress">
-        <th colspan="100%"
-            class="column"
+            Second Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Third Column: Not sorted. Activate to sort ascending."
+              aria-sort="none"
+              tabindex="0"
+              class="column sortable text-xs-right an array"
+          >
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            Third Column
+          </th>
+        </tr>
+        <tr class="datatable__progress">
+          <th colspan="100%"
+              class="column"
+          >
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td colspan="100%"
+              class="text-xs-center"
+          >
+            No matching records found
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="datatable table">
+    <div class="datatable__actions">
+      <div class="datatable__actions__select">
+        Rows per page:
+        <div tabindex="0"
+             data-uid="1"
+             aria-label="Rows per page:"
+             role="combobox"
+             class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
         >
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td colspan="100%"
-            class="text-xs-center"
-        >
-          No matching records found
-        </td>
-      </tr>
-    </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="100%">
-          <div class="datatable__actions">
-            <div class="datatable__actions__select">
-              Rows per page:
-              <div tabindex="0"
-                   data-uid="1"
-                   aria-label="Rows per page:"
-                   role="combobox"
-                   class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
+          <div class="input-group__input">
+            <div class="input-group__selections"
+                 style="overflow: hidden;"
+            >
+              <input aria-label="Rows per page:"
+                     disabled="disabled"
+                     tabindex="-1"
+                     class="input-group--select__autocomplete"
+                     style="display: none;"
               >
-                <div class="input-group__input">
-                  <div class="input-group__selections"
-                       style="overflow: hidden;"
-                  >
-                    <input aria-label="Rows per page:"
-                           disabled="disabled"
-                           tabindex="-1"
-                           class="input-group--select__autocomplete"
-                           style="display: none;"
-                    >
-                  </div>
-                  <div class="menu"
-                       style="display: inline-block;"
-                  >
-                    <div class="menu__content menu__content--select menu__content--auto"
-                         style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
-                    >
-                      <div class="card"
-                           style="height: auto;"
-                           data-ripple="false"
+            </div>
+            <div class="menu"
+                 style="display: inline-block;"
+            >
+              <div class="menu__content menu__content--select menu__content--auto"
+                   style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
+              >
+                <div class="card"
+                     style="height: auto;"
+                     data-ripple="false"
+                >
+                  <ul class="list">
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
                       >
-                        <ul class="list">
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  5
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  10
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  25
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  All
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                  <i aria-hidden="true"
-                     class="material-icons icon input-group__append-icon input-group__icon-cb"
-                     style="font-size: 24px;"
-                  >
-                    arrow_drop_down
-                  </i>
-                </div>
-                <div class="input-group__details">
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            5
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            10
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            25
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            All
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>
-            <div class="datatable__actions__pagination">
-              –
-            </div>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Previous page"
+            <i aria-hidden="true"
+               class="material-icons icon input-group__append-icon input-group__icon-cb"
+               style="font-size: 24px;"
             >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_left
-                </i>
-              </div>
-            </button>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Next page"
-            >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_right
-                </i>
-              </div>
-            </button>
+              arrow_drop_down
+            </i>
           </div>
-        </td>
-      </tr>
-    </tfoot>
-  </table>
+          <div class="input-group__details">
+          </div>
+        </div>
+      </div>
+      <div class="datatable__actions__pagination">
+        –
+      </div>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Previous page"
+      >
+        <div class="btn__content">
+          <i aria-hidden="true"
+             class="material-icons icon"
+             style="font-size: 24px;"
+          >
+            chevron_left
+          </i>
+        </div>
+      </button>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Next page"
+      >
+        <div class="btn__content">
+          <i aria-hidden="true"
+             class="material-icons icon"
+             style="font-size: 24px;"
+          >
+            chevron_right
+          </i>
+        </div>
+      </button>
+    </div>
+  </div>
 </div>
 
 `;
 
 exports[`VDataTable.vue should match a snapshot - with data 1`] = `
 
-<div class="table__overflow">
-  <table class="datatable table">
-    <thead>
-      <tr>
-        <th role="columnheader"
-            scope="col"
-            aria-label="First Column: Sorted ascending. Activate to sort descending."
-            aria-sort="ascending"
-            tabindex="0"
-            class="column sortable active asc text-xs-right a-string"
-        >
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 16px;"
+<div>
+  <div class="table__overflow">
+    <table class="datatable table">
+      <thead>
+        <tr>
+          <th role="columnheader"
+              scope="col"
+              aria-label="First Column: Sorted ascending. Activate to sort descending."
+              aria-sort="ascending"
+              tabindex="0"
+              class="column sortable active asc text-xs-right a-string"
           >
-            arrow_upward
-          </i>
-          First Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Second Column: Not sorted."
-            aria-sort="none"
-            class="column text-xs-right"
-        >
-          Second Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Third Column: Not sorted. Activate to sort ascending."
-            aria-sort="none"
-            tabindex="0"
-            class="column sortable text-xs-right an array"
-        >
-          <i aria-hidden="true"
-             class="material-icons icon"
-             style="font-size: 16px;"
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            First Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Second Column: Not sorted."
+              aria-sort="none"
+              class="column text-xs-right"
           >
-            arrow_upward
-          </i>
-          Third Column
-        </th>
-      </tr>
-      <tr class="datatable__progress">
-        <th colspan="100%"
-            class="column"
-        >
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <td>
-        b
-      </td>
-      <td>
-        c
-      </td>
-      <td>
-        a
-      </td>
-    </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="100%">
-          <div class="datatable__actions">
-            <div class="datatable__actions__select">
-              Rows per page:
-              <div tabindex="0"
-                   data-uid="27"
-                   aria-label="Rows per page:"
-                   role="combobox"
-                   class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
-              >
-                <div class="input-group__input">
-                  <div class="input-group__selections"
-                       style="overflow: hidden;"
-                  >
-                    <input aria-label="Rows per page:"
-                           disabled="disabled"
-                           tabindex="-1"
-                           class="input-group--select__autocomplete"
-                           style="display: none;"
-                    >
-                  </div>
-                  <div class="menu"
-                       style="display: inline-block;"
-                  >
-                    <div class="menu__content menu__content--select menu__content--auto"
-                         style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
-                    >
-                      <div class="card"
-                           style="height: auto;"
-                           data-ripple="false"
-                      >
-                        <ul class="list">
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  5
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  10
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  25
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                          <li>
-                            <a class="list__tile list__tile--link"
-                               data-ripple="true"
-                            >
-                              <div class="list__tile__content">
-                                <div class="list__tile__title">
-                                  All
-                                </div>
-                              </div>
-                            </a>
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                  <i aria-hidden="true"
-                     class="material-icons icon input-group__append-icon input-group__icon-cb"
-                     style="font-size: 24px;"
-                  >
-                    arrow_drop_down
-                  </i>
-                </div>
-                <div class="input-group__details">
-                </div>
-              </div>
-            </div>
-            <div class="datatable__actions__pagination">
-              1-3 of 3
-            </div>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Previous page"
+            Second Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Third Column: Not sorted. Activate to sort ascending."
+              aria-sort="none"
+              tabindex="0"
+              class="column sortable text-xs-right an array"
+          >
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
             >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_left
-                </i>
-              </div>
-            </button>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Next page"
-            >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_right
-                </i>
-              </div>
-            </button>
-          </div>
+              arrow_upward
+            </i>
+            Third Column
+          </th>
+        </tr>
+        <tr class="datatable__progress">
+          <th colspan="100%"
+              class="column"
+          >
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <td>
+          b
         </td>
-      </tr>
-    </tfoot>
-  </table>
+        <td>
+          c
+        </td>
+        <td>
+          a
+        </td>
+      </tbody>
+    </table>
+  </div>
+  <div class="datatable table">
+    <div class="datatable__actions">
+      <div class="datatable__actions__select">
+        Rows per page:
+        <div tabindex="0"
+             data-uid="27"
+             aria-label="Rows per page:"
+             role="combobox"
+             class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
+        >
+          <div class="input-group__input">
+            <div class="input-group__selections"
+                 style="overflow: hidden;"
+            >
+              <input aria-label="Rows per page:"
+                     disabled="disabled"
+                     tabindex="-1"
+                     class="input-group--select__autocomplete"
+                     style="display: none;"
+              >
+            </div>
+            <div class="menu"
+                 style="display: inline-block;"
+            >
+              <div class="menu__content menu__content--select menu__content--auto"
+                   style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
+              >
+                <div class="card"
+                     style="height: auto;"
+                     data-ripple="false"
+                >
+                  <ul class="list">
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            5
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            10
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            25
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li>
+                      <a class="list__tile list__tile--link"
+                         data-ripple="true"
+                      >
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            All
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <i aria-hidden="true"
+               class="material-icons icon input-group__append-icon input-group__icon-cb"
+               style="font-size: 24px;"
+            >
+              arrow_drop_down
+            </i>
+          </div>
+          <div class="input-group__details">
+          </div>
+        </div>
+      </div>
+      <div class="datatable__actions__pagination">
+        1-3 of 3
+      </div>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Previous page"
+      >
+        <div class="btn__content">
+          <i aria-hidden="true"
+             class="material-icons icon"
+             style="font-size: 24px;"
+          >
+            chevron_left
+          </i>
+        </div>
+      </button>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Next page"
+      >
+        <div class="btn__content">
+          <i aria-hidden="true"
+             class="material-icons icon"
+             style="font-size: 24px;"
+          >
+            chevron_right
+          </i>
+        </div>
+      </button>
+    </div>
+  </div>
 </div>
 
 `;
 
 exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 1`] = `
 
-<div class="table__overflow">
-  <table class="datatable table">
-    <thead>
-      <tr>
-        <th role="columnheader"
-            scope="col"
-            aria-label="First Column: Sorted ascending. Activate to sort descending."
-            aria-sort="ascending"
-            tabindex="0"
-            class="column sortable active asc text-xs-right a-string"
-        >
+<div>
+  <div class="table__overflow">
+    <table class="datatable table">
+      <thead>
+        <tr>
+          <th role="columnheader"
+              scope="col"
+              aria-label="First Column: Sorted ascending. Activate to sort descending."
+              aria-sort="ascending"
+              tabindex="0"
+              class="column sortable active asc text-xs-right a-string"
+          >
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            First Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Second Column: Not sorted."
+              aria-sort="none"
+              class="column text-xs-right"
+          >
+            Second Column
+          </th>
+          <th role="columnheader"
+              scope="col"
+              aria-label="Third Column: Not sorted. Activate to sort ascending."
+              aria-sort="none"
+              tabindex="0"
+              class="column sortable text-xs-right an array"
+          >
+            <i aria-hidden="true"
+               class="material-icons icon"
+               style="font-size: 16px;"
+            >
+              arrow_upward
+            </i>
+            Third Column
+          </th>
+        </tr>
+        <tr class="datatable__progress">
+          <th colspan="100%"
+              class="column"
+          >
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+  </div>
+  <div class="datatable table">
+    <div class="datatable__actions">
+      <div class="datatable__actions__pagination">
+        1-1 of 3
+      </div>
+      <button disabled="disabled"
+              type="button"
+              class="btn btn--disabled btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Previous page"
+      >
+        <div class="btn__content">
           <i aria-hidden="true"
              class="material-icons icon"
-             style="font-size: 16px;"
+             style="font-size: 24px;"
           >
-            arrow_upward
+            chevron_left
           </i>
-          First Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Second Column: Not sorted."
-            aria-sort="none"
-            class="column text-xs-right"
-        >
-          Second Column
-        </th>
-        <th role="columnheader"
-            scope="col"
-            aria-label="Third Column: Not sorted. Activate to sort ascending."
-            aria-sort="none"
-            tabindex="0"
-            class="column sortable text-xs-right an array"
-        >
+        </div>
+      </button>
+      <button type="button"
+              class="btn btn--flat btn--icon"
+              data-ripple="true"
+              aria-label="Next page"
+      >
+        <div class="btn__content">
           <i aria-hidden="true"
              class="material-icons icon"
-             style="font-size: 16px;"
+             style="font-size: 24px;"
           >
-            arrow_upward
+            chevron_right
           </i>
-          Third Column
-        </th>
-      </tr>
-      <tr class="datatable__progress">
-        <th colspan="100%"
-            class="column"
-        >
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-    </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="100%">
-          <div class="datatable__actions">
-            <div class="datatable__actions__pagination">
-              1-1 of 3
-            </div>
-            <button disabled="disabled"
-                    type="button"
-                    class="btn btn--disabled btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Previous page"
-            >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_left
-                </i>
-              </div>
-            </button>
-            <button type="button"
-                    class="btn btn--flat btn--icon"
-                    data-ripple="true"
-                    aria-label="Next page"
-            >
-              <div class="btn__content">
-                <i aria-hidden="true"
-                   class="material-icons icon"
-                   style="font-size: 24px;"
-                >
-                  chevron_right
-                </i>
-              </div>
-            </button>
-          </div>
-        </td>
-      </tr>
-    </tfoot>
-  </table>
+        </div>
+      </button>
+    </div>
+  </div>
 </div>
 
 `;

--- a/src/components/VDataTable/mixins/foot.js
+++ b/src/components/VDataTable/mixins/foot.js
@@ -1,25 +1,23 @@
 export default {
   methods: {
     genTFoot () {
-      const children = []
-
-      if (this.$slots.footer) {
-        const footer = this.$slots.footer
-        const row = this.needsTR(footer) ? this.genTR(footer) : footer
-
-        children.push(row)
+      if (!this.$slots.footer) {
+        return null
       }
 
-      if (!this.hideActions) {
-        children.push(this.genTR([
-          this.$createElement('td', {
-            attrs: { colspan: '100%' }
-          }, this.genActions())
-        ]))
+      const footer = this.$slots.footer
+      const row = this.needsTR(footer) ? this.genTR(footer) : footer
+
+      return this.$createElement('tfoot', [row])
+    },
+    genActionsFooter () {
+      if (this.hideActions) {
+        return null
       }
 
-      if (!children.length) return null
-      return this.$createElement('tfoot', children)
+      return this.$createElement('div', {
+        'class': this.classes
+      }, this.genActions())
     }
   }
 }

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -38,6 +38,7 @@ export default {
       },
       expanded: {},
       actionsClasses: 'data-iterator__actions',
+      actionsRangeControlsClasses: 'data-iterator__actions__range-controls',
       actionsSelectClasses: 'data-iterator__actions__select',
       actionsPaginationClasses: 'data-iterator__actions__pagination'
     }
@@ -433,13 +434,19 @@ export default {
       }, [pagination])
     },
     genActions () {
+      const rangeControls = this.$createElement('div', {
+        'class': this.actionsRangeControlsClasses
+      }, [
+        this.genPagination(),
+        this.genPrevIcon(),
+        this.genNextIcon()
+      ])
+
       return [this.$createElement('div', {
         'class': this.actionsClasses
       }, [
         this.rowsPerPageItems.length > 1 ? this.genSelect() : null,
-        this.genPagination(),
-        this.genPrevIcon(),
-        this.genNextIcon()
+        rangeControls
       ])]
     }
   }

--- a/src/stylus/components/_data-iterator.styl
+++ b/src/stylus/components/_data-iterator.styl
@@ -18,24 +18,32 @@ theme(dataiterator, "data-iterator")
 /** Actions */
 .data-iterator__actions
   display: flex
-  justify-content: center
+  justify-content: flex-end
   align-items: center
   font-size: 12px
+  flex-wrap: wrap-reverse
 
   .btn
     color: inherit
 
     &:last-of-type
-      margin-left: 18px
+      margin-left: 14px
+
+  &__range-controls
+    display: flex
+    align-items: center
+    min-height: 48px
 
   &__pagination
+    display: block
     text-align: center
-    margin: 0 26px 0 32px
+    margin: 0 32px 0 24px
 
   &__select
     display: flex
     align-items: center
     justify-content: center
+    margin-right: 14px
 
     .input-group--select
       margin: 13px 0 13px 34px

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -64,21 +64,29 @@ theme(datatable, "datatable")
   justify-content: flex-end
   align-items: center
   font-size: 12px
+  flex-wrap: wrap-reverse
 
   .btn
     color: inherit
 
     &:last-of-type
-      margin-left: 18px
+      margin-left: 14px
+
+  &__range-controls
+    display: flex
+    align-items: center
+    min-height: 48px
 
   &__pagination
+    display: block
     text-align: center
-    margin: 0 26px 0 32px
+    margin: 0 32px 0 24px
 
   &__select
     display: flex
     align-items: center
     justify-content: center
+    margin-right: 14px
 
     .input-group--select
       margin: 13px 0 13px 34px

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -20,6 +20,7 @@ datatable($material)
   .datatable__actions
     background-color: $material.cards
     color: rgba($material.fg-color, $material.secondary-text-percent)
+    border-top: 1px solid rgba($material.fg-color, $material.divider-percent)
 
     &__select
       .input-group--select

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -18,6 +18,7 @@ datatable($material)
           color: rgba($material.fg-color, $material.primary-text-percent)
 
   .datatable__actions
+    background-color: $material.cards
     color: rgba($material.fg-color, $material.secondary-text-percent)
 
     &__select

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -92,13 +92,9 @@ table.table
       .input-group--selection-controls__ripple
         left: 50%
         transform: translate(-50%, -50%)
+
   tfoot
-    tr:not(:last-child)
-      height: 48px
-
-      &:not(:only-child)
-        td
-          padding: 0 24px
-
     tr
-      height: 56px
+      height: 48px
+      td
+        padding: 0 24px


### PR DESCRIPTION
Fixes #2161 
Pull actions into its own div, outside of the table overflow, accounting for footer slot, heights and borders, make pagination controls wrap nicely on mobile

