### PR TITLE
Feat/v autocomplete issue4663 - open on items change

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -47,7 +47,7 @@ export default {
     noFilter: Boolean,
     openOnItemsChanged: {
       type: Boolean,
-      default: true
+      default: false
     },
     searchInput: {
       default: undefined

--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -45,6 +45,10 @@ export default {
     },
     hideNoData: Boolean,
     noFilter: Boolean,
+    openOnItemsChanged: {
+      type: Boolean,
+      default: true
+    },
     searchInput: {
       default: undefined
     },
@@ -180,6 +184,7 @@ export default {
       // User is probably async loading
       // items, try to activate the menu
       if (
+        this.openOnItemsChanged &&
         this.isFocused &&
         !this.isMenuActive &&
         val.length

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -744,4 +744,45 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
 
     expect(wrapper.vm.isMenuActive).toBe(true)
   })
+
+  it('should open the menu when focused and items change', async () => {
+    const wrapper = mount(VAutocomplete, {
+      propsData: {
+        value: 1,
+        items: []
+      }
+    })
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
+
+    const input = wrapper.first('input')
+    input.trigger('focus')
+
+    await wrapper.vm.$nextTick()
+    wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.isMenuActive).toBe(true)
+  })
+
+  it('should not open the menu when focused and items change and configured not to', async () => {
+    const wrapper = mount(VAutocomplete, {
+      propsData: {
+        value: 1,
+        items: [],
+        openOnItemsChanged: false
+      }
+    })
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
+
+    const input = wrapper.first('input')
+    input.trigger('focus')
+
+    await wrapper.vm.$nextTick()
+    wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
+  })
 })

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -230,20 +230,6 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.isMenuActive).toBe(false)
-
-    wrapper.setProps({
-      items: [
-        { text: 'Foo', value: 1 },
-        { text: 'Bar', value: 2 }
-      ]
-    })
-
-    await wrapper.vm.$nextTick()
-
-    // Once items refresh active will
-    // be updated to openif already
-    // focused
-    expect(wrapper.vm.isMenuActive).toBe(true)
   })
 
   it('should change selected index', async () => {
@@ -721,31 +707,7 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     expect(input.element.value).toBe('foo')
   })
 
-  it('should show menu when items are added and hide-no-data', async () => {
-    const wrapper = mount(VAutocomplete, {
-      propsData: {
-        hideNoData: true,
-        items: []
-      }
-    })
-
-    const input = wrapper.first('input')
-
-    input.trigger('focus')
-
-    expect(wrapper.vm.isMenuActive).toBe(false)
-    expect(wrapper.vm.isFocused).toBe(true)
-
-    wrapper.setProps({
-      items: ['Foo', 'Bar']
-    })
-
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.vm.isMenuActive).toBe(true)
-  })
-
-  it('should open the menu when focused and items change', async () => {
+  it('by default should not open the menu when focused and items change', async () => {
     const wrapper = mount(VAutocomplete, {
       propsData: {
         value: 1,
@@ -753,36 +715,36 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
       }
     })
 
-    expect(wrapper.vm.isMenuActive).toBe(false)
-
     const input = wrapper.first('input')
     input.trigger('focus')
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
 
     await wrapper.vm.$nextTick()
     wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.vm.isMenuActive).toBe(true)
+    expect(wrapper.vm.isMenuActive).toBe(false)
   })
 
-  it('should not open the menu when focused and items change and configured not to', async () => {
+  it('should open the menu when focused and items change and the openOnItemsChanged prop has been set', async () => {
     const wrapper = mount(VAutocomplete, {
       propsData: {
         value: 1,
         items: [],
-        openOnItemsChanged: false
+        openOnItemsChanged: true
       }
     })
 
-    expect(wrapper.vm.isMenuActive).toBe(false)
-
     const input = wrapper.first('input')
     input.trigger('focus')
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
 
     await wrapper.vm.$nextTick()
     wrapper.setProps({ items: [{ text: 'foo', value: 1 }] })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.vm.isMenuActive).toBe(false)
+    expect(wrapper.vm.isMenuActive).toBe(true)
   })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Adds a prop for controlling the behaviour of opening the menu when the input holds focus and the `items` change.  Current behaviour is to open the menu (when not already open) in all cases.  The prop allows this behaviour to be overridden. 

## Motivation and Context
This gives the client more flexibility in controlling when the menu is invoked.  Partially fixes #4663 

Default behaviour has been maintained in this PR, but given how many developers have been reporting it as a bug, there may be merit in changing default behaviour to suppress the menu opening instead.

## How Has This Been Tested?
There are specs included in the PR demonstrating existing default behaviour, as well as (new) overridden behaviour to suppress the menu from being invoked. 

I have also tested the changes manually in a local environment.

## Markup:
<!--- Paste markup for testing your change --->
<details>

Standard (will become default with the proposed solution) use case, autocomplete does not open when items change:
```vue
<v-btn label="Change contact types" @click="changesContactTypesImmediately">Change</v-btn>

<v-autocomplete :items="filteredContactNames(contactTypes)"
                :label="contactLabel"
                :item-text="contactName"
                v-model="contact">
</v-autocomplete>
```

Use case where there is an async call responsible for updating `items`, and the clients wishes for the menu to open when the call finishes and the menu holds focus:
```vue
<v-autocomplete :items="filteredContactNames(contactTypes)"
                :label="contactLabel"
                :item-text="contactName"
                open-on-items-changed
                v-model="contact">
</v-autocomplete>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
    - addresses a 'bug' issue, but I would argue is closer to new functionality.
- [x] New feature (non-breaking change which adds functionality) 
    - as per the new prop
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).  
    - I think this could be argued either way - I've targeted `dev` considering the new prop.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
    - will wait for initial feedback on this PR
