### PR TITLE
fix: expand-transition error

### DIFF
--- a/src/components/transitions/expand-transition.js
+++ b/src/components/transitions/expand-transition.js
@@ -33,7 +33,7 @@ export default function (expandedParentClass = '') {
     },
 
     afterLeave (el) {
-      expandedParentClass && el._parent.classList.remove(expandedParentClass)
+      expandedParentClass && el._parent && el._parent.classList.remove(expandedParentClass)
     }
   }
 }


### PR DESCRIPTION
## Description
expand-transition generated error if it started expanded, as el._parent was not set

## Motivation and Context
closes #3812, closes #3050

## How Has This Been Tested?
manually with markup for both issues

## Markup:
see issues

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
