### PR TITLE
time picker bugfix for empty string

### DIFF
--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -106,7 +106,7 @@ export default {
       }
     },
     setInputData (value) {
-      if (value == null) {
+      if (value == null || value === '') {
         this.inputHour = null
         this.inputMinute = null
         return

--- a/test/unit/components/VTimePicker/VTimePicker.spec.js
+++ b/test/unit/components/VTimePicker/VTimePicker.spec.js
@@ -182,6 +182,10 @@ test('VTimePicker.js', ({ mount }) => {
     wrapper.vm.setInputData(null)
     expect(wrapper.vm.inputHour).toBe(null)
     expect(wrapper.vm.inputMinute).toBe(null)
+    
+    wrapper.vm.setInputData('')
+    expect(wrapper.vm.inputHour).toBe(null)
+    expect(wrapper.vm.inputMinute).toBe(null)
 
     wrapper.vm.setInputData('12:34am')
     expect(wrapper.vm.inputHour).toBe(0)


### PR DESCRIPTION
## Description
I have enhanced the check on setInputData to also validate for empty strings instead of only null values.

## Motivation and Context
Otherwise, if empty string provided as value, it produces NaN:NaN

## How Has This Been Tested?
Changed the line, tested it - it fixed the issues. Now it will be treated as null value (--:--)

## Markup:
<details>

```vue
<template>
  <div>
    <v-checkbox v-model="landscape" label="Landscape"></v-checkbox>
    <v-time-picker v-model="picker" :landscape="landscape"></v-time-picker>
  </div>
</template>
<script>
  export default {
    data () {
      return {
        picker: '',
        landscape: false
      }
    }
  }
</script>
```
</details>

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
