### PR TITLE
(WIP) Add support to light and dark theme sets

### DIFF
--- a/src/components/VApp/VApp.js
+++ b/src/components/VApp/VApp.js
@@ -33,6 +33,7 @@ export default {
     classes () {
       return {
         'application--is-rtl': this.$vuetify.rtl,
+        'background': true,
         ...this.themeClasses
       }
     }

--- a/src/components/VApp/mixins/app-theme.js
+++ b/src/components/VApp/mixins/app-theme.js
@@ -19,7 +19,7 @@ export default {
         if (css != null) return css
       }
 
-      css = Theme.genStyles(theme, this.$vuetify.options.customProperties)
+      css = Theme.genStyles(theme, this.$vuetify.options.customProperties, this.$vuetify.dark)
 
       if (this.$vuetify.options.minifyTheme != null) {
         css = this.$vuetify.options.minifyTheme(css)

--- a/src/components/Vuetify/mixins/theme.ts
+++ b/src/components/Vuetify/mixins/theme.ts
@@ -2,13 +2,26 @@ import { VuetifyUseOptions, VuetifyTheme } from 'types'
 
 /* eslint-disable no-multi-spaces */
 const THEME_DEFAULTS = {
-  primary: '#1976D2',   // blue.darken2
-  secondary: '#424242', // grey.darken3
-  accent: '#82B1FF',    // blue.accent1
-  error: '#FF5252',     // red.accent2
-  info: '#2196F3',      // blue.base
-  success: '#4CAF50',   // green.base
-  warning: '#FFC107'    // amber.base
+  light: {
+    background: '#fafafa',  // from stylus
+    primary: '#1976D2',     // blue.darken2
+    secondary: '#424242',   // grey.darken3
+    accent: '#82B1FF',      // blue.accent1
+    error: '#FF5252',       // red.accent2
+    info: '#2196F3',        // blue.base
+    success: '#4CAF50',     // green.base
+    warning: '#FFC107'      // amber.base
+  },
+  dark: {
+    background: '#303030',  // from stylus
+    primary: '#1976D2',     // blue.darken2
+    secondary: '#424242',   // grey.darken3
+    accent: '#82B1FF',      // blue.accent1
+    error: '#FF5252',       // red.accent2
+    info: '#2196F3',        // blue.base
+    success: '#4CAF50',     // green.base
+    warning: '#FFC107'      // amber.base
+  }
 }
 
 export default function theme (theme: VuetifyUseOptions['theme'] = {}): VuetifyTheme | false {

--- a/src/stylus/settings/_theme.styl
+++ b/src/stylus/settings/_theme.styl
@@ -14,7 +14,6 @@ $material-light := {
     lights-out: rgba(#fff, .7)
   },
   app-bar: #F5F5F5,
-  background: #FAFAFA,
   cards: #FFFFFF,
   chips: {
     background: $grey.lighten-2,
@@ -107,7 +106,6 @@ $material-dark := {
     lights-out: rgba(#000, .2)
   },
   app-bar: #212121,
-  background: #303030,
   cards: #424242,
   chips: {
     background: #FFF,

--- a/test/unit/components/VApp/VApp.spec.js
+++ b/test/unit/components/VApp/VApp.spec.js
@@ -46,7 +46,7 @@ test('VApp.js', ({ mount }) => {
     const wrapper = mount(VApp)
 
     expect(wrapper.vm.style).toMatchSnapshot()
-    wrapper.vm.$vuetify.theme.primary = '#000'
+    wrapper.vm.$vuetify.theme.light.primary = '#000'
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.style).toMatchSnapshot()
   })

--- a/test/unit/components/VApp/__snapshots__/VApp.spec.js.snap
+++ b/test/unit/components/VApp/__snapshots__/VApp.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`VApp.js should allow a custom id 1`] = `
 
 <div data-app="true"
-     class="application theme--light"
+     class="application background theme--light"
      id="inspire"
 >
   <div class="application--wrap">
@@ -18,6 +18,7 @@ exports[`VApp.js should generate theme using css variables 1`] = `
   type="text/css"
 >
   :root {
+  --v-background-base: #fafafa;
   --v-primary-base: #000000;
   --v-primary-lighten5: #777777;
   --v-primary-lighten4: #5e5e5e;
@@ -91,6 +92,14 @@ exports[`VApp.js should generate theme using css variables 1`] = `
 }
 
 a { color: var(--v-primary-base); }
+.background {
+  background-color: var(--v-background-base) !important;
+  border-color: var(--v-background-base) !important;
+}
+.background--text {
+  color: var(--v-background-base) !important;
+  caret-color: var(--v-background-base) !important;
+}
 .primary {
   background-color: var(--v-primary-base) !important;
   border-color: var(--v-primary-base) !important;
@@ -657,7 +666,7 @@ a { color: var(--v-primary-base); }
 exports[`VApp.js should match a snapshot 1`] = `
 
 <div data-app="true"
-     class="application theme--light"
+     class="application background theme--light"
      id="app"
 >
   <div class="application--wrap">
@@ -672,6 +681,14 @@ exports[`VApp.js should watch theme 1`] = `
   type="text/css"
 >
   a { color: #1976d2; }
+.background {
+  background-color: #fafafa !important;
+  border-color: #fafafa !important;
+}
+.background--text {
+  color: #fafafa !important;
+  caret-color: #fafafa !important;
+}
 .primary {
   background-color: #1976d2 !important;
   border-color: #1976d2 !important;
@@ -1241,6 +1258,14 @@ exports[`VApp.js should watch theme 2`] = `
   type="text/css"
 >
   a { color: #000000; }
+.background {
+  background-color: #fafafa !important;
+  border-color: #fafafa !important;
+}
+.background--text {
+  color: #fafafa !important;
+  caret-color: #fafafa !important;
+}
 .primary {
   background-color: #000000 !important;
   border-color: #000000 !important;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -122,7 +122,9 @@ export interface VuetifyBreakpoint {
   xsOnly: boolean
 }
 
-export type VuetifyThemeItem = string | number | {
+export interface VuetifyThemeItem {
+  [name: string]: string | number
+
   base: string | number
   lighten5: string | number
   lighten4: string | number
@@ -135,16 +137,23 @@ export type VuetifyThemeItem = string | number | {
   darken4: string | number
 }
 
-export interface VuetifyTheme {
-  [name: string]: VuetifyThemeItem
+export interface VuetifyThemeSet {
+  [name: string]: VuetifyThemeItem | string | number
 
-  primary: VuetifyThemeItem
-  accent: VuetifyThemeItem
-  secondary: VuetifyThemeItem
-  info: VuetifyThemeItem
-  warning: VuetifyThemeItem
-  error: VuetifyThemeItem
-  success: VuetifyThemeItem
+  primary: VuetifyThemeItem | string | number
+  accent: VuetifyThemeItem | string | number
+  secondary: VuetifyThemeItem | string | number
+  info: VuetifyThemeItem | string | number
+  warning: VuetifyThemeItem | string | number
+  error: VuetifyThemeItem | string | number
+  success: VuetifyThemeItem | string | number
+}
+
+export interface VuetifyTheme {
+  [name: string]: VuetifyThemeSet
+
+  light: VuetifyThemeSet
+  dark: VuetifyThemeSet
 }
 
 export interface VuetifyThemeCache {

--- a/types/test/global.ts
+++ b/types/test/global.ts
@@ -34,12 +34,22 @@ Vue.component('theme', {
     // this.$vuetify.theme = { primary: 123 }
 
     Object.assign(this.$vuetify.theme, {
-      primary: 123
+      light: {
+        primary: 123
+      }
     })
 
     this.$vuetify.theme = {
       ...this.$vuetify.theme,
-      primary: 132
+      light: {
+        primary: 132,
+        secondary: '#424242',
+        accent: '#82B1FF',
+        error: '#FF5252',
+        info: '#2196F3',
+        success: '#4CAF50',
+        warning: '#FFC107'
+      }
     }
   }
 })

--- a/types/test/plugin.ts
+++ b/types/test/plugin.ts
@@ -11,16 +11,19 @@ Vuetify.install(Vue, {
 
 Vuetify.install(Vue, {
   theme: {
-    primary: '#123456',
-    accent: '#123456',
-    secondary: '#123456',
-    info: '#123456',
-    warning: '#123456',
-    error: '#123456',
-    success: '#123456',
+    light: {
+      background: '#FFFFFF',
+      primary: '#123456',
+      accent: '#123456',
+      secondary: '#123456',
+      info: '#123456',
+      warning: '#123456',
+      error: '#123456',
+      success: '#123456',
 
-    'something-else': '#123456',
-    'as-number': 123456
+      'something-else': '#123456',
+      'as-number': 123456
+    }
   },
   iconfont: 'fa',
   icons: {


### PR DESCRIPTION
Signed-off-by: Agnaldo Junior <agnaldo.junior01@gmail.com>

# *THIS IS A WORK IN PROGRESS*

Add support to light and dark theme sets

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
It fixes issue #4954 

## How Has This Been Tested?
I just needed to update unit tests to:
- add snapshots that reflect the changes
- change a method that changes the theme to add the new prefix

## Markup:
<details>

```vue
<template>
  <v-app :dark="dark">
    <v-btn @click="dark = !dark">{{ dark ? 'dark' : 'light' }}</v-btn>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      dark: false,
    }),
    created() {
      this.$vuetify.theme.dark.background = '#334D34'
      this.$vuetify.theme.light.background = '#ccccee'
    }
  }
</script>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
