### PR TITLE
fix(v-tab): added back removed nextTick

### DIFF
--- a/src/components/VTabs/VTab.js
+++ b/src/components/VTabs/VTab.js
@@ -85,9 +85,11 @@ export default {
 
       const path = `_vnode.data.class.${this.activeClass}`
 
-      if (getObjectValueByPath(this.$refs.link, path)) {
-        this.tabClick(this)
-      }
+      this.$nextTick(() => {
+        if (getObjectValueByPath(this.$refs.link, path)) {
+          this.tabClick(this)
+        }
+      })
     },
     toggle (action) {
       this.isActive = (action === this) || (action === this.action)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
was evaluating before the route change was actually resolved
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3203
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->

## Markup:
<!--- Paste markup that showcases your contribution --->
```vue
<template lang="pug">
  v-app#app
    v-container

        v-card
            v-card-title
                .title.indigo--text v-tabs with v-model
            v-divider

            v-card-text.hide-overflow
                p The problem is that in Beta.6 clicking on a tab with a <code>:to</code> attribute delays the change of tab contents, that is, it is lagging. Follow the instructions in Tab 1 contents, below.
                p This used to work as expected in Beta.5

                pre.blue.white--text.pa-2: b active_tab: {{ active_tab }}
                v-tabs(
                    v-model="active_tab",
                    slider-color="blue lighten-2",
                    )
                    v-tab(:to="{ path:'/page1' }") One
                    v-tab(:to="{ path:'/page2' }") Two
                    v-tab(:to="{ path:'/page3' }") Three

                v-card(v-if="active_tab=='/page1'", key="1")
                    v-card-text
                        h1 Tab 1 contents
                        li Click on tab TWO and notice that the tab does not change, neither does the <code>active_tab</code>
                        li Now, click on tab THREE and notice that tab 2 contents is shown and <code>active_tab</code> is now <code>/two</code>
                v-card(v-if="active_tab=='/page2'", key="2")
                    v-card-text
                        h1 Contents of tab 2
                        p CLick tab TWO again and notice that the contents of tab THREE is shown.
                v-card(v-if="active_tab=='/page3'", key="3")
                    v-card-text
                        h1 And finally tab 3
                        p CLick tab TWO again and notice that the contents of tab THREE is shown.
</template>

<style lang="stylus">
p {
    font-size: 16px;
}

</style>

<script>
export default {
  data: () => ({
    active_tab: null
  })
}
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
