### PR TITLE
feat(VMenu): disable-keys prop

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -216,9 +216,9 @@ export default Vue.extend({
         name: 'resize',
         value: this.onResize
       }],
-      on: this.keyable ? {
+      on: this.disableKeys ? undefined : {
         keydown: this.onKeyDown
-      } : undefined
+      }
     }
 
     return h('div', data, [

--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -216,9 +216,9 @@ export default Vue.extend({
         name: 'resize',
         value: this.onResize
       }],
-      on: {
+      on: this.keyable ? {
         keydown: this.onKeyDown
-      }
+      } : undefined
     }
 
     return h('div', data, [

--- a/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
@@ -13,6 +13,13 @@ import { keyCodes } from '../../../util/helpers'
 
 /* @vue/component */
 export default {
+  props: {
+    keyable: {
+      type: Boolean,
+      default: true
+    }
+  },
+
   data: () => ({
     listIndex: -1,
     tiles: []

--- a/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
@@ -14,10 +14,7 @@ import { keyCodes } from '../../../util/helpers'
 /* @vue/component */
 export default {
   props: {
-    keyable: {
-      type: Boolean,
-      default: true
-    }
+    disableKeys: Boolean
   },
 
   data: () => ({

--- a/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
+++ b/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
@@ -38,7 +38,7 @@ test('VMenu.js', ({ mount, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isActive).toBe(false)
 
-    wrapper.setProps({ keyable: false })
+    wrapper.setProps({ disableKeys: true })
     wrapper.vm.isActive = true
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isActive).toBe(true)

--- a/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
+++ b/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
@@ -29,6 +29,26 @@ test('VMenu.js', ({ mount, compileToFunctions }) => {
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
+  it('should close menu when tab is pressed', async () => {
+    const wrapper = mount(VMenu)
+
+    wrapper.vm.isActive = true
+    await wrapper.vm.$nextTick()
+    wrapper.trigger(`keydown.tab`)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+
+    wrapper.setProps({ keyable: false })
+    wrapper.vm.isActive = true
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
+    wrapper.trigger(`keydown.tab`)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
   it('should render component with custom top and match snapshot', () => {
     const wrapper = mount(VMenu, {
       propsData: {

--- a/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
+++ b/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
@@ -29,26 +29,6 @@ test('VMenu.js', ({ mount, compileToFunctions }) => {
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
-  it('should close menu when tab is pressed', async () => {
-    const wrapper = mount(VMenu)
-
-    wrapper.vm.isActive = true
-    await wrapper.vm.$nextTick()
-    wrapper.trigger(`keydown.tab`)
-    await wrapper.vm.$nextTick()
-    expect(wrapper.vm.isActive).toBe(false)
-
-    wrapper.setProps({ disableKeys: true })
-    wrapper.vm.isActive = true
-    await wrapper.vm.$nextTick()
-    expect(wrapper.vm.isActive).toBe(true)
-    wrapper.trigger(`keydown.tab`)
-    await wrapper.vm.$nextTick()
-    expect(wrapper.vm.isActive).toBe(true)
-
-    expect('Unable to locate target [data-app]').toHaveBeenTipped()
-  })
-
   it('should render component with custom top and match snapshot', () => {
     const wrapper = mount(VMenu, {
       propsData: {
@@ -406,6 +386,26 @@ test('VMenu.js', ({ mount, compileToFunctions }) => {
 
     wrapper.setProps({ openOnHover: true })
     expect(Object.keys(wrapper.find('.v-menu__activator')[0].vNode.data.on)).toHaveLength(0)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should close menu when tab is pressed', async () => {
+    const wrapper = mount(VMenu)
+
+    wrapper.vm.isActive = true
+    await wrapper.vm.$nextTick()
+    wrapper.trigger(`keydown.tab`)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+
+    wrapper.setProps({ disableKeys: true })
+    wrapper.vm.isActive = true
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
+    wrapper.trigger(`keydown.tab`)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })

--- a/packages/vuetifyjs.com/src/lang/en/components/Menus.json
+++ b/packages/vuetifyjs.com/src/lang/en/components/Menus.json
@@ -41,6 +41,7 @@
     "closeOnClick": "Designates if menu should close on outside-activator click",
     "closeOnContentClick": "Designates if menu should close when its content is clicked",
     "disabled": "Disables the menu",
+    "disableKeys": "Removes all keyboard interaction",
     "offsetX": "Offset the menu on the x-axis. Works in conjunction with direction left/right",
     "offsetY": "Offset the menu on the y-axis. Works in conjunction with direction top/bottom",
     "openOnClick": "Designates whether menu should open on activator click",


### PR DESCRIPTION
## Description
Adds `disable-keys` prop to disable the keyboard event handlers used only when the `v-menu` is used as a real menu with selecting items by pressing up/down/enter etc

## Motivation and Context
fixes #5103

## How Has This Been Tested?
visually, unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-menu attach :close-on-content-click="false" :close-on-click="false" disable-keys>
          <v-btn slot="activator">Open</v-btn>
          <v-card class="pa-3" width="800">
            <v-text-field label="Focus me and press TAB"></v-text-field>
            <v-text-field></v-text-field>
          </v-card>
        </v-menu>
      </v-container>
    </v-content>
  </v-app>
</template>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
