### PR TITLE
fix: do not apply ripple on disabled routable

### DIFF
--- a/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -105,7 +105,7 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -119,7 +119,7 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">
@@ -253,7 +253,7 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -267,7 +267,7 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">
@@ -392,7 +392,7 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -406,7 +406,7 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">
@@ -535,7 +535,7 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -549,7 +549,7 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -161,7 +161,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -175,7 +175,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">
@@ -354,7 +354,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -368,7 +368,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">
@@ -549,7 +549,7 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">
@@ -563,7 +563,7 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Next page"
         >
           <div class="btn__content">
@@ -647,7 +647,7 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
         <button disabled="disabled"
                 type="button"
                 class="btn btn--disabled btn--flat btn--icon"
-                data-ripple="true"
+                data-ripple="false"
                 aria-label="Previous page"
         >
           <div class="btn__content">

--- a/src/mixins/routable.js
+++ b/src/mixins/routable.js
@@ -32,7 +32,7 @@ export default {
         props: {},
         directives: [{
           name: 'ripple',
-          value: this.ripple || false
+          value: (this.ripple && !this.disabled) || false
         }],
         on: {
           ...(this.$listeners || {}),


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Disables ripple effect on disabled routable

## Motivation and Context
This change solves the problem of applying ripple effect on disabled routables

## How Has This Been Tested?
Manually + snapshots

## Markup:
```vue
      <v-tabs centered>
          <v-tab to="/page1" disabled>a</v-tab>
      </v-tabs> 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
