### PR TITLE
fix(v-bottom-sheets): proper pass-through of props

### DIFF
--- a/src/components/VBottomSheet/VBottomSheet.js
+++ b/src/components/VBottomSheet/VBottomSheet.js
@@ -5,16 +5,14 @@ import VDialog from '../VDialog/VDialog'
 export default {
   name: 'v-bottom-sheet',
 
+  inheritAttrs: false,
+
   props: {
-    disabled: Boolean,
-    fullWidth: Boolean,
     inset: Boolean,
-    lazy: Boolean,
     maxWidth: {
       type: [String, Number],
       default: 'auto'
     },
-    persistent: Boolean,
     value: null
   },
 
@@ -30,12 +28,13 @@ export default {
 
     return h(VDialog, {
       attrs: {
-        ...this.$props
+        ...this.$attrs
       },
       on: {
         ...this.$listeners
       },
       props: {
+        maxWidth: this.maxWidth,
         contentClass: contentClass,
         transition: 'bottom-sheet-transition',
         value: this.value


### PR DESCRIPTION
## Description
v-bottom-sheet needs to pass through all unused props to v-dialog

- Removed unused prop declarations to allow proper passthrough
- Enabled prop passthrough by setting `inheritAttrs: false`
- Fixed passthrough by changing `this.$props` to `this.$attrs`

## Motivation and Context
Fixes #2668

## How Has This Been Tested?
Manually

## Markup:
```
<v-bottom-sheet inset hide-overlay>
  <v-card tile>
    <v-progress-linear height="3" :value="50" class="my-0"></v-progress-linear>
  </v-card>
</v-bottom-sheet>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
