### PR TITLE
fix: hides selection control's input in IE11

### DIFF
--- a/src/stylus/components/_selection-controls.styl
+++ b/src/stylus/components/_selection-controls.styl
@@ -31,8 +31,7 @@ rtl(v-selection-control-rtl, "v-input--selection-controls")
     width: 24px
 
     input
-      appearance: none
-      position: absolute
+      display: none
 
   &__ripple
     cursor: pointer


### PR DESCRIPTION
## Description

Replaces `appearance: none / position: absolute` with `display: none`

## Motivation and Context
![image](https://user-images.githubusercontent.com/15625235/39914980-cd03e912-5530-11e8-8d7a-760af829ec31.png)

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-switch />
      <v-checkbox />
      <v-radio />
    </v-content>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
