### PR TITLE
fix(v-select): add back fake virtualization

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -142,7 +142,7 @@ export default {
       const data = VSelect.computed.listData.call(this)
 
       Object.assign(data.props, {
-        items: this.filteredItems,
+        items: this.virtualizedItems,
         noFilter: (
           this.noFilter ||
           !this.isSearching ||
@@ -152,6 +152,11 @@ export default {
       })
 
       return data
+    },
+    virtualizedItems () {
+      return !this.auto
+        ? this.filteredItems.slice(0, this.lastItem)
+        : this.filteredItems
     }
   },
 

--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -152,11 +152,6 @@ export default {
       })
 
       return data
-    },
-    virtualizedItems () {
-      return !this.auto
-        ? this.filteredItems.slice(0, this.lastItem)
-        : this.filteredItems
     }
   },
 

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -41,7 +41,10 @@ export default {
   data: vm => ({
     attrsInput: { role: 'combobox' },
     cachedItems: vm.cacheItems ? vm.items : [],
+    content: null,
+    isBooted: false,
     isMenuActive: false,
+    lastItem: 20,
     // As long as a value is defined, show it
     // Otherwise, check if multiple
     // to determine which default to provide
@@ -176,7 +179,7 @@ export default {
           dark: this.dark,
           dense: this.dense,
           hideSelected: this.hideSelected,
-          items: this.items,
+          items: this.virtualizedItems,
           light: this.light,
           noDataText: this.noDataText,
           selectedItems: this.selectedItems,
@@ -199,11 +202,28 @@ export default {
       }
 
       return this.$createElement(VSelectList, this.listData)
+    },
+    virtualizedItems () {
+      return !this.auto
+        ? this.items.slice(0, this.lastItem)
+        : this.items
     }
   },
 
   watch: {
     internalValue: 'setSelectedItems',
+    isBooted () {
+      this.$nextTick(() => {
+        if (this.content && this.content.addEventListener) {
+          this.content.addEventListener('scroll', this.onScroll, false)
+        }
+      })
+    },
+    isMenuActive (val) {
+      if (!val) return
+
+      this.isBooted = true
+    },
     items (val) {
       if (this.cacheItems) {
         this.cachedItems = this.filterDuplicates(this.cachedItems.concat(val))
@@ -215,6 +235,14 @@ export default {
 
   created () {
     this.setSelectedItems()
+  },
+
+  mounted () {
+    // If instance is being destroyed
+    // do not run mounted functions
+    if (this._isDestroyed) return
+
+    this.content = this.$refs.menu.$refs.content
   },
 
   methods: {
@@ -488,6 +516,23 @@ export default {
       }
 
       VTextField.methods.onMouseUp.call(this, e)
+    },
+    onScroll () {
+      if (!this.isMenuActive) {
+        requestAnimationFrame(() => (this.content.scrollTop = 0))
+      } else {
+        if (this.lastItem >= this.computedItems.length) return
+
+        const showMoreItems = (
+          this.content.scrollHeight -
+          (this.content.scrollTop +
+          this.content.clientHeight)
+        ) < 200
+
+        if (showMoreItems) {
+          this.lastItem += 20
+        }
+      }
     },
     selectItem (item) {
       if (!this.isMulti) {

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -205,8 +205,8 @@ export default {
     },
     virtualizedItems () {
       return !this.auto
-        ? this.items.slice(0, this.lastItem)
-        : this.items
+        ? this.computedItems.slice(0, this.lastItem)
+        : this.computedItems
     }
   },
 

--- a/test/unit/components/VSelect/VSelect3.spec.js
+++ b/test/unit/components/VSelect/VSelect3.spec.js
@@ -38,4 +38,24 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(wrapper.vm.isMenuActive).toBe(true)
   })
+
+  it('should return auto', () => {
+    const wrapper = mount(VSelect)
+
+    expect(wrapper.vm.dynamicHeight).toBe('auto')
+  })
+
+  it('should return full items if using auto prop', () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        items: [...Array(100).keys()]
+      }
+    })
+
+    expect(wrapper.vm.virtualizedItems.length).toBe(20)
+
+    wrapper.setProps({ auto: true })
+
+    expect(wrapper.vm.virtualizedItems.length).toBe(100)
+  })
 })

--- a/test/unit/components/VSelect/VSelect3.spec.js
+++ b/test/unit/components/VSelect/VSelect3.spec.js
@@ -39,12 +39,6 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(wrapper.vm.isMenuActive).toBe(true)
   })
 
-  it('should return auto', () => {
-    const wrapper = mount(VSelect)
-
-    expect(wrapper.vm.dynamicHeight).toBe('auto')
-  })
-
   it('should return full items if using auto prop', () => {
     const wrapper = mount(VSelect, {
       propsData: {


### PR DESCRIPTION
select used to at least try to reduce the burden on massive lists, accidentally removed

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added back functionality that would slice the list (fake virtualization)
<!--- Describe your changes in detail -->

## Motivation and Context
Performance issues
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
n/a
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup that showcases your contribution --->
<!--- You can use ```vue to style the code -->

``` vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-container>
        <v-autocomplete label="5k items" :items="items" v-model="selected">
          <template slot="item" slot-scope="props">
            <v-list-tile-title>
              {{ props.item }} - {{ time }}
            </v-list-tile-title>
          </template>
          <template slot="label">{{ time }}</template>
        </v-autocomplete>

        <v-autocomplete :items="['foo', 'bar']"/>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      selected: '',
      items: [...Array(5000).keys()],
      time: 0
    }),
    mounted () {
      this.count()
    },
    methods: {
      count () {
        // setTimeout(() => {
        //   this.time++
        //   this.count()
        // }, 1000)
      }
    }
  }
</script>
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
