### PR TITLE
feat(VTimePicker): readonly prop

### DIFF
--- a/src/components/VDatePicker/VDatePickerTitle.js
+++ b/src/components/VDatePicker/VDatePickerTitle.js
@@ -58,7 +58,7 @@ export default {
       return this.genPickerButton('selectingYear', true, [
         this.year,
         this.yearIcon ? this.genYearIcon() : null
-      ], 'v-date-picker-title__year')
+      ], false, 'v-date-picker-title__year')
     },
     genTitleText () {
       return this.$createElement('transition', {
@@ -73,7 +73,7 @@ export default {
       ])
     },
     genTitleDate (title) {
-      return this.genPickerButton('selectingYear', false, this.genTitleText(title), 'v-date-picker-title__date')
+      return this.genPickerButton('selectingYear', false, this.genTitleText(title), false, 'v-date-picker-title__date')
     }
   },
 

--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -32,6 +32,7 @@ export default {
     },
     min: String,
     max: String,
+    readonly: Boolean,
     scrollable: Boolean,
     value: null
   },
@@ -170,6 +171,7 @@ export default {
           light: this.light,
           max: this.selectingHour ? (this.isAmPm && this.period === 'am' ? 11 : 23) : 59,
           min: this.selectingHour && this.isAmPm && this.period === 'pm' ? 12 : 0,
+          readonly: this.readonly,
           scrollable: this.scrollable,
           size: this.width - ((!this.fullWidth && this.landscape) ? 80 : 20),
           step: this.selectingHour ? 1 : 5,
@@ -199,6 +201,7 @@ export default {
           hour: this.inputHour,
           minute: this.inputMinute,
           period: this.period,
+          readonly: this.readonly,
           selectingHour: this.selectingHour
         },
         on: {

--- a/src/components/VTimePicker/VTimePickerClock.js
+++ b/src/components/VTimePicker/VTimePickerClock.js
@@ -29,6 +29,7 @@ export default {
       required: true
     },
     scrollable: Boolean,
+    readonly: Boolean,
     rotate: {
       type: Number,
       default: 0
@@ -215,7 +216,7 @@ export default {
         'v-time-picker-clock--indeterminate': this.value == null,
         ...this.themeClasses
       },
-      on: {
+      on: this.readonly ? undefined : {
         mousedown: this.onMouseDown,
         mouseup: this.onMouseUp,
         mouseleave: () => (this.isDragging && this.onMouseUp()),
@@ -231,7 +232,7 @@ export default {
       ref: 'clock'
     }
 
-    this.scrollable && (data.on.wheel = this.wheel)
+    !this.readonly && this.scrollable && (data.on.wheel = this.wheel)
 
     return this.$createElement('div', data, [
       this.genHand(),

--- a/src/components/VTimePicker/VTimePickerTitle.js
+++ b/src/components/VTimePicker/VTimePickerTitle.js
@@ -20,6 +20,7 @@ export default {
       type: String,
       validator: period => period === 'am' || period === 'pm'
     },
+    readonly: Boolean,
     selectingHour: Boolean
   },
 
@@ -45,8 +46,8 @@ export default {
       return this.$createElement('div', {
         staticClass: 'v-time-picker-title__ampm'
       }, [
-        this.genPickerButton('period', 'am', 'am'),
-        this.genPickerButton('period', 'pm', 'pm')
+        this.genPickerButton('period', 'am', 'am', this.readonly),
+        this.genPickerButton('period', 'pm', 'pm', this.readonly)
       ])
     }
   },

--- a/src/mixins/picker-button.js
+++ b/src/mixins/picker-button.js
@@ -1,7 +1,7 @@
 /* @vue/component */
 export default {
   methods: {
-    genPickerButton (prop, value, content, staticClass = '') {
+    genPickerButton (prop, value, content, readonly = false, staticClass = '') {
       const active = this[prop] === value
       const click = event => {
         event.stopPropagation()
@@ -10,8 +10,11 @@ export default {
 
       return this.$createElement('div', {
         staticClass: `v-picker__title__btn ${staticClass}`.trim(),
-        'class': { active },
-        on: active ? undefined : { click }
+        'class': {
+          'v-picker__title__btn--active': active,
+          'v-picker__title__btn--readonly': readonly
+        },
+        on: (active || readonly) ? undefined : { click }
       }, Array.isArray(content) ? content : [content])
     }
   }

--- a/src/stylus/components/_pickers.styl
+++ b/src/stylus/components/_pickers.styl
@@ -32,15 +32,19 @@ theme(v-picker-body, 'v-picker__body')
 .v-picker__title__btn
   transition: $primary-transition
 
-  &.active
-    opacity: 1
-
   &:not(.active)
     opacity: .6
     cursor: pointer
 
     &:hover
       opacity: 1
+
+.v-picker__title__btn--readonly
+  pointer-events: none
+
+
+.v-picker__title__btn--active
+    opacity: 1
 
 .v-picker__body
   height: auto

--- a/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -8,7 +8,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2005
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Tue, Nov 1
         </div>
@@ -377,7 +377,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2005
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Tue, Nov 1
         </div>
@@ -746,7 +746,7 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2013
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Tue, May 7
         </div>
@@ -1126,7 +1126,7 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2013
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Tue, May 7
         </div>
@@ -1510,7 +1510,7 @@ exports[`VDatePicker.js should match snapshot with year icon 1`] = `
         year
       </i>
     </div>
-    <div class="v-picker__title__btn v-date-picker-title__date active">
+    <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
       <div>
         Tue, Nov 1
       </div>
@@ -1528,7 +1528,7 @@ exports[`VDatePicker.js should render component with min/max props 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2013
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Mon, Jan 7
         </div>
@@ -1924,7 +1924,7 @@ exports[`VDatePicker.js should render component with min/max props 2`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2013
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Mon, Jan 7
         </div>
@@ -2483,7 +2483,7 @@ exports[`VDatePicker.js should render component with min/max props 3`] = `
 <div class="v-picker v-card v-picker--date theme--light">
   <div class="v-picker__title primary">
     <div class="v-date-picker-title">
-      <div class="v-picker__title__btn v-date-picker-title__year active">
+      <div class="v-picker__title__btn v-date-picker-title__year v-picker__title__btn--active">
         2013
       </div>
       <div class="v-picker__title__btn v-date-picker-title__date">
@@ -3057,7 +3057,7 @@ exports[`VDatePicker.js should render readonly picker 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2013
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           Tue, May 7
         </div>

--- a/test/unit/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
+++ b/test/unit/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
@@ -139,7 +139,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2005
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           November
         </div>
@@ -315,7 +315,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2005
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           November
         </div>
@@ -614,7 +614,7 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
       <div class="v-picker__title__btn v-date-picker-title__year">
         2013
       </div>
-      <div class="v-picker__title__btn v-date-picker-title__date active">
+      <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
         <div>
           May
         </div>

--- a/test/unit/components/VDatePicker/__snapshots__/VDatePickerTitle.spec.js.snap
+++ b/test/unit/components/VDatePicker/__snapshots__/VDatePickerTitle.spec.js.snap
@@ -6,7 +6,7 @@ exports[`VDatePickerTitle.js should render component and match snapshot 1`] = `
   <div class="v-picker__title__btn v-date-picker-title__year">
     1234
   </div>
-  <div class="v-picker__title__btn v-date-picker-title__date active">
+  <div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
     <div>
       2005-11-01
     </div>
@@ -18,7 +18,7 @@ exports[`VDatePickerTitle.js should render component and match snapshot 1`] = `
 exports[`VDatePickerTitle.js should render component when selecting year and match snapshot 1`] = `
 
 <div class="v-date-picker-title">
-  <div class="v-picker__title__btn v-date-picker-title__year active">
+  <div class="v-picker__title__btn v-date-picker-title__year v-picker__title__btn--active">
     1234
   </div>
   <div class="v-picker__title__btn v-date-picker-title__date">

--- a/test/unit/components/VTimePicker/VTimePickerClock.spec.js
+++ b/test/unit/components/VTimePicker/VTimePickerClock.spec.js
@@ -49,6 +49,23 @@ test('VTimePickerClock.js', ({ mount }) => {
     expect(input).toBeCalledWith(3)
   })
 
+  it('should not emit input event on wheel if readonly and scrollable', () => {
+    const wrapper = mount(VTimePickerClock, {
+      propsData: {
+        max: 10,
+        min: 1,
+        value: 6,
+        scrollable: true,
+        readonly: true
+      }
+    })
+
+    const input = jest.fn()
+    wrapper.vm.$on('input', input)
+    wrapper.trigger('wheel')
+    expect(input).not.toBeCalled()
+  })
+
   it('should emit input event on wheel if scrollable and has allowedValues', () => {
     const wrapper = mount(VTimePickerClock, {
       propsData: {
@@ -100,6 +117,27 @@ test('VTimePickerClock.js', ({ mount }) => {
 
     wrapper.trigger('touchend')
     expect(change).toBeCalledWith(55)
+  })
+
+  it('should not emit change event on mouseup/touchend if readonly', () => {
+    const wrapper = mount(VTimePickerClock, {
+      propsData: {
+        value: 59,
+        min: 0,
+        max: 60,
+        readonly: true
+      }
+    })
+
+    const change = jest.fn()
+    wrapper.vm.$on('change', change)
+
+    wrapper.vm.valueOnMouseUp = 55
+    wrapper.trigger('mouseup')
+    expect(change).not.toBeCalled()
+
+    wrapper.trigger('touchend')
+    expect(change).not.toBeCalled()
   })
 
   it('should emit change event on mouseleave', () => {

--- a/test/unit/components/VTimePicker/VTimePickerTitle.spec.js
+++ b/test/unit/components/VTimePicker/VTimePickerTitle.spec.js
@@ -54,9 +54,9 @@ test('VTimePickerTitle.js', ({ mount }) => {
     const period = jest.fn()
     wrapper.vm.$on('update:period', period)
 
-    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn.active')[0].trigger('click')
+    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn--active')[0].trigger('click')
     expect(period).not.toBeCalled()
-    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn:not(.active)')[0].trigger('click')
+    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn:not(.v-picker__title__btn--active)')[0].trigger('click')
     expect(period).toBeCalledWith('am')
 
     wrapper.setProps({
@@ -64,8 +64,26 @@ test('VTimePickerTitle.js', ({ mount }) => {
       minute: 13,
       period: 'am'
     })
-    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn:not(.active)')[0].trigger('click')
+    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn:not(.v-picker__title__btn--active)')[0].trigger('click')
     expect(period).toBeCalledWith('pm')
+  })
+
+  it('should not emit event when clicked on readonly am/pm', async () => {
+    const wrapper = mount(VTimePickerTitle, {
+      propsData: {
+        hour: 14,
+        minute: 13,
+        period: 'pm',
+        ampm: true,
+        readonly: true
+      }
+    })
+
+    const period = jest.fn()
+    wrapper.vm.$on('update:period', period)
+
+    wrapper.find('.v-time-picker-title__ampm .v-picker__title__btn:not(.v-picker__title__btn--active)')[0].trigger('click')
+    expect(period).not.toBeCalled()
   })
 
   it('should emit event when clicked on hours/minutes', async () => {
@@ -88,5 +106,22 @@ test('VTimePickerTitle.js', ({ mount }) => {
     await wrapper.vm.$nextTick()
     wrapper.find('.v-time-picker-title__time .v-picker__title__btn')[1].trigger('click')
     expect(selectingHour).toBeCalledWith(false)
+  })
+
+  it('should emit event when clicked on readonly hours/minutes', async () => {
+    const wrapper = mount(VTimePickerTitle, {
+      propsData: {
+        hour: 14,
+        minute: 13,
+        period: 'pm',
+        readonly: true
+      }
+    })
+
+    const selectingHour = jest.fn()
+    wrapper.vm.$on('update:selectingHour', selectingHour)
+
+    wrapper.find('.v-time-picker-title__time .v-picker__title__btn')[0].trigger('click')
+    expect(selectingHour).toBeCalledWith(true)
   })
 })

--- a/test/unit/components/VTimePicker/__snapshots__/VTimePicker.spec.js.snap
+++ b/test/unit/components/VTimePicker/__snapshots__/VTimePicker.spec.js.snap
@@ -6,7 +6,7 @@ exports[`VTimePicker.js should accept a date object for a value 1`] = `
   <div class="v-picker__title primary">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           12
         </div>
         <span>
@@ -17,7 +17,7 @@ exports[`VTimePicker.js should accept a date object for a value 1`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">
@@ -110,7 +110,7 @@ exports[`VTimePicker.js should accept a value 1`] = `
   <div class="v-picker__title primary">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           9
         </div>
         <span>
@@ -121,7 +121,7 @@ exports[`VTimePicker.js should accept a value 1`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">
@@ -214,7 +214,7 @@ exports[`VTimePicker.js should change am/pm when updated from model 1`] = `
   <div class="v-picker__title primary">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           9
         </div>
         <span>
@@ -225,7 +225,7 @@ exports[`VTimePicker.js should change am/pm when updated from model 1`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">
@@ -318,7 +318,7 @@ exports[`VTimePicker.js should render colored time picker 1`] = `
   <div class="v-picker__title orange darken-1">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           9
         </div>
         <span>
@@ -329,7 +329,7 @@ exports[`VTimePicker.js should render colored time picker 1`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">
@@ -422,7 +422,7 @@ exports[`VTimePicker.js should render colored time picker 2`] = `
   <div class="v-picker__title orange darken-1">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           9
         </div>
         <span>
@@ -433,7 +433,7 @@ exports[`VTimePicker.js should render colored time picker 2`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">
@@ -526,7 +526,7 @@ exports[`VTimePicker.js should render dark time picker 1`] = `
   <div class="v-picker__title">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           --
         </div>
         <span>
@@ -537,7 +537,7 @@ exports[`VTimePicker.js should render dark time picker 1`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">
@@ -630,7 +630,7 @@ exports[`VTimePicker.js should render landscape component 1`] = `
   <div class="v-picker__title v-picker__title--landscape primary">
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           9
         </div>
         <span>
@@ -641,7 +641,7 @@ exports[`VTimePicker.js should render landscape component 1`] = `
         </div>
       </div>
       <div class="v-time-picker-title__ampm">
-        <div class="v-picker__title__btn active">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
           am
         </div>
         <div class="v-picker__title__btn">

--- a/test/unit/components/VTimePicker/__snapshots__/VTimePickerTitle.spec.js.snap
+++ b/test/unit/components/VTimePicker/__snapshots__/VTimePickerTitle.spec.js.snap
@@ -10,7 +10,7 @@ exports[`VTimePickerTitle.js should render component in 12hr 1`] = `
     <span>
       :
     </span>
-    <div class="v-picker__title__btn active">
+    <div class="v-picker__title__btn v-picker__title__btn--active">
       13
     </div>
   </div>
@@ -18,7 +18,7 @@ exports[`VTimePickerTitle.js should render component in 12hr 1`] = `
     <div class="v-picker__title__btn">
       am
     </div>
-    <div class="v-picker__title__btn active">
+    <div class="v-picker__title__btn v-picker__title__btn--active">
       pm
     </div>
   </div>
@@ -36,7 +36,7 @@ exports[`VTimePickerTitle.js should render component in 24hr 1`] = `
     <span>
       :
     </span>
-    <div class="v-picker__title__btn active">
+    <div class="v-picker__title__btn v-picker__title__btn--active">
       13
     </div>
   </div>
@@ -48,7 +48,7 @@ exports[`VTimePickerTitle.js should render component when selecting hour 1`] = `
 
 <div class="v-time-picker-title">
   <div class="v-time-picker-title__time">
-    <div class="v-picker__title__btn active">
+    <div class="v-picker__title__btn v-picker__title__btn--active">
       14
     </div>
     <span>


### PR DESCRIPTION
## Description
Add `readonly` prop to **VTimePicker**

## Motivation and Context
fixes #3715

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content class="pa-5">
      <v-time-picker readonly v-model="time"></v-time-picker>
      <v-time-picker v-model="time"></v-time-picker>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({ time: '12:17' })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
