### PR TITLE
Fix deepEqual helper - Enable Date values for v-radio

### DIFF
--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -130,6 +130,11 @@ export function getNestedValue (obj: any, path: (string | number)[], fallback?: 
 export function deepEqual (a: any, b: any): boolean {
   if (a === b) return true
 
+  if (a instanceof Date && b instanceof Date) {
+    // If the values are Date, they were convert to timestamp with getTime and compare it
+    if (a.getTime() !== b.getTime()) return false
+  }
+
   if (a !== Object(a) || b !== Object(b)) {
     // If the values aren't objects, they were already checked for equality
     return false

--- a/test/unit/util/helpers.spec.js
+++ b/test/unit/util/helpers.spec.js
@@ -84,6 +84,15 @@ test('helpers.js', () => {
     expect(deepEqual({x: 1}, {})).toEqual(false)
     expect(deepEqual({x: {a: 1, b: 2}}, {x: {a: 1, b: 2}})).toEqual(true)
 
+    // Date
+    const currentDate = new Date
+    const futureDate = new Date(1000)
+
+    expect(deepEqual(currentDate, currentDate)).toEqual(true)
+    expect(deepEqual({date: currentDate}, {date: currentDate})).toEqual(true)
+    expect(deepEqual(currentDate, futureDate)).toEqual(false)
+    expect(deepEqual({date: currentDate}, {date: futureDate})).toEqual(false)
+
     const circular = {}
     circular.me = circular
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Add Date comparison in deepEqual function in helper.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->`deepEqual` function can't compare `Date`. When `Date` are use as values in `v-radio`, all radio are selected when user check one.It's because comparison between selected value and radio value return true every time.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #4637 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
test visually and unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
    <v-container fluid px-0>
      <v-radio-group v-model="radioGroup">
        <v-radio label="one"
          :value="dates.one"
        ></v-radio>
        <v-radio label="two"
          :value="dates.two"
        ></v-radio>
        <v-radio label="three"
          :value="dates.three"
        ></v-radio>
      </v-radio-group>
    </v-container>
</template>

<script>
  export default {
    data () {
      return {
        radioGroup: 'default date',
      }
    },
    computed: {
      dates () {
        return {
          one: new Date(),
          two: new Date(1000),
          three: new Date(2000)
        }
      }
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
