### PR TITLE
feature: readonly date picker

### DIFF
--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -85,6 +85,7 @@ export default {
       type: String,
       default: 'chevron_left'
     },
+    readonly: Boolean,
     scrollable: Boolean,
     // Function formatting currently selected date in the picker title
     titleDateFormat: {
@@ -277,6 +278,7 @@ export default {
       return this.$createElement('v-date-picker-title', {
         props: {
           date: this.formatters.titleDate(this.inputDate),
+          readonly: this.readonly,
           selectingYear: this.activePicker === 'YEAR',
           year: this.formatters.year(`${this.year}`),
           yearIcon: this.yearIcon
@@ -295,6 +297,7 @@ export default {
           format: this.headerDateFormat,
           locale: this.locale,
           prependIcon: this.prependIcon,
+          readonly: this.readonly,
           value: this.activePicker === 'DATE' ? this.tableDate : `${this.tableYear}`
         },
         on: {
@@ -311,8 +314,9 @@ export default {
           firstDayOfWeek: this.firstDayOfWeek,
           format: this.dayFormat,
           locale: this.locale,
+          readonly: this.readonly,
           tableDate: this.tableDate,
-          scrollable: this.scrollable,
+          scrollable: this.scrollable && !this.readonly,
           value: this.value
         },
         ref: 'table',
@@ -329,7 +333,8 @@ export default {
           color: this.color,
           format: this.monthFormat,
           locale: this.locale,
-          scrollable: this.scrollable,
+          readonly: this.readonly,
+          scrollable: this.scrollable && !this.readonly,
           value: (!this.value || this.type === 'month') ? this.value : this.value.substr(0, 7),
           tableDate: `${this.tableYear}`
         },

--- a/src/components/VDatePicker/VDatePickerDateTable.js
+++ b/src/components/VDatePicker/VDatePickerDateTable.js
@@ -73,11 +73,14 @@ export default {
         attrs: {
           type: 'button'
         },
+        style: this.readonly ? {
+          'pointer-events': 'none'
+        } : undefined,
         domProps: {
           disabled,
           innerHTML: `<span class="btn__content">${this.formatter(date)}</span>`
         },
-        on: disabled ? {} : {
+        on: (this.readonly || disabled)  ? {} : {
           click: () => this.$emit('input', date)
         }
       })

--- a/src/components/VDatePicker/VDatePickerDateTable.spec.js
+++ b/src/components/VDatePicker/VDatePickerDateTable.spec.js
@@ -15,6 +15,19 @@ test('VDatePickerDateTable.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should render readonly component and match snapshot', () => {
+    const wrapper = mount(VDatePickerDateTable, {
+      propsData: {
+        tableDate: '2005-05',
+        current: '2005-07',
+        value: '2005-11-03',
+        readonly: true
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should match snapshot with first day of week', function () {
     const wrapper = mount(VDatePickerDateTable, {
       propsData: {

--- a/src/components/VDatePicker/VDatePickerHeader.js
+++ b/src/components/VDatePicker/VDatePickerHeader.js
@@ -112,9 +112,7 @@ export default {
 
       return this.$createElement('div', {
         staticClass: 'date-picker-header__value',
-        'class': this.addTextColorClassChecks({
-          'date-picker-header__value--disabled': this.readonly
-        })
+        'class': this.readonly ? ['date-picker-header__value--disabled'] : this.addTextColorClassChecks()
       }, [transition])
     }
   },

--- a/src/components/VDatePicker/VDatePickerHeader.js
+++ b/src/components/VDatePicker/VDatePickerHeader.js
@@ -44,6 +44,7 @@ export default {
       type: String,
       default: 'chevron_left'
     },
+    readonly: Boolean,
     value: {
       type: [Number, String],
       required: true
@@ -73,6 +74,7 @@ export default {
       return this.$createElement('v-btn', {
         props: {
           dark: this.dark,
+          disabled: this.readonly,
           icon: true
         },
         nativeOn: {
@@ -96,9 +98,8 @@ export default {
     },
     genHeader () {
       const header = this.$createElement('strong', {
-        'class': this.addTextColorClassChecks(),
         key: String(this.value),
-        on: {
+        on: this.readonly ? undefined : {
           click: () => this.$emit('toggle')
         }
       }, [this.$slots.default || this.formatter(String(this.value))])
@@ -110,7 +111,10 @@ export default {
       }, [header])
 
       return this.$createElement('div', {
-        'class': 'date-picker-header__value'
+        staticClass: 'date-picker-header__value',
+        'class': this.addTextColorClassChecks({
+          'date-picker-header__value--disabled': this.readonly
+        })
       }, [transition])
     }
   },

--- a/src/components/VDatePicker/VDatePickerHeader.spec.js
+++ b/src/components/VDatePicker/VDatePickerHeader.spec.js
@@ -55,7 +55,7 @@ test('VDatePickerHeader.js', ({ mount }) => {
       }
     })
 
-    const strong = wrapper.find('.date-picker-header__value strong')[0]
+    const strong = wrapper.find('.date-picker-header__value')[0]
     expect(strong.hasClass('green--text')).toBe(true)
     expect(strong.hasClass('text--lighten-1')).toBe(true)
   })

--- a/src/components/VDatePicker/VDatePickerHeader.spec.js
+++ b/src/components/VDatePicker/VDatePickerHeader.spec.js
@@ -13,6 +13,17 @@ test('VDatePickerHeader.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should render readonly component and match snapshot', () => {
+    const wrapper = mount(VDatePickerHeader, {
+      propsData: {
+        value: '2005-11',
+        readonly: true
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should render component with year value and match snapshot', () => {
     const wrapper = mount(VDatePickerHeader, {
       propsData: {

--- a/src/components/VDatePicker/VDatePickerMonthTable.js
+++ b/src/components/VDatePicker/VDatePickerMonthTable.js
@@ -24,10 +24,9 @@ export default {
     calculateTableDate (delta) {
       return `${parseInt(this.tableDate, 10) + Math.sign(delta || 1)}`
     },
-    genMonthButtonClasses (month) {
+    genMonthButtonClasses (month, isDisabled) {
       const isSelected = this.selectedYear === this.displayedYear && this.selectedMonth === month
       const isCurrent = this.currentYear === this.displayedYear && this.currentMonth === month
-      const isDisabled = !isValueAllowed(`${this.displayedYear}-${pad(month + 1)}`, this.allowedDates)
       const classes = {
         'btn--flat': !isSelected,
         'btn--active btn--depressed': isSelected,
@@ -50,9 +49,12 @@ export default {
 
       return this.$createElement('button', {
         staticClass: 'btn',
-        'class': this.genMonthButtonClasses(month),
+        'class': this.genMonthButtonClasses(month, isDisabled),
         attrs: { type: 'button' },
-        on: isDisabled ? undefined : {
+        style: this.readonly ? {
+          'pointer-events': 'none'
+        } : undefined,
+        on: (this.readonly || isDisabled) ? undefined : {
           click: () => this.$emit('input', `${value}`)
         }
       }, [btnContent])

--- a/src/components/VDatePicker/VDatePickerMonthTable.spec.js
+++ b/src/components/VDatePicker/VDatePickerMonthTable.spec.js
@@ -15,6 +15,19 @@ test('VDatePickerMonthTable.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should render readonly component and match snapshot', () => {
+    const wrapper = mount(VDatePickerMonthTable, {
+      propsData: {
+        tableDate: '2005',
+        current: '2005-05',
+        readonly: true,
+        value: '2005-11'
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should watch tableDate value and run transition', async () => {
     const wrapper = mount(VDatePickerMonthTable, {
       propsData: {

--- a/src/components/VDatePicker/VDatePickerTitle.js
+++ b/src/components/VDatePicker/VDatePickerTitle.js
@@ -24,6 +24,7 @@ export default {
       type: String,
       default: ''
     },
+    readonly: Boolean,
     selectingYear: Boolean,
     year: {
       type: [Number, String],
@@ -54,7 +55,7 @@ export default {
       }, this.yearIcon)
     },
     getYearBtn () {
-      return this.genPickerButton('selectingYear', true, [
+      return this.genPickerButton('selectingYear', !this.readonly, [
         this.year,
         this.yearIcon ? this.genYearIcon() : null
       ], 'date-picker-title__year')

--- a/src/components/VDatePicker/VDatePickerTitle.spec.js
+++ b/src/components/VDatePicker/VDatePickerTitle.spec.js
@@ -13,6 +13,18 @@ test('VDatePickerTitle.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should render readonly component and match snapshot', () => {
+    const wrapper = mount(VDatePickerTitle, {
+      propsData: {
+        year: '1234',
+        date: '2005-11-01',
+        readonly: true
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should render component when selecting year and match snapshot', () => {
     const wrapper = mount(VDatePickerTitle, {
       propsData: {

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -364,8 +364,8 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="primary--text">
+        <div class="date-picker-header__value primary--text">
+          <strong>
             November 2005
           </strong>
         </div>
@@ -736,8 +736,8 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="orange--text text--darken-1">
+        <div class="date-picker-header__value orange--text text--darken-1">
+          <strong>
             November 2005
           </strong>
         </div>
@@ -1108,8 +1108,8 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="accent--text">
+        <div class="date-picker-header__value accent--text">
+          <strong>
             May 2013
           </strong>
         </div>
@@ -1491,8 +1491,8 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="accent--text">
+        <div class="date-picker-header__value accent--text">
+          <strong>
             May 2013
           </strong>
         </div>

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
@@ -156,8 +156,8 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="primary--text">
+        <div class="date-picker-header__value primary--text">
+          <strong>
             2005
           </strong>
         </div>
@@ -335,8 +335,8 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="orange--text text--darken-1">
+        <div class="date-picker-header__value orange--text text--darken-1">
+          <strong>
             2005
           </strong>
         </div>
@@ -637,8 +637,8 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
             </i>
           </div>
         </button>
-        <div class="date-picker-header__value">
-          <strong class="accent--text">
+        <div class="date-picker-header__value accent--text">
+          <strong>
             2013
           </strong>
         </div>

--- a/src/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
@@ -661,3 +661,359 @@ exports[`VDatePickerDateTable.js should render component and match snapshot 1`] 
 </div>
 
 `;
+
+exports[`VDatePickerDateTable.js should render readonly component and match snapshot 1`] = `
+
+<div class="date-picker-table date-picker-table--date">
+  <table>
+    <thead>
+      <tr>
+        <th>
+          S
+        </th>
+        <th>
+          M
+        </th>
+        <th>
+          T
+        </th>
+        <th>
+          W
+        </th>
+        <th>
+          T
+        </th>
+        <th>
+          F
+        </th>
+        <th>
+          S
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              1
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              2
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              3
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              4
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              5
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              6
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              7
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              8
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              9
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              10
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              11
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              12
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              13
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              14
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              15
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              16
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              17
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              18
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              19
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              20
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              21
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              22
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              23
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              24
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              25
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              26
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              27
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              28
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              29
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              30
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--raised btn--icon"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              31
+            </span>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+`;

--- a/src/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
@@ -73,3 +73,41 @@ exports[`VDatePickerHeader.js should render component with default slot and matc
 </div>
 
 `;
+
+exports[`VDatePickerHeader.js should render readonly component and match snapshot 1`] = `
+
+<div class="date-picker-header">
+  <button disabled="disabled"
+          type="button"
+          class="btn btn--disabled btn--icon"
+          data-ripple="false"
+  >
+    <div class="btn__content">
+      <i aria-hidden="true"
+         class="icon material-icons"
+      >
+        chevron_left
+      </i>
+    </div>
+  </button>
+  <div class="date-picker-header__value date-picker-header__value--disabled">
+    <strong>
+      November 2005
+    </strong>
+  </div>
+  <button disabled="disabled"
+          type="button"
+          class="btn btn--disabled btn--icon"
+          data-ripple="false"
+  >
+    <div class="btn__content">
+      <i aria-hidden="true"
+         class="icon material-icons"
+      >
+        chevron_right
+      </i>
+    </div>
+  </button>
+</div>
+
+`;

--- a/src/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
@@ -15,8 +15,8 @@ exports[`VDatePickerHeader.js should render component and match snapshot 1`] = `
       </i>
     </div>
   </button>
-  <div class="date-picker-header__value">
-    <strong class="accent--text">
+  <div class="date-picker-header__value accent--text">
+    <strong>
       November 2005
     </strong>
   </div>
@@ -51,8 +51,8 @@ exports[`VDatePickerHeader.js should render component with default slot and matc
       </i>
     </div>
   </button>
-  <div class="date-picker-header__value">
-    <strong class="accent--text">
+  <div class="date-picker-header__value accent--text">
+    <strong>
       <span>
         foo
       </span>

--- a/src/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
@@ -126,3 +126,142 @@ exports[`VDatePickerMonthTable.js should render component and match snapshot 1`]
 </div>
 
 `;
+
+exports[`VDatePickerMonthTable.js should render readonly component and match snapshot 1`] = `
+
+<div class="date-picker-table date-picker-table--month">
+  <table>
+    <tbody>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Jan
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Feb
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Mar
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Apr
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat btn--outline accent"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              May
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Jun
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Jul
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Aug
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Sep
+            </span>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Oct
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--active btn--depressed accent"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Nov
+            </span>
+          </button>
+        </td>
+        <td>
+          <button type="button"
+                  class="btn btn--flat"
+                  style="pointer-events: none;"
+          >
+            <span class="btn__content">
+              Dec
+            </span>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+`;

--- a/src/components/VDatePicker/__snapshots__/VDatePickerTitle.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerTitle.spec.js.snap
@@ -30,6 +30,21 @@ exports[`VDatePickerTitle.js should render component when selecting year and mat
 
 `;
 
+exports[`VDatePickerTitle.js should render readonly component and match snapshot 1`] = `
+
+<div class="date-picker-title">
+  <div class="picker__title__btn date-picker-title__year active">
+    1234
+  </div>
+  <div class="picker__title__btn date-picker-title__date active">
+    <div>
+      2005-11-01
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`VDatePickerTitle.js should render year icon 1`] = `
 
 <div class="picker__title__btn date-picker-title__year">

--- a/src/components/VDatePicker/mixins/date-picker-table.js
+++ b/src/components/VDatePicker/mixins/date-picker-table.js
@@ -30,6 +30,7 @@ export default {
       type: String,
       default: 'en-us'
     },
+    readonly: Boolean,
     scrollable: Boolean,
     tableDate: {
       type: String,

--- a/src/stylus/components/_date-picker-header.styl
+++ b/src/stylus/components/_date-picker-header.styl
@@ -5,9 +5,6 @@ date-picker-header($material)
   .date-picker-header__value:not(:hover)
     color: $material.text.primary !important
 
-  .date-picker-header__value--disabled strong
-    color: $material.text.disabled !important
-
 theme(date-picker-header, "date-picker-header")
 
 .date-picker-header
@@ -35,4 +32,4 @@ theme(date-picker-header, "date-picker-header")
     width: 100%
 
 .date-picker-header__value--disabled
-  cursor: default
+  pointer-events: none

--- a/src/stylus/components/_date-picker-header.styl
+++ b/src/stylus/components/_date-picker-header.styl
@@ -2,9 +2,11 @@
 @import '../theme'
 
 date-picker-header($material)
-  .date-picker-header__value
-    strong:not(:hover)
-      color: $material.text.primary !important
+  .date-picker-header__value:not(:hover)
+    color: $material.text.primary !important
+
+  .date-picker-header__value--disabled strong
+    color: $material.text.disabled !important
 
 theme(date-picker-header, "date-picker-header")
 
@@ -20,18 +22,17 @@ theme(date-picker-header, "date-picker-header")
     margin: 0
     z-index: auto
 
-  .icon
-    cursor: pointer
-    user-select: none
-
 .date-picker-header__value
   flex: 1
   text-align: center
   position: relative
   overflow: hidden
+  cursor: pointer
 
   strong
-    cursor: pointer
     transition: $primary-transition
     display: block
     width: 100%
+
+.date-picker-header__value--disabled
+  cursor: default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds **readonly** prop to date/month picker

## Motivation and Context
fixes #2750

## How Has This Been Tested?
Snapshot tests

## Markup:
```vue
<template>
  <v-app>
    <v-date-picker readonly type="month" v-model="month"></v-date-picker>
    <v-date-picker readonly type="date" v-model="date"></v-date-picker>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    date: '2018-01-10',
    month: '2018-02'
  }),
};
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

  