### PR TITLE
fix(DatePicker): Title spacing when month === August

### DIFF
--- a/src/stylus/components/_date-picker-title.styl
+++ b/src/stylus/components/_date-picker-title.styl
@@ -26,6 +26,8 @@ rtl(v-date-picker-title-rtl, "v-date-picker-title")
     font-weight: 500
     position: relative
     overflow: hidden
+    padding-bottom: 8px
+    margin-bottom: -8px
 
     > div
       position: relative


### PR DESCRIPTION
## Description
Before
![screen shot 2018-08-31 at 09 12 14](https://user-images.githubusercontent.com/2115696/44901649-e1384780-acff-11e8-8c95-4af9a8fbfba9.png)
After
![screen shot 2018-08-31 at 09 19 30](https://user-images.githubusercontent.com/2115696/44901666-eeedcd00-acff-11e8-90c8-0e55308b01a0.png)

## Motivation and Context
It's ugly.

## How Has This Been Tested?
Visually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
