### PR TITLE
Refactor (VIcon): Add missing v- prefix to icon classes

### DIFF
--- a/src/components/VCheckbox/VCheckbox.js
+++ b/src/components/VCheckbox/VCheckbox.js
@@ -65,7 +65,7 @@ export default {
       h(VIcon, {
         staticClass: 'v-icon--selection-control',
         'class': {
-          'icon--checkbox': this.icon === '$vuetify.icons.checkboxOn'
+          'v-icon--checkbox': this.icon === '$vuetify.icons.checkboxOn'
         },
         key: this.icon,
         on: Object.assign({

--- a/src/components/VRadioGroup/VRadio.js
+++ b/src/components/VRadioGroup/VRadio.js
@@ -144,7 +144,7 @@ export default {
       h(VIcon, {
         staticClass: 'v-icon--selection-control',
         'class': {
-          'icon--radio': this.isActive
+          'v-icon--radio': this.isActive
         },
         key: this.icon,
         on: Object.assign({

--- a/test/unit/components/VRadioGroup/__snapshots__/VRadioGroup.spec.js.snap
+++ b/test/unit/components/VRadioGroup/__snapshots__/VRadioGroup.spec.js.snap
@@ -20,7 +20,7 @@ exports[`VRadioGroup.vue should be in error when v-radio-group is 1`] = `
           radio_button_unchecked
         </i>
         <i aria-hidden="true"
-           class="v-icon v-icon--selection-control material-icons icon--radio fade-transition-enter fade-transition-enter-active"
+           class="v-icon v-icon--selection-control material-icons v-icon--radio fade-transition-enter fade-transition-enter-active"
            style="-webkit-transform-origin: top center 0;"
         >
           radio_button_checked
@@ -59,7 +59,7 @@ exports[`VRadioGroup.vue should be in error when v-radio-group is 2`] = `
           radio_button_unchecked
         </i>
         <i aria-hidden="true"
-           class="v-icon v-icon--selection-control material-icons icon--radio fade-transition-enter fade-transition-enter-active"
+           class="v-icon v-icon--selection-control material-icons v-icon--radio fade-transition-enter fade-transition-enter-active"
            style="-webkit-transform-origin: top center 0;"
         >
           radio_button_checked

--- a/test/unit/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/test/unit/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -45,7 +45,7 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
                         check_box_outline_blank
                       </i>
                       <i aria-hidden="true"
-                         class="v-icon v-icon--selection-control material-icons icon--checkbox fade-transition-enter fade-transition-enter-active"
+                         class="v-icon v-icon--selection-control material-icons v-icon--checkbox fade-transition-enter fade-transition-enter-active"
                          style="-webkit-transform-origin: top center 0;"
                       >
                         check_box


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Fix missing v- prefix
## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
