### PR TITLE
fix(VSelect): dont open menu on keydown when readonly

### DIFF
--- a/src/components/VSelect/VSelect.js
+++ b/src/components/VSelect/VSelect.js
@@ -556,7 +556,7 @@ export default {
       const keyCode = e.keyCode
 
       // If enter, space, up, or down is pressed, open menu
-      if (!this.isMenuActive && [
+      if (!this.readonly && !this.isMenuActive && [
         keyCodes.enter,
         keyCodes.space,
         keyCodes.up, keyCodes.down

--- a/test/unit/components/VSelect/VSelect2.spec.js
+++ b/test/unit/components/VSelect/VSelect2.spec.js
@@ -30,6 +30,28 @@ test('VSelect2', ({ mount, compileToFunctions }) => {
     }
   })
 
+  it('should not open the select when readonly and focused and enter, space, up or down are pressed', async () => {
+    const wrapper = mount(VSelect, {
+      attachToDocument: true,
+      propsData: {
+        items: ['foo', 'bar'],
+        readonly: true
+      }
+    })
+
+    const input = wrapper.first('input')
+
+    for (const key of ['up', 'down', 'space', 'enter']) {
+      input.trigger('focus')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.isMenuActive).toBe(false)
+      input.trigger(`keydown.${key}`)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.isMenuActive).toBe(false)
+      await wrapper.vm.$nextTick()
+    }
+  })
+
   it('should clear input value', async () => {
     const wrapper = mount(VSelect, {
       attachToDocument: true,


### PR DESCRIPTION
## Motivation and Context
fixes #5005

## How Has This Been Tested?
visually, unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-select :items="items" label="Standard"></v-select>
        <v-select :items="items" label="Readonly" readonly></v-select>
        <v-select :items="items" label="Disabled" disabled></v-select>

        <v-autocomplete :items="items" label="Standard"></v-autocomplete>
        <v-autocomplete :items="items" label="Readonly" readonly></v-autocomplete>
        <v-autocomplete :items="items" label="Disabled" disabled></v-autocomplete>

        <v-combobox :items="items" label="Standard"></v-combobox>
        <v-combobox :items="items" label="Readonly" readonly></v-combobox>
        <v-combobox :items="items" label="Disabled" disabled></v-combobox>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    items: ['Foo', 'Bar', 'Fizz', 'Buzz']
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have created a PR in the [documentation](https://github.com/vuetifyjs/vuetifyjs.com) with the necessary changes.
