### PR TITLE
fix(v-stepper-content): visibility desync

### DIFF
--- a/src/components/VStepper/VStepperContent.js
+++ b/src/components/VStepper/VStepperContent.js
@@ -103,7 +103,7 @@ export default {
       this.height = 0
 
       // Give the collapsing element time to collapse
-      setTimeout(() => (this.height = (scrollHeight || 'auto')), 450)
+      setTimeout(() => this.isActive && (this.height = (scrollHeight || 'auto')), 450)
     },
     leave () {
       this.height = this.$refs.wrapper.clientHeight

--- a/test/unit/components/VStepper/VStepperContent.spec.js
+++ b/test/unit/components/VStepper/VStepperContent.spec.js
@@ -102,6 +102,10 @@ test('VStepperContent.js', ({ mount }) => {
       attachToDocument: true,
       propsData: { step: 1 }
     })
+    
+    wrapper.setData({ isActive: false })
+    
+    await wrapper.vm.$nextTick()
 
     wrapper.setData({ isActive: true })
 
@@ -123,6 +127,10 @@ test('VStepperContent.js', ({ mount }) => {
       attachToDocument: true,
       propsData: { step: 1 }
     })
+
+    wrapper.setData({ isActive: false })
+    
+    await wrapper.vm.$nextTick()
 
     wrapper.setData({ isActive: true })
     

--- a/test/unit/components/VStepper/VStepperContent.spec.js
+++ b/test/unit/components/VStepper/VStepperContent.spec.js
@@ -103,7 +103,7 @@ test('VStepperContent.js', ({ mount }) => {
       propsData: { step: 1 }
     })
 
-    wrapper.vm.enter()
+    wrapper.setData({ isActive: true })
 
     expect(wrapper.vm.height).toBe(0)
 
@@ -111,9 +111,28 @@ test('VStepperContent.js', ({ mount }) => {
 
     expect(wrapper.vm.height).toBe('auto')
 
-    wrapper.vm.leave()
+    wrapper.setData({ isActive: false })
 
     await new Promise(resolve => setTimeout(resolve, 10))
+
+    expect(wrapper.vm.height).toBe(0)
+  })
+  
+  it('should set height only if isActive', async () => {
+    const wrapper = mount(VStepperContent, {
+      attachToDocument: true,
+      propsData: { step: 1 }
+    })
+
+    wrapper.setData({ isActive: true })
+    
+    await wrapper.vm.$nextTick()
+    
+    expect(wrapper.vm.height).toBe(0)
+    
+    wrapper.setData({ isActive: false })
+    
+    await new Promise(resolve => setTimeout(resolve, 450))
 
     expect(wrapper.vm.height).toBe(0)
   })

--- a/test/unit/components/VStepper/VStepperContent.spec.js
+++ b/test/unit/components/VStepper/VStepperContent.spec.js
@@ -100,7 +100,7 @@ test('VStepperContent.js', ({ mount }) => {
   it('should set height', async () => {
     const wrapper = mount(VStepperContent, {
       attachToDocument: true,
-      propsData: { step: 1 }
+      propsData: { step: 1, isVertical: true }
     })
     
     wrapper.setData({ isActive: false })
@@ -125,7 +125,7 @@ test('VStepperContent.js', ({ mount }) => {
   it('should set height only if isActive', async () => {
     const wrapper = mount(VStepperContent, {
       attachToDocument: true,
-      propsData: { step: 1 }
+      propsData: { step: 1, isVertical: true }
     })
 
     wrapper.setData({ isActive: false })

--- a/test/unit/components/VStepper/VStepperContent.spec.js
+++ b/test/unit/components/VStepper/VStepperContent.spec.js
@@ -100,10 +100,10 @@ test('VStepperContent.js', ({ mount }) => {
   it('should set height', async () => {
     const wrapper = mount(VStepperContent, {
       attachToDocument: true,
-      propsData: { step: 1, isVertical: true }
+      propsData: { step: 1 }
     })
     
-    wrapper.setData({ isActive: false })
+    wrapper.setData({ isActive: false, isVertical: true })
     await wrapper.vm.$nextTick()
 
     wrapper.setData({ isActive: true })
@@ -126,10 +126,10 @@ test('VStepperContent.js', ({ mount }) => {
   it('should set height only if isActive', async () => {
     const wrapper = mount(VStepperContent, {
       attachToDocument: true,
-      propsData: { step: 1, isVertical: true }
+      propsData: { step: 1 }
     })
 
-    wrapper.setData({ isActive: false })
+    wrapper.setData({ isActive: false, isVertical: true })
     await wrapper.vm.$nextTick()
 
     wrapper.setData({ isActive: true })

--- a/test/unit/components/VStepper/VStepperContent.spec.js
+++ b/test/unit/components/VStepper/VStepperContent.spec.js
@@ -104,10 +104,10 @@ test('VStepperContent.js', ({ mount }) => {
     })
     
     wrapper.setData({ isActive: false })
-    
     await wrapper.vm.$nextTick()
 
     wrapper.setData({ isActive: true })
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.height).toBe(0)
 
@@ -116,6 +116,7 @@ test('VStepperContent.js', ({ mount }) => {
     expect(wrapper.vm.height).toBe('auto')
 
     wrapper.setData({ isActive: false })
+    await wrapper.vm.$nextTick()
 
     await new Promise(resolve => setTimeout(resolve, 10))
 
@@ -129,16 +130,15 @@ test('VStepperContent.js', ({ mount }) => {
     })
 
     wrapper.setData({ isActive: false })
-    
     await wrapper.vm.$nextTick()
 
     wrapper.setData({ isActive: true })
-    
     await wrapper.vm.$nextTick()
     
     expect(wrapper.vm.height).toBe(0)
     
     wrapper.setData({ isActive: false })
+    await wrapper.vm.$nextTick()
     
     await new Promise(resolve => setTimeout(resolve, 450))
 


### PR DESCRIPTION
Fixed a desync issue with the visibility of `v-stepper-content`.

## Description
Added a test for `this.isActive` before setting `this.height` in a `setTimeout`-called function.

## Motivation and Context
The issue occurs when toggling the visibility (via `toggle`) faster than the `setTimeout`'s 450ms.

## How Has This Been Tested?
yes, i also added an additional test that fails w/o the fix

## Markup
<details>

```vue

<template>
  <v-app class="ma-4">
    <v-stepper v-model="step" vertical>
      <template v-for="i of steps">
        <v-stepper-step :complete="step > i" :step="i">
          Step {{i}}
        </v-stepper-step>
        <v-stepper-content :step="i">
          Some text
        </v-stepper-content>
      </template>
    </v-stepper>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        step: 0,
        steps: 3,
      }
    },
    async mounted() {
      this.step = 1;
      await new Promise(resolve => setTimeout(resolve, 100));
      this.step = 2;
    }
  }
</script>

```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
