### PR TITLE
fix(VSelect): add tags with tab when the menu is open

### DIFF
--- a/src/components/VSelect/VSelect-tags.spec.js
+++ b/src/components/VSelect/VSelect-tags.spec.js
@@ -96,12 +96,12 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
 
     input.element.value = 'b'
     input.trigger('input')
-    await wrapper.vm.$nextTick()
     input.trigger('keydown.down')
     input.trigger('keydown.tab')
     await wrapper.vm.$nextTick()
 
     expect(change).toBeCalledWith(['bar'])
+    expect(wrapper.vm.getMenuIndex()).toBe(-1)
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
@@ -113,20 +113,16 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
     const input = wrapper.find('input')[0]
 
     wrapper.vm.focus()
-    await wrapper.vm.$nextTick()
+
     wrapper.setProps({ searchInput: 'ba' })
-    await wrapper.vm.$nextTick()
-    input.trigger('keydown.down')
-    await wrapper.vm.$nextTick()
     input.trigger('keydown.tab')
     await wrapper.vm.$nextTick()
-    expect(change).toBeCalledWith(['bar'])
+    expect(change).toBeCalledWith(['ba'])
 
     wrapper.setProps({ searchInput: 'it' })
-    await wrapper.vm.$nextTick()
     input.trigger('keydown.tab')
     await wrapper.vm.$nextTick()
-    expect(change).toBeCalledWith(['bar', 'it'])
+    expect(change).toBeCalledWith(['ba', 'it'])
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
@@ -143,9 +139,6 @@ test('VSelect - tags', ({ mount, compileToFunctions }) => {
 
     input.element.value = 'ba'
     input.trigger('input')
-    input.element.setSelectionRange(2, 2)
-    await wrapper.vm.$nextTick()
-    input.trigger('keydown.right')
     await wrapper.vm.$nextTick()
     input.trigger('keydown.enter')
     await wrapper.vm.$nextTick()

--- a/src/components/VSelect/mixins/select-autocomplete.js
+++ b/src/components/VSelect/mixins/select-autocomplete.js
@@ -74,12 +74,14 @@ export default {
       // update, blur the v-select
       if (!this.isAutocomplete || !this.getCurrentTag() || this.combobox) return this.tabOut()
 
+      const menuIndex = this.getMenuIndex()
+
       // When adding tags, if searching and
       // there is not a filtered options,
       // add the value to the tags list
       if (this.tags &&
         this.searchValue &&
-        !this.filteredItems.length
+        menuIndex === -1
       ) {
         e.preventDefault()
 
@@ -89,8 +91,12 @@ export default {
       // An item that is selected by
       // menu-index should toggled
       if (this.menuIsActive) {
+        console.log(this.searchValue)
+        // Reset the list index if searching
+        this.searchValue && this.$nextTick(() => setTimeout(this.resetMenuIndex, 0))
+
         e.preventDefault()
-        this.selectListTile(this.getMenuIndex())
+        this.selectListTile(menuIndex)
       }
     },
     onEnterDown () {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
- also resets the menu index afterwards for more consistent behaviour

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since 0.17, it hasn't been possible to add a *new* tag with the tab key if there is a search match. This change was made in e6993e5aac5ec4bd417841365e416d54778a1b0d judging by the test changes. 

## Markup:
```html
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-select chips tags v-model="tags" :items="['foo', 'bar', 'baz', 'Programming']"/>
        <v-select combobox :items="['foo', 'bar', 'baz', 'Programming']" v-model="combo"/>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      tags: [],
      combo: ''
    })
  }
</script>
```

## Reproduction steps
 - type `pro`
 - press tab
 - `pro` should be added as a tag, but instead nothing happens

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
