### PR TITLE
Fix for 3750

### DIFF
--- a/src/stylus/components/_radio-group.styl
+++ b/src/stylus/components/_radio-group.styl
@@ -27,3 +27,7 @@ theme(radiogroup, "radio-group")
       label,
       .icon--selection-control
         color: inherit
+
+  &.input-group--required
+    > label:after
+      content: ''

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -212,6 +212,8 @@ theme(textfield, "input-group--text-field")
       height: 2px
       border-bottom-left-radius: 4px
       border-bottom-right-radius: 4px
+      margin-left: 16px
+      max-width: calc(100% - 16px)
 
   &.input-group--multi-line
     textarea
@@ -241,10 +243,5 @@ theme(textfield, "input-group--text-field")
           transform: translate(0, -10px) scale(0.75)
   // Icons
   &.input-group--prepend-icon
-    .input-group__details
-      &:before, &:after
-        margin-left: 56px
-        max-width: calc(100% - 56px)
-
     label
       left: 56px

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -212,8 +212,6 @@ theme(textfield, "input-group--text-field")
       height: 2px
       border-bottom-left-radius: 4px
       border-bottom-right-radius: 4px
-      margin-left: 16px
-      max-width: calc(100% - 16px)
 
   &.input-group--multi-line
     textarea
@@ -243,5 +241,10 @@ theme(textfield, "input-group--text-field")
           transform: translate(0, -10px) scale(0.75)
   // Icons
   &.input-group--prepend-icon
+    .input-group__details
+      &:before, &:after
+        margin-left: 16px
+        max-width: calc(100% - 16px)
+
     label
       left: 56px


### PR DESCRIPTION

## Description
"*" is added to every label in the radio group

## Motivation and Context
It will fix the bug [#3750](https://github.com/vuetifyjs/vuetify/issues/3750) 

## How Has This Been Tested?
"*" should only be added for radio labels 

## Markup:

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
