### PR TITLE
fix: allow to override the elevation’s Stylus variables

### DIFF
--- a/src/stylus/settings/_elevations.styl
+++ b/src/stylus/settings/_elevations.styl
@@ -1,8 +1,8 @@
-$shadow-key-umbra-opacity = rgba(0,0,0, .2)
-$shadow-key-penumbra-opacity = rgba(0,0,0, .14)
-$shadow-key-ambient-opacity = rgba(0,0,0, .12)
+$shadow-key-umbra-opacity := rgba(0,0,0, .2)
+$shadow-key-penumbra-opacity := rgba(0,0,0, .14)
+$shadow-key-ambient-opacity := rgba(0,0,0, .12)
 
-$shadow-key-umbra = 0px 0px 0px 0px $shadow-key-umbra-opacity,
+$shadow-key-umbra := 0px 0px 0px 0px $shadow-key-umbra-opacity,
                     0px 2px 1px -1px $shadow-key-umbra-opacity,
                     0px 3px 1px -2px $shadow-key-umbra-opacity,
                     0px 3px 3px -2px $shadow-key-umbra-opacity,
@@ -28,7 +28,7 @@ $shadow-key-umbra = 0px 0px 0px 0px $shadow-key-umbra-opacity,
                     0px 11px 14px -7px $shadow-key-umbra-opacity,
                     0px 11px 15px -7px $shadow-key-umbra-opacity
 
-$shadow-key-penumbra = 0px 0px 0px 0px $shadow-key-penumbra-opacity,
+$shadow-key-penumbra := 0px 0px 0px 0px $shadow-key-penumbra-opacity,
                         0px 1px 1px 0px $shadow-key-penumbra-opacity,
                         0px 2px 2px 0px $shadow-key-penumbra-opacity,
                         0px 3px 4px 0px $shadow-key-penumbra-opacity,
@@ -54,7 +54,7 @@ $shadow-key-penumbra = 0px 0px 0px 0px $shadow-key-penumbra-opacity,
                         0px 23px 36px 3px $shadow-key-penumbra-opacity,
                         0px 24px 38px 3px $shadow-key-penumbra-opacity
 
-$shadow-key-ambient = 0px 0px 0px 0px $shadow-key-ambient-opacity,
+$shadow-key-ambient := 0px 0px 0px 0px $shadow-key-ambient-opacity,
                       0px 1px 3px 0px $shadow-key-ambient-opacity,
                       0px 1px 5px 0px $shadow-key-ambient-opacity,
                       0px 1px 8px 0px $shadow-key-ambient-opacity,


### PR DESCRIPTION
## Description
Changed the `=` operator to `:=` for all variables in [_elevations.styl](https://github.com/vuetifyjs/vuetify/blob/master/src/stylus/settings/_elevations.styl).

## Motivation and Context
It’s currently not possible to change `box-shadow` variations across the framework via Stylus, and a developer has to work around it with CSS.

## How Has This Been Tested?
Manually: I declared the variables before the imported [main.styl](https://github.com/vuetifyjs/vuetify/blob/master/src/stylus/main.styl) to make sure that the default ones can be overridden.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.