### PR TITLE
Fixed one more case of hard-coded icon (clear, if clearable)

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -47,7 +47,7 @@ export default {
     clearable: Boolean,
     clearIcon: {
       type: String,
-      default: 'clear'
+      default: '$vuetify.icons.clear'
     },
     clearIconCb: Function,
     color: {
@@ -254,7 +254,7 @@ export default {
         // Make sure the slot takes space
         // so layout doesn't jump when
         // dirty
-        const icon = !this.isDirty ? false : 'clear'
+        const icon = !this.isDirty ? false : '$vuetify.icons.clear'
 
         slot.push(this.genIcon(icon,
           this.clearIconCb || this.clearableCallback

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -254,7 +254,7 @@ export default {
         // Make sure the slot takes space
         // so layout doesn't jump when
         // dirty
-        const icon = !this.isDirty ? false : '$vuetify.icons.clear'
+        const icon = !this.isDirty ? false : 'clear'
 
         slot.push(this.genIcon(icon,
           this.clearIconCb || this.clearableCallback


### PR DESCRIPTION
## Description
`VTextField` had a hard-coded `clear` icon, preventing config-based iconfont replacement.

## Motivation and Context
Fixes a missing update from the 1.1 enhancement for configurable icon sets.

## How Has This Been Tested?
Before/after testing with "fa" iconfont and a clearable v-select input.  "clear" prior to fix, proper icon after fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
