### PR TITLE
fix(v-date-picker): adjusted styles and markup

### DIFF
--- a/src/components/VDatePicker/VDatePickerDateTable.js
+++ b/src/components/VDatePicker/VDatePickerDateTable.js
@@ -67,23 +67,29 @@ export default {
         'btn--disabled': disabled
       }, this.themeClasses)
 
-      return (isActive || isCurrent)
+      return isActive
         ? this.addBackgroundColorClassChecks(classes)
-        : classes
+        // Normally with a v-btn component
+        // using the outline prop would envoke
+        // to TextColor classes as opposed
+        // to BackgroundColor
+        : isCurrent
+          ? this.addTextColorClassChecks(classes)
+          : classes
     },
     genButton (day) {
       const date = `${this.displayedYear}-${pad(this.displayedMonth + 1)}-${pad(day)}`
       const disabled = !isValueAllowed(date, this.allowedDates)
 
       return this.$createElement('button', {
-        staticClass: 'btn btn--raised btn--icon',
+        staticClass: 'btn btn--icon',
         'class': this.genButtonClasses(day, disabled),
         attrs: {
           type: 'button'
         },
         domProps: {
           disabled,
-          innerHTML: `<span class="btn__content">${this.formatter(date)}</span>`
+          innerHTML: `<div class="btn__content">${this.formatter(date)}</div>`
         },
         on: disabled ? {} : {
           click: () => this.$emit('input', date)

--- a/src/components/VDatePicker/VDatePickerDateTable.js
+++ b/src/components/VDatePicker/VDatePickerDateTable.js
@@ -69,10 +69,9 @@ export default {
 
       return isActive
         ? this.addBackgroundColorClassChecks(classes)
-        // Normally with a v-btn component
-        // using the outline prop would envoke
-        // to TextColor classes as opposed
-        // to BackgroundColor
+        // Normally a v-btn component using
+        // the outline prop would run the
+        // addTextColorClasses method
         : isCurrent
           ? this.addTextColorClassChecks(classes)
           : classes

--- a/src/components/VDatePicker/VDatePickerMonthTable.js
+++ b/src/components/VDatePicker/VDatePickerMonthTable.js
@@ -44,7 +44,7 @@ export default {
     genMonthButton (month) {
       const value = `${this.displayedYear}-${pad(month + 1)}`
       const isDisabled = !isValueAllowed(value, this.allowedDates)
-      const btnContent = this.$createElement('span', {
+      const btnContent = this.$createElement('div', {
         staticClass: 'btn__content'
       }, [
         this.formatter(value)

--- a/src/components/VDatePicker/VDatePickerMonthTable.js
+++ b/src/components/VDatePicker/VDatePickerMonthTable.js
@@ -35,9 +35,11 @@ export default {
         'btn--disabled': isDisabled
       }
 
-      return (isSelected || isCurrent)
+      return isSelected
         ? this.addBackgroundColorClassChecks(classes)
-        : classes
+        : isCurrent
+          ? this.addTextColorClassChecks(classes)
+          : classes
     },
     genMonthButton (month) {
       const value = `${this.displayedYear}-${pad(month + 1)}`

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -12,318 +12,318 @@ exports[`VDatePicker.js should match snapshot with allowed dates as array 1`] = 
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           1
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           2
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           3
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           4
-        </span>
+        </div>
       </button>
     </td>
   </tr>
   <tr>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           5
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon"
+              class="btn btn--icon"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           6
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--active accent"
+              class="btn btn--icon btn--active accent"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           7
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           8
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           9
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           10
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           11
-        </span>
+        </div>
       </button>
     </td>
   </tr>
   <tr>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           12
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           13
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           14
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           15
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           16
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           17
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           18
-        </span>
+        </div>
       </button>
     </td>
   </tr>
   <tr>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           19
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           20
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           21
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           22
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           23
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           24
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           25
-        </span>
+        </div>
       </button>
     </td>
   </tr>
   <tr>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           26
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           27
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           28
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           29
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           30
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
-              class="btn btn--raised btn--icon btn--disabled"
+              class="btn btn--icon btn--disabled"
               disabled
       >
-        <span class="btn__content">
+        <div class="btn__content">
           31
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -417,280 +417,280 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon btn--active primary"
+                        class="btn btn--icon btn--active primary"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     1
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     2
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     3
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     4
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     5
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     6
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     7
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     8
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     9
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     10
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     11
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     12
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     13
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     14
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     15
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     16
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     17
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     18
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     19
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     20
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     21
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     22
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     23
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     24
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     25
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     26
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     27
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     28
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     29
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     30
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -789,280 +789,280 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon btn--active orange darken-1"
+                        class="btn btn--icon btn--active orange darken-1"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     1
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     2
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     3
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     4
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     5
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     6
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     7
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     8
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     9
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     10
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     11
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     12
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     13
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     14
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     15
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     16
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     17
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     18
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     19
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     20
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     21
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     22
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     23
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     24
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     25
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     26
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     27
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     28
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     29
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     30
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -1163,289 +1163,289 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     1
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     2
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     3
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     4
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     5
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     6
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon btn--active accent"
+                        class="btn btn--icon btn--active accent"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     7
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     8
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     9
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     10
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     11
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     12
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     13
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     14
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     15
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     16
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     17
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     18
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     19
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     20
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     21
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     22
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     23
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     24
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     25
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     26
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     27
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     28
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     29
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     30
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     31
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -1546,289 +1546,289 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     1
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     2
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     3
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     4
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     5
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     6
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon btn--active accent"
+                        class="btn btn--icon btn--active accent"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     7
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     8
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     9
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     10
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     11
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     12
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     13
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     14
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     15
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     16
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     17
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     18
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     19
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     20
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     21
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     22
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     23
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     24
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     25
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
             <tr>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     26
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     27
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     28
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     29
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     30
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
-                        class="btn btn--raised btn--icon"
+                        class="btn btn--icon"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     31
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
@@ -8,27 +8,27 @@ exports[`VDatePicker.js should match snapshot with allowed dates as array 1`] = 
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Jan
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Feb
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Mar
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -37,27 +37,27 @@ exports[`VDatePicker.js should match snapshot with allowed dates as array 1`] = 
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Apr
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--active btn--depressed accent"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           May
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Jun
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -66,27 +66,27 @@ exports[`VDatePicker.js should match snapshot with allowed dates as array 1`] = 
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Jul
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Aug
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Sep
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -95,27 +95,27 @@ exports[`VDatePicker.js should match snapshot with allowed dates as array 1`] = 
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Oct
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Nov
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat btn--disabled"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           Dec
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -182,27 +182,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jan
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Feb
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Mar
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -211,27 +211,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Apr
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     May
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jun
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -240,27 +240,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jul
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Aug
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Sep
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -269,27 +269,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Oct
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--active btn--depressed primary"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Nov
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Dec
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -361,27 +361,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jan
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Feb
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Mar
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -390,27 +390,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Apr
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     May
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jun
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -419,27 +419,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jul
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Aug
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Sep
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -448,27 +448,27 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Oct
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--active btn--depressed orange darken-1"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Nov
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Dec
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -489,27 +489,27 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (01)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (02)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (03)
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -518,27 +518,27 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (04)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (05)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (06)
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -547,27 +547,27 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (07)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (08)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (09)
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -576,27 +576,27 @@ exports[`VDatePicker.js should match snapshot with month formatting functions 1`
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (10)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--active btn--depressed accent"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (11)
-        </span>
+        </div>
       </button>
     </td>
     <td>
       <button type="button"
               class="btn btn--flat"
       >
-        <span class="btn__content">
+        <div class="btn__content">
           (12)
-        </span>
+        </div>
       </button>
     </td>
   </tr>
@@ -663,27 +663,27 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jan
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Feb
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Mar
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -692,27 +692,27 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Apr
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--active btn--depressed accent"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     May
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jun
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -721,27 +721,27 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Jul
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Aug
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Sep
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>
@@ -750,27 +750,27 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Oct
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Nov
-                  </span>
+                  </div>
                 </button>
               </td>
               <td>
                 <button type="button"
                         class="btn btn--flat"
                 >
-                  <span class="btn__content">
+                  <div class="btn__content">
                     Dec
-                  </span>
+                  </div>
                 </button>
               </td>
             </tr>

--- a/src/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
@@ -1022,293 +1022,293 @@ exports[`VDatePickerDateTable.js should render component with events colored by 
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               1
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               2
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               3
-            </span>
+            </div>
           </button>
           <div class="date-picker-table__event red">
           </div>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               4
-            </span>
+            </div>
           </button>
           <div class="date-picker-table__event blue lighten-1">
           </div>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               5
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               6
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               7
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               8
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               9
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               10
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               11
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               12
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               13
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               14
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               15
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               16
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               17
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               18
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               19
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               20
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               21
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               22
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               23
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               24
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               25
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               26
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               27
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               28
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               29
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               30
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               31
-            </span>
+            </div>
           </button>
         </td>
       </tr>
@@ -1351,293 +1351,293 @@ exports[`VDatePickerDateTable.js should render component with events colored by 
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               1
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               2
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               3
-            </span>
+            </div>
           </button>
           <div class="date-picker-table__event red">
           </div>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               4
-            </span>
+            </div>
           </button>
           <div class="date-picker-table__event accent">
           </div>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               5
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               6
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               7
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               8
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               9
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               10
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               11
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               12
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               13
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               14
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               15
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               16
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               17
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               18
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               19
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               20
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               21
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               22
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               23
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               24
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               25
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               26
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               27
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               28
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               29
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               30
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               31
-            </span>
+            </div>
           </button>
         </td>
       </tr>

--- a/src/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
@@ -43,291 +43,291 @@ exports[`VDatePickerDateTable.js should match snapshot with first day of week 1`
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               1
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               2
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               3
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               4
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               5
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               6
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               7
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               8
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               9
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               10
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               11
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               12
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               13
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               14
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               15
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               16
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               17
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               18
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               19
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               20
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               21
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               22
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               23
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               24
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               25
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               26
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               27
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               28
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               29
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               30
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               31
-            </span>
+            </div>
           </button>
         </td>
       </tr>
@@ -370,289 +370,289 @@ exports[`VDatePickerDateTable.js should render component and match snapshot 1`] 
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               1
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               2
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               3
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               4
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               5
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               6
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               7
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               8
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               9
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               10
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               11
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               12
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               13
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               14
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               15
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               16
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               17
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               18
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               19
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               20
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               21
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               22
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               23
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               24
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               25
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               26
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               27
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               28
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               29
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               30
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               31
-            </span>
+            </div>
           </button>
         </td>
       </tr>
@@ -695,291 +695,291 @@ exports[`VDatePickerDateTable.js should render component with events and match s
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               1
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               2
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               3
-            </span>
+            </div>
           </button>
           <div class="date-picker-table__event red">
           </div>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               4
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               5
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               6
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               7
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               8
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               9
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               10
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               11
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               12
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               13
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               14
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               15
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               16
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               17
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               18
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               19
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               20
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               21
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               22
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               23
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               24
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               25
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               26
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               27
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               28
-            </span>
+            </div>
           </button>
         </td>
       </tr>
       <tr>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               29
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               30
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
-                  class="btn btn--raised btn--icon"
+                  class="btn btn--icon"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               31
-            </span>
+            </div>
           </button>
         </td>
       </tr>

--- a/src/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
@@ -46,7 +46,7 @@ exports[`VDatePickerMonthTable.js should render component and match snapshot 1`]
         </td>
         <td>
           <button type="button"
-                  class="btn btn--flat btn--outline accent"
+                  class="btn btn--flat btn--outline accent--text"
           >
             <span class="btn__content">
               May

--- a/src/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
@@ -10,27 +10,27 @@ exports[`VDatePickerMonthTable.js should render component and match snapshot 1`]
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Jan
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Feb
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Mar
-            </span>
+            </div>
           </button>
         </td>
       </tr>
@@ -39,27 +39,27 @@ exports[`VDatePickerMonthTable.js should render component and match snapshot 1`]
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Apr
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat btn--outline accent--text"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               May
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Jun
-            </span>
+            </div>
           </button>
         </td>
       </tr>
@@ -68,27 +68,27 @@ exports[`VDatePickerMonthTable.js should render component and match snapshot 1`]
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Jul
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Aug
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Sep
-            </span>
+            </div>
           </button>
         </td>
       </tr>
@@ -97,27 +97,27 @@ exports[`VDatePickerMonthTable.js should render component and match snapshot 1`]
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Oct
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--active btn--depressed accent"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Nov
-            </span>
+            </div>
           </button>
         </td>
         <td>
           <button type="button"
                   class="btn btn--flat"
           >
-            <span class="btn__content">
+            <div class="btn__content">
               Dec
-            </span>
+            </div>
           </button>
         </td>
       </tr>

--- a/src/components/VPicker/VPicker.js
+++ b/src/components/VPicker/VPicker.js
@@ -26,7 +26,7 @@ export default {
     landscape: Boolean,
     transition: {
       type: String,
-      default: 'picker-transition'
+      default: 'fade-transition'
     }
   },
 

--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -67,7 +67,7 @@ theme(button, "btn")
     border-radius: inherit
     color: inherit
     display: flex
-    height: 100%
+    height: inherit
     flex: 1 0 auto
     justify-content: center
     margin: 0 auto

--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -67,7 +67,7 @@ theme(button, "btn")
     border-radius: inherit
     color: inherit
     display: flex
-    height: inherit
+    height: 100%
     flex: 1 0 auto
     justify-content: center
     margin: 0 auto

--- a/src/stylus/components/_date-picker-title.styl
+++ b/src/stylus/components/_date-picker-title.styl
@@ -5,6 +5,7 @@
   justify-content: space-between
   flex-direction: column
   flex-wrap: wrap
+  line-height: 1
 
 .date-picker-title__year
     align-items: center

--- a/src/stylus/components/_pickers.styl
+++ b/src/stylus/components/_pickers.styl
@@ -21,7 +21,6 @@ theme(picker-title, "picker")
   border-radius: $card-border-radius
   display: flex
   flex-direction: column
-  line-height: 1
   width: 290px
   contain: content
 

--- a/src/stylus/components/_pickers.styl
+++ b/src/stylus/components/_pickers.styl
@@ -54,6 +54,9 @@ theme(picker-title, "picker")
 
   > div
     width: 100%
+    
+    &.fade-transition-leave-active
+      position: absolute
 
 .picker--landscape
   flex-direction: row

--- a/src/stylus/components/_time-picker-title.styl
+++ b/src/stylus/components/_time-picker-title.styl
@@ -3,6 +3,7 @@
 .time-picker-title
   color: #fff
   display: flex
+  line-height: 1
   justify-content: flex-end
 
 .time-picker-title__time


### PR DESCRIPTION
- removed unused class string from button generation
- adjusted content tag to match what is output by `v-btn` normally
- added conditional for class generation type, **outline** uses
**addTextColorClasses** normally within `v-btn`
- fixed bug where on some browsers the text inside of the generated button would not be vertically center

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The `v-date-picker` had incorrect styles for the currently active day. This component generates a mock `v-btn` and was not using logic that normally would change the classes added by the **colorable** mixin.  This lead me to the incorrect html tag for the **.btn__content** class. Fixed a bug caused by my merge conflict resolution where **this.current** was not being passed to `v-date-picker-date-table`. There was a weird bug caused by recent changes where the text inside of the generated buttons was not properly centered (vertically). Switched the **height** declaration from **100%** to **inherit** as this was always the intended behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes some irregularities with `v-date-picker`

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
Jest

## Markup:
<!--- Paste markup that showcases your contribution --->
```vue
<template>
  <v-app>
    <v-date-picker event-color="green" v-model="date" :events="['2018-01-06', '2018-01-10', '2018-01-22']"></v-date-picker>
  </v-app>
</template>

<script>
export default {
  data: () => ({ date: '2018-01-01' })
}
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
