### PR TITLE
fix: icons now show in IE11 when Compatibility View is enabled

### DIFF
--- a/src/stylus/components/_icons.styl
+++ b/src/stylus/components/_icons.styl
@@ -13,6 +13,7 @@ theme(icon, "icon")
 .icon
   align-items: center
   display: inline-flex
+  font-feature-settings: 'liga'
   font-size: 24px
   justify-content: center
   line-height: 1


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Icons in IE11 when Compatibility View is enabled don't display. This has something to do with the way IE is handling font ligatures. While `<meta http-equiv="x-ua-compatible" content="ie=edge">` does force the browser to render IE without Compatibility View, for whatever reason font ligatures are still broken. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3020

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
No new automated tests.
Tested in IE11 with Compatibility View enabled for `localhost`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
