### PR TITLE
Fix: Prevent stylus variable vs. animation name collision ("query")

### DIFF
--- a/src/stylus/components/_grid.styl
+++ b/src/stylus/components/_grid.styl
@@ -6,9 +6,9 @@
   padding: $grid-gutters.lg
   width: 100%
 
-  for size, width in $container-max-widths
-    @media only screen and (min-width: width)
-      max-width: (width * 0.9375) // Credit to bootstrap
+  for $size, $width in $container-max-widths
+    @media only screen and (min-width: $width)
+      max-width: ($width * 0.9375) // Credit to bootstrap
 
   @media $display-breakpoints.xs-only
     padding: $grid-gutters.xl
@@ -71,19 +71,19 @@
   &.wrap
     flex-wrap: wrap
 
-for size, width in $grid-breakpoints
-  @media all and (min-width: width)
+for $size, $width in $grid-breakpoints
+  @media all and (min-width: $width)
     for n in (1..$grid-columns)
-      .flex.{size}{n}
+      .flex.{$size}{n}
         flex-basis: (n / $grid-columns * 100)%
         flex-grow: 0
         max-width: (n / $grid-columns * 100)%
 
-      .flex.order-{size}{n}
+      .flex.order-{$size}{n}
         order: n
 
     for n in (0..$grid-columns)
-      .flex.offset-{size}{n}
+      .flex.offset-{$size}{n}
         // Offsets can only ever work in row layouts
         margin-left: (n / $grid-columns * 100)%
 
@@ -184,6 +184,6 @@ for size, width in $grid-breakpoints
 
 .d-inline-block
   display: inline-block !important
-  
+
 .d-inline
   display: inline !important

--- a/src/stylus/generic/_bootstrap.styl
+++ b/src/stylus/generic/_bootstrap.styl
@@ -32,14 +32,14 @@ global-color-accent(color_name, color_value)
       textarea
         caret-color: color_value !important
 
-for color_name, color_value in $shades
-  global-color(color_name, color_value)
+for $color_name, $color_value in $shades
+  global-color($color_name, $color_value)
 
 if ($color-pack)
-  for color_name, color_color in $colors
-    for color_type, color_value in color_color
-      if color_type == 'base'
-        global-color(color_name, color_value)
+  for $color_name, $color_color in $colors
+    for $color_type, $color_value in $color_color
+      if $color_type == 'base'
+        global-color($color_name, $color_value)
 
-      else if color_type != 'shades'
-        global-color-accent(color_name, color_value)
+      else if $color_type != 'shades'
+        global-color-accent($color_name, $color_value)

--- a/src/stylus/trumps/_display.styl
+++ b/src/stylus/trumps/_display.styl
@@ -1,7 +1,7 @@
-for size, mediaQuery in $display-breakpoints
+for $size, $media_query in $display-breakpoints
   .hidden
-    &-{size}
-      @media mediaQuery
+    &-{$size}
+      @media $media_query
         display: none !important
 
 .overflow-hidden

--- a/src/stylus/trumps/_display.styl
+++ b/src/stylus/trumps/_display.styl
@@ -1,7 +1,7 @@
-for size, query in $display-breakpoints
+for size, mediaQuery in $display-breakpoints
   .hidden
     &-{size}
-      @media query
+      @media mediaQuery
         display: none !important
 
 .overflow-hidden

--- a/src/stylus/trumps/_spacing.styl
+++ b/src/stylus/trumps/_spacing.styl
@@ -3,39 +3,39 @@
   margin-right: auto !important
 
 $i = 0
-for level, spacer in $spacers
+for $level, $spacer in $spacers
   .mt-{$i}
-    margin-top: spacer.y !important
+    margin-top: $spacer.y !important
   .mr-{$i}
-    margin-right: spacer.x !important
+    margin-right: $spacer.x !important
   .mb-{$i}
-    margin-bottom: spacer.y !important
+    margin-bottom: $spacer.y !important
   .ml-{$i}
-    margin-left: spacer.x !important
+    margin-left: $spacer.x !important
   .mx-{$i}
-    margin-left: spacer.x !important
-    margin-right: spacer.x !important
+    margin-left: $spacer.x !important
+    margin-right: $spacer.x !important
   .my-{$i}
-    margin-top: spacer.y !important
-    margin-bottom: spacer.y !important
+    margin-top: $spacer.y !important
+    margin-bottom: $spacer.y !important
   .ma-{$i}
-    margin: spacer.y spacer.x !important
-    
+    margin: $spacer.y $spacer.x !important
+
   .pt-{$i}
-    padding-top: spacer.y !important
+    padding-top: $spacer.y !important
   .pr-{$i}
-    padding-right: spacer.x !important
+    padding-right: $spacer.x !important
   .pb-{$i}
-    padding-bottom: spacer.y !important
+    padding-bottom: $spacer.y !important
   .pl-{$i}
-    padding-left: spacer.x !important
+    padding-left: $spacer.x !important
   .px-{$i}
-    padding-left: spacer.x !important
-    padding-right: spacer.x !important
+    padding-left: $spacer.x !important
+    padding-right: $spacer.x !important
   .py-{$i}
-    padding-top: spacer.y !important
-    padding-bottom: spacer.y !important
+    padding-top: $spacer.y !important
+    padding-bottom: $spacer.y !important
   .pa-{$i}
-    padding: spacer.y spacer.x !important
-    
+    padding: $spacer.y $spacer.x !important
+
   $i = $i + 1

--- a/src/stylus/trumps/_text.styl
+++ b/src/stylus/trumps/_text.styl
@@ -1,13 +1,13 @@
-for size, width in $grid-breakpoints
-  @media all and (min-width: width)
-    .text-{size}-left
+for $size, $width in $grid-breakpoints
+  @media all and (min-width: $width)
+    .text-{$size}-left
       text-align: left !important
 
-    .text-{size}-center
+    .text-{$size}-center
       text-align: center !important
-      
-    .text-{size}-right
+
+    .text-{$size}-right
       text-align: right !important
-      
-    .text-{size}-justify
+
+    .text-{$size}-justify
       text-align: justify !important


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This bugfix prevents the final value of the stylus iteration variable "query" from being injected as the v-linear-progress component's animation title of the same name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

"query" is used as both a non-prefixed variable in _display.styl and an animation name used in v-linear-progress:

![stylus-collision](https://user-images.githubusercontent.com/18492423/39407435-600f3780-4bc6-11e8-9b29-d0c61a8da015.png)

This results in the final iteration value being injected in place of the animation name "query":

![stylus-keyframe-fuckups](https://user-images.githubusercontent.com/18492423/39407389-ab8bd886-4bc5-11e8-860b-9ad3746b1294.png)


## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

Proposed change allows building app.css with intended animation name:

![image](https://user-images.githubusercontent.com/18492423/39407719-c0f6359a-4bca-11e8-863f-5453cc459f52.png)


## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
