### PR TITLE
fix (v-text-field): required attr stripped off

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -288,7 +288,6 @@ export default {
           ...this.$attrs,
           autofocus: this.autofocus,
           disabled: this.disabled,
-          required: this.required,
           readonly: this.readonly,
           tabindex: this.tabindex,
           type: this.type,

--- a/test/unit/components/VTextField/VTextField.spec.js
+++ b/test/unit/components/VTextField/VTextField.spec.js
@@ -10,6 +10,17 @@ test('VTextField.js', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should pass required attr to the input', () => {
+    const wrapper = mount(VTextField, {
+      attrs: {
+        required: true
+      }
+    })
+
+    const input = wrapper.find('input')[0]
+    expect(input.getAttribute('required')).toBe('required')
+  })
+
   it('should pass events to internal input field', () => {
     const keyup = jest.fn()
     const component = {


### PR DESCRIPTION
## Motivation and Context
fixes #4223

## How Has This Been Tested?
added unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="app">
    <v-container>
      <v-text-field required />
      <v-autocomplete required />
      <v-select required />
    </v-container>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
