### PR TITLE
fix(VStepper): Use name instead of tag name

### DIFF
--- a/src/components/VStepper/VStepper.js
+++ b/src/components/VStepper/VStepper.js
@@ -75,10 +75,9 @@ export default {
       this.content = []
       for (let index = 0; index < this.$children.length; index++) {
         const child = this.$children[index]
-        // TODO: use the component name instead of tag
-        if (child.$options._componentTag === 'v-stepper-step') {
+        if (child.$options.name === 'v-stepper-step') {
           this.steps.push(child)
-        } else if (child.$options._componentTag === 'v-stepper-content') {
+        } else if (child.$options.name === 'v-stepper-content') {
           child.isVertical = this.vertical
           this.content.push(child)
         }


### PR DESCRIPTION
## Description

Find v-stepper-step & v-stepper-content by component name.

## Motivation and Context

We are using jsx instead of html template.  
Our code will look like this:  

```js
import {VStepper, VStepperContent} from 'vuetify/src/components/VStepper'

// ...

render (h) {
  return (
    <VStepper>
      <VStepperContent />
    </VStepper>
}
```

So the `_compoentTag` will be `undefined`.

## How Has This Been Tested?
nono

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:

- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
