### PR TITLE
feat(inputs): remove icon slots

### DIFF
--- a/src/components/VInput/VInput.js
+++ b/src/components/VInput/VInput.js
@@ -208,11 +208,7 @@ export default {
     genPrependSlot () {
       const slot = []
 
-      // Backwards compat
-      // TODO: Deprecate prepend-icon slot 2.0
-      if (this.$slots['prepend-icon']) {
-        slot.push(this.$slots['prepend-icon'])
-      } else if (this.$slots['prepend']) {
+      if (this.$slots['prepend']) {
         slot.push(this.$slots['prepend'])
       } else if (this.prependIcon) {
         slot.push(this.genIcon('prepend'))
@@ -229,8 +225,6 @@ export default {
       // backwards compat
       if (this.$slots['append']) {
         slot.push(this.$slots['append'])
-      } else if (this.$slots['append-icon']) {
-        slot.push(this.$slots['append-icon'])
       } else if (this.appendIcon) {
         slot.push(this.genIcon('append'))
       }

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -41,6 +41,7 @@ export default {
 
   props: {
     appendOuterIcon: String,
+    appendOuterIconCb: Function,
     autofocus: Boolean,
     box: Boolean,
     browserAutocomplete: String,

--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -208,13 +208,22 @@ export default {
 
       if (this.$slots['append-outer']) {
         slot.push(this.$slots['append-outer'])
-      } else if (this.$slots['append-outer-icon']) {
-        slot.push(this.$slots['append-outer-icon'])
       } else if (this.appendOuterIcon) {
         slot.push(this.genIcon('appendOuter'))
       }
 
       return this.genSlot('append', 'outer', slot)
+    },
+    genIconSlot () {
+      const slot = []
+
+      if (this.$slots['append']) {
+        slot.push(this.$slots['append'])
+      } else if (this.appendIcon) {
+        slot.push(this.genIcon('append'))
+      }
+
+      return this.genSlot('append', 'inner', slot)
     },
     genClearIcon () {
       if (!this.clearable) return null
@@ -267,19 +276,6 @@ export default {
       if (this.$attrs.id) data.props.for = this.$attrs.id
 
       return this.$createElement(VLabel, data, this.$slots.label || this.label)
-    },
-    genIconSlot () {
-      const slot = []
-
-      if (this.$slots['append']) {
-        slot.push(this.$slots['append'])
-      } else if (this.$slots['append-icon']) {
-        slot.push(this.$slots['append-icon'])
-      } else if (this.appendIcon) {
-        slot.push(this.genIcon('append'))
-      }
-
-      return this.genSlot('append', 'inner', slot)
     },
     genInput () {
       const listeners = Object.assign({}, this.$listeners)

--- a/test/unit/components/VInput/VInput.spec.js
+++ b/test/unit/components/VInput/VInput.spec.js
@@ -35,22 +35,14 @@ test('VInput.js', ({ mount }) => {
       render: h => h('div', slot)
     })
     const wrapper = mount(VInput, {
-      slots: { 'prepend-icon': [el('prepend-icon')] }
+      slots: { 'append': [el('append')] }
     })
     const wrapper2 = mount(VInput, {
-      slots: { 'append-icon': [el('append-icon')] }
-    })
-    const wrapper3 = mount(VInput, {
       slots: { 'prepend': [el('prepend')] }
-    })
-    const wrapper4 = mount(VInput, {
-      slots: { 'append': [el('append')] }
     })
 
     expect(wrapper.html()).toMatchSnapshot()
     expect(wrapper2.html()).toMatchSnapshot()
-    expect(wrapper3.html()).toMatchSnapshot()
-    expect(wrapper4.html()).toMatchSnapshot()
   })
 
   it('should generate an icon and match snapshot', () => {

--- a/test/unit/components/VInput/__snapshots__/VInput.spec.js.snap
+++ b/test/unit/components/VInput/__snapshots__/VInput.spec.js.snap
@@ -81,26 +81,6 @@ exports[`VInput.js should generate an icon and match snapshot 2`] = `
 exports[`VInput.js should generate append and prepend slots 1`] = `
 
 <div class="v-input">
-  <div class="v-input__prepend-outer">
-    <div>
-      prepend-icon
-    </div>
-  </div>
-  <div class="v-input__control">
-    <div class="v-input__slot">
-    </div>
-    <div class="v-messages">
-      <div class="v-messages__wrapper">
-      </div>
-    </div>
-  </div>
-</div>
-
-`;
-
-exports[`VInput.js should generate append and prepend slots 2`] = `
-
-<div class="v-input">
   <div class="v-input__control">
     <div class="v-input__slot">
     </div>
@@ -111,14 +91,14 @@ exports[`VInput.js should generate append and prepend slots 2`] = `
   </div>
   <div class="v-input__append-outer">
     <div>
-      append-icon
+      append
     </div>
   </div>
 </div>
 
 `;
 
-exports[`VInput.js should generate append and prepend slots 3`] = `
+exports[`VInput.js should generate append and prepend slots 2`] = `
 
 <div class="v-input">
   <div class="v-input__prepend-outer">
@@ -132,26 +112,6 @@ exports[`VInput.js should generate append and prepend slots 3`] = `
     <div class="v-messages">
       <div class="v-messages__wrapper">
       </div>
-    </div>
-  </div>
-</div>
-
-`;
-
-exports[`VInput.js should generate append and prepend slots 4`] = `
-
-<div class="v-input">
-  <div class="v-input__control">
-    <div class="v-input__slot">
-    </div>
-    <div class="v-messages">
-      <div class="v-messages__wrapper">
-      </div>
-    </div>
-  </div>
-  <div class="v-input__append-outer">
-    <div>
-      append
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removed `prepend-icon` and `append-icon` slots from input components
Also added missing `appendOuterIconCb` prop

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These two were marked for deprecation, even though none of these slots existed before v1.1
Resolves #4209

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
