### PR TITLE
fix(grid): set v-flex max-width in column layouts

### DIFF
--- a/src/stylus/components/_grid.styl
+++ b/src/stylus/components/_grid.styl
@@ -51,9 +51,6 @@
   // https://github.com/vuetifyjs/vuetify/issues/3873
   min-width: 0
 
-  > .flex
-    max-width: 100%
-
   &.row
     flex-direction: row
 
@@ -65,6 +62,9 @@
 
     &.reverse
       flex-direction: column-reverse
+
+    > .flex
+      max-width: 100%
 
   &.wrap
     flex-wrap: wrap
@@ -88,6 +88,7 @@ for $size, $width in $grid-breakpoints
 .flex,
 .child-flex > *
   flex: 1 1 auto
+  max-width: 100%
 
 .align
   &-start


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
reverts a4b5ce8

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4258

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-container fluid fill-height>
        <v-layout column>
          <v-flex xs6>
            <h1> This should fill the whole width </h1>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>

<style>
  .flex {
    background: blue;
  }
</style>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
