### PR TITLE
fix(time-body): handle fast double click

### DIFF
--- a/src/components/VTimePicker/mixins/time-body.js
+++ b/src/components/VTimePicker/mixins/time-body.js
@@ -166,6 +166,11 @@ export default {
     onDragMove (e) {
       e.preventDefault()
       if (!this.isDragging && e.type !== 'click') return
+      if (typeof this.$refs.clock === 'undefined') {
+        // necessary to set the correct minute on second click
+        e.stopPropagation()
+        return
+      }
 
       const rect = this.$refs.clock.getBoundingClientRect()
       const center = { x: rect.width / 2, y: 0 - rect.width / 2 }


### PR DESCRIPTION
Closes 3265

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->
#3265 reported an issue when double clicking on the clock interface. This prevents the error from occurring and results in the correct hour/time selected.

## Description
<!--- Describe your changes in detail -->
The second click occurs before the "minute" portion of the clock appears. Thus `this.$refs.clock` is undefined. The `stopPropagation()` makes it so that the clock isn't just hidden on second click, but actually selects the time where the second click actually occurs (as expected).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3265 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
Ran the jest tests, no new tests were written as this doesn't seem to be a unit testable issue.

## Markup:
<!--- Paste markup that showcases your contribution --->

Playground - pulled from (https://vuetifyjs.com/components/pickers#example-17) as reported in issue.
```javascript
<template>
  <v-app>
    <v-layout row wrap>
      <v-flex xs11 sm5>
        <v-menu
          lazy
          :close-on-content-click="false"
          v-model="menu2"
          transition="scale-transition"
          offset-y
          full-width
          :nudge-right="40"
          max-width="290px"
          min-width="290px"
        >
          <v-text-field
            slot="activator"
            label="Picker in menu"
            v-model="time"
            prepend-icon="access_time"
            readonly
          ></v-text-field>
          <v-time-picker v-model="time" autosave></v-time-picker>
        </v-menu>
      </v-flex>
      <v-spacer></v-spacer>
      <v-flex xs11 sm5>
        <v-dialog
          persistent
          v-model="modal2"
          lazy
          full-width
          width="290px"
        >
          <v-text-field
            slot="activator"
            label="Picker in dialog"
            v-model="time"
            prepend-icon="access_time"
            readonly
          ></v-text-field>
          <v-time-picker v-model="time" actions>
            <template slot-scope="{ save, cancel }">
              <v-card-actions>
                <v-btn flat color="primary" @click="cancel">Cancel</v-btn>
                <v-btn flat color="primary" @click="save">Save</v-btn>
              </v-card-actions>
            </template>
          </v-time-picker>
        </v-dialog>
      </v-flex>
    </v-layout>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      time: null,
      menu2: false,
      modal2: false
    })
  }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
