### PR TITLE
fix(v-navigation-drawer): pull in Dependent mixin for click-outside

### DIFF
--- a/src/components/VNavigationDrawer/VNavigationDrawer.js
+++ b/src/components/VNavigationDrawer/VNavigationDrawer.js
@@ -2,6 +2,7 @@ import '../../stylus/components/_navigation-drawer.styl'
 
 // Mixins
 import Applicationable from '../../mixins/applicationable'
+import Dependent from '../../mixins/dependent'
 import Overlayable from '../../mixins/overlayable'
 import SSRBootable from '../../mixins/ssr-bootable'
 import Themeable from '../../mixins/themeable'
@@ -30,6 +31,7 @@ export default {
       'right',
       'width'
     ]),
+    Dependent,
     Overlayable,
     SSRBootable,
     Themeable
@@ -259,7 +261,8 @@ export default {
         name: 'click-outside',
         value: () => (this.isActive = false),
         args: {
-          closeConditional: this.closeConditional
+          closeConditional: this.closeConditional,
+          include: this.getOpenDependentElements
         }
       }]
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Pulls in the dependent mixin for the `click-outside` directive, this will include all of the dependent children (in this case `v-dialog`) and ensure those are closed first.

@johnleider I've tested this with multiple use-cases (mobile, nested navigation-drawers, drawers inside dialogs etc.) and I don't see a difference in z-index regarding `v-navigation-drawer`. as I understand it the `include` in the `click-outside` directive will just track the children and ensures those are closed first (just like in nested dialogs).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/vuetifyjs/vuetify/issues/5089

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
visually, inspect element and logging

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-navigation-drawer app temporary :value="drawer">
      <v-dialog v-model="dialog" width="500">
        <v-btn slot="activator" color="red lighten-2" dark>
          Click Me
        </v-btn>

        <v-card>
          <v-card-title class="headline grey lighten-2" primary-title>
            Privacy Policy
          </v-card-title>

          <v-card-text>
            Lorem ipsum dolor sit amet, consectetur adipiscing elit
          </v-card-text>

          <v-divider></v-divider>

          <v-card-actions>
            <v-spacer></v-spacer>
            <v-btn color="primary" flat @click="dialog = false">
              I accept
            </v-btn>
          </v-card-actions>
        </v-card>
      </v-dialog>

    </v-navigation-drawer>
    <v-content>
      <v-container>
        content here
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
       dialog: false,
       drawer: true
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
