### PR TITLE
Fix(V-Btn): resolve heavy CPU usage in IE11

### DIFF
--- a/src/stylus/components/_buttons.styl
+++ b/src/stylus/components/_buttons.styl
@@ -52,7 +52,6 @@ theme(button, "v-btn")
     top: 0
     height: 100%
     opacity: .12
-    transition: $primary-transition
     width: 100%
 
 /** Content */


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This solves the CPU usage in IE11 by removing the transition from the `::before` pseudo class, this didn't seem to have any visual impact since the v-btn itself keeps the transition. this is my first PR so if this approach is wrong please tell me so I can learn from it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/vuetifyjs/vuetify/issues/4873
https://github.com/vuetifyjs/vuetify/issues/4045

## How Has This Been Tested?
visually + CPU profiler in IE11

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
    <v-btn>Test</v-btn>
  </div>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
