### PR TITLE
fix(goTo): validate target correctly when vue is minified

### DIFF
--- a/src/components/Vuetify/util/goTo.js
+++ b/src/components/Vuetify/util/goTo.js
@@ -24,18 +24,18 @@ function getWindowHeight () {
 }
 
 function isVueComponent (obj) {
-  return obj &&
-    obj.constructor &&
-    obj.constructor.name === 'VueComponent'
+  return obj != null && obj._isVue
 }
 
 function getTargetLocation (target, settings) {
   let location
 
+  if (isVueComponent(target)) {
+    target = target.$el
+  }
+
   if (target instanceof Element) {
-    location = target.offsetTop
-  } else if (isVueComponent(target)) {
-    location = target.$el.offsetTop
+    location = target.getBoundingClientRect().top + window.scrollY
   } else if (typeof target === 'string') {
     location = document.querySelector(target).offsetTop
   } else if (typeof target === 'number') {
@@ -64,7 +64,7 @@ export default function goTo (target, options) {
   const easingFunction = typeof settings.easing === 'function' ? settings.easing : easingPatterns[settings.easing]
 
   if (isNaN(targetLocation)) {
-    const type = target && target.constructor ? target.constructor.name : target
+    const type = target == null ? target : target.constructor.name
     return consoleError(`Target must be a Selector/Number/DOMElement/VueComponent, received ${type} instead.`)
   }
   if (!easingFunction) return consoleError(`Easing function '${settings.easing}' not found.`)


### PR DESCRIPTION
## Description
constructor.name isn't reliable for type checking when function names
are minified, but vue components will always have an _isVue property

Also fixed position calculation of elements in relative contexts,
Element.offsetTop only returns the offset to the offsetParent in such
cases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3611

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
N/A, used http://localhost:8095/motion/scrolling

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
