### PR TITLE
Fix exception when menu is destroyed quickly

### DIFF
--- a/src/components/VMenu/mixins/menu-position.js
+++ b/src/components/VMenu/mixins/menu-position.js
@@ -23,7 +23,7 @@ export default {
         )
       }
 
-      if(this.$refs.content) {
+      if (this.$refs.content) {
         this.$refs.content.scrollTop = scrollTop
       }
     },

--- a/src/components/VMenu/mixins/menu-position.js
+++ b/src/components/VMenu/mixins/menu-position.js
@@ -23,7 +23,9 @@ export default {
         )
       }
 
-      this.$refs.content.scrollTop = scrollTop
+      if(this.$refs.content) {
+        this.$refs.content.scrollTop = scrollTop
+      }
     },
     calcLeftAuto () {
       if (this.isAttached) return 0


### PR DESCRIPTION
If the component is destroyed before the 50ms it takes to call this function, an exception is thrown.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
The `calculateScroll` method is called after a 50ms timeout to wait for the animation to finish (if I understand correctly).
However, while running automated tests, I happen to destroy the component faster than 50ms. It results in an exception being thrown because `this.$refs.content` is undefined.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It avoids an exception being thrown and my app's automated tests to break.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
I've tested this visually. No more exception with this simple `if` clause.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
