### PR TITLE
fix(VTextField): outline border color in error state

### DIFF
--- a/packages/vuetify/src/stylus/components/_text-fields.styl
+++ b/packages/vuetify/src/stylus/components/_text-fields.styl
@@ -52,7 +52,7 @@ v-text-field($material)
     .v-input__slot
       border: 2px solid $material.text.secondary
 
-    &:not(.v-input--is-focused)
+    &:not(.v-input--is-focused):not(.v-input--has-state)
       .v-input__slot:hover
         border: 2px solid $material.text.primary
 
@@ -308,7 +308,7 @@ rtl(v-text-field-rtl, "v-text-field")
     .v-input__append-outer
       margin-top: 18px // 2px for border
 
-    &.v-input--is-focused
+    &.v-input--is-focused, &.v-input--has-state
       .v-input__slot
         border: 2px solid currentColor
         transition: border $primary-transition


### PR DESCRIPTION
## Motivation and Context
fixes #5274

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-container fluid grid-list-md>
      <v-layout row wrap>
        <v-flex xs6>
          <v-textarea
            name="input-7-1"
            value="Delete this then click out of the textarea"
            outline
            :rules=required
          ></v-textarea>
        </v-flex>
      </v-layout>
    </v-container>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    required: [v => !!v || 'This field is required']
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
