### PR TITLE
Small fix of $grid-gutter definition

### DIFF
--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -16,7 +16,7 @@ $grid-breakpoints := {
   xl: (1920px - 16px) // https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints
 }
 
-$grid-gutter = 8px
+$grid-gutter := 8px
 $grid-columns := 12
 $grid-gutters := {
   xs: ($grid-gutter / 4)


### PR DESCRIPTION
It is probably necessary to freely overwrite the `$grid-gutter` value in custom styles.