### PR TITLE
Fix #5316

### DIFF
--- a/src/components/VTimePicker/VTimePickerClock.js
+++ b/src/components/VTimePicker/VTimePickerClock.js
@@ -175,10 +175,10 @@ export default {
       const value = Math.round(handAngle / this.degreesPerUnit) +
         this.min + (insideClick ? this.roundCount : 0)
 
-      // Necessary to fix edge case when selecting left part of max value
+      // Necessary to fix edge case when selecting left part of the value(s) at 12 o'clock
       let newValue
       if (handAngle >= (360 - this.degreesPerUnit / 2)) {
-        newValue = insideClick ? this.max : this.min
+        newValue = insideClick ? this.max - this.roundCount + 1 : this.min
       } else {
         newValue = value
       }

--- a/test/unit/components/VTimePicker/VTimePickerClock.spec.js
+++ b/test/unit/components/VTimePicker/VTimePickerClock.spec.js
@@ -218,6 +218,8 @@ test('VTimePickerClock.js', ({ mount }) => {
     finger.move(120, 0)
     expect(input).toBeCalledWith(0)
     finger.move(135, 90)
+    expect(input).toBeCalledWith(4)
+    finger.move(90, 135)
     expect(input).toBeCalledWith(7)
   })
 })


### PR DESCRIPTION
In 24hr mode, when clicking on the left part of `12`, `23` was selected

## Description
For the edge case on an insideClick, instead of selecting `this.max` (i.e. 23), `this.max - this.roundCount + 1` (i.e. 23 - 12 + 1 = 12) is selected

## Motivation and Context
Fixes #5316

## How Has This Been Tested?
Tested manually, no test have been added

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
