### PR TITLE
fix(VAutocomplete): update input value when items change

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -393,6 +393,7 @@ export default {
         this.selectedItems = [this.internalValue]
       } else {
         VSelect.methods.setSelectedItems.call(this)
+        this.setSearch()
       }
     },
     setSearch () {

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -274,8 +274,6 @@ test('VAutocomplete.js', ({ mount, shallow }) => {
     expect(wrapper.vm.isMenuActive).toBe(false)
   })
 
-
-
   it('should change selected index', async () => {
     const wrapper = shallow(VAutocomplete, {
       attachToDocument: true,
@@ -803,5 +801,20 @@ test('VAutocomplete.js', ({ mount, shallow }) => {
     const content = wrapper.first('.v-autocomplete__content')
 
     expect(content.element.classList.contains('foobar')).toBe(true)
+  })
+
+  it('should update the displayed value when items changes', async () => {
+    const wrapper = mount(VAutocomplete, {
+      propsData: {
+        value: 1,
+        items: []
+      }
+    })
+
+    const input = wrapper.first('input')
+
+    wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
+    await wrapper.vm.$nextTick()
+    expect(input.element.value).toBe('foo')
   })
 })


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should show "State 1": https://codepen.io/anon/pen/yEgxOV?editors=1010
Similar to #1788 but for v-autocomplete

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container fluid>
      <v-layout row wrap>
        <v-flex xs6>
          <v-subheader>Standard</v-subheader>
        </v-flex>
        <v-flex xs6>
          <v-autocomplete :items="items" v-model="selected" label="Select"></v-autocomplete>
        </v-flex>
      </v-layout>
      <pre>selected: {{ selected }}</pre>
      <pre>items: {{ items }}</pre>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      selected: 1,
      items: []
    }),
    mounted () {
      setTimeout(() => {
        this.items = [
          { text: "State 1", value: 1 },
          { text: "State 2", value: 2 },
          { text: "State 3", value: 3 },
          { text: "State 4", value: 4 },
          { text: "State 5", value: 5 },
          { text: "State 6", value: 6 },
          { text: "State 7", value: 7 }
        ]
      }, 20000)
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
