### PR TITLE
paramaterize sort icon

### DIFF
--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -1,6 +1,12 @@
 import { consoleWarn } from '../../../util/console'
 
 export default {
+  props: {
+    sortIcon: {
+      type: String,
+      default: 'arrow_upward'
+    }
+  },
   methods: {
     genTHead () {
       if (this.hideHeaders) return // Exit Early since no headers are needed.
@@ -99,7 +105,7 @@ export default {
         props: {
           small: true
         }
-      }, 'arrow_upward')
+      }, this.sortIcon)
       if (!header.align || header.align === 'left') {
         children.push(icon)
       } else {

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -7,7 +7,7 @@ export default {
       default: 'arrow_upward'
     }
   },
-  
+
   methods: {
     genTHead () {
       if (this.hideHeaders) return // Exit Early since no headers are needed.

--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -7,6 +7,7 @@ export default {
       default: 'arrow_upward'
     }
   },
+  
   methods: {
     genTHead () {
       if (this.hideHeaders) return // Exit Early since no headers are needed.


### PR DESCRIPTION
Adds the ability to set as a prop the v-icon for data table sort. 
`
<v-data-table  sort-icon="arrow_drop_down" .../>
`
## Description
- Added property "sortIcon"
- use this.sortIcon in genHeaderSortingData

## Motivation and Context
There is currently no way to override the default icon for sort in Data Tables

## How Has This Been Tested?
Ran locally, testing in company storybook

## Markup:

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
