### PR TITLE
feat(theme): allow a nonce to be specified for the stylesheet

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,6 +130,8 @@ declare interface VuetifyOptions {
   themeVariations: string[]
   minifyTheme: ((css: string) => string) | null
   themeCache: VuetifyThemeCache | null
+  /** @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_inline_script */
+  cspNonce: string | null
 }
 
 declare type VuetifyGoToEasing =

--- a/src/components/VApp/mixins/app-theme.js
+++ b/src/components/VApp/mixins/app-theme.js
@@ -102,6 +102,9 @@ export default {
         style = document.createElement('style')
         style.type = 'text/css'
         style.id = 'vuetify-theme-stylesheet'
+        if (this.$vuetify.options.cspNonce) {
+          style.setAttribute('nonce', this.$vuetify.options.cspNonce)
+        }
         document.head.appendChild(style)
       }
 

--- a/src/components/Vuetify/mixins/options.js
+++ b/src/components/Vuetify/mixins/options.js
@@ -1,7 +1,8 @@
 const OPTIONS_DEFAULTS = {
   themeVariations: ['primary', 'secondary', 'accent'],
   minifyTheme: null,
-  themeCache: null
+  themeCache: null,
+  cspNonce: null
 }
 
 export default function options (options = {}) {

--- a/test/unit/components/VApp/VApp.spec.js
+++ b/test/unit/components/VApp/VApp.spec.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import VApp from '@/components/VApp'
 import { test } from '@/test'
 
@@ -48,5 +49,18 @@ test('VApp.js', ({ mount }) => {
     wrapper.vm.$vuetify.theme.primary = '#000'
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.style).toMatchSnapshot()
+  })
+
+  it('should set a CSP nonce', async () => {
+    // Delete the old stylesheet first
+    let el = document.getElementById('vuetify-theme-stylesheet')
+    el.parentNode.removeChild(el)
+
+    Vue.prototype.$vuetify.options.cspNonce = 'asdfghjkl'
+    const app = mount(VApp, { attachToDocument: true })
+
+    el = document.getElementById('vuetify-theme-stylesheet')
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('nonce')).toBe('asdfghjkl')
   })
 })


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
resolves #3950 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_inline_script

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```js
Vue.use(Vuetify, {
  options: {
    cspNonce: '2726c7f26c'
  }
})
```
Resulting HTML:
```html
<style type="text/css" id="vuetify-theme-stylesheet" nonce="2726c7f26c">
  ...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
