### PR TITLE
Fixed VSelect genSelectedItems method

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -176,7 +176,7 @@ export default {
 
       let selectedItems = this.computedItems.filter(i => {
         if (!this.isMultiple) {
-          return this.getValue(i) === this.getValue(val)
+          return this.valueComparator(this.getValue(i), val)
         } else {
           // Always return Boolean
           return this.findExistingItem(i) > -1


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`genSelectedItems` method doesn't use `valueComparator` property when multiple is false, so initial selection is empty if value is an object.

## Motivation and Context
Bugfix.

## How Has This Been Tested?
Manually tested.

## Markup:
<!--- Paste markup that showcases your contribution --->
```js
let items = [
	{id: {x: 1, y: 1}, text: "A"},
	{id: {x: 2, y: 2}, text: "B"}
];
let selected = {x: 2, y: 2};

<v-select :items="items" v-model="selected" item-value="id"></v-select>
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
