### PR TITLE
perf(VSelect): cache list VNode

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -137,6 +137,21 @@ export default {
       return this.selectedItems.find(i => {
         return this.valueComparator(this.getValue(i), this.getValue(this.internalValue))
       })
+    },
+    listData () {
+      const data = VSelect.computed.listData.call(this)
+
+      Object.assign(data.props, {
+        items: this.filteredItems,
+        noFilter: (
+          this.noFilter ||
+          !this.isSearching ||
+          !this.filteredItems.length
+        ),
+        searchInput: this.internalSearch
+      })
+
+      return data
     }
   },
 
@@ -240,19 +255,6 @@ export default {
       input.data.domProps.value = this.internalSearch
 
       return input
-    },
-    genList () {
-      const list = VSelect.methods.genList.call(this)
-
-      list.componentOptions.propsData.items = this.filteredItems
-      list.componentOptions.propsData.noFilter = (
-        this.noFilter ||
-        !this.isSearching ||
-        !this.filteredItems.length
-      )
-      list.componentOptions.propsData.searchInput = this.internalSearch
-
-      return list
     },
     genSelections () {
       return this.hasSlot || this.isMulti

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -187,12 +187,15 @@ export default {
         },
         on: {
           select: this.selectItem
+        },
+        scopedSlots: {
+          item: this.$scopedSlots.item
         }
       }
     },
     staticList () {
-      if (this.$scopedSlots.item || this.$slots['no-data']) {
-        consoleError('assert: staticList should not be called if scoped slots are used')
+      if (this.$slots['no-data']) {
+        consoleError('assert: staticList should not be called if slots are used')
       }
 
       return this.$createElement(VSelectList, this.listData)
@@ -334,19 +337,15 @@ export default {
       return input
     },
     genList () {
-      if (this.$scopedSlots.item || this.$slots['no-data']) {
+      // If there's no slots, we can use a cached VNode to improve performance
+      if (this.$slots['no-data']) {
         return this.genListWithSlot()
       } else {
         return this.staticList
       }
     },
     genListWithSlot () {
-      return this.$createElement(VSelectList, {
-        ...this.listData,
-        scopedSlots: {
-          item: this.$scopedSlots.item
-        }
-      }, [
+      return this.$createElement(VSelectList, this.listData, [
         this.$slots['no-data'] ? this.$createElement('div', {
           slot: 'no-data'
         }, this.$slots['no-data']) : null

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -21,6 +21,7 @@ import ClickOutside from '../../directives/click-outside'
 
 // Helpers
 import { getPropertyFromItem, keyCodes } from '../../util/helpers'
+import { consoleError } from '../../util/console'
 
 export default {
   name: 'v-select',
@@ -166,6 +167,35 @@ export default {
         offsetY: this.offsetY,
         nudgeBottom: this.offsetY ? 1 : 0 // convert to int
       }
+    },
+    listData () {
+      return {
+        props: {
+          action: this.isMulti && !this.isHidingSelected,
+          color: this.color,
+          dark: this.dark,
+          dense: this.dense,
+          hideSelected: this.hideSelected,
+          items: this.items,
+          light: this.light,
+          noDataText: this.noDataText,
+          selectedItems: this.selectedItems,
+          itemAvatar: this.itemAvatar,
+          itemDisabled: this.itemDisabled,
+          itemValue: this.itemValue,
+          itemText: this.itemText
+        },
+        on: {
+          select: this.selectItem
+        }
+      }
+    },
+    staticList () {
+      if (this.$scopedSlots.item || this.$slots['no-data']) {
+        consoleError('assert: staticList should not be called if scoped slots are used')
+      }
+
+      return this.$createElement(VSelectList, this.listData)
     }
   },
 
@@ -304,25 +334,15 @@ export default {
       return input
     },
     genList () {
+      if (this.$scopedSlots.item || this.$slots['no-data']) {
+        return this.genListWithSlot()
+      } else {
+        return this.staticList
+      }
+    },
+    genListWithSlot () {
       return this.$createElement(VSelectList, {
-        props: {
-          action: this.isMulti && !this.isHidingSelected,
-          color: this.color,
-          dark: this.dark,
-          dense: this.dense,
-          hideSelected: this.hideSelected,
-          items: this.items,
-          light: this.light,
-          noDataText: this.noDataText,
-          selectedItems: this.selectedItems,
-          itemAvatar: this.itemAvatar,
-          itemDisabled: this.itemDisabled,
-          itemValue: this.itemValue,
-          itemText: this.itemText
-        },
-        on: {
-          select: this.selectItem
-        },
+        ...this.listData,
         scopedSlots: {
           item: this.$scopedSlots.item
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Uses a computed property to cache the list VNode instead of rendering a new one with each update. 
Turns out it's fairly safe to use scoped slots in computed properties, it's just regular ones that won't update. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I felt like it. 
It improves performance quite a bit with a large number of items, here I have 5000:

##### Before:
![chrome_2018-05-08_19-19-06](https://user-images.githubusercontent.com/16421948/39751752-7f6586d8-52fc-11e8-805d-2834dadfef76.png)

##### After:
![chrome_2018-05-08_19-20-54](https://user-images.githubusercontent.com/16421948/39751763-8709cdea-52fc-11e8-811a-f63fd22200d2.png)

Search is still slow as a dog but we can't really do much about that other than virtualise the list again. 

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->
```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-container>
        <v-autocomplete label="5k items" :items="items" v-model="selected">
          <template slot="item" slot-scope="props">
            <v-list-tile-title>
              {{ props.item }} - {{ time }}
            </v-list-tile-title>
          </template>
          <template slot="label">{{ time }}</template>
        </v-autocomplete>

        <v-autocomplete :items="['foo', 'bar']"/>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      selected: '',
      items: [...Array(5000).keys()],
      time: 0
    }),
    mounted () {
      this.count()
    },
    methods: {
      count () {
        setTimeout(() => {
          this.time++
          this.count()
        }, 1000)
      }
    }
  }
</script>
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)