### PR TITLE
feat: routable target prop NOT for anchors only

### DIFF
--- a/src/mixins/routable.js
+++ b/src/mixins/routable.js
@@ -73,11 +73,10 @@ export default {
       } else {
         tag = (this.href && 'a') || this.tag || 'a'
 
-        if (tag === 'a') {
-          if (this.href) data.attrs.href = this.href
-          if (this.target) data.attrs.target = this.target
-        }
+        if (tag === 'a' && this.href) data.attrs.href = this.href
       }
+
+      if (this.target) data.attrs.target = this.target
 
       return { tag, data }
     }


### PR DESCRIPTION
## Description
Removes limitations for `target` attribute in the `routable` mixin.

## Motivation and Context
The `target` attribute only works on anchor elements. But it should also work on router/nuxt links. There is no need to limit it. It does no harm on a normal button. Anyway why would you provide `target` on a button?

## How Has This Been Tested?

Playground.vue

```vue
<template>
  <v-app>
    <v-btn to="/page2">
      open in the same tab
    </v-btn>
    <v-btn to="/page2" target="_blank">
      open in a new tab
    </v-btn>
    <v-btn @click="alert" target="_blank">
      just an alert button
    </v-btn>
    <router-view/>
  </v-app>
</template>

<script>
  export default {
    methods: {
      alert() {
        alert('hi')
      }
    }
  }
</script>
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

## Docs

In the documentation the text

`Specify the target attribute, only works with anchor tag.`

should be changed to this

`Specify the target attribute.`

I can create a PR in the documentation, if you agree with this pull request.
