### PR TITLE
fix(VSlider): allow step to be set to 0

### DIFF
--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -52,7 +52,7 @@ export default {
     range: Boolean,
     step: {
       type: [Number, String],
-      default: 1
+      default: 0
     },
     ticks: {
       type: [Boolean, String],
@@ -141,7 +141,7 @@ export default {
       }
     },
     stepNumeric () {
-      return this.step > 0 ? parseFloat(this.step) : 1
+      return this.step > 0 ? parseFloat(this.step) : 0
     },
     trackFillStyles () {
       let left = this.$vuetify.rtl ? 'auto' : 0
@@ -490,7 +490,7 @@ export default {
       if (![pageup, pagedown, end, home, left, right, down, up].includes(e.keyCode)) return
 
       e.preventDefault()
-      const step = this.stepNumeric
+      const step = this.stepNumeric || 1
       const steps = (this.max - this.min) / step
       if ([left, right, down, up].includes(e.keyCode)) {
         this.keyPressed += 1
@@ -513,6 +513,7 @@ export default {
       return value
     },
     roundValue (value) {
+      if (!this.stepNumeric) return value
       // Format input value using the same number
       // of decimals places as in the step prop
       const trimmedStep = this.step.toString().trim()
@@ -520,7 +521,7 @@ export default {
         ? (trimmedStep.length - trimmedStep.indexOf('.') - 1)
         : 0
 
-      const newValue = 1 * Math.round(value / this.stepNumeric) * this.stepNumeric
+      const newValue = Math.round(value / this.stepNumeric) * this.stepNumeric
 
       return parseFloat(Math.min(newValue, this.max).toFixed(decimals))
     },

--- a/src/components/VSlider/VSlider.js
+++ b/src/components/VSlider/VSlider.js
@@ -52,7 +52,7 @@ export default {
     range: Boolean,
     step: {
       type: [Number, String],
-      default: 0
+      default: 1
     },
     ticks: {
       type: [Boolean, String],

--- a/test/unit/components/VRangeSlider/VRangeSlider.spec.js
+++ b/test/unit/components/VRangeSlider/VRangeSlider.spec.js
@@ -16,7 +16,8 @@ test('VRangeSlider.vue', ({ mount }) => {
   it('should round values and swap order if needed', () => {
     const wrapper = mount(VRangeSlider, {
       propsData: {
-        value: [0, 0]
+        value: [0, 0],
+        step: 1
       }
     })
 

--- a/test/unit/components/VRangeSlider/VRangeSlider.spec.js
+++ b/test/unit/components/VRangeSlider/VRangeSlider.spec.js
@@ -16,8 +16,7 @@ test('VRangeSlider.vue', ({ mount }) => {
   it('should round values and swap order if needed', () => {
     const wrapper = mount(VRangeSlider, {
       propsData: {
-        value: [0, 0],
-        step: 1
+        value: [0, 0]
       }
     })
 

--- a/test/unit/components/VSlider/VSlider.spec.js
+++ b/test/unit/components/VSlider/VSlider.spec.js
@@ -316,6 +316,10 @@ test('VSlider.vue', ({ mount }) => {
 
     expect(wrapper.vm.roundValue(1.234)).toBe(1.234)
 
+    wrapper.setProps({ step: 1 })
+
+    expect(wrapper.vm.roundValue(1.234)).toBe(1)
+
     wrapper.setProps({ step: 4 })
 
     expect(wrapper.vm.roundValue(5.667)).toBe(4)
@@ -482,6 +486,7 @@ test('VSlider.vue', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
 
     expect(warning).toHaveBeenTipped()
+    wrapper.vm.$vuetify.rtl = undefined
   })
 
   it('should display tick labels', () => {

--- a/test/unit/components/VSlider/VSlider.spec.js
+++ b/test/unit/components/VSlider/VSlider.spec.js
@@ -314,7 +314,7 @@ test('VSlider.vue', ({ mount }) => {
       propsData: { step: 0 }
     })
 
-    expect(wrapper.vm.roundValue(1.234)).toBe(1)
+    expect(wrapper.vm.roundValue(1.234)).toBe(1.234)
 
     wrapper.setProps({ step: 4 })
 
@@ -488,6 +488,7 @@ test('VSlider.vue', ({ mount }) => {
     const wrapper = mount(VSlider, {
       propsData: {
         max: 1,
+        step: 1,
         tickLabels: ['foo', 'bar']
       }
     })

--- a/test/unit/components/VSlider/VSlider.spec.js
+++ b/test/unit/components/VSlider/VSlider.spec.js
@@ -488,7 +488,6 @@ test('VSlider.vue', ({ mount }) => {
     const wrapper = mount(VSlider, {
       propsData: {
         max: 1,
-        step: 1,
         tickLabels: ['foo', 'bar']
       }
     })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
~In v1.0 sliders didn't have stepping by default~
The cause looks like a5ed2f5419a456a01b85fdb3b01f0e44265bcbd2, ~~but for some reason I had to change the default prop value too, even though it was `1` in 1.0 as well.~~ Default was 1 in 1.0, but you could set it to 0 to override. 

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-slider v-model="slider" min="0" max="1" ticks step="0.1"></v-slider>
      <v-slider v-model="slider" min="-1" max="2" ticks step="0.01"></v-slider>
      <pre>{{ slider }}</pre>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      slider: 0
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

