### PR TITLE
feat: Set header font via `$header-font-family`

### DIFF
--- a/src/stylus/elements/_typography.styl
+++ b/src/stylus/elements/_typography.styl
@@ -3,36 +3,42 @@
   font-weight: $headings.h1.weight
   line-height: $headings.h1.line-height !important
   letter-spacing: $headings.h1.letter-spacing !important
+  font-family: $headings.h1.font-family !important
   
 .display-3
   font-size: $headings.h2.size !important
   font-weight: $headings.h2.weight
   line-height: $headings.h2.line-height !important
   letter-spacing: $headings.h2.letter-spacing !important
+  font-family: $headings.h2.font-family !important
   
 .display-2
   font-size: $headings.h3.size !important
   font-weight: $headings.h3.weight
   line-height: $headings.h3.line-height !important
   letter-spacing: $headings.h3.letter-spacing !important
+  font-family: $headings.h3.font-family !important
   
 .display-1
   font-size: $headings.h4.size !important
   font-weight: $headings.h4.weight
   line-height: $headings.h4.line-height !important
   letter-spacing: $headings.h4.letter-spacing !important
+  font-family: $headings.h4.font-family !important
   
 .headline
   font-size: $headings.h5.size !important
   font-weight: $headings.h5.weight
   line-height: $headings.h5.line-height !important
   letter-spacing: $headings.h5.letter-spacing !important
+  font-family: $headings.h5.font-family !important
   
 .title
   font-size: $headings.h6.size !important
   font-weight: $headings.h6.weight
   line-height: $headings.h6.line-height !important
   letter-spacing: $headings.h6.letter-spacing !important
+  font-family: $headings.h6.font-family !important
   
 .subheading
   font-size: $headings.subheading.size !important

--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -93,13 +93,14 @@ $font-weights := {
 
 // Headings
 // ============================================================
+$heading-font-family := $body-font-family
 $headings := {
-  h1: { size: 112px, weight: 300, line-height: 1, letter-spacing: -.04em },
-  h2: { size: 56px, weight: 400, line-height: 1.35, letter-spacing: -.02em },
-  h3: { size: 45px, weight: 400, line-height: 48px, letter-spacing: normal },
-  h4: { size: 34px, weight: 400, line-height: 40px, letter-spacing: normal },
-  h5: { size: 24px, weight: 400, line-height: 32px, letter-spacing: normal },
-  h6: { size: 20px, weight: 500, line-height: 1, letter-spacing: .02em },
+  h1: { size: 112px, weight: 300, line-height: 1, letter-spacing: -.04em, font-family: $heading-font-family },
+  h2: { size: 56px, weight: 400, line-height: 1.35, letter-spacing: -.02em, font-family: $heading-font-family },
+  h3: { size: 45px, weight: 400, line-height: 48px, letter-spacing: normal, font-family: $heading-font-family },
+  h4: { size: 34px, weight: 400, line-height: 40px, letter-spacing: normal, font-family: $heading-font-family },
+  h5: { size: 24px, weight: 400, line-height: 32px, letter-spacing: normal, font-family: $heading-font-family },
+  h6: { size: 20px, weight: 500, line-height: 1, letter-spacing: .02em, font-family: $heading-font-family },
   subheading: { size: 16px, weight: 400 },
   body-2: { size: 14px, weight: 500 },
   body-1: { size: 14px, weight: 400 },


### PR DESCRIPTION
- Follow existing method used for `$badge-font-family`
  - Headers default to `$body-font-family`
  - Defined in `_variables.styl`, not `theme.styl`
- Sets the font for:
  - classes: `.display-4`, `.display-3`, `.display-2`, `.display-1`, `.headline`, `.title`

## Description
Add the ability to set a different font for headings.

## Motivation and Context
It is common for web applications to use a separate font for headings and body copy.  Currently, there is no standard way to do that in Vuetify.

I raised the question in Discord and suggested iusing `$heading-font-family` similar to how `$badge-font-family` is used. @johnleider said to submit a PR.

## How Has This Been Tested?
Tested via `Playground.vue`
I didn't see any existing tests related to stylus variables.

## Markup:
```vue
$body-font-family = 'Open Sans'
$heading-font-family = 'Roboto'
 
@import '~vuetify/src/stylus/main'
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
