### PR TITLE
feat(a-la-carte): Enable global single components in plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "mini-css-extract-plugin": "^0.4.0",
     "optimize-css-assets-webpack-plugin": "^4.0.2",
     "postcss-loader": "^2.1.5",
+    "posthtml-parser": "^0.4.1",
+    "posthtml-render": "^1.1.4",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",
     "rimraf": "^2.6.2",
@@ -115,7 +117,8 @@
   "jest": {
     "verbose": false,
     "roots": [
-      "<rootDir>/test/unit"
+      "<rootDir>/test/unit",
+      "<rootDir>/test/integration"
     ],
     "moduleFileExtensions": [
       "ts",

--- a/src/components/Vuetify/index.ts
+++ b/src/components/Vuetify/index.ts
@@ -50,9 +50,14 @@ const Vuetify: VuetifyPlugin = {
     }
 
     if (opts.components) {
-      Object.values(opts.components).forEach(component => {
-        Vue.use(component)
-      })
+      for (const key in opts.components) {
+        const component = opts.components[key]
+        if (typeof component === 'function' || component.install) {
+          Vue.use(component)
+        } else {
+          Vue.component(key, component)
+        }
+      }
     }
   },
   version: __VUETIFY_VERSION__

--- a/src/util/stringcase.ts
+++ b/src/util/stringcase.ts
@@ -1,0 +1,32 @@
+// Beautiful utils stolen directly from Vue.js
+
+function cached<O> (fn: (i: string) => O): (i: string) => O {
+  const cache: { [index: string]: O } = Object.create(null)
+  return str => cache[str] || (cache[str] = fn(str))
+}
+
+const camelizeRE = /-(\w)/g
+export const camelize = cached(
+  (str: string): string =>
+    str.replace(camelizeRE, (_, c) => (c ? c.toUpperCase() : ''))
+)
+
+export const capitalize = cached(
+  (str: string): string => str.charAt(0).toUpperCase() + str.slice(1)
+)
+
+export const pascalize = cached(
+  (str: string): string =>
+    str.charAt(0).toUpperCase() +
+    str.replace(camelizeRE, (_, c) => (c ? c.toUpperCase() : '')).slice(1)
+)
+
+const hyphenateRE = /([^-])([A-Z])/g
+export const hyphenate = cached(
+  (str: string): string => {
+    return str
+      .replace(hyphenateRE, '$1-$2')
+      .replace(hyphenateRE, '$1-$2')
+      .toLowerCase()
+  }
+)

--- a/test/integration/describe.js
+++ b/test/integration/describe.js
@@ -1,0 +1,179 @@
+import Vue from 'vue'
+import { mount, shallow } from 'avoriaz'
+import toHaveBeenWarnedInit from '@/test/util/to-have-been-warned'
+import Vuetify from '@/components/Vuetify'
+import { compileToFunctions } from 'vue-template-compiler'
+
+export function test(name, cb) {
+  toHaveBeenWarnedInit()
+
+/*
+  const app = document.createElement('div')
+  app.setAttribute('data-app', true)
+  document.body.appendChild(app)
+*/
+
+  rafPolyfill(window)
+
+  // Very naive polyfill for performance.now()
+  window.performance = { now: () => (new Date()).getTime() }
+
+  describe(name, () => cb({
+    functionalContext,
+    mount (component, options) {
+      if (component.options) {
+        component = component.options
+      }
+      return mount(component, options)
+    },
+    shallow,
+    compileToFunctions
+  }))
+}
+
+test.skip = describe.skip
+
+export function functionalContext(context = {}, children = []) {
+  if (!Array.isArray(children)) children = [children]
+  return {
+    context: Object.assign({
+      data: {},
+      props: {}
+    }, context),
+    children
+  }
+}
+
+//requestAnimationFrame polyfill | Milos Djakonovic ( @Miloshio ) | MIT | https://github.com/milosdjakonovic/requestAnimationFrame-polyfill
+export function rafPolyfill(w) {
+  /**
+   *
+   * How many times should polyfill call
+   * update callback? By canon, it should
+   * be 60 times per second, so that ideal
+   * framerate 60fps could be reached.
+   *
+   * However, even native implementations
+   * of requestAnimationFrame often cannot
+   * do 60fps, but, unlike any polyfill,
+   * they can synchronise achievable fps
+   * rate with screen refresh rate.
+   *
+   * So, leave this value 1000/60 unless
+   * you target specific browser on spec
+   * ific device that is going to work
+   * better with custom value. I think
+   * that this is the longest comment I've
+   * written on single variable so far.
+  **/
+  var FRAME_RATE_INTERVAL = 1000/60,
+
+  /**
+   * All queued callbacks in given cycle.
+  **/
+  allCallbacks = [],
+
+  executeAllScheduled = false,
+
+  shouldCheckCancelRaf = false,
+
+  /**
+   * Callbacks queued for cancellation.
+  **/
+  callbacksForCancellation = [],
+
+  /**
+   * Should callback be cancelled?
+   * @param cb - callback
+  **/
+  isToBeCancelled = function(cb){
+    for(var i=0;i<callbacksForCancellation.length;i++){
+      if(callbacksForCancellation[i] === cb ){
+        callbacksForCancellation.splice(i,1);
+        return true;
+      }
+    }
+  },
+
+
+
+  /**
+   *
+   * Executes all (surprise) callbacks in
+   * and removes them from callback queue.
+   *
+  **/
+  executeAll = function(){
+    executeAllScheduled = false;
+    var _allCallbacks = allCallbacks;
+    allCallbacks = [];
+    for(var i=0;i<_allCallbacks.length;i++){
+      if(shouldCheckCancelRaf===true){
+        if (isToBeCancelled(_allCallbacks[i])){
+          shouldCheckCancelRaf = false;
+          return;
+        }
+      }
+      _allCallbacks[i].apply(w, [ new Date().getTime() ] );
+    }
+  },
+
+  /**
+   *
+   * requestAnimationFrame polyfill
+   * @param callback - callback to be queued & executed | executed
+   * @return callback
+   *
+  **/
+  raf = function(callback){
+    allCallbacks.push(callback);
+    if(executeAllScheduled===false){
+      w.setTimeout(executeAll, FRAME_RATE_INTERVAL);
+      executeAllScheduled = true;
+    }
+    return callback;
+  },
+
+  /**
+   *
+   * Cancels raf.
+  **/
+  cancelRaf = function(callback){
+    callbacksForCancellation.push(callback);
+    shouldCheckCancelRaf = true;
+  },
+
+
+  //https://gist.github.com/paulirish/1579671
+  vendors = ['ms', 'moz', 'webkit', 'o'];
+
+    for(var x = 0; x < vendors.length && !w.requestAnimationFrame; ++x) {
+        w.requestAnimationFrame = w[vendors[x]+'RequestAnimationFrame'];
+        w.cancelAnimationFrame = w[vendors[x]+'CancelAnimationFrame']
+        || w[vendors[x]+'CancelRequestAnimationFrame'];
+    }
+
+  if (!w.requestAnimationFrame) w.requestAnimationFrame = raf;
+  if (!w.cancelAnimationFrame)  w.cancelAnimationFrame  = cancelRaf;
+}
+
+export function touch(element) {
+  const createTrigger = eventName => (clientX, clientY) => {
+    const touches = [{ clientX, clientY }]
+    element.trigger(eventName, ({ touches, changedTouches: touches }))
+    return touch(element)
+  }
+
+  return {
+    start: createTrigger('touchstart'),
+    move: createTrigger('touchmove'),
+    end: createTrigger('touchend')
+  }
+}
+
+export const resizeWindow = (width = global.innerWidth, height = global.innerHeight) => {
+  global.innerWidth = width
+  global.innerHeight = height
+  global.dispatchEvent(new Event('resize'))
+  return new Promise(resolve => setTimeout(resolve, 200))
+}

--- a/test/integration/fixtures/fixtures.ts
+++ b/test/integration/fixtures/fixtures.ts
@@ -1,0 +1,24 @@
+import { readFile as _readFile } from 'fs'
+import { resolve } from 'path'
+import { promisify } from 'util'
+
+import { compileToFunctions } from 'vue-template-compiler'
+import parse from 'posthtml-parser'
+import render from 'posthtml-render'
+
+import { pascalizeTree } from './transformTree'
+
+const readFile = promisify(_readFile)
+
+const kitchensink = readFile(resolve(__dirname, './kitchensink.html'), 'utf8')
+
+export const pascalSink = kitchensink
+  .then(text => {
+    const ast = parse(text)
+    const newAst = pascalizeTree(ast)
+    const output = render(newAst)
+    return output
+  })
+  .then(compileToFunctions)
+
+export const kebabSink = kitchensink.then(compileToFunctions)

--- a/test/integration/fixtures/index.d.ts
+++ b/test/integration/fixtures/index.d.ts
@@ -1,0 +1,24 @@
+declare module 'vue-template-compiler' {
+  const compileToFunctions: (
+    template: string,
+    options?: any
+  ) => {
+    render: Function
+  }
+}
+declare namespace PostHTML{
+  type PostHTMLBranch = PostHTMLNode | string
+  type PostHTMLTree = PostHTMLBranch[]
+  interface PostHTMLNode {
+    tag: string
+    content?: PostHTMLTree
+  }
+}
+declare module 'posthtml-parser' {
+  const parse: (html: string) => PostHTML.PostHTMLTree
+  export default parse
+}
+declare module 'posthtml-render' {
+  const render: (html: PostHTML.PostHTMLTree) => string
+  export default render
+}

--- a/test/integration/fixtures/kitchensink.html
+++ b/test/integration/fixtures/kitchensink.html
@@ -1,0 +1,72 @@
+<v-app>
+  <v-navigation-drawer app></v-navigation-drawer>
+  <v-toolbar app></v-toolbar>
+  <v-content>
+    <v-container fluid>
+      <v-layout>
+        <v-alert></v-alert>
+        <v-app></v-app>
+        <!-- <v-autocomplete></v-autocomplete> -->
+        <v-avatar></v-avatar>
+        <v-badge></v-badge>
+        <v-bottom-nav></v-bottom-nav>
+        <!-- <v-bottom-sheet></v-bottom-sheet> -->
+        <v-breadcrumbs></v-breadcrumbs>
+        <v-btn></v-btn>
+        <v-btn-toggle></v-btn-toggle>
+        <v-card></v-card>
+        <v-carousel></v-carousel>
+        <v-checkbox></v-checkbox>
+        <v-chip></v-chip>
+        <!-- <v-combobox></v-combobox> -->
+        <v-counter></v-counter>
+        <!-- <v-data-iterator></v-data-iterator> -->
+        <!-- <v-data-table></v-data-table> -->
+        <v-date-picker></v-date-picker>
+        <!-- <v-dialog></v-dialog> -->
+        <v-divider></v-divider>
+        <v-expansion-panel></v-expansion-panel>
+        <v-footer></v-footer>
+        <v-form></v-form>
+        <!-- <v-grid></v-grid> -->
+        <v-icon></v-icon>
+        <v-input></v-input>
+        <v-jumbotron></v-jumbotron>
+        <v-label></v-label>
+        <v-list>
+          <v-list-tile>
+            <v-list-tile-avatar></v-list-tile-avatar>
+            <v-list-tile-action></v-list-tile-action>
+          </v-list-tile>
+        </v-list>
+        <!-- <v-menu></v-menu> -->
+        <v-messages></v-messages>
+        <!-- <v-overflow-btn></v-overflow-btn> -->
+        <v-pagination></v-pagination>
+        <v-parallax></v-parallax>
+        <v-picker></v-picker>
+        <v-progress-circular></v-progress-circular>
+        <v-progress-linear></v-progress-linear>
+        <v-radio-group></v-radio-group>
+        <!-- <v-range-slider></v-range-slider> -->
+        <!-- <v-select></v-select> -->
+        <!-- <v-slider></v-slider> -->
+        <v-snackbar></v-snackbar>
+        <v-speed-dial></v-speed-dial>
+        <!-- <v-stepper></v-stepper> -->
+        <v-subheader></v-subheader>
+        <v-switch></v-switch>
+        <v-system-bar></v-system-bar>
+        <v-tabs></v-tabs>
+        <v-textarea></v-textarea>
+        <v-text-field></v-text-field>
+        <v-time-picker></v-time-picker>
+        <!-- <v-tooltip>
+          <span slot="activator">This text has a tooltip</span>
+          <span>Tooltip</span>
+        </v-tooltip> -->
+      </v-layout>
+    </v-container>
+  </v-content>
+  <v-footer app></v-footer>
+</v-app>

--- a/test/integration/fixtures/transformTree.spec.js
+++ b/test/integration/fixtures/transformTree.spec.js
@@ -1,0 +1,13 @@
+import { pascalizeTree } from './transformTree'
+import parse from 'posthtml-parser'
+import render from 'posthtml-render'
+
+describe('pascalizeTree', () => {
+  it('should pascalize node names starting with `v-`', () => {
+    const input = `<v-app><router-view><v-icon/></router-view></v-app>`
+    const tested = render(pascalizeTree(parse(input)))
+    expect(tested).toEqual(
+      '<VApp><router-view><VIcon></VIcon></router-view></VApp>'
+    )
+  })
+})

--- a/test/integration/fixtures/transformTree.ts
+++ b/test/integration/fixtures/transformTree.ts
@@ -1,0 +1,21 @@
+import { pascalize } from '../../../src/util/stringcase'
+import { mapOrUndefined } from './utils'
+export const pascalizeTree = (
+  tree: PostHTML.PostHTMLTree
+): PostHTML.PostHTMLTree => mapOrUndefined(tree, pascalizeTag) || tree
+
+const pascalizeTag = (
+  node: PostHTML.PostHTMLBranch
+): PostHTML.PostHTMLBranch => {
+  if (typeof node === 'string') return node
+
+  const tag = node.tag.substr(0, 2) === 'v-' && pascalize(node.tag)
+  const content = node.content && mapOrUndefined(node.content, pascalizeTag)
+  return tag
+    ? content
+      ? { ...node, tag, content }
+      : { ...node, tag }
+    : content
+      ? { ...node, content }
+      : node
+}

--- a/test/integration/fixtures/utils.spec.js
+++ b/test/integration/fixtures/utils.spec.js
@@ -1,0 +1,18 @@
+import { mapOrUndefined } from './utils'
+
+describe('mapOrUndefined', () => {
+  it('should act like unary map if items are changed', () => {
+    const arr = ['string', 1]
+    const cb = x => typeof x
+    const tested = mapOrUndefined(arr, cb)
+    const original = arr.map(cb)
+    expect(tested).toEqual(original)
+  })
+
+  it('should return undefined if items are unchanged', () => {
+    const arr = [0, 1, {}]
+    const cb = x => x
+    const tested = mapOrUndefined(arr, cb)
+    expect(tested).toBe(undefined)
+  })
+})

--- a/test/integration/fixtures/utils.ts
+++ b/test/integration/fixtures/utils.ts
@@ -1,0 +1,21 @@
+export const mapOrUndefined = <T>(arr: T[], cb: (element: T) => T): T[] | undefined => {
+  let output = undefined;
+  let len = arr.length;
+  let i = 0;
+  for (; i < len; i++) {
+    const element = arr[i];
+    const processed = cb(element);
+    if (processed !== element) {
+      output = [...arr];
+      output[i] = processed;
+      break;
+    }
+  }
+  if (output) {
+    for (; i < len; i++) {
+      const element = arr[i];
+      output[i] = cb(element);
+    }
+  }
+  return output;
+};

--- a/test/integration/importA-la-carte.spec.js
+++ b/test/integration/importA-la-carte.spec.js
@@ -1,0 +1,132 @@
+import Vue from 'vue'
+import VAlert from '../../src/components/VAlert'
+import VApp from '../../src/components/VApp'
+import VAutocomplete from '../../src/components/VAutocomplete'
+import VAvatar from '../../src/components/VAvatar'
+import VBadge from '../../src/components/VBadge'
+import VBottomNav from '../../src/components/VBottomNav'
+import VBottomSheet from '../../src/components/VBottomSheet'
+import VBreadcrumbs from '../../src/components/VBreadcrumbs'
+import VBtn from '../../src/components/VBtn'
+import VBtnToggle from '../../src/components/VBtnToggle'
+import VCard from '../../src/components/VCard'
+import VCarousel from '../../src/components/VCarousel'
+import VCheckbox from '../../src/components/VCheckbox'
+import VChip from '../../src/components/VChip'
+import VCombobox from '../../src/components/VCombobox'
+import VCounter from '../../src/components/VCounter'
+import VDataIterator from '../../src/components/VDataIterator'
+import VDataTable from '../../src/components/VDataTable'
+import VDatePicker from '../../src/components/VDatePicker'
+import VDialog from '../../src/components/VDialog'
+import VDivider from '../../src/components/VDivider'
+import VExpansionPanel from '../../src/components/VExpansionPanel'
+import VFooter from '../../src/components/VFooter'
+import VForm from '../../src/components/VForm'
+import VGrid from '../../src/components/VGrid'
+import VIcon from '../../src/components/VIcon'
+import VInput from '../../src/components/VInput'
+import VJumbotron from '../../src/components/VJumbotron'
+import VLabel from '../../src/components/VLabel'
+import VList from '../../src/components/VList'
+import VMenu from '../../src/components/VMenu'
+import VMessages from '../../src/components/VMessages'
+import VNavigationDrawer from '../../src/components/VNavigationDrawer'
+import VOverflowBtn from '../../src/components/VOverflowBtn'
+import VPagination from '../../src/components/VPagination'
+import VParallax from '../../src/components/VParallax'
+import VPicker from '../../src/components/VPicker'
+import VProgressCircular from '../../src/components/VProgressCircular'
+import VProgressLinear from '../../src/components/VProgressLinear'
+import VRadioGroup from '../../src/components/VRadioGroup'
+import VRangeSlider from '../../src/components/VRangeSlider'
+import VSelect from '../../src/components/VSelect'
+import VSlider from '../../src/components/VSlider'
+import VSnackbar from '../../src/components/VSnackbar'
+import VSpeedDial from '../../src/components/VSpeedDial'
+import VStepper from '../../src/components/VStepper'
+import VSubheader from '../../src/components/VSubheader'
+import VSwitch from '../../src/components/VSwitch'
+import VSystemBar from '../../src/components/VSystemBar'
+import VTabs from '../../src/components/VTabs'
+import VTextarea from '../../src/components/VTextarea'
+import VTextField from '../../src/components/VTextField'
+import VTimePicker from '../../src/components/VTimePicker'
+import VToolbar from '../../src/components/VToolbar'
+import VTooltip from '../../src/components/VTooltip'
+import Vuetify from '../../src/components/Vuetify'
+import { mount } from 'avoriaz'
+import { test } from './describe'
+import { kebabSink, pascalSink } from './fixtures/fixtures'
+
+test('a-la-carte import', () => {
+  Vue.use(Vuetify, {
+    components: {
+      VAlert,
+      VApp,
+      VAutocomplete,
+      VAvatar,
+      VBadge,
+      VBottomNav,
+      VBottomSheet,
+      VBreadcrumbs,
+      VBtn,
+      VBtnToggle,
+      VCard,
+      VCarousel,
+      VCheckbox,
+      VChip,
+      VCombobox,
+      VCounter,
+      VDataIterator,
+      VDataTable,
+      VDatePicker,
+      VDialog,
+      VDivider,
+      VExpansionPanel,
+      VFooter,
+      VForm,
+      VGrid,
+      VIcon,
+      VInput,
+      VJumbotron,
+      VLabel,
+      VList,
+      VMenu,
+      VMessages,
+      VNavigationDrawer,
+      VOverflowBtn,
+      VPagination,
+      VParallax,
+      VPicker,
+      VProgressCircular,
+      VProgressLinear,
+      VRadioGroup,
+      VRangeSlider,
+      VSelect,
+      VSlider,
+      VSnackbar,
+      VSpeedDial,
+      VStepper,
+      VSubheader,
+      VSwitch,
+      VSystemBar,
+      VTabs,
+      VTextarea,
+      VTextField,
+      VTimePicker,
+      VToolbar,
+      VTooltip
+    }
+  })
+  it('should render kebab sink', async () => {
+    const { render } = await kebabSink
+    const app = Vue.extend({ render })
+    mount(app)
+  })
+  it.skip('should render pascal sink', async () => {
+    const { render } = await pascalSink
+    const app = Vue.extend({ render })
+    mount(app)
+  })
+})

--- a/test/integration/importFull.spec.js
+++ b/test/integration/importFull.spec.js
@@ -1,0 +1,19 @@
+import Vue from 'vue'
+import Vuetify from '@/'
+import { mount } from 'avoriaz'
+import { test } from './describe'
+import { kebabSink, pascalSink } from './fixtures/fixtures'
+
+test('full import', () => {
+  Vue.use(Vuetify)
+  it('should render kebab sink', async () => {
+    const { render } = await kebabSink
+    const app = Vue.extend({ render })
+    mount(app)
+  })
+  it.skip('should render pascal sink', async () => {
+    const { render } = await pascalSink
+    const app = Vue.extend({ render })
+    mount(app)
+  })
+})

--- a/test/integration/importSuperA-la-carte.spec.js
+++ b/test/integration/importSuperA-la-carte.spec.js
@@ -1,0 +1,52 @@
+import Vue from 'vue'
+import VApp from '../../src/components/VApp/VApp'
+import VFooter from '../../src/components/VFooter/VFooter'
+import VContainer from '../../src/components/VGrid/VContainer'
+import VContent from '../../src/components/VGrid/VContent'
+import VNavigationDrawer from '../../src/components/VNavigationDrawer/VNavigationDrawer'
+import VToolbar from '../../src/components/VToolbar/VToolbar'
+import Vuetify from '../../src/components/Vuetify'
+import { mount } from 'avoriaz'
+import { test } from './describe'
+
+import parse from 'posthtml-parser'
+import renderxml from 'posthtml-render'
+
+import { pascalizeTree } from './fixtures/transformTree'
+
+import { compileToFunctions } from 'vue-template-compiler'
+
+const kebabTemplate = `<v-app>
+<v-navigation-drawer app></v-navigation-drawer>
+<v-toolbar app></v-toolbar>
+<v-content>
+  <v-container fluid>
+  </v-container>
+</v-content>
+<v-footer app></v-footer>
+</v-app>`
+
+test('super a-la-carte import', () => {
+  Vue.use(Vuetify, {
+    components: {
+      VApp,
+      VContainer,
+      VContent,
+      VFooter,
+      VNavigationDrawer,
+      VToolbar
+    }
+  })
+  it('should render kebab cpmponents', () => {
+    const { render } = compileToFunctions(kebabTemplate)
+    const app = Vue.extend({ render })
+    mount(app)
+  })
+  it('should render PascalCase components', () => {
+    const { render } = compileToFunctions(
+      renderxml(pascalizeTree(parse(kebabTemplate)))
+    )
+    const app = Vue.extend({ render })
+    mount(app)
+  })
+})

--- a/test/unit/components/Vuetify/Vuetify.install.spec.js
+++ b/test/unit/components/Vuetify/Vuetify.install.spec.js
@@ -10,10 +10,13 @@ test('Vuetify.install.js', () => {
     Vue.directive = jest.fn()
     Vue.use = jest.fn()
 
+    const noopInstallPack = { install: () => { } }
+
     Vuetify.installed = false
     Vuetify.install(Vue, {
       components: {
-        component: 'foobarbaz'
+        ComponentPack: noopInstallPack,
+        OneComponent: {}
       },
       directives: {
         directive: {
@@ -31,9 +34,9 @@ test('Vuetify.install.js', () => {
       }
     })
 
-    expect(Vue.use.mock.calls).toEqual([['foobarbaz']])
+    expect(Vue.use.mock.calls).toEqual([[noopInstallPack]])
     expect(Vue.directive.mock.calls).toEqual([["foobarbaz", {"name": "foobarbaz"}]])
-    expect(Vue.component.mock.calls).toEqual([["v-foobarbaz", {"name": "v-foobarbaz"}]])
+    expect(Vue.component.mock.calls).toEqual([["v-foobarbaz", {"name": "v-foobarbaz"}],["OneComponent", {}]])
 
     Vue.use = jest.fn()
     Vuetify.install(Vue, {

--- a/test/unit/util/stringcase.spec.js
+++ b/test/unit/util/stringcase.spec.js
@@ -1,0 +1,43 @@
+import { test } from '@/test'
+import {
+  camelize,
+  capitalize,
+  pascalize,
+  hyphenate
+} from '../../../src/util/stringcase'
+
+const sampleStrings = ['hyphenated-string', 'PascalCase', 'camelCase']
+
+test('stringcase.ts', () => {
+  it('should camelize hyphenated string', () => {
+    expect(sampleStrings.map(camelize)).toEqual([
+      'hyphenatedString',
+      'PascalCase',
+      'camelCase'
+    ])
+  })
+
+  it('should capitalize string', () => {
+    expect(sampleStrings.map(capitalize)).toEqual([
+      'Hyphenated-string',
+      'PascalCase',
+      'CamelCase'
+    ])
+  })
+
+  it('should pascalize hyphenated string', () => {
+    expect(sampleStrings.map(pascalize)).toEqual([
+      'HyphenatedString',
+      'PascalCase',
+      'CamelCase'
+    ])
+  })
+
+  it('should hyphenate PascalCase or camelCase string', () => {
+    expect(sampleStrings.map(hyphenate)).toEqual([
+      'hyphenated-string',
+      'pascal-case',
+      'camel-case'
+    ])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6437,6 +6437,17 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.16, postcss@^6.0.20, postcss@^6.0.2
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+posthtml-parser@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.4.1.tgz#95b78fef766fbbe0a6f861b6e95582bc3d1ff933"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    object-assign "^4.1.1"
+
+posthtml-render@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.4.tgz#95dac09892f4f183fad5ac823f08f42c0256551e"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This changes how `components` object in `Vuetify` installation is used
Enables globally registering single components without an `.install`
Also ignores `.name` and uses object key instead, which happens to also
register the PascalCase name

## How Has This Been Tested?
This builds on the tests added in #4365
Also includes rudimentary test for specific component registration
Also has a (non-skipped) PascalCase test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. **HMMM, DOES IT?!**
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
