### PR TITLE
fix(v-tab): updated logic for determining action

### DIFF
--- a/src/components/VTabs/VTab.js
+++ b/src/components/VTabs/VTab.js
@@ -43,15 +43,17 @@ export default {
       }
     },
     action () {
-      const to = this.to || this.href
+      let to = this.to || this.href
 
-      if (typeof to === 'string') return to.replace('#', '')
-      if (to === Object(to) &&
-        (to.hasOwnProperty('name') ||
-          to.hasOwnProperty('path'))
-      ) return to.name || to.path
+      if (this.$router && this.to) {
+        const resolve = this.$router.resolve(this.to)
 
-      return this
+        to = resolve.href
+      }
+
+      return typeof to === 'string'
+        ? to.replace('#', '')
+        : this
     }
   },
 

--- a/test/unit/components/VTabs/VTab.spec.js
+++ b/test/unit/components/VTabs/VTab.spec.js
@@ -188,8 +188,6 @@ test('VTab', ({ mount }) => {
     expect(wrapper.vm.action).toBe('foo')
     wrapper.setProps({ href: null, to: '/foo' })
     expect(wrapper.vm.action).toBe('/foo')
-    wrapper.setProps({ to: { path: '/bar' }})
-    expect(wrapper.vm.action).toBe('/bar')
     wrapper.setProps({ to: null })
     expect(wrapper.vm.action).toBe(wrapper.vm)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
vue-router dynamically updates the to prop which causes issues with our logic, instead use their
same method to resolve the proper path
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3418
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
none - cannot mock vue router. it is understood if the using is using the **to** prop, they have the $router instance
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
``` vue
<template>
  <boilerplate>
    <v-tabs centered v-model="tabs">
      <v-tab :to="{name: 'Register'}" key="register">
        Regular Page
      </v-tab>
      <v-tab to="/login/1" key="login-1">
        Test 1
      </v-tab>

      <v-tab :to="{name: 'Login', params:{id:2}}" key="login-2">
        Test 2
      </v-tab>
      <v-tab :to="{name: 'Login', params:{id:3}}" key="login-3">
        Test 3
      </v-tab>
    </v-tabs>
    {{ tabs }}
    <router-view></router-view>
  </boilerplate>
</template>

<script>
export default {
  data: () => ({
    isFocused: false,
    input: 'asdf',
    tabs: null
  }),

  methods: {
    onBlur () {
      this.isFocused = false
    },
    onFocus () {
      this.isFocused = true
    }
  }
}
</script>
```

**router.js**
```
import VueRouter from 'vue-router'

const component1 = {
  template: `<div class="title">Page 1</div>`
}
const component2 = {
  template: `<div class="title">Page 2</div>`
}

const router = new VueRouter({
  routes: [
    {
      path: '/page1',
      name: 'Register',
      component: component1
    },
    {
      path: '/login/:id',
      name: 'Login',
      component: component2
    },
    { path: '*', redirect: '/page1' }
  ]
})

export default router
```

<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
