### PR TITLE
fix(VSelect): override v-text-field's blur method

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -268,6 +268,7 @@ export default {
     blur () {
       this.isMenuActive = false
       this.isFocused = false
+      this.$refs.input.blur()
       this.selectedIndex = -1
     },
     /** @public */

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -147,8 +147,7 @@ export default {
     directives () {
       return [{
         name: 'click-outside',
-        // TODO: Check into this firing when it shouldn't
-        value: this.onClickOutside,
+        value: this.blur,
         args: {
           closeConditional: e => {
             return (
@@ -265,6 +264,13 @@ export default {
   },
 
   methods: {
+    /** @public */
+    blur () {
+      this.isMenuActive = false
+      this.isFocused = false
+      this.selectedIndex = -1
+    },
+    /** @public */
     activateMenu () {
       this.isMenuActive = true
     },
@@ -518,11 +524,6 @@ export default {
         this.isFocused = true
         this.$emit('focus')
       }
-    },
-    onClickOutside () {
-      this.isMenuActive = false
-      this.isFocused = false
-      this.selectedIndex = -1
     },
     onEnterDown () {
       this.onBlur()

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -148,17 +148,7 @@ export default {
       return [{
         name: 'click-outside',
         // TODO: Check into this firing when it shouldn't
-        value: e => {
-          if (this.isMenuActive) {
-            this.onKeyDown(e)
-          }
-
-          /* eslint-disable vue/no-side-effects-in-computed-properties */
-          this.isMenuActive = false
-          this.isFocused = false
-          this.selectedIndex = -1
-          /* eslint-enable vue/no-side-effects-in-computed-properties */
-        },
+        value: this.onClickOutside,
         args: {
           closeConditional: e => {
             return (
@@ -529,6 +519,11 @@ export default {
         this.$emit('focus')
       }
     },
+    onClickOutside (e) {
+      this.isMenuActive = false
+      this.isFocused = false
+      this.selectedIndex = -1
+    },
     onEnterDown () {
       this.onBlur()
     },
@@ -548,7 +543,7 @@ export default {
       ].includes(keyCode)) this.activateMenu()
 
       // This should do something different
-      if (e.keyCode === keyCodes.enter) return this.onEnterDown()
+      if (keyCode === keyCodes.enter) return this.onEnterDown()
 
       // If escape deactivate the menu
       if (keyCode === keyCodes.esc) return this.onEscDown(e)

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -519,7 +519,7 @@ export default {
         this.$emit('focus')
       }
     },
-    onClickOutside (e) {
+    onClickOutside () {
       this.isMenuActive = false
       this.isFocused = false
       this.selectedIndex = -1


### PR DESCRIPTION
## Description
Makes easier to simulate clicking outside programmatically. Also calling onKeyDown in the handler was useless

## How Has This Been Tested?
manually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-container>
      <v-btn @click="click">Click and wait for it...</v-btn>
      <v-select :items="['foo']" ref="ref" />
    </v-container>
  </v-app>
</template>

<script>
export default {
  methods: {
    click () {
      const ref = this.$refs.ref
      setTimeout(() => {
        ref.onClick()
        ref.focus()
        setTimeout(ref.onClickOutside, 1000)
      });
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
