### PR TITLE
Added clearable-icon prop on v-text-field and v-select

### DIFF
--- a/src/components/VSelect/mixins/select-props.js
+++ b/src/components/VSelect/mixins/select-props.js
@@ -15,7 +15,10 @@ export default {
     cacheItems: Boolean,
     chips: Boolean,
     clearable: Boolean,
-    clearableIcon: String,
+    clearableIcon: {
+      type: String,
+      default: 'clear'
+    },
     combobox: Boolean,
     contentClass: String,
     deletableChips: Boolean,

--- a/src/components/VSelect/mixins/select-props.js
+++ b/src/components/VSelect/mixins/select-props.js
@@ -15,6 +15,7 @@ export default {
     cacheItems: Boolean,
     chips: Boolean,
     clearable: Boolean,
+    clearableIcon: String,
     combobox: Boolean,
     contentClass: String,
     deletableChips: Boolean,

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -34,7 +34,10 @@ export default {
     autoGrow: Boolean,
     box: Boolean,
     clearable: Boolean,
-    clearableIcon: String,
+    clearableIcon: {
+      type: String,
+      default: 'clear'
+    },
     color: {
       type: String,
       default: 'primary'

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -34,6 +34,7 @@ export default {
     autoGrow: Boolean,
     box: Boolean,
     clearable: Boolean,
+    clearableIcon: String,
     color: {
       type: String,
       default: 'primary'

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -118,7 +118,7 @@ export default {
     },
     genIcon (type, defaultCallback = null) {
       const shouldClear = type === 'append' && this.clearable && this.isDirty
-      const icon = shouldClear ? (this.clearableIcon || 'clear') : this[`${type}Icon`]
+      const icon = shouldClear ? this.clearableIcon : this[`${type}Icon`]
       const callback = shouldClear
         ? this.clearableCallback
         : (this[`${type}IconCb`] || defaultCallback)

--- a/src/mixins/input.js
+++ b/src/mixins/input.js
@@ -118,7 +118,7 @@ export default {
     },
     genIcon (type, defaultCallback = null) {
       const shouldClear = type === 'append' && this.clearable && this.isDirty
-      const icon = shouldClear ? 'clear' : this[`${type}Icon`]
+      const icon = shouldClear ? (this.clearableIcon || 'clear') : this[`${type}Icon`]
       const callback = shouldClear
         ? this.clearableCallback
         : (this[`${type}IconCb`] || defaultCallback)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is my first PR I do on github.

I've decided to use [Material Design Icons](https://materialdesignicons.com/) instead of [Material Icons](https://material.io/icons/). 

So I deleted Material Icons from index.html: `|Material+Icons'` from `<link href...` and added `materialdesignicons.min.css`

Then when I added a text field with the "clearable" property. Instead of leaving the "X" icon, the text "CLEAR" appeared. This happens because by default `<v-text-field>` and `<v-select>` uses the "clear" icon from Material Icon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Don't depend on Material Icons and be able to use Material Design Icons.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
I tested it locally on my computer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
