### PR TITLE
fix(v-text-field): wrong label position in empty time input

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -155,12 +155,7 @@ export default {
       }
     },
     showLabel () {
-      if (!this.hasLabel ||
-        (this.isSingle &&
-        (this.isDirty || !!this.placeholder))
-      ) return false
-
-      return true
+      return this.hasLabel && (!this.isSingle || (!this.isDirty && !this.placeholder))
     }
   },
 

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -155,7 +155,7 @@ export default {
       }
     },
     showLabel () {
-      return this.hasLabel && (!this.isSingle || (!this.isDirty && !this.placeholder))
+      return this.hasLabel && (!this.isSingle || (!this.isLabelActive && !this.placeholder))
     }
   },
 

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -126,6 +126,41 @@ export default {
     },
     isSolo () {
       return this.solo || this.soloInverted
+    },
+    labelPosition () {
+      let value = 0
+      let left = 'auto'
+      let right = 'auto'
+
+      // Create spacing
+      if ((this.prefix || this.reverse) &&
+        (this.isSingle || !this.isFocused) &&
+        !this.isDirty
+      ) value = 16
+
+      // Check if RTL
+      if (this.$vuetify.rtl) right = value
+      else left = value
+
+      // Check if reversed
+      if (this.reverse) {
+        const direction = right
+        right = left
+        left = direction
+      }
+
+      return {
+        left,
+        right
+      }
+    },
+    showLabel () {
+      if (!this.hasLabel ||
+        (this.isSingle &&
+        (this.isDirty || !!this.placeholder))
+      ) return false
+
+      return true
     }
   },
 
@@ -218,43 +253,19 @@ export default {
       ]
     },
     genLabel () {
-      if (!this.hasLabel ||
-        (this.isSingle &&
-        (this.isDirty || !!this.placeholder))
-      ) return null
+      if (!this.showLabel) return null
 
       const isSingleLine = this.isSingle
-      let value = 0
-      let left = 'auto'
-      let right = 'auto'
-
-      // Create spacing
-      if ((this.prefix || this.reverse) &&
-        (isSingleLine || !this.isFocused) &&
-        !this.isDirty
-      ) value = 16
-
-      // Check if RTL
-      if (this.$vuetify.rtl) right = value
-      else left = value
-
-      // Check if reversed
-      if (this.reverse) {
-        const direction = right
-        right = left
-        left = direction
-      }
-
       const data = {
         props: {
           absolute: true,
           color: this.validationState,
           disabled: this.disabled,
           focused: !isSingleLine && (this.isFocused || !!this.validationState),
-          left,
-          right,
+          left: this.labelPosition.left,
+          right: this.labelPosition.right,
           value: Boolean(!isSingleLine &&
-            (this.isFocused || this.isDirty || this.placeholder))
+            (this.isFocused || this.isLabelActive || this.placeholder))
         }
       }
 

--- a/test/unit/components/VTextField/VTextField.spec.js
+++ b/test/unit/components/VTextField/VTextField.spec.js
@@ -532,16 +532,6 @@ test('VTextField.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('render active label for dirtyTypes (time/date/color/etc)', () => {
-    const wrapper = mount(VTextField, {
-      propsData: {
-        type: "time"
-      }
-    })
-
-    expect(wrapper.element.classList).toContain('v-input--is-label-active')
-  })
-
   it('should use a custom clear callback', async () => {
     const clearIconCb = jest.fn()
     const wrapper = mount(VTextField, {
@@ -719,5 +709,32 @@ test('VTextField.js', ({ mount }) => {
 
     wrapper.vm.blur()
     expect(blur).toHaveBeenCalledTimes(1)
+  })
+
+  it('should activate label when using dirtyTypes', async () => {
+    const dirtyTypes = ['color', 'file', 'time', 'date', 'datetime-local', 'week', 'month']
+    const wrapper = mount(VTextField, {
+      propsData: {
+        label: 'Foobar'
+      }
+    })
+    const label = wrapper.first('.v-label')
+
+
+    for (const type of dirtyTypes) {
+      wrapper.setProps({ type })
+
+      await wrapper.vm.$nextTick()
+
+      expect(label.element.classList).toContain('v-label--active')
+      expect(wrapper.vm.$el.classList).toContain('v-input--is-label-active')
+
+      wrapper.setProps({ type: undefined })
+
+      await wrapper.vm.$nextTick()
+
+      expect(label.element.classList).not.toContain('v-label--active')
+      expect(wrapper.vm.$el.classList).not.toContain('v-input--is-label-active')
+    }
   })
 })


### PR DESCRIPTION
## Description
Fixes label and additionally moves some code to a computed prop
The main fix introduces a minor issue with `reversed` field, see the second text field in playground

## Motivation and Context
fixes #4187

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-text-field label="test" type="time" />
      <v-text-field label="test" reverse type="time" />
      <v-text-field label="test" solo type="time" />
    </v-content>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
