### PR TITLE
Refactor (VBadge): Add v- prefix to badge classes

### DIFF
--- a/src/components/VBadge/VBadge.js
+++ b/src/components/VBadge/VBadge.js
@@ -29,16 +29,16 @@ export default {
   computed: {
     classes () {
       return {
-        'badge--bottom': this.bottom,
-        'badge--left': this.left,
-        'badge--overlap': this.overlap
+        'v-badge--bottom': this.bottom,
+        'v-badge--left': this.left,
+        'v-badge--overlap': this.overlap
       }
     }
   },
 
   render (h) {
     const badge = this.$slots.badge ? [h('span', {
-      staticClass: 'badge__badge',
+      staticClass: 'v-badge__badge',
       'class': this.addBackgroundColorClassChecks(),
       attrs: this.attrs,
       directives: [{
@@ -48,7 +48,7 @@ export default {
     }, this.$slots.badge)] : null
 
     return h('span', {
-      staticClass: 'badge',
+      staticClass: 'v-badge',
       'class': this.classes
     }, [
       this.$slots.default,

--- a/src/stylus/components/_badges.styl
+++ b/src/stylus/components/_badges.styl
@@ -1,9 +1,9 @@
 @import '../bootstrap'
 
-.badge
+.v-badge
   display: inline-block
   position: relative
-  
+
   &__badge
     color: $badge-color
     display: flex
@@ -19,30 +19,30 @@
     flex-direction: row
     flex-wrap: wrap
     transition: $primary-transition
-    
+
     .icon
       font-size: $badge-font-size
 
   &--overlap
-    .badge__badge
+    .v-badge__badge
       top: -8px
       right: -8px
 
-    &.badge--left
-      .badge__badge
+    &.v-badge--left
+      .v-badge__badge
         left: -8px
         right: initial
 
-    &.badge--bottom
-      .badge__badge
+    &.v-badge--bottom
+      .v-badge__badge
         bottom: -8px
         top: initial
 
   &--left
-    .badge__badge
+    .v-badge__badge
       left: -($badge-width)
 
   &--bottom
-    .badge__badge
+    .v-badge__badge
       bottom: -($badge-height / 2)
       top: initial;

--- a/test/unit/components/VBadge/VBadge.spec.js
+++ b/test/unit/components/VBadge/VBadge.spec.js
@@ -34,7 +34,7 @@ test('VBadge.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    expect(wrapper.hasClass('badge--bottom')).toBe(true)
+    expect(wrapper.hasClass('v-badge--bottom')).toBe(true)
   })
 
   it('should render component with left prop', () => {
@@ -44,7 +44,7 @@ test('VBadge.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    expect(wrapper.hasClass('badge--left')).toBe(true)
+    expect(wrapper.hasClass('v-badge--left')).toBe(true)
   })
 
   it('should render component with overlap prop', () => {
@@ -54,7 +54,7 @@ test('VBadge.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    expect(wrapper.hasClass('badge--overlap')).toBe(true)
+    expect(wrapper.hasClass('v-badge--overlap')).toBe(true)
   })
 
   it('should render component with color prop', () => {
@@ -67,7 +67,7 @@ test('VBadge.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const badge = wrapper.find('.badge__badge')[0]
+    const badge = wrapper.find('.v-badge__badge')[0]
     expect(badge.hasClass('green')).toBe(true)
     expect(badge.hasClass('lighten-1')).toBe(true)
   })

--- a/test/unit/components/VBadge/__snapshots__/VBadge.spec.js.snap
+++ b/test/unit/components/VBadge/__snapshots__/VBadge.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`VBadge.js should render component and match snapshot 1`] = `
 
-<span class="badge">
+<span class="v-badge">
   <span>
     element
   </span>
-  <span class="badge__badge primary">
+  <span class="v-badge__badge primary">
     <span>
       content
     </span>
@@ -17,11 +17,11 @@ exports[`VBadge.js should render component and match snapshot 1`] = `
 
 exports[`VBadge.js should render component with with value=false and match snapshot 1`] = `
 
-<span class="badge">
+<span class="v-badge">
   <span>
     element
   </span>
-  <span class="badge__badge primary"
+  <span class="v-badge__badge primary"
         style="display: none;"
   >
     <span>


### PR DESCRIPTION

## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
