### PR TITLE
fix: removed unnecessary prefix from lang keys

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -45,7 +45,7 @@ export default {
     hideHeaders: Boolean,
     rowsPerPageText: {
       type: String,
-      default: '$vuetify.lang.dataTable.rowsPerPageText'
+      default: 'dataTable.rowsPerPageText'
     },
     customFilter: {
       type: Function,

--- a/src/components/Vuetify/mixins/lang.ts
+++ b/src/components/Vuetify/mixins/lang.ts
@@ -3,20 +3,19 @@ import { getObjectValueByPath } from '../../../util/helpers'
 import { VuetifyUseOptions as Options } from 'types'
 import { VuetifyLanguage, VuetifyLocale } from 'types/lang'
 import { consoleError, consoleWarn } from '../../../util/console'
+import { VueConstructor } from 'vue'
 
-const LANG_PREFIX = '$vuetify.lang.'
 const fallback = Symbol('Lang fallback')
 
 function getTranslation (locale: VuetifyLocale, key: string, usingFallback = false): string {
-  const shortKey = key.replace(LANG_PREFIX, '')
-  let translation = getObjectValueByPath(locale, shortKey, fallback) as string | typeof fallback
+  let translation = getObjectValueByPath(locale, key, fallback) as string | typeof fallback
 
   if (translation === fallback) {
     if (usingFallback) {
-      consoleError(`Translation key "${shortKey}" not found in fallback`)
+      consoleError(`Translation key "${key}" not found in fallback`)
       translation = key
     } else {
-      consoleWarn(`Translation key "${shortKey}" not found, falling back to default`)
+      consoleWarn(`Translation key "${key}" not found, falling back to default`)
       translation = getTranslation(en, key, true)
     }
   }
@@ -29,8 +28,6 @@ export default function lang (config: Options['lang'] = {}): VuetifyLanguage {
     locales: Object.assign({ en }, config.locales),
     current: config.current || 'en',
     t (key, ...params) {
-      if (!key.startsWith(LANG_PREFIX)) return key
-
       const translation = getTranslation(this.locales[this.current], key)
 
       return translation.replace(/\{(\d+)\}/g, (match: string, index: string) => {

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -48,7 +48,7 @@ export default {
     mustSort: Boolean,
     noResultsText: {
       type: String,
-      default: '$vuetify.lang.dataIterator.noResultsText'
+      default: 'dataIterator.noResultsText'
     },
     nextIcon: {
       type: String,
@@ -66,7 +66,7 @@ export default {
           10,
           25,
           {
-            text: '$vuetify.lang.dataIterator.rowsPerPageAll',
+            text: 'dataIterator.rowsPerPageAll',
             value: -1
           }
         ]
@@ -74,7 +74,7 @@ export default {
     },
     rowsPerPageText: {
       type: String,
-      default: '$vuetify.lang.dataIterator.rowsPerPageText'
+      default: 'dataIterator.rowsPerPageText'
     },
     selectAll: [Boolean, String],
     search: {
@@ -385,7 +385,7 @@ export default {
           }
         },
         attrs: {
-          'aria-label': this.$vuetify.t('$vuetify.lang.dataIterator.prevPage')
+          'aria-label': this.$vuetify.t('dataIterator.prevPage')
         }
       }, [this.$createElement(VIcon, this.prevIcon)])
     },
@@ -410,7 +410,7 @@ export default {
           }
         },
         attrs: {
-          'aria-label': this.$vuetify.t('$vuetify.lang.dataIterator.nextPage')
+          'aria-label': this.$vuetify.t('dataIterator.nextPage')
         }
       }, [this.$createElement(VIcon, this.nextIcon)])
     },
@@ -455,7 +455,7 @@ export default {
             pageStop: stop,
             itemsLength: this.itemsLength
           })
-          : this.$vuetify.t('$vuetify.lang.dataIterator.pageText', this.pageStart + 1, stop, this.itemsLength)
+          : this.$vuetify.t('dataIterator.pageText', this.pageStart + 1, stop, this.itemsLength)
       }
 
       return this.$createElement('div', {

--- a/src/mixins/filterable.js
+++ b/src/mixins/filterable.js
@@ -4,7 +4,7 @@ export default {
   props: {
     noDataText: {
       type: String,
-      default: '$vuetify.lang.noDataText'
+      default: 'noDataText'
     }
   }
 }


### PR DESCRIPTION
## Description
When using our internal translation engine there is no need to use a prefix. It only leads to verbose code, e.g. `{{ $vuetify.t('$vuetify.lang.component.key') }}`. Now it's `{{ $vuetify.t('component.key') }}`. Prefixing the keys should only be relevant if we perhaps want to integrate with vue-i18n down the line? But then it should be user configurable.

## Motivation and Context
See above

## How Has This Been Tested?
manually

## Markup:
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
