### PR TITLE
fix(VTextField): allow error container to shrink

### DIFF
--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -310,7 +310,7 @@ theme(input-group, "input-group")
 .input-group
   &__error
     color: inherit
-    flex: 1 0 100%
+    flex: 1 1 100%
     transition: .3s $transition.fast-in-fast-out
 
 /** Types */

--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -310,7 +310,6 @@ theme(input-group, "input-group")
 .input-group
   &__error
     color: inherit
-    flex: 1 1 100%
     transition: .3s $transition.fast-in-fast-out
 
 /** Types */

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -90,6 +90,7 @@ theme(textfield, "input-group--text-field")
 .input-group--text-field
   .input-group__counter
     margin-left: auto
+    white-space: nowrap
 
     &--error
       color: inherit


### PR DESCRIPTION
## Description
Turns out that flex rule isn't even needed, it hasn't been touched since e735b181e32ae6123f24f0043aa20a8b927b826c  
I still prevented the counter from wrapping, there isn't any scenario I can think of that you would want that to happen.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3381

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Avoids regression of #3077

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```html
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-text-field :counter="10" required :rules="[v => !!v || 'Required']"/>
      </v-container>
    </v-content>
  </v-app>
</template>
```

---

```html
<template>
  <v-app>
    <v-content>
      <v-container text-xs-center>
        <v-text-field
            :counter="10"
            hint="foobar longish hint this should wrap at some point"
            persistent-hint
            required
            :rules="[v => !!v || 'Required']"
        />
      </v-container>
    </v-content>
  </v-app>
</template>
```

---

```html
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-text-field
            label="Legal last name"
            hint="example of persistent helper text"
            persistent-hint
            v-model="last"
            :rules="[() => last.length > 0 || 'This field is required']"
            required
        ></v-text-field>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      last: ''
    })
  }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
