### PR TITLE
fix(detachable): apply lazy behavior to initDetach

### DIFF
--- a/src/mixins/bootable.js
+++ b/src/mixins/bootable.js
@@ -17,6 +17,12 @@ export default {
     lazy: Boolean
   },
 
+  computed: {
+    hasContent () {
+      return this.isBooted || !this.lazy || this.isActive
+    }
+  },
+
   watch: {
     isActive () {
       this.isBooted = true
@@ -25,9 +31,7 @@ export default {
 
   methods: {
     showLazyContent (content) {
-      return (this.isBooted || !this.lazy || this.isActive)
-        ? content
-        : null
+      return this.hasContent ? content : null
     }
   }
 }

--- a/src/mixins/detachable.js
+++ b/src/mixins/detachable.js
@@ -14,6 +14,10 @@ export default {
 
   mixins: [Bootable],
 
+  data: () => ({
+    hasDetached: false
+  }),
+
   props: {
     attach: {
       type: null,
@@ -25,8 +29,12 @@ export default {
     }
   },
 
+  watch: {
+    hasContent: 'initDetach'
+  },
+
   mounted () {
-    this.initDetach()
+    !this.lazy && this.initDetach()
   },
 
   deactivated () {
@@ -46,6 +54,7 @@ export default {
     initDetach () {
       if (this._isDestroyed ||
         !this.$refs.content ||
+        this.hasDetached ||
         // Leave menu in place if attached
         // and dev has not changed target
         this.attach === '' || // If used as a boolean prop (<v-menu attach>)
@@ -74,6 +83,8 @@ export default {
         this.$refs.content,
         target.firstChild
       )
+
+      this.hasDetached = true
     }
   }
 }

--- a/test/unit/components/VDialog/VDialog.spec.js
+++ b/test/unit/components/VDialog/VDialog.spec.js
@@ -50,7 +50,6 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render a scrollable component and match snapshot', () => {

--- a/test/unit/components/VMenu/VMenu.spec.js
+++ b/test/unit/components/VMenu/VMenu.spec.js
@@ -223,7 +223,6 @@ test('VMenu.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
-    expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
   it('should render component with custom closeOnClick and match snapshot', () => {

--- a/test/unit/mixins/bootable.spec.js
+++ b/test/unit/mixins/bootable.spec.js
@@ -62,4 +62,19 @@ test('bootable.js', ({ mount }) => {
 
     expect(wrapper.vm.showLazyContent('content')).toBe('content')
   })
+
+  it('should boot', async () => {
+    const wrapper = mount({
+      data: () => ({ isActive: false }),
+      mixins: [Bootable],
+      render: h => h('div')
+    })
+
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(wrapper.vm.isBooted).toBe(false)
+
+    wrapper.setData({ isActive: true })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isBooted).toBe(true)
+  })
 })

--- a/test/unit/mixins/detachable.spec.js
+++ b/test/unit/mixins/detachable.spec.js
@@ -1,0 +1,123 @@
+import { test } from '@/test'
+import VApp from '@/components/VApp'
+import Detachable from '@/mixins/detachable'
+
+const Mock = () => ({
+  name: 'mock',
+
+  mixins: [Detachable],
+
+  render (h) {
+    const content = h('div', {
+      staticClass: 'content',
+      ref: 'content'
+    })
+
+    return h('div', {
+      staticClass: 'mock'
+    }, [this.$slots.default, content])
+  }
+})
+
+test('detachable.js', ({ mount }) => {
+  it('should detach to app', async () => {
+    const localMock = Mock()
+    const wrapper = mount(VApp, {
+      attachToDocument: true,
+      slots: {
+        default: [{
+          render: h => h(localMock)
+        }]
+      }
+    })
+
+    const detach = wrapper.find(localMock)[0]
+
+    expect(detach.vm.hasDetached).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('should not detach when lazy', async () => {
+    const localMock = Mock()
+    const wrapper = mount(VApp, {
+      attachToDocument: true,
+      slots: {
+        default: [{
+          render: h => h(localMock, {
+            props: { lazy: true }
+          })
+        }]
+      }
+    })
+
+    const detach = wrapper.find(localMock)[0]
+
+    expect(detach.vm.hasDetached).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('should attach and detach', () => {
+    const localMock = Mock()
+    const elementMock = mount(Mock())
+    const wrapper = mount(localMock, {
+      attachToDocument: true,
+      propsData: {
+        attach: ''
+      },
+      slots: {
+        default: [{
+          render: h => h('div', { staticClass: 'foo' })
+        }]
+      }
+    })
+
+    expect('[Vuetify] Unable to locate target [data-app] in "mock"').toHaveBeenTipped()
+
+    expect(wrapper.vm.initDetach()).toBe(undefined)
+
+    wrapper.setProps({ attach: true })
+
+    expect(wrapper.vm.initDetach()).toBe(undefined)
+
+    wrapper.setProps({ attach: 'attach' })
+
+    expect(wrapper.vm.initDetach()).toBe(undefined)
+
+    wrapper.setProps({ attach: elementMock.vm.$el })
+
+    wrapper.vm.initDetach()
+
+    expect(wrapper.vm.hasDetached).toBe(true)
+
+    wrapper.setData({ hasDetached: false })
+
+    wrapper.setProps({ attach: '.foo' })
+
+    wrapper.vm.initDetach()
+
+    expect(wrapper.vm.hasDetached).toBe(true)
+
+    wrapper.setData({ hasDetached: false })
+
+    wrapper.setProps({ attach: '.bar' })
+
+    wrapper.vm.initDetach()
+
+    expect('[Vuetify] Unable to locate target .bar in "mock"').toHaveBeenTipped()
+
+    delete wrapper.vm.$refs.content
+    wrapper.vm.$destroy()
+  })
+
+  it('should validate attach prop', () => {
+    const validator = Detachable.props.attach.validator
+
+    expect(validator(true)).toBe(true)
+    expect(validator(false)).toBe(true)
+    expect(validator('foo')).toBe(true)
+    expect(validator({ nodeType: Node.ELEMENT_NODE })).toBe(true)
+    expect(validator({})).toBe(false)
+  })
+})


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Lazy will now affect the detaching of the content at mount. This avoids unnecessary DOM manipulation when specified as lazy
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3570
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
``` vue
<template>
  <div id="app">
  <v-app id="inspire">
    <v-content>
      <v-data-table
     :pagination.sync="pagination"
    :headers="headers"
    :items="items"
  >
    <template slot="items" slot-scope="props">
      <td>
        <v-edit-dialog
          :return-value.sync="props.item.name"
          lazy
        > {{ props.item.name }}
          <v-text-field
            slot="input"
            label="Edit"
            v-model="props.item.name"
            single-line
            counter
            :rules="[max25chars]"
          ></v-text-field>
        </v-edit-dialog>
      </td>
      <td class="text-xs-right">{{ props.item.calories }}</td>
      <td class="text-xs-right">{{ props.item.fat }}</td>
      <td class="text-xs-right">{{ props.item.carbs }}</td>
      <td class="text-xs-right">{{ props.item.protein }}</td>
      <td class="text-xs-right">
        <v-edit-dialog
          :return-value.sync="props.item.iron"
          large
          lazy
          persistent
        >
          <div>{{ props.item.iron }}</div>
          <div slot="input" class="mt-3 title">Update Iron</div>
          <v-text-field
            slot="input"
            label="Edit"
            v-model="props.item.iron"
            single-line
            counter
            autofocus
            :rules="[max25chars]"
          ></v-text-field>
        </v-edit-dialog>
      </td>
    </template>
  </v-data-table>
    </v-content>
  </v-app>
</div>
</template>

<script>
export default {
  data() {
let items = []
          for (var i = 0; i < 1000; i++) {
            items.push({
              value: false,
              name: 'Frozen Yogurt',
              calories: 159,
              fat: 6.0,
              carbs: 24,
              protein: 4.0,
              iron: '1%'
            })
          }
      return {
        max25chars: (v) => v.length <= 25 || 'Input too long!',
        pagination: {
          rowsPerPage: -1
        },
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name'
          },
          {text: 'Calories', value: 'calories'},
          {text: 'Fat (g)', value: 'fat'},
          {text: 'Carbs (g)', value: 'carbs'},
          {text: 'Protein (g)', value: 'protein'},
          {text: 'Iron (%)', value: 'iron'}
        ],
        items: items
      }
    }
}
</script>
```
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
