### PR TITLE
style(v-pagination): button cutting the page number

### DIFF
--- a/src/stylus/components/_pagination.styl
+++ b/src/stylus/components/_pagination.styl
@@ -5,6 +5,9 @@ v-pagination($material)
   .v-pagination__item
     background: $material.cards
     color: $material.fg-color
+    width: auto
+    min-width: 34px
+    padding: 0 5px
 
     &--active
       color: $material.text.theme


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When props:length is a very large number,
the number of the button protrudes.
So set the `min-width: 34px` in class `.v-pagination__item`.
And set `padding` as style fine adjustment.

## Motivation and Context
fixes #5126 

## How Has This Been Tested?
visually and inspect element

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-pagination :length="100000000" :total-visible="6" :value="999999" />
  </v-app>
</template>

<script>
  export default {
    data: () => ({
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
