### PR TITLE
fix(tests): all tests were failing after latest dependency bump

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -7,10 +7,10 @@ module.exports = {
   resolve: {
     extensions: ['*', '.js', '.json', '.vue'],
     alias: {
-      '~components': resolve('../src/components'),
-      '~directives': resolve('../src/directives'),
-      '~mixins': resolve('../src/mixins'),
-      '~util': resolve('../src/util'),
+      '@components': resolve('../src/components'),
+      '@directives': resolve('../src/directives'),
+      '@mixins': resolve('../src/mixins'),
+      '@util': resolve('../src/util'),
       'stylus': resolve('../src/stylus')
     }
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
       "node_modules"
     ],
     "moduleNameMapper": {
-      "src/(.*)": "<rootDir>/src/$1"
+      "src/(.*)": "<rootDir>/src/$1",
+      "^@(.*)$": "<rootDir>/src/$1"
     },
     "transform": {
       ".*\\.(vue)$": "<rootDir>/node_modules/jest-vue-preprocessor",

--- a/src/components/VAlert/VAlert.spec.js
+++ b/src/components/VAlert/VAlert.spec.js
@@ -1,6 +1,6 @@
-import { test } from '~util/testing'
-import VAlert from '~components/VAlert'
-import VIcon from '~components/VIcon'
+import { test } from '@util/testing'
+import VAlert from '@components/VAlert'
+import VIcon from '@components/VIcon'
 
 test('VAlert.vue', ({ mount }) => {
   it('should be closed by default', async () => {

--- a/src/components/VApp/VApp.spec.js
+++ b/src/components/VApp/VApp.spec.js
@@ -1,5 +1,5 @@
-import VApp from '~components/VApp'
-import { test } from '~util/testing'
+import VApp from '@components/VApp'
+import { test } from '@util/testing'
 
 test('VApp.js', ({ mount }) => {
   it('should match a snapshot', () => {

--- a/src/components/VApp/mixins/app-breakpoint.spec.js
+++ b/src/components/VApp/mixins/app-breakpoint.spec.js
@@ -1,5 +1,5 @@
-import VApp from '~components/VApp'
-import { test } from '~util/testing'
+import VApp from '@components/VApp'
+import { test } from '@util/testing'
 
 test('breakpoint.js', ({ mount }) => {
   const scenarios = [

--- a/src/components/VAvatar/VAvatar.spec.js
+++ b/src/components/VAvatar/VAvatar.spec.js
@@ -1,5 +1,5 @@
-import VAvatar from '~components/VAvatar'
-import { test } from '~util/testing'
+import VAvatar from '@components/VAvatar'
+import { test } from '@util/testing'
 
 test('VAvatar.vue', ({ mount, functionalContext }) => {
   it('should have an avatar class', () => {

--- a/src/components/VBadge/VBadge.spec.js
+++ b/src/components/VBadge/VBadge.spec.js
@@ -1,5 +1,5 @@
-import VBadge from '~components/VBadge'
-import { test } from '~util/testing'
+import VBadge from '@components/VBadge'
+import { test } from '@util/testing'
 
 test('VBadge.js', ({ mount, compileToFunctions }) => {
   it('should render component and match snapshot', async () => {

--- a/src/components/VBottomNav/VBottomNav.spec.js
+++ b/src/components/VBottomNav/VBottomNav.spec.js
@@ -1,6 +1,6 @@
 import VBottomNav from './VBottomNav'
 import VBtn from '../VBtn'
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import Vue from 'vue'
 
 function createBtn (val = null) {

--- a/src/components/VBreadcrumbs/VBreadcrumbs.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbs.js
@@ -59,7 +59,7 @@ export default {
           i === length - 1
         ) return
 
-        children.push(this.$createElement('li', Object.assign({ key: i }, dividerData), this.computedDivider))
+        children.push(this.$createElement('li', dividerData, this.computedDivider))
       })
 
       return children

--- a/src/components/VBreadcrumbs/VBreadcrumbs.spec.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbs.spec.js
@@ -1,8 +1,8 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import {
   VBreadcrumbs,
   VBreadcrumbsItem
-} from '~components/VBreadcrumbs'
+} from '@components/VBreadcrumbs'
 import Vue from 'vue'
 
 test('VBreadcrumbs.js', ({ mount, compileToFunctions }) => {

--- a/src/components/VBreadcrumbs/VBreadcrumbsItem.spec.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbsItem.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VBreadcrumbsItem } from '~components/VBreadcrumbs'
+import { test } from '@util/testing'
+import { VBreadcrumbsItem } from '@components/VBreadcrumbs'
 
 // TODO: Enable when Vue has optional injects
 test.skip('VBreadcrumbsItem.js', ({ mount }) => {

--- a/src/components/VBtn/VBtn.spec.js
+++ b/src/components/VBtn/VBtn.spec.js
@@ -1,7 +1,7 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import Vue from 'vue'
-import VBtn from '~components/VBtn'
-import VProgressCircular from '~components/VProgressCircular'
+import VBtn from '@components/VBtn'
+import VProgressCircular from '@components/VProgressCircular'
 
 const stub = {
   name: 'router-link',

--- a/src/components/VBtnToggle/VBtnToggle.spec.js
+++ b/src/components/VBtnToggle/VBtnToggle.spec.js
@@ -1,7 +1,7 @@
 import VBtnToggle from './VBtnToggle'
 import VBtn from '../VBtn'
 import VIcon from '../VIcon'
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import Vue from 'vue'
 
 function createBtn (val = null) {

--- a/src/components/VCard/VCard.spec.js
+++ b/src/components/VCard/VCard.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VCard from '~components/VCard'
+import { test } from '@util/testing'
+import VCard from '@components/VCard'
 
 test('VCard.vue', ({ mount }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VCard/VCardMedia.spec.js
+++ b/src/components/VCard/VCardMedia.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VCardMedia } from '~components/VCard'
+import { test } from '@util/testing'
+import { VCardMedia } from '@components/VCard'
 
 test('VCardMedia.js', ({ mount }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VCard/VCardTitle.spec.js
+++ b/src/components/VCard/VCardTitle.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VCardTitle } from '~components/VCard'
+import { test } from '@util/testing'
+import { VCardTitle } from '@components/VCard'
 
 test('VCardTitle.js', ({ mount, functionalContext }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VCarousel/VCarousel.spec.js
+++ b/src/components/VCarousel/VCarousel.spec.js
@@ -1,6 +1,6 @@
 import VCarousel from './VCarousel'
 import VCarouselItem from './VCarouselItem'
-import { test, touch } from '~util/testing'
+import { test, touch } from '@util/testing'
 import Vue from 'vue'
 
 const create = (props = {}, slots = 3) => Vue.component('zxc', {

--- a/src/components/VCarousel/VCarouselItem.spec.js
+++ b/src/components/VCarousel/VCarouselItem.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VCarouselItem } from '~components/VCarousel'
+import { test } from '@util/testing'
+import { VCarouselItem } from '@components/VCarousel'
 
 const imageSrc = 'https://vuetifyjs.com/static/doc-images/cards/sunshine.jpg'
 const warning = '[Vuetify] Warn: The v-carousel-item component must be used inside a v-carousel.'

--- a/src/components/VCheckbox/VCheckbox.spec.js
+++ b/src/components/VCheckbox/VCheckbox.spec.js
@@ -1,5 +1,5 @@
-﻿import { test } from '~util/testing'
-import VCheckbox from '~components/VCheckbox'
+import { test } from '@util/testing'
+import VCheckbox from '@components/VCheckbox'
 
 test('VCheckbox.js', ({ mount }) => {
   it('should return true when clicked', () => {

--- a/src/components/VChip/VChip.spec.js
+++ b/src/components/VChip/VChip.spec.js
@@ -1,5 +1,5 @@
-import VChip from '~components/VChip'
-import { test } from '~util/testing'
+import VChip from '@components/VChip'
+import { test } from '@util/testing'
 
 test('VChip.vue', ({ mount, compileToFunctions }) => {
   it('should have a chip class', () => {

--- a/src/components/VDataIterator/VDataIterator.spec.js
+++ b/src/components/VDataIterator/VDataIterator.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VDataIterator from './VDataIterator'
-import VBtn from '~components/VBtn'
+import VBtn from '@components/VBtn'
 
 test('VDataIterator.js', ({ mount, compileToFunctions }) => {
   function dataIteratorTestData () {

--- a/src/components/VDataTable/VDataTable.spec.js
+++ b/src/components/VDataTable/VDataTable.spec.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VDataTable from './VDataTable'
 
 test('VDataTable.vue', ({ mount, compileToFunctions }) => {

--- a/src/components/VDatePicker/VDatePicker.date.spec.js
+++ b/src/components/VDatePicker/VDatePicker.date.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import VDatePicker from '~components/VDatePicker'
+import { test } from '@util/testing'
+import VDatePicker from '@components/VDatePicker'
 
 test('VDatePicker.js', ({ mount, compileToFunctions }) => {
   it('should display the correct date in title and header', () => {

--- a/src/components/VDatePicker/VDatePicker.month.spec.js
+++ b/src/components/VDatePicker/VDatePicker.month.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import VDatePicker from '~components/VDatePicker'
+import { test } from '@util/testing'
+import VDatePicker from '@components/VDatePicker'
 
 test('VDatePicker.js', ({ mount, compileToFunctions }) => {
   it('should emit input event on year click', async () => {

--- a/src/components/VDialog/VDialog.spec.js
+++ b/src/components/VDialog/VDialog.spec.js
@@ -1,5 +1,5 @@
-import VDialog from '~components/VDialog'
-import { test } from '~util/testing'
+import VDialog from '@components/VDialog'
+import { test } from '@util/testing'
 
 test('VDialog.js', ({ mount, compileToFunctions }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VDivider/VDivider.spec.js
+++ b/src/components/VDivider/VDivider.spec.js
@@ -1,5 +1,5 @@
-import VDivider from '~components/VDivider'
-import { test } from '~util/testing'
+import VDivider from '@components/VDivider'
+import { test } from '@util/testing'
 
 test('VDivider.js', ({ mount, compileToFunctions, functionalContext }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VExpansionPanel/VExpansionPanel.spec.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import VExpansionPanel from '~components/VExpansionPanel'
-import { VExpansionPanelContent } from '~components/VExpansionPanel'
+import { test } from '@util/testing'
+import VExpansionPanel from '@components/VExpansionPanel'
+import { VExpansionPanelContent } from '@components/VExpansionPanel'
 
 const createPanel = props => {
   return Vue.component('test', {

--- a/src/components/VExpansionPanel/VExpansionPanelContent.spec.js
+++ b/src/components/VExpansionPanel/VExpansionPanelContent.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VExpansionPanelContent from './VExpansionPanelContent'
 
 test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {

--- a/src/components/VFooter/VFooter.spec.js
+++ b/src/components/VFooter/VFooter.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VFooter from './VFooter'
 
 test('VFooter.js', ({ mount, functionalContext }) => {

--- a/src/components/VForm/VForm.spec.js
+++ b/src/components/VForm/VForm.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import VTextField from '~components/VTextField'
-import VBtn from '~components/VBtn'
+import { test } from '@util/testing'
+import VTextField from '@components/VTextField'
+import VBtn from '@components/VBtn'
 import VForm from './VForm'
 
 const inputOne = Vue.component('input-one', {

--- a/src/components/VGrid/VGrid.spec.js
+++ b/src/components/VGrid/VGrid.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VFlex from '~components/VGrid/VFlex'
+import { test } from '@util/testing'
+import VFlex from '@components/VGrid/VFlex'
 
 test('VFlex', ({ mount, functionalContext }) => {
   it('should conditionally apply if boolean is used', () => {

--- a/src/components/VIcon/VIcon.spec.js
+++ b/src/components/VIcon/VIcon.spec.js
@@ -1,5 +1,5 @@
-import VIcon from '~components/VIcon'
-import { test, functionalContext } from '~util/testing'
+import VIcon from '@components/VIcon'
+import { test, functionalContext } from '@util/testing'
 
 test('VIcon.js', ({ mount, compileToFunctions }) => {
   it('should render component', () => {

--- a/src/components/VList/VList.spec.js
+++ b/src/components/VList/VList.spec.js
@@ -1,5 +1,5 @@
-import VList from '~components/VList'
-import { test } from '~util/testing'
+import VList from '@components/VList'
+import { test } from '@util/testing'
 
 // TODO: Test actual behaviour instead of classes
 test('VList.js', ({ mount }) => {

--- a/src/components/VList/VListGroup.spec.js
+++ b/src/components/VList/VListGroup.spec.js
@@ -1,5 +1,5 @@
-import { VList, VListGroup } from '~components/VList'
-import { test } from '~util/testing'
+import { VList, VListGroup } from '@components/VList'
+import { test } from '@util/testing'
 
 // TODO: Test actual behaviour instead of classes
 test('VListGroup.js', ({ mount }) => {

--- a/src/components/VList/VListTile.spec.js
+++ b/src/components/VList/VListTile.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VListTile } from '~components/VList'
+import { test } from '@util/testing'
+import { VListTile } from '@components/VList'
 import { compileToFunctions } from 'vue-template-compiler'
 import Vue from 'vue/dist/vue.common'
 

--- a/src/components/VList/VListTileAction.spec.js
+++ b/src/components/VList/VListTileAction.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { VListTileAction } from '~components/VList'
-import { test } from '~util/testing'
+import { VListTileAction } from '@components/VList'
+import { test } from '@util/testing'
 
 test('VListTileAction.js', ({ mount, functionalContext }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VList/VListTileAvatar.spec.js
+++ b/src/components/VList/VListTileAvatar.spec.js
@@ -1,5 +1,5 @@
-import { VListTileAvatar } from '~components/VList'
-import { test } from '~util/testing'
+import { VListTileAvatar } from '@components/VList'
+import { test } from '@util/testing'
 
 test('VListTileAvatar.js', ({ mount, functionalContext }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VMenu/VMenu.spec.js
+++ b/src/components/VMenu/VMenu.spec.js
@@ -1,7 +1,7 @@
-import VBtn from '~components/VBtn'
-import VCard from '~components/VCard'
-import VMenu from '~components/VMenu'
-import { test } from '~util/testing'
+import VBtn from '@components/VBtn'
+import VCard from '@components/VCard'
+import VMenu from '@components/VMenu'
+import { test } from '@util/testing'
 
 // TODO: Most of these have exactly the same snapshots
 test('VMenu.js', ({ mount }) => {

--- a/src/components/VNavigationDrawer/VNavigationDrawer.spec.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.spec.js
@@ -1,6 +1,6 @@
-import VApp from '~components/VApp'
-import VNavigationDrawer from '~components/VNavigationDrawer'
-import { test, resizeWindow } from '~util/testing'
+import VApp from '@components/VApp'
+import VNavigationDrawer from '@components/VNavigationDrawer'
+import { test, resizeWindow } from '@util/testing'
 
 beforeEach(() => resizeWindow(1920, 1080))
 

--- a/src/components/VPagination/VPagination.spec.js
+++ b/src/components/VPagination/VPagination.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VPagination from './VPagination'
 
 test('VPagination.vue', ({ mount }) => {

--- a/src/components/VParallax/VParallax.spec.js
+++ b/src/components/VParallax/VParallax.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VParallax from '~components/VParallax'
+import { test } from '@util/testing'
+import VParallax from '@components/VParallax'
 
 test('VParallax.js', ({ mount }) => {
   it('should render', async () => {

--- a/src/components/VProgressCircular/VProgressCircular.spec.js
+++ b/src/components/VProgressCircular/VProgressCircular.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VProgressCircular from './VProgressCircular'
 import { compileToFunctions } from 'vue-template-compiler'
 

--- a/src/components/VProgressLinear/VProgressLinear.spec.js
+++ b/src/components/VProgressLinear/VProgressLinear.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VProgressLinear from './VProgressLinear'
 
 test('VProgressLinear.js', ({ mount }) => {

--- a/src/components/VRadioGroup/VRadio.spec.js
+++ b/src/components/VRadioGroup/VRadio.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VRadioGroup, VRadio } from '~components/VRadioGroup'
+import { test } from '@util/testing'
+import { VRadioGroup, VRadio } from '@components/VRadioGroup'
 
 test('VRadio.vue', ({ mount }) => {
   it('should advise about v-radio-group being necessary', () => {

--- a/src/components/VRadioGroup/VRadioGroup.spec.js
+++ b/src/components/VRadioGroup/VRadioGroup.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import { VRadioGroup, VRadio } from '~components/VRadioGroup'
+import { test } from '@util/testing'
+import { VRadioGroup, VRadio } from '@components/VRadioGroup'
 
 test('VRadioGroup.vue', ({ mount }) => {
   it('should render role on radio group', () => {

--- a/src/components/VSelect/VSelect-autocomplete.spec.js
+++ b/src/components/VSelect/VSelect-autocomplete.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VSelect from '~components/VSelect'
+import { test } from '@util/testing'
+import VSelect from '@components/VSelect'
 
 test('VSelect - autocomplete', ({ mount }) => {
   it('should have -1 tabindex when disabled', () => {

--- a/src/components/VSelect/VSelect-combobox.spec.js
+++ b/src/components/VSelect/VSelect-combobox.spec.js
@@ -1,6 +1,6 @@
-import { test } from '~util/testing'
-import VSelect from '~components/VSelect'
-import VMenu from '~components/VMenu'
+import { test } from '@util/testing'
+import VSelect from '@components/VSelect'
+import VMenu from '@components/VMenu'
 
 test('VSelect - combobox', ({ mount }) => {
   it('should emit custom value on blur', async () => {

--- a/src/components/VSelect/VSelect-tags.spec.js
+++ b/src/components/VSelect/VSelect-tags.spec.js
@@ -1,6 +1,6 @@
-import { test } from '~util/testing'
-import VSelect from '~components/VSelect'
-import VMenu from '~components/VMenu'
+import { test } from '@util/testing'
+import VSelect from '@components/VSelect'
+import VMenu from '@components/VMenu'
 
 test('VSelect - tags', ({ mount, compileToFunctions }) => {
   const backspace = new Event('keydown')

--- a/src/components/VSelect/VSelect.spec.js
+++ b/src/components/VSelect/VSelect.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import VSelect from '~components/VSelect'
+import { test } from '@util/testing'
+import VSelect from '@components/VSelect'
 
 test('VSelect', ({ mount, compileToFunctions }) => {
   it('should return numeric 0', () => {

--- a/src/components/VSelect/VSelect2.spec.js
+++ b/src/components/VSelect/VSelect2.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VSelect from '~components/VSelect'
+import { test } from '@util/testing'
+import VSelect from '@components/VSelect'
 
 test('VSelect', ({ mount, compileToFunctions }) => {
   // Inspired by https://github.com/vuetifyjs/vuetify/pull/1425 - Thanks @kevmo314

--- a/src/components/VSlider/VSlider.spec.js
+++ b/src/components/VSlider/VSlider.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VSlider from './VSlider'
 
 const warning = 'The v-slider component requires the presence of v-app or a non-body wrapping element with the [data-app] attribute.'

--- a/src/components/VSnackbar/VSnackbar.spec.js
+++ b/src/components/VSnackbar/VSnackbar.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VSnackbar from '~components/VSnackbar'
+import { test } from '@util/testing'
+import VSnackbar from '@components/VSnackbar'
 
 test('VSnackbar.vue', ({ mount }) => {
   it('should have a snack class', () => {

--- a/src/components/VSpeedDial/VSpeedDial.spec.js
+++ b/src/components/VSpeedDial/VSpeedDial.spec.js
@@ -1,5 +1,5 @@
-import VSpeedDial from '~components/VSpeedDial'
-import { test } from '~util/testing'
+import VSpeedDial from '@components/VSpeedDial'
+import { test } from '@util/testing'
 import { compileToFunctions } from 'vue-template-compiler'
 
 test('VSpeedDial.js', ({ mount }) => {

--- a/src/components/VSwitch/VSwitch.spec.js
+++ b/src/components/VSwitch/VSwitch.spec.js
@@ -1,5 +1,5 @@
-import { test, touch } from '~util/testing'
-import VSwitch from '~components/VSwitch'
+import { test, touch } from '@util/testing'
+import VSwitch from '@components/VSwitch'
 
 test('VSwitch.js', ({ mount }) => {
   it('should set ripple data attribute based on ripple prop state', () => {

--- a/src/components/VSystemBar/VSystemBar.spec.js
+++ b/src/components/VSystemBar/VSystemBar.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VSystemBar from '~components/VSystemBar'
+import { test } from '@util/testing'
+import VSystemBar from '@components/VSystemBar'
 
 test('VSystemBar.vue', ({ mount }) => {
   it('should render a colored system bar', () => {

--- a/src/components/VTabs/VTabs.spec.js
+++ b/src/components/VTabs/VTabs.spec.js
@@ -1,9 +1,9 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import VTabs from './VTabs'
 import VTabsBar from './VTabsBar'
 import VTabsItem from './VTabsItem'
 import Vue from 'vue'
-import { createRange } from '~util/helpers'
+import { createRange } from '@util/helpers'
 
 function createBar (items = ['foo', 'bar']) {
   return Vue.extend({

--- a/src/components/VTabs/VTabsSlider.spec.js
+++ b/src/components/VTabs/VTabsSlider.spec.js
@@ -1,5 +1,5 @@
-import { test } from '~util/testing'
-import VTabsSlider from '~components/VTabs/VTabsSlider.js'
+import { test } from '@util/testing'
+import VTabsSlider from '@components/VTabs/VTabsSlider.js'
 
 test('VTabsSlider.vue', ({ mount }) => {
   it('should render a tabs slider', () => {

--- a/src/components/VTextField/VTextField.spec.js
+++ b/src/components/VTextField/VTextField.spec.js
@@ -1,7 +1,7 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import Vue from 'vue/dist/vue.common'
-import VTextField from '~components/VTextField'
-import VProgressLinear from '~components/VProgressLinear'
+import VTextField from '@components/VTextField'
+import VProgressLinear from '@components/VProgressLinear'
 
 test('VTextField.js', ({ mount }) => {
   it('should render component and match snapshot', () => {

--- a/src/components/VTimePicker/VTimePicker.spec.js
+++ b/src/components/VTimePicker/VTimePicker.spec.js
@@ -1,5 +1,5 @@
-import VTimePicker from '~components/VTimePicker'
-import { test } from '~util/testing'
+import VTimePicker from '@components/VTimePicker'
+import { test } from '@util/testing'
 
 test('VTimePicker.js', ({ mount }) => {
   it('should accept a value', () => {

--- a/src/components/VToolbar/VToolbar.spec.js
+++ b/src/components/VToolbar/VToolbar.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
-import { test, resizeWindow } from '~util/testing'
-import VApp from '~components/VApp'
-import VToolbar from '~components/VToolbar'
+import { test, resizeWindow } from '@util/testing'
+import VApp from '@components/VApp'
+import VToolbar from '@components/VToolbar'
 
 const scrollWindow = y => {
   global.pageYOffset = y

--- a/src/components/VToolbar/VToolbarSideIcon.spec.js
+++ b/src/components/VToolbar/VToolbarSideIcon.spec.js
@@ -1,6 +1,6 @@
-import { test } from '~util/testing'
-import VIcon from '~components/VIcon'
-import { VToolbarSideIcon } from '~components/VToolbar'
+import { test } from '@util/testing'
+import VIcon from '@components/VIcon'
+import { VToolbarSideIcon } from '@components/VToolbar'
 
 test('VToolbarSideIcon.js', ({ mount, functionalContext }) => {
   it('should create default icon when no slot used', () => {

--- a/src/components/VTooltip/VTooltip.spec.js
+++ b/src/components/VTooltip/VTooltip.spec.js
@@ -1,5 +1,5 @@
-import VTooltip from '~components/VTooltip'
-import { test } from '~util/testing'
+import VTooltip from '@components/VTooltip'
+import { test } from '@util/testing'
 
 test('VTooltip.js', ({ mount, compileToFunctions }) => {
   it('should render component and match snapshot', async () => {

--- a/src/components/Vuetify/Vuetify.install.spec.js
+++ b/src/components/Vuetify/Vuetify.install.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import Vuetify from '~components/Vuetify'
-import { test } from '~util/testing'
+import Vuetify from '@components/Vuetify'
+import { test } from '@util/testing'
 
 test('Vuetify.install.js', () => {
   it('should install transitions, directives and components', async () => {

--- a/src/directives/ripple.spec.js
+++ b/src/directives/ripple.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import Ripple from '~directives/ripple'
+import { test } from '@util/testing'
+import Ripple from '@directives/ripple'
 
 test('VRipple', ({ mount }) => {
   it('Ripple with no value should render data attribute true', () => {

--- a/src/directives/touch.spec.js
+++ b/src/directives/touch.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import Touch from './touch'
-import { test, touch } from '~util/testing'
+import { test, touch } from '@util/testing'
 
 test('touch.js', ({ mount }) => {
   function create(value) {

--- a/src/mixins/applicationable.spec.js
+++ b/src/mixins/applicationable.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import Applicationable from '~mixins/applicationable'
+import { test } from '@util/testing'
+import Applicationable from '@mixins/applicationable'
 
 test('applicationable.js', ({ mount }) => {
   it('should update application on mount', async () => {

--- a/src/mixins/bootable.spec.js
+++ b/src/mixins/bootable.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import Bootable from '~mixins/bootable'
+import { test } from '@util/testing'
+import Bootable from '@mixins/bootable'
 
 test('bootable.js', ({ mount }) => {
   it('should be booted after activation', async () => {

--- a/src/mixins/menuable.spec.js
+++ b/src/mixins/menuable.spec.js
@@ -1,6 +1,6 @@
-import { test } from '~util/testing'
-import Menuable from '~mixins/menuable'
-import VBtn from '~components/VBtn'
+import { test } from '@util/testing'
+import Menuable from '@mixins/menuable'
+import VBtn from '@components/VBtn'
 
 test('menuable.js', ({ mount }) => {
   it('should bind custom activator', () => {

--- a/src/mixins/routable.spec.js
+++ b/src/mixins/routable.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
-import { test } from '~util/testing'
-import Routable from '~mixins/routable'
+import { test } from '@util/testing'
+import Routable from '@mixins/routable'
 
 test('routable.js', ({ mount }) => {
   it('should generate exact route link with to="/" and undefined exact', async () => {

--- a/src/util/mask.spec.js
+++ b/src/util/mask.spec.js
@@ -1,4 +1,4 @@
-import { test } from '~util/testing'
+import { test } from '@util/testing'
 import { maskText, unmaskText } from './mask'
 
 test('mask.js', ({ mount }) => {

--- a/src/util/testing.js
+++ b/src/util/testing.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { mount, shallow } from 'avoriaz'
-import toHaveBeenWarnedInit from '~util/to-have-been-warned'
-import Vuetify from '~components/Vuetify'
+import toHaveBeenWarnedInit from '@util/to-have-been-warned'
+import Vuetify from '@components/Vuetify'
 import { compileToFunctions } from 'vue-template-compiler'
 
 export function test(name, cb) {


### PR DESCRIPTION
All tests were failing after https://github.com/vuetifyjs/vuetify/commit/130bcb3d222ca9431e61c8e2f5d1e700643ca1b0. I tried unsuccessfully to set up a moduleNameMapper regex (`^~(.*)$`) for tilde, but it didn't work. When I changed alias prefix to `@` it immediately worked fine.

When using `~`, it complains about (notice the lack of tilde)
```Cannot find module 'util/testing' from 'VBtn.spec.js'```

If I change the import to `@util/testing` I get
```Cannot find module '@util/testing' from 'VBtn.spec.js'```

So `~` seems to be removed somewhere along the line.
