### PR TITLE
Add appear prop to VSnackbar to enable transition on load

### DIFF
--- a/src/components/VSnackbar/VSnackbar.ts
+++ b/src/components/VSnackbar/VSnackbar.ts
@@ -16,6 +16,10 @@ export default mixins(
   name: 'v-snackbar',
 
   props: {
+    appear: {
+      type: Boolean,
+      default: false,
+    },
     autoHeight: Boolean,
     multiLine: Boolean,
     // TODO: change this to closeDelay to match other API in delayable.js
@@ -92,7 +96,7 @@ export default mixins(
     }
 
     return h('transition', {
-      attrs: { name: 'v-snack-transition' }
+      attrs: { name: 'v-snack-transition', appear: this.appear }
     }, children)
   }
 })

--- a/src/components/VSnackbar/VSnackbar.ts
+++ b/src/components/VSnackbar/VSnackbar.ts
@@ -18,7 +18,7 @@ export default mixins(
   props: {
     appear: {
       type: Boolean,
-      default: false,
+      default: false
     },
     autoHeight: Boolean,
     multiLine: Boolean,


### PR DESCRIPTION
## Description
Adds an `appear` prop which is passed along to the transition component, allowing the snackbar transition to run on page load.  Ref:
https://vuejs.org/v2/guide/transitions.html#Transitions-on-Initial-Render

## Motivation and Context
I wanted the snackbar slide animation for a snackbar that is displayed on page load.

## How Has This Been Tested?
I couldn't think of a good way to test this functionality in a unit test.  Perhaps it could check that the appropriate CSS classes are set?  Wasn't sure that was necessary in this case, since it's just passing the prop to Vue.  It is working fine in my dev environment.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<v-snackbar appear/>
```

</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
