### PR TITLE
Add missing `d-inline` class

### DIFF
--- a/src/stylus/components/_grid.styl
+++ b/src/stylus/components/_grid.styl
@@ -182,3 +182,6 @@ for size, width in $grid-breakpoints
 
 .d-inline-block
   display: inline-block !important
+  
+.d-inline
+  display: inline !important


### PR DESCRIPTION
## Description
Add missing `d-inline` class as listed at https://vuetifyjs.com/en/layout/display

## Motivation and Context
There was a missing implementation of the `d-inline` class.

## How Has This Been Tested?
Simply.

## Markup:
`<div class="d-inline"></div>`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
