### PR TITLE
Don't offset last tab when scrolling

### DIFF
--- a/src/components/VTabs/VTabs.js
+++ b/src/components/VTabs/VTabs.js
@@ -188,7 +188,10 @@ export default {
       const wrapperWidth = this.$refs.wrapper.clientWidth
       const totalWidth = wrapperWidth + this.scrollOffset
       const itemOffset = clientWidth + offsetLeft
-      const additionalOffset = clientWidth * 0.3
+      let additionalOffset = clientWidth * 0.3
+      if (this.activeIndex === this.tabs.length - 1) {
+        additionalOffset = 0 // don't add an offset if selecting the last tab
+      }
 
       /* instanbul ignore else */
       if (offsetLeft < this.scrollOffset) {


### PR DESCRIPTION
fixes #3294

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Check if active tab is last in list and don't add an offset when scrolling if it is.

## Motivation and Context
When using `grow` sometimes tabs would get scrolled (and offset) incorrectly.
This change also improves look and feel of normal scrolling tabs

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```vue
<template>
  <v-app>
    <v-toolbar
      dark
      dense
    >
      <v-tabs
        grow
      >
        <v-tabs-slider></v-tabs-slider>
        <v-tab
          v-for="item in tabs"
          :key="item.key"
        >
          {{ item.label }}
        </v-tab>
        <v-tab
          v-for="(item, index) in tabs"
          :key="index + 3"
        >
          {{ item.label }}
        </v-tab>
        <v-tab
          v-for="(item, index) in tabs"
          :key="index + 6"
        >
          {{ item.label }}
        </v-tab>
      </v-tabs>
    </v-toolbar>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      tabs: [
        {
          key: 'about',
          label: 'About',
          target: '/about/'
        },
        {
          key: 'resume',
          label: 'Resume',
          target: '/resume/'
        },
        {
          key: 'contact',
          label: 'Contact',
          target: '/contact/'
        }
      ]
    }
  }
}
</script>
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
