### PR TITLE
fix: apply will-change to btn only when necessary

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -85,8 +85,10 @@ theme(button, "btn")
     background-color: transparent !important
     box-shadow: none !important
 
-  &:not(.btn--depressed)
+  &:not(.btn--flat):not(.btn--icon):not(.btn--disabled)
     will-change: box-shadow
+
+  &:not(.btn--depressed)
     elevation(2)
 
     &:active


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
## Motivation and Context
v-btn shadow won't change if the button is flat/icon/disabled, and
it will change for other buttons not only when depressed
Maybe it will speed up things by 0.0003s?

## How Has This Been Tested?
thoroughly

## Markup:
```vue
<v-btn icon>X</v-btn>
<v-btn disabled>X</v-btn>
<v-btn flat>X</v-btn>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
