### PR TITLE
Fixed missing hamburger 'menu' icon from customizable icon map.

### DIFF
--- a/src/components/VToolbar/VToolbarSideIcon.js
+++ b/src/components/VToolbar/VToolbarSideIcon.js
@@ -21,6 +21,6 @@ export default {
 
     const defaultSlot = slots().default
 
-    return h(VBtn, d, defaultSlot || [h(VIcon, 'menu')])
+    return h(VBtn, d, defaultSlot || [h(VIcon, '$vuetify.icons.menu')])
   }
 }

--- a/src/components/Vuetify/mixins/icons.js
+++ b/src/components/Vuetify/mixins/icons.js
@@ -17,6 +17,7 @@ const ICONS_MATERIAL = {
   'delimiter': 'fiber_manual_record', // for carousel
   'sort': 'arrow_upward',
   'expand': 'keyboard_arrow_down',
+  'menu': 'menu',
   'subgroup': 'arrow_drop_down',
   'dropdown': 'arrow_drop_down',
   'radioOn': 'radio_button_checked',
@@ -43,6 +44,7 @@ const ICONS_MDI = {
   'delimiter': 'mdi-circle', // for carousel
   'sort': 'mdi-arrow-up',
   'expand': 'mdi-chevron-down',
+  'menu': 'mdi-menu',
   'subgroup': 'mdi-menu-down',
   'dropdown': 'mdi-menu-down',
   'radioOn': 'mdi-radiobox-marked',
@@ -69,6 +71,7 @@ const ICONS_FONTAWESOME4 = {
   'delimiter': 'fa fa-circle', // for carousel
   'sort': 'fa fa-sort-up',
   'expand': 'fa fa-chevron-down',
+  'menu': 'fa fa-bars',
   'subgroup': 'fa fa-caret-down',
   'dropdown': 'fa fa-caret-down',
   'radioOn': 'fa fa-dot-circle',
@@ -95,6 +98,7 @@ const ICONS_FONTAWESOME = {
   'delimiter': 'fas fa-circle', // for carousel
   'sort': 'fas fa-sort-up',
   'expand': 'fas fa-chevron-down',
+  'menu': 'fas fa-bars',
   'subgroup': 'fas fa-caret-down',
   'dropdown': 'fas fa-caret-down',
   'radioOn': 'far fa-dot-circle',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,6 +68,7 @@ export interface VuetifyIcons {
   delimiter: string
   sort: string
   expand: string
+  menu: string
   subgroup: string
   dropdown: string
   radioOn: string


### PR DESCRIPTION
## Description
Fixed the undesired requirement when using `v-toolbar-side-icon` for MD icons to be available, even if the `iconfont` option was used to specify 'mdi', 'fa' or 'fa4'.

## Motivation and Context
This PR allow a Vuetify app to rely solely on a single icon font, such as Font-Awesome or MDI.

## How Has This Been Tested?
Visually, with [a test app](https://github.com/appurist/vuetify-test-wp) and verified all unit tests continue to pass.

## Markup:
Load Vuetify with: `Vue.use(Vuetify, { iconfont: 'fa' })` and then include:
```vue
<v-toolbar app>
  <v-toolbar-side-icon></v-toolbar-side-icon>
</v-toolbar>
```
The above would show "MENU" rather than the three-bars hamburger icon unless the MD icons were loaded.
See a complete app example here:
https://github.com/appurist/vuetify-test-wp/blob/master/src/App.vue
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.

This change adds `menu` to the list of internally-recognized icons defined in the `$vuetify.icons` icon map, and used by `v-toolbar-side-icon`.