### PR TITLE
demo of adding prefix and suffix props to vSelect

### DIFF
--- a/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/src/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -22,6 +22,8 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Items per page:"
                      disabled="disabled"
                      tabindex="-1"
@@ -159,6 +161,8 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Items per page:"
                      disabled="disabled"
                      tabindex="-1"
@@ -287,6 +291,8 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Items per page:"
                      disabled="disabled"
                      tabindex="-1"
@@ -419,6 +425,8 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Items per page:"
                      disabled="disabled"
                      tabindex="-1"

--- a/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/src/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -78,6 +78,8 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Rows per page:"
                      disabled="disabled"
                      tabindex="-1"
@@ -260,6 +262,8 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Rows per page:"
                      disabled="disabled"
                      tabindex="-1"
@@ -444,6 +448,8 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
             <div class="input-group__selections"
                  style="overflow: hidden;"
             >
+              <div class="input-group__selected__items">
+              </div>
               <input aria-label="Rows per page:"
                      disabled="disabled"
                      tabindex="-1"

--- a/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -31,13 +31,15 @@ exports[`VSelect should render buttons correctly when using items array with seg
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <button type="button"
-              class="btn btn--flat"
-      >
-        <div class="btn__content">
-          Hello
-        </div>
-      </button>
+      <div class="input-group__selected__items">
+        <button type="button"
+                class="btn btn--flat"
+        >
+          <div class="btn__content">
+            Hello
+          </div>
+        </button>
+      </div>
       <input disabled="disabled"
              tabindex="-1"
              class="input-group--select__autocomplete"
@@ -90,8 +92,10 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <div>
-        Hello
+      <div class="input-group__selected__items">
+        <div>
+          Hello
+        </div>
       </div>
       <input disabled="disabled"
              tabindex="-1"
@@ -145,8 +149,10 @@ exports[`VSelect should render v-select correctly when not using scope slot 1`] 
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <div class="input-group__selections__comma">
-        Text 0
+      <div class="input-group__selected__items">
+        <div class="input-group__selections__comma">
+          Text 0
+        </div>
       </div>
       <input disabled="disabled"
              tabindex="-1"
@@ -209,8 +215,10 @@ exports[`VSelect should render v-select correctly when not using v-list-tile in 
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <div class="input-group__selections__comma">
-        Text 0
+      <div class="input-group__selected__items">
+        <div class="input-group__selections__comma">
+          Text 0
+        </div>
       </div>
       <input disabled="disabled"
              tabindex="-1"
@@ -273,8 +281,10 @@ exports[`VSelect should render v-select correctly when using v-list-tile in item
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <div class="input-group__selections__comma">
-        Text 0
+      <div class="input-group__selected__items">
+        <div class="input-group__selections__comma">
+          Text 0
+        </div>
       </div>
       <input disabled="disabled"
              tabindex="-1"

--- a/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/src/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -11,8 +11,10 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <div class="input-group__selections__comma">
-        1
+      <div class="input-group__selected__items">
+        <div class="input-group__selections__comma">
+          1
+        </div>
       </div>
       <input disabled="disabled"
              tabindex="-1"
@@ -119,8 +121,10 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
     <div class="input-group__selections"
          style="overflow: hidden;"
     >
-      <div class="input-group__selections__comma">
-        1
+      <div class="input-group__selected__items">
+        <div class="input-group__selections__comma">
+          1
+        </div>
       </div>
       <input disabled="disabled"
              tabindex="-1"

--- a/src/components/VSelect/mixins/select-computed.js
+++ b/src/components/VSelect/mixins/select-computed.js
@@ -22,7 +22,9 @@ export default {
         'input-group--chips': this.chips,
         'input-group--multiple': this.multiple,
         'input-group--open': this.menuIsVisible,
-        'input-group--select--selecting-index': this.selectedIndex > -1
+        'input-group--select--selecting-index': this.selectedIndex > -1,
+        'input-group--select--prefix': this.prefix,
+        'input-group--select--suffix': this.suffix
       }
 
       if (this.hasError) {

--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -59,14 +59,24 @@ export default {
       return this.menuIsActive && this.menuItems.length && this.getMenuIndex() > -1
     },
     genSelectionsAndSearch () {
+      const children = [
+        this.genSelections(),
+        this.genSearch()
+      ]
+
+      this.prefix && children.unshift(this.genFix('prefix'))
+      this.suffix && children.push(this.genFix('suffix'))
+
       return this.$createElement('div', {
         'class': 'input-group__selections',
         style: { 'overflow': 'hidden' },
         ref: 'activator'
-      }, [
-        ...this.genSelections(),
-        this.genSearch()
-      ])
+      }, children)
+    },
+    genFix (type) {
+      return this.$createElement('span', {
+        'class': `input-group--select__${type}`
+      }, this[type])
     },
     genSelections () {
       if (this.hideSelections) return []
@@ -89,7 +99,9 @@ export default {
         children[length] = genSelection(this.selectedItems[length], length, length === children.length - 1)
       }
 
-      return children
+      return this.$createElement('div', {
+        class: 'input-group__selected__items'
+      }, children)
     },
     genSearch () {
       const data = {

--- a/src/components/VSelect/mixins/select-props.js
+++ b/src/components/VSelect/mixins/select-props.js
@@ -53,12 +53,14 @@ export default {
     multiLine: Boolean,
     openOnClear: Boolean,
     overflow: Boolean,
+    prefix: String,
     returnObject: Boolean,
     searchInput: {
       default: null
     },
     segmented: Boolean,
     singleLine: Boolean,
+    suffix: String,
     tags: Boolean,
     valueComparator: {
       type: Function,

--- a/src/stylus/components/_select.styl
+++ b/src/stylus/components/_select.styl
@@ -12,6 +12,11 @@ selects($material)
       &.input-group--focused .input-group__input
         background: $material.cards
 
+    &:not(.input-group--error)
+    .input-group--select__prefix,
+    .input-group--select__suffix
+      color: $material.text.secondary
+
 theme(selects, "input-group--select")
 
 .input-group--select
@@ -56,6 +61,24 @@ theme(selects, "input-group--select")
     pointer-events: none
 
 .input-group--select
+  /** Prefix/Suffix */
+  &:not(.input-group--focused):not(.input-group--dirty)
+    label
+      left: 16px
+
+  .input-group--select__prefix,
+  .input-group--select__suffix
+    align-items: center
+    display: inline-flex
+    font-size: 16px
+    margin-top: 1px
+
+  .input-group--select__prefix
+    margin-right: 3px
+
+  .input-group--select__suffix
+    margin-left: 3px
+
   .input-group__selections
     align-items: center
     display: flex
@@ -77,6 +100,14 @@ theme(selects, "input-group--select")
   .fade-transition-leave-active
     position: absolute
     left: 0
+
+  .input-group__selected__items
+    display: inline-block
+    flex: 1
+
+  &.input-group--autocomplete
+    .input-group__selected__items
+      flex: unset
 
   &.input-group--autocomplete.input-group--search-focused
     .input-group__selections__comma


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

add a prefix and suffix prop to VSelect similar to what is present on VTextField

## Description
changes in this PR include:
add props to select-props,
add classes to select-computed,
add generator and update existing generators in select-generators,
add styles to select.styl

update snapshots for tests that make use of VSelect

## Motivation and Context
would fix #3305 

## How Has This Been Tested?
tested in Playground with a number of VSelect configurations, all unit tests pass

I'm happy to add unit tests and update docs for these props if this is a direction that is acceptable.

## Markup:


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
