### PR TITLE
fix: reset page to 1 when sorting changes

### DIFF
--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -221,9 +221,8 @@ export default {
     search () {
       this.updatePagination({ page: 1, totalItems: this.itemsLength })
     },
-    'computedPagination.sortBy': function () {
-      this.updatePagination({ page: 1 })
-    }
+    'computedPagination.sortBy': function () { this.updatePagination({ page: 1 }) },
+    'computedPagination.descending': function () { this.updatePagination({ page: 1 }) }
   },
 
   methods: {

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -220,6 +220,9 @@ export default {
   watch: {
     search () {
       this.updatePagination({ page: 1, totalItems: this.itemsLength })
+    },
+    'computedPagination.sortBy': function () {
+      this.updatePagination({ page: 1 })
     }
   },
 


### PR DESCRIPTION
## Description
Pagination should reset when changing sortBy.

## Motivation and Context
There is very little correlation between page 5 of sorting on X and sorting on Y.

## How Has This Been Tested?
Quick test in playground

## Markup:
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
