### PR TITLE
remove justify-content: flex-start

### DIFF
--- a/src/stylus/components/_lists.styl
+++ b/src/stylus/components/_lists.styl
@@ -243,8 +243,7 @@ theme(list, "list")
           margin-right: 8px
 
       .list__group__header__prepend-icon
-        display: flex
-        justify-content: flex-start
+        display: flex        
         min-width: 56px
 
       &--active


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->
Remove `justify-content: flex-start` from `.list__group__header__prepend-icon`

## Description
<!--- Describe your changes in detail -->
This enables the `prepend-icon` from `v-list-group` and icons on `v-list-tile-action` to line up properly, especially when used in a `v-nav-drawer` in mini mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As mentioned in the description, ensures prepend-icon of the v-list- groups lines up properly with recular icons used in v-list-tile-action,particylarly when the nav-drawer is  in `mini` mode

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested in my local copy of vuetify as well as in chrome devTools, by toggling that line of stylus code 

## Markup:
<!--- Paste markup that showcases your contribution --->
![screen2](https://user-images.githubusercontent.com/1735005/36386975-df8b6d72-1597-11e8-9485-d4c340bfbbeb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] My code follows the code style of this project.

