### PR TITLE
fix: expansion-panel can't find nested content

### DIFF
--- a/src/components/VExpansionPanel/VExpansionPanel.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.js
@@ -1,16 +1,23 @@
 require('../../stylus/components/_expansion-panel.styl')
 
 import Themeable from '../../mixins/themeable'
+import { provide as RegistrableProvide } from '../../mixins/registrable'
 
 export default {
   name: 'v-expansion-panel',
 
-  mixins: [Themeable],
+  mixins: [Themeable, RegistrableProvide('expansionPanel')],
 
   provide () {
     return {
       panelClick: this.panelClick,
       focusable: this.focusable
+    }
+  },
+
+  data () {
+    return {
+      items: []
     }
   },
 
@@ -22,27 +29,26 @@ export default {
   },
 
   methods: {
-    getChildren () {
-      return this.$children.filter(c => {
-        return c.$options && c.$options.name === 'v-expansion-panel-content'
-      })
-    },
     panelClick (uid) {
-      const children = this.getChildren()
-
       if (!this.expand) {
-        for (let index = children.length; --index >= 0;) {
-          children[index].toggle(uid)
+        for (let i = 0; i < this.items.length; i++) {
+          this.items[i].toggle(uid)
         }
         return
       }
 
-      for (let index = children.length; --index >= 0;) {
-        if (children[index]._uid === uid) {
-          children[index].toggle(uid)
+      for (let i = 0; i < this.items.length; i++) {
+        if (this.items[i].uid === uid) {
+          this.items[i].toggle(uid)
           return
         }
       }
+    },
+    register (uid, toggle) {
+      this.items.push({ uid, toggle })
+    },
+    unregister (uid) {
+      this.items = this.items.filter(i => i.uid !== uid)
     }
   },
 

--- a/src/components/VExpansionPanel/VExpansionPanelContent.js
+++ b/src/components/VExpansionPanel/VExpansionPanelContent.js
@@ -3,6 +3,7 @@ import { VExpandTransition } from '../transitions'
 import Bootable from '../../mixins/bootable'
 import Toggleable from '../../mixins/toggleable'
 import Rippleable from '../../mixins/rippleable'
+import { inject as RegistrableInject } from '../../mixins/registrable'
 
 import VIcon from '../VIcon'
 
@@ -11,7 +12,7 @@ import ClickOutside from '../../directives/click-outside'
 export default {
   name: 'v-expansion-panel-content',
 
-  mixins: [Bootable, Toggleable, Rippleable],
+  mixins: [Bootable, Toggleable, Rippleable, RegistrableInject('expansionPanel', 'v-expansion-panel', 'v-expansion-panel-content')],
 
   components: {
     VIcon
@@ -84,6 +85,14 @@ export default {
       // Needs time to calc height
       this.$nextTick(() => (this.isActive = isActive))
     }
+  },
+
+  mounted () {
+    this.expansionPanel.register(this._uid, this.toggle)
+  },
+
+  beforeDestroy () {
+    this.expansionPanel.unregister(this._uid)
   },
 
   render (h) {

--- a/src/components/VExpansionPanel/VExpansionPanelContent.spec.js
+++ b/src/components/VExpansionPanel/VExpansionPanelContent.spec.js
@@ -1,6 +1,8 @@
 import { test } from '@util/testing'
 import VExpansionPanelContent from './VExpansionPanelContent'
 
+const registrableWarning = '[Vuetify] The v-expansion-panel component must be used inside a v-expansion-panel-content'
+
 test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
   it('should render component and match snapshot', () => {
     const wrapper = mount(VExpansionPanelContent, {
@@ -16,6 +18,7 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
+    expect(registrableWarning).toHaveBeenTipped()
   })
 
   it('should respect hideActions prop', () => {
@@ -34,6 +37,7 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
+    expect(registrableWarning).toHaveBeenTipped()
   })
 
   it('should toggle panel on header click', async () => {
@@ -50,6 +54,7 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
     wrapper.find('.expansion-panel__header')[0].trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
+    expect(registrableWarning).toHaveBeenTipped()
   })
 
   it('should render an expanded component and match snapshot', () => {
@@ -64,6 +69,7 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
+    expect(registrableWarning).toHaveBeenTipped()
   })
 
   it('should render an expanded component with lazy prop and match snapshot', () => {
@@ -78,5 +84,6 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
+    expect(registrableWarning).toHaveBeenTipped()
   })
 })

--- a/src/mixins/registrable.js
+++ b/src/mixins/registrable.js
@@ -11,7 +11,7 @@ export function inject (namespace, child, parent) {
   } : null
 
   return {
-    name: 'registerable-inject',
+    name: 'registrable-inject',
 
     inject: {
       [namespace]: {
@@ -23,7 +23,7 @@ export function inject (namespace, child, parent) {
 
 export function provide (namespace) {
   return {
-    name: 'registerable-provide',
+    name: 'registrable-provide',
 
     methods: {
       register: null,


### PR DESCRIPTION
## Description
expansion-panel only looked for expansion-panel-content in direct children.
moved to use registrable mixin instead.

## Motivation and Context
fixes #2617

## How Has This Been Tested?
using markup from issue, and making sure tests pass

## Markup:
https://codepen.io/anon/pen/RjydZy

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
