### PR TITLE
Fixes ripple not filling its entire container button

### DIFF
--- a/src/directives/ripple.ts
+++ b/src/directives/ripple.ts
@@ -26,10 +26,7 @@ const ripple = {
       container.className += ` ${value.class}`
     }
 
-    const size = (
-      Math.min(el.clientWidth, el.clientHeight) *
-      (value.center ? 1 : el.clientWidth / el.clientHeight * 1.6)
-    )
+    const size = Math.max(el.clientWidth, el.clientHeight) * (value.center ? 1 : 2)
     const halfSize = size / 2
     animation.className = 'v-ripple__animation'
     animation.style.width = `${size}px`
@@ -45,7 +42,7 @@ const ripple = {
 
     animation.classList.add('v-ripple__animation--enter')
     animation.classList.add('v-ripple__animation--visible')
-    style(animation, `translate(${x}px, ${y}px) scale3d(0.5, 0.5, 0.5)`)
+    style(animation, `translate(${x}px, ${y}px) scale3d(0, 0, 0)`)
     animation.dataset.activated = String(performance.now())
 
     setTimeout(() => {


### PR DESCRIPTION
## Description
Fixes how the ripple effect doesn't fill the entire button when you click on one edge of the button.

## Motivation and Context
Fixes #5021 

## How Has This Been Tested?
This PR simply reverts commit 7f396e69d24fc75e0318832e060b23173d55198a and nothing else. The ripple was working fine before that. (Not tested.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
