### PR TITLE
feat: **persistent** prop for v-edit-dialog

### DIFF
--- a/src/components/VDataTable/VEditDialog.js
+++ b/src/components/VDataTable/VEditDialog.js
@@ -21,6 +21,7 @@ export default {
     },
     large: Boolean,
     lazy: Boolean,
+    persistent: Boolean,
     saveText: {
       default: 'Save'
     },
@@ -85,6 +86,7 @@ export default {
         origin: 'top right',
         right: true,
         value: this.isActive,
+        closeOnClick: !this.persistent,
         closeOnContentClick: false,
         lazy: this.lazy
       },


### PR DESCRIPTION
## Description
Adds **persistent** prop to `v-edit-dialog`

## Motivation and Context
fixes #3195

## How Has This Been Tested?
docs

## Markup:
`<v-edit-dialog persistent>...</v-edit-dialog>`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

## Docs
https://github.com/vuetifyjs/vuetifyjs.com/pull/267