### PR TITLE
fix toolbar spacing

### DIFF
--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -36,7 +36,7 @@ theme(v-toolbar, "v-toolbar")
     font-size: $headings.h6.size
     font-weight: $headings.h6.weight
     letter-spacing: $headings.h6.letter-spacing
-    margin-left: 16px
+    margin-left: 12px
     white-space: nowrap
     overflow: hidden
     text-overflow: ellipsis
@@ -51,10 +51,10 @@ theme(v-toolbar, "v-toolbar")
       max-height: 100%
 
     > .v-btn:last-child, > .menu:last-child
-      margin-right: 8px
+      margin-right: 16px
 
     > .v-btn:first-child, > .menu:first-child
-      margin-left: 8px
+      margin-left: 16px
 
     > *:not(.v-btn):not(.menu):first-child:not(:only-child)
       margin-left: $grid-gutters.lg


### PR DESCRIPTION
## Description
I changed the padding and margin of buttons and toolbar title to let toolbar have more space and a better look:
![image](https://user-images.githubusercontent.com/24871883/38469636-3a569a7e-3b6d-11e8-993f-81e96bb0c71e.png)

## Motivation and Context
The previous toolbar spacing did not match the Material guidelines.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Visually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
