### PR TITLE
Refactor (VFooter): Add v- prefix to footer classes

### DIFF
--- a/src/components/VFooter/VFooter.js
+++ b/src/components/VFooter/VFooter.js
@@ -79,11 +79,11 @@ export default {
 
   render (h) {
     const data = {
-      staticClass: 'footer',
+      staticClass: 'v-footer',
       'class': this.addBackgroundColorClassChecks({
-        'footer--absolute': this.absolute,
-        'footer--fixed': !this.absolute && (this.app || this.fixed),
-        'footer--inset': this.inset,
+        'v-footer--absolute': this.absolute,
+        'v-footer--fixed': !this.absolute && (this.app || this.fixed),
+        'v-footer--inset': this.inset,
         'theme--dark': this.dark,
         'theme--light': this.light
       }),

--- a/src/stylus/components/_footer.styl
+++ b/src/stylus/components/_footer.styl
@@ -1,13 +1,13 @@
 @import '../bootstrap'
 @import '../theme'
 
-footer($material)
+v-footer($material)
   background: $material.app-bar
   color: $material.text.primary
-  
-theme(footer, "footer")
 
-.footer
+theme(footer, "v-footer")
+
+.v-footer
   align-items: center
   display: flex
   flex: 0 1 auto !important // Don't let devs break their code
@@ -20,7 +20,7 @@ theme(footer, "footer")
     left: 0
     width: 100%
     z-index: 3
-    
+
   &--inset
     z-index: 2
 

--- a/test/unit/components/VFooter/VFooter.spec.js
+++ b/test/unit/components/VFooter/VFooter.spec.js
@@ -5,7 +5,7 @@ test('VFooter.js', ({ mount, functionalContext }) => {
   it('should render component and match snapshot', () => {
     const wrapper = mount(VFooter)
 
-    expect(wrapper.element.classList).toContain('footer')
+    expect(wrapper.element.classList).toContain('v-footer')
   })
 
   it('should render a colored footer', () => {
@@ -26,7 +26,7 @@ test('VFooter.js', ({ mount, functionalContext }) => {
       }
     })
 
-    expect(wrapper.element.classList).toContain('footer--absolute')
+    expect(wrapper.element.classList).toContain('v-footer--absolute')
   })
 
   it('should render a fixed positioned component and match snapshot', () => {
@@ -36,7 +36,7 @@ test('VFooter.js', ({ mount, functionalContext }) => {
       }
     })
 
-    expect(wrapper.element.classList).toContain('footer--fixed')
+    expect(wrapper.element.classList).toContain('v-footer--fixed')
   })
 
   it('should render a fixed and absolute positioned and match snapshot', () => {
@@ -47,9 +47,9 @@ test('VFooter.js', ({ mount, functionalContext }) => {
       }
     })
 
-    expect(wrapper.element.classList).toContain('footer--absolute')
+    expect(wrapper.element.classList).toContain('v-footer--absolute')
     wrapper.setProps({ absolute: false })
-    expect(wrapper.element.classList).toContain('footer--fixed')
+    expect(wrapper.element.classList).toContain('v-footer--fixed')
   })
 
   it('should get the right padding with app prop', async () => {

--- a/test/unit/components/VFooter/__snapshots__/VFooter.spec.js.snap
+++ b/test/unit/components/VFooter/__snapshots__/VFooter.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`VFooter.js should accept an auto height 1`] = `
 
-<footer class="footer"
+<footer class="v-footer"
         style="height: auto;"
 >
 </footer>
@@ -11,7 +11,7 @@ exports[`VFooter.js should accept an auto height 1`] = `
 
 exports[`VFooter.js should get the right padding with app prop 1`] = `
 
-<footer class="footer footer--absolute"
+<footer class="v-footer v-footer--absolute"
         style="height: 32px;"
 >
 </footer>
@@ -20,7 +20,7 @@ exports[`VFooter.js should get the right padding with app prop 1`] = `
 
 exports[`VFooter.js should get the right padding with app prop 2`] = `
 
-<footer class="footer footer--absolute"
+<footer class="v-footer v-footer--absolute"
         style="height: 32px; padding-right: 30px;"
 >
 </footer>


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
