### PR TITLE
Refactor (VBreadcrumbs): Add v- prefix on breadcrumbs classes

### DIFF
--- a/src/components/VBreadcrumbs/VBreadcrumbs.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbs.js
@@ -16,7 +16,7 @@ export default {
   computed: {
     classes () {
       return {
-        'breadcrumbs--large': this.large
+        'v-breadcrumbs--large': this.large
       }
     },
     computedDivider () {
@@ -48,7 +48,7 @@ export default {
       if (!this.$slots.default) return null
 
       const children = []
-      const dividerData = { staticClass: 'breadcrumbs__divider' }
+      const dividerData = { staticClass: 'v-breadcrumbs__divider' }
       const length = this.$slots.default.length
 
       for (let i = 0; i < length; i++) {
@@ -70,7 +70,7 @@ export default {
 
   render (h) {
     return h('ul', {
-      staticClass: 'breadcrumbs',
+      staticClass: 'v-breadcrumbs',
       'class': this.classes,
       style: this.styles
     }, this.genChildren())

--- a/src/components/VBreadcrumbs/VBreadcrumbsItem.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbsItem.js
@@ -10,14 +10,14 @@ export default {
     // active item should be dimmed
     activeClass: {
       type: String,
-      default: 'breadcrumbs__item--disabled'
+      default: 'v-breadcrumbs__item--disabled'
     }
   },
 
   computed: {
     classes () {
       return {
-        'breadcrumbs__item': true,
+        'v-breadcrumbs__item': true,
         [this.activeClass]: this.disabled
       }
     }

--- a/src/stylus/components/_breadcrumbs.styl
+++ b/src/stylus/components/_breadcrumbs.styl
@@ -1,15 +1,15 @@
 ﻿@import '../bootstrap'
 @import '../theme'
 
-breadcrumbs($material)
-  li.breadcrumbs__divider,
-  li:last-child .breadcrumbs__item,
-  li .breadcrumbs__item--disabled
+v-breadcrumbs($material)
+  li.v-breadcrumbs__divider,
+  li:last-child .v-breadcrumbs__item,
+  li .v-breadcrumbs__item--disabled
     color: $material.text.disabled
 
-theme(breadcrumbs, "breadcrumbs")
+theme(v-breadcrumbs, "v-breadcrumbs")
 
-.breadcrumbs
+.v-breadcrumbs
   align-items: center
   display: flex
   flex-wrap: wrap
@@ -29,14 +29,14 @@ theme(breadcrumbs, "breadcrumbs")
     &:last-child a
       cursor: default
       pointer-events: none
-      
+
     &:nth-child(even)
       padding: $breadcrumbs-even-child-padding
 
   &--large
     li
       font-size: $breadcrumbs-item-large-font-size
-      
+
       .icon
         font-size: $breadcrumbs-item-large-font-size
 

--- a/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
+++ b/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
@@ -9,7 +9,7 @@ test('VBreadcrumbs.js', ({ mount, compileToFunctions }) => {
   it('should have breadcrumbs classes', () => {
     const wrapper = mount(VBreadcrumbs)
 
-    expect(wrapper.hasClass('breadcrumbs')).toBe(true)
+    expect(wrapper.hasClass('v-breadcrumbs')).toBe(true)
     expect(wrapper.html()).toMatchSnapshot()
   })
 

--- a/test/unit/components/VBreadcrumbs/VBreadcrumbsItem.spec.js
+++ b/test/unit/components/VBreadcrumbs/VBreadcrumbsItem.spec.js
@@ -13,7 +13,7 @@ test.skip('VBreadcrumbsItem.js', ({ mount }) => {
   it.skip('should have a custom active class', () => {
     const wrapper = mount(VBreadcrumbsItem, {
       propsData: {
-        activeClass: 'breadcrumbs-item--active',
+        activeClass: 'v-breadcrumbs-item--active',
         to: '/'
       }
     })

--- a/test/unit/components/VBreadcrumbs/__snapshots__/VBreadcrumbs.spec.js.snap
+++ b/test/unit/components/VBreadcrumbs/__snapshots__/VBreadcrumbs.spec.js.snap
@@ -2,37 +2,37 @@
 
 exports[`VBreadcrumbs.js should have breadcrumbs classes 1`] = `
 
-<ul class="breadcrumbs">
+<ul class="v-breadcrumbs">
 </ul>
 
 `;
 
 exports[`VBreadcrumbs.js should inject slot to children 1`] = `
 
-<ul class="breadcrumbs">
+<ul class="v-breadcrumbs">
   <li>
-    <a class="breadcrumbs__item">
+    <a class="v-breadcrumbs__item">
     </a>
   </li>
-  <li class="breadcrumbs__divider">
+  <li class="v-breadcrumbs__divider">
     /
   </li>
   <li>
-    <a class="breadcrumbs__item">
+    <a class="v-breadcrumbs__item">
     </a>
   </li>
-  <li class="breadcrumbs__divider">
+  <li class="v-breadcrumbs__divider">
     /
   </li>
   <li>
-    <a class="breadcrumbs__item">
+    <a class="v-breadcrumbs__item">
     </a>
   </li>
-  <li class="breadcrumbs__divider">
+  <li class="v-breadcrumbs__divider">
     /
   </li>
   <li>
-    <a class="breadcrumbs__item">
+    <a class="v-breadcrumbs__item">
     </a>
   </li>
 </ul>
@@ -41,16 +41,16 @@ exports[`VBreadcrumbs.js should inject slot to children 1`] = `
 
 exports[`VBreadcrumbs.js should use a custom divider slot 1`] = `
 
-<ul class="breadcrumbs">
+<ul class="v-breadcrumbs">
   <li>
-    <a class="breadcrumbs__item">
+    <a class="v-breadcrumbs__item">
     </a>
   </li>
-  <li class="breadcrumbs__divider">
+  <li class="v-breadcrumbs__divider">
     /divider/
   </li>
   <li>
-    <a class="breadcrumbs__item">
+    <a class="v-breadcrumbs__item">
     </a>
   </li>
 </ul>
@@ -59,14 +59,14 @@ exports[`VBreadcrumbs.js should use a custom divider slot 1`] = `
 
 exports[`VBreadcrumbs.js should use custom justify props 1`] = `
 
-<ul class="breadcrumbs">
+<ul class="v-breadcrumbs">
 </ul>
 
 `;
 
 exports[`VBreadcrumbs.js should use custom justify props 2`] = `
 
-<ul class="breadcrumbs">
+<ul class="v-breadcrumbs">
 </ul>
 
 `;


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case


## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
