### PR TITLE
feat(v-text-field) Add noResize prop

### DIFF
--- a/src/components/VForm/VForm.spec.js
+++ b/src/components/VForm/VForm.spec.js
@@ -85,12 +85,14 @@ test('VForm.js', ({ mount }) => {
     wrapper.vm.watchChild(input)
     await wrapper.vm.$nextTick()
 
-    expect(input._watchers.length).toBe(26)
+    // beware, depends on number of computeds in VTextField
+    const watchers = 28
+    expect(input._watchers.length).toBe(watchers)
     input.shouldValidate = false
     wrapper.vm.watchChild(input)
     await wrapper.vm.$nextTick()
 
-    expect(input._watchers.length).toBe(27)
+    expect(input._watchers.length).toBe(watchers + 1)
     input.shouldValidate = true
     await wrapper.vm.$nextTick()
 

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -41,10 +41,18 @@ export default {
     counter: [Boolean, Number, String],
     fullWidth: Boolean,
     multiLine: Boolean,
+    noResize: Boolean,
     placeholder: String,
     prefix: String,
+    rowHeight: {
+      type: [Number, String],
+      default: 24,
+      validator: v => !isNaN(parseFloat(v))
+    },
     rows: {
-      default: 5
+      type: [Number, String],
+      default: 5,
+      validator: v => !isNaN(parseInt(v, 10))
     },
     singleLine: Boolean,
     suffix: String,
@@ -64,6 +72,7 @@ export default {
         'input-group--single-line': this.singleLine || this.isSolo,
         'input-group--multi-line': this.multiLine,
         'input-group--full-width': this.fullWidth,
+        'input-group--no-resize': this.noResizeHandle,
         'input-group--prefix': this.prefix,
         'input-group--suffix': this.suffix,
         'input-group--textarea': this.textarea
@@ -108,8 +117,14 @@ export default {
         this.badInput ||
         ['time', 'date', 'datetime-local', 'week', 'month'].includes(this.type)
     },
+    isTextarea () {
+      return this.multiLine || this.textarea
+    },
+    noResizeHandle () {
+      return this.isTextarea && (this.noResize || this.shouldAutoGrow)
+    },
     shouldAutoGrow () {
-      return (this.multiLine || this.textarea) && this.autoGrow
+      return this.isTextarea && this.autoGrow
     }
   },
 
@@ -153,9 +168,8 @@ export default {
         const height = this.$refs.input
           ? this.$refs.input.scrollHeight
           : 0
-        const minHeight = this.rows * 24
-        const inputHeight = height < minHeight ? minHeight : height
-        this.inputHeight = inputHeight + (this.textarea ? 4 : 0)
+        const minHeight = parseInt(this.rows, 10) * parseFloat(this.rowHeight)
+        this.inputHeight = Math.max(minHeight, height)
       })
     },
     onInput (e) {
@@ -189,7 +203,7 @@ export default {
       // Prevents closing of a
       // dialog when pressing
       // enter
-      if (this.multiLine &&
+      if (this.isTextarea &&
         this.isFocused &&
         e.keyCode === 13
       ) {
@@ -207,7 +221,7 @@ export default {
       }, this.count)
     },
     genInput () {
-      const tag = this.multiLine || this.textarea ? 'textarea' : 'input'
+      const tag = this.isTextarea ? 'textarea' : 'input'
       const listeners = Object.assign({}, this.$listeners)
       delete listeners['change'] // Change should not be bound externally
 
@@ -240,7 +254,7 @@ export default {
 
       if (this.placeholder) data.domProps.placeholder = this.placeholder
 
-      if (!this.textarea && !this.multiLine) {
+      if (!this.isTextarea) {
         data.domProps.type = this.type
       } else {
         data.domProps.rows = this.rows

--- a/src/components/VTextField/VTextField.spec.js
+++ b/src/components/VTextField/VTextField.spec.js
@@ -371,10 +371,10 @@ test('VTextField.js', ({ mount }) => {
     wrapper.setProps({ value: '4444' })
     await wrapper.vm.$nextTick()
 
-    expect(value).toBe('44')    
+    expect(value).toBe('44')
     expect(input).toBeCalled()
   })
-  
+
   it('should mask value if return-masked-value is true', async () => {
     let value = '44'
     const component = {
@@ -391,18 +391,18 @@ test('VTextField.js', ({ mount }) => {
         })
       }
     }
-    
+
     const wrapper = mount(component)
     const input = wrapper.find('input')[0]
-    
+
     expect(value).toBe('4-4')
-    
+
     input.trigger('focus')
     await wrapper.vm.$nextTick()
     input.element.value = '33'
     input.trigger('input')
     await wrapper.vm.$nextTick()
-    
+
     expect(value).toBe('3-3')
   })
 
@@ -422,21 +422,21 @@ test('VTextField.js', ({ mount }) => {
         })
       }
     }
-    
+
     const wrapper = mount(component)
     const input = wrapper.find('input')[0]
-    
+
     expect(value).toBe('44')
-    
+
     input.trigger('focus')
     await wrapper.vm.$nextTick()
     input.element.value = '33'
     input.trigger('input')
     await wrapper.vm.$nextTick()
-    
+
     expect(value).toBe('33')
   })
-  
+
   it('should use pre-defined mask if prop matches', async () => {
     let value = '12311999'
     const component = {
@@ -453,9 +453,9 @@ test('VTextField.js', ({ mount }) => {
         })
       }
     }
-    
+
     const wrapper = mount(component)
-    
+
     expect(value).toBe('12/31/1999')
   })
 
@@ -501,7 +501,7 @@ test('VTextField.js', ({ mount }) => {
 
     const wrapper = mount(component)
     const input = wrapper.find('textarea')[0]
-    
+
     input.trigger('focus')
     await wrapper.vm.$nextTick()
     input.element.value = 'this is a really long text that should hopefully make auto-grow kick in. maybe?'
@@ -510,5 +510,55 @@ test('VTextField.js', ({ mount }) => {
 
     expect(wrapper.html()).toMatchSnapshot()
     expect(input.element.style.getPropertyValue('height').length).not.toBe(0)
+  })
+
+  it('should match multi-line snapshot', () => {
+    const wrapper = mount(VTextField, {
+      propsData: {
+        multiLine: true
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should match textarea snapshot', () => {
+    const wrapper = mount(VTextField, {
+      propsData: {
+        textarea: true
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should match auto-grow snapshot', async () => {
+    const wrapper = mount(VTextField, {
+      propsData: {
+        textarea: true,
+        autoGrow: true
+      }
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should render no-resize the same if already auto-grow', () => {
+    const wrappers = [
+      { autoGrow:true, multiLine: true },
+      { autoGrow:true, textarea: true }
+    ].map(propsData => mount(VTextField,{propsData}))
+
+    wrappers.forEach(async wrapper => {
+      await wrapper.vm.$nextTick()
+      const html1 = wrapper.html()
+
+      wrapper.setProps({ noResize: true })
+      // will still pass without this, do not remove
+      await wrapper.vm.$nextTick()
+      const html2 = wrapper.html()
+
+      expect(html2).toBe(html1)
+    })
   })
 })

--- a/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
+++ b/src/components/VTextField/__snapshots__/VTextField.spec.js.snap
@@ -2,11 +2,57 @@
 
 exports[`VTextField.js should calculate element height when using auto-grow prop 1`] = `
 
-<div class="input-group input-group--focused input-group--dirty input-group--text-field input-group--multi-line primary--text">
+<div class="input-group input-group--focused input-group--dirty input-group--text-field input-group--multi-line input-group--no-resize primary--text">
   <div class="input-group__input">
     <textarea tabindex="0"
               rows="5"
               style="height: 120px;"
+    >
+    </textarea>
+  </div>
+  <div class="input-group__details">
+  </div>
+</div>
+
+`;
+
+exports[`VTextField.js should match auto-grow snapshot 1`] = `
+
+<div class="input-group input-group--text-field input-group--no-resize input-group--textarea primary--text">
+  <div class="input-group__input">
+    <textarea tabindex="0"
+              rows="5"
+              style="height: 120px;"
+    >
+    </textarea>
+  </div>
+  <div class="input-group__details">
+  </div>
+</div>
+
+`;
+
+exports[`VTextField.js should match multi-line snapshot 1`] = `
+
+<div class="input-group input-group--text-field input-group--multi-line primary--text">
+  <div class="input-group__input">
+    <textarea tabindex="0"
+              rows="5"
+    >
+    </textarea>
+  </div>
+  <div class="input-group__details">
+  </div>
+</div>
+
+`;
+
+exports[`VTextField.js should match textarea snapshot 1`] = `
+
+<div class="input-group input-group--text-field input-group--textarea primary--text">
+  <div class="input-group__input">
+    <textarea tabindex="0"
+              rows="5"
     >
     </textarea>
   </div>

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -101,6 +101,11 @@ theme(textfield, "input-group--text-field")
     textarea::placeholder
       opacity: 0
 
+/** No Resize */
+.input-group--text-field
+  &.input-group--no-resize textarea
+      resize: none
+
 /** Types */
 .input-group--text-field
   // Icons


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the `resize: none` css attribute when a multiline input is `auto-grow`, or by manual `no-resize` attribute.
Also refactor all of the places that depend on the type of domnode to use a single `isTextarea` computed.
Also extract `row-height` as an attribute.
Also add validators to `row-height` and `rows` attributes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Manually resizing auto-grow inputs was undefined behavior and a bug.
Also visually removes the resize handle.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added snapshot and unit tests.
Manual testing.
<!--- Have you created new tests or updated existing ones? -->

## Markup:
<!--- Paste markup that showcases your contribution --->
```vue
<template>
  <v-app>
    <v-content>
      <v-layout flex>
        <v-card>
          <v-text-field v-model='model' auto-grow multi-line rows='1'>

          </v-text-field>
        </v-card>
      </v-layout>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      model: null
    })
  }
</script>
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes. 