### PR TITLE
Added seconds support to the VTimePicker

### DIFF
--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -131,7 +131,7 @@ export default {
       }
     },
     setInputData (value) {
-      if (value == null || value === '') {
+      if (value == null) {
         this.inputHour = null
         this.inputMinute = null
         this.inputSecond = null

--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -52,6 +52,30 @@ export default {
   },
 
   computed: {
+    selectingHour: {
+      get () {
+        return this.selecting === selectingTimes.hour
+      },
+      set (v) {
+        this.selecting = selectingTimes.hour
+      }
+    },
+    selectingMinute: {
+      get () {
+        return this.selecting === selectingTimes.minute
+      },
+      set (v) {
+        this.selecting = selectingTimes.minute
+      }
+    },
+    selectingSecond: {
+      get () {
+        return this.selecting === selectingTimes.second
+      },
+      set (v) {
+        this.selecting = selectingTimes.second
+      }
+    },
     isAllowedHourCb () {
       if (!this.min && !this.max) return this.allowedHours
 
@@ -171,6 +195,7 @@ export default {
     onChange () {
       if (this.selecting === (this.useSeconds ? selectingTimes.second : selectingTimes.minute)) {
         this.$emit('change', this.value)
+        // this.selecting = selectingTimes.hour
       } else {
         this.selecting++
       }

--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -131,7 +131,7 @@ export default {
       }
     },
     setInputData (value) {
-      if (value == null) {
+      if (value == null || value === '') {
         this.inputHour = null
         this.inputMinute = null
         this.inputSecond = null

--- a/src/components/VTimePicker/VTimePicker.js
+++ b/src/components/VTimePicker/VTimePicker.js
@@ -13,6 +13,8 @@ const rangeHours24 = createRange(24)
 const rangeHours12am = createRange(12)
 const rangeHours12pm = rangeHours12am.map(v => v + 12)
 const rangeMinutes = createRange(60)
+const rangeSeconds = createRange(60)
+const selectingTimes = { hour: 1, minute: 2, second: 3 }
 
 /* @vue/component */
 export default {
@@ -21,8 +23,10 @@ export default {
   mixins: [Picker],
 
   props: {
+    useSeconds: Boolean,
     allowedHours: Function,
     allowedMinutes: Function,
+    allowedSeconds: Function,
     format: {
       type: String,
       default: 'ampm',
@@ -41,8 +45,9 @@ export default {
     return {
       inputHour: null,
       inputMinute: null,
+      inputSecond: null,
       period: 'am',
-      selectingHour: true
+      selecting: selectingTimes.hour
     }
   },
 
@@ -78,6 +83,26 @@ export default {
           (!this.allowedMinutes || this.allowedMinutes(val))
       }
     },
+    isAllowedSecondCb () {
+      const isHourAllowed = !this.allowedHours || this.allowedHours(this.inputHour)
+      const isMinuteAllowed = !this.allowedMinutes || this.allowedMinutes(this.inputMinute)
+      if (!this.min && !this.max) {
+        return isHourAllowed && isMinuteAllowed ? this.allowedSeconds : () => false
+      }
+
+      const [minHour, minMinute, minSecond] = this.min ? this.min.split(':') : [0, 0, 0]
+      const [maxHour, maxMinute, maxSecond] = this.max ? this.max.split(':') : [23, 59, 59]
+      const minTime = minHour * 3600 + minMinute * 60 + (minSecond || 0) * 1
+      const maxTime = maxHour * 3600 + maxMinute * 60 + (maxSecond || 0) * 1
+
+      return val => {
+        const time = 3600 * this.inputHour + 60 * this.inputMinute + val
+        return time >= minTime &&
+          time <= maxTime &&
+          isHourAllowed && isMinuteAllowed &&
+          (!this.allowedSeconds || this.allowedSeconds(val))
+      }
+    },
     isAmPm () {
       return this.format === 'ampm'
     }
@@ -93,8 +118,8 @@ export default {
 
   methods: {
     emitValue () {
-      if (this.inputHour != null && this.inputMinute != null) {
-        this.$emit('input', `${pad(this.inputHour)}:${pad(this.inputMinute)}`)
+      if (this.inputHour != null && this.inputMinute != null && (!this.useSeconds || this.inputSecond != null)) {
+        this.$emit('input', `${pad(this.inputHour)}:${pad(this.inputMinute)}` + (this.useSeconds ? `:${pad(this.inputSecond)}` : ''))
       }
     },
     setPeriod (period) {
@@ -106,20 +131,23 @@ export default {
       }
     },
     setInputData (value) {
-      if (value == null) {
+      if (value == null || value === '') {
         this.inputHour = null
         this.inputMinute = null
+        this.inputSecond = null
         return
       }
 
       if (value instanceof Date) {
         this.inputHour = value.getHours()
         this.inputMinute = value.getMinutes()
+        this.inputSecond = value.getSeconds()
       } else {
-        const [, hour, minute, , period] = value.trim().toLowerCase().match(/^(\d+):(\d+)(:\d+)?([ap]m)?$/, '') || []
+        const [, hour, minute, , second, period] = value.trim().toLowerCase().match(/^(\d+):(\d+)(:)?(\d+)?([ap]m)?$/, '') || []
 
         this.inputHour = period ? this.convert12to24(parseInt(hour, 10), period) : parseInt(hour, 10)
         this.inputMinute = parseInt(minute, 10)
+        this.inputSecond = parseInt(second || 0, 10)
       }
 
       this.period = this.inputHour < 12 ? 'am' : 'pm'
@@ -131,51 +159,64 @@ export default {
       return hour % 12 + (period === 'pm' ? 12 : 0)
     },
     onInput (value) {
-      if (this.selectingHour) {
+      if (this.selecting === selectingTimes.hour) {
         this.inputHour = this.isAmPm ? this.convert12to24(value, this.period) : value
-      } else {
+      } else if (this.selecting === selectingTimes.minute) {
         this.inputMinute = value
+      } else {
+        this.inputSecond = value
       }
       this.emitValue()
     },
     onChange () {
-      if (!this.selectingHour) {
+      if (this.selecting === (this.useSeconds ? selectingTimes.second : selectingTimes.minute)) {
         this.$emit('change', this.value)
       } else {
-        this.selectingHour = false
+        this.selecting++
       }
     },
     firstAllowed (type, value) {
-      const allowedFn = type === 'hour' ? this.isAllowedHourCb : this.isAllowedMinuteCb
+      const allowedFn = type === 'hour' ? this.isAllowedHourCb : (type === 'minute' ? this.isAllowedMinuteCb : this.isAllowedSecondCb)
       if (!allowedFn) return value
 
       // TODO: clean up
       const range = type === 'minute'
         ? rangeMinutes
-        : (this.isAmPm
-          ? (value < 12
-            ? rangeHours12am
-            : rangeHours12pm)
-          : rangeHours24)
+        : (type === 'second'
+          ? rangeSeconds
+          : (this.isAmPm
+            ? (value < 12
+              ? rangeHours12am
+              : rangeHours12pm)
+            : rangeHours24))
       const first = range.find(v => allowedFn((v + value) % range.length + range[0]))
       return ((first || 0) + value) % range.length + range[0]
     },
     genClock () {
       return this.$createElement(VTimePickerClock, {
         props: {
-          allowedValues: this.selectingHour ? this.isAllowedHourCb : this.isAllowedMinuteCb,
+          allowedValues:
+            this.selecting === selectingTimes.hour
+              ? this.isAllowedHourCb
+              : (this.selecting === selectingTimes.minute
+                ? this.isAllowedMinuteCb
+                : this.isAllowedSecondCb),
           color: this.color,
           dark: this.dark,
-          double: this.selectingHour && !this.isAmPm,
-          format: this.selectingHour ? (this.isAmPm ? this.convert24to12 : val => val) : val => pad(val, 2),
+          double: this.selecting === selectingTimes.hour && !this.isAmPm,
+          format: this.selecting === selectingTimes.hour ? (this.isAmPm ? this.convert24to12 : val => val) : val => pad(val, 2),
           light: this.light,
-          max: this.selectingHour ? (this.isAmPm && this.period === 'am' ? 11 : 23) : 59,
-          min: this.selectingHour && this.isAmPm && this.period === 'pm' ? 12 : 0,
+          max: this.selecting === selectingTimes.hour ? (this.isAmPm && this.period === 'am' ? 11 : 23) : 59,
+          min: this.selecting === selectingTimes.hour && this.isAmPm && this.period === 'pm' ? 12 : 0,
           readonly: this.readonly,
           scrollable: this.scrollable,
           size: this.width - ((!this.fullWidth && this.landscape) ? 80 : 20),
-          step: this.selectingHour ? 1 : 5,
-          value: this.selectingHour ? this.inputHour : this.inputMinute
+          step: this.selecting === selectingTimes.hour ? 1 : 5,
+          value: this.selecting === selectingTimes.hour
+            ? this.inputHour
+            : (this.selecting === selectingTimes.minute
+              ? this.inputMinute
+              : this.inputSecond)
         },
         on: {
           input: this.onInput,
@@ -187,7 +228,7 @@ export default {
     genPickerBody () {
       return this.$createElement('div', {
         staticClass: 'v-time-picker-clock__container',
-        key: this.selectingHour
+        key: this.selecting
       }, [this.genClock()])
     },
     genPickerTitle () {
@@ -196,12 +237,14 @@ export default {
           ampm: this.isAmPm,
           hour: this.inputHour,
           minute: this.inputMinute,
+          second: this.inputSecond,
           period: this.period,
           readonly: this.readonly,
-          selectingHour: this.selectingHour
+          useSeconds: this.useSeconds,
+          selecting: this.selecting
         },
         on: {
-          'update:selectingHour': value => (this.selectingHour = value),
+          'update:selecting': value => (this.selecting = value),
           'update:period': this.setPeriod
         },
         ref: 'title',

--- a/src/components/VTimePicker/VTimePickerTitle.js
+++ b/src/components/VTimePicker/VTimePickerTitle.js
@@ -16,12 +16,14 @@ export default {
     ampm: Boolean,
     hour: Number,
     minute: Number,
+    second: Number,
     period: {
       type: String,
       validator: period => period === 'am' || period === 'pm'
     },
     readonly: Boolean,
-    selectingHour: Boolean
+    useSeconds: Boolean,
+    selecting: Number
   },
 
   methods: {
@@ -33,14 +35,20 @@ export default {
 
       const displayedHour = this.hour == null ? '--' : this.ampm ? hour : pad(hour)
       const displayedMinute = this.minute == null ? '--' : pad(this.minute)
+      const displayedSecond = this.second == null ? '--' : pad(this.second)
 
+      const titleContent = [
+        this.genPickerButton('selecting', 1, displayedHour),
+        this.$createElement('span', ':'),
+        this.genPickerButton('selecting', 2, displayedMinute)
+      ]
+      if (this.useSeconds) {
+        titleContent.push(this.$createElement('span', ':'))
+        titleContent.push(this.genPickerButton('selecting', 3, displayedSecond))
+      }
       return this.$createElement('div', {
         'class': 'v-time-picker-title__time'
-      }, [
-        this.genPickerButton('selectingHour', true, displayedHour),
-        this.$createElement('span', ':'),
-        this.genPickerButton('selectingHour', false, displayedMinute)
-      ])
+      }, titleContent)
     },
     genAmPm () {
       return this.$createElement('div', {

--- a/src/components/VTimePicker/VTimePickerTitle.js
+++ b/src/components/VTimePicker/VTimePickerTitle.js
@@ -23,7 +23,10 @@ export default {
     },
     readonly: Boolean,
     useSeconds: Boolean,
-    selecting: Number
+    selecting: {
+      type: Number,
+      default: 2
+    }
   },
 
   methods: {

--- a/test/unit/components/VTimePicker/VTimePicker.spec.js
+++ b/test/unit/components/VTimePicker/VTimePicker.spec.js
@@ -11,7 +11,7 @@ test('VTimePicker.js', ({ mount }) => {
     })
 
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.selectingHour).toBe(true)
+    expect(wrapper.vm.selecting).toBe(1)
     expect(wrapper.vm.inputHour).toBe(9)
     expect(wrapper.vm.inputMinute).toBe(12)
     expect(wrapper.html()).toMatchSnapshot()
@@ -162,7 +162,7 @@ test('VTimePicker.js', ({ mount }) => {
     clock.$emit('input', 8)
     expect(wrapper.vm.inputHour).toBe(8)
 
-    wrapper.vm.selectingHour = false
+    wrapper.vm.selecting = 2
     clock.$emit('input', 33)
     expect(wrapper.vm.inputHour).toBe(8)
     expect(wrapper.vm.inputMinute).toBe(33)
@@ -212,7 +212,7 @@ test('VTimePicker.js', ({ mount }) => {
     expect(wrapper.vm.inputHour).toBe(15)
   })
 
-  it('should change selectingHour when hour/minute is selected', () => {
+  it('should change selecting when hour/minute is selected', () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '01:23pm',
@@ -223,12 +223,12 @@ test('VTimePicker.js', ({ mount }) => {
     const clock = wrapper.vm.$refs.clock
 
     clock.$emit('change')
-    expect(wrapper.vm.selectingHour).toBe(false)
+    expect(wrapper.vm.selecting).toBe(2)
     clock.$emit('change')
-    expect(wrapper.vm.selectingHour).toBe(false)
+    expect(wrapper.vm.selecting).toBe(2)
   })
 
-  it('should change selectingHour when clicked in title', () => {
+  it('should change selecting when clicked in title', () => {
     const wrapper = mount(VTimePicker, {
       propsData: {
         value: '01:23pm',
@@ -238,11 +238,11 @@ test('VTimePicker.js', ({ mount }) => {
 
     const title = wrapper.vm.$refs.title
 
-    expect(wrapper.vm.selectingHour).toBe(true)
-    title.$emit('update:selectingHour', false)
-    expect(wrapper.vm.selectingHour).toBe(false)
-    title.$emit('update:selectingHour', true)
-    expect(wrapper.vm.selectingHour).toBe(true)
+    expect(wrapper.vm.selecting).toBe(1)
+    title.$emit('update:selecting', 2)
+    expect(wrapper.vm.selecting).toBe(2)
+    title.$emit('update:selecting', 3)
+    expect(wrapper.vm.selecting).toBe(3)
   })
 
   it('should change period when clicked in title', () => {

--- a/test/unit/components/VTimePicker/VTimePickerTitle.spec.js
+++ b/test/unit/components/VTimePicker/VTimePickerTitle.spec.js
@@ -34,7 +34,7 @@ test('VTimePickerTitle.js', ({ mount }) => {
         hour: 14,
         minute: 13,
         period: 'pm',
-        selectingHour: true
+        selecting: 1
       }
     })
 
@@ -95,17 +95,17 @@ test('VTimePickerTitle.js', ({ mount }) => {
       }
     })
 
-    const selectingHour = jest.fn()
-    wrapper.vm.$on('update:selectingHour', selectingHour)
+    const selecting = jest.fn()
+    wrapper.vm.$on('update:selecting', selecting)
 
     wrapper.find('.v-time-picker-title__time .v-picker__title__btn')[1].trigger('click')
-    expect(selectingHour).not.toBeCalled()
+    expect(selecting).not.toBeCalled()
     wrapper.find('.v-time-picker-title__time .v-picker__title__btn')[0].trigger('click')
-    expect(selectingHour).toBeCalledWith(true)
-    wrapper.setProps({ selectingHour: true })
+    expect(selecting).toBeCalledWith(1)
+    wrapper.setProps({ selecting: 1 })
     await wrapper.vm.$nextTick()
     wrapper.find('.v-time-picker-title__time .v-picker__title__btn')[1].trigger('click')
-    expect(selectingHour).toBeCalledWith(false)
+    expect(selecting).toBeCalledWith(2)
   })
 
   it('should emit event when clicked on readonly hours/minutes', async () => {
@@ -118,10 +118,10 @@ test('VTimePickerTitle.js', ({ mount }) => {
       }
     })
 
-    const selectingHour = jest.fn()
-    wrapper.vm.$on('update:selectingHour', selectingHour)
+    const selecting = jest.fn()
+    wrapper.vm.$on('update:selecting', selecting)
 
     wrapper.find('.v-time-picker-title__time .v-picker__title__btn')[0].trigger('click')
-    expect(selectingHour).toBeCalledWith(true)
+    expect(selecting).toBeCalledWith(1)
   })
 })


### PR DESCRIPTION
Fixes #5211

## Added seconds support to the VTimePicker:
- [x] added "use-seconds" props (default: false, type: Boolean) - on/off seconds support
- [x] added "allowed-seconds" props (default: null, type: Function) - Restricts which minutes can be selected


<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added seconds support to the VTimePicker

## Motivation and Context
The VTimePicker component did not support seconds. I fixed it.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-layout row wrap>
    <v-flex xs11 sm5>
      <v-menu
        ref="menu"
        :close-on-content-click="false"
        v-model="menu2"
        :nudge-right="40"
        :return-value.sync="time"
        lazy
        transition="scale-transition"
        offset-y
        full-width
        max-width="290px"
        min-width="290px"
      >
        <v-text-field
          slot="activator"
          v-model="time"
          label="Picker in menu"
          prepend-icon="access_time"
          readonly
        ></v-text-field>
        <v-time-picker
          v-if="menu2"
          v-model="time"
          :use-seconds="useSeconds"
          :allowed-hours="allowedHours"
          :allowed-minutes="allowedMinutes"
          :allowed-seconds="allowedSeconds"
          min="9:30"
          max="22:15"
          format="24hr"
          full-width
          scrollable
          @change="$refs.menu.save(time)"
        ></v-time-picker>
        <!-- use-seconds -->
      </v-menu>
      <v-btn @click="useSeconds = !useSeconds" color="primary">Seconds {{ useSeconds ? 'on' : 'off' }}</v-btn>
    </v-flex>
  </v-layout>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        useSeconds: false,
        time: null,
        menu2: false,
        modal2: false
      }
    },
    methods: {
      allowedHours: v => v % 2,
      allowedMinutes: v => v >= 10 && v <= 50,
      allowedSeconds: v => v >= 30 && v <= 40,
      allowedStep: (m) => m % 10 === 0
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
