### PR TITLE
Fix warning for 'wheel' event

### DIFF
--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -191,13 +191,13 @@ export default {
       if (this.$vuetify.breakpoint.smAndDown) {
         document.documentElement.classList.add('overflow-y-hidden')
       } else {
-        window.addEventListener('wheel', this.scrollListener)
+        window.addEventListener('wheel', this.scrollListener, {passive: true})
         window.addEventListener('keydown', this.scrollListener)
       }
     },
     showScroll () {
       document.documentElement.classList.remove('overflow-y-hidden')
-      window.removeEventListener('wheel', this.scrollListener)
+      window.removeEventListener('wheel', this.scrollListener, {passive: true})
       window.removeEventListener('keydown', this.scrollListener)
     }
   }

--- a/src/mixins/overlayable.js
+++ b/src/mixins/overlayable.js
@@ -191,13 +191,13 @@ export default {
       if (this.$vuetify.breakpoint.smAndDown) {
         document.documentElement.classList.add('overflow-y-hidden')
       } else {
-        window.addEventListener('wheel', this.scrollListener, {passive: true})
+        window.addEventListener('wheel', this.scrollListener, { passive: true })
         window.addEventListener('keydown', this.scrollListener)
       }
     },
     showScroll () {
       document.documentElement.classList.remove('overflow-y-hidden')
-      window.removeEventListener('wheel', this.scrollListener, {passive: true})
+      window.removeEventListener('wheel', this.scrollListener, { passive: true })
       window.removeEventListener('keydown', this.scrollListener)
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Spec change for Passive event listeners :
https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Warning in Chrome 51 and FF 49 :
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
