### PR TITLE
fix: #5444 - Remove v-footer min-height

### DIFF
--- a/src/stylus/components/_footer.styl
+++ b/src/stylus/components/_footer.styl
@@ -11,7 +11,6 @@ theme(v-footer, "v-footer")
   align-items: center
   display: flex
   flex: 0 1 auto !important // Don't let devs break their code
-  min-height: $footer-height
   transition: .2s $transition.fast-out-slow-in
 
   &--absolute,

--- a/src/stylus/settings/_variables.styl
+++ b/src/stylus/settings/_variables.styl
@@ -212,9 +212,6 @@ $chip-icon-negative-offset := -8px
 $expansion-panel-collapse-height := 48px
 $collapsible-transition-height := 0.23s
 
-// Footer
-$footer-height := 36px
-
 /** Lists */
 // List fonts and weights
 $list-tile-font-size := $headings.subheading.size // 16px - the mdc scss uses subheading to configure like this


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Remove the `min-height` attribute of the `v-footer` component so that the `height` prop determines the height of the `v-footer` component. 

## Motivation and Context
See the issue #5444.

The `height` prop of the `v-footer` component is largely useless because the `v-footer` has a large min-height. The default `height` prop of the `v-footer` component is lower than the `min-height`.

## How Has This Been Tested?
none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
