### PR TITLE
fix (v-time-picker): allow null value

### DIFF
--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -87,9 +87,7 @@ export default {
   },
 
   watch: {
-    value: 'setInputData',
-    inputHour: 'emitValue',
-    inputMinute: 'emitValue'
+    value: 'setInputData'
   },
 
   methods: {
@@ -103,6 +101,7 @@ export default {
       if (this.inputHour != null) {
         const newHour = this.inputHour + (period === 'am' ? -12 : 12)
         this.inputHour = this.firstAllowed('hour', newHour)
+        this.emitValue()
       }
     },
     setInputData (value) {
@@ -144,6 +143,7 @@ export default {
       } else {
         this.inputHour = this.isAmPm ? this.convert12to24(value, this.period) : value
       }
+      this.emitValue()
     },
     onChange () {
       if (!this.selectingHour) {

--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -102,19 +102,16 @@ export default {
       this.inputHour = inputHour
       this.inputMinute = inputMinute
     },
-    inputHour (val) {
+    inputHour: 'emitValue',
+    inputMinute: 'emitValue'
+  },
+
+  methods: {
+    emitValue () {
       if (this.inputHour != null && this.inputMinute != null) {
         this.$emit('input', `${pad(this.inputHour)}:${pad(this.inputMinute)}`)
       }
     },
-    inputMinute (val) {
-      if (this.inputHour != null && this.inputMinute != null) {
-        this.$emit('input', `${pad(this.inputHour)}:${pad(this.inputMinute)}`)
-      }
-    }
-  },
-
-  methods: {
     getInputTime (value) {
       if (value instanceof Date) {
         return {

--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -105,31 +105,23 @@ export default {
       }
     },
     setInputData (value) {
-      const { inputHour, inputMinute } = this.getInputTime(value)
-      this.inputHour = inputHour
-      this.inputMinute = inputMinute
-      if (inputHour != null) {
-        this.period = inputHour < 12 ? 'am' : 'pm'
-      }
-    },
-    getInputTime (value) {
-      if (value instanceof Date) {
-        return {
-          inputHour: value.getHours(),
-          inputMinute: value.getMinutes()
-        }
+      if (value == null) {
+        this.inputHour = null
+        this.inputMinute = null
+        return
       }
 
-      if (value) {
+      if (value instanceof Date) {
+        this.inputHour = value.getHours()
+        this.inputMinute = value.getMinutes()
+      } else {
         const [, hour, minute, , period] = value.trim().toLowerCase().match(/^(\d+):(\d+)(:\d+)?([ap]m)?$/, '') || []
 
-        return {
-          inputMinute: parseInt(minute, 10),
-          inputHour: period ? this.convert12to24(parseInt(hour, 10), period) : parseInt(hour, 10)
-        }
+        this.inputHour = period ? this.convert12to24(parseInt(hour, 10), period) : parseInt(hour, 10)
+        this.inputMinute = parseInt(minute, 10)
       }
 
-      return {}
+      this.period = this.inputHour < 12 ? 'am' : 'pm'
     },
     convert24to12 (hour) {
       return hour ? ((hour - 1) % 12 + 1) : 12
@@ -138,10 +130,10 @@ export default {
       return hour % 12 + (period === 'pm' ? 12 : 0)
     },
     onInput (value) {
-      if (!this.selectingHour) {
-        this.inputMinute = value
-      } else {
+      if (this.selectingHour) {
         this.inputHour = this.isAmPm ? this.convert12to24(value, this.period) : value
+      } else {
+        this.inputMinute = value
       }
       this.emitValue()
     },

--- a/src/components/VTimePicker/VTimePicker.spec.js
+++ b/src/components/VTimePicker/VTimePicker.spec.js
@@ -129,28 +129,6 @@ test('VTimePicker.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should set input hour when setting hour', () => {
-    const wrapper = mount(VTimePicker, {
-      propsData: {
-        value: '12:34'
-      }
-    })
-
-    wrapper.vm.hour = 15
-    expect(wrapper.vm.inputHour).toBe(15)
-  })
-
-  it('should set input minute when setting minute', () => {
-    const wrapper = mount(VTimePicker, {
-      propsData: {
-        value: '12:34'
-      }
-    })
-
-    wrapper.vm.minute = 15
-    expect(wrapper.vm.inputMinute).toBe(15)
-  })
-
   it('should set input hour when setting hour in 12hr mode', () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
@@ -291,25 +269,25 @@ test('VTimePicker.js', ({ mount }) => {
     expect(wrapper.vm.isAllowedHourCb(12)).toBe(true)
     expect(wrapper.vm.isAllowedHourCb(13)).toBe(false)
 
-    wrapper.vm.hour = 8
+    wrapper.vm.inputHour = 8
     expect(wrapper.vm.isAllowedMinuteCb(30)).toBe(false)
 
-    wrapper.vm.hour = 9
+    wrapper.vm.inputHour = 9
     expect(wrapper.vm.isAllowedMinuteCb(30)).toBe(false)
     expect(wrapper.vm.isAllowedMinuteCb(31)).toBe(false)
     expect(wrapper.vm.isAllowedMinuteCb(35)).toBe(true)
 
-    wrapper.vm.hour = 10
+    wrapper.vm.inputHour = 10
     expect(wrapper.vm.isAllowedMinuteCb(30)).toBe(true)
     expect(wrapper.vm.isAllowedMinuteCb(31)).toBe(false)
     expect(wrapper.vm.isAllowedMinuteCb(35)).toBe(true)
 
-    wrapper.vm.hour = 11
+    wrapper.vm.inputHour = 11
     expect(wrapper.vm.isAllowedMinuteCb(30)).toBe(false)
     expect(wrapper.vm.isAllowedMinuteCb(31)).toBe(false)
     expect(wrapper.vm.isAllowedMinuteCb(35)).toBe(false)
 
-    wrapper.vm.hour = 12
+    wrapper.vm.inputHour = 12
     expect(wrapper.vm.isAllowedMinuteCb(30)).toBe(true)
     expect(wrapper.vm.isAllowedMinuteCb(31)).toBe(false)
     expect(wrapper.vm.isAllowedMinuteCb(35)).toBe(false)

--- a/src/components/VTimePicker/VTimePicker.spec.js
+++ b/src/components/VTimePicker/VTimePicker.spec.js
@@ -4,20 +4,21 @@ import VTimePicker from '@components/VTimePicker'
 import VMenu from '@components/VMenu'
 
 test('VTimePicker.js', ({ mount }) => {
-  it('should accept a value', () => {
+  it('should accept a value', async () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '09:12:34'
       }
     })
 
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.selectingHour).toBe(true)
     expect(wrapper.vm.inputHour).toBe(9)
     expect(wrapper.vm.inputMinute).toBe(12)
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render landscape component', function () {
+  it('should render landscape component', async () => {
     var wrapper = mount(VTimePicker, {
       propsData: {
         value: '09:12:34',
@@ -25,6 +26,7 @@ test('VTimePicker.js', ({ mount }) => {
       }
     })
 
+    await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -39,7 +41,7 @@ test('VTimePicker.js', ({ mount }) => {
     expect(wrapper.find('.picker__title')).toHaveLength(0)
   })
 
-  it('should accept a date object for a value', () => {
+  it('should accept a date object for a value', async () => {
     const now = new Date('2017-01-01 12:00 AM')
     const wrapper = mount(VTimePicker, {
       propsData: {
@@ -47,19 +49,21 @@ test('VTimePicker.js', ({ mount }) => {
       }
     })
 
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.inputHour).toBe(0)
     expect(wrapper.vm.inputMinute).toBe(0)
     expect(wrapper.vm.period).toBe('am')
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should change am/pm when updated from model', () => {
+  it('should change am/pm when updated from model', async () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '9:00am'
       }
     })
 
+    await wrapper.vm.$nextTick()
     wrapper.setProps({ value: '9:00pm' })
 
     expect(wrapper.vm.period).toBe('pm')
@@ -106,7 +110,7 @@ test('VTimePicker.js', ({ mount }) => {
     expect(wrapper.vm.period).toBe('am')
   })
 
-  it('should render colored time picker', () => {
+  it('should render colored time picker', async () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '09:00:00',
@@ -115,10 +119,11 @@ test('VTimePicker.js', ({ mount }) => {
       }
     })
 
+    await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render colored time picker', () => {
+  it('should render colored time picker', async () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '09:00:00',
@@ -126,6 +131,7 @@ test('VTimePicker.js', ({ mount }) => {
       }
     })
 
+    await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -165,16 +171,18 @@ test('VTimePicker.js', ({ mount }) => {
     expect(wrapper.vm.getInputTime('7:34pm').inputHour).toBe(19)
   })
 
-  it('should update hour when changing period', () => {
+  it('should update hour when changing period', async () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '15:34'
       }
     })
 
-    wrapper.vm.period = 'am'
+    wrapper.vm.setPeriod('am')
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.inputHour).toBe(3)
-    wrapper.vm.period = 'pm'
+    wrapper.vm.setPeriod('pm')
+    await wrapper.vm.$nextTick()
     expect(wrapper.vm.inputHour).toBe(15)
   })
 

--- a/src/components/VTimePicker/VTimePicker.spec.js
+++ b/src/components/VTimePicker/VTimePicker.spec.js
@@ -165,10 +165,26 @@ test('VTimePicker.js', ({ mount }) => {
       }
     })
 
-    expect(wrapper.vm.getInputTime('12:34am')).toEqual({ inputHour: 0, inputMinute: 34 })
-    expect(wrapper.vm.getInputTime('7:34am').inputHour).toBe(7)
-    expect(wrapper.vm.getInputTime('12:34pm').inputHour).toBe(12)
-    expect(wrapper.vm.getInputTime('7:34pm').inputHour).toBe(19)
+    wrapper.vm.setInputData(new Date('2001-01-01 17:35'))
+    expect(wrapper.vm.inputHour).toBe(17)
+    expect(wrapper.vm.inputMinute).toBe(35)
+
+    wrapper.vm.setInputData(null)
+    expect(wrapper.vm.inputHour).toBe(null)
+    expect(wrapper.vm.inputMinute).toBe(null)
+
+    wrapper.vm.setInputData('12:34am')
+    expect(wrapper.vm.inputHour).toBe(0)
+    expect(wrapper.vm.inputMinute).toBe(34)
+
+    wrapper.vm.setInputData('7:34am')
+    expect(wrapper.vm.inputHour).toBe(7)
+
+    wrapper.vm.setInputData('12:34pm')
+    expect(wrapper.vm.inputHour).toBe(12)
+
+    wrapper.vm.setInputData('7:34pm')
+    expect(wrapper.vm.inputHour).toBe(19)
   })
 
   it('should update hour when changing period', async () => {

--- a/src/components/VTimePicker/VTimePickerClock.js
+++ b/src/components/VTimePicker/VTimePickerClock.js
@@ -48,10 +48,7 @@ export default {
       type: Number,
       default: 1
     },
-    value: {
-      type: Number,
-      required: true
-    }
+    value: Number
   },
 
   computed: {
@@ -75,6 +72,9 @@ export default {
     },
     radius () {
       return this.size / 2
+    },
+    displayedValue () {
+      return this.value == null ? this.min : this.value
     }
   },
 
@@ -87,7 +87,7 @@ export default {
   methods: {
     wheel (e) {
       e.preventDefault()
-      const value = this.value + Math.sign(e.wheelDelta || 1)
+      const value = this.displayedValue + Math.sign(e.wheelDelta || 1)
       this.update((value - this.min + this.count) % this.count + this.min)
     },
     handScale (value) {
@@ -101,7 +101,7 @@ export default {
 
       for (let value = this.min; value <= this.max; value = value + this.step) {
         const classes = {
-          active: value === this.value,
+          active: value === this.displayedValue,
           disabled: !this.isAllowed(value)
         }
 
@@ -115,12 +115,12 @@ export default {
       return children
     },
     genHand () {
-      const scale = `scaleY(${this.handScale(this.value)})`
-      const angle = this.rotate + this.degreesPerUnit * (this.value - this.min)
+      const scale = `scaleY(${this.handScale(this.displayedValue)})`
+      const angle = this.rotate + this.degreesPerUnit * (this.displayedValue - this.min)
 
       return this.$createElement('div', {
         staticClass: 'time-picker-clock__hand',
-        'class': this.addBackgroundColorClassChecks(),
+        'class': this.value == null ? {} : this.addBackgroundColorClassChecks(),
         style: {
           transform: `rotate(${angle}deg) ${scale}`
         }
@@ -189,6 +189,9 @@ export default {
   render (h) {
     const data = {
       staticClass: 'time-picker-clock',
+      class: {
+        'time-picker-clock--indeterminate': this.value == null
+      },
       on: {
         mousedown: this.onMouseDown,
         mouseup: this.onMouseUp,

--- a/src/components/VTimePicker/VTimePickerTitle.js
+++ b/src/components/VTimePicker/VTimePickerTitle.js
@@ -15,13 +15,11 @@ export default {
     ampm: Boolean,
     hour: Number,
     minute: Number,
+    period: {
+      type: String,
+      validator: period => period === 'am' || period === 'pm'
+    },
     selectingHour: Boolean
-  },
-
-  computed: {
-    period () {
-      return this.hour < 12 ? 'am' : 'pm'
-    }
   },
 
   methods: {

--- a/src/components/VTimePicker/VTimePickerTitle.js
+++ b/src/components/VTimePicker/VTimePickerTitle.js
@@ -13,17 +13,12 @@ export default {
 
   props: {
     ampm: Boolean,
-    selectingHour: Boolean,
-    value: String
+    hour: Number,
+    minute: Number,
+    selectingHour: Boolean
   },
 
   computed: {
-    hour () {
-      return parseInt(this.value.split(':')[0], 10)
-    },
-    minute () {
-      return parseInt(this.value.split(':')[1], 10)
-    },
     period () {
       return this.hour < 12 ? 'am' : 'pm'
     }
@@ -36,12 +31,15 @@ export default {
         hour = hour ? ((hour - 1) % 12 + 1) : 12
       }
 
+      const displayedHour = this.hour == null ? '--' : this.ampm ? hour : pad(hour)
+      const displayedMinute = this.minute == null ? '--' : pad(this.minute)
+
       return this.$createElement('div', {
         'class': 'time-picker-title__time'
       }, [
-        this.genPickerButton('selectingHour', true, this.ampm ? hour : pad(hour)),
+        this.genPickerButton('selectingHour', true, displayedHour),
         this.$createElement('span', ':'),
-        this.genPickerButton('selectingHour', false, pad(this.minute))
+        this.genPickerButton('selectingHour', false, displayedMinute)
       ])
     },
     genAmPm () {

--- a/src/components/VTimePicker/VTimePickerTitle.spec.js
+++ b/src/components/VTimePicker/VTimePickerTitle.spec.js
@@ -5,7 +5,8 @@ test('VTimePickerTitle.js', ({ mount }) => {
   it('should render component in 24hr', () => {
     const wrapper = mount(VTimePickerTitle, {
       propsData: {
-        value: '14:13',
+        hour: 14,
+        minute: 13,
         ampm: false
       }
     })
@@ -16,7 +17,8 @@ test('VTimePickerTitle.js', ({ mount }) => {
   it('should render component in 12hr', () => {
     const wrapper = mount(VTimePickerTitle, {
       propsData: {
-        value: '14:13',
+        hour: 14,
+        minute: 13,
         ampm: true
       }
     })
@@ -27,7 +29,8 @@ test('VTimePickerTitle.js', ({ mount }) => {
   it('should render component when selecting hour', () => {
     const wrapper = mount(VTimePickerTitle, {
       propsData: {
-        value: '14:13',
+        hour: 14,
+        minute: 13,
         selectingHour: true
       }
     })
@@ -38,7 +41,8 @@ test('VTimePickerTitle.js', ({ mount }) => {
   it('should emit event when clicked on am/pm', async () => {
     const wrapper = mount(VTimePickerTitle, {
       propsData: {
-        value: '14:13',
+        hour: 14,
+        minute: 13,
         ampm: true
       }
     })
@@ -52,7 +56,8 @@ test('VTimePickerTitle.js', ({ mount }) => {
     expect(period).toBeCalledWith('am')
 
     wrapper.setProps({
-      value: '2:13'
+      hour: 2,
+      minute: 13,
     })
     wrapper.find('.time-picker-title__ampm .picker__title__btn:not(.active)')[0].trigger('click')
     expect(period).toBeCalledWith('pm')
@@ -61,7 +66,8 @@ test('VTimePickerTitle.js', ({ mount }) => {
   it('should emit event when clicked on hours/minutes', async () => {
     const wrapper = mount(VTimePickerTitle, {
       propsData: {
-        value: '14:13'
+        hour: 14,
+        minute: 13,
       }
     })
 

--- a/src/components/VTimePicker/VTimePickerTitle.spec.js
+++ b/src/components/VTimePicker/VTimePickerTitle.spec.js
@@ -7,6 +7,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
       propsData: {
         hour: 14,
         minute: 13,
+        period: 'pm',
         ampm: false
       }
     })
@@ -19,6 +20,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
       propsData: {
         hour: 14,
         minute: 13,
+        period: 'pm',
         ampm: true
       }
     })
@@ -31,6 +33,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
       propsData: {
         hour: 14,
         minute: 13,
+        period: 'pm',
         selectingHour: true
       }
     })
@@ -43,6 +46,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
       propsData: {
         hour: 14,
         minute: 13,
+        period: 'pm',
         ampm: true
       }
     })
@@ -58,6 +62,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
     wrapper.setProps({
       hour: 2,
       minute: 13,
+      period: 'am'
     })
     wrapper.find('.time-picker-title__ampm .picker__title__btn:not(.active)')[0].trigger('click')
     expect(period).toBeCalledWith('pm')
@@ -68,6 +73,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
       propsData: {
         hour: 14,
         minute: 13,
+        period: 'pm'
       }
     })
 

--- a/src/stylus/components/_time-picker-clock.styl
+++ b/src/stylus/components/_time-picker-clock.styl
@@ -11,6 +11,16 @@ time-picker-clock($material)
     &.active
       color: $material-dark.buttons.disabled
 
+  &--indeterminate
+    .time-picker-clock__hand
+      background-color: $material.picker.indeterminateTime
+
+      &:after
+        color: $material.picker.indeterminateTime
+
+    > span.active
+      background-color: $material.picker.indeterminateTime
+
 theme(time-picker-clock, "time-picker-clock")
 
 .time-picker-clock

--- a/src/stylus/settings/_theme.styl
+++ b/src/stylus/settings/_theme.styl
@@ -79,6 +79,7 @@ $material-light := {
   picker: {
     body: #fff,
     clock: $grey.lighten-2,
+    indeterminateTime: $grey.base,
     title: $grey.lighten-2
   },
   bg-color: #fff
@@ -164,6 +165,7 @@ $material-dark := {
   picker: {
     body: #424242,
     clock: $grey.darken-2,
+    indeterminateTime: $grey.base,
     title: $grey.darken-2
   },
   bg-color: #303030

--- a/src/stylus/settings/_theme.styl
+++ b/src/stylus/settings/_theme.styl
@@ -79,7 +79,7 @@ $material-light := {
   picker: {
     body: #fff,
     clock: $grey.lighten-2,
-    indeterminateTime: $grey.base,
+    indeterminateTime: $grey.lighten-1,
     title: $grey.lighten-2
   },
   bg-color: #fff
@@ -165,7 +165,7 @@ $material-dark := {
   picker: {
     body: #424242,
     clock: $grey.darken-2,
-    indeterminateTime: $grey.base,
+    indeterminateTime: $grey.darken-1,
     title: $grey.darken-2
   },
   bg-color: #303030


### PR DESCRIPTION
## Description
Null value doesn't set the picker internals to the current time anymore
![timepicker](https://user-images.githubusercontent.com/15625235/35439552-cb999712-02cd-11e8-9330-d6b5eea38bd1.gif)


## Motivation and Context
fixes #2616

## How Has This Been Tested?
jest, manually

## Markup:
```vue
<template>
  <v-app id="app">
    <v-content>
      <v-container grid-list-xl>
        <v-layout>
          <v-flex xs6>
            <v-dialog ref="dialog" full-width v-model="modal" lazy width="330px" :return-value.sync="time">
              <v-text-field clearable readonly slot="activator" :value="displayTime" @input="time = null"></v-text-field>
              <v-time-picker v-model="time">
                <v-spacer></v-spacer>
                <v-btn flat @click="modal = false">Cancel</v-btn>
                <v-btn flat @click="$refs.dialog.save(time)">Save</v-btn>
              </v-time-picker>
            </v-dialog>
          </v-flex>
          <v-flex xs6>
            <v-time-picker v-model="time"></v-time-picker>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    modal: false,
    time: "3:15am"
  }),
  computed: {
    displayTime() {
      return `Formatted display time... ${this.time}`;
    }
  }
};
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
