### PR TITLE
fix: pagination for server-side data-table with search val

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -187,7 +187,7 @@ export default {
       return this.selectAll !== undefined && this.selectAll !== false
     },
     itemsLength () {
-      if (this.search) return this.searchLength || this.totalItems
+      if (this.search) return this.totalItems || this.searchLength
       return this.totalItems || this.items.length
     },
     indeterminate () {

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -187,7 +187,7 @@ export default {
       return this.selectAll !== undefined && this.selectAll !== false
     },
     itemsLength () {
-      if (this.search) return this.searchLength
+      if (this.search) return this.searchLength || this.totalItems
       return this.totalItems || this.items.length
     },
     indeterminate () {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed pagination for server-side data-table with search val, so computed prop `itemsLength` will use `totalItems` if available.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #2761 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
Snapshot tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
