### PR TITLE
feat: Specify custom translation function

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -45,7 +45,7 @@ export default {
     hideHeaders: Boolean,
     rowsPerPageText: {
       type: String,
-      default: '$vuetify.lang.dataTable.rowsPerPageText'
+      default: '$vuetify.dataTable.rowsPerPageText'
     },
     customFilter: {
       type: Function,

--- a/src/components/Vuetify/mixins/lang.ts
+++ b/src/components/Vuetify/mixins/lang.ts
@@ -31,6 +31,8 @@ export default function lang (config: Options['lang'] = {}): VuetifyLanguage {
     t (key, ...params) {
       if (!key.startsWith(LANG_PREFIX)) return key
 
+      if (config.t) return config.t(key, ...params)
+
       const translation = getTranslation(this.locales[this.current], key)
 
       return translation.replace(/\{(\d+)\}/g, (match: string, index: string) => {

--- a/src/components/Vuetify/mixins/lang.ts
+++ b/src/components/Vuetify/mixins/lang.ts
@@ -4,7 +4,7 @@ import { VuetifyUseOptions as Options } from 'types'
 import { VuetifyLanguage, VuetifyLocale } from 'types/lang'
 import { consoleError, consoleWarn } from '../../../util/console'
 
-const LANG_PREFIX = '$vuetify.lang.'
+const LANG_PREFIX = '$vuetify.'
 const fallback = Symbol('Lang fallback')
 
 function getTranslation (locale: VuetifyLocale, key: string, usingFallback = false): string {

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -48,7 +48,7 @@ export default {
     mustSort: Boolean,
     noResultsText: {
       type: String,
-      default: '$vuetify.lang.dataIterator.noResultsText'
+      default: '$vuetify.dataIterator.noResultsText'
     },
     nextIcon: {
       type: String,
@@ -66,7 +66,7 @@ export default {
           10,
           25,
           {
-            text: '$vuetify.lang.dataIterator.rowsPerPageAll',
+            text: '$vuetify.dataIterator.rowsPerPageAll',
             value: -1
           }
         ]
@@ -74,7 +74,7 @@ export default {
     },
     rowsPerPageText: {
       type: String,
-      default: '$vuetify.lang.dataIterator.rowsPerPageText'
+      default: '$vuetify.dataIterator.rowsPerPageText'
     },
     selectAll: [Boolean, String],
     search: {
@@ -385,7 +385,7 @@ export default {
           }
         },
         attrs: {
-          'aria-label': this.$vuetify.t('$vuetify.lang.dataIterator.prevPage')
+          'aria-label': this.$vuetify.t('$vuetify.dataIterator.prevPage')
         }
       }, [this.$createElement(VIcon, this.prevIcon)])
     },
@@ -410,7 +410,7 @@ export default {
           }
         },
         attrs: {
-          'aria-label': this.$vuetify.t('$vuetify.lang.dataIterator.nextPage')
+          'aria-label': this.$vuetify.t('$vuetify.dataIterator.nextPage')
         }
       }, [this.$createElement(VIcon, this.nextIcon)])
     },
@@ -455,7 +455,7 @@ export default {
             pageStop: stop,
             itemsLength: this.itemsLength
           })
-          : this.$vuetify.t('$vuetify.lang.dataIterator.pageText', this.pageStart + 1, stop, this.itemsLength)
+          : this.$vuetify.t('$vuetify.dataIterator.pageText', this.pageStart + 1, stop, this.itemsLength)
       }
 
       return this.$createElement('div', {

--- a/src/mixins/filterable.js
+++ b/src/mixins/filterable.js
@@ -4,7 +4,7 @@ export default {
   props: {
     noDataText: {
       type: String,
-      default: '$vuetify.lang.noDataText'
+      default: '$vuetify.noDataText'
     }
   }
 }

--- a/test/unit/components/Vuetify/Vuetify.lang.spec.js
+++ b/test/unit/components/Vuetify/Vuetify.lang.spec.js
@@ -13,12 +13,12 @@ test('$vuetify.lang', () => {
     lang.locales.foreign = { foo: 'foreignBar' }
     lang.current = 'foreign'
 
-    expect(lang.t('$vuetify.lang.foo')).toBe('foreignBar')
+    expect(lang.t('$vuetify.foo')).toBe('foreignBar')
 
-    expect(lang.t('$vuetify.lang.bar')).toBe('baz')
+    expect(lang.t('$vuetify.bar')).toBe('baz')
     expect('Translation key "bar" not found, falling back to default').toHaveBeenTipped()
 
-    expect(lang.t('$vuetify.lang.baz')).toBe('$vuetify.lang.baz')
+    expect(lang.t('$vuetify.baz')).toBe('$vuetify.baz')
     expect('Translation key "baz" not found, falling back to default').toHaveBeenTipped()
     expect('Translation key "baz" not found in fallback').toHaveBeenWarned()
   })
@@ -35,6 +35,6 @@ test('$vuetify.lang', () => {
       }
     })
 
-    expect(lang.t('$vuetify.lang.foo')).toBe('foreignBar')
+    expect(lang.t('$vuetify.foo')).toBe('foreignBar')
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ export interface VuetifyUseOptions {
   icons?: Partial<VuetifyIcons>
   /** @see https://vuetifyjs.com/style/theme#options */
   options?: Partial<VuetifyOptions>
-  lang?: Partial<Pick<VuetifyLanguage, 'locales' | 'current'>>
+  lang?: Partial<VuetifyLanguage>
   rtl?: boolean
 }
 


### PR DESCRIPTION
## Description
Allows one to specify a custom translation function to use for internal translations.

## Motivation and Context
Allows integration of 3rd party translation plugins such as vue-i18n

## How Has This Been Tested?
manually

## Markup:
```vue
import VueI18n from 'vue-i18n'

Vue.use(VueI18n)

const messages = {
  en: {
    $vuetify: {
      message: {
        hello: 'hello world',
        params: 'hello {0}'
      }
    },
  },
  ja: {
    $vuetify: {
      message: {
        hello: 'こんにちは、世界',
        params: 'こんにちは、{0}'
      }
    },
  }
}

// Create VueI18n instance with options
const i18n = new VueI18n({
  locale: 'ja', // set locale
  messages, // set locale messages
})

Vue.use(Vuetify, {
  lang: {
    t: (key, ...params) => i18n.t(key, params)
  }
})
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
