### PR TITLE
fix: increase specificity of outline chips to override theme background

### DIFF
--- a/src/stylus/components/_chips.styl
+++ b/src/stylus/components/_chips.styl
@@ -74,7 +74,8 @@ theme(chip, "chip")
     .chip__content
       border-radius: $chip-label-border-radius
 
-  &.chip--outline
+  // Increase specificity to override theme background
+  &\&.chip--outline
     background: $chip-outline-background
     border-color: currentColor
     color: $chip-outline-color


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`.chip.chip--outline { background }` was overridden by `.primary.darken-1 { background-color }` due to declaration order. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3374

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none
visually 

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```html
<template>
  <v-app>
    <v-content>
      <v-chip outline color="blue">blue</v-chip>
      <v-chip outline text-color="green">green</v-chip>
      <v-chip outline color="blue" text-color="green">blue + green</v-chip>
      <br>
      <v-chip outline color="primary darken-1">primary</v-chip>
      <v-chip outline text-color="secondary darken-1">secondary</v-chip>
      <v-chip outline color="primary darken-1" text-color="secondary darken-1">primary + secondary</v-chip>
      <br>
      <v-chip outline color="primary">primary Border</v-chip>
      <v-chip outline color="primary lighten-4">primary Border lighten-4</v-chip>
      <v-chip outline color="primary darken-4">primary Border darken-4</v-chip>
      <br>
      <v-chip outline color="secondary">secondary Border</v-chip>
      <v-chip outline color="secondary lighten-4">secondary Border lighten-4</v-chip>
      <v-chip outline color="secondary darken-4">secondary Border darken-4</v-chip>
      <br>
      <v-chip outline color="accent">accent Border</v-chip>
      <v-chip outline color="accent lighten-4">accent Border lighten-4</v-chip>
      <v-chip outline color="accent darken-4">accent Border darken-4</v-chip>
      <br>
      <v-chip outline color="warning">warning Border</v-chip>
      <v-chip outline color="warning lighten-4">warning Border lighten-4</v-chip>
      <v-chip outline color="warning darken-4">warning Border darken-4</v-chip>
      <br>
      <v-chip outline color="success">success Border</v-chip>
      <v-chip outline color="success lighten-4">success Border lighten-4</v-chip>
      <v-chip outline color="success darken-4">success Border darken-4</v-chip>
      <br>
      <v-chip outline color="red">red border</v-chip>
      <v-chip outline color="red lighten-4">red border lighten4</v-chip>
      <v-chip outline color="red darken-4">red border darken-4</v-chip>
    </v-content>
  </v-app>
</template>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
