### PR TITLE
Fix v-timeline, opposite slot css bug

### DIFF
--- a/src/stylus/components/_timeline.styl
+++ b/src/stylus/components/_timeline.styl
@@ -40,6 +40,10 @@ timeline-dots($dot-size, $inner-dot-size, $inner-dot-margin)
     .v-timeline-item__opposite
       margin-left: 96px
       text-align: left
+      
+      .v-card:before, .v-card:after
+        transform: rotate(0)
+        left: -10px
 
   &:nth-child(even):not(.v-timeline-item--left), &--right
     .v-card:before, .v-card:after
@@ -48,6 +52,10 @@ timeline-dots($dot-size, $inner-dot-size, $inner-dot-margin)
     .v-timeline-item__opposite
       margin-right: 96px
       text-align: right
+      
+      .v-card:before, .v-card:after
+        transform: rotate(180deg)
+        right: -10px
 
   &__dot,
   &__inner-dot


### PR DESCRIPTION
## Description
This fixes a css bug when using v-card in the opposite slot, which makes the indication arrow point in the wrong direction.
[https://codepen.io/jvanst/pen/zmJgao](https://codepen.io/jvanst/pen/zmJgao)

## Motivation and Context
This change is required because its incredibly annoying and only a minor style change is needed.

## How Has This Been Tested?
I have visually tested this change by creating a playground with v-timeline.

## Markup:

<details>

```vue
  <v-container>
      <v-timeline>
        <v-timeline-item>
          <span slot="opposite">
            <v-card height="200">
            </v-card>
          </span>
          <v-card height="200">
          </v-card>
        </v-timeline-item>
      </v-timeline>
    </v-container>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
