### PR TITLE
fix(VDialog): inherit z-index from wrapper

### DIFF
--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -8,6 +8,7 @@
   pointer-events: auto
   transition: .3s ease-in-out
   width: 100%
+  z-index: inherit
 
   &__content
     align-items: center

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -118,10 +118,11 @@ export function createRange (length) {
 
 export function getZIndex (el) {
   if (!el || el.nodeType !== Node.ELEMENT_NODE) return 0
-  var zi = document.defaultView.getComputedStyle(el).getPropertyValue('z-index')
-  if (isNaN(zi)) return getZIndex(el.parentNode)
 
-  return zi
+  const index = window.getComputedStyle(el).getPropertyValue('z-index')
+
+  if (isNaN(index)) return getZIndex(el.parentNode)
+  return index
 }
 
 const tagsToReplace = {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
safari returns 0 instead of 'auto' if an element's parent is positioned,
inheriting the z-index should prevent that

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #2111

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
I don't have any apple devices, so this will need testing by someone else (@chewy94?)
I did verify that it doesn't affect anything in win10 chrome however

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```vue
<template>
  <boilerplate>
    <v-dialog max-width="320">
      <v-btn slot="activator">Open dialog</v-btn>
      <v-card>
        <v-card-text>
          <v-menu>
            <v-btn slot="activator">Open menu</v-btn>
            <v-list>
              <v-list-tile v-for="i in 10" :key="i">
                <v-list-tile-title>Item {{ i }}</v-list-tile-title>
              </v-list-tile>
            </v-list>
          </v-menu>
        </v-card-text>
      </v-card>
    </v-dialog>
  </boilerplate>
</template>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
