### PR TITLE
fix: TypeScript declaration merging

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 import "vuetify/src/util/helpers";
 import {PluginFunction} from "vue";
 
-declare class Vuetify {
+export declare class Vuetify {
   static install: PluginFunction<never>;
 }
 
-declare class VuetifyApplication {
+export declare class VuetifyApplication {
   bar: number;
   bottom: number;
   left: number;
@@ -13,7 +13,7 @@ declare class VuetifyApplication {
   top: number;
 }
 
-declare class VuetifyBreakpoint {
+export declare class VuetifyBreakpoint {
   height: number;
   lg: boolean;
   lgAndDown: boolean;
@@ -35,7 +35,7 @@ declare class VuetifyBreakpoint {
   xsOnly: boolean;
 }
 
-declare class VuetifyTheme {
+export declare class VuetifyTheme {
   primary: string;
   accent: string;
   secondary: string;
@@ -45,7 +45,7 @@ declare class VuetifyTheme {
   success: string;
 }
 
-declare class VuetifyObject {
+export declare class VuetifyObject {
   application: VuetifyApplication;
   breakpoint: VuetifyBreakpoint;
   dark: boolean;


### PR DESCRIPTION
This PR will give developers the flexibility to modify/add to/merge `vuetify`'s declarations (`types`, `interfaces`, `classes`, etc.)

### Example:
```typescript
import * as Vuetify from 'vuetify'

export interface DaBestAppBreakpoints extends Vuetify.VuetifyBreakpoint {
	xxl: boolean
	xxlOnly: boolean
	xxs: boolean
	xxsOnly: boolean
}
```
Now I can modify the original `VuetifyBreakpoint` interface to my liking.
#### [`TypeScript Documentation: Declaration Merging`](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#basic-concepts)

### Words cannot even describe how well you are doing with this project!
Thanks friend =]

----

## Description
All I did was add `export` before the necessary `declare` statements.

## Motivation and Context
For better type safety and flexibility.

## How Has This Been Tested?
In my editor Sublime Text 3 with the TypeScript Plugin

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
