### PR TITLE
Fixed stylus path for es5/index.js

### DIFF
--- a/build/babel-transform-stylus-paths.js
+++ b/build/babel-transform-stylus-paths.js
@@ -5,11 +5,11 @@ var wrapListener = require('babel-plugin-detective/wrap-listener');
 module.exports = wrapListener(listener, 'transform-stylus-paths');
 
 function listener(path, file, opts) {
-  const regex = /((?:\.\.\/)+)/gi
+  const regex = /((?:\.\.?\/)+)/gi
   if (path.isLiteral() && path.node.value.endsWith('.styl')) {
     const matches = regex.exec(path.node.value)
     if (!matches) return
-
-    path.node.value = path.node.value.replace(matches[0], `${matches[0]}../src/`)
+    const m = matches[0].startsWith('./') ? matches[0].substr(2) : matches[0]
+    path.node.value = path.node.value.replace(matches[0], `${m}../src/`)
   }
 }


### PR DESCRIPTION
In `es5/index.js` the path to stylus is wrong
```js
require('./stylus/app.styl');  // should be ../src/stylus/app.styl
```
This patch fixes it.