### PR TITLE
fix(grid): prevent .flex from growing instead of using max-width

### DIFF
--- a/src/stylus/components/_grid.styl
+++ b/src/stylus/components/_grid.styl
@@ -71,13 +71,14 @@ for size, width in $grid-breakpoints
     for n in (1..$grid-columns)
       .flex.{size}{n}
         flex-basis: (n / $grid-columns * 100)%
-        max-width: (n / $grid-columns * 100)%
+        flex-grow: 0
 
       .flex.order-{size}{n}
         order: n
 
     for n in (0..$grid-columns)
       .flex.offset-{size}{n}
+        // Offsets can only ever work in row layouts
         margin-left: (n / $grid-columns * 100)%
 
 .flex,

--- a/src/stylus/components/_grid.styl
+++ b/src/stylus/components/_grid.styl
@@ -134,10 +134,12 @@ for size, width in $grid-breakpoints
   flex-grow: 1 !important
 
 .grow
+  flex-grow: 1 !important
   flex-shrink: 0 !important
 
 .shrink
   flex-grow: 0 !important
+  flex-shrink: 1 !important
 
 .scroll-y
   overflow-y: auto


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Use `flex-grow: 0` instead of `max-width` to allow setting the height of rows in a column v-layout (#3470)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3470

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
coming soon...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
