### PR TITLE
fix(v-time-picker-clock): allows time picker clock to be scrollable with allowed-values

### DIFF
--- a/src/components/VTimePicker/VTimePickerClock.js
+++ b/src/components/VTimePicker/VTimePickerClock.js
@@ -87,8 +87,17 @@ export default {
   methods: {
     wheel (e) {
       e.preventDefault()
-      const value = this.displayedValue + Math.sign(e.wheelDelta || 1)
-      this.update((value - this.min + this.count) % this.count + this.min)
+
+      const delta = Math.sign(e.wheelDelta || 1)
+      let value = this.displayedValue
+      do {
+        value = value + delta
+        value = (value - this.min + this.count) % this.count + this.min
+      } while (!this.isAllowed(value) && value !== this.displayedValue)
+
+      if (value !== this.displayedValue) {
+        this.update(value)
+      }
     },
     handScale (value) {
       return this.double && (value - this.min >= this.roundCount) ? (this.innerRadius / this.radius) : (this.outerRadius / this.radius)

--- a/test/unit/components/VTimePicker/VTimePickerClock.spec.js
+++ b/test/unit/components/VTimePicker/VTimePickerClock.spec.js
@@ -49,6 +49,23 @@ test('VTimePickerClock.js', ({ mount }) => {
     expect(input).toBeCalledWith(3)
   })
 
+  it('should emit input event on wheel if scrollable and has allowedValues', () => {
+    const wrapper = mount(VTimePickerClock, {
+      propsData: {
+        max: 10,
+        min: 1,
+        value: 6,
+        scrollable: true,
+        allowedValues: val => !(val % 3)
+      }
+    })
+
+    const input = jest.fn()
+    wrapper.vm.$on('input', input)
+    wrapper.trigger('wheel')
+    expect(input).toBeCalledWith(9)
+  })
+
   it('should not emit input event on wheel if not scrollable', () => {
     const wrapper = mount(VTimePickerClock, {
       propsData: {


### PR DESCRIPTION
## Motivation and Context
fixes #4195

## How Has This Been Tested?
visually, added unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-time-picker v-model="t" scrollable :allowed-hours="h => h === 7 || h === 14" :allowed-minutes="h => !(h%3)"></v-time-picker>
      <v-time-picker v-model="t" scrollable min="14:03" max="17:27"></v-time-picker>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({t: null})
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
