### PR TITLE
fix(tabs): render all other elements in the tabs container

### DIFF
--- a/src/components/VTabs/VTabs.js
+++ b/src/components/VTabs/VTabs.js
@@ -157,7 +157,6 @@ export default {
       for (let i = 0; i < length; i++) {
         const vnode = this.$slots.default[i]
 
-        /* istanbul ignore else */
         if (vnode.componentOptions) {
           switch (vnode.componentOptions.Ctor.options.name) {
             case 'v-tabs-slider': slider.push(vnode)
@@ -169,6 +168,8 @@ export default {
             // case 'v-tab' - intentionally omitted
             default: tab.push(vnode)
           }
+        } else {
+          tab.push(vnode)
         }
       }
 

--- a/test/unit/components/VTabs/VTabs.spec.js
+++ b/test/unit/components/VTabs/VTabs.spec.js
@@ -371,4 +371,21 @@ test('VTabs', ({ mount, shallow }) => {
     const slider = wrapper.find('.tabs__slider')
     expect(slider).toHaveLength(0)
   })
+
+  it('should render generic elements in the tab container', async () => {
+    const component = {
+      render (h) {
+        return h(VTabs, {
+          props: { hideSlider: true }
+        }, [
+          h('div', { staticClass: 'test-element' }, ['foobar'])
+        ])
+      }
+    }
+    const wrapper = mount(component, {
+      attachToDocument: true
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/test/unit/components/VTabs/__snapshots__/VTabs.spec.js.snap
+++ b/test/unit/components/VTabs/__snapshots__/VTabs.spec.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VTabs should render generic elements in the tab container 1`] = `
+
+<div class="tabs">
+  <div class="tabs__bar">
+    <div class="tabs__wrapper">
+      <div class="tabs__container">
+        <div class="test-element">
+          foobar
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`VTabs should show tabs arrows 1`] = `
 
 <div class="tabs">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
bde89441229b2240de8fe5c8ab59e78480d16d0c was supposed to fix this, but I forgot to account for non-components (any vnode without `componentOptions`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3434

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
