### PR TITLE
fix(vDatePicker): Scroll selected year into view

### DIFF
--- a/src/components/VDatePicker/VDatePickerYears.js
+++ b/src/components/VDatePicker/VDatePickerYears.js
@@ -38,7 +38,11 @@ export default {
   },
 
   mounted () {
-    this.$el.scrollTop = this.$el.scrollHeight / 2 - this.$el.offsetHeight / 2
+    if (this.value && this.$el.scrollIntoView) {
+      this.$el.getElementsByClassName('active')[0].scrollIntoView()
+    } else {
+      this.$el.scrollTop = this.$el.scrollHeight / 2 - this.$el.offsetHeight / 2
+    }
   },
 
   methods: {

--- a/src/components/VDatePicker/VDatePickerYears.js
+++ b/src/components/VDatePicker/VDatePickerYears.js
@@ -38,7 +38,7 @@ export default {
   },
 
   mounted () {
-    if (this.value && this.$el.scrollIntoView) {
+    if (this.value) {
       this.$el.getElementsByClassName('active')[0].scrollIntoView()
     } else {
       this.$el.scrollTop = this.$el.scrollHeight / 2 - this.$el.offsetHeight / 2

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ export function test(name, cb) {
 
   // Very naive polyfill for performance.now()
   window.performance = { now: () => (new Date()).getTime() }
+  window.HTMLElement.prototype.scrollIntoView = function() {};
 
   describe(name, () => cb({
     functionalContext,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change get selected year in view by scrolling on year click.

## Motivation and Context
This fix #3828 

## How Has This Been Tested?
This has been tested by code shared in codepen and also by removing min and max dates.

## Markup:
```vue
<template>
  <v-app>
     <div>
      <v-date-picker
        type="month"
        class="mt-3"
        min="2017-06"
        max="2050-10"
        v-model="date"
      ></v-date-picker>
    </div>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    date: '2017-12'
  })
}
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
