### PR TITLE
add specific translation term for allItems with dataTables

### DIFF
--- a/src/components/VDataTable/VDataTable.js
+++ b/src/components/VDataTable/VDataTable.js
@@ -39,9 +39,27 @@ export default {
       default: null
     },
     hideHeaders: Boolean,
+    rowsPerPageItems: {
+      type: Array,
+      default () {
+        return [
+          5,
+          10,
+          25,
+          {
+            text: '$vuetify.dataTable.rowsPerPageAll',
+            value: -1
+          }
+        ]
+      }
+    },
     rowsPerPageText: {
       type: String,
       default: '$vuetify.dataTable.rowsPerPageText'
+    },
+    rowsPerPageAll: {
+      type: String,
+      default: '$vuetify.dataTable.rowsPerPageAll'
     },
     customFilter: {
       type: Function,

--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Vorherige Seite'
   },
   dataTable: {
-    rowsPerPageText: 'Zeilen pro Seite:'
+    rowsPerPageText: 'Zeilen pro Seite:',
+    rowsPerPageAll: 'Alle'
   },
   noDataText: 'Keine Daten vorhanden'
 }

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Previous page'
   },
   dataTable: {
-    rowsPerPageText: 'Rows per page:'
+    rowsPerPageText: 'Rows per page:',
+    rowsPerPageAll: 'All'
   },
   noDataText: 'No data available'
 }

--- a/src/locale/fa.ts
+++ b/src/locale/fa.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'صفحه قبل'
   },
   dataTable: {
-    rowsPerPageText: 'ردیف در صفحه:'
+    rowsPerPageText: 'ردیف در صفحه:',
+    rowsPerPageAll: 'همه'
   },
   noDataText: 'اطلاعاتی یافت نشد'
 }

--- a/src/locale/fr.ts
+++ b/src/locale/fr.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Page précédente'
   },
   dataTable: {
-    rowsPerPageText: 'Lignes par page:'
+    rowsPerPageText: 'Lignes par page:',
+    rowsPerPageAll: 'Toutes'
   },
   noDataText: 'Aucune donnée disponible'
 }

--- a/src/locale/gr.ts
+++ b/src/locale/gr.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Προηγούμενη σελίδα'
   },
   dataTable: {
-    rowsPerPageText: 'Γραμμές ανά σελίδα:'
+    rowsPerPageText: 'Γραμμές ανά σελίδα:',
+    rowsPerPageAll: 'Όλα'
   },
   noDataText: 'Χωρίς δεδομένα'
 }

--- a/src/locale/nl.ts
+++ b/src/locale/nl.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Vorige pagina'
   },
   dataTable: {
-    rowsPerPageText: 'Rijen per pagina:'
+    rowsPerPageText: 'Rijen per pagina:',
+    rowsPerPageAll: 'Alles'
   },
   noDataText: 'Geen gegevens beschikbaar'
 }

--- a/src/locale/pl.ts
+++ b/src/locale/pl.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Poprzednia strona'
   },
   dataTable: {
-    rowsPerPageText: 'Wierszy na stronie:'
+    rowsPerPageText: 'Wierszy na stronie:',
+    rowsPerPageAll: 'Wszystkie'
   },
   noDataText: 'Brak danych'
 }

--- a/src/locale/pt.ts
+++ b/src/locale/pt.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Página anterior'
   },
   dataTable: {
-    rowsPerPageText: 'Linhas por página:'
+    rowsPerPageText: 'Linhas por página:',
+    rowsPerPageAll: 'Todos'
   },
   noDataText: 'Não há dados disponíveis'
 }

--- a/src/locale/ru.ts
+++ b/src/locale/ru.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Предыдущая страница'
   },
   dataTable: {
-    rowsPerPageText: 'Строк на странице:'
+    rowsPerPageText: 'Строк на странице:',
+    rowsPerPageAll: 'Все'
   },
   noDataText: 'Отсутствуют данные'
 }

--- a/src/locale/uk.ts
+++ b/src/locale/uk.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: 'Попередня сторінка'
   },
   dataTable: {
-    rowsPerPageText: 'Рядків на сторінці:'
+    rowsPerPageText: 'Рядків на сторінці:',
+    rowsPerPageAll: 'Всі'
   },
   noDataText: 'Немає даних для відображення'
 }

--- a/src/locale/zh-Hans.ts
+++ b/src/locale/zh-Hans.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: '上一页'
   },
   dataTable: {
-    rowsPerPageText: '每页行数：'
+    rowsPerPageText: '每页行数：',
+    rowsPerPageAll: '全部'
   },
   noDataText: '无可用数据'
 }

--- a/src/locale/zh-Hant.ts
+++ b/src/locale/zh-Hant.ts
@@ -8,7 +8,8 @@ export default {
     prevPage: '上一頁'
   },
   dataTable: {
-    rowsPerPageText: '每頁行數：'
+    rowsPerPageText: '每頁行數：',
+    rowsPerPageAll: '全部'
   },
   noDataText: '無可用數據'
 }

--- a/src/mixins/data-iterable.js
+++ b/src/mixins/data-iterable.js
@@ -59,6 +59,10 @@ export default {
       type: String,
       default: '$vuetify.dataIterator.rowsPerPageText'
     },
+    rowsPerPageAll: {
+      type: String,
+      default: '$vuetify.dataIterator.rowsPerPageAll'
+    },
     selectAll: [Boolean, String],
     search: {
       required: false


### PR DESCRIPTION
## Description

Add specific translation term to show all rows in datatable compare to show all items in dataIterator

## Motivation and Context

May be a common language problem

## How Has This Been Tested?

visually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:

- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
