### PR TITLE
fix (VTooltip): top

### DIFF
--- a/src/components/VTooltip/VTooltip.js
+++ b/src/components/VTooltip/VTooltip.js
@@ -70,9 +70,9 @@ export default {
 
       if (this.top || this.bottom) {
         top = (
-          activator.top -
-          (this.top ? activator.height : -activator.height) -
-          (this.top ? 0 : -10)
+          activator.top +
+          (this.bottom ? activator.height : -content.height) +
+          (this.bottom ? 10 : -10)
         )
       } else if (this.left || this.right) {
         top = (


### PR DESCRIPTION
## Description
Fixes #3016.

## Motivation and Context
Position on top was based on activator's height and not content's height.

## How Has This Been Tested?
Tested all positions: `top`, `right`, `bottom` and `left`. Tested also multi-line and single-line text inside the tooltip.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
