### PR TITLE
feat(dependent): convert to ts

### DIFF
--- a/src/mixins/dependent.ts
+++ b/src/mixins/dependent.ts
@@ -1,7 +1,22 @@
-function searchChildren (children) {
+import Vue from 'vue'
+
+import mixins from '../util/mixins'
+
+interface options extends Vue {
+  $refs: {
+    content: HTMLElement
+  }
+}
+
+interface DependentInstance extends Vue {
+  isActive?: boolean
+  isDependent?: boolean
+}
+
+function searchChildren (children: Vue[]): DependentInstance[] {
   const results = []
   for (let index = 0; index < children.length; index++) {
-    const child = children[index]
+    const child = children[index] as DependentInstance
     if (child.isActive && child.isDependent) {
       results.push(child)
     } else {
@@ -13,12 +28,13 @@ function searchChildren (children) {
 }
 
 /* @vue/component */
-export default {
+export default mixins<options>().extend({
   name: 'dependent',
 
   data () {
     return {
       closeDependents: true,
+      isActive: false,
       isDependent: true
     }
   },
@@ -35,12 +51,12 @@ export default {
   },
 
   methods: {
-    getOpenDependents () {
+    getOpenDependents (): any[] {
       if (this.closeDependents) return searchChildren(this.$children)
 
       return []
     },
-    getOpenDependentElements () {
+    getOpenDependentElements (): HTMLElement[] {
       const result = []
       const openDependents = this.getOpenDependents()
 
@@ -50,7 +66,7 @@ export default {
 
       return result
     },
-    getClickableDependentElements () {
+    getClickableDependentElements (): HTMLElement[] {
       const result = [this.$el]
       if (this.$refs.content) result.push(this.$refs.content)
       result.push(...this.getOpenDependentElements())
@@ -58,4 +74,4 @@ export default {
       return result
     }
   }
-}
+})


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Convert `dependent` mixin to TS. Not entirely sure about how to handle this https://github.com/vuetifyjs/vuetify/pull/5105/files#diff-f2a871db5433a55bc434c6526c30edecR16 , looking for feedback

<!--- Describe your changes in detail -->

## Motivation and Context
Update framework to TS
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
