### PR TITLE
fix(v-date-picker-title): fixed improper comparison for transition

### DIFF
--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -299,7 +299,8 @@ export default {
           date: this.formatters.titleDate(this.inputDate),
           selectingYear: this.activePicker === 'YEAR',
           year: this.formatters.year(`${this.year}`),
-          yearIcon: this.yearIcon
+          yearIcon: this.yearIcon,
+          value: this.inputDate
         },
         slot: 'title',
         style: this.readonly ? {

--- a/src/components/VDatePicker/VDatePickerTitle.js
+++ b/src/components/VDatePicker/VDatePickerTitle.js
@@ -44,8 +44,7 @@ export default {
   },
 
   watch: {
-    value: 'setReversing',
-    year: 'setReversing'
+    value: 'setReversing'
   },
 
   methods: {

--- a/src/components/VDatePicker/VDatePickerTitle.js
+++ b/src/components/VDatePicker/VDatePickerTitle.js
@@ -44,7 +44,9 @@ export default {
   },
 
   watch: {
-    value: 'setReversing'
+    value (val, prev) {
+      this.isReversing = val < prev
+    }
   },
 
   methods: {
@@ -75,9 +77,6 @@ export default {
     },
     genTitleDate (title) {
       return this.genPickerButton('selectingYear', false, this.genTitleText(title), 'date-picker-title__date')
-    },
-    setReversing (val, prev) {
-      this.isReversing = val < prev
     }
   },
 

--- a/src/components/VDatePicker/VDatePickerTitle.js
+++ b/src/components/VDatePicker/VDatePickerTitle.js
@@ -31,6 +31,9 @@ export default {
     },
     yearIcon: {
       type: String
+    },
+    value: {
+      type: String
     }
   },
 
@@ -41,7 +44,7 @@ export default {
   },
 
   watch: {
-    date: 'setReversing',
+    value: 'setReversing',
     year: 'setReversing'
   },
 
@@ -67,7 +70,7 @@ export default {
       }, [
         this.$createElement('div', {
           domProps: { innerHTML: this.date },
-          key: this.date
+          key: this.value
         })
       ])
     },

--- a/src/components/VDatePicker/VDatePickerTitle.spec.js
+++ b/src/components/VDatePicker/VDatePickerTitle.spec.js
@@ -59,4 +59,30 @@ test('VDatePickerTitle.js', ({ mount }) => {
     wrapper.find('.date-picker-title__year')[0].trigger('click')
     expect(input).toBeCalledWith(false)
   })
+
+  it('should have the correct transition', () => {
+    const wrapper = mount(VDatePickerTitle, {
+      propsData: {
+        year: '2018',
+        date: 'Tue, Mar 3',
+        value: '2018-03-03'
+      }
+    })
+
+    expect(wrapper.vm.isReversing).toBe(false)
+
+    wrapper.setProps({
+      date: 'Wed, Mar 4',
+      value: '2018-03-04'
+    })
+
+    expect(wrapper.vm.isReversing).toBe(false)
+
+    wrapper.setProps({
+      date: 'Wed, Mar 3',
+      value: '2018-03-03'
+    })
+
+    expect(wrapper.vm.isReversing).toBe(true)
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
was comparing the formatted string value of `date` when determining the transition direction.
updated to use the iso value
<!--- Describe your changes in detail -->

## Motivation and Context
incorrect transition when changing dates
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest/visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->

## Markup:
```vue
<template>
  <v-app id="app" dark>
    <v-content>
      <v-container grid-list-xl>
        <v-layout>
          <v-flex xs4>
            <v-dialog ref="dialog" full-width v-model="modal" lazy width="330px">
              <v-text-field label="Date" readonly slot="activator" v-model="date" clearable></v-text-field>
              <v-date-picker v-model="date" @input="modal = false"></v-date-picker>
            </v-dialog>
          </v-flex>
          <v-flex xs4>
            <div class="headline">reactive: true</div>
            <v-date-picker reactive v-model="date"></v-date-picker>
          </v-flex>
          <v-flex xs4>
            <div class="headline">reactive: false</div>
            <v-date-picker v-model="date"></v-date-picker>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    modal: false,
    date: null
  })
};
</script>
```
<!--- Paste markup that showcases your contribution --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
