### PR TITLE
fix(v-treeview): empty children expand icon

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -122,6 +122,9 @@ export default mixins<options>(
       if (this.isIndeterminate) return this.indeterminateIcon
       else if (this.isSelected) return this.onIcon
       else return this.offIcon
+    },
+    hasChildren (): boolean {
+      return !!this.children && (!!this.children.length || !!this.loadChildren)
     }
   },
 
@@ -218,7 +221,7 @@ export default mixins<options>(
       const children = [this.genContent()]
 
       if (this.selectable) children.unshift(this.genCheckbox())
-      if (this.children && (this.children.length || this.loadChildren)) children.unshift(this.genToggle())
+      if (this.hasChildren) children.unshift(this.genToggle())
 
       return this.$createElement('div', {
         staticClass: 'v-treeview-node__root',
@@ -283,7 +286,7 @@ export default mixins<options>(
       staticClass: 'v-treeview-node',
       class: {
         [this.activeClass]: this.isActive,
-        'v-treeview-node--leaf': !this.children || (!this.children.length && !this.loadChildren),
+        'v-treeview-node--leaf': !this.hasChildren,
         'v-treeview-node--click': this.openOnClick,
         'v-treeview-node--selected': this.isSelected
       }

--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -218,7 +218,7 @@ export default mixins<options>(
       const children = [this.genContent()]
 
       if (this.selectable) children.unshift(this.genCheckbox())
-      if (this.children) children.unshift(this.genToggle())
+      if (this.children && (this.children.length || this.loadChildren)) children.unshift(this.genToggle())
 
       return this.$createElement('div', {
         staticClass: 'v-treeview-node__root',
@@ -283,7 +283,7 @@ export default mixins<options>(
       staticClass: 'v-treeview-node',
       class: {
         [this.activeClass]: this.isActive,
-        'v-treeview-node--leaf': !this.children,
+        'v-treeview-node--leaf': !this.children || (!this.children.length && !this.loadChildren),
         'v-treeview-node--click': this.openOnClick,
         'v-treeview-node--selected': this.isSelected
       }

--- a/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
+++ b/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
@@ -310,4 +310,37 @@ test('VTreeView.ts', ({ mount }) => {
 
     expect('[Vuetify] The prepend and append slots require a slot-scope attribute').toHaveBeenTipped()
   })
+
+  it('should not show expand icon when children is empty', () => {
+    const wrapper = mount(VTreeview, {
+      propsData: {
+        items: [
+          {
+            text: 'root',
+            children: []
+          }
+        ],
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapper.find('.v-treeview-node__toggle').length).toBe(0)
+  })
+
+  it('should show expand icon when children is empty and load-children prop used', () => {
+    const wrapper = mount(VTreeview, {
+      propsData: {
+        loadChildren: () => {},
+        items: [
+          {
+            text: 'root',
+            children: []
+          }
+        ],
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapper.find('.v-treeview-node__toggle').length).toBe(1)
+  })
 })

--- a/packages/vuetify/test/unit/components/VTreeview/__snapshots__/VTreeview.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VTreeview/__snapshots__/VTreeview.spec.js.snap
@@ -105,6 +105,21 @@ exports[`VTreeView.ts should load children when selecting, but not render 2`] = 
 
 `;
 
+exports[`VTreeView.ts should not show expand icon when children is empty 1`] = `
+
+<div class="v-treeview theme--light">
+  <div class="v-treeview-node v-treeview-node--leaf">
+    <div class="v-treeview-node__root">
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`VTreeView.ts should open all children when using open-all prop 1`] = `
 
 <div class="v-treeview theme--light">
@@ -382,6 +397,26 @@ exports[`VTreeView.ts should select all descendants 1`] = `
       <div class="v-treeview-node__content">
         <label class="v-treeview-node__label">
           Root
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
+exports[`VTreeView.ts should show expand icon when children is empty and load-children prop used 1`] = `
+
+<div class="v-treeview theme--light">
+  <div class="v-treeview-node">
+    <div class="v-treeview-node__root">
+      <i aria-hidden="true"
+         class="v-icon v-treeview-node__toggle v-icon--link material-icons theme--light"
+      >
+        arrow_drop_down
+      </i>
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
         </label>
       </div>
     </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
changed logic for rendering expand icon to only show when children has items, or load-children prop is used

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #5357

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
playground and tests

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-treeview :items="items"></v-treeview>
        <v-treeview :items="items" :load-children="fn"></v-treeview>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
  export default {
    methods: {
      fn() {}
    },
    data: () => ({
      items: [
        {
        'id': 1,
        'name': 'root',
        children: [
          {
            id: 2,
            'name': 'child',
            'children' : []
          },
          {
            id: 3,
            'name': 'child',
          }
        ]
      }
          ]
    })
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
