### PR TITLE
prev/next-icon & expand-icon props

### DIFF
--- a/src/components/VCarousel/VCarousel.js
+++ b/src/components/VCarousel/VCarousel.js
@@ -41,13 +41,13 @@ export default {
       default: 6000,
       validator: value => value > 0
     },
-    prependIcon: {
-      type: [Boolean, String],
-      default: 'chevron_left'
-    },
-    appendIcon: {
+    nextIcon: {
       type: [Boolean, String],
       default: 'chevron_right'
+    },
+    prevIcon: {
+      type: [Boolean, String],
+      default: 'chevron_left'
     },
     value: Number
   },
@@ -182,8 +182,8 @@ export default {
         }
       }]
     }, [
-      this.hideControls ? null : this.genIcon('left', this.prependIcon, this.prev),
-      this.hideControls ? null : this.genIcon('right', this.appendIcon, this.next),
+      this.hideControls ? null : this.genIcon('left', this.prevIcon, this.prev),
+      this.hideControls ? null : this.genIcon('right', this.nextIcon, this.next),
       this.hideDelimiters ? null : this.genDelimiters(),
       this.$slots.default
     ])

--- a/src/components/VCarousel/VCarousel.spec.js
+++ b/src/components/VCarousel/VCarousel.spec.js
@@ -54,10 +54,10 @@ test('VCarousel.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom prepended icon and match snapshot', async () => {
+  it('should render component with custom prev icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
-        prependIcon: 'stop'
+        prevIcon: 'stop'
       }
     })
     await wrapper.vm.$nextTick()
@@ -66,10 +66,10 @@ test('VCarousel.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component without prepended icon and match snapshot', async () => {
+  it('should render component without prev icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
-        prependIcon: false
+        prevIcon: false
       }
     })
     await wrapper.vm.$nextTick()
@@ -78,10 +78,10 @@ test('VCarousel.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with custom appended icon and match snapshot', async () => {
+  it('should render component with custom next icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
-        appendIcon: 'stop'
+        nextIcon: 'stop'
       }
     })
     await wrapper.vm.$nextTick()
@@ -90,10 +90,10 @@ test('VCarousel.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component without appended icon and match snapshot', async () => {
+  it('should render component without next icon and match snapshot', async () => {
     const wrapper = mount(VCarousel, {
       propsData: {
-        appendIcon: false
+        nextIcon: false
       }
     })
     await wrapper.vm.$nextTick()

--- a/src/components/VCarousel/__snapshots__/VCarousel.spec.js.snap
+++ b/src/components/VCarousel/__snapshots__/VCarousel.spec.js.snap
@@ -37,43 +37,6 @@ exports[`VCarousel.js should render component and match snapshot 1`] = `
 
 `;
 
-exports[`VCarousel.js should render component with custom appended icon and match snapshot 1`] = `
-
-<div class="carousel">
-  <div class="carousel__left">
-    <button type="button"
-            class="btn btn--icon theme--dark"
-    >
-      <div class="btn__content">
-        <i aria-hidden="true"
-           class="icon material-icons"
-           style="font-size: 46px;"
-        >
-          chevron_left
-        </i>
-      </div>
-    </button>
-  </div>
-  <div class="carousel__right">
-    <button type="button"
-            class="btn btn--icon theme--dark"
-    >
-      <div class="btn__content">
-        <i aria-hidden="true"
-           class="icon material-icons"
-           style="font-size: 46px;"
-        >
-          stop
-        </i>
-      </div>
-    </button>
-  </div>
-  <div class="carousel__controls">
-  </div>
-</div>
-
-`;
-
 exports[`VCarousel.js should render component with custom duration between image cycles and match snapshot 1`] = `
 
 <div class="carousel">
@@ -214,7 +177,44 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
 
 `;
 
-exports[`VCarousel.js should render component with custom prepended icon and match snapshot 1`] = `
+exports[`VCarousel.js should render component with custom next icon and match snapshot 1`] = `
+
+<div class="carousel">
+  <div class="carousel__left">
+    <button type="button"
+            class="btn btn--icon theme--dark"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="icon material-icons"
+           style="font-size: 46px;"
+        >
+          chevron_left
+        </i>
+      </div>
+    </button>
+  </div>
+  <div class="carousel__right">
+    <button type="button"
+            class="btn btn--icon theme--dark"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="icon material-icons"
+           style="font-size: 46px;"
+        >
+          stop
+        </i>
+      </div>
+    </button>
+  </div>
+  <div class="carousel__controls">
+  </div>
+</div>
+
+`;
+
+exports[`VCarousel.js should render component with custom prev icon and match snapshot 1`] = `
 
 <div class="carousel">
   <div class="carousel__left">
@@ -391,29 +391,6 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
 
 `;
 
-exports[`VCarousel.js should render component without appended icon and match snapshot 1`] = `
-
-<div class="carousel">
-  <div class="carousel__left">
-    <button type="button"
-            class="btn btn--icon theme--dark"
-    >
-      <div class="btn__content">
-        <i aria-hidden="true"
-           class="icon material-icons"
-           style="font-size: 46px;"
-        >
-          chevron_left
-        </i>
-      </div>
-    </button>
-  </div>
-  <div class="carousel__controls">
-  </div>
-</div>
-
-`;
-
 exports[`VCarousel.js should render component without delimiters 1`] = `
 
 <div class="carousel">
@@ -479,7 +456,30 @@ exports[`VCarousel.js should render component without delimiters 1`] = `
 
 `;
 
-exports[`VCarousel.js should render component without prepended icon and match snapshot 1`] = `
+exports[`VCarousel.js should render component without next icon and match snapshot 1`] = `
+
+<div class="carousel">
+  <div class="carousel__left">
+    <button type="button"
+            class="btn btn--icon theme--dark"
+    >
+      <div class="btn__content">
+        <i aria-hidden="true"
+           class="icon material-icons"
+           style="font-size: 46px;"
+        >
+          chevron_left
+        </i>
+      </div>
+    </button>
+  </div>
+  <div class="carousel__controls">
+  </div>
+</div>
+
+`;
+
+exports[`VCarousel.js should render component without prev icon and match snapshot 1`] = `
 
 <div class="carousel">
   <div class="carousel__right">

--- a/src/components/VDatePicker/VDatePicker.date.spec.js
+++ b/src/components/VDatePicker/VDatePicker.date.spec.js
@@ -399,8 +399,8 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
   it('should use prev and next icons', () => {
     const wrapper = mount(VDatePicker, {
       propsData: {
-        prependIcon: 'block',
-        appendIcon: 'check'
+        prevIcon: 'block',
+        nextIcon: 'check'
       }
     })
 

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -53,10 +53,6 @@ export default {
 
   props: {
     allowedDates: Function,
-    appendIcon: {
-      type: String,
-      default: 'chevron_right'
-    },
     // Function formatting the day in date picker table
     dayFormat: {
       type: Function,
@@ -90,8 +86,12 @@ export default {
       type: Function,
       default: null
     },
+    nextIcon: {
+      type: String,
+      default: 'chevron_right'
+    },
     pickerDate: String,
-    prependIcon: {
+    prevIcon: {
       type: String,
       default: 'chevron_left'
     },
@@ -313,14 +313,14 @@ export default {
     genTableHeader () {
       return this.$createElement('v-date-picker-header', {
         props: {
-          appendIcon: this.appendIcon,
+          nextIcon: this.nextIcon,
           color: this.color,
           disabled: this.readonly,
           format: this.headerDateFormat,
           locale: this.locale,
           min: this.activePicker === 'DATE' ? this.minMonth : this.minYear,
           max: this.activePicker === 'DATE' ? this.maxMonth : this.maxYear,
-          prependIcon: this.prependIcon,
+          prevIcon: this.prevIcon,
           value: this.activePicker === 'DATE' ? `${this.tableYear}-${pad(this.tableMonth + 1)}` : `${this.tableYear}`
         },
         on: {

--- a/src/components/VDatePicker/VDatePicker.month.spec.js
+++ b/src/components/VDatePicker/VDatePicker.month.spec.js
@@ -205,8 +205,8 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     const wrapper = mount(VDatePicker, {
       propsData: {
         type: 'month',
-        prependIcon: 'block',
-        appendIcon: 'check'
+        prevIcon: 'block',
+        nextIcon: 'check'
       }
     })
 

--- a/src/components/VDatePicker/VDatePickerHeader.js
+++ b/src/components/VDatePicker/VDatePickerHeader.js
@@ -28,10 +28,6 @@ export default {
   },
 
   props: {
-    appendIcon: {
-      type: String,
-      default: 'chevron_right'
-    },
     disabled: Boolean,
     format: {
       type: Function,
@@ -43,7 +39,11 @@ export default {
     },
     min: String,
     max: String,
-    prependIcon: {
+    nextIcon: {
+      type: String,
+      default: 'chevron_right'
+    },
+    prevIcon: {
       type: String,
       default: 'chevron_left'
     },
@@ -90,7 +90,7 @@ export default {
           }
         }
       }, [
-        this.$createElement('v-icon', change < 0 ? this.prependIcon : this.appendIcon)
+        this.$createElement('v-icon', change < 0 ? this.prevIcon : this.nextIcon)
       ])
     },
     calculateChange (sign) {

--- a/src/components/VDatePicker/VDatePickerHeader.spec.js
+++ b/src/components/VDatePicker/VDatePickerHeader.spec.js
@@ -23,12 +23,12 @@ test('VDatePickerHeader.js', ({ mount }) => {
     expect(wrapper.find('.date-picker-header__value strong')[0].element.textContent).toBe('2005')
   })
 
-  it('should render prepend/append icons', () => {
+  it('should render prev/next icons', () => {
     const wrapper = mount(VDatePickerHeader, {
       propsData: {
         value: '2005',
-        prependIcon: 'foo',
-        appendIcon: 'bar'
+        prevIcon: 'foo',
+        nextIcon: 'bar'
       }
     })
 

--- a/src/components/VExpansionPanel/VExpansionPanelContent.js
+++ b/src/components/VExpansionPanel/VExpansionPanelContent.js
@@ -31,6 +31,10 @@ export default {
   },
 
   props: {
+    expandIcon: {
+      type: String,
+      default: 'keyboard_arrow_down'
+    },
     hideActions: Boolean,
     ripple: {
       type: [Boolean, Object],
@@ -70,7 +74,7 @@ export default {
       if (this.hideActions) return null
 
       const icon = this.$slots.actions ||
-        this.$createElement('v-icon', 'keyboard_arrow_down')
+        this.$createElement('v-icon', this.expandIcon)
 
       return this.$createElement('div', {
         staticClass: 'header__icon'

--- a/src/components/VExpansionPanel/VExpansionPanelContent.spec.js
+++ b/src/components/VExpansionPanel/VExpansionPanelContent.spec.js
@@ -40,6 +40,24 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
     expect(registrableWarning).toHaveBeenTipped()
   })
 
+  it('should render proper expand-icon', () => {
+    const wrapper = mount(VExpansionPanelContent, {
+      propsData: {
+        expandIcon: 'block'
+      },
+      slots: {
+        header: [compileToFunctions('<span>header</span>')]
+      },
+      provide: {
+        focusable: true,
+        panelClick: jest.fn()
+      }
+    })
+
+    expect(wrapper.find('.icon')[0].element.textContent).toBe('block')
+    expect(registrableWarning).toHaveBeenTipped()
+  })
+
   it('should toggle panel on header click', async () => {
     const wrapper = mount(VExpansionPanelContent, {
       slots: {

--- a/src/components/VTabs/VTabs.js
+++ b/src/components/VTabs/VTabs.js
@@ -62,13 +62,13 @@ export default {
 
   data () {
     return {
-      prependIconVisible: false,
-      appendIconVisible: false,
       bar: [],
       content: [],
       isBooted: false,
       isOverflowing: false,
       lazyValue: this.value,
+      nextIconVisible: false,
+      prevIconVisible: false,
       resizeTimeout: null,
       reverse: false,
       scrollOffset: 0,
@@ -83,10 +83,10 @@ export default {
   },
 
   methods: {
-    checkPrependIcon () {
+    checkPrevIcon () {
       return this.scrollOffset > 0
     },
-    checkAppendIcon () {
+    checkNextIcon () {
       // Check one scroll ahead to know the width of right-most item
       const container = this.$refs.container
       const wrapper = this.$refs.wrapper
@@ -220,8 +220,8 @@ export default {
 
   mounted () {
     this.callSlider()
-    this.prependIconVisible = this.checkPrependIcon()
-    this.appendIconVisible = this.checkAppendIcon()
+    this.prevIconVisible = this.checkPrevIcon()
+    this.nextIconVisible = this.checkNextIcon()
   },
 
   render (h) {

--- a/src/components/VTabs/VTabs.spec.js
+++ b/src/components/VTabs/VTabs.spec.js
@@ -159,14 +159,14 @@ test('VTabs', ({ mount, shallow }) => {
 
     await ssrBootable()
 
-    wrapper.vm.scrollTo('append')
-    wrapper.vm.scrollTo('prepend')
+    wrapper.vm.scrollTo('next')
+    wrapper.vm.scrollTo('prev')
     expect(newOffset.mock.calls.length).toBe(2)
 
     wrapper.setMethods({ newOffset: () => 5 })
     await wrapper.vm.$nextTick()
 
-    wrapper.vm.scrollTo('prepend')
+    wrapper.vm.scrollTo('prev')
     expect(wrapper.vm.scrollOffset).toBe(5)
   })
 
@@ -208,13 +208,13 @@ test('VTabs', ({ mount, shallow }) => {
     expect(wrapper.vm.target).toBe(null)
   })
 
-  it('should not conditionally render append and prepend icons', async () => {
+  it('should not conditionally render prev and next icons', async () => {
     const scrollTo = jest.fn()
     const wrapper = mount(VTabs, {
       attachToDocument: true
     })
 
-    expect(wrapper.vm.genIcon('prepend')).toBe(null)
+    expect(wrapper.vm.genIcon('prev')).toBe(null)
 
     // // Mock display state
     wrapper.setData({ isOverflowing: true, scrollOffset: 1 })
@@ -223,18 +223,18 @@ test('VTabs', ({ mount, shallow }) => {
     await ssrBootable()
     wrapper.setProps({ mobileBreakPoint: 1200 })
 
-    expect(wrapper.vm.genIcon('prepend')).toBeTruthy()
+    expect(wrapper.vm.genIcon('prev')).toBeTruthy()
 
     wrapper.setMethods({ scrollTo })
     // Since the elements will have no width
-    // trick append icon to show
+    // trick next icon to show
     wrapper.setData({ scrollOffset: -1 })
     await wrapper.vm.$nextTick()
 
-    const next = wrapper.find('.tabs__icon--append')[0]
+    const next = wrapper.find('.tabs__icon--next')[0]
     next.trigger('click')
     await wrapper.vm.$nextTick()
-    expect(scrollTo).toHaveBeenCalledWith('append')
+    expect(scrollTo).toHaveBeenCalledWith('next')
   })
 
   it('should call on touch methods', async () => {

--- a/src/components/VTabs/mixins/tabs-generators.js
+++ b/src/components/VTabs/mixins/tabs-generators.js
@@ -14,11 +14,11 @@ export default {
         }),
         ref: 'bar'
       }, [
-        this.genTransition('prepend'),
+        this.genTransition('prev'),
         this.genWrapper(
           this.genContainer(items)
         ),
-        this.genTransition('append')
+        this.genTransition('next')
       ])
     },
     genContainer (items) {

--- a/src/components/VTabs/mixins/tabs-props.js
+++ b/src/components/VTabs/mixins/tabs-props.js
@@ -6,10 +6,6 @@
 export default {
   props: {
     alignWithTitle: Boolean,
-    appendIcon: {
-      type: String,
-      default: 'chevron_right'
-    },
     centered: Boolean,
     fixedTabs: Boolean,
     grow: Boolean,
@@ -25,7 +21,11 @@ export default {
       default: 1264,
       validator: v => !isNaN(parseInt(v))
     },
-    prependIcon: {
+    nextIcon: {
+      type: String,
+      default: 'chevron_right'
+    },
+    prevIcon: {
       type: String,
       default: 'chevron_left'
     },

--- a/src/components/VTabs/mixins/tabs-touch.js
+++ b/src/components/VTabs/mixins/tabs-touch.js
@@ -8,7 +8,7 @@ export default {
     newOffset (direction) {
       const clientWidth = this.$refs.wrapper.clientWidth
 
-      if (direction === 'prepend') {
+      if (direction === 'prev') {
         return Math.max(this.scrollOffset - clientWidth, 0)
       } else {
         return Math.min(this.scrollOffset + clientWidth, this.$refs.container.clientWidth - clientWidth)

--- a/src/components/VTabs/mixins/tabs-watchers.js
+++ b/src/components/VTabs/mixins/tabs-watchers.js
@@ -31,8 +31,8 @@ export default {
     scrollOffset (val) {
       this.$refs.container.style.transform = `translateX(${-val}px)`
       if (this.hasArrows) {
-        this.prependIconVisible = this.checkPrependIcon()
-        this.appendIconVisible = this.checkAppendIcon()
+        this.prevIconVisible = this.checkPrevIcon()
+        this.nextIconVisible = this.checkNextIcon()
       }
     }
   }

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -56,6 +56,14 @@ export default {
       type: String,
       default: 'No matching records found'
     },
+    nextIcon: {
+      type: String,
+      default: 'chevron_right'
+    },
+    prevIcon: {
+      type: String,
+      default: 'chevron_left'
+    },
     rowsPerPageItems: {
       type: Array,
       default () {
@@ -361,7 +369,7 @@ export default {
         attrs: {
           'aria-label': 'Previous page' // TODO: Localization
         }
-      }, [this.$createElement('v-icon', 'chevron_left')])
+      }, [this.$createElement('v-icon', this.prevIcon)])
     },
     genNextIcon () {
       const pagination = this.computedPagination
@@ -386,7 +394,7 @@ export default {
         attrs: {
           'aria-label': 'Next page' // TODO: Localization
         }
-      }, [this.$createElement('v-icon', 'chevron_right')])
+      }, [this.$createElement('v-icon', this.nextIcon)])
     },
     genSelect () {
       return this.$createElement('div', {

--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -29,10 +29,10 @@ theme(tabs__bar, "tabs__bar")
   user-select: none
   width: 32px
 
-  &--prepend
+  &--prev
     left: 4px
 
-  &--append
+  &--next
     right: 4px
 
 .tabs__wrapper


### PR DESCRIPTION
## Description
- `v-carousel`: renamed **append-icon** and **prepend-icon** props to **next-icon** and **prev-icon**
- `v-date-picker`: renamed **append-icon** and **prepend-icon** props to **next-icon** and **prev-icon**
- `v-tabs`: renamed **append-icon** and **prepend-icon** props to **next-icon** and **prev-icon**
- `data-iterable` (affects `v-data-table` and `v-data-iterator`): added **next-icon** and **prev-icon** props
- `v-expansion-panel-content`: added **expand-icon** prop

## Motivation and Context
Unification of prop names and making their names matching their semantics

## How Has This Been Tested?
jest, docs

## Markup:
docs for carousel, tabs, picker, pagination

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

## Docs
https://github.com/vuetifyjs/vuetifyjs.com/pull/253