### PR TITLE
fixes #2791, VSelect input loses focus after chip is removed

### DIFF
--- a/src/stylus/components/_select.styl
+++ b/src/stylus/components/_select.styl
@@ -8,7 +8,7 @@ selects($material)
     &--segmented
       .input-group__input:hover
         background: $material.cards
-      
+
       &.input-group--focused .input-group__input
         background: $material.cards
 
@@ -21,7 +21,7 @@ theme(selects, "input-group--select")
     height: 0px
 
     &--index
-      opacity: 0 !important
+      background-color: transparent !important
 
   .input-group__append-icon
     transition: .3s $transition.linear-out-slow-in


### PR DESCRIPTION


## Description
Change css class so that the input is not hidden when deleting a chip, resulting in loss of focus to the input.

## Motivation and Context
fixes #2791

## How Has This Been Tested?
Tested in Playground

## Markup:
<!--- Paste markup that showcases your contribution --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
