### PR TITLE
[New feature] Mouseover event for VDatePicker #4884

### DIFF
--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -355,8 +355,8 @@ export default {
         ref: 'table',
         on: {
           input: this.dateClick,
-          mouseenter: this.dateMouseEnter,
-          mouseleave: this.dateMouseLeave,
+          dateMouseEnter: this.dateMouseEnter,
+          dateMouseLeave: this.dateMouseLeave,
           tableDate: value => this.tableDate = value
         }
       })

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -246,7 +246,6 @@ export default {
             : this.value.filter(x => x !== newInput)
         )
         : newInput
-
       this.$emit('input', output)
       this.multiple || this.$emit('change', newInput)
     },
@@ -287,6 +286,22 @@ export default {
       this.inputMonth = parseInt(value.split('-')[1], 10) - 1
       this.inputDay = parseInt(value.split('-')[2], 10)
       this.emitInput(this.inputDate)
+    },
+    mouseEnter (value) {
+      this.inputYear = parseInt(value.split('-')[0], 10)
+      this.inputMonth = parseInt(value.split('-')[1], 10) - 1
+      this.inputDay = parseInt(value.split('-')[2], 10)
+      const output = this.multiple
+        ? (
+          this.value.indexOf(value) === -1
+            ? this.value.concat([value])
+            : this.value.filter(x => x !== value)
+        )
+        : value
+      this.$emit('mouseover', output)
+    },
+    mouseLeave () {
+      this.$emit('mouseover', null)
     },
     genPickerTitle () {
       return this.$createElement(VDatePickerTitle, {
@@ -350,6 +365,8 @@ export default {
         ref: 'table',
         on: {
           input: this.dateClick,
+          mouseenter: this.mouseEnter,
+          mouseleave: this.mouseLeave,
           tableDate: value => this.tableDate = value
         }
       })

--- a/src/components/VDatePicker/VDatePicker.js
+++ b/src/components/VDatePicker/VDatePicker.js
@@ -287,21 +287,11 @@ export default {
       this.inputDay = parseInt(value.split('-')[2], 10)
       this.emitInput(this.inputDate)
     },
-    mouseEnter (value) {
-      this.inputYear = parseInt(value.split('-')[0], 10)
-      this.inputMonth = parseInt(value.split('-')[1], 10) - 1
-      this.inputDay = parseInt(value.split('-')[2], 10)
-      const output = this.multiple
-        ? (
-          this.value.indexOf(value) === -1
-            ? this.value.concat([value])
-            : this.value.filter(x => x !== value)
-        )
-        : value
-      this.$emit('mouseover', output)
+    dateMouseEnter (value) {
+      this.$emit('date-mouse-enter', value)
     },
-    mouseLeave () {
-      this.$emit('mouseover', null)
+    dateMouseLeave (value) {
+      this.$emit('date-mouse-leave', value)
     },
     genPickerTitle () {
       return this.$createElement(VDatePickerTitle, {
@@ -365,8 +355,8 @@ export default {
         ref: 'table',
         on: {
           input: this.dateClick,
-          mouseenter: this.mouseEnter,
-          mouseleave: this.mouseLeave,
+          mouseenter: this.dateMouseEnter,
+          mouseleave: this.dateMouseLeave,
           tableDate: value => this.tableDate = value
         }
       })

--- a/src/components/VDatePicker/mixins/date-picker-table.js
+++ b/src/components/VDatePicker/mixins/date-picker-table.js
@@ -87,7 +87,7 @@ export default {
         on: (this.disabled || !isAllowed) ? {} : {
           click: () => this.$emit('input', value),
           mouseenter: () => this.$emit('mouseenter', value),
-          mouseleave: () => this.$emit('mouseleave')
+          mouseleave: () => this.$emit('mouseleave', value)
         }
       }))
     },

--- a/src/components/VDatePicker/mixins/date-picker-table.js
+++ b/src/components/VDatePicker/mixins/date-picker-table.js
@@ -85,7 +85,9 @@ export default {
           innerHTML: `<div class="v-btn__content">${this.formatter(value)}</div>`
         },
         on: (this.disabled || !isAllowed) ? {} : {
-          click: () => this.$emit('input', value)
+          click: () => this.$emit('input', value),
+          mouseenter: () => this.$emit('mouseenter', value),
+          mouseleave: () => this.$emit('mouseleave')
         }
       }))
     },

--- a/src/components/VDatePicker/mixins/date-picker-table.js
+++ b/src/components/VDatePicker/mixins/date-picker-table.js
@@ -86,8 +86,8 @@ export default {
         },
         on: (this.disabled || !isAllowed) ? {} : {
           click: () => this.$emit('input', value),
-          mouseenter: () => this.$emit('mouseenter', value),
-          mouseleave: () => this.$emit('mouseleave', value)
+          mouseenter: () => this.$emit('dateMouseEnter', value),
+          mouseleave: () => this.$emit('dateMouseLeave', value)
         }
       }))
     },

--- a/test/unit/components/VDatePicker/VDatePicker.date.spec.js
+++ b/test/unit/components/VDatePicker/VDatePicker.date.spec.js
@@ -56,6 +56,34 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     expect(change).toBeCalledWith('2013-05-05')
   })
 
+  it('should emit mouseenter event on date hover', async () => {
+    const wrapper = mount(VDatePicker, {
+      propsData: {
+        value: '2013-05-07'
+      }
+    })
+
+    const mouseenter = jest.fn()
+    wrapper.vm.$on('mouseover', mouseenter)
+
+    wrapper.find('.v-date-picker-table--date tbody tr+tr td:first-child button')[0].trigger('mouseenter')
+    expect(mouseenter).toBeCalledWith('2013-05-05')
+  })
+
+  it('should emit mouseover null event on date mouseleave', async () => {
+    const wrapper = mount(VDatePicker, {
+      propsData: {
+        value: '2013-05-07'
+      }
+    })
+
+    const mouseleave = jest.fn()
+    wrapper.vm.$on('mouseover', mouseleave)
+
+    wrapper.find('.v-date-picker-table--date tbody tr+tr td:first-child button')[0].trigger('mouseleave')
+    expect(mouseleave).toBeCalledWith(null)
+  })
+
   it('should not emit input event on month click if date is not allowed', async () => {
     const cb = jest.fn()
     const wrapper = mount(VDatePicker, {

--- a/test/unit/components/VDatePicker/VDatePicker.date.spec.js
+++ b/test/unit/components/VDatePicker/VDatePicker.date.spec.js
@@ -56,7 +56,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     expect(change).toBeCalledWith('2013-05-05')
   })
 
-  it('should emit mouseenter event on date hover', async () => {
+  it('should emit date-mouse-enter event on date mouseenter', async () => {
     const wrapper = mount(VDatePicker, {
       propsData: {
         value: '2013-05-07'
@@ -64,13 +64,13 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     })
 
     const mouseenter = jest.fn()
-    wrapper.vm.$on('mouseover', mouseenter)
+    wrapper.vm.$on('date-mouse-enter', mouseenter)
 
     wrapper.find('.v-date-picker-table--date tbody tr+tr td:first-child button')[0].trigger('mouseenter')
     expect(mouseenter).toBeCalledWith('2013-05-05')
   })
 
-  it('should emit mouseover null event on date mouseleave', async () => {
+  it('should emit date-mouse-leave event on date mouseleave', async () => {
     const wrapper = mount(VDatePicker, {
       propsData: {
         value: '2013-05-07'
@@ -78,10 +78,10 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     })
 
     const mouseleave = jest.fn()
-    wrapper.vm.$on('mouseover', mouseleave)
+    wrapper.vm.$on('date-mouse-leave', mouseleave)
 
     wrapper.find('.v-date-picker-table--date tbody tr+tr td:first-child button')[0].trigger('mouseleave')
-    expect(mouseleave).toBeCalledWith(null)
+    expect(mouseleave).toBeCalledWith('2013-05-05')
   })
 
   it('should not emit input event on month click if date is not allowed', async () => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added two additional events @date-mouse-enter and @date-mouse-leave that returns the date value on hover.

`<v-date-picker @date-mouse-enter="mouseEnter($event)" @date-mouse-leave="mouseLeave($event)"`

## Motivation and Context
Idea is to display the list of events for the hovered date in a small popup. On date click, user be will shown the detailed view. Currently, v-date-picker only supports @input. Thus the events introduced in this MR, @date-mouse-enter and @date-mouse-leave, could come in handy for such use cases.

fixes #4884 

## How Has This Been Tested?
Added new unit test cases

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-date-picker 
      @date-mouse-enter="mouseEnter($event)" 
      @date-mouse-leave="mouseLeave($event)">
    </v-date-picker>
  </v-app>
</template>

<script>
  export default {
    methods: {
      mouseEnter(dateValue) {
        //Event handler
      },
      mouseLeave (dateValue) {
        //Event handler
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
