### PR TITLE
fix: Bring back momentum in the scrollable dialogs on iOS

### DIFF
--- a/src/stylus/components/_dialogs.styl
+++ b/src/stylus/components/_dialogs.styl
@@ -5,6 +5,7 @@
   border-radius: $card-border-radius
   margin: 24px
   overflow-y: auto
+  -webkit-overflow-scrolling: touch
   pointer-events: auto
   transition: .3s $transition.fast-in-fast-out
   width: 100%


### PR DESCRIPTION
Resolves #4866 

## Description

Dialogs with scroll were missing momentum scrolling on iOS devices. `-webkit-overflow-scrolling: touch` brings back the momentum back into those dialogs.

See [-webkit-overflow-scrolling
](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling)

## Motivation and Context

Fixes #4866 

## How Has This Been Tested?

Tested visually

<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
