### PR TITLE
V-Autocomplete: hide-no-data also controls opening menu upon item update

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -174,12 +174,15 @@ export default {
 
       this.lazySearch = null
     },
-    items (val) {
+    items (val, oldVal) {
       // If we are focused, the menu
-      // is not active and items change
+      // is not active, hide no data is enabled,
+      // and items change
       // User is probably async loading
       // items, try to activate the menu
       if (
+        !(oldVal && oldVal.length) &&
+        this.hideNoData &&
         this.isFocused &&
         !this.isMenuActive &&
         val.length

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -230,20 +230,6 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.isMenuActive).toBe(false)
-
-    wrapper.setProps({
-      items: [
-        { text: 'Foo', value: 1 },
-        { text: 'Bar', value: 2 }
-      ]
-    })
-
-    await wrapper.vm.$nextTick()
-
-    // Once items refresh active will
-    // be updated to openif already
-    // focused
-    expect(wrapper.vm.isMenuActive).toBe(true)
   })
 
   it('should change selected index', async () => {
@@ -721,7 +707,7 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     expect(input.element.value).toBe('foo')
   })
 
-  it('should show menu when items are added and hide-no-data', async () => {
+  it('should show menu when items are added for the first time and hide-no-data is enabled', async () => {
     const wrapper = mount(VAutocomplete, {
       propsData: {
         hideNoData: true,
@@ -743,5 +729,29 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.isMenuActive).toBe(true)
+  })
+
+  it('should not show menu when items are updated and hide-no-data is enabled ', async () => {
+    const wrapper = mount(VAutocomplete, {
+      propsData: {
+        hideNoData: true,
+        items: [ 'Something first' ]
+      }
+    })
+
+    const input = wrapper.first('input')
+
+    input.trigger('focus')
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
+    expect(wrapper.vm.isFocused).toBe(true)
+
+    wrapper.setProps({
+      items: ['Foo', 'Bar']
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.isMenuActive).toBe(false)
   })
 })


### PR DESCRIPTION
 
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This will change the default behaviour of opening the menu every time the source items change, to only opening when the `hide-no-data` has been enabled, and the previous `items` was empty. 

Adds `hide-no-data` prop as a condition for opening the menu when the source items have changed (along with focus, the menu being closed already, and the old result set being empty)
## Motivation and Context
This fixes the issue of the menu opening at undesired times due to non-asynchronous manipulation of the source items.  Fixes #4663 

## How Has This Been Tested?

I've added unit tests to cover the changes

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>

  <!-- standard use case that will no longer be subject to the menu opening if the item list changes if proposed changes are accepted -->
  <!-- as taken from original issue codepen:  https://codepen.io/Flamenco/pen/pZEqGo -->
  <p>Issue is when combo has focus after selecting item 2, and then button is pressed</p>
  <li>menu should not re-open</li>
  <li>menu will not close when selecting item</li>
  <br />
  <v-btn @click=updateItems>Update Items</v-btn>
  <div>
    <v-autocomplete label='select 1' v-model='item' :items='items' />
  </div>
  
  <!-- use case where opening upon items list changing may still be desired/invoked. -->
  <!-- type a character to start the call, press esc to close the menu before it finished -->
  <!-- the menu will open once the 'async' call completes (and the query matches any of the results) -->
  <v-autocomplete :items="contacts"
                label="Type to search for contacts"
                hide-no-data
               :search-input.sync="contactSearch"
                v-model="contact"/>
</template>

<script>
export default {
  data: () => ({
    item: 1,
    items: [{ text: "one", value: 1 }, { text: "two", value: 2 }],
    contacts: [],
    contact: null,
    contactSearch: ''
  }),
  methods: {
    updateItems() {
      this.value = null
      this.items = this.items.filter(it => it.value !== 1)
    },
    loadContacts() {
      // simulate an async call
      return setTimeout(() => {
        this.contacts = [{ text: "Joe", value: 1 }, { text: "Jane", value: 2 }]
      }, 2000)
    }
  },
  watch: {
    contactSearch (newVal) {
      if (newVal && this.contacts.length === 0) {
        this.loadContacts()
      }
   }
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
    - targeting `master` as a bug fix
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
    - not yet
