### PR TITLE
Refactor (VDataTable): Add v- prefix on datatable classes

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -21,10 +21,10 @@ export default {
 
   data () {
     return {
-      actionsClasses: 'datatable__actions',
-      actionsRangeControlsClasses: 'datatable__actions__range-controls',
-      actionsSelectClasses: 'datatable__actions__select',
-      actionsPaginationClasses: 'datatable__actions__pagination'
+      actionsClasses: 'v-datatable__actions',
+      actionsRangeControlsClasses: 'v-datatable__actions__range-controls',
+      actionsSelectClasses: 'v-datatable__actions__select',
+      actionsPaginationClasses: 'v-datatable__actions__pagination'
     }
   },
 
@@ -60,8 +60,8 @@ export default {
   computed: {
     classes () {
       return {
-        'datatable table': true,
-        'datatable--select-all': this.selectAll !== false,
+        'v-datatable table': true,
+        'v-datatable--select-all': this.selectAll !== false,
         'theme--dark': this.dark,
         'theme--light': this.light
       }

--- a/src/components/VDataTable/index.js
+++ b/src/components/VDataTable/index.js
@@ -5,7 +5,7 @@ import {
 import VDataTable from './VDataTable'
 import VEditDialog from './VEditDialog'
 
-const VTableOverflow = createSimpleFunctional('table__overflow')
+const VTableOverflow = createSimpleFunctional('v-table__overflow')
 
 export { VDataTable, VEditDialog, VTableOverflow }
 

--- a/src/components/VDataTable/index.js
+++ b/src/components/VDataTable/index.js
@@ -5,7 +5,7 @@ import {
 import VDataTable from './VDataTable'
 import VEditDialog from './VEditDialog'
 
-const VTableOverflow = createSimpleFunctional('v-table__overflow')
+const VTableOverflow = createSimpleFunctional('table__overflow')
 
 export { VDataTable, VEditDialog, VTableOverflow }
 

--- a/src/components/VDataTable/mixins/body.js
+++ b/src/components/VDataTable/mixins/body.js
@@ -12,7 +12,7 @@ export default {
 
       if (this.isExpanded(props.item)) {
         const expand = this.$createElement('div', {
-          class: 'datatable__expand-content',
+          class: 'v-datatable__expand-content',
           key: props.item[this.itemKey]
         }, this.$scopedSlots.expand(props))
 
@@ -20,15 +20,15 @@ export default {
       }
 
       const transition = this.$createElement('transition-group', {
-        class: 'datatable__expand-col',
+        class: 'v-datatable__expand-col',
         attrs: { colspan: this.headerColumns },
         props: {
           tag: 'td'
         },
-        on: ExpandTransitionGenerator('datatable__expand-col--expanded')
+        on: ExpandTransitionGenerator('v-datatable__expand-col--expanded')
       }, children)
 
-      return this.genTR([transition], { class: 'datatable__expand-row' })
+      return this.genTR([transition], { class: 'v-datatable__expand-row' })
     },
     genFilteredItems () {
       if (!this.$scopedSlots.items) {

--- a/src/components/VDataTable/mixins/progress.js
+++ b/src/components/VDataTable/mixins/progress.js
@@ -9,7 +9,7 @@ export default {
       }, [this.genProgress()])
 
       return this.genTR([col], {
-        staticClass: 'datatable__progress'
+        staticClass: 'v-datatable__progress'
       })
     }
   }

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -2,7 +2,7 @@
 @import '../theme'
 
 /* Theme */
-datatable($material)
+v-datatable($material)
   thead
     th.column.sortable
       i
@@ -17,7 +17,7 @@ datatable($material)
         i
           color: rgba($material.fg-color, $material.primary-text-percent)
 
-  .datatable__actions
+  .v-datatable__actions
     background-color: $material.cards
     color: rgba($material.fg-color, $material.secondary-text-percent)
     border-top: 1px solid rgba($material.fg-color, $material.divider-percent)
@@ -30,9 +30,9 @@ datatable($material)
         .input-group__append-icon
           color: rgba($material.fg-color, $material.secondary-text-percent) !important
 
-theme(datatable, "datatable")
+theme(v-datatable, "v-datatable")
 
-.datatable
+.v-datatable
   thead
     th.column.sortable
       cursor: pointer
@@ -61,7 +61,7 @@ theme(datatable, "datatable")
             transform: rotate(-180deg)
 
 /** Actions */
-.datatable__actions
+.v-datatable__actions
   display: flex
   justify-content: flex-end
   align-items: center
@@ -98,7 +98,7 @@ theme(datatable, "datatable")
       .input-group__selections__comma
         font-size: 12px
 
-.datatable__progress
+.v-datatable__progress
   height: auto !important
 
   tr, td, th
@@ -111,7 +111,7 @@ theme(datatable, "datatable")
       top: -2px
       margin: 0 0 -2px
 
-.datatable__expand
+.v-datatable__expand
   &-row
     border: none !important
 

--- a/test/unit/components/VDataTable/VDataTable.spec.js
+++ b/test/unit/components/VDataTable/VDataTable.spec.js
@@ -60,7 +60,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.html()).toMatchSnapshot()
 
-    const content = wrapper.find('table.datatable tbody > tr > td')[0]
+    const content = wrapper.find('table.v-datatable tbody > tr > td')[0]
     expect(content.element.textContent).toBe('No matching records found')
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
@@ -73,7 +73,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.html()).toMatchSnapshot()
 
-    const content = wrapper.find('table.datatable tbody > tr > td')[0]
+    const content = wrapper.find('table.v-datatable tbody > tr > td')[0]
     expect(content.element.textContent).toBe('No data available')
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
@@ -204,7 +204,7 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
       }
     }))
 
-    expect(wrapper.find('.datatable__progress')).toHaveLength(1)
+    expect(wrapper.find('.v-datatable__progress')).toHaveLength(1)
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 

--- a/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -4,7 +4,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
 
 <div>
   <div class="table__overflow">
-    <table class="datatable table">
+    <table class="v-datatable table">
       <thead>
         <tr>
           <th role="columnheader"
@@ -46,7 +46,7 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
             </i>
           </th>
         </tr>
-        <tr class="datatable__progress">
+        <tr class="v-datatable__progress">
           <th colspan="3"
               class="column"
           >
@@ -64,9 +64,9 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
       </tbody>
     </table>
   </div>
-  <div class="datatable table">
-    <div class="datatable__actions">
-      <div class="datatable__actions__select">
+  <div class="v-datatable table">
+    <div class="v-datatable__actions">
+      <div class="v-datatable__actions__select">
         Rows per page:
         <div tabindex="0"
              data-uid="14"
@@ -145,8 +145,8 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
           </div>
         </div>
       </div>
-      <div class="datatable__actions__range-controls">
-        <div class="datatable__actions__pagination">
+      <div class="v-datatable__actions__range-controls">
+        <div class="v-datatable__actions__pagination">
           –
         </div>
         <button disabled="disabled"
@@ -186,7 +186,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
 
 <div>
   <div class="table__overflow">
-    <table class="datatable table">
+    <table class="v-datatable table">
       <thead>
         <tr>
           <th role="columnheader"
@@ -228,7 +228,7 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
             </i>
           </th>
         </tr>
-        <tr class="datatable__progress">
+        <tr class="v-datatable__progress">
           <th colspan="3"
               class="column"
           >
@@ -246,9 +246,9 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
       </tbody>
     </table>
   </div>
-  <div class="datatable table">
-    <div class="datatable__actions">
-      <div class="datatable__actions__select">
+  <div class="v-datatable table">
+    <div class="v-datatable__actions">
+      <div class="v-datatable__actions__select">
         Rows per page:
         <div tabindex="0"
              data-uid="2"
@@ -327,8 +327,8 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
           </div>
         </div>
       </div>
-      <div class="datatable__actions__range-controls">
-        <div class="datatable__actions__pagination">
+      <div class="v-datatable__actions__range-controls">
+        <div class="v-datatable__actions__pagination">
           –
         </div>
         <button disabled="disabled"
@@ -368,7 +368,7 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
 
 <div>
   <div class="table__overflow">
-    <table class="datatable table">
+    <table class="v-datatable table">
       <thead>
         <tr>
           <th role="columnheader"
@@ -410,7 +410,7 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
             </i>
           </th>
         </tr>
-        <tr class="datatable__progress">
+        <tr class="v-datatable__progress">
           <th colspan="3"
               class="column"
           >
@@ -430,9 +430,9 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
       </tbody>
     </table>
   </div>
-  <div class="datatable table">
-    <div class="datatable__actions">
-      <div class="datatable__actions__select">
+  <div class="v-datatable table">
+    <div class="v-datatable__actions">
+      <div class="v-datatable__actions__select">
         Rows per page:
         <div tabindex="0"
              data-uid="28"
@@ -511,8 +511,8 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
           </div>
         </div>
       </div>
-      <div class="datatable__actions__range-controls">
-        <div class="datatable__actions__pagination">
+      <div class="v-datatable__actions__range-controls">
+        <div class="v-datatable__actions__pagination">
           1-3 of 3
         </div>
         <button disabled="disabled"
@@ -552,7 +552,7 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
 
 <div>
   <div class="table__overflow">
-    <table class="datatable table">
+    <table class="v-datatable table">
       <thead>
         <tr>
           <th role="columnheader"
@@ -594,7 +594,7 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
             </i>
           </th>
         </tr>
-        <tr class="datatable__progress">
+        <tr class="v-datatable__progress">
           <th colspan="3"
               class="column"
           >
@@ -605,10 +605,10 @@ exports[`VDataTable.vue should match a snapshot with single rows-per-page-items 
       </tbody>
     </table>
   </div>
-  <div class="datatable table">
-    <div class="datatable__actions">
-      <div class="datatable__actions__range-controls">
-        <div class="datatable__actions__pagination">
+  <div class="v-datatable table">
+    <div class="v-datatable__actions">
+      <div class="v-datatable__actions__range-controls">
+        <div class="v-datatable__actions__pagination">
           1-1 of 3
         </div>
         <button disabled="disabled"


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
