### PR TITLE
fix(v-autocomplete): search input event now kebab cased

### DIFF
--- a/src/components/VAutocomplete/VAutocomplete.js
+++ b/src/components/VAutocomplete/VAutocomplete.js
@@ -96,7 +96,7 @@ export default {
       set (val) {
         this.lazySearch = val
 
-        this.$emit('update:searchInput', val)
+        this.$emit('update:search-input', val)
       }
     },
     isAnyValueAllowed () {

--- a/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -44,7 +44,7 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     const input = wrapper.first('input')
 
     const update = jest.fn()
-    wrapper.vm.$on('update:searchInput', update)
+    wrapper.vm.$on('update:search-input', update)
 
     input.element.value = 'test'
     input.trigger('input')


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fixes #5046.  Changed the event name from camel to kebab case to make it compatible with case-insensitivity of HTML.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Restore expected and [documented](https://vuetifyjs.com/en/components/autocompletes#api) behaviour.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Covered in unit tests, as well as tested locally

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<!-- HTML bound event handler will now register properly, as expected -->
<v-autocomplete @update:search-input="callback"></v-autocomplete>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
    - against `master` as a bug fix
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
