### PR TITLE
Temporary fixes #2111, workaround Safari z-index menu/dialog

### DIFF
--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -149,7 +149,12 @@ export default {
     if (!this.fullscreen) {
       data.style = {
         maxWidth: this.maxWidth === 'none' ? undefined : (isNaN(this.maxWidth) ? this.maxWidth : `${this.maxWidth}px`),
-        width: this.width === 'auto' ? undefined : (isNaN(this.width) ? this.width : `${this.width}px`)
+        width: this.width === 'auto' ? undefined : (isNaN(this.width) ? this.width : `${this.width}px`),
+        zIndex: this.activeZIndex // temp workaround for #2111, set same zIndex of parent div
+      }
+    } else {
+      data.style = {
+        zIndex: this.activeZIndex // temp workaround for #2111, set same zIndex of parent div
       }
     }
 


### PR DESCRIPTION
Hello, this is just a workaround to fix a nasty bug in Safari. When a v-select is put inside a full screen v-dialog, the z-index is below the current dialog, so the menu is not displayed.

## Description
I've debugged the following files (with console.log), and found that there is a bug in Safari or getZIndex() function that fails to calculate the zIndex correctly. This bug is present in Mac OS X and iOS versions of Safari.

## Motivation and Context
This PR fixes bug #2111.

We need this temporary fix because we need to run our apps in production ;-) and the original bug was reported on Oct/2017, 4 months ago.

It can gives us time to fix the real problem:
1. fix the getZIndex() function so it works always well in Safari
2. maybe there is something we can do to avoid Safari gives the wrong z-index. Seems something related to `position: fixed`, but I'm not sure.

## How Has This Been Tested?
1. Just debugged with console.log, and checked the problem was present in 1.0.8 and then it was gone with my fix.
2. Published our app and:
   - manually checked in Safari, iOS Simulator and a real iPhone; all of them with latests versions.
   - manually checked in Chrome, and Android
   - manually checked in Firefox 59

## Markup:


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.