### PR TITLE
feat(VDialog): Forward 'after-leave' transition event

### DIFF
--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -176,9 +176,7 @@ export default {
         css: this.transitionCss
       },
       on: {
-        afterLeave: () => {
-          this.$emit('after-leave')
-        }
+        afterLeave: () => { this.$emit('after-leave') }
       }
     }, [h('div', data,
       this.showLazyContent(this.$slots.default)

--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -59,6 +59,10 @@ export default {
     transition: {
       type: [String, Boolean],
       default: 'dialog-transition'
+    },
+    transitionCss: {
+      type: Boolean,
+      default: true
     }
   },
 
@@ -168,7 +172,13 @@ export default {
     const dialog = h('transition', {
       props: {
         name: this.transition || '', // If false, show nothing
-        origin: this.origin
+        origin: this.origin,
+        css: this.transitionCss
+      },
+      on: {
+        afterLeave: () => {
+          this.$emit('after-leave')
+        }
       }
     }, [h('div', data,
       this.showLazyContent(this.$slots.default)

--- a/src/components/VDialog/VDialog.spec.js
+++ b/src/components/VDialog/VDialog.spec.js
@@ -184,4 +184,24 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
+
+  it('should emit after-leave event', async () => {
+    const afterLeave = jest.fn()
+
+    const wrapper = mount(VDialog, {
+      propsData: {
+        value: true,
+        transitionCss: false
+      }
+    })
+
+    wrapper.vm.$on('after-leave', afterLeave)
+
+    wrapper.setProps({ value: false })
+    await wrapper.vm.$nextTick()
+
+    expect(afterLeave).toBeCalled()
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Forward `after-leave` event from `transition` component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows to make an action after the `VDialog` closing transition is ended.
For exemple, if you have a route-based `VDialog` (a dialog directly bound to a route component), you can go back to the previous route only after the dialog is closed.
<!--- If it fixes an open issue, please link to the issue here. -->
Should fix #467

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added `@after-leave` attribute in my `VDialog`, the event is triggered on close.
<!--- Have you created new tests or updated existing ones? -->
No new test, no update.
<!--- e.g. unit | visually | e2e | none

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```
  <v-dialog
    :value="true"
    @after-leave="onClose"
  >test</v-dialog>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
