### PR TITLE
removeChild error when moving mouse away from an active ripple

### DIFF
--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -68,8 +68,14 @@ const ripple = {
       setTimeout(() => {
         // Need to figure out a new way to do this
         try {
-          if (ripples.length < 1) el.style.position = null
-          animation.parentNode && el.removeChild(animation.parentNode)
+          // refresh ripples and animation since this is async
+          const ripples = el.getElementsByClassName('v-ripple__animation')
+          if (ripples.length === 0) {
+            el.style.position = null
+          } else {
+            const animation = ripples[ripples.length - 1]
+            animation.parentNode && el.removeChild(animation.parentNode)
+          }
         } catch (e) { console.log(e) }
       }, 300)
     }, delay)

--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -66,17 +66,14 @@ const ripple = {
       animation.classList.remove('v-ripple__animation--visible')
 
       setTimeout(() => {
-        // Need to figure out a new way to do this
-        try {
-          // refresh ripples and animation since this is async
-          const ripples = el.getElementsByClassName('v-ripple__animation')
-          if (ripples.length === 0) {
-            el.style.position = null
-          } else {
-            const animation = ripples[ripples.length - 1]
-            animation.parentNode && el.removeChild(animation.parentNode)
-          }
-        } catch (e) { console.log(e) }
+        // refresh ripples and animation since this is async
+        const ripples = el.getElementsByClassName('v-ripple__animation')
+        if (ripples.length === 0) {
+          el.style.position = null
+        } else {
+          const animation = ripples[ripples.length - 1]
+          animation.parentNode && el.removeChild(animation.parentNode)
+        }
       }, 300)
     }, delay)
   }


### PR DESCRIPTION
## Description
Fixed the `removeChild` console errors that could occur if the mouse was moved outside of focus (blur) within the ripple timer period.

## Motivation and Context
The problem was producing console errors, an attempt to remove a child that no longer existed.

## How Has This Been Tested?
Visually based on steps that were easy to reproduce before the changes (and not possible to reproduce after the changes) and by placing a breakpoint inside the timer code and tracing and inspecting.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project. (I think.)
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
