### PR TITLE
fix (v-tabs): disabled tab is not disabled

### DIFF
--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -8,8 +8,9 @@ tabs__bar($material)
   .tabs__div
     color: $material.tabs.active
 
-    &.tabs__item--disabled
+    .tabs__item--disabled
       color: $material.buttons.disabled
+      pointer-events: none
 
 theme(tabs__bar, "tabs__bar")
 

--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -8,9 +8,8 @@ tabs__bar($material)
   .tabs__div
     color: $material.tabs.active
 
-    .tabs__item--disabled
-      color: $material.buttons.disabled
-      pointer-events: none
+  .tabs__item--disabled
+    color: $material.buttons.disabled
 
 theme(tabs__bar, "tabs__bar")
 
@@ -143,6 +142,9 @@ theme(tabs__bar, "tabs__bar")
 
   &:not(.tabs__item--active)
     opacity: .7
+
+  &--disabled
+    pointer-events: none
 
 .tabs__slider
   height: 2px


### PR DESCRIPTION
## Description
Fixes wrong styling and adds `pointer-events: none` to avoid calling click handler on click

## Motivation and Context
fixes #3644

## How Has This Been Tested?
visually

## Markup:
```vue
<template>
  <v-app>
    <v-content>
      <v-tabs v-model="tab">
        <v-tab>One</v-tab>
        <v-tab disabled>Two</v-tab>
        <v-tab>Three</v-tab>
      </v-tabs>
    </v-content>
  </v-app>
</template>

<script>
 export default {
   data () {
      return {
        tab: null
      }
   },
 }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
