### PR TITLE
chore: removes HTML comments from jest snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3085,15 +3085,6 @@
       "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
       "dev": true
     },
-    "diffable-html": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-2.1.0.tgz",
-      "integrity": "sha1-DUwt4RWsWPkEqrG3LmZJzvyl8CU=",
-      "dev": true,
-      "requires": {
-        "htmlparser2": "3.9.2"
-      }
-    },
     "diffie-hellman": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
@@ -6272,12 +6263,23 @@
       }
     },
     "jest-serializer-html": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-4.0.1.tgz",
-      "integrity": "sha1-+eBAIq3Qe44D2lrTBVgfEATY9+g=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-5.0.0.tgz",
+      "integrity": "sha512-WfBvUnFdcZNJZMHuOWQFry+5qScsLhoaPxUOzXTqxGIp7BzWMEgr2sG/GKdLTIIfyNviAVp3k4jcqHtBkG18Lg==",
       "dev": true,
       "requires": {
-        "diffable-html": "2.1.0"
+        "diffable-html": "3.0.0"
+      },
+      "dependencies": {
+        "diffable-html": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-3.0.0.tgz",
+          "integrity": "sha512-lUxHiU00DexR/wKcY56OiJZmB0D66ghidYfU4VxUMG09TDx+1jjO7/dFrZKI2p9z00tWY/7ZeO9BBEi6n0jUYQ==",
+          "dev": true,
+          "requires": {
+            "htmlparser2": "3.9.2"
+          }
+        }
       }
     },
     "jest-snapshot": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
     "jest-css-modules": "^1.1.0",
-    "jest-serializer-html": "^4.0.1",
+    "jest-serializer-html": "^5.0.0",
     "jest-vue-preprocessor": "^1.3.1",
     "optimize-css-assets-webpack-plugin": "^3.2.0",
     "optimize-js-plugin": "^0.0.4",

--- a/src/components/VProgressLinear/__snapshots__/VProgressLinear.spec.js.snap
+++ b/src/components/VProgressLinear/__snapshots__/VProgressLinear.spec.js.snap
@@ -10,7 +10,6 @@ exports[`VProgressLinear.js should render component and match snapshot 1`] = `
   >
   </div>
   <div class="progress-linear__bar">
-    <!---->
     <div class="progress-linear__bar__determinate primary"
          style="width: 33%;"
     >
@@ -32,7 +31,6 @@ exports[`VProgressLinear.js should render component with buffer value and match 
   <div class="progress-linear__bar"
        style="width: 80%;"
   >
-    <!---->
     <div class="progress-linear__bar__determinate primary"
          style="width: 41.25%;"
     >
@@ -54,7 +52,6 @@ exports[`VProgressLinear.js should render component with buffer value and match 
   <div class="progress-linear__bar"
        style="width: 0%;"
   >
-    <!---->
     <div class="progress-linear__bar__determinate primary"
          style="width: 0%;"
     >
@@ -76,7 +73,6 @@ exports[`VProgressLinear.js should render component with buffer value and value 
   <div class="progress-linear__bar"
        style="width: 80%;"
   >
-    <!---->
     <div class="progress-linear__bar__determinate primary"
          style="width: 112.5%;"
     >
@@ -96,7 +92,6 @@ exports[`VProgressLinear.js should render component with color and background co
   >
   </div>
   <div class="progress-linear__bar">
-    <!---->
     <div class="progress-linear__bar__determinate orange"
          style="width: 33%;"
     >
@@ -116,7 +111,6 @@ exports[`VProgressLinear.js should render component with color and background co
   >
   </div>
   <div class="progress-linear__bar">
-    <!---->
     <div class="progress-linear__bar__determinate orange"
          style="width: 33%;"
     >
@@ -136,7 +130,6 @@ exports[`VProgressLinear.js should render component with color and background op
   >
   </div>
   <div class="progress-linear__bar">
-    <!---->
     <div class="progress-linear__bar__determinate orange"
          style="width: 33%;"
     >
@@ -156,7 +149,6 @@ exports[`VProgressLinear.js should render component with color and match snapsho
   >
   </div>
   <div class="progress-linear__bar">
-    <!---->
     <div class="progress-linear__bar__determinate orange"
          style="width: 33%;"
     >
@@ -178,7 +170,6 @@ exports[`VProgressLinear.js should render inactive component and match snapshot 
   <div class="progress-linear__bar"
        style="height: 0px;"
   >
-    <!---->
     <div class="progress-linear__bar__determinate primary"
          style="width: 33%;"
     >
@@ -204,7 +195,6 @@ exports[`VProgressLinear.js should render indeterminate progress and match snaps
       <div class="progress-linear__bar__indeterminate short primary">
       </div>
     </div>
-    <!---->
   </div>
 </div>
 
@@ -226,7 +216,6 @@ exports[`VProgressLinear.js should render indeterminate progress with query prop
       <div class="progress-linear__bar__indeterminate short primary">
       </div>
     </div>
-    <!---->
   </div>
 </div>
 

--- a/src/components/VRadioGroup/__snapshots__/VRadioGroup.spec.js.snap
+++ b/src/components/VRadioGroup/__snapshots__/VRadioGroup.spec.js.snap
@@ -36,7 +36,6 @@ exports[`VRadioGroup.vue should be in error when v-radio-group is 1`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -78,7 +77,6 @@ exports[`VRadioGroup.vue should be in error when v-radio-group is 2`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -92,7 +90,6 @@ exports[`VRadioGroup.vue should render role on radio group 1`] = `
   <div class="input-group__input">
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 

--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -78,7 +78,6 @@ exports[`VSelect should render buttons correctly when using items array with seg
     </i>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -137,7 +136,6 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
     </i>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -59,7 +59,6 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                       </div>
                     </div>
                     <div class="input-group__details">
-                      <!---->
                     </div>
                   </div>
                 </div>
@@ -92,7 +91,6 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                       </div>
                     </div>
                     <div class="input-group__details">
-                      <!---->
                     </div>
                   </div>
                 </div>
@@ -114,7 +112,6 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
     </i>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -184,7 +181,6 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
     </i>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 

--- a/src/components/VSlider/__snapshots__/VSlider.spec.js.snap
+++ b/src/components/VSlider/__snapshots__/VSlider.spec.js.snap
@@ -23,7 +23,6 @@ exports[`Vslider.vue should be focused when active 1`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -50,7 +49,6 @@ exports[`Vslider.vue should match a snapshot 1`] = `
     </div>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -85,7 +83,6 @@ exports[`Vslider.vue should render component with thumbLabel and match a snapsho
     </div>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -134,7 +131,6 @@ exports[`Vslider.vue should render component with ticks and match a snapshot 1`]
     </div>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 

--- a/src/components/VTabs/__snapshots__/VTabs.spec.js.snap
+++ b/src/components/VTabs/__snapshots__/VTabs.spec.js.snap
@@ -4,7 +4,6 @@ exports[`VTabs should show tabs arrows 1`] = `
 
 <div class="tabs">
   <div class="tabs__bar">
-    <!---->
     <div class="tabs__wrapper tabs__wrapper--show-arrows">
       <div class="tabs__container tabs__container--overflow">
         <div class="tabs__slider-wrapper">
@@ -13,7 +12,6 @@ exports[`VTabs should show tabs arrows 1`] = `
         </div>
       </div>
     </div>
-    <!---->
   </div>
 </div>
 

--- a/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
+++ b/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
@@ -11,7 +11,6 @@ exports[`VTextField.js should calculate element height when using auto-grow prop
     </textarea>
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -26,7 +25,6 @@ exports[`VTextField.js should not display counter when set to false 1`] = `
     >
   </div>
   <div class="input-group__details">
-    <!---->
     <div class="input-group__counter">
       0 / 25
     </div>
@@ -44,7 +42,6 @@ exports[`VTextField.js should not display counter when set to false 2`] = `
     >
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -59,7 +56,6 @@ exports[`VTextField.js should render component and match snapshot 1`] = `
     >
   </div>
   <div class="input-group__details">
-    <!---->
   </div>
 </div>
 
@@ -88,10 +84,8 @@ exports[`VTextField.js should render component with async loading and custom pro
           <div class="progress-linear__bar__indeterminate short orange">
           </div>
         </div>
-        <!---->
       </div>
     </div>
-    <!---->
   </div>
 </div>
 
@@ -120,10 +114,8 @@ exports[`VTextField.js should render component with async loading and match snap
           <div class="progress-linear__bar__indeterminate short primary">
           </div>
         </div>
-        <!---->
       </div>
     </div>
-    <!---->
   </div>
 </div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2004,9 +2004,9 @@ diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
-diffable-html@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/diffable-html/-/diffable-html-2.1.0.tgz#0d4c2de115ac58f904aab1b72e6649cefca5f025"
+diffable-html@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/diffable-html/-/diffable-html-3.0.0.tgz#3766be8bcf6e90e061bdc321e04e14fc0630853f"
   dependencies:
     htmlparser2 "^3.9.2"
 
@@ -3871,11 +3871,11 @@ jest-runtime@^21.2.1:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
-jest-serializer-html@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer-html/-/jest-serializer-html-4.0.1.tgz#f9e04022add07b8e03da5ad305581f1004d8f7e8"
+jest-serializer-html@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer-html/-/jest-serializer-html-5.0.0.tgz#6848c4d8fb0f6c6dcb1e26a05e46d66c7ff9edb9"
   dependencies:
-    diffable-html "^2.0.0"
+    diffable-html "^3.0.0"
 
 jest-snapshot@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
This PR updates the https://github.com/rayrutjes/jest-serializer-html to v5.0.0.


## Motivation and Context
This new version strips out HTML comments making the Jest snapshots even cleaner.

## How Has This Been Tested?


## Markup:
<!--- Paste markup that showcases your contribution --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
