### PR TITLE
fix(v-select): fixed select keyboard functionality

### DIFF
--- a/src/components/VSelect/VSelect-tags.spec.js
+++ b/src/components/VSelect/VSelect-tags.spec.js
@@ -293,6 +293,10 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     expect(change).toHaveBeenCalledWith(['foo'])
     expect(wrapper.vm.selectedIndex).toBe(0)
 
+    // Must be reset for input to update
+    wrapper.vm.selectedIndex = -1
+    await wrapper.vm.$nextTick()
+
     input.element.value = 'baz'
     await wrapper.vm.$nextTick()
     input.trigger('input')
@@ -343,6 +347,57 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(change).toBeCalledWith(['foo', 'baz'])
+    expect(wrapper.vm.selectedIndex).toBe(-1)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should not change search when selecting an index', () => {
+    const wrapper = mount(VSelect, {
+      attachToDocument: true,
+      propsData: {
+        chips: true,
+        multiple: true,
+        tags: true,
+        value: ['foo', 'bar']
+      }
+    })
+
+    const input = wrapper.find('input')[0]
+
+    input.trigger('focus')
+    expect(wrapper.vm.selectedIndex).toBe(-1)
+
+    input.trigger('keydown.left')
+    expect(wrapper.vm.selectedIndex).toBe(1)
+
+    input.element.value = 'fizz'
+    input.trigger('input')
+    expect(wrapper.vm.searchValue).toBe(null)
+
+    input.trigger('keydown.right')
+    expect(wrapper.vm.selectedIndex).toBe(-1)
+
+    input.element.value = 'fizz'
+    input.trigger('input')
+    expect(wrapper.vm.searchValue).toBe('fizz')
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should reset selected index when clicked', () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        items: ['foo']
+      }
+    })
+
+    const input = wrapper.find('input')[0]
+
+    wrapper.vm.selectedIndex = 0
+    input.trigger('focus')
+    expect(wrapper.vm.selectedIndex).toBe(0)
+    wrapper.trigger('click')
     expect(wrapper.vm.selectedIndex).toBe(-1)
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()

--- a/src/components/VSelect/mixins/select-computed.js
+++ b/src/components/VSelect/mixins/select-computed.js
@@ -21,7 +21,8 @@ export default {
         'input-group--multi-line': this.multiLine,
         'input-group--chips': this.chips,
         'input-group--multiple': this.multiple,
-        'input-group--open': this.menuIsVisible
+        'input-group--open': this.menuIsVisible,
+        'input-group--select--selecting-index': this.selectedIndex > -1
       }
 
       if (this.hasError) {

--- a/src/components/VSelect/mixins/select-events.js
+++ b/src/components/VSelect/mixins/select-events.js
@@ -45,7 +45,9 @@ export default {
             return this.showMenuItems()
           }
 
-          this.focus()
+          this.selectedIndex > -1
+            ? (this.selectedIndex = -1)
+            : this.focus()
         },
         focus: e => {
           if (this.disabled || this.readonly || this.isFocused) {

--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -125,6 +125,8 @@ export default {
         data.on = {
           ...this.genListeners(),
           input: e => {
+            if (this.selectedIndex > -1) return
+
             this.searchValue = this.unmaskText(e.target.value)
           }
         }

--- a/src/stylus/components/_select.styl
+++ b/src/stylus/components/_select.styl
@@ -40,6 +40,10 @@ theme(selects, "input-group--select")
       display: inline-block
       opacity: 1
 
+    &.input-group--select--selecting-index
+      .input-group--select__autocomplete
+        opacity: 0
+
     &.input-group--open
       .input-group__append-icon:not(.input-group__icon-clearable)
         transform: rotate(-180deg)


### PR DESCRIPTION
## Description
when selecting with left and right, should always hide and remove input from updating the
searchValue
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3069
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->

## Markup:
<!--- Paste markup that showcases your contribution --->
```vue
<template>
  <div id="app">
  <v-app id="inspire">
    <v-container fluid>
      <v-layout row wrap>
        <v-flex xs12 sm6>
          <v-subheader v-text="'Slots'"></v-subheader>
        </v-flex>
        <v-flex xs12 sm6>
          <v-select
            label="Select"
            v-bind:items="people"
            v-model="e11"
            item-text="name"
            item-value="name"
            multiple
            tags
            chips
            deletable-chips
            max-height="auto"
            autocomplete
          >
            <template slot="item" slot-scope="data">
              <template v-if="typeof data.item !== 'object'">
                <v-list-tile-content v-text="data.item"></v-list-tile-content>
              </template>
              <template v-else>
                <v-list-tile-avatar>
                </v-list-tile-avatar>
                <v-list-tile-content>
                  <v-list-tile-title v-html="data.item.name"></v-list-tile-title>
                  <v-list-tile-sub-title v-html="data.item.group"></v-list-tile-sub-title>
                </v-list-tile-content>
              </template>
            </template>
          </v-select>
        </v-flex>
      </v-layout>
    </v-container>
  </v-app>
</div>
</template>

<script>
export default {
  data () {
    let srcs = {
      1: '/static/doc-images/lists/1.jpg',
      2: '/static/doc-images/lists/2.jpg',
      3: '/static/doc-images/lists/3.jpg',
      4: '/static/doc-images/lists/4.jpg',
      5: '/static/doc-images/lists/5.jpg'
    }

    return {
      e11: [],
      people: [
        { header: 'Group 1'},
        { name: 'Sandra Adams', group: 'Group 1', avatar: srcs[1] },
        { name: 'Ali Connors', group: 'Group 1', avatar: srcs[2] },
        { name: 'Trevor Hansen', group: 'Group 1', avatar: srcs[3] },
        { divider: true },
        { header: 'Group 2'},
        { name: 'Britta Holt', group: 'Group 2', avatar: srcs[4] },
        { name: 'Jane Smith ', group: 'Group 2', avatar: srcs[5] },
      ]
    }
  }
}
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
