### PR TITLE
fix(v-rating): switched from using offsetX to calculate half-increments

### DIFF
--- a/src/components/VRating/VRating.ts
+++ b/src/components/VRating/VRating.ts
@@ -175,7 +175,7 @@ export default mixins(
     isHalfEvent (e: MouseEvent): boolean {
       if (this.halfIncrements) {
         const rect = e.target && (e.target as HTMLElement).getBoundingClientRect()
-        if (rect && e.offsetX < rect.width / 2) return true
+        if (rect && (e.pageX - rect.left) < rect.width / 2) return true
       }
 
       return false

--- a/test/unit/components/VRating/VRating.spec.js
+++ b/test/unit/components/VRating/VRating.spec.js
@@ -132,16 +132,16 @@ test('VRating.js', ({ mount }) => {
     wrapper.setProps({ halfIncrements: true })
 
     expect(wrapper.vm.genHoverIndex({
-      offsetX: 4,
+      pageX: 0,
       target: {
-        getBoundingClientRect: () => ({ width: 10 })
+        getBoundingClientRect: () => ({ width: 10, left: 0 })
       }
     }, 1)).toBe(1.5)
 
     expect(wrapper.vm.genHoverIndex({
-      offsetX: 8,
+      pageX: 6,
       target: {
-        getBoundingClientRect: () => ({ width: 10 })
+        getBoundingClientRect: () => ({ width: 10, left: 0 })
       }
     }, 1)).toBe(2)
   })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Firefox always seem to return 0 for offsetX in mousemove event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #5240

## How Has This Been Tested?
playground and tests

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <div class="text-xs-center">
      <v-rating v-model="rating" half-increments hover></v-rating>
    </div>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      rating: 3
    })
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
