### PR TITLE
fix #2794 - badges in floating action buttons now visible again

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -143,7 +143,7 @@ theme(button, "btn")
       :not(:only-child)
         transition: $primary-transition
 
-        &:last-child
+        &:last-child:not(span)
           opacity: 0
           position: absolute
           transform: rotate(-45deg)


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Badges where affected by the styles that are responsible for turning the icon inside an active FAB button by 45 degree. Encapsulated the styles so they won't affect the badge or any other (potential) button text inside.


## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/2794 - [Bug Report] Badge doesn't work for FAB button

## How Has This Been Tested?
Tested in MS Edge, IE11 and Chrome 63 with Windows 10 (64 Bit)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
