### PR TITLE
fix(v-tabs): reset scrollOffset if not overflowing

### DIFF
--- a/src/components/VTabs/VTabs.js
+++ b/src/components/VTabs/VTabs.js
@@ -124,8 +124,8 @@ export default {
       clearTimeout(this.resizeTimeout)
       this.resizeTimeout = setTimeout(() => {
         this.callSlider()
-        this.checkIcons()
         this.scrollIntoView()
+        this.checkIcons()
       }, this.transitionTime)
     },
     overflowCheck (e, fn) {
@@ -194,14 +194,15 @@ export default {
       this.tabs.push(options)
     },
     scrollIntoView () {
-      if (!this.activeTab) return false
+      if (!this.activeTab) return
+      if (!this.isOverflowing) return (this.scrollOffset = 0)
 
-      const { clientWidth, offsetLeft } = this.activeTab.$el
       const totalWidth = this.widths.wrapper + this.scrollOffset
+      const { clientWidth, offsetLeft } = this.activeTab.$el
       const itemOffset = clientWidth + offsetLeft
       const additionalOffset = clientWidth * 0.3
 
-      /* instanbul ignore else */
+      /* istanbul ignore else */
       if (offsetLeft < this.scrollOffset) {
         this.scrollOffset = Math.max(offsetLeft - additionalOffset, 0)
       } else if (totalWidth < itemOffset) {

--- a/test/unit/components/VTabs/VTabs.spec.js
+++ b/test/unit/components/VTabs/VTabs.spec.js
@@ -333,23 +333,37 @@ test('VTabs', ({ mount, shallow }) => {
 
     await ssrBootable()
 
-    expect(wrapper.vm.scrollIntoView()).toEqual(false)
+    wrapper.vm.scrollIntoView()
+
+    expect(wrapper.vm.scrollOffset).toBe(0)
+    expect(wrapper.vm.isOverflowing).toBe(false)
 
     wrapper.setProps({ value: 'foo' })
-    // Simulate being scrolled too far to the right
-    wrapper.setData({ scrollOffset: 400 })
     await wrapper.vm.$nextTick()
 
+    // Simulate being scrolled too far to the left
+    wrapper.setData({
+      isOverflowing: true,
+      scrollOffset: 100
+    })
+
     wrapper.vm.scrollIntoView()
-    await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.scrollOffset).toBe(0)
 
-    // DOM elements have no actual widths
-    // Trick into running else condition
-    wrapper.setData({ scrollOffset: -1 })
+    // Simulate being scrolled too far to the right
+    wrapper.setData({
+      isOverflowing: true,
+      scrollOffset: -100
+    })
+
     wrapper.vm.scrollIntoView()
-    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.scrollOffset).toBe(0)
+
+    wrapper.setData({ isOverflowing: true })
+
+    wrapper.vm.scrollIntoView()
 
     expect(wrapper.vm.scrollOffset).toBe(0)
   })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
When `v-tabs` is scrolling items into view, it was possible
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #3294
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
``` vue
<template>
  <v-app>
    <v-toolbar
      dark
      dense
    >
      <v-tabs
        grow
      >
        <v-tabs-slider></v-tabs-slider>
        <v-tab
          v-for="item in tabs"
          :key="item.key"
        >
          {{ item.label }}
        </v-tab>
        <v-tab
          v-for="(item, index) in tabs"
          :key="index + 3"
        >
          {{ item.label }}
        </v-tab>
        <v-tab
          v-for="(item, index) in tabs"
          :key="index + 6"
        >
          {{ item.label }}
        </v-tab>
      </v-tabs>
    </v-toolbar>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      tabs: [
        {
          key: 'about',
          label: 'About',
          target: '/about/'
        },
        {
          key: 'resume',
          label: 'Resume',
          target: '/resume/'
        },
        {
          key: 'contact',
          label: 'Contact',
          target: '/contact/'
        }
      ]
    }
  }
}
</script>
```
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
