### PR TITLE
fix(v-speed-dial): renamed hover prop to open-on-hover

### DIFF
--- a/src/components/VSpeedDial/VSpeedDial.js
+++ b/src/components/VSpeedDial/VSpeedDial.js
@@ -20,7 +20,7 @@ export default {
         return ['top', 'right', 'bottom', 'left'].includes(val)
       }
     },
-    hover: Boolean,
+    openOnHover: Boolean,
     transition: {
       type: String,
       default: 'scale-transition'
@@ -54,7 +54,7 @@ export default {
       }
     }
 
-    if (this.hover) {
+    if (this.openOnHover) {
       data.on.mouseenter = () => (this.isActive = true)
       data.on.mouseleave = () => (this.isActive = false)
     }

--- a/src/components/VSpeedDial/VSpeedDial.spec.js
+++ b/src/components/VSpeedDial/VSpeedDial.spec.js
@@ -43,7 +43,7 @@ test('VSpeedDial.js', ({ mount }) => {
   it('should activate on hover', () => {
     const wrapper = mount(VSpeedDial, {
       propsData: {
-        hover: true
+        openOnHover: true
       }
     })
 


### PR DESCRIPTION
## Description
Renamed prop `hover` to `open-on-hover` . Done to match similar prop in v-menu

## Motivation and Context
API consistency

## How Has This Been Tested?
Tests updated and run

## Markup:
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
