### PR TITLE
Fix Weird Text Field Spacing

### DIFF
--- a/src/components/VTextField/VTextField.js
+++ b/src/components/VTextField/VTextField.js
@@ -338,6 +338,8 @@ export default {
       return this.$createElement('input', data)
     },
     genMessages () {
+      if (this.hideDetails) return null
+
       return this.$createElement('div', {
         staticClass: 'v-text-field__details'
       }, [

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -253,7 +253,7 @@ rtl(v-text-field-rtl, "v-text-field")
     .v-text-field__details
       margin-bottom: 8px
 
-  &--full-width
+  &.v-text-field--full-width
     &.v-input
       margin-bottom: 0
       margin-top: 0
@@ -261,8 +261,8 @@ rtl(v-text-field-rtl, "v-text-field")
     .v-label
       top: calc(50% - 10px)
 
-    .v-input__slot
-      padding: 16px 0
+    .v-input__control
+      padding: 12px 0
 
     .v-input__prepend-outer,
     .v-input__append-outer

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -239,12 +239,12 @@ rtl(v-text-field-rtl, "v-text-field")
     &:not(.v-text-field--box)
       .v-progress-linear__background
         display: none
-    &:not(.v-text-field--single-line)
-      .v-input__prepend-outer,
-      .v-input__prepend-inner,
-      .v-input__append-inner,
-      .v-input__append-outer
-        margin-top: 16px
+
+    .v-input__prepend-outer,
+    .v-input__prepend-inner,
+    .v-input__append-inner,
+    .v-input__append-outer
+      margin-top: 16px
 
     .v-text-field__details,
     .v-input__slot

--- a/src/stylus/components/_text-fields.styl
+++ b/src/stylus/components/_text-fields.styl
@@ -239,12 +239,12 @@ rtl(v-text-field-rtl, "v-text-field")
     &:not(.v-text-field--box)
       .v-progress-linear__background
         display: none
-
-    .v-input__prepend-outer,
-    .v-input__prepend-inner,
-    .v-input__append-inner,
-    .v-input__append-outer
-      margin-top: 16px
+    &:not(.v-text-field--single-line)
+      .v-input__prepend-outer,
+      .v-input__prepend-inner,
+      .v-input__append-inner,
+      .v-input__append-outer
+        margin-top: 16px
 
     .v-text-field__details,
     .v-input__slot

--- a/test/unit/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
+++ b/test/unit/components/VDataIterator/__snapshots__/VDataIterator.spec.js.snap
@@ -90,8 +90,6 @@ exports[`VDataIterator.js should match a snapshot - footer slot 1`] = `
                 </div>
               </div>
             </div>
-            <div class="v-text-field__details">
-            </div>
           </div>
         </div>
       </div>
@@ -233,8 +231,6 @@ exports[`VDataIterator.js should match a snapshot - no data 1`] = `
                 </div>
               </div>
             </div>
-            <div class="v-text-field__details">
-            </div>
           </div>
         </div>
       </div>
@@ -366,8 +362,6 @@ exports[`VDataIterator.js should match a snapshot - no matching records 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="v-text-field__details">
             </div>
           </div>
         </div>
@@ -504,8 +498,6 @@ exports[`VDataIterator.js should match a snapshot - with data 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="v-text-field__details">
             </div>
           </div>
         </div>

--- a/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
+++ b/test/unit/components/VDataTable/__snapshots__/VDataTable.spec.js.snap
@@ -143,8 +143,6 @@ exports[`VDataTable.vue should match a snapshot - no data 1`] = `
                 </div>
               </div>
             </div>
-            <div class="v-text-field__details">
-            </div>
           </div>
         </div>
       </div>
@@ -327,8 +325,6 @@ exports[`VDataTable.vue should match a snapshot - no matching results 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="v-text-field__details">
             </div>
           </div>
         </div>
@@ -514,8 +510,6 @@ exports[`VDataTable.vue should match a snapshot - with data 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="v-text-field__details">
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Fixes `genMessages` for `v-text-field` and resolves some spacing for the inner icon for `v-autocomplete`

## Description
<!--- Describe your changes in detail -->
Inside the `genMessages` function for `VTextField.js` we were missing a check to return null if `hideDetails` was true. Also changed some css to account for `single-line` prop. The enclosed drop down icon for `autocomplete` was spaced wrong

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is an example on the docs that these issues were causing to look weird. Doc example found here: https://vuetifyjs.com/en/components/text-fields#example-full-width-with-character-counter

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <boilerplate>
    <v-card>
      <v-toolbar
        card
        color="pink"
        dark
      >
        <v-icon>arrow_back</v-icon>
        <v-toolbar-title>Compose</v-toolbar-title>
        <v-spacer></v-spacer>
        <v-icon>send</v-icon>
      </v-toolbar>
      <v-form>
        <v-autocomplete
          v-model="selected"
          :items="['Trevor Handsen', 'Alex Nelson']"
          chips
          label="To"
          full-width
          hide-details
          hide-no-data
          hide-selected
          multiple
          single-line
        ></v-autocomplete>
        <v-divider></v-divider>
        <v-text-field
          label="Subject"
          value="Plans for the weekend"
          single-line
          full-width
          hide-details
        ></v-text-field>
        <v-divider></v-divider>
        <v-textarea
          v-model="title"
          label="Message"
          counter
          maxlength="120"
          full-width
          single-line
        ></v-textarea>
      </v-form>
    </v-card>
  </boilerplate>
</template>

<script>
export default {
  data () {
    return {
      selected: ['Trevor Handsen'],
      items: ['Trevor Handsen', 'Alex Nelson'],
      title: 'Hi,\nI just wanted to check in and see if you had any plans the upcoming weekend. We are thinking of heading up to Napa'
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
