### PR TITLE
Refactor (VCheckbox): Add v- prefix on checkbox classes

### DIFF
--- a/src/components/VCheckbox/VCheckbox.js
+++ b/src/components/VCheckbox/VCheckbox.js
@@ -24,7 +24,7 @@ export default {
   computed: {
     classes () {
       const classes = {
-        'checkbox': true,
+        'v-checkbox': true,
         'input-group--selection-controls': true,
         'input-group--active': this.isActive
       }

--- a/src/stylus/components/_tables.styl
+++ b/src/stylus/components/_tables.styl
@@ -84,7 +84,7 @@ table.table
     .input-group__details
       display: none
 
-    &.checkbox
+    &.v-checkbox
       .icon
         left: 50%
         transform: translateX(-50%)

--- a/test/unit/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/test/unit/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -36,7 +36,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="true"
-                       class="input-group input-group--dirty checkbox input-group--selection-controls input-group--active primary--text"
+                       class="input-group input-group--dirty v-checkbox input-group--selection-controls input-group--active primary--text"
                   >
                     <div class="input-group__input">
                       <i aria-hidden="true"
@@ -70,7 +70,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                   <div tabindex="0"
                        role="checkbox"
                        aria-checked="false"
-                       class="input-group checkbox input-group--selection-controls primary--text"
+                       class="input-group v-checkbox input-group--selection-controls primary--text"
                   >
                     <div class="input-group__input">
                       <i aria-hidden="true"


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
