### PR TITLE
fix (v-date-picker): picker body doesnt't show in IE11

### DIFF
--- a/src/stylus/components/_pickers.styl
+++ b/src/stylus/components/_pickers.styl
@@ -55,8 +55,7 @@ theme(picker-title, "picker")
   overflow: hidden
   position: relative
 
-
-  flex: 1
+  flex: 1 0 auto
   display: flex
   flex-direction: column
   align-items: center


### PR DESCRIPTION

## How Has This Been Tested?
manually

## Markup:
`<v-date-picker></v-date-picker>`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
