### PR TITLE
fix: generate row in data-table no-data slot

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -77,14 +77,11 @@ export default {
   },
 
   methods: {
-    needsTR (row) {
-      return row.length && row.find(c => c.tag === 'td' || c.tag === 'th')
+    hasTag (elements, tag) {
+      return Array.isArray(elements) && elements.find(e => e.tag === tag)
     },
     genTR (children, data = {}) {
       return this.$createElement('tr', data, children)
-    },
-    hasTR (row) {
-      return row.length && row.find(c => c.tag === 'tr')
     }
   },
 

--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -82,6 +82,9 @@ export default {
     },
     genTR (children, data = {}) {
       return this.$createElement('tr', data, children)
+    },
+    hasTR (row) {
+      return row.length && row.find(c => c.tag === 'tr')
     }
   },
 

--- a/src/components/VDataTable/VDataTable.spec.js
+++ b/src/components/VDataTable/VDataTable.spec.js
@@ -131,7 +131,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     data.propsData.search = "no such item"
     const wrapper = mount(VDataTable, data)
 
-    expect(wrapper.find('tbody td')[0].html()).toMatchSnapshot()
+    expect(wrapper.find('tbody tr td')[0].html()).toMatchSnapshot()
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
@@ -274,6 +274,25 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     }))
 
     expect(wrapper.find('table tbody tr td.custom-class').length).toBe(1)
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should render tr and td when using no-results slot', async () => {
+    const wrapper = mount(Vue.component('test', {
+      components: {
+        VDataTable
+      },
+      render (h) {
+        return h('v-data-table', {
+          props: {
+            items: [{}],
+            search: 'foo'
+          },
+        }, [h('div', { slot: 'no-results', class: 'custom-class' })])
+      }
+    }))
+
+    expect(wrapper.find('table tbody tr td div.custom-class').length).toBe(1)
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -55,7 +55,9 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
       </thead>
       <tbody>
         <tr>
-          <td colspan="3">
+          <td colspan="3"
+              class="text-xs-center"
+          >
             No data available
           </td>
         </tr>
@@ -246,7 +248,9 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
       </thead>
       <tbody>
         <tr>
-          <td colspan="3">
+          <td colspan="3"
+              class="text-xs-center"
+          >
             No matching records found
           </td>
         </tr>
@@ -676,7 +680,9 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
 
 exports[`VDataTable.vue should match display no-data-text when no data 1`] = `
 
-<td colspan="3">
+<td colspan="3"
+    class="text-xs-center"
+>
   foo
 </td>
 
@@ -684,7 +690,9 @@ exports[`VDataTable.vue should match display no-data-text when no data 1`] = `
 
 exports[`VDataTable.vue should match display no-results-text when no results 1`] = `
 
-<td colspan="3">
+<td colspan="3"
+    class="text-xs-center"
+>
   bar
 </td>
 

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -55,9 +55,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
       </thead>
       <tbody>
         <tr>
-          <td colspan="100%"
-              class="text-xs-center"
-          >
+          <td colspan="3">
             No data available
           </td>
         </tr>
@@ -248,9 +246,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
       </thead>
       <tbody>
         <tr>
-          <td colspan="100%"
-              class="text-xs-center"
-          >
+          <td colspan="3">
             No matching records found
           </td>
         </tr>
@@ -680,9 +676,7 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
 
 exports[`VDataTable.vue should match display no-data-text when no data 1`] = `
 
-<td colspan="100%"
-    class="text-xs-center"
->
+<td colspan="3">
   foo
 </td>
 
@@ -690,9 +684,7 @@ exports[`VDataTable.vue should match display no-data-text when no data 1`] = `
 
 exports[`VDataTable.vue should match display no-results-text when no results 1`] = `
 
-<td colspan="100%"
-    class="text-xs-center"
->
+<td colspan="3">
   bar
 </td>
 

--- a/src/components/VDataTable/mixins/body.js
+++ b/src/components/VDataTable/mixins/body.js
@@ -57,13 +57,14 @@ export default {
       return rows
     },
     genEmptyItems (content) {
-      if (typeof content === 'string') {
+      if (typeof content === 'string' || (!this.hasTR(content) && !this.needsTR(content))) {
         return this.genTR([this.$createElement('td', {
-          'class': 'text-xs-center',
-          attrs: { colspan: '100%' }
+          attrs: { colspan: `${this.headers.length}` }
         }, content)])
+      } else if (this.needsTR(content)) {
+        return this.genTR(content)
       } else {
-        return this.needsTR(content) ? this.genTR(content) : content
+        return content
       }
     }
   }

--- a/src/components/VDataTable/mixins/body.js
+++ b/src/components/VDataTable/mixins/body.js
@@ -41,7 +41,7 @@ export default {
         const props = this.createProps(item, index)
         const row = this.$scopedSlots.items(props)
 
-        rows.push(this.needsTR(row)
+        rows.push(this.hasTag(row, 'td')
           ? this.genTR(row, {
             key: index,
             attrs: { active: this.isSelected(item) }
@@ -57,14 +57,17 @@ export default {
       return rows
     },
     genEmptyItems (content) {
-      if (typeof content === 'string' || (!this.hasTR(content) && !this.needsTR(content))) {
-        return this.genTR([this.$createElement('td', {
-          attrs: { colspan: `${this.headers.length}` }
-        }, content)])
-      } else if (this.needsTR(content)) {
+      if (this.hasTag(content, 'tr')) {
+        return content
+      } else if (this.hasTag(content, 'td')) {
         return this.genTR(content)
       } else {
-        return content
+        return this.genTR([this.$createElement('td', {
+          class: {
+            'text-xs-center': typeof content === 'string'
+          },
+          attrs: { colspan: `${this.headers.length}` }
+        }, content)])
       }
     }
   }

--- a/src/components/VDataTable/mixins/foot.js
+++ b/src/components/VDataTable/mixins/foot.js
@@ -6,7 +6,7 @@ export default {
       }
 
       const footer = this.$slots.footer
-      const row = this.needsTR(footer) ? this.genTR(footer) : footer
+      const row = this.hasTag(footer, 'td') ? this.genTR(footer) : footer
 
       return this.$createElement('tfoot', [row])
     },

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -14,7 +14,7 @@ export default {
           all: this.everyItem
         })
 
-        children = [this.needsTR(row) ? this.genTR(row) : row, this.genTProgress()]
+        children = [this.hasTag(row, 'th') ? this.genTR(row) : row, this.genTProgress()]
       } else {
         const row = this.headers.map(o => this.genHeader(o))
         const checkbox = this.$createElement('v-checkbox', {


### PR DESCRIPTION
## Description
make sure to generate tr/td for no-data slot when needed

## Motivation and Context
closes #3088

## How Has This Been Tested?
created test. tested manually

## Markup:
```
<v-data-table
    :headers="headers"
    :items="items"
  >
  <template slot="no-data">
    <v-alert :value="true" color="error" icon="warning">
      Sorry, nothing to display here :(
    </v-alert>
  </template>
</v-data-table>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
