### PR TITLE
[Feature Request] #2857 introduce new stylus variable $tab-text-transform and use it in tab

### DIFF
--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -129,7 +129,7 @@ theme(tabs, "tabs__bar")
     opacity: .7
     text-align: center
     text-decoration: none
-    text-transform: uppercase
+    text-transform: $tab-text-transform
     text-overflow: ellipsis
     white-space: nowrap
 

--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -285,6 +285,9 @@ $navigation-drawer-group-item-font-weight := $font-weights.regular
 /** Snackbar */
 $snackbar-background-color := #323232
 
+// Tab
+$tab-text-transform := uppercase
+
 /* Text Input */
 $input-group-padding := 18px 0 0
 $input-font-size := 16px


### PR DESCRIPTION
In `stylus/settings/_variables.styl`a new variable `$tab-text-transform` can be set to configure whether to use or not to use text-capitalization in `v-tab-items`.

fixes #2857 