### PR TITLE
fix(VInput): allow input to fill width when in a flex container

### DIFF
--- a/src/stylus/components/_inputs.styl
+++ b/src/stylus/components/_inputs.styl
@@ -23,6 +23,7 @@ theme(v-input, "v-input")
 .v-input
   align-items: flex-start
   display: flex
+  flex: 1 1 0px
   font-size: 16px
   margin-top: 28px // 12px for label, 16px for spec
   text-align: left


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4022

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-container>
      <v-layout row>
        <v-flex>
          <v-text-field label="normal width"/>
        </v-flex>
      </v-layout>
      <v-layout row>
        <v-flex>
          <v-menu full-width>
            <v-text-field slot="activator" label="broken width"/>
          </v-menu>
        </v-flex>
      </v-layout>
    </v-container>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
