### PR TITLE
fix(VSelect): prevent emitting change again on blur

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -234,7 +234,8 @@ export default {
   },
 
   watch: {
-    internalValue () {
+    internalValue (val) {
+      this.initialValue = val
       this.$emit('change', this.internalValue)
       this.setSelectedItems()
     },

--- a/test/unit/components/VSelect/VSelect.spec.js
+++ b/test/unit/components/VSelect/VSelect.spec.js
@@ -447,4 +447,30 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isMenuActive).toBe(false)
   })
+
+  it('should emit a single change event', async () => {
+    const wrapper = mount(VSelect, {
+      attachToDocument: true,
+      propsData: {
+        attach: true,
+        items: ['foo', 'bar']
+      }
+    })
+
+    const change = jest.fn()
+    wrapper.vm.$on('change', change)
+
+    const menu = wrapper.first('.v-input__slot')
+
+    menu.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.selectItem('foo')
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.blur()
+    await wrapper.vm.$nextTick()
+
+    expect(change.mock.calls).toEqual([['foo']])
+  })
 })


### PR DESCRIPTION
Not sure if initialValue is used for anything other than change detection. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #4481

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-select
          autocomplete
          :items="employees"
          item-text="compoundName"
          label="Employees"
          required
          return-object
          @change="onEmployeeChange"
      ></v-select>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      employee: null,
      employees: [
        {
          compoundName: '1: Guy1',
          id: '1'
        },
        {
          compoundName: '2: Guy2',
          id: '2'
        }
      ],
      orders: [
        {
          compoundName: "Order1"
        },
        {
          compoundName: 'Order2'
        }
      ]
    }),
    methods: {
      onEmployeeChange (event) {
        console.log('onEmployeeChange', event)
      }
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
