### PR TITLE
enhancement: changes the way of passing color to colorable mixin

### DIFF
--- a/src/components/VAlert/VAlert.js
+++ b/src/components/VAlert/VAlert.js
@@ -38,14 +38,14 @@ export default {
 
   computed: {
     classes () {
-      const colorProp = (this.type && !this.color) ? 'type' : 'computedColor'
+      const color = (this.type && !this.color) ? this.type : this.computedColor
       const classes = {
         'alert--dismissible': this.dismissible,
         'alert--outline': this.outline
       }
 
-      return this.outline ? this.addTextColorClassChecks(classes, colorProp)
-        : this.addBackgroundColorClassChecks(classes, colorProp)
+      return this.outline ? this.addTextColorClassChecks(classes, color)
+        : this.addBackgroundColorClassChecks(classes, color)
     },
     computedIcon () {
       if (this.icon || !this.type) return this.icon

--- a/src/components/VAvatar/VAvatar.js
+++ b/src/components/VAvatar/VAvatar.js
@@ -27,7 +27,7 @@ export default {
     const size = `${parseInt(props.size)}px`
     data.style.height = size
     data.style.width = size
-    data.class = Colorable.methods.addBackgroundColorClassChecks.call(props, {}, 'color')
+    data.class = Colorable.methods.addBackgroundColorClassChecks.call(props, {}, props.color)
 
     return h('div', data, children)
   }

--- a/src/components/VChip/VChip.js
+++ b/src/components/VChip/VChip.js
@@ -43,7 +43,7 @@ export default {
       })
 
       return (this.textColor || this.outline)
-        ? this.addTextColorClassChecks(classes, this.textColor ? 'textColor' : 'color')
+        ? this.addTextColorClassChecks(classes, this.textColor || this.color)
         : classes
     }
   },

--- a/src/components/VIcon/VIcon.js
+++ b/src/components/VIcon/VIcon.js
@@ -82,7 +82,7 @@ export default {
       'icon--right': props.right,
       'theme--dark': props.dark,
       'theme--light': props.light
-    }, props.color ? Colorable.methods.addTextColorClassChecks.call(props, {}, 'color') : {})
+    }, props.color ? Colorable.methods.addTextColorClassChecks.call(props, {}, props.color) : {})
 
     // Order classes
     // * Component class

--- a/src/components/VPicker/VPicker.js
+++ b/src/components/VPicker/VPicker.js
@@ -44,7 +44,7 @@ export default {
         staticClass: 'picker__title',
         'class': this.addBackgroundColorClassChecks({
           'picker__title--landscape': this.landscape
-        }, 'computedTitleColor')
+        }, this.computedTitleColor)
       }, this.$slots.title)
     },
     genBodyTransition () {

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -241,7 +241,7 @@ export default {
         }, [
           h('div', {
             staticClass: 'slider__thumb--label',
-            'class': this.addBackgroundColorClassChecks({}, 'computedThumbColor')
+            'class': this.addBackgroundColorClassChecks({}, this.computedThumbColor)
           }, [
             h('span', {}, this.inputValue)
           ])
@@ -263,7 +263,7 @@ export default {
       const children = []
       children.push(h('div', {
         staticClass: 'slider__thumb',
-        'class': this.addBackgroundColorClassChecks({}, 'computedThumbColor')
+        'class': this.addBackgroundColorClassChecks({}, this.computedThumbColor)
       }))
 
       this.thumbLabel && children.push(this.genThumbLabel(h))
@@ -303,7 +303,7 @@ export default {
       const children = [
         h('div', {
           staticClass: 'slider__track',
-          'class': this.addBackgroundColorClassChecks({}, 'computedTrackColor'),
+          'class': this.addBackgroundColorClassChecks({}, this.computedTrackColor),
           style: this.trackStyles
         }),
         h('div', {

--- a/src/components/VTimePicker/VTimePickerClock.js
+++ b/src/components/VTimePicker/VTimePickerClock.js
@@ -110,7 +110,7 @@ export default {
         }
 
         children.push(this.$createElement('span', {
-          'class': this.addBackgroundColorClassChecks(classes, value === this.value ? 'computedColor' : null),
+          'class': this.addBackgroundColorClassChecks(classes, value === this.value ? this.computedColor : null),
           style: this.getTransform(value),
           domProps: { innerHTML: `<span>${pad(value, this.pad)}</span>` }
         }))

--- a/src/mixins/colorable.js
+++ b/src/mixins/colorable.js
@@ -18,26 +18,22 @@ export default {
   },
 
   methods: {
-    addBackgroundColorClassChecks (obj = {}, prop = 'computedColor') {
+    addBackgroundColorClassChecks (obj = {}, color = this.computedColor) {
       const classes = Object.assign({}, obj)
 
-      if (prop && this[prop]) {
-        classes[this[prop]] = true
+      if (color) {
+        classes[color] = true
       }
 
       return classes
     },
-    addTextColorClassChecks (obj = {}, prop = 'computedColor') {
+    addTextColorClassChecks (obj = {}, color = this.computedColor) {
       const classes = Object.assign({}, obj)
 
-      if (prop && this[prop]) {
-        const parts = this[prop].trim().split(' ')
-
-        let color = parts[0] + '--text'
-
-        if (parts.length > 1) color += ' text--' + parts[1]
-
-        classes[color] = !!this[prop]
+      if (color) {
+        const [colorName, colorModifier] = color.trim().split(' ')
+        classes[colorName + '--text'] = true
+        colorModifier && (classes['text--' + colorModifier] = true)
       }
 
       return classes


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the way of passing color to colorable mixin

## Motivation and Context
Currently the colorable mixin takes the name of the prop/computed
to get the color. This is not enough if the color is more dynamic,
for example planned events in date picker PR (#2946) could potentially use
different colors for different event and this needs the actual color to
be passed instead of the prop name

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
jest

## Markup:
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor/enhancement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
