### PR TITLE
fix(VSelect): move out slot usage from computed listData

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -223,7 +223,7 @@ export default {
       }
     },
     staticList () {
-      if (this.$slots['no-data']) {
+      if (this.$slots['no-data'] || this.$scopedSlots.item) {
         consoleError('assert: staticList should not be called if slots are used')
       }
 

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -219,9 +219,6 @@ export default {
         },
         on: {
           select: this.selectItem
-        },
-        scopedSlots: {
-          item: this.$scopedSlots.item
         }
       }
     },
@@ -393,14 +390,20 @@ export default {
     },
     genList () {
       // If there's no slots, we can use a cached VNode to improve performance
-      if (this.$slots['no-data']) {
+      if (this.$slots['no-data'] || this.$scopedSlots.item) {
         return this.genListWithSlot()
       } else {
         return this.staticList
       }
     },
     genListWithSlot () {
-      return this.$createElement(VSelectList, this.listData, [
+      const listDataWithSlot = Object.assign({
+        scopedSlots: {
+          item: this.$scopedSlots.item
+        }
+      }, this.listData)
+
+      return this.$createElement(VSelectList, listDataWithSlot, [
         this.$createElement('template', {
           slot: 'no-data'
         }, this.$slots['no-data'])


### PR DESCRIPTION
## Motivation and Context
fixes #4359

## How Has This Been Tested?
organoleptically

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-container>
        <div class="headline">no-data</div>
        <v-select :items="states" v-model="a1" label="VSelect">
          <template slot="no-data">No data</template>
        </v-select>
        <v-autocomplete :items="states" v-model="a2" label="VAutocomplete">
          <template slot="no-data">No data</template>
        </v-autocomplete>
        <v-combobox :items="states" v-model="a3" label="VCombobox">
          <template slot="no-data">No data</template>
        </v-combobox>

        <div class="headline">item</div>
        <v-select :items="states" v-model="a1" label="VSelect">
          <template slot="item" slot-scope="data"><v-list-tile>(slot) {{ data.item }}</v-list-tile></template>
        </v-select>
        <v-autocomplete :items="states" v-model="a2" label="VAutocomplete">
          <template slot="item" slot-scope="data"><v-list-tile>(slot) {{ data.item }}</v-list-tile></template>
        </v-autocomplete>
        <v-combobox :items="states" v-model="a3" label="VCombobox">
          <template slot="item" slot-scope="data"><v-list-tile>(slot) {{ data.item }}</v-list-tile></template>
        </v-combobox>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data () {
    return {
      a1: null,
      a2: null,
      a3: null,
      states: [
        'Alabama', 'Alaska', 'American Samoa', 'Arizona',
        'Arkansas', 'California', 'Colorado', 'Connecticut',
        'Delaware', 'District of Columbia', 'Federated States of Micronesia',
        'Florida', 'Georgia', 'Guam', 'Hawaii', 'Idaho',
        'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky',
        'Louisiana', 'Maine', 'Marshall Islands', 'Maryland',
        'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi',
        'Missouri', 'Montana', 'Nebraska', 'Nevada',
        'New Hampshire', 'New Jersey', 'New Mexico', 'New York',
        'North Carolina', 'North Dakota', 'Northern Mariana Islands', 'Ohio',
        'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico',
        'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee',
        'Texas', 'Utah', 'Vermont', 'Virgin Island', 'Virginia',
        'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
      ]
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
