### PR TITLE
 fix: `update:returnValue` event emitted twice in returnable mixin

### DIFF
--- a/src/components/VTabs/VTab.js
+++ b/src/components/VTabs/VTab.js
@@ -45,8 +45,14 @@ export default {
     action () {
       let to = this.to || this.href
 
-      if (this.$router && this.to) {
-        const resolve = this.$router.resolve(this.to)
+      if (this.$router &&
+        this.to === Object(this.to)
+      ) {
+        const resolve = this.$router.resolve(
+          this.to,
+          this.$route,
+          this.append
+        )
 
         to = resolve.href
       }

--- a/src/components/Vuetify/util/goTo.js
+++ b/src/components/Vuetify/util/goTo.js
@@ -24,18 +24,18 @@ function getWindowHeight () {
 }
 
 function isVueComponent (obj) {
-  return obj &&
-    obj.constructor &&
-    obj.constructor.name === 'VueComponent'
+  return obj != null && obj._isVue
 }
 
 function getTargetLocation (target, settings) {
   let location
 
+  if (isVueComponent(target)) {
+    target = target.$el
+  }
+
   if (target instanceof Element) {
-    location = target.offsetTop
-  } else if (isVueComponent(target)) {
-    location = target.$el.offsetTop
+    location = target.getBoundingClientRect().top + window.scrollY
   } else if (typeof target === 'string') {
     location = document.querySelector(target).offsetTop
   } else if (typeof target === 'number') {
@@ -64,7 +64,7 @@ export default function goTo (target, options) {
   const easingFunction = typeof settings.easing === 'function' ? settings.easing : easingPatterns[settings.easing]
 
   if (isNaN(targetLocation)) {
-    const type = target && target.constructor ? target.constructor.name : target
+    const type = target == null ? target : target.constructor.name
     return consoleError(`Target must be a Selector/Number/DOMElement/VueComponent, received ${type} instead.`)
   }
   if (!easingFunction) return consoleError(`Easing function '${settings.easing}' not found.`)

--- a/src/mixins/returnable.js
+++ b/src/mixins/returnable.js
@@ -22,7 +22,6 @@ export default {
   methods: {
     save (value) {
       this.originalValue = value
-      this.$emit('update:returnValue', value)
       this.isActive = false
     }
   }

--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -8,6 +8,7 @@
   pointer-events: auto
   transition: .3s ease-in-out
   width: 100%
+  z-index: inherit
 
   &__content
     align-items: center

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -118,10 +118,11 @@ export function createRange (length) {
 
 export function getZIndex (el) {
   if (!el || el.nodeType !== Node.ELEMENT_NODE) return 0
-  var zi = document.defaultView.getComputedStyle(el).getPropertyValue('z-index')
-  if (isNaN(zi)) return getZIndex(el.parentNode)
 
-  return zi
+  const index = window.getComputedStyle(el).getPropertyValue('z-index')
+
+  if (isNaN(index)) return getZIndex(el.parentNode)
+  return index
 }
 
 const tagsToReplace = {

--- a/test/unit/components/VTabs/VTab.spec.js
+++ b/test/unit/components/VTabs/VTab.spec.js
@@ -140,7 +140,7 @@ test('VTab', ({ mount }) => {
   //
   // Current conversation on vue-router tests
   // https://github.com/vuejs/vue-router/issues/1768
-  it.skip('should call tabClick', async () => {
+  it('should call tabClick', async () => {
     const instance = Vue.extend()
     instance.component('router-link', stub)
     const wrapper = mount(VTab, {
@@ -182,7 +182,18 @@ test('VTab', ({ mount }) => {
       propsData: {
         href: '#foo'
       },
-      instance
+      instance,
+      globals: {
+        $route: { path: '/' },
+        $router: {
+          resolve: (to, route, append) => {
+            let href
+            if (to.path) href = to.path
+
+            return { href }
+          }
+        }
+      }
     })
 
     expect(wrapper.vm.action).toBe('foo')
@@ -190,6 +201,8 @@ test('VTab', ({ mount }) => {
     expect(wrapper.vm.action).toBe('/foo')
     wrapper.setProps({ to: null })
     expect(wrapper.vm.action).toBe(wrapper.vm)
+    wrapper.setProps({ to: { path: 'bar' }})
+    expect(wrapper.vm.action).toBe('bar')
 
     expect(tabClick).toHaveBeenWarned()
     expect(tabsWarning).toHaveBeenTipped()


### PR DESCRIPTION
The `returnable` mixin emits `update:returnValue` event twice on save.
The first time inside `save` method, the second time directly after
this when the value of `isActive` flag is changed to `false`
(in this case the watcher emits the event), so it is enough to just
set the `isActive` flag to false inside `save` method and the
`update:returnValue` event will be called "automatically" by watcher.
