### PR TITLE
fix (v-picker): reverted default width to 290px

### DIFF
--- a/src/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -18,7 +18,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -389,7 +389,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -760,7 +760,7 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -1142,7 +1142,7 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -1546,7 +1546,7 @@ exports[`VDatePicker.js should render component with min/max props 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -1944,7 +1944,7 @@ exports[`VDatePicker.js should render component with min/max props 2`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="fade-transition-leave fade-transition-leave-active">
       <div class="date-picker-header">
@@ -2508,7 +2508,7 @@ exports[`VDatePicker.js should render component with min/max props 3`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="fade-transition-leave fade-transition-leave-active">
       <div class="date-picker-header">
@@ -3081,7 +3081,7 @@ exports[`VDatePicker.js should render readonly picker 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div style="pointer-events: none;">
       <div class="date-picker-header">

--- a/src/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
+++ b/src/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
@@ -149,7 +149,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -327,7 +327,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">
@@ -628,7 +628,7 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div>
       <div class="date-picker-header">

--- a/src/components/VPicker/VPicker.js
+++ b/src/components/VPicker/VPicker.js
@@ -31,7 +31,7 @@ export default {
     },
     width: {
       type: [Number, String],
-      default: 330,
+      default: 290,
       validator: value => parseInt(value, 10) > 0
     }
   },

--- a/src/components/VPicker/__snapshots__/VPicker.spec.js.snap
+++ b/src/components/VPicker/__snapshots__/VPicker.spec.js.snap
@@ -11,7 +11,7 @@ exports[`VPicker.js should render component with title and match snapshot 1`] = 
     </span>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <span>
       default
@@ -27,7 +27,7 @@ exports[`VPicker.js should render component without title and match snapshot 1`]
      style="height: auto;"
 >
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <span>
       default
@@ -48,7 +48,7 @@ exports[`VPicker.js should render dark component and match snapshot 1`] = `
     </span>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <span>
       default

--- a/src/components/VTimePicker/__snapshots__/VTimePicker.spec.js.snap
+++ b/src/components/VTimePicker/__snapshots__/VTimePicker.spec.js.snap
@@ -29,13 +29,13 @@ exports[`VTimePicker.js should accept a date object for a value 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="time-picker-clock__container"
-         style="width: 330px; height: 330px;"
+         style="width: 290px; height: 290px;"
     >
       <div class="time-picker-clock"
-           style="height: 310px; width: 310px;"
+           style="height: 270px; width: 270px;"
       >
         <div class="time-picker-clock__hand accent">
         </div>
@@ -135,13 +135,13 @@ exports[`VTimePicker.js should accept a value 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="time-picker-clock__container"
-         style="width: 330px; height: 330px;"
+         style="width: 290px; height: 290px;"
     >
       <div class="time-picker-clock"
-           style="height: 310px; width: 310px;"
+           style="height: 270px; width: 270px;"
       >
         <div class="time-picker-clock__hand accent">
         </div>
@@ -241,13 +241,13 @@ exports[`VTimePicker.js should change am/pm when updated from model 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="time-picker-clock__container"
-         style="width: 330px; height: 330px;"
+         style="width: 290px; height: 290px;"
     >
       <div class="time-picker-clock"
-           style="height: 310px; width: 310px;"
+           style="height: 270px; width: 270px;"
       >
         <div class="time-picker-clock__hand accent">
         </div>
@@ -347,13 +347,13 @@ exports[`VTimePicker.js should render colored time picker 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="time-picker-clock__container"
-         style="width: 330px; height: 330px;"
+         style="width: 290px; height: 290px;"
     >
       <div class="time-picker-clock"
-           style="height: 310px; width: 310px;"
+           style="height: 270px; width: 270px;"
       >
         <div class="time-picker-clock__hand primary">
         </div>
@@ -453,13 +453,13 @@ exports[`VTimePicker.js should render colored time picker 2`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="time-picker-clock__container"
-         style="width: 330px; height: 330px;"
+         style="width: 290px; height: 290px;"
     >
       <div class="time-picker-clock"
-           style="height: 310px; width: 310px;"
+           style="height: 270px; width: 270px;"
       >
         <div class="time-picker-clock__hand orange darken-1">
         </div>
@@ -559,13 +559,13 @@ exports[`VTimePicker.js should render landscape component 1`] = `
     </div>
   </div>
   <div class="picker__body"
-       style="width: 330px;"
+       style="width: 290px;"
   >
     <div class="time-picker-clock__container"
-         style="width: 330px; height: 270px;"
+         style="width: 290px; height: 230px;"
     >
       <div class="time-picker-clock"
-           style="height: 250px; width: 250px;"
+           style="height: 210px; width: 210px;"
       >
         <div class="time-picker-clock__hand accent">
         </div>

--- a/src/mixins/picker.js
+++ b/src/mixins/picker.js
@@ -24,7 +24,7 @@ export default {
     noTitle: Boolean,
     width: {
       type: [Number, String],
-      default: 330,
+      default: 290,
       validator: value => parseInt(value, 10) > 0
     }
   },

--- a/src/stylus/components/_date-picker-table.styl
+++ b/src/stylus/components/_date-picker-table.styl
@@ -13,7 +13,7 @@ theme(date-picker-table, "date-picker-table")
 .date-picker-table
   position: relative
   padding: 0 12px
-  height: 290px
+  height: 242px
 
   table
     transition: $primary-transition
@@ -29,8 +29,8 @@ theme(date-picker-table, "date-picker-table")
     font-size: 12px
 
   &--date .btn
-    height: 40px
-    width: 40px
+    height: 32px
+    width: 32px
 
   .btn
     z-index: auto
@@ -63,7 +63,7 @@ theme(date-picker-table, "date-picker-table")
 
 .date-picker-table__event
   border-radius: 50%
-  bottom: 6px
+  bottom: 2px
   content: ""
   display: block
   height: 8px
@@ -72,15 +72,3 @@ theme(date-picker-table, "date-picker-table")
   transform: translateX(-4px)
   width: 8px
 
-.picker--landscape
-  .date-picker-table
-  .date-picker-table
-    height: 242px
-
-  .date-picker-table--date
-    .btn
-      height: 32px
-      width: 32px
-
-  .date-picker-table__event
-    bottom: 2px


### PR DESCRIPTION
## Description
Change default picker width from 330px to 290px (like it was in 0.17)
It's a breaking change comparing to previous beta, but not comparing to 0.17 branch

## Motivation and Context
330px width was a breaking change that also made pickers cropped in new docs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

## Docs
https://github.com/vuetifyjs/vuetifyjs.com/pull/261