### PR TITLE
fix(detachable): allow any object in the attach prop

### DIFF
--- a/src/mixins/detachable.js
+++ b/src/mixins/detachable.js
@@ -16,7 +16,7 @@ export default {
 
   props: {
     attach: {
-      type: [Boolean, String, Object],
+      type: null,
       default: false,
       validator: validateAttachTarget
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3226 

## Markup:
```html
<template>
  <v-app>
    <v-content>
      <my-component/>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    components: {
      'my-component': {
        data: function () {
          return {
            showTooltip: false
          }
        },
        template: `
        <v-layout id="test">
          <v-tooltip v-if="showTooltip" lazy :attach="$el">
            <span slot="activator">This text has a tooltip</span>
            <slot>
              <span>Tooltip</span>
            </slot>
          </v-tooltip>
        </v-layout>
      `,
        mounted () {
          this.showTooltip = true
        }
      }
    }
  }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
