### PR TITLE
fix(v-form): restore ability to work with inputs through $refs

### DIFF
--- a/src/components/VForm/VForm.js
+++ b/src/components/VForm/VForm.js
@@ -19,6 +19,7 @@ export default {
   data () {
     return {
       inputs: [],
+      watchers: [],
       errorBag: {}
     }
   },
@@ -43,6 +44,7 @@ export default {
       }
 
       const watchers = {
+        _uid: input._uid,
         valid: undefined,
         shouldValidate: undefined
       }
@@ -80,22 +82,21 @@ export default {
     },
     register (input) {
       const unwatch = this.watchInput(input)
-      this.inputs.push({
-        uid: input._uid,
-        validate: input.validate,
-        reset: input.reset,
-        unwatch
-      })
+      this.inputs.push(input)
+      this.watchers.push(unwatch)
     },
     unregister (input) {
-      const found = this.inputs.find(i => i.uid === input._uid)
+      const found = this.inputs.find(i => i._uid === input._uid)
 
       if (!found) return
 
-      found.unwatch.valid && found.unwatch.valid()
-      found.unwatch.shouldValidate && found.unwatch.shouldValidate()
-      this.inputs = this.inputs.filter(i => i.uid !== found.uid)
-      this.$delete(this.errorBag, found.uid)
+      const unwatch = this.watchers.find(i => i._uid === found._uid)
+      unwatch.valid && unwatch.valid()
+      unwatch.shouldValidate && unwatch.shouldValidate()
+
+      this.watchers = this.watchers.filter(i => i._uid !== found._uid)
+      this.inputs = this.inputs.filter(i => i._uid !== found._uid)
+      this.$delete(this.errorBag, found._uid)
     }
   },
 

--- a/test/unit/components/VForm/VForm.spec.js
+++ b/test/unit/components/VForm/VForm.spec.js
@@ -146,4 +146,38 @@ test('VForm.js', ({ mount }) => {
     await new Promise(resolve => setTimeout(resolve, 0))
     expect(Object.keys(wrapper.vm.errorBag).length).toBe(0)
   })
+
+  it('should register and unregister items', () => {
+    const wrapper = mount(VForm, {
+      slots: {
+        default: [VTextField]
+      }
+    })
+
+    expect(wrapper.vm.inputs.length).toBe(1)
+
+    const input = wrapper.vm.inputs[0]
+
+    // Should not modify inputs if
+    // does not exist
+    wrapper.vm.unregister({ _uid: input._uid + 1 })
+
+    expect(wrapper.vm.inputs.length).toBe(1)
+
+    wrapper.vm.unregister(input)
+
+    expect(wrapper.vm.inputs.length).toBe(0)
+
+    // Add back input
+    wrapper.vm.register(input)
+
+    expect(wrapper.vm.inputs.length).toBe(1)
+
+    const shouldValidate = jest.fn()
+    wrapper.vm.watchers[0].shouldValidate = shouldValidate
+
+    wrapper.vm.unregister(input)
+
+    expect(shouldValidate).toBeCalled()
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Restores the ability to work directly with input components in a v-form through `$refs.inputs` by registering the entire instance.

## Motivation and Context
In 1.0 you could access the input components in a v-form through `$refs.form.inputs`. This is not possible in 1.1 and has created problems for people using the inputs array for more complex validation features such as focusing on or scrolling to invalid inputs, or getting all validation errors from a form (#4573).

## How Has This Been Tested?
manually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-form ref="form" v-model="valid" lazy-validation>
      <v-text-field
        v-model="name"
        :rules="nameRules"
        :counter="10"
        label="Name"
        required
      ></v-text-field>
      <v-text-field
        v-if="show"
        v-model="email"
        :rules="emailRules"
        label="E-mail"
        required
      ></v-text-field>
      <v-select
        v-model="select"
        :items="items"
        :rules="[v => !!v || 'Item is required']"
        label="Item"
        required
      ></v-select>
      <v-checkbox
        v-model="checkbox"
        :rules="[v => !!v || 'You must agree to continue!']"
        label="Do you agree?"
        required
      ></v-checkbox>

      <v-btn
        :disabled="!valid"
        @click="submit"
      >
        submit
      </v-btn>
      <v-btn @click="clear">clear</v-btn>
      <v-btn @click="show = !show">toggle</v-btn>
    </v-form>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      show: true,
      valid: true,
      name: '',
      nameRules: [
        v => !!v || 'Name is required',
        v => (v && v.length <= 10) || 'Name must be less than 10 characters'
      ],
      email: '',
      emailRules: [
        v => !!v || 'E-mail is required',
        v => /.+@.+/.test(v) || 'E-mail must be valid'
      ],
      select: null,
      items: [
        'Item 1',
        'Item 2',
        'Item 3',
        'Item 4'
      ],
      checkbox: false
    }),

    methods: {
      submit () {
        console.log(this.$refs.form.validate())
        console.log(this.$refs.form.inputs)
      },
      clear () {
        this.$refs.form.reset()
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
