### PR TITLE
Fix navigation drawer resize events

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -328,12 +328,11 @@ export default {
         transitionend: e => {
           this.$emit('transitionend', e)
 
-          if(e.srcElement.localName === 'aside') {
-            // IE11 does not support new Event('resize')
-            const resizeEvent = document.createEvent('UIEvents')
-            resizeEvent.initUIEvent('resize', true, false, window, 0)
-            window.dispatchEvent(resizeEvent)
-          }
+          if (e.target !== e.currentTarget) return
+          // IE11 does not support new Event('resize')
+          const resizeEvent = document.createEvent('UIEvents')
+          resizeEvent.initUIEvent('resize', true, false, window, 0)
+          window.dispatchEvent(resizeEvent)
         }
       }
     }

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -326,9 +326,9 @@ export default {
           this.$emit('update:miniVariant', false)
         },
         transitionend: e => {
+          if (e.target !== e.currentTarget) return
           this.$emit('transitionend', e)
 
-          if (e.target !== e.currentTarget) return
           // IE11 does not support new Event('resize')
           const resizeEvent = document.createEvent('UIEvents')
           resizeEvent.initUIEvent('resize', true, false, window, 0)

--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -328,10 +328,12 @@ export default {
         transitionend: e => {
           this.$emit('transitionend', e)
 
-          // IE11 does not support new Event('resize')
-          const resizeEvent = document.createEvent('UIEvents')
-          resizeEvent.initUIEvent('resize', true, false, window, 0)
-          window.dispatchEvent(resizeEvent)
+          if(e.srcElement.localName === 'aside') {
+            // IE11 does not support new Event('resize')
+            const resizeEvent = document.createEvent('UIEvents')
+            resizeEvent.initUIEvent('resize', true, false, window, 0)
+            window.dispatchEvent(resizeEvent)
+          }
         }
       }
     }


### PR DESCRIPTION
Hover and click event on components in a navigation-drawer is currently emitting resize events on the navigation-drawer. This is breaking mapbox transitions i my app.
This PR ensures that resize event only are emitted when the navigation-drawer changes

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Preventing the navigation-drawer to emit resize event when clicking af hovering components in the navigation-drawer. 

## Motivation and Context
I have a solution with a Mapbox map and a navigation drawer with a button to fit the map.
When clicking the button, the map should zoom out with an animation, but the animation stops because the navigation-drawer is emitting a resize event.
This PR ensures that resize event only are emitted when the navigation-drawer changes.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-navigation-drawer app>
      <v-btn @click="fitMap">Fit map</v-btn>
    </v-navigation-drawer>
    <v-content>
      <v-container
        fluid
        pa-0
        fill-height>
        <v-layout>
          <v-flex d-flex>
            <div id="map"/>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>
<script>
require('mapbox-gl/dist/mapbox-gl.css')
let map
export default {
  mounted () {
    const mapboxgl = require('mapbox-gl/dist/mapbox-gl.js')
    mapboxgl.accessToken = 'pk.eyJ1IjoicnVuZXR2aWx1bSIsImEiOiJjaml0enJhejYxdXFkM2txbXA1aXE0b3MxIn0.qrQfSVCs4YHmTRR0MPT9TA'
    map = new mapboxgl.Map({
      container: 'map',
      style: 'mapbox://styles/mapbox/streets-v9',
      center: [-74.50, 40],
      zoom: 9
    })
  },
  methods: {
    fitMap () {
      map.fitBounds([[-170, -80], [170, 80]])
    }
  }
}
</script>
<style lang="stylus" scoped>
#map
  height 100%
  width 100%
</style>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
