### PR TITLE
fix(VSelect): disable the menu transition with false instead of ''

### DIFF
--- a/src/components/VSelect/mixins/select-generators.js
+++ b/src/components/VSelect/mixins/select-generators.js
@@ -56,7 +56,7 @@ export default {
         }
       }
 
-      if (this.isAutocomplete) data.props.transition = ''
+      if (this.isAutocomplete) data.props.transition = false
 
       this.minWidth && (data.props.minWidth = this.minWidth)
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3526

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```html
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-select autocomplete :items="['']"/>
      </v-container>
    </v-content>
  </v-app>
</template>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
