### PR TITLE
Refactor (VDivider): Add v- prefix to divider classes

### DIFF
--- a/src/components/VDivider/VDivider.js
+++ b/src/components/VDivider/VDivider.js
@@ -14,9 +14,9 @@ export default {
   },
 
   render (h, { props, data }) {
-    data.staticClass = (`divider ${data.staticClass || ''}`).trim()
+    data.staticClass = (`v-divider ${data.staticClass || ''}`).trim()
 
-    if (props.inset) data.staticClass += ' divider--inset'
+    if (props.inset) data.staticClass += ' v-divider--inset'
     if (props.light) data.staticClass += ' theme--light'
     if (props.dark) data.staticClass += ' theme--dark'
 

--- a/src/stylus/components/_dividers.styl
+++ b/src/stylus/components/_dividers.styl
@@ -1,12 +1,12 @@
 @import '../bootstrap'
 @import '../theme'
 
-divider($material)
+v-divider($material)
   background-color: $material.dividers
 
-theme(divider, "divider")
+theme(v-divider, "v-divider")
 
-.divider
+.v-divider
   border: none
   display: block
   height: 1px

--- a/src/stylus/components/_dividers.styl
+++ b/src/stylus/components/_dividers.styl
@@ -4,7 +4,7 @@
 v-divider($material)
   background-color: $material.dividers
 
-theme(v-divider, "v-divider")
+theme(divider, "v-divider")
 
 .v-divider
   border: none

--- a/test/unit/components/VDivider/VDivider.spec.js
+++ b/test/unit/components/VDivider/VDivider.spec.js
@@ -15,7 +15,7 @@ test('VDivider.js', ({ mount, compileToFunctions, functionalContext }) => {
       }
     }))
 
-    expect(wrapper.hasClass('divider--inset')).toBe(true)
+    expect(wrapper.hasClass('v-divider--inset')).toBe(true)
   })
 
   it('should render a light component', () => {

--- a/test/unit/components/VDivider/__snapshots__/VDivider.spec.js.snap
+++ b/test/unit/components/VDivider/__snapshots__/VDivider.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`VDivider.js should render component and match snapshot 1`] = `
 
-<hr class="divider">
+<hr class="v-divider">
 
 `;


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
