### PR TITLE
fix data table sort icon not working when using font awesome 5

### DIFF
--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -33,7 +33,7 @@ theme(v-datatable, "v-datatable")
       cursor: pointer
       outline: 0
 
-      i
+      i, svg
         font-size: 16px
         display: inline-block
         opacity: 0
@@ -41,17 +41,17 @@ theme(v-datatable, "v-datatable")
 
       &:focus,
       &:hover
-        i
+        i, svg
           opacity: .6
 
       &.active
         transform: none
 
-        i
+        i, svg
           opacity: 1
 
         &.desc
-          i
+          i, svg
             transform: rotate(-180deg)
 
 /** Actions */

--- a/src/stylus/components/_data-table.styl
+++ b/src/stylus/components/_data-table.styl
@@ -5,7 +5,7 @@
 v-datatable($material)
   thead
     th.column.sortable
-      i
+      .v-icon
         color: rgba($material.fg-color, $material.disabledORhints-text-percent)
 
       &:hover
@@ -14,7 +14,7 @@ v-datatable($material)
       &.active
         color: rgba($material.fg-color, $material.primary-text-percent)
 
-        i
+        .v-icon
           color: rgba($material.fg-color, $material.primary-text-percent)
 
   .v-datatable__actions
@@ -33,7 +33,7 @@ theme(v-datatable, "v-datatable")
       cursor: pointer
       outline: 0
 
-      i, svg
+      .v-icon
         font-size: 16px
         display: inline-block
         opacity: 0
@@ -41,17 +41,17 @@ theme(v-datatable, "v-datatable")
 
       &:focus,
       &:hover
-        i, svg
+        .v-icon
           opacity: .6
 
       &.active
         transform: none
 
-        i, svg
+        .v-icon
           opacity: 1
 
         &.desc
-          i, svg
+          .v-icon
             transform: rotate(-180deg)
 
 /** Actions */


### PR DESCRIPTION
## Description

Fix data table sort icon not working when using font awesome 5 as default icon font.

Fixes #3548

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
