### PR TITLE
fix(rippleable): added explicit click event

### DIFF
--- a/src/mixins/rippleable.js
+++ b/src/mixins/rippleable.js
@@ -20,9 +20,12 @@ export default {
         name: 'ripple',
         value: this.ripple && !this.disabled && { center: true }
       })
-      data.on = Object.assign({
-        click: this.toggle
-      }, this.$listeners)
+      data.on = Object.assign({}, this.$listeners, {
+        click: e => {
+          this.$emit('click', e)
+          this.toggle()
+        }
+      })
 
       return this.$createElement('div', data)
     }

--- a/test/unit/mixins/__snapshots__/rippleable.spec.js.snap
+++ b/test/unit/mixins/__snapshots__/rippleable.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`menuable.js should match snapshot 1`] = `
+
+<div class="input-group--selection-controls__ripple">
+</div>
+
+`;
+
+exports[`menuable.js should match snapshot 2`] = `
+
+<div class="foo">
+</div>
+
+`;

--- a/test/unit/mixins/rippleable.spec.js
+++ b/test/unit/mixins/rippleable.spec.js
@@ -1,0 +1,37 @@
+import { test } from '@/test'
+import Rippleable from '@/mixins/rippleable'
+
+const Mock = {
+  mixins: [Rippleable],
+
+  data: () => ({
+    rippleClasses: null
+  }),
+
+  render (h) {
+    return this.genRipple()
+  }
+}
+
+test('menuable.js', ({ mount }) => {
+  it('should react to click', () => {
+    const wrapper = mount(Mock)
+
+    const click = jest.fn()
+
+    wrapper.setMethods({ toggle: click })
+    wrapper.trigger('click')
+
+    expect(click).toHaveBeenCalled()
+  })
+
+  it('should match snapshot', () => {
+    const wrapper = mount(Mock)
+
+    expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.setData({ rippleClasses: 'foo' })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Rippleable mixin did not explicitly emit a click event, and bound click events would overwrite the default
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3554
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
``` vue
<template>
  <div id="app">
    <v-app id="inspire">
      <v-container fluid>
        <v-switch :label="`Switch 1: ${switch1.toString()}`"
                  v-model="switch1"
                  @click="toggleMessage">
        </v-switch>
        <p v-if="showMessage">I'm showing!</p>
      </v-container>
    </v-app>
  </div>
</template>

<script>
export default {
  data () {
    return {
      switch1: false,
      showMessage: false,
    }
  },
  methods: {
    toggleMessage() {
      this.$data.showMessage = !this.$data.showMessage
    }
  }
}
</script>
```
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
