### PR TITLE
refactor (VSystemBar): Add v- prefix on system bar classes

### DIFF
--- a/src/components/VSystemBar/VSystemBar.js
+++ b/src/components/VSystemBar/VSystemBar.js
@@ -29,11 +29,11 @@ export default {
   computed: {
     classes () {
       return this.addBackgroundColorClassChecks(Object.assign({
-        'system-bar--lights-out': this.lightsOut,
-        'system-bar--absolute': this.absolute,
-        'system-bar--fixed': !this.absolute && (this.app || this.fixed),
-        'system-bar--status': this.status,
-        'system-bar--window': this.window
+        'v-system-bar--lights-out': this.lightsOut,
+        'v-system-bar--absolute': this.absolute,
+        'v-system-bar--fixed': !this.absolute && (this.app || this.fixed),
+        'v-system-bar--status': this.status,
+        'v-system-bar--window': this.window
       }, this.themeClasses))
     },
     computedHeight () {
@@ -56,7 +56,7 @@ export default {
 
   render (h) {
     const data = {
-      staticClass: 'system-bar',
+      staticClass: 'v-system-bar',
       'class': this.classes,
       style: {
         height: `${this.computedHeight}px`

--- a/src/stylus/components/_system-bars.styl
+++ b/src/stylus/components/_system-bars.styl
@@ -2,7 +2,7 @@
 @import '../theme'
 
 /* Theme */
-system-bar($material)
+v-system-bar($material)
   background-color: $material.status-bar.regular
   color: $material.text.secondary
 
@@ -12,9 +12,9 @@ system-bar($material)
   &--lights-out
     background-color: $material.status-bar.lights-out !important
 
-theme(system-bar, "system-bar")
+theme(v-system-bar, "v-system-bar")
 
-.system-bar
+.v-system-bar
   align-items: center
   display: flex
   font-size: $headings.body-2.size

--- a/test/unit/components/VSystemBar/VSystemBar.spec.js
+++ b/test/unit/components/VSystemBar/VSystemBar.spec.js
@@ -20,7 +20,7 @@ test('VSystemBar.vue', ({ mount }) => {
       }
     })
 
-    expect(wrapper.element.classList).toContain('system-bar--fixed')
+    expect(wrapper.element.classList).toContain('v-system-bar--fixed')
   })
 
   it('should render system bar with absolute prop', () => {
@@ -30,7 +30,7 @@ test('VSystemBar.vue', ({ mount }) => {
       }
     })
 
-    expect(wrapper.element.classList).toContain('system-bar--absolute')
+    expect(wrapper.element.classList).toContain('v-system-bar--absolute')
   })
 
   it('should update height when window prop change', async () => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Related to https://github.com/vuetifyjs/vuetify/issues/1561

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Start working on adding prefix to classes https://github.com/vuetifyjs/vuetify/issues/1561

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
- `yarn test`
- no new test case

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
