### PR TITLE
Refactor (VMenu): Add v-prefix to v-menu classes

### DIFF
--- a/src/components/VMenu/VMenu.js
+++ b/src/components/VMenu/VMenu.js
@@ -185,9 +185,9 @@ export default {
 
   render (h) {
     const data = {
-      staticClass: 'menu',
+      staticClass: 'v-menu',
       class: {
-        'menu--disabled': this.disabled
+        'v-menu--disabled': this.disabled
       },
       style: {
         display: this.fullWidth ? 'block' : 'inline-block'

--- a/src/components/VMenu/mixins/menu-generators.js
+++ b/src/components/VMenu/mixins/menu-generators.js
@@ -11,9 +11,9 @@ export default {
       if (!this.$slots.activator) return null
 
       const options = {
-        staticClass: 'menu__activator',
+        staticClass: 'v-menu__activator',
         'class': {
-          'menu__activator--active': this.hasJustFocused || this.isActive
+          'v-menu__activator--active': this.hasJustFocused || this.isActive
         },
         ref: 'activator',
         on: {}
@@ -60,7 +60,7 @@ export default {
 
     genContent () {
       const options = {
-        staticClass: 'menu__content',
+        staticClass: 'v-menu__content',
         'class': {
           [this.contentClass.trim()]: true,
           'menuable__content__active': this.isActive,

--- a/src/stylus/components/_menus.styl
+++ b/src/stylus/components/_menus.styl
@@ -1,6 +1,6 @@
 @import '../bootstrap'
 
-.menu
+.v-menu
   display: inline-block
   position: relative
   vertical-align: middle
@@ -8,8 +8,8 @@
   &--disabled
     cursor: default
 
-    .menu__activator,
-    .menu__activator > *
+    .v-menu__activator,
+    .v-menu__activator > *
       cursor: default
       pointer-events: none
 
@@ -47,7 +47,7 @@
       contain: content
       backface-visibility: hidden
 
-  > .menu__content
+  > .v-menu__content
     max-width: none
 
   &-transition
@@ -82,8 +82,8 @@
     &-enter-active, &-leave-active
       transition: all .5s $transition.swing
 
-.menu-transition-enter
-  &.menu__content--auto
+.v-menu-transition-enter
+  &.v-menu__content--auto
     .v-list__tile--active
       opacity: 1
       transform: none !important

--- a/test/unit/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/test/unit/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -29,10 +29,10 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"
@@ -166,10 +166,10 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"
@@ -294,10 +294,10 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"
@@ -426,10 +426,10 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"

--- a/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -85,10 +85,10 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"
@@ -267,10 +267,10 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"
@@ -451,10 +451,10 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
                      style="display: none;"
               >
             </div>
-            <div class="menu"
+            <div class="v-menu"
                  style="display: inline-block;"
             >
-              <div class="menu__content menu__content--select menu__content--auto"
+              <div class="v-menu__content menu__content--select menu__content--auto"
                    style="max-height: 200px; min-width: 75px; max-width: auto; top: 18px; left: 12px; z-index: 0; display: none;"
               >
                 <div class="v-card"

--- a/test/unit/components/VMenu/VMenu.spec.js
+++ b/test/unit/components/VMenu/VMenu.spec.js
@@ -16,7 +16,7 @@ test('VMenu.js', ({ mount }) => {
       }
     })
 
-    const activator = wrapper.find('.menu__activator')[0]
+    const activator = wrapper.find('.v-menu__activator')[0]
     const input = jest.fn()
     wrapper.instance().$on('input', input)
     activator.trigger('click')
@@ -345,7 +345,7 @@ test('VMenu.js', ({ mount }) => {
       }
     })
 
-    const content = wrapper.find('.menu__content')[0]
+    const content = wrapper.find('.v-menu__content')[0]
 
     const getBoundingClientRect = () => {
       return {

--- a/test/unit/components/VMenu/__snapshots__/VMenu.spec.js.snap
+++ b/test/unit/components/VMenu/__snapshots__/VMenu.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`VMenu.js should render component with custom absolute and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -15,10 +15,10 @@ exports[`VMenu.js should render component with custom absolute and match snapsho
 
 exports[`VMenu.js should render component with custom activator and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -28,10 +28,10 @@ exports[`VMenu.js should render component with custom activator and match snapsh
 
 exports[`VMenu.js should render component with custom auto and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: 200px; min-width: 16px; max-width: auto; top: 12px; left: 12px; z-index: 0; display: none;"
   >
   </div>
@@ -41,10 +41,10 @@ exports[`VMenu.js should render component with custom auto and match snapshot 1`
 
 exports[`VMenu.js should render component with custom bottom and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -54,10 +54,10 @@ exports[`VMenu.js should render component with custom bottom and match snapshot 
 
 exports[`VMenu.js should render component with custom closeOnClick and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -67,10 +67,10 @@ exports[`VMenu.js should render component with custom closeOnClick and match sna
 
 exports[`VMenu.js should render component with custom closeOnContentClick and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -80,10 +80,10 @@ exports[`VMenu.js should render component with custom closeOnContentClick and ma
 
 exports[`VMenu.js should render component with custom disabled and match snapshot 1`] = `
 
-<div class="menu menu--disabled"
+<div class="v-menu v-menu--disabled"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -93,10 +93,10 @@ exports[`VMenu.js should render component with custom disabled and match snapsho
 
 exports[`VMenu.js should render component with custom fullWidth and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -106,10 +106,10 @@ exports[`VMenu.js should render component with custom fullWidth and match snapsh
 
 exports[`VMenu.js should render component with custom lazy and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -119,10 +119,10 @@ exports[`VMenu.js should render component with custom lazy and match snapshot 1`
 
 exports[`VMenu.js should render component with custom left and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -132,10 +132,10 @@ exports[`VMenu.js should render component with custom left and match snapshot 1`
 
 exports[`VMenu.js should render component with custom maxHeight and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: 100px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -145,10 +145,10 @@ exports[`VMenu.js should render component with custom maxHeight and match snapsh
 
 exports[`VMenu.js should render component with custom maxWidth and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: 100px; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -158,10 +158,10 @@ exports[`VMenu.js should render component with custom maxWidth and match snapsho
 
 exports[`VMenu.js should render component with custom minWidth and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 100px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -171,10 +171,10 @@ exports[`VMenu.js should render component with custom minWidth and match snapsho
 
 exports[`VMenu.js should render component with custom nudgeBottom and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 100px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -184,10 +184,10 @@ exports[`VMenu.js should render component with custom nudgeBottom and match snap
 
 exports[`VMenu.js should render component with custom nudgeLeft and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 12px; z-index: 0; display: none;"
   >
   </div>
@@ -197,10 +197,10 @@ exports[`VMenu.js should render component with custom nudgeLeft and match snapsh
 
 exports[`VMenu.js should render component with custom nudgeRight and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 100px; z-index: 0; display: none;"
   >
   </div>
@@ -210,10 +210,10 @@ exports[`VMenu.js should render component with custom nudgeRight and match snaps
 
 exports[`VMenu.js should render component with custom nudgeTop and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -223,10 +223,10 @@ exports[`VMenu.js should render component with custom nudgeTop and match snapsho
 
 exports[`VMenu.js should render component with custom nudgeWidth and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 100px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -236,10 +236,10 @@ exports[`VMenu.js should render component with custom nudgeWidth and match snaps
 
 exports[`VMenu.js should render component with custom offsetX and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -249,10 +249,10 @@ exports[`VMenu.js should render component with custom offsetX and match snapshot
 
 exports[`VMenu.js should render component with custom offsetY and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -262,10 +262,10 @@ exports[`VMenu.js should render component with custom offsetY and match snapshot
 
 exports[`VMenu.js should render component with custom openOnClick and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -275,10 +275,10 @@ exports[`VMenu.js should render component with custom openOnClick and match snap
 
 exports[`VMenu.js should render component with custom openOnHover and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -288,10 +288,10 @@ exports[`VMenu.js should render component with custom openOnHover and match snap
 
 exports[`VMenu.js should render component with custom origin and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -301,10 +301,10 @@ exports[`VMenu.js should render component with custom origin and match snapshot 
 
 exports[`VMenu.js should render component with custom positionX and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -314,10 +314,10 @@ exports[`VMenu.js should render component with custom positionX and match snapsh
 
 exports[`VMenu.js should render component with custom positionY and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -327,10 +327,10 @@ exports[`VMenu.js should render component with custom positionY and match snapsh
 
 exports[`VMenu.js should render component with custom right and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -340,10 +340,10 @@ exports[`VMenu.js should render component with custom right and match snapshot 1
 
 exports[`VMenu.js should render component with custom top and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -353,10 +353,10 @@ exports[`VMenu.js should render component with custom top and match snapshot 1`]
 
 exports[`VMenu.js should render component with custom transition and match snapshot 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__content"
+  <div class="v-menu__content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
   >
   </div>
@@ -368,10 +368,10 @@ exports[`VMenu.js should round dimensions 1`] = `"max-height: auto; min-width: 1
 
 exports[`VMenu.js should work 1`] = `
 
-<div class="menu"
+<div class="v-menu"
      style="display: inline-block;"
 >
-  <div class="menu__activator menu__activator--active">
+  <div class="v-menu__activator v-menu__activator--active">
     <button type="button"
             class="v-btn"
     >
@@ -379,7 +379,7 @@ exports[`VMenu.js should work 1`] = `
       </div>
     </button>
   </div>
-  <div class="menu__content menuable__content__active"
+  <div class="v-menu__content menuable__content__active"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 8; display: none; z-index: 8;"
   >
     <div class="v-card"

--- a/test/unit/components/VSelect/VSelect.spec.js
+++ b/test/unit/components/VSelect/VSelect.spec.js
@@ -310,13 +310,13 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     const wrapper = mount(VSelect, {
       propsData: {
-        contentClass: 'menu-class',
+        contentClass: 'v-menu-class',
         items
       }
     })
 
-    const menu = wrapper.find('.menu__content')[0]
-    expect(menu.element.classList).toContain('menu-class')
+    const menu = wrapper.find('.v-menu__content')[0]
+    expect(menu.element.classList).toContain('v-menu-class')
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 

--- a/test/unit/components/VSelect/__snapshots__/VSelect.spec.js.snap
+++ b/test/unit/components/VSelect/__snapshots__/VSelect.spec.js.snap
@@ -44,10 +44,10 @@ exports[`VSelect should render buttons correctly when using items array with seg
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select  menu__content--dropdown"
+      <div class="v-menu__content menu__content--select  menu__content--dropdown"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"
@@ -99,10 +99,10 @@ exports[`VSelect should render buttons correctly when using slot with segmented 
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select  menu__content--dropdown"
+      <div class="v-menu__content menu__content--select  menu__content--dropdown"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"
@@ -154,10 +154,10 @@ exports[`VSelect should render v-select correctly when not using scope slot 1`] 
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select"
+      <div class="v-menu__content menu__content--select"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 18px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"
@@ -218,10 +218,10 @@ exports[`VSelect should render v-select correctly when not using v-list-tile in 
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select"
+      <div class="v-menu__content menu__content--select"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 18px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"
@@ -282,10 +282,10 @@ exports[`VSelect should render v-select correctly when using v-list-tile in item
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select"
+      <div class="v-menu__content menu__content--select"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 18px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"

--- a/test/unit/components/VSelect/__snapshots__/VSelect2.spec.js.snap
+++ b/test/unit/components/VSelect/__snapshots__/VSelect2.spec.js.snap
@@ -20,10 +20,10 @@ exports[`VSelect should be clearable with prop, dirty and multi select 1`] = `
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select"
+      <div class="v-menu__content menu__content--select"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 18px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"
@@ -128,10 +128,10 @@ exports[`VSelect should be clearable with prop, dirty and single select 1`] = `
              style="display: none;"
       >
     </div>
-    <div class="menu"
+    <div class="v-menu"
          style="display: inline-block;"
     >
-      <div class="menu__content menu__content--select"
+      <div class="v-menu__content menu__content--select"
            style="max-height: 300px; min-width: 0px; max-width: auto; top: 18px; left: 0px; z-index: 0; display: none;"
       >
         <div class="v-card"


### PR DESCRIPTION
## Description
* Related to [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## Motivation and Context

* Start working on adding prefix to classes [#1561](https://github.com/vuetifyjs/vuetify/issues/1561)

## How Has This Been Tested?

* Yarn test
* no new test case

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
