### PR TITLE
Fix divider color on navigation drawer and steppers

### DIFF
--- a/src/stylus/components/_navigation-drawer.styl
+++ b/src/stylus/components/_navigation-drawer.styl
@@ -9,7 +9,7 @@ v-navigation-drawer($material)
       background-color: $material.dividers
 
   .v-divider
-    background-color: $material.dividers
+    border-color: $material.dividers
 
 theme(v-navigation-drawer, "v-navigation-drawer")
 

--- a/src/stylus/components/_steppers.styl
+++ b/src/stylus/components/_steppers.styl
@@ -17,7 +17,7 @@ v-stepper($material)
 
   .v-stepper__header
     .v-divider
-      background: rgba($material.fg-color, $material.divider-percent)
+      border-color: rgba($material.fg-color, $material.divider-percent)
 
   .v-stepper__step
     &--active


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
The default divider uses `border-color` to set its color.
So, navigation drawer and stepper should overwrite the divider `border-color`, not its `background`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Different divider colors on navigation drawer and stepper.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
none

## Markup:
<!--- Paste markup for testing your change --->
All `<v-divider>` should have the same color in the codepen markup below:
Light theme: https://codepen.io/anon/pen/KBvwqN?&editors=101
Dark theme: https://codepen.io/anon/pen/BPdydN?&editors=101

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
