### PR TITLE
fix(v-ripple): decrease click target size on selection control ripple

### DIFF
--- a/src/stylus/components/_selection-controls.styl
+++ b/src/stylus/components/_selection-controls.styl
@@ -54,12 +54,13 @@ rtl(v-selection-control-rtl, "v-input--selection-controls")
 
   &__ripple
     cursor: pointer
-    height: 48px
+    height: 34px
     position: absolute
     transition: inherit
-    width: 48px
+    width: 34px
     left: -12px
     top: calc(50% - 24px)
+    margin: 7px
 
     &:before
       border-radius: 50%
@@ -73,6 +74,9 @@ rtl(v-selection-control-rtl, "v-input--selection-controls")
       transform-origin: center center
       transform: scale(0.2)
       transition: inherit
+
+    .v-ripple__container
+      transform: scale(1.4)
 
   &.v-input .v-label
     align-items: center


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
hopefully removes instances where click targets overlap between adjacent inputs. keep in mind that click target is still larger than actual input to account for mobile users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #2661

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually in playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-layout>
        <v-checkbox
          :label="`Checkbox 1: ${checkbox.toString()}`"
          v-model="checkbox"
        ></v-checkbox>
        <v-radio-group v-model="radioGroup">
          <v-radio
            v-for="n in 3"
            :key="n"
            :label="`Radio ${n}`"
            :value="n"
          ></v-radio>
        </v-radio-group>
        <v-switch
          :label="`Switch 1: ${switch1.toString()}`"
          v-model="switch1"
        ></v-switch>
      </v-layout>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        checkbox: true,
        radioGroup: 1,
        switch1: true
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
