### PR TITLE
fix(VSelect): allow null values to be selected

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -58,7 +58,7 @@ export default {
   data: vm => ({
     attrsInput: null,
     lazySearch: vm.searchInput,
-    lazyValue: vm.value != null
+    lazyValue: vm.value !== undefined
       ? vm.value
       : vm.multiple ? [] : undefined
   }),
@@ -338,9 +338,7 @@ export default {
       this.setSearch()
     },
     setSelectedItems () {
-      if (this.internalValue == null ||
-        this.internalValue === ''
-      ) {
+      if (this.internalValue === undefined) {
         this.selectedItems = []
       } else {
         VSelect.methods.setSelectedItems.call(this)

--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -270,7 +270,7 @@ export default {
       }
     },
     clearableCallback () {
-      this.internalSearch = null
+      this.internalSearch = undefined
 
       VSelect.methods.clearableCallback.call(this)
     },

--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -338,7 +338,7 @@ export default {
       VSelect.methods.setSelectedItems.call(this)
 
       // #4273 Don't replace if searching
-      // #4403 Don't replace is focused
+      // #4403 Don't replace if focused
       if (!this.isFocused) this.setSearch()
     },
     setSearch () {

--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -57,10 +57,7 @@ export default {
 
   data: vm => ({
     attrsInput: null,
-    lazySearch: vm.searchInput,
-    lazyValue: vm.value !== undefined
-      ? vm.value
-      : vm.multiple ? [] : undefined
+    lazySearch: vm.searchInput
   }),
 
   computed: {
@@ -338,15 +335,11 @@ export default {
       this.setSearch()
     },
     setSelectedItems () {
-      if (this.internalValue === undefined) {
-        this.selectedItems = []
-      } else {
-        VSelect.methods.setSelectedItems.call(this)
+      VSelect.methods.setSelectedItems.call(this)
 
-        // #4273 Don't replace if searching
-        // #4403 Don't replace is focused
-        if (!this.isFocused) this.setSearch()
-      }
+      // #4273 Don't replace if searching
+      // #4403 Don't replace is focused
+      if (!this.isFocused) this.setSearch()
     },
     setSearch () {
       // Wait for nextTick so selectedItem

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -121,7 +121,7 @@ export default {
     // As long as a value is defined, show it
     // Otherwise, check if multiple
     // to determine which default to provide
-    lazyValue: vm.value != null
+    lazyValue: vm.value !== undefined
       ? vm.value
       : vm.multiple ? [] : undefined,
     selectedIndex: -1,

--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -267,7 +267,7 @@ export default {
       this.isMenuActive = true
     },
     clearableCallback () {
-      this.internalValue = this.multiple ? [] : null
+      this.internalValue = this.multiple ? [] : undefined
       this.$emit('change', this.internalValue)
       this.$nextTick(() => this.$refs.input.focus())
 

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -690,7 +690,7 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
 
     icon.trigger('click')
 
-    expect(wrapper.vm.internalSearch).toBe(null)
+    expect(wrapper.vm.internalSearch).toBe(undefined)
   })
 
   it('should propagate content class', () => {

--- a/test/unit/components/VSelect/VSelect2.spec.js
+++ b/test/unit/components/VSelect/VSelect2.spec.js
@@ -51,8 +51,8 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.vm.internalValue).toBe(null)
-    expect(input).toHaveBeenCalledWith(null)
+    expect(wrapper.vm.internalValue).toBe(undefined)
+    expect(input).toHaveBeenCalledWith(undefined)
   })
 
   it('should be clearable with prop, dirty and single select', async () => {
@@ -73,7 +73,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     clear.trigger('click')
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.internalValue).toBe(null)
+    expect(wrapper.vm.internalValue).toBe(undefined)
     expect(wrapper.vm.isMenuActive).toBe(false)
   })
 

--- a/test/unit/components/VSelect/VSelect3.spec.js
+++ b/test/unit/components/VSelect/VSelect3.spec.js
@@ -105,4 +105,31 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     // Will be undefined if fails
     expect(wrapper.vm.listData.on).toBeTruthy()
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/4431
+  it('should accept null and "" as values', async () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        clearable: true,
+        items: [
+          { text: 'Foo', value: null },
+          { text: 'Bar', value: 'bar' }
+        ],
+        value: null
+      },
+    })
+
+    const icon = wrapper.first('.v-input__append-inner .v-icon')
+
+    expect(wrapper.vm.selectedItems.length).toBe(1)
+    expect(wrapper.vm.isDirty).toBe(true)
+
+    icon.trigger('click')
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.selectedItems.length).toBe(0)
+    expect(wrapper.vm.isDirty).toBe(false)
+    expect(wrapper.vm.internalValue).toBe(undefined)
+  })
 })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fixes #4431

Clearable still needs work, if you clear the select it'll revert to `null` and select the first item again. 
~~No idea what those original checks were there for, it seems to work fine and tests still pass.~~
The `internalValue === ''` check was for #4032, but that's a separate component now and doesn't seem to have regressed. 

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
          v-model="selected"
          :items="items"
          label="Standard"
          clearable
      ></v-autocomplete>
      <pre>{{ JSON.stringify(selected) }}</pre>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      selected: null,
      items: [
        { text: 'all of them', value: null },
        { text: 'fizz', value: 'Fizz' },
        { text: 'buzz', value: 'Buzz' },
        { text: 'foo', value: 'Foo' }
      ]
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
