### PR TITLE
enh/v-treeview: switched from array to set for caches

### DIFF
--- a/test/unit/components/VTreeview/VTreeview.spec.js
+++ b/test/unit/components/VTreeview/VTreeview.spec.js
@@ -172,6 +172,9 @@ test('VTreeView.ts', ({ mount }) => {
       }
     })
 
+    const fn = jest.fn()
+
+    wrapper.vm.$on('update:open', fn)
     wrapper.setProps({ open: [0, 1]})
 
     await wrapper.vm.$nextTick()
@@ -190,7 +193,7 @@ test('VTreeView.ts', ({ mount }) => {
 
     expect(wrapper.html()).toMatchSnapshot()
 
-    expect(wrapper.vm.openCache).toEqual([0, 1])
+    expect(fn).toHaveBeenCalledWith([0, 1])
 
     // Should not update open values that do not exist in the tree
     wrapper.setProps({ open: [7] })
@@ -198,7 +201,7 @@ test('VTreeView.ts', ({ mount }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
 
-    expect(wrapper.vm.openCache).toEqual([])
+    expect(fn).toHaveBeenCalledWith([])
   })
 
   it('should update selected and active on created', async () => {
@@ -210,8 +213,12 @@ test('VTreeView.ts', ({ mount }) => {
       }
     })
 
-    expect(wrapper.vm.activeCache).toEqual([2])
-    expect(wrapper.vm.selectedCache).toEqual([1, 2])
+    // TODO: I can not find away in avoriaz
+    // to catch events being emitted from a
+    // lifecycle hook. We should not assert
+    // internal state.
+    expect([...wrapper.vm.activeCache]).toEqual([2])
+    expect([...wrapper.vm.selectedCache]).toEqual([1, 2])
   })
 
   it('should react to changes for value, selected and activated', async () => {
@@ -223,26 +230,31 @@ test('VTreeView.ts', ({ mount }) => {
       }
     })
 
+    const active = jest.fn()
+    const selected = jest.fn()
+    wrapper.vm.$on('update:active', active)
+    wrapper.vm.$on('change', selected)
+
     wrapper.setProps({ active: [0] })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.vm.activeCache).toEqual([0])
+    expect(active).toHaveBeenCalledWith([0])
 
     // Should not update values that do not exist in the tree
 
     wrapper.setProps({ active: [7], value: [7] })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.vm.activeCache).toEqual([])
-    expect(wrapper.vm.selectedCache).toEqual([1, 2])
+    expect(active).toHaveBeenCalledWith([])
+    expect(selected).toHaveBeenCalledWith([1, 2])
 
     // Should rebuild tree and reuse cached values
 
     wrapper.setProps({ active: [0], items: singleRootTwoChildren })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.vm.activeCache).toEqual([0])
-    expect(wrapper.vm.selectedCache).toEqual([1, 2, 0])
+    expect(active).toHaveBeenCalledWith([0])
+    expect(selected).toHaveBeenCalledWith([1, 2, 0])
   })
 
   it('should accept string value for id', async () => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
switched caches from array to set

## Motivation and Context
cleaner code and potential performance improvement

## How Has This Been Tested?
tests, visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-container fluid grid-list-xl>
        <v-layout row wrap>
          <v-flex xs6>
            Default
            <v-treeview :items="items"></v-treeview>
          </v-flex>
          <v-flex xs6>
            Selectable
            <v-treeview :items="items" selectable :selected.sync="selected"></v-treeview>
          </v-flex>
          <v-flex xs6>
            Transition
            <v-treeview :items="items" transition></v-treeview>
          </v-flex>
          <v-flex xs6>
            Slots prepend & append
            <v-treeview :items="items">
              <v-icon slot="prepend" slot-scope="props">{{ props.item.icon }}</v-icon>
              <div class="d-flex grow justify-end" slot="append" slot-scope="props">
                <v-btn class="shrink" v-if="props.active" small icon @click.stop="remove(items, props.item.id)">
                  <v-icon color="error">delete</v-icon>
                </v-btn>
              </div>
            </v-treeview>
          </v-flex>
          <v-flex xs6>
            Multiple active
            <v-treeview :items="items" multiple-active></v-treeview>
          </v-flex>
          <v-flex xs6>
            Dynamic loading of children
            <v-treeview :items="dynamic" :load-children="loadChildren"></v-treeview>
          </v-flex>
          <v-flex xs12>
            <v-btn @click="addRootTree">add another root</v-btn>
          </v-flex>
        </v-layout>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>

let id = 0

function generateTree (depth = 2, minChildren = 2, maxChildren = 4, parent = null) {
  const node = {
    id: ++id,
    icon: 'home',
    name: 'whatever'
  }

  if (depth === 0) return node

  const childCount = Math.floor(Math.random() * (maxChildren - minChildren + 1) + minChildren)

  if (childCount > 0) node.children = []

  for (let i = 0; i < childCount; i++) {
    node.children.push(generateTree(depth - 1, minChildren, maxChildren, node))
  }

  return node
}

const pause = (ms) => new Promise(resolve => setTimeout(resolve, ms))

export default {
  methods: {
    addRootTree () {
      this.items.push(generateTree())
    },
    findNode (items, id) {
      if (id === null || !items) return null

      for (let i = 0; i < items.length; i) {
        const item = items[i]

        if (item.id === id) return item

        const found = this.findNode(item.children, id)

        if (found) return found
      }

      return null
    },
    async loadChildren (item) {
      await pause(1000)
      id += 1
      item.children = [{
        id,
        name: 'Generated child',
        children: []
      }]
    },
    remove (items, id) {
      for (let i = 0; i < items.length; i++) {
        const item = items[i]

        if (item.id === id) {
          items.splice(i, 1)
          return true
        }

        if (item.children) {
          if (this.remove(item.children, id) && !item.children.length) {
            delete item.children
          }
        }
      }
    }
  },
  data: () => ({
    selected: [],
    items: [generateTree()],
    dynamic: [
      { id: 0, name: 'Root', children: [] }
    ]
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
