### PR TITLE
Fix v-slider readonly bug

### DIFF
--- a/src/stylus/components/_sliders.styl
+++ b/src/stylus/components/_sliders.styl
@@ -73,7 +73,7 @@ rtl(v-slider-rtl, "v-input--slider")
       .v-input__slot
         margin-bottom: 16px
 
-  &.v-input--is-readonly
+  &.v-input--is-readonly .v-input__control
     pointer-events: none
 
   &.v-input--is-disabled


### PR DESCRIPTION
## Description
The PR solves the issue with the click on the prepend icon when the v-slider is set to `readonly`. I had to move the CSS property `pointer-events: none` from `.v-input--slider.v-input--is-readonly` to `.v-input--slider.v-input--is-readonly .v-input__control`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #5389 

## How Has This Been Tested?
Manually in the local development environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
