### PR TITLE
fix: stopped dialog activator event propagation

### DIFF
--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -141,7 +141,9 @@ export default {
         },
         { name: 'show', value: this.isActive }
       ],
-      on: { click: e => e.stopPropagation() }
+      on: {
+        click: e => { e.stopPropagation() }
+      }
     }
 
     if (!this.fullscreen) {
@@ -156,6 +158,7 @@ export default {
         'class': 'dialog__activator',
         on: {
           click: e => {
+            e.stopPropagation()
             if (!this.disabled) this.isActive = !this.isActive
           }
         }


### PR DESCRIPTION
## Description
dialog activator should not propagate click event

## Motivation and Context
closes #2942

## How Has This Been Tested?
was unable to create test, tested manually with markup

## Markup:
```
<v-layout @click="alert">
    <v-dialog>
        <v-btn slot="activator">Open Dialog</v-btn>
    </v-dialog>
</v-layout>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
