### PR TITLE
fix(v-breadcrumbs): change breadcrumb item genChildren logic #3747

### DIFF
--- a/src/components/VBreadcrumbs/VBreadcrumbs.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbs.js
@@ -50,7 +50,6 @@ export default {
       const children = []
       const dividerData = { staticClass: 'breadcrumbs__divider' }
       const breadcrumbItemList = this.$slots.default.filter(
-        // TODO: use the component name instead of tag
         elm => elm.componentOptions && elm.componentOptions.tag === 'v-breadcrumbs-item')
       const length = breadcrumbItemList.length
 
@@ -58,7 +57,6 @@ export default {
         const elm = breadcrumbItemList[i]
         children.push(elm)
 
-        // TODO: use the component name instead of tag
         if (i === length - 1) continue
 
         children.push(this.$createElement('li', dividerData, this.computedDivider))

--- a/src/components/VBreadcrumbs/VBreadcrumbs.js
+++ b/src/components/VBreadcrumbs/VBreadcrumbs.js
@@ -49,17 +49,17 @@ export default {
 
       const children = []
       const dividerData = { staticClass: 'breadcrumbs__divider' }
-      const length = this.$slots.default.length
+      const breadcrumbItemList = this.$slots.default.filter(
+        // TODO: use the component name instead of tag
+        elm => elm.componentOptions && elm.componentOptions.tag === 'v-breadcrumbs-item')
+      const length = breadcrumbItemList.length
 
       for (let i = 0; i < length; i++) {
-        const elm = this.$slots.default[i]
+        const elm = breadcrumbItemList[i]
         children.push(elm)
 
         // TODO: use the component name instead of tag
-        if (!elm.componentOptions ||
-          elm.componentOptions.tag !== 'v-breadcrumbs-item' ||
-          i === length - 1
-        ) continue
+        if (i === length - 1) continue
 
         children.push(this.$createElement('li', dividerData, this.computedDivider))
       }

--- a/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
+++ b/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
@@ -30,6 +30,23 @@ test('VBreadcrumbs.js', ({ mount, compileToFunctions }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should have only three dividers', () => {
+    const { render } = compileToFunctions(`
+      <v-breadcrumbs>
+        <v-breadcrumbs-item v-for="i in 4" :key="i"/>
+      </v-breadcrumbs>
+    `)
+    const component = Vue.component('test', {
+      components: {
+        VBreadcrumbs, VBreadcrumbsItem
+      },
+      render
+    })
+    const wrapper = mount(component)
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should use a custom divider slot', () => {
     const { render } = compileToFunctions(`
       <v-breadcrumbs>

--- a/test/unit/components/VBreadcrumbs/__snapshots__/VBreadcrumbs.spec.js.snap
+++ b/test/unit/components/VBreadcrumbs/__snapshots__/VBreadcrumbs.spec.js.snap
@@ -7,6 +7,38 @@ exports[`VBreadcrumbs.js should have breadcrumbs classes 1`] = `
 
 `;
 
+exports[`VBreadcrumbs.js should have only three dividers 1`] = `
+
+<ul class="breadcrumbs">
+  <li>
+    <a class="breadcrumbs__item">
+    </a>
+  </li>
+  <li class="breadcrumbs__divider">
+    /
+  </li>
+  <li>
+    <a class="breadcrumbs__item">
+    </a>
+  </li>
+  <li class="breadcrumbs__divider">
+    /
+  </li>
+  <li>
+    <a class="breadcrumbs__item">
+    </a>
+  </li>
+  <li class="breadcrumbs__divider">
+    /
+  </li>
+  <li>
+    <a class="breadcrumbs__item">
+    </a>
+  </li>
+</ul>
+
+`;
+
 exports[`VBreadcrumbs.js should inject slot to children 1`] = `
 
 <ul class="breadcrumbs">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR modifies the genChildren Fn logic for generating breadcrumb item within breadcrumbs component.
Instead of returning all items found in the $slot.default object, the list of children is filtered to contain all valid breadcrumb item elements and then a check is made to avoid adding a divider to the last breadcrumb item.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It resolves reported bug #3747 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I have tested to code by adding the same code found in codepen attached to the reported issue to the dev playground and confirmed that the issue is fixed.
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup that showcases your contribution --->
```
<template>
  <v-app>
    <div>
      <v-breadcrumbs>
        <v-icon slot="divider">forward</v-icon>
        <v-breadcrumbs-item
          v-for="item in items"
          :key="item.text"
          :disabled="item.disabled"
        >
          {{ item.text }}
        </v-breadcrumbs-item>
      </v-breadcrumbs>
    </div>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    items: [
      {
        text: "Dashboard",
        disabled: false
      },
      {
        text: "Link 1",
        disabled: false
      },
      {
        text: "Link 2",
        disabled: true
      }
    ]
  })
};
</script>

```
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
