### PR TITLE
Fixes bug #3924 where dialog transitions can't be disabled.

### DIFF
--- a/src/components/VDialog/VDialog.js
+++ b/src/components/VDialog/VDialog.js
@@ -193,14 +193,19 @@ export default {
       }, [this.$slots.activator]))
     }
 
-    const dialog = h('transition', {
-      props: {
-        name: this.transition || '', // If false, show nothing
-        origin: this.origin
-      }
-    }, [h('div', data,
-      this.showLazyContent(this.$slots.default)
-    )])
+    var dialog
+    if (this.transition) {
+      dialog = h('transition', {
+        props: {
+          name: this.transition,
+          origin: this.origin
+        }
+      }, [h('div', data, this.showLazyContent(this.$slots.default))])
+    } else {
+      dialog = h('div', data,
+        this.showLazyContent(this.$slots.default)
+      )
+    }
 
     children.push(h('div', {
       'class': this.contentClasses,


### PR DESCRIPTION
## Description
Fixes bug #3924 where dialog transitions can't be disabled.

## Motivation and Context
v-dialog includes the 'transition' tag even when transition is set to false. This causes a delay of a few hundred milliseconds when the v-dialog is opened or closed, leading to the feeling of an unresponsive UI. Details are in issue #3924.

## How Has This Been Tested?
Tested in my own vuetify project, to confirm that v-dialog now works properly both with and without transitions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.