### PR TITLE
fix(VMenu): auto positioning with dense prop

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -135,7 +135,7 @@ export default Vue.extend({
     calculatedTop () {
       if (!this.auto || this.isAttached) return this.calcTop()
 
-      return `${this.calcYOverflow(this.calcTopAuto())}px`
+      return `${this.calcYOverflow(this.calculatedTopAuto)}px`
     },
     styles () {
       return {
@@ -147,9 +147,6 @@ export default Vue.extend({
         transformOrigin: this.origin,
         zIndex: this.zIndex || this.activeZIndex
       }
-    },
-    tileHeight () {
-      return this.dense ? 36 : 48
     }
   },
 
@@ -173,8 +170,11 @@ export default Vue.extend({
       this.updateDimensions()
       // Start the transition
       requestAnimationFrame(this.startTransition)
-      // Once transitioning, calculate scroll position
-      setTimeout(this.calculateScroll, 50)
+      // Once transitioning, calculate scroll and top position
+      setTimeout(() => {
+        this.calculatedTopAuto = this.calcTopAuto()
+        this.auto && this.setScrollPosition()
+      }, 50)
     },
     closeConditional () {
       return this.isActive && this.closeOnClick

--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -88,9 +88,6 @@ export default Vue.extend({
   data () {
     return {
       defaultOffset: 8,
-      maxHeightAutoDefault: '200px',
-      startIndex: 3,
-      stopIndex: 0,
       hasJustFocused: false,
       resizeTimeout: null
     }

--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -169,12 +169,15 @@ export default Vue.extend({
       // and its activator
       this.updateDimensions()
       // Start the transition
-      requestAnimationFrame(this.startTransition)
-      // Once transitioning, calculate scroll and top position
-      setTimeout(() => {
-        this.calculatedTopAuto = this.calcTopAuto()
-        this.auto && this.setScrollPosition()
-      }, 50)
+      requestAnimationFrame(() => {
+        // Once transitioning, calculate scroll and top position
+        this.startTransition().then(() => {
+          if (this.$refs.content) {
+            this.calculatedTopAuto = this.calcTopAuto()
+            this.auto && (this.$refs.content.scrollTop = this.calcScrollPosition())
+          }
+        })
+      })
     },
     closeConditional () {
       return this.isActive && this.closeOnClick

--- a/packages/vuetify/src/components/VMenu/mixins/menu-position.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-position.js
@@ -12,16 +12,14 @@ export default {
     calculatedTopAuto: 0
   }),
   methods: {
-    setScrollPosition () {
+    calcScrollPosition () {
       const $el = this.$refs.content
-      if (!$el || this.selectedIndex === null) return
+      const activeTile = $el.querySelector('.v-list__tile--active')
+      const maxScrollTop = $el.scrollHeight - $el.offsetHeight
 
-      const activeItem = this.tiles[this.selectedIndex]
-      if (activeItem) {
-        $el.scrollTop = activeItem.offsetTop - $el.offsetHeight / 2 + activeItem.offsetHeight / 2
-      } else {
-        $el.scrollTop = 0
-      }
+      return activeTile
+        ? Math.min(maxScrollTop, Math.max(0, activeTile.offsetTop - $el.offsetHeight / 2 + activeTile.offsetHeight / 2))
+        : $el.scrollTop
     },
     calcLeftAuto () {
       if (this.isAttached) return 0
@@ -29,47 +27,20 @@ export default {
       return parseInt(this.dimensions.activator.left - this.defaultOffset * 2)
     },
     calcTopAuto () {
-      const selectedIndex = Array.from(this.tiles)
-        .findIndex(n => n.classList.contains('v-list__tile--active'))
+      const $el = this.$refs.content
+      const activeTile = $el.querySelector('.v-list__tile--active')
 
-      if (selectedIndex === -1) {
+      if (!activeTile) {
         this.selectedIndex = null
-
         return this.computedTop
       }
 
-      const tileHeight = this.tiles[selectedIndex].offsetHeight
+      this.selectedIndex = Array.from(this.tiles).indexOf(activeTile)
 
-      this.selectedIndex = selectedIndex
-      this.stopIndex = this.tiles.length > 4
-        ? this.tiles.length - 4
-        : this.tiles.length
-      let additionalOffset = this.defaultOffset
-      let offsetPadding
+      const tileDistanceFromMenuTop = activeTile.offsetTop - this.getScrollPosition()
+      const firstTileOffsetTop = $el.querySelector('.v-list__tile').offsetTop
 
-      // Menu should be centered
-      if (selectedIndex > this.startIndex &&
-        selectedIndex < this.stopIndex
-      ) {
-        offsetPadding = 1.5 * tileHeight
-      // Menu should be offset top
-      } else if (selectedIndex >= this.stopIndex) {
-        // Being offset top means
-        // we have to account for top
-        // and bottom list padding
-        additionalOffset *= 2
-        offsetPadding = (selectedIndex - this.stopIndex) * tileHeight
-      // Menu should be offset bottom
-      } else {
-        offsetPadding = selectedIndex * tileHeight
-      }
-
-      return (
-        this.computedTop +
-        additionalOffset -
-        offsetPadding -
-        (tileHeight / 2)
-      )
+      return this.computedTop - tileDistanceFromMenuTop - firstTileOffsetTop
     }
   }
 }

--- a/packages/vuetify/src/components/VMenu/mixins/menu-position.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-position.js
@@ -8,30 +8,19 @@
  */
 /* @vue/component */
 export default {
+  data: () => ({
+    calculatedTopAuto: 0
+  }),
   methods: {
-    // Revisit this
-    calculateScroll () {
-      if (this.selectedIndex === null) return
+    setScrollPosition () {
+      const $el = this.$refs.content
+      if (!$el || this.selectedIndex === null) return
 
-      let scrollTop = 0
-
-      if (this.selectedIndex >= this.stopIndex) {
-        scrollTop = this.$refs.content.scrollHeight
-      } else if (this.selectedIndex > this.startIndex) {
-        scrollTop = (
-          // Top position of selected item
-          (this.selectedIndex * this.tileHeight) +
-          // Remove half of a tile's height
-          (this.tileHeight / 2) +
-          // Account for padding offset on lists
-          (this.defaultOffset / 2) -
-          // Half of the auto content's height
-          100
-        )
-      }
-
-      if (this.$refs.content) {
-        this.$refs.content.scrollTop = scrollTop
+      const activeItem = this.tiles[this.selectedIndex]
+      if (activeItem) {
+        $el.scrollTop = activeItem.offsetTop - $el.offsetHeight / 2 + activeItem.offsetHeight / 2
+      } else {
+        $el.scrollTop = 0
       }
     },
     calcLeftAuto () {
@@ -49,6 +38,8 @@ export default {
         return this.computedTop
       }
 
+      const tileHeight = this.tiles[selectedIndex].offsetHeight
+
       this.selectedIndex = selectedIndex
       this.stopIndex = this.tiles.length > 4
         ? this.tiles.length - 4
@@ -60,24 +51,24 @@ export default {
       if (selectedIndex > this.startIndex &&
         selectedIndex < this.stopIndex
       ) {
-        offsetPadding = 1.5 * this.tileHeight
+        offsetPadding = 1.5 * tileHeight
       // Menu should be offset top
       } else if (selectedIndex >= this.stopIndex) {
         // Being offset top means
         // we have to account for top
         // and bottom list padding
         additionalOffset *= 2
-        offsetPadding = (selectedIndex - this.stopIndex) * this.tileHeight
+        offsetPadding = (selectedIndex - this.stopIndex) * tileHeight
       // Menu should be offset bottom
       } else {
-        offsetPadding = selectedIndex * this.tileHeight
+        offsetPadding = selectedIndex * tileHeight
       }
 
       return (
         this.computedTop +
         additionalOffset -
         offsetPadding -
-        (this.tileHeight / 2)
+        (tileHeight / 2)
       )
     }
   }

--- a/packages/vuetify/src/components/VMenu/mixins/menu-position.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-position.js
@@ -37,7 +37,7 @@ export default {
 
       this.selectedIndex = Array.from(this.tiles).indexOf(activeTile)
 
-      const tileDistanceFromMenuTop = activeTile.offsetTop - this.getScrollPosition()
+      const tileDistanceFromMenuTop = activeTile.offsetTop - this.calcScrollPosition()
       const firstTileOffsetTop = $el.querySelector('.v-list__tile').offsetTop
 
       return this.computedTop - tileDistanceFromMenuTop - firstTileOffsetTop

--- a/packages/vuetify/src/components/VMenu/mixins/menu-position.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-position.js
@@ -32,6 +32,9 @@ export default {
 
       if (!activeTile) {
         this.selectedIndex = null
+      }
+
+      if (this.offsetY || !activeTile) {
         return this.computedTop
       }
 

--- a/packages/vuetify/src/mixins/menuable.js
+++ b/packages/vuetify/src/mixins/menuable.js
@@ -328,7 +328,10 @@ export default Vue.extend({
       })
     },
     startTransition () {
-      requestAnimationFrame(() => (this.isContentActive = true))
+      return new Promise(resolve => requestAnimationFrame(() => {
+        this.isContentActive = true
+        resolve()
+      }))
     },
     isShown (el) {
       return el.style.display !== 'none'

--- a/packages/vuetify/src/stylus/components/_menus.styl
+++ b/packages/vuetify/src/stylus/components/_menus.styl
@@ -44,16 +44,6 @@
     max-width: none
 
   &-transition
-    &-enter
-      .v-list__tile
-        min-width: 0
-        pointer-events: none
-
-    &-enter-to
-      .v-list__tile
-        pointer-events: auto
-        transition-delay: .1s
-
     &-leave-active,
     &-leave-to
       pointer-events: none
@@ -64,15 +54,4 @@
 
     &-enter-active,
     &-leave-active
-      transition: all .3s $transition.fast-in-fast-out
-
-.v-menu-transition-enter
-  &.v-menu__content--auto
-    .v-list__tile
-        opacity: 0
-        transform: translateY(-15px)
-
-    .v-list__tile--active
-      opacity: 1
-      transform: none !important
-      pointer-events: auto
+      transition: all .3s $transition.fast-in-fast-out, top 0

--- a/packages/vuetify/src/stylus/components/_menus.styl
+++ b/packages/vuetify/src/stylus/components/_menus.styl
@@ -54,4 +54,7 @@
 
     &-enter-active,
     &-leave-active
-      transition: all .3s $transition.fast-in-fast-out, top 0
+      transition: all .3s $transition.fast-in-fast-out
+
+.v-menu__content--auto
+  transition: none !important

--- a/packages/vuetify/src/stylus/components/_menus.styl
+++ b/packages/vuetify/src/stylus/components/_menus.styl
@@ -44,6 +44,15 @@
     max-width: none
 
   &-transition
+    &-enter
+      .v-list__tile
+        min-width: 0
+        pointer-events: none
+    &-enter-to
+      .v-list__tile
+        pointer-events: auto
+        transition-delay: .1s
+
     &-leave-active,
     &-leave-to
       pointer-events: none
@@ -56,5 +65,15 @@
     &-leave-active
       transition: all .3s $transition.fast-in-fast-out
 
-.v-menu__content--auto
-  transition: none !important
+.v-menu-transition-enter
+  &.v-menu__content--auto
+    transition: none !important
+
+    .v-list__tile
+      opacity: 0
+      transform: translateY(-15px)
+
+    .v-list__tile--active
+      opacity: 1
+      transform: none !important
+      pointer-events: auto


### PR DESCRIPTION
## Description
adds dense prop to menu, fixes dense list item height and menu position when opened first time

## Motivation and Context
fixes #5149

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-btn v-for="state in [null, 'Alabama', 'Missouri', 'Wyoming']" @click="e1 = state" :key="state || ''">{{ state || 'null' }}</v-btn>
      <div style="height: 200px"></div>
      <v-select :items="states" v-model="e1" menu-props="auto" label="select, auto, dense" dense></v-select>
      <v-select :items="states" v-model="e1" menu-props="auto" label="select, auto, normal"></v-select>
      <v-autocomplete :items="states" v-model="e1" menu-props="auto" label="autocomplete, auto, dense" dense></v-autocomplete>
      <v-autocomplete :items="states" v-model="e1" menu-props="auto" label="autocomplete, auto, normal"></v-autocomplete>
      <v-combobox :items="states" v-model="e1" menu-props="auto" label="combobox, auto, dense" dense></v-combobox>
      <v-combobox :items="states" v-model="e1" menu-props="auto" label="combobox, auto, normal"></v-combobox>
      <v-select :items="states" v-model="e1" label="select, non-auto, dense" dense></v-select>
      <v-select :items="states" v-model="e1" label="select, non-auto, normal"></v-select>
      <v-autocomplete :items="states" v-model="e1" label="autocomplete, non-auto, dense" dense></v-autocomplete>
      <v-autocomplete :items="states" v-model="e1" label="autocomplete, non-auto, normal"></v-autocomplete>
      <v-combobox :items="states" v-model="e1" label="combobox, non-auto, dense" dense></v-combobox>
      <v-combobox :items="states" v-model="e1" label="combobox, non-auto, normal"></v-combobox>
      <div style="height: 200px"></div>
    </v-container>
  </v-app>
</template>

<script>
export default {
  data () {
    return {
      e1: null,
      states: [
        'Alabama', 'Alaska', 'American Samoa', 'Arizona',
        'Arkansas', 'California', 'Colorado', 'Connecticut',
        'Delaware', 'District of Columbia', 'Federated States of Micronesia',
        'Florida', 'Georgia', 'Guam', 'Hawaii', 'Idaho',
        'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky',
        'Louisiana', 'Maine', 'Marshall Islands', 'Maryland',
        'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi',
        'Missouri', 'Montana', 'Nebraska', 'Nevada',
        'New Hampshire', 'New Jersey', 'New Mexico', 'New York',
        'North Carolina', 'North Dakota', 'Northern Mariana Islands', 'Ohio',
        'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico',
        'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee',
        'Texas', 'Utah', 'Vermont', 'Virgin Island', 'Virginia',
        'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
      ]
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
