### PR TITLE
Refactor (VDialog): Add v- prefix on dialog & card classes

### DIFF
--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -33,7 +33,7 @@ export default {
   data () {
     return {
       isDependent: false,
-      stackClass: 'dialog__content__active',
+      stackClass: 'v-dialog__content__active',
       stackMinZIndex: 200
     }
   },
@@ -65,17 +65,17 @@ export default {
   computed: {
     classes () {
       return {
-        [(`dialog ${this.contentClass}`).trim()]: true,
-        'dialog--active': this.isActive,
-        'dialog--persistent': this.persistent,
-        'dialog--fullscreen': this.fullscreen,
-        'dialog--scrollable': this.scrollable
+        [(`v-dialog ${this.contentClass}`).trim()]: true,
+        'v-dialog--active': this.isActive,
+        'v-dialog--persistent': this.persistent,
+        'v-dialog--fullscreen': this.fullscreen,
+        'v-dialog--scrollable': this.scrollable
       }
     },
     contentClasses () {
       return {
-        'dialog__content': true,
-        'dialog__content__active': this.isActive
+        'v-dialog__content': true,
+        'v-dialog__content__active': this.isActive
       }
     }
   },
@@ -155,7 +155,7 @@ export default {
 
     if (this.$slots.activator) {
       children.push(h('div', {
-        'class': 'dialog__activator',
+        'class': 'v-dialog__activator',
         on: {
           click: e => {
             e.stopPropagation()
@@ -182,7 +182,7 @@ export default {
     }, [dialog]))
 
     return h('div', {
-      staticClass: 'dialog__container',
+      staticClass: 'v-dialog__container',
       style: {
         display: (!this.$slots.activator || this.fullWidth) ? 'block' : 'inline-block'
       }

--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -1,6 +1,6 @@
 @import '../bootstrap'
 
-.dialog
+.v-dialog
   elevation(24)
   border-radius: $card-border-radius
   margin: 24px
@@ -24,7 +24,7 @@
     z-index: 6
     outline: none
 
-  &:not(.dialog--fullscreen)
+  &:not(.v-dialog--fullscreen)
     max-height: 90%
 
   &__container
@@ -39,7 +39,7 @@
     top: 0
     left 0
 
-    > .card
+    > .v-card
       min-height 100%
       min-width 100%
       margin 0 !important
@@ -48,15 +48,15 @@
   &--scrollable
     display: flex
 
-    > .card
+    > .v-card
       display: flex
       flex: 1 1 auto
       flex-direction: column
 
-      > .card__title
-      > .card__actions
+      > .v-card__title
+      > .v-card__actions
         flex: 1 0 auto
 
-      > .card__text
+      > .v-card__text
         overflow-y: auto
         backface-visibility: hidden

--- a/test/unit/components/VDialog/VDialog.spec.js
+++ b/test/unit/components/VDialog/VDialog.spec.js
@@ -107,7 +107,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     wrapper.vm.$on('input', input)
 
     expect(wrapper.vm.isActive).toBe(false)
-    wrapper.find('.dialog__activator')[0].trigger('click')
+    wrapper.find('.v-dialog__activator')[0].trigger('click')
     expect(wrapper.vm.isActive).toBe(true)
     await wrapper.vm.$nextTick()
     expect(input).toBeCalledWith(true)
@@ -129,7 +129,7 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
     wrapper.vm.$on('input', input)
 
     expect(wrapper.vm.isActive).toBe(false)
-    wrapper.find('.dialog__activator')[0].trigger('click')
+    wrapper.find('.v-dialog__activator')[0].trigger('click')
     expect(wrapper.vm.isActive).toBe(false)
     await wrapper.vm.$nextTick()
     expect(input).not.toBeCalled()

--- a/test/unit/components/VDialog/__snapshots__/VDialog.spec.js.snap
+++ b/test/unit/components/VDialog/__snapshots__/VDialog.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`VDialog.js should render a disabled component and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog"
+    <div class="v-dialog"
          style="display: none;"
     >
     </div>
@@ -20,14 +20,14 @@ exports[`VDialog.js should render a disabled component and match snapshot 1`] = 
 
 exports[`VDialog.js should render a fullscreen component and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog dialog--fullscreen"
+    <div class="v-dialog v-dialog--fullscreen"
          style="display: none;"
     >
     </div>
@@ -38,14 +38,14 @@ exports[`VDialog.js should render a fullscreen component and match snapshot 1`] 
 
 exports[`VDialog.js should render a lazy component and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog"
+    <div class="v-dialog"
          style="display: none;"
     >
     </div>
@@ -56,14 +56,14 @@ exports[`VDialog.js should render a lazy component and match snapshot 1`] = `
 
 exports[`VDialog.js should render a persistent component and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog dialog--persistent"
+    <div class="v-dialog v-dialog--persistent"
          style="display: none;"
     >
     </div>
@@ -74,14 +74,14 @@ exports[`VDialog.js should render a persistent component and match snapshot 1`] 
 
 exports[`VDialog.js should render a scrollable component and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog dialog--scrollable"
+    <div class="v-dialog v-dialog--scrollable"
          style="display: none;"
     >
     </div>
@@ -92,14 +92,14 @@ exports[`VDialog.js should render a scrollable component and match snapshot 1`] 
 
 exports[`VDialog.js should render component and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog"
+    <div class="v-dialog"
          style="display: none;"
     >
     </div>
@@ -110,14 +110,14 @@ exports[`VDialog.js should render component and match snapshot 1`] = `
 
 exports[`VDialog.js should render component with custom origin and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog"
+    <div class="v-dialog"
          style="display: none;"
     >
     </div>
@@ -128,14 +128,14 @@ exports[`VDialog.js should render component with custom origin and match snapsho
 
 exports[`VDialog.js should render component with custom transition and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog"
+    <div class="v-dialog"
          style="display: none;"
     >
     </div>
@@ -146,14 +146,14 @@ exports[`VDialog.js should render component with custom transition and match sna
 
 exports[`VDialog.js should render component with custom width (max-width) and match snapshot 1`] = `
 
-<div class="dialog__container"
+<div class="v-dialog__container"
      style="display: block;"
 >
-  <div class="dialog__content"
+  <div class="v-dialog__content"
        tabindex="-1"
        style="z-index: 0;"
   >
-    <div class="dialog"
+    <div class="v-dialog"
          style="max-width: 100px; display: none;"
     >
     </div>


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
