### PR TITLE
fix(VTextField): don't show v-counter if counter is null/undefined

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -259,7 +259,7 @@ export default {
       ])
     },
     genCounter () {
-      if (this.counter === false) return null
+      if (this.counter === false || this.counter == null) return null
 
       const value = (this.internalValue || '').length
       const max = this.counter === true ? this.$attrs.maxlength : this.counter

--- a/test/unit/components/VTextField/VTextField.spec.js
+++ b/test/unit/components/VTextField/VTextField.spec.js
@@ -106,7 +106,7 @@ test('VTextField.js', ({ mount }) => {
     expect(wrapper.vm.shouldValidate).toEqual(false)
   })
 
-  it('should not display counter when set to false', async () => {
+  it('should not display counter when set to false/undefined/null', async () => {
     const wrapper = mount(VTextField, {
       propsData: {
         counter: true
@@ -123,6 +123,16 @@ test('VTextField.js', ({ mount }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapper.find('.v-counter')[0]).toBe(undefined)
+
+    wrapper.setProps({ counter: undefined })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.v-counter')[0]).toBe(undefined)
+
+    wrapper.setProps({ counter: null })
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.find('.v-counter')[0]).toBe(undefined)
   })
 

--- a/test/unit/components/VTextField/__snapshots__/VTextField.spec.js.snap
+++ b/test/unit/components/VTextField/__snapshots__/VTextField.spec.js.snap
@@ -28,7 +28,7 @@ exports[`VTextField.js should have prefix and suffix 1`] = `
 
 `;
 
-exports[`VTextField.js should not display counter when set to false 1`] = `
+exports[`VTextField.js should not display counter when set to false/undefined/null 1`] = `
 
 <div class="v-input v-text-field">
   <div class="v-input__control">
@@ -54,7 +54,7 @@ exports[`VTextField.js should not display counter when set to false 1`] = `
 
 `;
 
-exports[`VTextField.js should not display counter when set to false 2`] = `
+exports[`VTextField.js should not display counter when set to false/undefined/null 2`] = `
 
 <div class="v-input v-text-field">
   <div class="v-input__control">


### PR DESCRIPTION
## Description
`:counter="undefined"` shows the counter, worked properly in 1.0

1.0
https://codepen.io/anon/pen/aKEGXe

1.1
https://codepen.io/anon/pen/GGydeW

The difference between 1.0 and this PR is that in 1.0 it doesn't show the counter when value is `0`, in PR it shows, but not showing it when the numeric value is passed i'd consider as a bug

## How Has This Been Tested?
unit

## Markup:
<!--- Paste markup for testing your change --->
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field label="10" :counter="10" />
      <v-text-field label="0" :counter="0" />
      <v-text-field label="null" :counter="null" />
      <v-text-field label="undefined" :counter="undefined" />
      <v-text-field label="false" :counter="false" />
    </v-container>
  </v-app>
</template>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
