### PR TITLE
fix: Avoid high CPU usage in Safari

### DIFF
--- a/src/stylus/components/_navigation-drawer.styl
+++ b/src/stylus/components/_navigation-drawer.styl
@@ -28,6 +28,9 @@ theme(navigation-drawer, "navigation-drawer")
   z-index: 3
   -webkit-overflow-scrolling: touch
 
+  &[data-booted="true"]
+    transition-property: background,background-color,border,border-bottom,border-bottom-color,border-bottom-width,border-color,border-left,border-left-color,border-left-width,border-right,border-right-color,border-right-width,border-top,border-top-color,border-top-width,border-width,bottom,box-shadow,color,height,left,margin,margin-bottom,margin-left,margin-right,margin-top,max-width,min-height,min-width,opacity,padding,padding-bottom,padding-left,padding-right,padding-top,right,top,transform,transform-origin,width;
+    
   &__border
     position: absolute
     right: 0

--- a/src/stylus/components/_navigation-drawer.styl
+++ b/src/stylus/components/_navigation-drawer.styl
@@ -29,6 +29,8 @@ theme(navigation-drawer, "navigation-drawer")
   -webkit-overflow-scrolling: touch
 
   &[data-booted="true"]
+  	/* Work around for Safari bug. See https://github.com/vuetifyjs/vuetify/issues/2773
+	   We really want transition-property: all but must exclude max-height. */
     transition-property: background,background-color,border,border-bottom,border-bottom-color,border-bottom-width,border-color,border-left,border-left-color,border-left-width,border-right,border-right-color,border-right-width,border-top,border-top-color,border-top-width,border-width,bottom,box-shadow,color,height,left,margin,margin-bottom,margin-left,margin-right,margin-top,max-width,min-height,min-width,opacity,padding,padding-bottom,padding-left,padding-right,padding-top,right,top,transform,transform-origin,width;
     
   &__border


### PR DESCRIPTION
A v-navigation-drawer with the app param causes Safari to repeatedly
invalidate and recalculate the layout, permanently consuming a CPU
core.

This is a bug in Safari (fixed in current tech preview) which is
triggered by the combination of using calc in the max-height,
transition-property including max-height and the element being created
using document.createElement (as vue does).

fixes #2773

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Explicitly list a wide range of CSS properties in transition-property for navigation drawers but exclude max-height to avoid triggering a bug in Safari.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/vuetifyjs/vuetify/issues/2773

Note this bug only applies to the dev branch.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
No new tests - can only verify fix works by checking activity monitor and the Timeline tab in Safari dev tools to confirm the layout is no longer constantly revalidating and CPU usage is low.

## Markup:
<!--- Paste markup that showcases your contribution --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.