### PR TITLE
Refactor (VCarousel): Add v- prefix to carousel classes

### DIFF
--- a/src/components/VCarousel/VCarousel.js
+++ b/src/components/VCarousel/VCarousel.js
@@ -93,14 +93,14 @@ export default {
   methods: {
     genDelimiters () {
       return this.$createElement('div', {
-        staticClass: 'carousel__controls'
+        staticClass: 'v-carousel__controls'
       }, this.genItems())
     },
     genIcon (direction, icon, fn) {
       if (!icon) return null
 
       return this.$createElement('div', {
-        staticClass: `carousel__${direction}`
+        staticClass: `v-carousel__${direction}`
       }, [
         this.$createElement(VBtn, {
           props: {
@@ -120,8 +120,8 @@ export default {
       return this.items.map((item, index) => {
         return this.$createElement(VBtn, {
           class: {
-            'carousel__controls__item': true,
-            'carousel__controls__item--active': index === this.inputValue
+            'v-carousel__controls__item': true,
+            'v-carousel__controls__item--active': index === this.inputValue
           },
           props: {
             icon: true,
@@ -173,7 +173,7 @@ export default {
 
   render (h) {
     return h('div', {
-      staticClass: 'carousel',
+      staticClass: 'v-carousel',
       directives: [{
         name: 'touch',
         value: {

--- a/src/stylus/components/_carousel.styl
+++ b/src/stylus/components/_carousel.styl
@@ -1,6 +1,6 @@
 @import '../bootstrap'
 
-.carousel
+.v-carousel
   height: 500px
   width: 100%
   position: relative
@@ -28,7 +28,7 @@
 
   &__left
     left: 5px
-    
+
   &__right
     right: 5px
 

--- a/test/unit/components/VCarousel/VCarousel.spec.js
+++ b/test/unit/components/VCarousel/VCarousel.spec.js
@@ -62,7 +62,7 @@ test('VCarousel.js', ({ mount }) => {
     })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.find('.carousel__left .icon')[0].text()).toBe('stop')
+    expect(wrapper.find('.v-carousel__left .icon')[0].text()).toBe('stop')
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -74,7 +74,7 @@ test('VCarousel.js', ({ mount }) => {
     })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.contains('.carousel__left')).toBe(false)
+    expect(wrapper.contains('.v-carousel__left')).toBe(false)
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -86,7 +86,7 @@ test('VCarousel.js', ({ mount }) => {
     })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.find('.carousel__right .icon')[0].text()).toBe('stop')
+    expect(wrapper.find('.v-carousel__right .icon')[0].text()).toBe('stop')
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -98,7 +98,7 @@ test('VCarousel.js', ({ mount }) => {
     })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.contains('.carousel__right')).toBe(false)
+    expect(wrapper.contains('.v-carousel__right')).toBe(false)
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -152,8 +152,8 @@ test('VCarousel.js', ({ mount }) => {
     const wrapper = mount(component)
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.find('.carousel__left')).toHaveLength(0)
-    expect(wrapper.find('.carousel__right')).toHaveLength(0)
+    expect(wrapper.find('.v-carousel__left')).toHaveLength(0)
+    expect(wrapper.find('.v-carousel__right')).toHaveLength(0)
   })
 
   it('should change item on swipe', async () => {
@@ -178,7 +178,7 @@ test('VCarousel.js', ({ mount }) => {
     const input = jest.fn()
     wrapper.vm.$children[0].$on('input', input)
 
-    wrapper.find('.carousel__controls__item')[2].trigger('click')
+    wrapper.find('.v-carousel__controls__item')[2].trigger('click')
     await wrapper.vm.$nextTick()
     expect(input).toBeCalledWith(2)
   })

--- a/test/unit/components/VCarousel/__snapshots__/VCarousel.spec.js.snap
+++ b/test/unit/components/VCarousel/__snapshots__/VCarousel.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`VCarousel.js should render component and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -17,7 +17,7 @@ exports[`VCarousel.js should render component and match snapshot 1`] = `
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -31,7 +31,7 @@ exports[`VCarousel.js should render component and match snapshot 1`] = `
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 
@@ -39,8 +39,8 @@ exports[`VCarousel.js should render component and match snapshot 1`] = `
 
 exports[`VCarousel.js should render component with custom duration between image cycles and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -54,7 +54,7 @@ exports[`VCarousel.js should render component with custom duration between image
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -68,7 +68,7 @@ exports[`VCarousel.js should render component with custom duration between image
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 
@@ -76,8 +76,8 @@ exports[`VCarousel.js should render component with custom duration between image
 
 exports[`VCarousel.js should render component with custom icon and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -91,7 +91,7 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -105,9 +105,9 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
     <button type="button"
-            class="btn btn--icon btn--small theme--dark carousel__controls__item carousel__controls__item--active"
+            class="btn btn--icon btn--small theme--dark v-carousel__controls__item v-carousel__controls__item--active"
     >
       <div class="btn__content">
         <i aria-hidden="true"
@@ -119,7 +119,7 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
       </div>
     </button>
     <button type="button"
-            class="btn btn--icon btn--small theme--dark carousel__controls__item"
+            class="btn btn--icon btn--small theme--dark v-carousel__controls__item"
     >
       <div class="btn__content">
         <i aria-hidden="true"
@@ -131,7 +131,7 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
       </div>
     </button>
     <button type="button"
-            class="btn btn--icon btn--small theme--dark carousel__controls__item"
+            class="btn btn--icon btn--small theme--dark v-carousel__controls__item"
     >
       <div class="btn__content">
         <i aria-hidden="true"
@@ -179,8 +179,8 @@ exports[`VCarousel.js should render component with custom icon and match snapsho
 
 exports[`VCarousel.js should render component with custom next icon and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -194,7 +194,7 @@ exports[`VCarousel.js should render component with custom next icon and match sn
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -208,7 +208,7 @@ exports[`VCarousel.js should render component with custom next icon and match sn
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 
@@ -216,8 +216,8 @@ exports[`VCarousel.js should render component with custom next icon and match sn
 
 exports[`VCarousel.js should render component with custom prev icon and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -231,7 +231,7 @@ exports[`VCarousel.js should render component with custom prev icon and match sn
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -245,7 +245,7 @@ exports[`VCarousel.js should render component with custom prev icon and match sn
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 
@@ -253,8 +253,8 @@ exports[`VCarousel.js should render component with custom prev icon and match sn
 
 exports[`VCarousel.js should render component with image cycling off and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -268,7 +268,7 @@ exports[`VCarousel.js should render component with image cycling off and match s
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -282,7 +282,7 @@ exports[`VCarousel.js should render component with image cycling off and match s
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 
@@ -290,8 +290,8 @@ exports[`VCarousel.js should render component with image cycling off and match s
 
 exports[`VCarousel.js should render component with selected active item 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -305,7 +305,7 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -319,9 +319,9 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
     <button type="button"
-            class="btn btn--icon btn--small theme--dark carousel__controls__item"
+            class="btn btn--icon btn--small theme--dark v-carousel__controls__item"
     >
       <div class="btn__content">
         <i aria-hidden="true"
@@ -333,7 +333,7 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
       </div>
     </button>
     <button type="button"
-            class="btn btn--icon btn--small theme--dark carousel__controls__item carousel__controls__item--active"
+            class="btn btn--icon btn--small theme--dark v-carousel__controls__item v-carousel__controls__item--active"
     >
       <div class="btn__content">
         <i aria-hidden="true"
@@ -345,7 +345,7 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
       </div>
     </button>
     <button type="button"
-            class="btn btn--icon btn--small theme--dark carousel__controls__item"
+            class="btn btn--icon btn--small theme--dark v-carousel__controls__item"
     >
       <div class="btn__content">
         <i aria-hidden="true"
@@ -393,8 +393,8 @@ exports[`VCarousel.js should render component with selected active item 1`] = `
 
 exports[`VCarousel.js should render component without delimiters 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -408,7 +408,7 @@ exports[`VCarousel.js should render component without delimiters 1`] = `
       </div>
     </button>
   </div>
-  <div class="carousel__right">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -458,8 +458,8 @@ exports[`VCarousel.js should render component without delimiters 1`] = `
 
 exports[`VCarousel.js should render component without next icon and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__left">
+<div class="v-carousel">
+  <div class="v-carousel__left">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -473,7 +473,7 @@ exports[`VCarousel.js should render component without next icon and match snapsh
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 
@@ -481,8 +481,8 @@ exports[`VCarousel.js should render component without next icon and match snapsh
 
 exports[`VCarousel.js should render component without prev icon and match snapshot 1`] = `
 
-<div class="carousel">
-  <div class="carousel__right">
+<div class="v-carousel">
+  <div class="v-carousel__right">
     <button type="button"
             class="btn btn--icon theme--dark"
     >
@@ -496,7 +496,7 @@ exports[`VCarousel.js should render component without prev icon and match snapsh
       </div>
     </button>
   </div>
-  <div class="carousel__controls">
+  <div class="v-carousel__controls">
   </div>
 </div>
 


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
