### PR TITLE
#2841 remove occurences of "all" property in data-iterable mixin

### DIFF
--- a/src/components/VDataTable/VDataTable.spec.js
+++ b/src/components/VDataTable/VDataTable.spec.js
@@ -239,4 +239,28 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
+
+  it('should initialize everyItem state', async () => {
+    const data = dataTableTestData()
+    data.propsData.value = data.propsData.items
+    const wrapper = mount(VDataTable, data)
+
+    expect(wrapper.vm.everyItem).toBe(true);
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should update everyItem state', async () => {
+    const data = dataTableTestData()
+    data.propsData.itemKey = 'other';
+    const wrapper = mount(VDataTable, data)
+
+    expect(wrapper.vm.everyItem).toBe(false);
+    wrapper.vm.value.push(wrapper.vm.items[0]);
+    expect(wrapper.vm.everyItem).toBe(false);
+
+    wrapper.vm.value.push(wrapper.vm.items[1]);
+    wrapper.vm.value.push(wrapper.vm.items[2]);
+    expect(wrapper.vm.everyItem).toBe(true);
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
 })

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -11,7 +11,7 @@ export default {
         const row = this.$scopedSlots.headers({
           headers: this.headers,
           indeterminate: this.indeterminate,
-          all: this.all
+          all: this.everyItem
         })
 
         children = [this.needsTR(row) ? this.genTR(row) : row, this.genTProgress()]
@@ -23,7 +23,7 @@ export default {
             light: this.light,
             color: this.selectAll === true ? '' : this.selectAll,
             hideDetails: true,
-            inputValue: this.all,
+            inputValue: this.everyItem,
             indeterminate: this.indeterminate
           },
           on: { change: this.toggle }

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -29,7 +29,6 @@ export default {
 
   data () {
     return {
-      all: false,
       searchLength: 0,
       defaultPagination: {
         descending: false,
@@ -211,17 +210,8 @@ export default {
   },
 
   watch: {
-    indeterminate (val) {
-      if (val) this.all = true
-    },
-    someItems (val) {
-      if (!val) this.all = false
-    },
     search () {
       this.updatePagination({ page: 1, totalItems: this.itemsLength })
-    },
-    everyItem (val) {
-      if (val) this.all = true
     }
   },
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The property 'all' in 'mixins/data-iterable.js' seems to be a duplicate of 'everyItem' This PR replaces the occurrences of 'all' with 'everyItem' because VDataTable is the only component affected.

Although this is a bug fix, this PR is submitted to 'dev' as VDataTable has already been split up here to 'data-iterable' mixin.

## Motivation and Context
See bug for VDataTable [#2841](https://github.com/vuetifyjs/vuetify/issues/2841).

## How Has This Been Tested?
No new tests - searched project for occurrences of data-iterable and 'all'

## Markup:
<!--- Paste markup that showcases your contribution --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

  