### PR TITLE
Allow for more customisability - New slot for the VDataTable

### DIFF
--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -465,10 +465,11 @@ export default {
       const rangeControls = this.$createElement('div', {
         'class': this.actionsRangeControlsClasses
       }, [
+        this.$slots['actions-prepend'] ? this.$createElement('div', {}, this.$slots['actions-prepend']) : null,
         this.genPagination(),
         this.genPrevIcon(),
         this.genNextIcon(),
-        this.$slots['actions-extras'] ? this.$createElement('div', {}, this.$slots['actions-extras']) : null
+        this.$slots['actions-append'] ? this.$createElement('div', {}, this.$slots['actions-append']) : null
       ])
 
       return [this.$createElement('div', {

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -467,7 +467,8 @@ export default {
       }, [
         this.genPagination(),
         this.genPrevIcon(),
-        this.genNextIcon()
+        this.genNextIcon(),
+        this.$slots['actions-extras'] ? this.$createElement('div', {}, this.$slots['actions-extras']) : null
       ])
 
       return [this.$createElement('div', {

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -465,18 +465,18 @@ export default {
       const rangeControls = this.$createElement('div', {
         'class': this.actionsRangeControlsClasses
       }, [
-        this.$slots['actions-prepend'] ? this.$createElement('div', {}, this.$slots['actions-prepend']) : null,
         this.genPagination(),
         this.genPrevIcon(),
-        this.genNextIcon(),
-        this.$slots['actions-append'] ? this.$createElement('div', {}, this.$slots['actions-append']) : null
+        this.genNextIcon()
       ])
 
       return [this.$createElement('div', {
         'class': this.actionsClasses
       }, [
+        this.$slots['actions-prepend'] ? this.$createElement('div', {}, this.$slots['actions-prepend']) : null,
         this.rowsPerPageItems.length > 1 ? this.genSelect() : null,
-        rangeControls
+        rangeControls,
+        this.$slots['actions-append'] ? this.$createElement('div', {}, this.$slots['actions-append']) : null
       ])]
     }
   }


### PR DESCRIPTION
## Description
Added a scoped slot for adding additional things to the data table's actions footer.

## Motivation and Context
It allows for more customisability. Currently, to add anything to the actions footer one needs to remake whole table's footer.

## How Has This Been Tested?
Visually

#### Before
![](https://i.imgur.com/rMPzWp4.png)
#### After (gives possibility to append anything)
![](https://i.imgur.com/R1rg4R9.png)

## Markup:
<details>

```vue
<template>
  <v-data-table
    :headers="headers"
    :items="desserts"
    hide-actions
    class="elevation-1"
  >
    <template slot="items" slot-scope="props">
      <td>{{ props.item.name }}</td>
      <td class="text-xs-right">{{ props.item.calories }}</td>
      <td class="text-xs-right">{{ props.item.fat }}</td>
      <td class="text-xs-right">{{ props.item.carbs }}</td>
      <td class="text-xs-right">{{ props.item.protein }}</td>
      <td class="text-xs-right">{{ props.item.iron }}</td>
    </template>

    <!-- What was added -->

    <template slot="actions-extras">
      <v-btn color="green">New</v-btn>
    </template>
    
    <!-- /What was added -->

  </v-data-table>
</template>

<script>
  export default {
    data () {
      return {
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name'
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' }
        ],
        desserts: [
          {
            value: false,
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%'
          }
        ]
      }
    }
  }
</script>
```

</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
