### PR TITLE
Fix: Centres pagination button text on iOS 9.3.5

### DIFF
--- a/src/stylus/components/_pagination.styl
+++ b/src/stylus/components/_pagination.styl
@@ -45,9 +45,6 @@ theme(v-pagination, "v-pagination")
   &__item
     elevation(2)
     border-radius: 4px
-    display: inline-flex
-    justify-content: center
-    align-items: center
     font-size: $button-font-size
     background: transparent
     height: 34px


### PR DESCRIPTION
## Description

The current styles for `.v-pagination__item` are using `display: inline-flex` to centre the button text, which is actually unnecessary since button text is inheriting `text-align: center`. I removed the offending code and it seems to be rendering proper now on all devices.

## Motivation and Context

Fixes #5016

## How Has This Been Tested?

Tested visually using BrowserStack

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:

- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
