### PR TITLE
perf(v-select): Update menu dimensions only when active

### DIFF
--- a/src/components/VSelect/mixins/select-watchers.js
+++ b/src/components/VSelect/mixins/select-watchers.js
@@ -9,7 +9,7 @@
 export default {
   watch: {
     filteredItems () {
-      this.$refs.menu && this.$refs.menu.updateDimensions()
+      this.$refs.menu && this.isActive && this.$refs.menu.updateDimensions()
     },
     inputValue (val) {
       // Search for an existing item when a
@@ -90,7 +90,9 @@ export default {
       // Wrap input to next line if overflowing
       if (this.$refs.input.scrollWidth > this.$refs.input.clientWidth) {
         this.shouldBreak = true
-        this.$nextTick(this.$refs.menu.updateDimensions)
+        if (this.isActive) {
+          this.$nextTick(this.$refs.menu.updateDimensions)
+        }
       } else if (val === null) {
         this.shouldBreak = false
       }
@@ -117,7 +119,7 @@ export default {
       })
     },
     selectedItems () {
-      if (this.isAutocomplete) {
+      if (this.isAutocomplete && this.isActive) {
         this.$nextTick(this.$refs.menu.updateDimensions)
       }
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This avoid layout trashing as much as possible by invoking menuable mixin `updateDimensions` method only when menu is active.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I hit performance bottleneck when trying to display a form with multiple v-select, and it was even worse when using CSS transitions.

This is related to #3497 that was partially fixed only. Problem is that V-Select component is invoking `updateDimensions` of menuable mixin when menu is not active. This cause layout trashing and bad performance for no reason, because updateDimensions is called when the menu is activating.

#3497

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

Visually only, in the context of my webapp.

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
