### PR TITLE
feat(VProgress): normalized value and buffer, add a11y

### DIFF
--- a/src/components/VProgressCircular/VProgressCircular.ts
+++ b/src/components/VProgressCircular/VProgressCircular.ts
@@ -136,6 +136,12 @@ export default mixins(Colorable).extend({
 
     return h('div', this.setTextColor(this.color, {
       staticClass: 'v-progress-circular',
+      attrs: {
+        'role': 'progressbar',
+        'aria-valuemin': 0,
+        'aria-valuemax': 100,
+        'aria-valuenow': this.indeterminate ? undefined : this.normalizedValue
+      },
       class: this.classes,
       style: this.styles,
       on: this.$listeners

--- a/src/components/VProgressCircular/VProgressCircular.ts
+++ b/src/components/VProgressCircular/VProgressCircular.ts
@@ -32,7 +32,7 @@ export default mixins(Colorable).extend({
     },
 
     value: {
-      type: Number,
+      type: [Number, String],
       default: 0
     }
   },
@@ -62,7 +62,7 @@ export default mixins(Colorable).extend({
         return 100
       }
 
-      return this.value
+      return parseInt(this.value, 10)
     },
 
     radius (): number {

--- a/src/components/VProgressLinear/VProgressLinear.ts
+++ b/src/components/VProgressLinear/VProgressLinear.ts
@@ -53,26 +53,6 @@ export default mixins(Colorable).extend({
   },
 
   computed: {
-    styles (): object {
-      const styles: Record<string, any> = {}
-
-      if (!this.active) {
-        styles.height = 0
-      }
-
-      if (!this.indeterminate && parseInt(this.bufferValue, 10) !== 100) {
-        styles.width = `${this.bufferValue}%`
-      }
-
-      return styles
-    },
-    effectiveWidth (): number {
-      if (!this.bufferValue) {
-        return 0
-      }
-
-      return +this.value * 100 / +this.bufferValue
-    },
     backgroundStyle (): object {
       const backgroundOpacity = this.backgroundOpacity == null
         ? (this.backgroundColor ? 1 : 0.3)
@@ -81,8 +61,54 @@ export default mixins(Colorable).extend({
       return {
         height: this.active ? convertToUnit(this.height) : 0,
         opacity: backgroundOpacity,
-        width: `${this.bufferValue}%`
+        width: `${this.normalizedBufer}%`
       }
+    },
+
+    effectiveWidth (): number {
+      if (!this.normalizedBufer) {
+        return 0
+      }
+
+      return +this.normalizedValue * 100 / +this.normalizedBufer
+    },
+
+    normalizedBufer (): number {
+      if (this.bufferValue < 0) {
+        return 0
+      }
+
+      if (this.bufferValue > 100) {
+        return 100
+      }
+
+      return parseInt(this.bufferValue, 10)
+    },
+
+    normalizedValue (): number {
+      if (this.value < 0) {
+        return 0
+      }
+
+      if (this.value > 100) {
+        return 100
+      }
+
+      return parseInt(this.value, 10)
+    },
+
+    styles (): object {
+      const styles: Record<string, any> = {}
+
+      if (!this.active) {
+        styles.height = 0
+      }
+
+      if (!this.indeterminate && parseInt(this.normalizedBufer, 10) !== 100) {
+        styles.width = `${this.normalizedBufer}%`
+      }
+
+      return styles
     }
   },
 
@@ -137,8 +163,8 @@ export default mixins(Colorable).extend({
       attrs: {
         'role': 'progressbar',
         'aria-valuemin': 0,
-        'aria-valuemax': this.bufferValue,
-        'aria-valuenow': this.indeterminate ? undefined : this.value
+        'aria-valuemax': this.normalizedBufer,
+        'aria-valuenow': this.indeterminate ? undefined : this.normalizedValue
       },
       class: {
         'v-progress-linear--query': this.query

--- a/src/components/VProgressLinear/VProgressLinear.ts
+++ b/src/components/VProgressLinear/VProgressLinear.ts
@@ -134,6 +134,12 @@ export default mixins(Colorable).extend({
 
     return h('div', {
       staticClass: 'v-progress-linear',
+      attrs: {
+        'role': 'progressbar',
+        'aria-valuemin': 0,
+        'aria-valuemax': this.bufferValue,
+        'aria-valuenow': this.indeterminate ? undefined : this.value
+      },
       class: {
         'v-progress-linear--query': this.query
       },

--- a/test/unit/components/VBtn/__snapshots__/VBtn.spec.js.snap
+++ b/test/unit/components/VBtn/__snapshots__/VBtn.spec.js.snap
@@ -59,7 +59,10 @@ exports[`VBtn.js should render component with loader and match snapshot 1`] = `
   <div class="v-btn__content">
   </div>
   <span class="v-btn__loading">
-    <div class="v-progress-circular v-progress-circular--indeterminate"
+    <div role="progressbar"
+         aria-valuemin="0"
+         aria-valuemax="100"
+         class="v-progress-circular v-progress-circular--indeterminate"
          style="height: 26px; width: 26px;"
     >
       <svg xmlns="http://www.w3.org/2000/svg"

--- a/test/unit/components/VProgressCircular/VProgressCircular.spec.js
+++ b/test/unit/components/VProgressCircular/VProgressCircular.spec.js
@@ -30,6 +30,22 @@ test('VProgressCircular.js', ({ mount }) => {
     expect(htmlMinus1).toBe(html0)
     expect(html100).toBe(html101)
     expect(html0).not.toBe(html100)
+
+    wrapper.setProps({ value: '-1' })
+    const htmlMinus1String = wrapper.html()
+
+    wrapper.setProps({ value: '0' })
+    const html0String = wrapper.html()
+
+    wrapper.setProps({ value: '100' })
+    const html100String = wrapper.html()
+
+    wrapper.setProps({ value: '101' })
+    const html101String = wrapper.html()
+
+    expect(htmlMinus1String).toBe(html0String)
+    expect(html100String).toBe(html101String)
+    expect(html0String).not.toBe(html100String)
   })
 
   it('should render component with color prop and match snapshot', () => {

--- a/test/unit/components/VProgressCircular/__snapshots__/VProgressCircular.spec.js.snap
+++ b/test/unit/components/VProgressCircular/__snapshots__/VProgressCircular.spec.js.snap
@@ -2,7 +2,11 @@
 
 exports[`VProgressCircular.js should render component and match snapshot 1`] = `
 
-<div class="v-progress-circular"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular"
      style="height: 32px; width: 32px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -40,7 +44,11 @@ exports[`VProgressCircular.js should render component and match snapshot 1`] = `
 
 exports[`VProgressCircular.js should render component with button prop and match snapshot 1`] = `
 
-<div class="v-progress-circular v-progress-circular--button"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular v-progress-circular--button"
      style="height: 40px; width: 40px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -75,7 +83,11 @@ exports[`VProgressCircular.js should render component with button prop and match
 
 exports[`VProgressCircular.js should render component with color prop and match snapshot 1`] = `
 
-<div class="v-progress-circular orange--text text--lighten-1"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular orange--text text--lighten-1"
      style="height: 32px; width: 32px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -110,7 +122,11 @@ exports[`VProgressCircular.js should render component with color prop and match 
 
 exports[`VProgressCircular.js should render component with fill prop and match snapshot 1`] = `
 
-<div class="v-progress-circular"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular"
      style="height: 32px; width: 32px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -145,7 +161,10 @@ exports[`VProgressCircular.js should render component with fill prop and match s
 
 exports[`VProgressCircular.js should render component with indeterminate prop and match snapshot 1`] = `
 
-<div class="v-progress-circular v-progress-circular--indeterminate"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     class="v-progress-circular v-progress-circular--indeterminate"
      style="height: 32px; width: 32px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -170,7 +189,11 @@ exports[`VProgressCircular.js should render component with indeterminate prop an
 
 exports[`VProgressCircular.js should render component with rotate prop and match snapshot 1`] = `
 
-<div class="v-progress-circular"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular"
      style="height: 32px; width: 32px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -205,7 +228,11 @@ exports[`VProgressCircular.js should render component with rotate prop and match
 
 exports[`VProgressCircular.js should render component with size prop and match snapshot 1`] = `
 
-<div class="v-progress-circular"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular"
      style="height: 17px; width: 17px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -240,7 +267,11 @@ exports[`VProgressCircular.js should render component with size prop and match s
 
 exports[`VProgressCircular.js should render component with width prop and match snapshot 1`] = `
 
-<div class="v-progress-circular"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-circular"
      style="height: 32px; width: 32px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"

--- a/test/unit/components/VProgressLinear/VProgressLinear.spec.js
+++ b/test/unit/components/VProgressLinear/VProgressLinear.spec.js
@@ -10,6 +10,38 @@ test('VProgressLinear.js', ({ mount }) => {
     })
 
     expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.setProps({ value: -1, bufferValue: -1 })
+    const htmlMinus1 = wrapper.html()
+
+    wrapper.setProps({ value: 0, bufferValue: 0 })
+    const html0 = wrapper.html()
+
+    wrapper.setProps({ value: 100, bufferValue: 100 })
+    const html100 = wrapper.html()
+
+    wrapper.setProps({ value: 101, bufferValue: 101 })
+    const html101 = wrapper.html()
+
+    expect(htmlMinus1).toBe(html0)
+    expect(html100).toBe(html101)
+    expect(html0).not.toBe(html100)
+
+    wrapper.setProps({ value: '-1', bufferValue: '-1' })
+    const htmlMinus1String = wrapper.html()
+
+    wrapper.setProps({ value: '0', bufferValue: '0' })
+    const html0String = wrapper.html()
+
+    wrapper.setProps({ value: '100', bufferValue: '100' })
+    const html100String = wrapper.html()
+
+    wrapper.setProps({ value: '101', bufferValue: '101' })
+    const html101String = wrapper.html()
+
+    expect(htmlMinus1String).toBe(html0String)
+    expect(html100String).toBe(html101String)
+    expect(html0String).not.toBe(html100String)
   })
 
   it('should render inactive component and match snapshot', () => {

--- a/test/unit/components/VProgressLinear/__snapshots__/VProgressLinear.spec.js.snap
+++ b/test/unit/components/VProgressLinear/__snapshots__/VProgressLinear.spec.js.snap
@@ -2,7 +2,11 @@
 
 exports[`VProgressLinear.js should render component and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"
@@ -21,7 +25,11 @@ exports[`VProgressLinear.js should render component and match snapshot 1`] = `
 
 exports[`VProgressLinear.js should render component with buffer value and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="80"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"
@@ -42,7 +50,11 @@ exports[`VProgressLinear.js should render component with buffer value and match 
 
 exports[`VProgressLinear.js should render component with buffer value and match snapshot 2`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="0"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"
@@ -63,7 +75,11 @@ exports[`VProgressLinear.js should render component with buffer value and match 
 
 exports[`VProgressLinear.js should render component with buffer value and value > buffer value and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="80"
+     aria-valuenow="90"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"
@@ -84,7 +100,11 @@ exports[`VProgressLinear.js should render component with buffer value and value 
 
 exports[`VProgressLinear.js should render component with color and background color and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background blue"
@@ -103,7 +123,11 @@ exports[`VProgressLinear.js should render component with color and background co
 
 exports[`VProgressLinear.js should render component with color and background color and opacity and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background blue"
@@ -122,7 +146,11 @@ exports[`VProgressLinear.js should render component with color and background co
 
 exports[`VProgressLinear.js should render component with color and background opacity and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background orange"
@@ -141,7 +169,11 @@ exports[`VProgressLinear.js should render component with color and background op
 
 exports[`VProgressLinear.js should render component with color and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background orange"
@@ -160,7 +192,11 @@ exports[`VProgressLinear.js should render component with color and match snapsho
 
 exports[`VProgressLinear.js should render inactive component and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"
@@ -181,7 +217,10 @@ exports[`VProgressLinear.js should render inactive component and match snapshot 
 
 exports[`VProgressLinear.js should render indeterminate progress and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"
@@ -202,7 +241,10 @@ exports[`VProgressLinear.js should render indeterminate progress and match snaps
 
 exports[`VProgressLinear.js should render indeterminate progress with query prop and match snapshot 1`] = `
 
-<div class="v-progress-linear"
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     class="v-progress-linear"
      style="height: 7px;"
 >
   <div class="v-progress-linear__background primary"

--- a/test/unit/components/VTextField/__snapshots__/VTextField.spec.js.snap
+++ b/test/unit/components/VTextField/__snapshots__/VTextField.spec.js.snap
@@ -169,7 +169,10 @@ exports[`VTextField.js should render component with async loading and custom pro
       <div class="v-text-field__slot">
         <input type="text">
       </div>
-      <div class="v-progress-linear"
+      <div role="progressbar"
+           aria-valuemin="0"
+           aria-valuemax="100"
+           class="v-progress-linear"
            style="height: 7px;"
       >
         <div class="v-progress-linear__background orange"
@@ -205,7 +208,10 @@ exports[`VTextField.js should render component with async loading and match snap
       <div class="v-text-field__slot">
         <input type="text">
       </div>
-      <div class="v-progress-linear"
+      <div role="progressbar"
+           aria-valuemin="0"
+           aria-valuemax="100"
+           class="v-progress-linear"
            style="height: 2px;"
       >
         <div class="v-progress-linear__background primary"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Added role, aria-valuemin, valuemax and valuenow (if not indeterminate) to progressbars - https://w3c.github.io/aria/#progressbar
Also normalized value (and buffervalue for linear) input (in Circular it was Number|String with min 0 max 100) in Linear it was just Number without minmax

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Increase a11y, normalize properties between similar components

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
existing unit + playground with NVDA screenreader

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>

    <br/>
    <h2>Linear with number and string</h2>
    <v-progress-linear
      :value=50
    ></v-progress-linear>

    <v-progress-linear
      value=50
    ></v-progress-linear>

    <br/>
    <h2>Circular with number and string</h2>
    <v-progress-circular
      :value=75
    ></v-progress-circular>

    <v-progress-circular
      value="75"
    ></v-progress-circular>

    <br/>
    <h2>indeterminate</h2>
    <v-progress-linear
      indeterminate
    ></v-progress-linear>

    <v-progress-circular
      indeterminate
    ></v-progress-circular>


    <br/>
    <h2>Buffer which goes over 100%</h2>
    <v-progress-linear
      v-model="buffer"
      :buffer-value="bufferValue"
      buffer
    ></v-progress-linear>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        value: 0,
        buffer: 10,
        bufferValue: 20,
        interval: 0
      }
    },

    mounted () {
      this.startBuffer()
    },

    beforeDestroy () {
      clearInterval(this.interval)
    },

    methods: {
      startBuffer () {
        this.interval = setInterval(() => {
          this.buffer += Math.random() * (15 - 5) + 5
          this.bufferValue += Math.random() * (15 - 5) + 5
        }, 2000)
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
