### PR TITLE
Refactor (VExpansionPanel): Add v- prefix to expansion-panel classes

### DIFF
--- a/src/components/VExpansionPanel/VExpansionPanel.js
+++ b/src/components/VExpansionPanel/VExpansionPanel.js
@@ -92,11 +92,11 @@ export default {
 
   render (h) {
     return h('ul', {
-      staticClass: 'expansion-panel',
+      staticClass: 'v-expansion-panel',
       'class': {
-        'expansion-panel--focusable': this.focusable,
-        'expansion-panel--popout': this.popout,
-        'expansion-panel--inset': this.inset,
+        'v-expansion-panel--focusable': this.focusable,
+        'v-expansion-panel--popout': this.popout,
+        'v-expansion-panel--inset': this.inset,
         ...this.themeClasses
       }
     }, this.$slots.default)

--- a/src/components/VExpansionPanel/VExpansionPanelContent.js
+++ b/src/components/VExpansionPanel/VExpansionPanelContent.js
@@ -44,7 +44,7 @@ export default {
     genBody () {
       return this.$createElement('div', {
         ref: 'body',
-        class: 'expansion-panel__body',
+        class: 'v-expansion-panel__body',
         directives: [
           {
             name: 'show',
@@ -55,7 +55,7 @@ export default {
     },
     genHeader () {
       return this.$createElement('div', {
-        staticClass: 'expansion-panel__header',
+        staticClass: 'v-expansion-panel__header',
         directives: [{
           name: 'ripple',
           value: this.ripple
@@ -105,9 +105,9 @@ export default {
     children.push(h(VExpandTransition, [this.genBody()]))
 
     return h('li', {
-      staticClass: 'expansion-panel__container',
+      staticClass: 'v-expansion-panel__container',
       'class': {
-        'expansion-panel__container--active': this.isActive
+        'v-expansion-panel__container--active': this.isActive
       },
       attrs: {
         tabindex: 0

--- a/src/stylus/components/_expansion-panel.styl
+++ b/src/stylus/components/_expansion-panel.styl
@@ -2,7 +2,7 @@
 @import '../theme'
 
 /** Theme */
-expansion-panel($material)
+v-expansion-panel($material)
   .v-expansion-panel__container
     border-top: 1px solid rgba($material.fg-color, $material.divider-percent)
     background-color: $material.cards
@@ -17,7 +17,7 @@ expansion-panel($material)
       &:focus
         background-color: $material.v-expansion-panels.focus
 
-theme(v-expansion-panel, "v-expansion-panel")
+theme(expansion-panel, "v-expansion-panel")
 
 .v-expansion-panel
   display: flex

--- a/src/stylus/components/_expansion-panel.styl
+++ b/src/stylus/components/_expansion-panel.styl
@@ -3,23 +3,23 @@
 
 /** Theme */
 expansion-panel($material)
-  .expansion-panel__container
+  .v-expansion-panel__container
     border-top: 1px solid rgba($material.fg-color, $material.divider-percent)
     background-color: $material.cards
     color: $material.text.primary
 
-    .expansion-panel__header
+    .v-expansion-panel__header
       .icon
         color: $material.icons.active
 
   &--focusable
-    .expansion-panel__container
+    .v-expansion-panel__container
       &:focus
-        background-color: $material.expansion-panels.focus
+        background-color: $material.v-expansion-panels.focus
 
-theme(expansion-panel, "expansion-panel")
+theme(v-expansion-panel, "v-expansion-panel")
 
-.expansion-panel
+.v-expansion-panel
   display: flex
   flex-wrap: wrap
   justify-content: center
@@ -46,7 +46,7 @@ theme(expansion-panel, "expansion-panel")
         transition: none
 
     &--active
-      > .expansion-panel__header
+      > .v-expansion-panel__header
         .header__icon .icon
           transform: rotate(-180deg)
 
@@ -70,18 +70,18 @@ theme(expansion-panel, "expansion-panel")
   &--popout, &--inset
     elevation(0)
 
-    .expansion-panel__container--active
+    .v-expansion-panel__container--active
       margin: $spacers.three.x
       elevation(3)
 
   &--popout, &--inset
-    .expansion-panel__container
+    .v-expansion-panel__container
       max-width: 95%
 
   &--popout
-    .expansion-panel__container--active
+    .v-expansion-panel__container--active
       max-width: 100%
 
   &--inset
-    .expansion-panel__container--active
+    .v-expansion-panel__container--active
       max-width: 85%

--- a/test/unit/components/VExpansionPanel/VExpansionPanel.spec.js
+++ b/test/unit/components/VExpansionPanel/VExpansionPanel.spec.js
@@ -21,7 +21,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.html()).toMatchSnapshot()
 
-    wrapper.find('.expansion-panel__header')[0].trigger('click')
+    wrapper.find('.v-expansion-panel__header')[0].trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
@@ -31,7 +31,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
       inset: true
     }))
 
-    expect(wrapper.hasClass('expansion-panel--inset')).toBe(true)
+    expect(wrapper.hasClass('v-expansion-panel--inset')).toBe(true)
   })
 
   it('should render popout component', () => {
@@ -39,7 +39,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
       popout: true
     }))
 
-    expect(wrapper.hasClass('expansion-panel--popout')).toBe(true)
+    expect(wrapper.hasClass('v-expansion-panel--popout')).toBe(true)
   })
 
   it('should render an expanded component and match snapshot', async () => {
@@ -49,7 +49,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.html()).toMatchSnapshot()
 
-    wrapper.find('.expansion-panel__header')[0].trigger('click')
+    wrapper.find('.v-expansion-panel__header')[0].trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
@@ -66,7 +66,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
     wrapper.setProps({ value: 0 })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.first('.expansion-panel__container--active')).not.toBe(null)
+    expect(wrapper.first('.v-expansion-panel__container--active')).not.toBe(null)
   })
 
   it('should show content on mount using v-model', async () => {
@@ -80,7 +80,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
     })
 
     await wrapper.vm.$nextTick()
-    expect(wrapper.first('.expansion-panel__container--active')).not.toBe(null)
+    expect(wrapper.first('.v-expansion-panel__container--active')).not.toBe(null)
   })
 
   it('should allow array v-model when using expand prop', async () => {
@@ -95,7 +95,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
     })
 
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('.expansion-panel__container--active').length).toBe(2)
+    expect(wrapper.find('.v-expansion-panel__container--active').length).toBe(2)
   })
 
   it('should reset v-model when switching expand', async () => {
@@ -112,7 +112,7 @@ test('VExpansionPanel.js', ({ mount, compileToFunctions }) => {
 
     wrapper.instance().$on('input', fn)
 
-    expect(wrapper.find('.expansion-panel__container--active').length).toBe(0)
+    expect(wrapper.find('.v-expansion-panel__container--active').length).toBe(0)
 
     wrapper.setProps({ expand: false })
 

--- a/test/unit/components/VExpansionPanel/VExpansionPanelContent.spec.js
+++ b/test/unit/components/VExpansionPanel/VExpansionPanelContent.spec.js
@@ -69,7 +69,7 @@ test('VExpansionPanelContent.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    wrapper.find('.expansion-panel__header')[0].trigger('click')
+    wrapper.find('.v-expansion-panel__header')[0].trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
     expect(registrableWarning).toHaveBeenTipped()

--- a/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanel.spec.js.snap
+++ b/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanel.spec.js.snap
@@ -2,11 +2,11 @@
 
 exports[`VExpansionPanel.js should render an expanded component and match snapshot 1`] = `
 
-<ul class="expansion-panel">
+<ul class="v-expansion-panel">
   <li tabindex="0"
-      class="expansion-panel__container"
+      class="v-expansion-panel__container"
   >
-    <div class="expansion-panel__header">
+    <div class="v-expansion-panel__header">
       <div>
         header
       </div>
@@ -18,7 +18,7 @@ exports[`VExpansionPanel.js should render an expanded component and match snapsh
         </i>
       </div>
     </div>
-    <div class="expansion-panel__body"
+    <div class="v-expansion-panel__body"
          style="display: none;"
     >
       content
@@ -30,11 +30,11 @@ exports[`VExpansionPanel.js should render an expanded component and match snapsh
 
 exports[`VExpansionPanel.js should render an expanded component and match snapshot 2`] = `
 
-<ul class="expansion-panel">
+<ul class="v-expansion-panel">
   <li tabindex="0"
-      class="expansion-panel__container expansion-panel__container--active"
+      class="v-expansion-panel__container v-expansion-panel__container--active"
   >
-    <div class="expansion-panel__header">
+    <div class="v-expansion-panel__header">
       <div>
         header
       </div>
@@ -46,7 +46,7 @@ exports[`VExpansionPanel.js should render an expanded component and match snapsh
         </i>
       </div>
     </div>
-    <div class="expansion-panel__body expand-transition-enter expand-transition-enter-active"
+    <div class="v-expansion-panel__body expand-transition-enter expand-transition-enter-active"
          style="overflow: hidden; height: 0px; display: block;"
     >
       content
@@ -58,11 +58,11 @@ exports[`VExpansionPanel.js should render an expanded component and match snapsh
 
 exports[`VExpansionPanel.js should render component and match snapshot 1`] = `
 
-<ul class="expansion-panel">
+<ul class="v-expansion-panel">
   <li tabindex="0"
-      class="expansion-panel__container"
+      class="v-expansion-panel__container"
   >
-    <div class="expansion-panel__header">
+    <div class="v-expansion-panel__header">
       <div>
         header
       </div>
@@ -74,7 +74,7 @@ exports[`VExpansionPanel.js should render component and match snapshot 1`] = `
         </i>
       </div>
     </div>
-    <div class="expansion-panel__body"
+    <div class="v-expansion-panel__body"
          style="display: none;"
     >
       content
@@ -86,11 +86,11 @@ exports[`VExpansionPanel.js should render component and match snapshot 1`] = `
 
 exports[`VExpansionPanel.js should render component and match snapshot 2`] = `
 
-<ul class="expansion-panel">
+<ul class="v-expansion-panel">
   <li tabindex="0"
-      class="expansion-panel__container expansion-panel__container--active"
+      class="v-expansion-panel__container v-expansion-panel__container--active"
   >
-    <div class="expansion-panel__header">
+    <div class="v-expansion-panel__header">
       <div>
         header
       </div>
@@ -102,7 +102,7 @@ exports[`VExpansionPanel.js should render component and match snapshot 2`] = `
         </i>
       </div>
     </div>
-    <div class="expansion-panel__body expand-transition-enter expand-transition-enter-active"
+    <div class="v-expansion-panel__body expand-transition-enter expand-transition-enter-active"
          style="overflow: hidden; height: 0px; display: block;"
     >
       content
@@ -114,11 +114,11 @@ exports[`VExpansionPanel.js should render component and match snapshot 2`] = `
 
 exports[`VExpansionPanel.js should show content on v-model change 1`] = `
 
-<ul class="expansion-panel">
+<ul class="v-expansion-panel">
   <li tabindex="0"
-      class="expansion-panel__container"
+      class="v-expansion-panel__container"
   >
-    <div class="expansion-panel__body"
+    <div class="v-expansion-panel__body"
          style="display: none;"
     >
     </div>

--- a/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanelContent.spec.js.snap
+++ b/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanelContent.spec.js.snap
@@ -3,9 +3,9 @@
 exports[`VExpansionPanelContent.js should render an expanded component and match snapshot 1`] = `
 
 <li tabindex="0"
-    class="expansion-panel__container"
+    class="v-expansion-panel__container"
 >
-  <div class="expansion-panel__body"
+  <div class="v-expansion-panel__body"
        style="display: none;"
   >
   </div>
@@ -16,9 +16,9 @@ exports[`VExpansionPanelContent.js should render an expanded component and match
 exports[`VExpansionPanelContent.js should render an expanded component with lazy prop and match snapshot 1`] = `
 
 <li tabindex="0"
-    class="expansion-panel__container"
+    class="v-expansion-panel__container"
 >
-  <div class="expansion-panel__body"
+  <div class="v-expansion-panel__body"
        style="display: none;"
   >
   </div>
@@ -29,9 +29,9 @@ exports[`VExpansionPanelContent.js should render an expanded component with lazy
 exports[`VExpansionPanelContent.js should render component and match snapshot 1`] = `
 
 <li tabindex="0"
-    class="expansion-panel__container"
+    class="v-expansion-panel__container"
 >
-  <div class="expansion-panel__header">
+  <div class="v-expansion-panel__header">
     <span>
       header
     </span>
@@ -41,7 +41,7 @@ exports[`VExpansionPanelContent.js should render component and match snapshot 1`
       </span>
     </div>
   </div>
-  <div class="expansion-panel__body"
+  <div class="v-expansion-panel__body"
        style="display: none;"
   >
     <span>
@@ -55,14 +55,14 @@ exports[`VExpansionPanelContent.js should render component and match snapshot 1`
 exports[`VExpansionPanelContent.js should respect hideActions prop 1`] = `
 
 <li tabindex="0"
-    class="expansion-panel__container"
+    class="v-expansion-panel__container"
 >
-  <div class="expansion-panel__header">
+  <div class="v-expansion-panel__header">
     <span>
       header
     </span>
   </div>
-  <div class="expansion-panel__body"
+  <div class="v-expansion-panel__body"
        style="display: none;"
   >
   </div>
@@ -73,9 +73,9 @@ exports[`VExpansionPanelContent.js should respect hideActions prop 1`] = `
 exports[`VExpansionPanelContent.js should toggle panel on header click 1`] = `
 
 <li tabindex="0"
-    class="expansion-panel__container expansion-panel__container--active"
+    class="v-expansion-panel__container v-expansion-panel__container--active"
 >
-  <div class="expansion-panel__header">
+  <div class="v-expansion-panel__header">
     <span>
       header
     </span>
@@ -87,7 +87,7 @@ exports[`VExpansionPanelContent.js should toggle panel on header click 1`] = `
       </i>
     </div>
   </div>
-  <div class="expansion-panel__body expand-transition-enter expand-transition-enter-active"
+  <div class="v-expansion-panel__body expand-transition-enter expand-transition-enter-active"
        style="overflow: hidden; height: 0px; display: block;"
   >
   </div>


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
