### PR TITLE
feat(v-list-group): append-icon should work for sub-groups

### DIFF
--- a/src/components/VList/VListGroup.js
+++ b/src/components/VList/VListGroup.js
@@ -111,14 +111,12 @@ export default {
       return this.$createElement(VIcon, icon)
     },
     genAppendIcon () {
-      const icon = !this.subGroup ? this.appendIcon : false
-
-      if (!icon && !this.$slots.appendIcon) return null
+      if (!this.appendIcon && !this.$slots.appendIcon) return null
 
       return this.$createElement('li', {
         staticClass: 'list__group__header__append-icon'
       }, [
-        this.$slots.appendIcon || this.genIcon(icon)
+        this.$slots.appendIcon || this.genIcon(this.appendIcon)
       ])
     },
     genGroup () {


### PR DESCRIPTION
## Description
The append-icon prop of a v-list-group should also work when the prop sub-group is true.

## Motivation and Context
I would like to append the arrow_drop_down icon instead of prepending it for a "sub-group" list.

## How Has This Been Tested?
I did test with my local application and run ppm run test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.