### PR TITLE
Fix highlight status of tabs

### DIFF
--- a/src/components/VTabs/VTab.js
+++ b/src/components/VTabs/VTab.js
@@ -47,9 +47,9 @@ export default {
 
       if (typeof to === 'string') return to.replace('#', '')
       if (to === Object(to) &&
-        (to.hasOwnProperty('name') ||
-          to.hasOwnProperty('path'))
-      ) return to.name || to.path
+        (to.hasOwnProperty('path') ||
+          to.hasOwnProperty('name'))
+      ) return to.path || to.name
 
       return this
     }


### PR DESCRIPTION
First check for the complete path before falling back to the name.check.
Fixes Bug #3418

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
We should check for the full path including all params before we check on the route's name.

## Motivation and Context
Fixes the bug issued in #3418 

## How Has This Been Tested?
Tested in on a quite huge app I#M working on. As it's a very little change there should not be more tests required.

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x ] The PR title is no longer than 64 characters.
- [ x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
