### PR TITLE
fix(VSelect): refresh menu position when filteredItems changes

### DIFF
--- a/src/components/VSelect/mixins/select-watchers.js
+++ b/src/components/VSelect/mixins/select-watchers.js
@@ -8,6 +8,9 @@
  */
 export default {
   watch: {
+    filteredItems () {
+      this.$refs.menu && this.$refs.menu.updateDimensions()
+    },
     inputValue (val) {
       // Populate selected items
       this.genSelectedItems(val)

--- a/src/mixins/menuable.js
+++ b/src/mixins/menuable.js
@@ -183,6 +183,7 @@ export default {
       const isOverflowing = toTop < totalHeight
 
       // If overflowing bottom and offset
+      // TODO: set 'bottom' position instead of 'top'
       if (isOverflowing && this.offsetOverflow) {
         top = this.pageYOffset + (activator.top - contentHeight)
       // If overflowing bottom

--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -31,7 +31,6 @@
     max-width: 80%
     overflow-y: auto
     overflow-x: hidden
-    transition: .3s $transition.swing
     contain: content
     elevation(8)
 


### PR DESCRIPTION
fixes #2269

The menu transition was added in 7cff47738badc512452a4eaa1974c7512488dfca without any explanation, I had to remove it so the v-select menu doesn't animate its position while you're typing. 

Playground.vue:
```html
<template>
  <v-app>
    <v-content>
      <v-container fill-height align-end style="padding-bottom: 150px">
        <v-select autocomplete v-model="select" :items="items"/>
        <v-menu>
          <v-btn slot="activator">menu</v-btn>
          <v-list>
            <v-list-tile v-for="item in items" @click :key="item">
              <v-list-tile-title>
                {{ item }}
              </v-list-tile-title>
            </v-list-tile>
          </v-list>
        </v-menu>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      select: null,
      items: ['foo', 'bar', 'baz', 'lorem', 'ipsunm', 'dolor', 'sit', 'amet']
    })
  }
</script>

<style lang="stylus">
  .align-end
    align-items flex-end !important
</style>
```