### PR TITLE
feature: Add outer-grid-{size} class to v-container

### DIFF
--- a/src/stylus/components/_grid.styl
+++ b/src/stylus/components/_grid.styl
@@ -15,11 +15,11 @@
 
   &.fluid
     max-width: 100%
-    
+
   &.fill-height
     align-items: center
     display: flex
-    
+
     .layout
       height: 100%
       flex: 1 1 auto
@@ -32,14 +32,36 @@
         .layout
           .flex
             padding: ($gutter / 2)
-            
+
         .layout:only-child
           margin: -($gutter / 2)
 
         .layout:not(:only-child)
           margin: auto -($gutter / 2)
-        
+
         *:not(:only-child)
+          .layout:first-child
+            margin-top: -($gutter / 2)
+
+          .layout:last-child
+            margin-bottom: -($gutter / 2)
+
+  &.outer-grid
+    for $size, $gutter in $grid-gutters
+      &-{$size}
+        padding: $gutter
+
+        > .layout
+          > .flex
+            padding: ($gutter / 2)
+
+        > .layout:only-child
+          margin: -($gutter / 2)
+
+        > .layout:not(:only-child)
+          margin: auto -($gutter / 2)
+
+        > *:not(:only-child)
           .layout:first-child
             margin-top: -($gutter / 2)
 
@@ -96,7 +118,7 @@ for size, width in $grid-breakpoints
 
   &-baseline
     align-items: baseline
-    
+
 .align-content
   &-start
     align-content: flex-start
@@ -152,26 +174,26 @@ for size, width in $grid-breakpoints
 
 .no-wrap
   white-space: nowrap
-  
+
 .ellipsis
   white-space: nowrap
   overflow: hidden
   text-overflow: ellipsis
-  
+
 // Display helpers
 .d-flex
   display: flex !important
-    
+
 .d-inline-flex
   display: inline-flex !important
-  
+
 .d-flex,
 .d-inline-flex
   > *
     flex: 1 1 auto !important
-    
+
 .d-block
   display: block !important
-  
+
 .d-inline-block
   display: inline-block !important


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the `outer-grid-{size}` class to `v-container`. It is the same as `grid-list-{size}` but only applies gutter padding to direct `v-layout` children. Allows nested `v-layout`s and more predictability.

## Motivation and Context
Say we want a list of tiles (v-cards) with gutter between them. Then inside those cards we want to have a separate layout. Current `grid-list` implementation adds padding to all its descendants and that inner card layout is all messed up.

## Markup:
```html
<!-- Playground.vue -->
<template>
  <v-app>
    <v-content>
      <h1>grid-list-xl</h1>
      <v-container fluid grid-list-xl>
        <v-layout wrap>
          <v-flex xs3 v-for="n in 8" :key="n">
            <v-card flat tile class="red">
                <v-layout wrap pa-3>
                  <v-flex xs12>We want another layout here</v-flex>
                  <v-flex xs12>But there's a ton of padding</v-flex>
                  <v-flex xs12>NotLikeThis</v-flex>
                </v-layout>
            </v-card>
          </v-flex>
        </v-layout>
      </v-container>
      <v-divider></v-divider>
      <h1>outer-grid-xl</h1>
      <v-container fluid outer-grid-xl>
        <v-layout wrap>
          <v-flex xs3 v-for="n in 8" :key="n">
            <v-card flat tile class="green">
                <v-layout wrap pa-3>
                  <v-flex xs12>We want another layout here</v-flex>
                  <v-flex xs12>Without any padding</v-flex>
                  <v-flex xs12>More predictable</v-flex>
                </v-layout>
            </v-card>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
