### PR TITLE
fix(VAutocomplete): combobox - show no-data slot if provided

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -128,7 +128,7 @@ export default {
         ? this.filteredItems.length - this.selectedItems.length > 0
         : this.filteredItems.length > 0
 
-      if (this.isAnyValueAllowed) {
+      if (this.isAnyValueAllowed && !this.$slots['no-data']) {
         return filtered
       }
 

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -1,7 +1,7 @@
 import { test } from '@/test'
 import VAutocomplete from '@/components/VAutocomplete'
 
-test('VAutocomplete.js', ({ mount, shallow }) => {
+test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
   const app = document.createElement('div')
   app.setAttribute('data-app', true)
   document.body.appendChild(app)
@@ -746,6 +746,22 @@ test('VAutocomplete.js', ({ mount, shallow }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.menuCanShow).toBe(false)
+  })
+
+  it('should not hide menu when no data but has no-data slot', async () => {
+    const wrapper = mount(VAutocomplete, {
+      propsData: {
+        combobox: true
+      },
+      slots: {
+        'no-data': [compileToFunctions('<span>show me</span>')]
+      }
+    })
+
+    const input = wrapper.first('input')
+    input.trigger('focus')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.menuCanShow).toBe(true)
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/2834


### PR DESCRIPTION
## Motivation and Context
fixes #4220

## How Has This Been Tested?
unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-container fluid>
      <v-select combobox label="Select a Bookmark Post">
        <div slot="no-data">No data</div>
      </v-select>
    </v-container>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
