### PR TITLE
Add missing import of VueComponent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import 'vuetify/src/util/helpers'
-import { PluginFunction } from 'vue'
+import { PluginFunction, Component as VueComponent } from 'vue'
 
 declare class Vuetify {
   static install: PluginFunction<never>


### PR DESCRIPTION
## Description

As commented here. The `index.d.ts` file is missing an import: https://github.com/vuetifyjs/vuetify/commit/c62506034101dcde8e69c783d0ace0d3cd586cb5#r27374199

This PR adds the missing import.

I'm not 100% sure if `VueComponent` is supposed to be the `Component` from `'vue'` but from the wording it sounds like it is meant to be?

## Motivation and Context

Fix TS compiler complains about an undefined name `VueComponent`:

```
ERROR in /home/bikeshedder/projects/vuetify-test/node_modules/vuetify/index.d.ts
91:50 Cannot find name 'VueComponent'.
    89 |   theme: VuetifyTheme
    90 |   options: VuetifyOptions
  > 91 |   goTo: (target: string | number | HTMLElement | VueComponent, options?: VuetifyGoToOptions) => void
       |                                                  ^
    92 | }
    93 | 
    94 | declare module 'vue/types/vue' {
```

## How Has This Been Tested?

I fixed the file locally and the error goes away.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
