### PR TITLE
add padding to html list (ul, ol)

### DIFF
--- a/src/stylus/elements/_lists.styl
+++ b/src/stylus/elements/_lists.styl
@@ -1,8 +1,2 @@
-.browser-list
-  padding-left: $spacers.four.x
-  
-  &--unstyled
-    list-style-type: none
-
 ul, ol
   padding-left: $spacers.four.x

--- a/src/stylus/elements/_lists.styl
+++ b/src/stylus/elements/_lists.styl
@@ -3,3 +3,6 @@
   
   &--unstyled
     list-style-type: none
+
+ul, ol
+  padding-left: $spacers.four.x


### PR DESCRIPTION
## Description
Add padding to the html list to be more like standard html list.

## Motivation and Context
Right now bullets are left of the content https://i.imgur.com/EvYjEvm.png , which is pretty unusual, doesnt happen on any other major sites and doesnt match standard behaviour of html lists.


## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<div id="app">
  <v-app id="inspire">
    <main>
      <v-container>
        <p>content</p>
        <ol>
          <li>list item</li>
        </ol>
        <ul>
          <li>list item</li>
        </ul>
      </v-container>
    </main>
  </v-app>
</div>

new Vue({
  el: '#app',  
})
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
