### PR TITLE
Fix: missed icon updates for 1.1

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -56,7 +56,7 @@ export default {
     ...Menuable.props,
     appendIcon: {
       type: String,
-      default: 'arrow_drop_down'
+      default: '$vuetify.icons.dropdown'
     },
     appendIconCb: Function,
     attach: Boolean,


### PR DESCRIPTION
## Description
Fixed the one remaining hard-coded internal icon name.

## Motivation and Context
To allow Vuetify users to replace the iconfont set or individual icons.

## How Has This Been Tested?
Visually, also reran the tests. All automated tests continue to pass.

## Markup:
The dropdown icon in `v-select` now defaults to MD but can be overriden, with code such as:
```
Vue.use(Vuetify, { iconfont: 'fa' })
```
which replaces it with a Font-Awesome 5 icon (if they are available in the app).  Prior to this commit, it was hard-coded to use the Material Design (MD) icon.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
