### PR TITLE
fix missing export of types from colors.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 import Vue, { PluginFunction, PluginObject, VueConstructor, DirectiveFunction, DirectiveOptions } from 'vue'
 import { VuetifyLanguage } from './lang'
 import './alacarte'
+import './colors'
 
 declare const Vuetify: Vuetify
 export default Vuetify


### PR DESCRIPTION
Fixes #5163

Fix is as suggested in the issue.

I hope it's OK that this PR don't follow all the contribution requirements. 