### PR TITLE
Add actions slot to iterable components

### DIFF
--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -452,6 +452,7 @@ export default {
       return [this.$createElement('div', {
         'class': this.actionsClasses
       }, [
+        this.$slots.actions,
         this.rowsPerPageItems.length > 1 ? this.genSelect() : null,
         rangeControls
       ])]

--- a/test/unit/components/VDataIterator/VDataIterator.spec.js
+++ b/test/unit/components/VDataIterator/VDataIterator.spec.js
@@ -54,6 +54,17 @@ test('VDataIterator.js', ({ mount, compileToFunctions }) => {
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
+  it('should match a snapshot - actions slot', () => {
+    const data = dataIteratorTestData()
+    data.slots = {
+      actions: [compileToFunctions('<span>actions</span>')],
+    }
+    const wrapper = mount(VDataIterator, data)
+
+    expect(wrapper.html()).toMatchSnapshot()
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
   it('should match a snapshot - no data', () => {
     const data = dataIteratorTestData()
     data.propsData.items = []

--- a/test/unit/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/test/unit/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -1,5 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VDataIterator.js should match a snapshot - actions slot 1`] = `
+
+<div class="data-iterator">
+  <div>
+  </div>
+  <div>
+    <div class="data-iterator__actions">
+      <span>
+        actions
+      </span>
+      <div class="data-iterator__actions__select">
+        Items per page:
+        <div tabindex="0"
+             data-uid="29"
+             aria-label="Items per page:"
+             role="combobox"
+             class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
+        >
+          <div class="input-group__input">
+            <div class="input-group__selections"
+                 style="overflow: hidden;"
+            >
+              <input aria-label="Items per page:"
+                     disabled="disabled"
+                     tabindex="-1"
+                     class="input-group--select__autocomplete"
+                     style="display: none;"
+              >
+            </div>
+            <div class="menu"
+                 style="display: inline-block;"
+            >
+              <div class="menu__content menu__content--select menu__content--auto"
+                   style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
+              >
+                <div class="card"
+                     style="height: auto;"
+                >
+                  <div class="list">
+                    <div>
+                      <a class="list__tile list__tile--link">
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            5
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                    <div>
+                      <a class="list__tile list__tile--link">
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            10
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                    <div>
+                      <a class="list__tile list__tile--link">
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            25
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                    <div>
+                      <a class="list__tile list__tile--link">
+                        <div class="list__tile__content">
+                          <div class="list__tile__title">
+                            All
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <i aria-hidden="true"
+               class="icon material-icons input-group__append-icon input-group__icon-cb"
+            >
+              arrow_drop_down
+            </i>
+          </div>
+          <div class="input-group__details">
+          </div>
+        </div>
+      </div>
+      <div class="data-iterator__actions__range-controls">
+        <div class="data-iterator__actions__pagination">
+          1-3 of 3
+        </div>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                aria-label="Previous page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="icon material-icons"
+            >
+              chevron_left
+            </i>
+          </div>
+        </button>
+        <button disabled="disabled"
+                type="button"
+                class="btn btn--disabled btn--flat btn--icon"
+                aria-label="Next page"
+        >
+          <div class="btn__content">
+            <i aria-hidden="true"
+               class="icon material-icons"
+            >
+              chevron_right
+            </i>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
 
 <div class="data-iterator">
@@ -150,7 +276,7 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
       <div class="data-iterator__actions__select">
         Items per page:
         <div tabindex="0"
-             data-uid="28"
+             data-uid="41"
              aria-label="Items per page:"
              role="combobox"
              class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"
@@ -410,7 +536,7 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
       <div class="data-iterator__actions__select">
         Items per page:
         <div tabindex="0"
-             data-uid="42"
+             data-uid="55"
              aria-label="Items per page:"
              role="combobox"
              class="input-group input-group--append-icon input-group--hide-details input-group--text-field input-group--select input-group--auto primary--text"

--- a/test/unit/components/VDataTable/VDataTable.spec.js
+++ b/test/unit/components/VDataTable/VDataTable.spec.js
@@ -281,6 +281,21 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
+  it('should render additional place for actions', async () => {
+    const wrapper = mount(Vue.component('test', {
+      render (h) {
+        return h(VDataTable, {
+          props: {
+            items: [{}]
+          },
+        }, [h('div', { slot: 'actions', class: 'custom-class' })])
+      }
+    }))
+
+    expect(wrapper.find('.custom-class')).toHaveLength(1)
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
   it('should initialize everyItem state', async () => {
     const data = dataTableTestData()
     data.propsData.value = data.propsData.items


### PR DESCRIPTION
## Description
Sometimes you want to add some selects or other text / components nearby pagination.

## Motivation and Context
It gives more options to create ui.

## How Has This Been Tested?
Only unit

## Markup:
```pug
v-data-table(...)
   span(slot="actions") Some text or other components
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation. ***(to add information)***
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
