### PR TITLE
Added Pagination Props as example

### DIFF
--- a/packages/api-generator/src/map.js
+++ b/packages/api-generator/src/map.js
@@ -124,7 +124,13 @@ const sharedGridProps = [
 const dataIterableProps = [
   {
     name: 'pagination',
-    sync: true
+    sync: true,
+    example: {
+      descending: 'boolean',
+      sortBy: 'string',
+      rowsPerPage: '\'integer\' | \'-1 === All\'',
+      page: 'interger'
+    }
   },
   {
     name: 'filter',

--- a/packages/api-generator/src/map.js
+++ b/packages/api-generator/src/map.js
@@ -129,7 +129,7 @@ const dataIterableProps = [
       descending: 'boolean',
       sortBy: 'string',
       rowsPerPage: 'number // -1 for All',
-      page: 'interger'
+      page: 'number'
     }
   },
   {

--- a/packages/api-generator/src/map.js
+++ b/packages/api-generator/src/map.js
@@ -128,7 +128,7 @@ const dataIterableProps = [
     example: {
       descending: 'boolean',
       sortBy: 'string',
-      rowsPerPage: '\'integer\' | \'-1 === All\'',
+      rowsPerPage: 'number // -1 for All',
       page: 'interger'
     }
   },


### PR DESCRIPTION
## Description
Added Pagination Props as an example in the dataIterable Props Array, so it gets added as example in to both the v-data-table and the v-data-iterable doc pages.

## Motivation and Context
This answers a frequent questions seen on the Discord channel. Such as:
* How do I change sort direction by default?
* How do I sort by a specific column?
* How do I set the Rows Per Page by default?
* How do I set/change the page the component is on?

Resolves https://github.com/vuetifyjs/vuetifyjs.com/issues/503

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
