### PR TITLE
fix(VSelectList): use noDataText if item slot is provided

### DIFF
--- a/src/components/VSelect/VSelectList.js
+++ b/src/components/VSelect/VSelectList.js
@@ -70,6 +70,20 @@ export default {
     },
     tileActiveClass () {
       return Object.keys(this.addTextColorClassChecks()).join(' ')
+    },
+    staticNoDataTile () {
+      const tile = {
+        on: {
+          mousedown: e => e.preventDefault() // Prevent onBlur from being called
+        },
+        props: {
+          disabled: true
+        }
+      }
+
+      return this.$createElement(VListTile, tile, [
+        this.genTileContent(this.noDataText)
+      ])
     }
   },
 
@@ -209,14 +223,7 @@ export default {
       else children.push(this.genTile(item))
     }
 
-    if (!children.length) {
-      const noData = this.$slots['no-data']
-      if (noData) {
-        children.push(noData)
-      } else {
-        children.push(this.genTile(this.noDataText, true))
-      }
-    }
+    children.length || children.push(this.$slots['no-data'] || this.staticNoDataTile)
 
     return this.$createElement(VCard, {
       staticClass: 'v-select-list',

--- a/test/unit/components/VSelect/VSelectList.spec.js
+++ b/test/unit/components/VSelect/VSelectList.spec.js
@@ -48,6 +48,28 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(wrapper.vm.$slots['no-data'].length).toBe(1)
   })
 
+  it('should display no-data-text when item slot is provided', async () => {
+    const vm = new Vue()
+    const itemSlot = () => vm.$createElement('div', ['this is not ok'])
+    const component = Vue.component('test', {
+      render (h) {
+        return h(VSelectList, {
+          props: {
+            items: [],
+            noDataText: 'this is ok'
+          },
+          scopedSlots: {
+            item: itemSlot,
+          }
+        })
+      }
+    })
+
+    const wrapper = mount(component)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should generate children', () => {
     const wrapper = mount(VSelectList, {
       propsData: {

--- a/test/unit/components/VSelect/__snapshots__/VSelectList.spec.js.snap
+++ b/test/unit/components/VSelect/__snapshots__/VSelectList.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VSelect should display no-data-text when item slot is provided 1`] = `
+
+<div class="v-select-list v-card"
+     style="height: auto;"
+>
+  <div class="v-list">
+    <div disabled="disabled"
+         class="v-list--disabled"
+    >
+      <div class="v-list__tile v-list__tile--disabled">
+        <div class="v-list__tile__content">
+          <div class="v-list__tile__title">
+            this is ok
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`VSelect should generate children 1`] = `
 
 <div class="v-select-list v-card"


### PR DESCRIPTION
## Motivation and Context
fixes #4217

## How Has This Been Tested?
visually, unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <boilerplate>
    <v-autocomplete
      :items="items"
      v-model="selected"
      label="items"
      persistent-hint
      return-object
      item-text="name"
      item-value="username"
      required
    >
      <template
        slot="selection"
        slot-scope="data"
      >
        <template>
          <v-list-tile-avatar>
            <img :src="data.item.picture_url || '/static/images/user_default_img_simple.jpg'">
          </v-list-tile-avatar>
          <v-list-tile-content>
            <v-list-tile-title v-html="data.item.name"/>
          </v-list-tile-content>
        </template>
      </template>
      <template
        slot="item"
        slot-scope="data"
      >
        <template>
          <v-list-tile-avatar>
            <img :src="data.item.picture_url || '/static/images/user_default_img_simple.jpg'">
          </v-list-tile-avatar>
          <v-list-tile-content>
            <v-list-tile-title v-html="data.item.name"/>
            <v-list-tile-sub-title v-html="data.item.username"/>
          </v-list-tile-content>
        </template>
      </template>
    </v-autocomplete>
  </boilerplate>
</template>

<script>
  export default {
    data: () => ({
      selected: null,
      items: []
    })
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
