### PR TITLE
fix(v-tab): fixed resolve comparison and args

### DIFF
--- a/src/components/VTabs/VTab.js
+++ b/src/components/VTabs/VTab.js
@@ -45,8 +45,14 @@ export default {
     action () {
       let to = this.to || this.href
 
-      if (this.$router && this.to) {
-        const resolve = this.$router.resolve(this.to)
+      if (this.$router &&
+        this.to === Object(this.to)
+      ) {
+        const resolve = this.$router.resolve(
+          this.to,
+          this.$route,
+          this.append
+        )
 
         to = resolve.href
       }

--- a/test/unit/components/VTabs/VTab.spec.js
+++ b/test/unit/components/VTabs/VTab.spec.js
@@ -140,7 +140,7 @@ test('VTab', ({ mount }) => {
   //
   // Current conversation on vue-router tests
   // https://github.com/vuejs/vue-router/issues/1768
-  it.skip('should call tabClick', async () => {
+  it('should call tabClick', async () => {
     const instance = Vue.extend()
     instance.component('router-link', stub)
     const wrapper = mount(VTab, {
@@ -182,7 +182,18 @@ test('VTab', ({ mount }) => {
       propsData: {
         href: '#foo'
       },
-      instance
+      instance,
+      globals: {
+        $route: { path: '/' },
+        $router: {
+          resolve: (to, route, append) => {
+            let href
+            if (to.path) href = to.path
+
+            return { href }
+          }
+        }
+      }
     })
 
     expect(wrapper.vm.action).toBe('foo')
@@ -190,6 +201,8 @@ test('VTab', ({ mount }) => {
     expect(wrapper.vm.action).toBe('/foo')
     wrapper.setProps({ to: null })
     expect(wrapper.vm.action).toBe(wrapper.vm)
+    wrapper.setProps({ to: { path: 'bar' }})
+    expect(wrapper.vm.action).toBe('bar')
 
     expect(tabClick).toHaveBeenWarned()
     expect(tabsWarning).toHaveBeenTipped()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a particularly tricky thing to get right. I've added a useless mock in the test so we can at least start to test the expected output, but it would be better if vue-router was testable. The previous implementation wasn't using all available args in **router.resolve** which was the cause for @sindrepm 's issue (he commented in #3654). The actual fix for 3654 was the comparison of the `to` prop as a string without an associated route. While we never explicitly supported this, and the correct way would be to simply use **href**, it is an easy enough change to handle both.

- Added additional args to **resolve** function in order to allow for implicit params from routes
- Added type check for `to` prop to skip resolve
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3654
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest (kind of)
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
See attached issue
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
