### PR TITLE
Fix for pixel gap between and after menu and scrollbar

### DIFF
--- a/src/components/VMenu/VMenu.spec.js
+++ b/src/components/VMenu/VMenu.spec.js
@@ -335,4 +335,39 @@ test('VMenu.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
+
+  it('should render component with rounded min-width and left and match snapshot', async () => {
+    const wrapper = mount(VMenu, {
+      propsData: {
+        value: false
+      },
+      slots: {
+        activator: [VBtn]
+      }
+    })
+
+    const getBoundingClientRect = () => {
+      return {
+        width: 100.5,
+        height: 100.25,
+        top: 0.75,
+        left: 50.123,
+        right: 75.987,
+        bottom: 4,
+        x: 0,
+        y: 0
+      }
+    }
+
+    wrapper.vm.$refs.activator.querySelector('.btn').getBoundingClientRect = getBoundingClientRect
+    wrapper.vm.$refs.content.getBoundingClientRect = getBoundingClientRect
+
+    wrapper.setProps({ value: true})
+
+    // There's gotta be a better way
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(wrapper.html()).toMatchSnapshot()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
 })

--- a/src/components/VMenu/__snapshots__/VMenu.spec.js.snap
+++ b/src/components/VMenu/__snapshots__/VMenu.spec.js.snap
@@ -364,6 +364,28 @@ exports[`VMenu.js should render component with custom transition and match snaps
 
 `;
 
+exports[`VMenu.js should render component with rounded min-width and left and match snapshot 1`] = `
+
+<div class="menu"
+     style="display: inline-block;"
+>
+  <div class="menu__activator menu__activator--active">
+    <button type="button"
+            class="btn"
+            data-ripple="true"
+    >
+      <div class="btn__content">
+      </div>
+    </button>
+  </div>
+  <div class="menu__content menuable__content__active menu-transition-enter-active menu-transition-enter-to"
+       style="max-height: auto; min-width: 101px; max-width: auto; top: 12px; left: 50px; z-index: 8; z-index: 8;"
+  >
+  </div>
+</div>
+
+`;
+
 exports[`VMenu.js should work 1`] = `
 
 <div class="menu"

--- a/src/mixins/menuable.js
+++ b/src/mixins/menuable.js
@@ -266,28 +266,33 @@ export default {
       return window.pageYOffset ||
         document.documentElement.scrollTop
     },
+    getRoundedBoundedClientRect(el) {
+      const rect = el.getBoundingClientRect()
+      return {
+        top: Math.round(rect.top),
+        left: Math.round(rect.left),
+        bottom: Math.round(rect.bottom),
+        right: Math.round(rect.right),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height)
+      }
+    },
     measure (el, selector) {
       el = selector ? el.querySelector(selector) : el
 
       if (!el || !this.hasWindow) return null
 
-      const rect = el.getBoundingClientRect()
-      let top = rect.top
-      let left = rect.left
+      const rect = this.getRoundedBoundedClientRect(el)
 
       // Account for activator margin
       if (this.isAttached) {
         const style = window.getComputedStyle(el)
 
-        left = parseInt(style.marginLeft)
-        top = parseInt(style.marginTop)
+        rect.left = parseInt(style.marginLeft)
+        rect.top = parseInt(style.marginTop)
       }
 
-      return {
-        bottom: rect.bottom,
-        right: rect.right,
-        top, left, width: rect.width, height: rect.height
-      }
+      return rect
     },
     sneakPeek (cb) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is sometimes a pixel gap between a menu dropdown and the menu dropdown's scrollbar, as well as an occasional pixel of background bleed-through on the right side of the scrollbar.  This is caused by fractional pixel values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This rounds the bounded client rect values to their nearest pixel integer for use in calculating menu position and width.  Math.round was chosen based on research that seems to indicate that browsers render sub-pixel values at the nearest pixel.  Math.round also seems to be the fastest alternative for rounding:  https://jsperf.com/math-round-vs-hack/5

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
New test added as well as playground

## Markup:
<!--- Paste markup that showcases your contribution --->
```
<template>
  <Boilerplate>
    <v-container fluid>
      <v-layout row wrap>
        <v-flex xs6>
          <v-subheader>Standard</v-subheader>
        </v-flex>
        <v-flex xs6>
          <v-select
            v-bind:items="items"
            v-model="e1"
            label="Select"
            single-line
            bottom
          ></v-select>
        </v-flex>
        <v-flex xs6>
          <v-subheader>Standard with focus</v-subheader>
        </v-flex>
        <v-flex xs6>
          <v-select
            v-bind:items="items"
            v-model="e2"
            label="Select"
            class="input-group--focused"
            item-value="text"
          ></v-select>
        </v-flex>
        <v-flex xs6>
          <v-subheader>Error</v-subheader>
        </v-flex>
        <v-flex xs6>
          <v-select
            label="Select"
            v-bind:items="items"
            v-model="e3"
            v-bind:error-messages="['Please select an option']"
            item-value="text"
          ></v-select>
        </v-flex>
        <v-flex xs6>
          <v-subheader>Disabled</v-subheader>
        </v-flex>
        <v-flex xs6>
          <v-select
            label="Select"
            v-bind:items="items"
            v-model="e4"
            disabled
          ></v-select>
        </v-flex>
      </v-layout>
    </v-container>
  </Boilerplate>
</template>

<script>
export default {
    data () {
      return {
        e1: null,
        e2: null,
        e3: null,
        e4: null,
        items: [
          { text: 'State 1' },
          { text: 'State 2' },
          { text: 'State 3' },
          { text: 'State 4' },
          { text: 'State 5' },
          { text: 'State 6' },
          { text: 'State 7' }
        ],
        states: [
          'Alabama','Alaska','American Samoa','Arizona',
          'Arkansas','California','Colorado','Connecticut',
          'Delaware','District of Columbia','Federated States of Micronesia',
          'Florida','Georgia','Guam','Hawaii','Idaho',
          'Illinois','Indiana','Iowa','Kansas','Kentucky',
          'Louisiana','Maine','Marshall Islands','Maryland',
          'Massachusetts','Michigan','Minnesota','Mississippi',
          'Missouri','Montana','Nebraska','Nevada',
          'New Hampshire','New Jersey','New Mexico','New York',
          'North Carolina','North Dakota','Northern Mariana Islands','Ohio',
          'Oklahoma','Oregon','Palau','Pennsylvania','Puerto Rico',
          'Rhode Island','South Carolina','South Dakota','Tennessee',
          'Texas','Utah','Vermont','Virgin Island','Virginia',
          'Washington','West Virginia','Wisconsin','Wyoming'
        ]
      }
    }
  }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
