### PR TITLE
Added ability to prevent v-edit-dialog from saving

### DIFF
--- a/src/components/VDataTable/VEditDialog.js
+++ b/src/components/VDataTable/VEditDialog.js
@@ -54,6 +54,16 @@ export default {
       this.isActive = false
       this.$emit('cancel')
     },
+    dispatchSave (value) {
+      if (this.$el.dispatchEvent(new CustomEvent('save', { bubbles: false,
+        cancelable: true,
+        detail: {
+          vnodes: this.$slots.input
+        } }))) {
+        this.save(value)
+        this.$emit('save')
+      }
+    },
     focus () {
       const input = this.$refs.content.querySelector('input')
       input && input.focus()
@@ -74,8 +84,7 @@ export default {
       }, [
         this.genButton(this.cancel, this.cancelText),
         this.genButton(() => {
-          this.save(this.returnValue)
-          this.$emit('save')
+          this.dispatchSave(this.returnValue)
         }, this.saveText)
       ])
     },
@@ -86,8 +95,7 @@ export default {
             const input = this.$refs.content.querySelector('input')
             e.keyCode === keyCodes.esc && this.cancel()
             if (e.keyCode === keyCodes.enter && input) {
-              this.save(input.value)
-              this.$emit('save')
+              this.dispatchSave(input.value)
             }
           }
         },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

By using native custom events we could prevent dialog from closing without affecting general usage.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are not able to prevent v-edit-dialog from saving. For ex. when there is a validation error in the inputs saving shouldn't be done.
[issue#3344](https://github.com/vuetifyjs/vuetify/issues/3344)

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
There are two simple cases:
Does it save the value and close the dialog if event is prevented => should not save and shouldn't close
Does it save the value and close the dialog if event is not prevented => should save and close

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-edit-dialog
      :return-value.sync="name"
      lazy
      @save.native="beforeSave"
      @save="save"
      @cancel="cancel"
      @open="open"
      @close="close"
    > {{ name }}
      <v-text-field
        slot="input"
        v-model="name"
        :rules="[required]"
        label="Edit"
        single-line
        counter
      ></v-text-field>
    </v-edit-dialog>
    <v-snackbar v-model="snack" :timeout="3000" :color="snackColor">
      {{ snackText }}
      <v-btn flat @click="snack = false">Close</v-btn>
    </v-snackbar>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      snack: false,
      snackColor: '',
      snackText: '',
      name: "test",
      required: (v) => !!v || 'Required'
    }),
    methods: {
      // Event detail contains vnodes of passed input slots
      beforeSave ($event) {
        // Check if field/s has any error
        if ($event.detail.vnodes.filter(v => v.componentInstance.hasError).length > 0) {
          $event.preventDefault()
          this.snack = true
          this.snackColor = 'error'
          this.snackText = 'Has Error'
        }
      },
      save () {
        this.snack = true
        this.snackColor = 'success'
        this.snackText = 'Data saved'
      },
      cancel () {
        this.snack = true
        this.snackColor = 'error'
        this.snackText = 'Canceled'
      },
      open () {
        this.snack = true
        this.snackColor = 'info'
        this.snackText = 'Dialog opened'
      },
      close () {
        console.log('Dialog closed')
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
