### PR TITLE
fix(text-field): add color and file to dirty types

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -8,6 +8,8 @@ import Input from '../../mixins/input'
 import Maskable from '../../mixins/maskable'
 import Soloable from '../../mixins/soloable'
 
+const dirtyTypes = ['color', 'file', 'time', 'date', 'datetime-local', 'week', 'month']
+
 export default {
   name: 'v-text-field',
 
@@ -115,7 +117,7 @@ export default {
       return (this.lazyValue != null &&
         this.lazyValue.toString().length > 0) ||
         this.badInput ||
-        ['time', 'date', 'datetime-local', 'week', 'month'].includes(this.type)
+        dirtyTypes.includes(this.type)
     },
     isTextarea () {
       return this.multiLine || this.textarea


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3467

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```vue
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-layout v-for="type in dirtyTypes" :key="type">
          <v-text-field v-bind="{ type, label: type }"/>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  const dirtyTypes = ['color', 'file', 'time', 'date', 'datetime-local', 'week', 'month']

  export default {
    data: () => ({
      dirtyTypes
    })
  }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
