### PR TITLE
fix: rounding error that affects all dividers and thin lines

### DIFF
--- a/src/stylus/components/_dividers.styl
+++ b/src/stylus/components/_dividers.styl
@@ -2,15 +2,13 @@
 @import '../theme'
 
 divider($material)
-  background-color: $material.dividers
-
+  border-color: $material.dividers
+  
 theme(divider, "divider")
 
 .divider
-  border: none
+  border-width: thin 0 0 0
   display: block
-  height: 1px
-  min-height: 1px
   flex: 1
   width: 100%
 

--- a/src/stylus/components/_input-groups.styl
+++ b/src/stylus/components/_input-groups.styl
@@ -47,9 +47,6 @@ input-group($material)
       .input-group__selections__comma
         color: $material.text.disabled
 
-    .input-group__details:before
-      background-color: $material.input-bottom-line
-
     &:not(.input-group--focused):not(.input-group--disabled)
       .input-group__input
         .input-group__append-icon,
@@ -267,18 +264,22 @@ theme(input-group, "input-group")
       transition: .3s $transition.fast-out-slow-in
 
     &:after
+      border-style: solid
+      border-color: currentColor
+      border-width: medium 0 0 0
       background-color: currentColor
       color: inherit
       top: 0
-      height: 2px
       transform: scaleX(0)
       transform-origin: center center 0
       width: 100%
       z-index: 1
 
     &:before
+      border-style: solid
+      border-color: $material.input-bottom-line
+      border-width: thin 0 0 0
       top: 0
-      height: 1px
       width: 100%
       z-index: 0
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is an attempt to fix the following visual problems with all the thin lines (`v-divider`, `v-select`,  `v-text-field`, etc)

- 1px lines & borders are disappearing
- All lines & borders are rendered with 1px rounding error which makes them all look different and inconsistent depending on the elements surrounding them and the current page zoom value

These issues occur on different page zoom values (usually 67% - 150% but you can also see it at 100% since browsers are taking element position into calculation). 

Since it's impossible to display non-integer values (like 0.75px), browsers will have to round:

- all the `1px` lines to a value in range (`0px` - `2px`)
- all the `2px` lines to a value in range (`1px` - `3px`)
...
And there's no way to predict what it's going to be. You can add 1 element on the page and all the lines will look completely different than before.

Browsers are rounding float values inconsistently because position of the element is also taken into account during calculation, this is why all the identical lines on the same page ([example](https://codepen.io/anon/pen/gewZYm)) always look different depending on their position to other elements on the page - some of them are getting rendered as a `0px` lines, some as `1px` lines and some as `2px` lines (which is why some `v-divider`s and bottom borders in `v-text-filed` are disappearing and some look thicker than they supposed to)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #3588 
fixes #3090 
### P.S I'm new to this, please make sure I haven't removed or broke anything important and that everything still works the way it supposed to in all the browsers. 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
- Visually on [this test codepen](https://codepen.io/anon/pen/BrLNPa?editors=1000) using Chrome developer tools panel
- Here's a 4 mins video of the exact testing steps: [Video of the testing process in Chrome](https://drive.google.com/open?id=1cd5mBfb-liomGNzA4Y8Cz2HmtVmMs4g-)
- The changes work in Chrome and Firefox and resolve the issues.
- The changes suppose to fall back to the default "1px border" in the other browsers automatically, although I'm not sure if that's the case in all browsers and even if it is I'm not sure that removing some of the styles (like lines 50-52 in `_input-groups.styl`) didn't broke this auto fallback.


## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
