### PR TITLE
fix(theme): only apply theme to head element when not using vue-meta

### DIFF
--- a/src/components/VApp/mixins/app-theme.js
+++ b/src/components/VApp/mixins/app-theme.js
@@ -47,7 +47,7 @@ export default {
 
   watch: {
     generatedStyles () {
-      this.applyTheme()
+      !this.meta && this.applyTheme()
     }
   },
 
@@ -82,7 +82,7 @@ export default {
 
   methods: {
     applyTheme () {
-      this.style.innerHTML = this.generatedStyles
+      if (this.style) this.style.innerHTML = this.generatedStyles
     },
     genStyle () {
       let style = document.getElementById('vuetify-theme-stylesheet')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3405

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
