### PR TITLE
Fix v-snackbar color prop

### DIFF
--- a/src/components/VSnackbar/VSnackbar.js
+++ b/src/components/VSnackbar/VSnackbar.js
@@ -28,7 +28,7 @@ export default {
 
   computed: {
     classes () {
-      return this.addBackgroundColorClassChecks({
+      return {
         'snack--active': this.isActive,
         'snack--absolute': this.absolute,
         'snack--auto-height': this.autoHeight,
@@ -38,7 +38,7 @@ export default {
         'snack--right': this.right,
         'snack--top': this.top,
         'snack--vertical': this.vertical
-      })
+      }
     }
   },
 
@@ -75,7 +75,8 @@ export default {
           on: this.$listeners
         }, [
           h('div', {
-            staticClass: 'snack__wrapper'
+            staticClass: 'snack__wrapper',
+            class: this.addBackgroundColorClassChecks()
           }, [
             h('div', {
               staticClass: 'snack__content'

--- a/src/components/VSnackbar/VSnackbar.spec.js
+++ b/src/components/VSnackbar/VSnackbar.spec.js
@@ -12,7 +12,7 @@ test('VSnackbar.vue', ({ mount }) => {
     expect(wrapper.hasClass('snack')).toBe(true)
   })
 
-  it('should have a color class', () => {
+  it('should have a snack__wrapper with a color class', () => {
     const wrapper = mount(VSnackbar, {
       propsData: {
         value: true,
@@ -20,8 +20,8 @@ test('VSnackbar.vue', ({ mount }) => {
       }
     })
 
-    expect(wrapper.hasClass('orange')).toBe(true)
-    expect(wrapper.hasClass('lighten-2')).toBe(true)
+    expect(wrapper.find('.snack__wrapper.orange')).toHaveLength(1)
+    expect(wrapper.find('.snack__wrapper.lighten-2')).toHaveLength(1)
   })
 
   it('should have a snack__content class only when active', async () => {


### PR DESCRIPTION
This PR fixes the color prop for `v-select`.

## Description
Due to https://github.com/vuetifyjs/vuetify/pull/3155, the color was applied to the wrong DOM element.

## Motivation and Context
Fixes https://github.com/vuetifyjs/vuetify/issues/3199

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
