### PR TITLE
feat(v-toolbar): normalize gutter functionality

### DIFF
--- a/src/stylus/components/_tabs.styl
+++ b/src/stylus/components/_tabs.styl
@@ -72,7 +72,7 @@ theme(v-tabs__bar, "v-tabs__bar")
     height: 72px
 
   &--align-with-title
-    padding-left: 72px
+    padding-left: 56px
 
   &--fixed-tabs,
   &--icons-and-text

--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -6,17 +6,31 @@ v-toolbar($material)
   background-color: $material.app-bar
   color: $material.text.primary
 
+v-toolbar-content($direction)
+  margin-{$direction}: 0
+
+  &.v-btn--icon
+    margin-{$direction}: -6px
+
+  &.v-menu .v-menu__activator,
+  &.v-tooltip span
+    > .v-btn
+      margin-{$direction}: 0
+
+    > .v-btn--icon
+      margin-{$direction}: -6px
+
 theme(v-toolbar, "v-toolbar")
 
 .v-toolbar
   bootable()
   elevation(4)
 
-  display: block
   position: relative
   width: 100%
-  will-change: padding-left
+  will-change: padding-left, padding-right
 
+  // TODO: Do we even need this?
   .v-text-field--enclosed,
   .v-text-field--box
     margin: 0
@@ -33,7 +47,6 @@ theme(v-toolbar, "v-toolbar")
     font-size: $headings.h6.size
     font-weight: $headings.h6.weight
     letter-spacing: $headings.h6.letter-spacing
-    margin-left: $grid-gutters.lg
     white-space: nowrap
     overflow: hidden
     text-overflow: ellipsis
@@ -41,50 +54,25 @@ theme(v-toolbar, "v-toolbar")
     &:not(:first-child)
       margin-left: 20px
 
-  &__content, &__extension
+  &__content,
+  &__extension
     align-items: center
     display: flex
+    padding: 0 $grid-gutters.xl
+
+    @media $display-breakpoints.sm-and-down
+      padding: 0 $grid-gutters.lg
+
+    > *:first-child
+      v-toolbar-content(left)
+
+    > *:last-child
+      v-toolbar-content(right)
 
     > .v-list
       flex: 1 1 auto
       margin: 0 !important // come back to this
       max-height: 100%
-
-    > .v-btn:not(.v-btn--icon)
-      margin-left: $grid-gutters.sm
-      margin-right: $grid-gutters.sm
-
-    > .v-btn--icon,
-    > .v-menu > .v-menu__activator > .v-btn,
-    > .v-tooltip .v-btn
-      margin-left: 6px
-      margin-right: 6px
-
-    > .v-btn:first-child
-      margin-left: $grid-gutters.lg
-
-    > .v-btn:last-child
-      margin-right: $grid-gutters.lg
-
-    > .v-btn--icon:first-child
-      margin-left: 10px
-
-    > .v-btn--icon:last-child
-      margin-right: 10px
-
-    > .v-menu:first-child,
-    > .v-tooltip:first-child
-      margin-left: $grid-gutters.sm
-
-    > .v-menu:last-child,
-    > .v-tooltip:last-child
-      margin-right: $grid-gutters.sm
-
-    > *:not(.v-btn):not(.v-menu):not(.v-tooltip):first-child:not(:only-child)
-      margin-left: $grid-gutters.lg
-
-    > *:not(.v-btn):not(.v-menu):not(.v-tooltip):last-child:not(:only-child)
-      margin-right: $grid-gutters.lg
 
   &__items
     display: flex
@@ -104,9 +92,6 @@ theme(v-toolbar, "v-toolbar")
     .v-menu__activator
       height: inherit
       margin: 0
-
-  @media all and (max-width: $grid-breakpoints.sm) and (orientation: portrait)
-    v-toolbar-content(7px)
 
 /** Types */
 .v-toolbar
@@ -145,18 +130,3 @@ theme(v-toolbar, "v-toolbar")
 
   &--clipped
     z-index: 3
-
-  &--prominent
-    v-toolbar-content(15px)
-
-  &--dense
-    v-toolbar-content(7px)
-
-v-toolbar-content(left)
-  .v-toolbar__content,
-  .v-toolbar__extension
-    > *:first-child
-      margin-left: left
-
-    > *:last-child
-      margin-right: left

--- a/src/stylus/components/_toolbar.styl
+++ b/src/stylus/components/_toolbar.styl
@@ -63,6 +63,9 @@ theme(v-toolbar, "v-toolbar")
     @media $display-breakpoints.sm-and-down
       padding: 0 $grid-gutters.lg
 
+    .v-btn--icon
+      margin: 6px
+
     > *:first-child
       v-toolbar-content(left)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
removed code that wasn't even working, reduced complexity of gutter
[Reference](https://material.io/design/layout/responsive-layout-grid.html#breakpoints)
<!--- Describe your changes in detail -->

## Motivation and Context
Gutters were not dynamic and not matching `v-container` on the different resolution. Refactored a function that wasn't event working to begin with
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
visually chrome, ie, edge, ff
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-toolbar>
      <v-toolbar-side-icon />
      <v-toolbar-title>Title</v-toolbar-title>
      <v-spacer />
      <v-icon>menu</v-icon>
      <template slot="extension">
        <v-toolbar-title>Hello</v-toolbar-title>
      </template>
    </v-toolbar>
    <v-toolbar>
      <v-toolbar-title>Title</v-toolbar-title>
      <v-spacer />
      <v-menu>
        <v-icon slot="activator">menu</v-icon>
      </v-menu>
    </v-toolbar>
    <v-toolbar>
      <v-toolbar-title>Title</v-toolbar-title>
      <v-spacer />
      <v-menu>
        <v-toolbar-side-icon slot="activator" />
      </v-menu>
    </v-toolbar>
    <v-toolbar>
      <v-toolbar-title>Title</v-toolbar-title>
      <v-spacer />
      <v-toolbar-side-icon />
    </v-toolbar>
    <v-toolbar>
      <v-tooltip>
        <v-toolbar-side-icon slot="activator" />
      </v-tooltip>
      <v-spacer />
      <v-toolbar-title>Title</v-toolbar-title>
    </v-toolbar>
    <v-toolbar>
      <v-spacer />
      <v-btn color="success">Hello</v-btn>
    </v-toolbar>
    <v-toolbar>
      <v-spacer />
      <v-menu>
        <v-btn color="success" slot="activator">Hello</v-btn>
      </v-menu>
    </v-toolbar>
    <v-toolbar>
      <v-spacer />
      <v-tooltip>
        <v-btn color="success" slot="activator">Hello</v-btn>
      </v-tooltip>
    </v-toolbar>
    <v-content>
      <v-container fluid>
        <v-layout column>
          <v-flex>Hello</v-flex>
          <v-flex text-xs-right>Hello</v-flex>
          <v-flex text-xs-center>
            <v-btn @click="$vuetify.rtl = !$vuetify.rtl">Click me</v-btn>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
