### PR TITLE
fix(VTextField): add back focus and blur methods

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -18,6 +18,9 @@ import Ripple from '../../directives/ripple'
 import {
   keyCodes
 } from '../../util/helpers'
+import {
+  consoleWarn
+} from '../../util/console'
 
 const dirtyTypes = ['color', 'file', 'time', 'date', 'datetime-local', 'week', 'month']
 
@@ -163,10 +166,12 @@ export default {
   methods: {
     /** @public */
     focus () {
+      consoleWarn('The <focus> function is deprecated, use <onFocus> instead', this)
       this.onFocus()
     },
     /** @public */
     blur () {
+      consoleWarn('The <blur> function is deprecated, use <onBlur> instead', this)
       this.onBlur()
     },
     clearableCallback () {

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -161,6 +161,14 @@ export default {
   },
 
   methods: {
+    /** @public */
+    focus () {
+      this.onFocus()
+    },
+    /** @public */
+    blur () {
+      this.onBlur()
+    },
     clearableCallback () {
       this.internalValue = null
       this.$nextTick(() => this.$refs.input.focus())

--- a/test/unit/components/VTextField/VTextField.spec.js
+++ b/test/unit/components/VTextField/VTextField.spec.js
@@ -747,8 +747,10 @@ test('VTextField.js', ({ mount }) => {
 
     wrapper.vm.focus()
     expect(focus).toHaveBeenCalledTimes(1)
+    expect('[Vuetify] The <focus> function is deprecated, use <onFocus> instead in "v-text-field"').toHaveBeenTipped()
 
     wrapper.vm.blur()
     expect(blur).toHaveBeenCalledTimes(1)
+    expect('[Vuetify] The <blur> function is deprecated, use <onBlur> instead in "v-text-field"').toHaveBeenTipped()
   })
 })

--- a/test/unit/components/VTextField/VTextField.spec.js
+++ b/test/unit/components/VTextField/VTextField.spec.js
@@ -737,4 +737,18 @@ test('VTextField.js', ({ mount }) => {
 
     expect(change).toHaveBeenCalledTimes(2)
   })
+
+  it('should have focus and blur methods', () => {
+    const wrapper = mount(VTextField)
+    const focus = jest.fn()
+    const blur = jest.fn()
+    wrapper.vm.$on('focus', focus)
+    wrapper.vm.$on('blur', blur)
+
+    wrapper.vm.focus()
+    expect(focus).toHaveBeenCalledTimes(1)
+
+    wrapper.vm.blur()
+    expect(blur).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
in 1.0 you could call focus and blur directly, but they were renamed in the refactor

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-card>
      <v-card-text>
        <v-layout align-center>
          <v-checkbox v-model="enabled" hide-details class="shrink mr-2"/>
          <v-text-field ref="textField" label="I want to be edited without clicking on this field!" :disabled="!enabled"/>
        </v-layout>
      </v-card-text>
    </v-card>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      includeFiles: true,
      enabled: false
    }),
    watch: {
      enabled (val) {
        this.$nextTick(() => {
          val
            ? this.$refs.textField.focus()
            : this.$refs.textField.blur()
        })
      }
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
