### PR TITLE
fix: don't reduce animation keyframes

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -77,7 +77,8 @@ function genConfig (opts) {
           cssProcessor: require('cssnano'),
           cssProcessorOptions: {
             discardComments: { removeAll: true },
-            postcssZindex: false
+            postcssZindex: false,
+            reduceIdents: false
           },
           canPrint: false
         })


### PR DESCRIPTION
## Description
cssnano minifies the keyframes names so they conflict with other reduced keyframes from other libs

## Motivation and Context
fixes #4563
related to #1141
related to #4143

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
