### PR TITLE
Fixes #4201 outline in pagination when circle prop set

### DIFF
--- a/src/stylus/components/_pagination.styl
+++ b/src/stylus/components/_pagination.styl
@@ -35,6 +35,7 @@ theme(v-pagination, "v-pagination")
     .v-pagination__more,
     .v-pagination__navigation
       border-radius: 50%
+      outline: none
 
   &--disabled
     pointer-events: none


### PR DESCRIPTION
## Description
In `src/stylus/components/_pagination.styl`, I added `outline: none` to the `&--circle` selector to remove the square outline from the pagination when the circle property is active.  Tested and working properly.

## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/4201
The fix is in response to this issue.

## How Has This Been Tested?
I performed existing unit tests and visually inspected the component to ensure that the square outline was no longer displayed.

```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-pagination circle :length="4" v-model="page" ></v-pagination>
    </v-content>
  </v-app>
</template>

<script>
  export default {
  data: () => ({
    page: 1
  })  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
