### PR TITLE
Fixes #3841 VDataTable: duplicate key

### DIFF
--- a/src/components/VDataTable/mixins/head.js
+++ b/src/components/VDataTable/mixins/head.js
@@ -58,7 +58,7 @@ export default {
     genHeaderData (header, children) {
       const classes = ['column']
       const data = {
-        key: header[this.headerText],
+        key: header['key'] ? header['key'] : header[this.headerText],
         attrs: {
           role: 'columnheader',
           scope: 'col',


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
As in #3841 reported, using the same header text in a VDataTable causes vue to output an console error "duplicate key". This pull request keeps the original behaviour, but allows to pass a `key` property to the headers object to be used as the internal key instead. This allows using the same header text while using different keys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #3841

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually tested via the dev tools console

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
