### PR TITLE
Update applicationable mixin to check uid before removing state

### DIFF
--- a/src/mixins/applicationable.js
+++ b/src/mixins/applicationable.js
@@ -27,6 +27,8 @@ export default function applicationable (value, events = []) {
     },
 
     created () {
+      this.$vuetify.application['activeuid'] = this._uid
+
       for (let i = 0, length = events.length; i < length; i++) {
         this.$watch(events[i], this.callUpdate)
       }
@@ -44,7 +46,9 @@ export default function applicationable (value, events = []) {
         this.$vuetify.application[this.applicationProperty] = this.updateApplication()
       },
       removeApplication () {
-        this.$vuetify.application[this.applicationProperty] = 0
+        if (this.$vuetify.application['activeuid'] === this._uid) {
+          this.$vuetify.application[this.applicationProperty] = 0
+        }
       },
       updateApplication: () => {}
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
When making a change to a component that has ```applicationable``` mixin, state will get reset because according to https://github.com/vuejs/vue/issues/6518 the vdom always creates before removing nodes, so ```removeApplication()``` is always called after the new node is inserted.

## Motivation and Context
Testing Vuetify for a new project I noticed it when trying one of the default layouts, mentioned it in Discord, but it was bugging me when trying to test a layout to see if I could switch to this framework.

## How Has This Been Tested?
vuetify dev environment with Playground.vue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.