### PR TITLE
fix(v-time-picker): don't switch to hours after selecting minutes

### DIFF
--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -135,9 +135,9 @@ export default {
     onChange () {
       if (!this.selectingHour) {
         this.$emit('change', this.value)
+      } else {
+        this.selectingHour = false
       }
-
-      this.selectingHour = !this.selectingHour
     },
     firstAllowed (type, value) {
       const allowedFn = type === 'hour' ? this.isAllowedHourCb : this.isAllowedMinuteCb

--- a/test/unit/components/VTimePicker/VTimePicker.spec.js
+++ b/test/unit/components/VTimePicker/VTimePicker.spec.js
@@ -215,7 +215,7 @@ test('VTimePicker.js', ({ mount }) => {
     clock.$emit('change')
     expect(wrapper.vm.selectingHour).toBe(false)
     clock.$emit('change')
-    expect(wrapper.vm.selectingHour).toBe(true)
+    expect(wrapper.vm.selectingHour).toBe(false)
   })
 
   it('should change selectingHour when clicked in title', () => {


### PR DESCRIPTION


## Motivation and Context
fixes #3371

## How Has This Been Tested?
visually, updated unit test

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-time-picker v-model="t" />
      <v-menu :close-on-content-click="false">
        <v-btn slot="activator">Picker in popup</v-btn>
        <v-time-picker v-model="t" />
      </v-menu>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({t: null})
}
</script>
```
</details>

It works fine with standalone picker, but I'm not sure if the behaviour is now correct with the picker in menu. Afair @nekosaur was ok with this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
