### PR TITLE
feat(VDatePicker): multiple event indicators

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.js
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.js
@@ -27,12 +27,12 @@ export default {
       default: null
     },
     events: {
-      type: [Array, Object, Function],
+      type: [Array, Function, Object],
       default: () => null
     },
     eventColor: {
-      type: [String, Function, Object],
-      default: 'warning'
+      type: [Array, Function, Object, String],
+      default: () => 'warning'
     },
     firstDayOfWeek: {
       type: [String, Number],

--- a/packages/vuetify/src/stylus/components/_date-picker-table.styl
+++ b/packages/vuetify/src/stylus/components/_date-picker-table.styl
@@ -58,17 +58,23 @@ theme(v-date-picker-table, "v-date-picker-table")
   td
     width: 45px
 
-.v-date-picker-table__event
-  border-radius: 50%
-  display: block
+.v-date-picker-table__events
   height: 8px
-  left: 50%
+  left: 0
   position: absolute
-  transform: translateX(-4px)
-  width: 8px
+  text-align: center
+  white-space: pre
+  width: 100%
 
-.v-date-picker-table--date .v-date-picker-table__event
-  bottom: 2px
+  > div
+    border-radius: 50%
+    display: inline-block
+    height: 8px
+    margin: 0 1px
+    width: 8px
 
-.v-date-picker-table--month .v-date-picker-table__event
-  bottom: 3px
+.v-date-picker-table--date .v-date-picker-table__events
+  bottom: 6px
+
+.v-date-picker-table--month .v-date-picker-table__events
+  bottom: 8px

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerDateTable.spec.js.snap
@@ -1043,7 +1043,9 @@ exports[`VDatePickerDateTable.js should render component with events (array) and
             <div class="v-btn__content">
               3
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -1370,7 +1372,9 @@ exports[`VDatePickerDateTable.js should render component with events (function) 
             <div class="v-btn__content">
               3
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -1697,7 +1701,9 @@ exports[`VDatePickerDateTable.js should render component with events colored by 
             <div class="v-btn__content">
               3
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -1707,8 +1713,6 @@ exports[`VDatePickerDateTable.js should render component with events colored by 
           >
             <div class="v-btn__content">
               4
-            </div>
-            <div class="v-date-picker-table__event accent">
             </div>
           </button>
         </td>
@@ -2026,7 +2030,9 @@ exports[`VDatePickerDateTable.js should render component with events colored by 
             <div class="v-btn__content">
               3
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -2037,7 +2043,9 @@ exports[`VDatePickerDateTable.js should render component with events colored by 
             <div class="v-btn__content">
               4
             </div>
-            <div class="v-date-picker-table__event blue lighten-1">
+            <div class="v-date-picker-table__events">
+              <div class="blue lighten-1">
+              </div>
             </div>
           </button>
         </td>

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerMonthTable.spec.js.snap
@@ -325,7 +325,9 @@ exports[`VDatePickerMonthTable.js should render component with events (array) an
             <div class="v-btn__content">
               Jul
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -365,7 +367,9 @@ exports[`VDatePickerMonthTable.js should render component with events (array) an
             <div class="v-btn__content">
               Nov
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -456,7 +460,9 @@ exports[`VDatePickerMonthTable.js should render component with events (function)
             <div class="v-btn__content">
               Jul
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -496,7 +502,9 @@ exports[`VDatePickerMonthTable.js should render component with events (function)
             <div class="v-btn__content">
               Nov
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -587,7 +595,9 @@ exports[`VDatePickerMonthTable.js should render component with events colored by
             <div class="v-btn__content">
               Jul
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -627,7 +637,9 @@ exports[`VDatePickerMonthTable.js should render component with events colored by
             <div class="v-btn__content">
               Nov
             </div>
-            <div class="v-date-picker-table__event blue lighten-1">
+            <div class="v-date-picker-table__events">
+              <div class="blue lighten-1">
+              </div>
             </div>
           </button>
         </td>
@@ -718,7 +730,9 @@ exports[`VDatePickerMonthTable.js should render component with events colored by
             <div class="v-btn__content">
               Jul
             </div>
-            <div class="v-date-picker-table__event red">
+            <div class="v-date-picker-table__events">
+              <div class="red">
+              </div>
             </div>
           </button>
         </td>
@@ -758,7 +772,9 @@ exports[`VDatePickerMonthTable.js should render component with events colored by
             <div class="v-btn__content">
               Nov
             </div>
-            <div class="v-date-picker-table__event blue lighten-1">
+            <div class="v-date-picker-table__events">
+              <div class="blue lighten-1">
+              </div>
             </div>
           </button>
         </td>

--- a/packages/vuetifyjs.com/src/examples/date-pickers/dateEvents.vue
+++ b/packages/vuetifyjs.com/src/examples/date-pickers/dateEvents.vue
@@ -39,7 +39,9 @@
     methods: {
       functionEvents (date) {
         const [,, day] = date.split('-')
-        return parseInt(day, 10) % 3 === 0
+        if ([12, 17, 28].includes(parseInt(day, 10))) return true
+        if ([1, 19, 22].includes(parseInt(day, 10))) return ['red', '#00f']
+        return false
       }
     }
   }

--- a/packages/vuetifyjs.com/src/examples/date-pickers/monthEvents.vue
+++ b/packages/vuetifyjs.com/src/examples/date-pickers/monthEvents.vue
@@ -13,7 +13,6 @@
       <div class="subheading">Defined by function</div>
       <v-date-picker
         v-model="date2"
-        :event-color="functionEventColors"
         :events="functionEvents"
         type="month"
       ></v-date-picker>
@@ -41,11 +40,9 @@
     methods: {
       functionEvents (date) {
         const month = parseInt(date.split('-')[1], 10)
-        return month % 2 === 1
-      },
-      functionEventColors (date) {
-        const month = parseInt(date.split('-')[1], 10)
-        return [false, 'purple', false, 'red'][month % 4]
+        if ([1, 3, 7].includes(month)) return true
+        if ([2, 5, 12].includes(month)) return ['error', 'purple', 'rgba(0, 128, 0, 0.5)']
+        return false
       }
     }
   }

--- a/packages/vuetifyjs.com/src/lang/en/components/DatePickers.json
+++ b/packages/vuetifyjs.com/src/lang/en/components/DatePickers.json
@@ -44,7 +44,7 @@
     },
     "dateEvents": {
       "header": "Date pickers - Events",
-      "desc": "You can specify events using arrays, objects, and functions. To change the default color of the event use **event-color** prop."
+      "desc": "You can specify events using arrays, objects or functions. To change the default color of the event use **event-color** prop. Your **events** function or object can return an array of colors (material or css) in case you want to display multiple event indicators."
     },
     "dateInternationalization": {
       "header": "Date pickers - Internationalization",
@@ -76,7 +76,7 @@
     },
     "monthAllowedMonths": {
       "header": "Month pickers - Allowed months",
-      "desc": "You can specify allowed months using arrays, objects, and functions."
+      "desc": "You can specify allowed months using arrays, objects or functions."
     },
     "monthMultiple": {
       "header": "Month pickers - Multiple",
@@ -88,7 +88,7 @@
     },
     "monthEvents": {
       "header": "Month pickers - Events",
-      "desc": "You can specify events using arrays, objects, and functions. To change the default color of the event use **event-color** prop."
+      "desc": "You can specify events using arrays, objects or functions. To change the default color of the event use **event-color** prop. Your **events** function or object can return an array of colors (material or css) in case you want to display multiple event indicators."
     },
     "monthInternationalization": {
       "header": "Month pickers - Internationalization",
@@ -112,8 +112,8 @@
       "type": "Determines the type of the picker - `date` for date picker, `month` for month picker",
       "monthFormat": "Formatting function used for displaying months in the months table. Called with date (ISO 8601 string) and locale (string) arguments.",
       "allowedDates": "Restricts which dates can be selected",
-      "eventColor": "Sets the color for event dot. It can be string (all events will have the same color) or `object` where attribute is the event date and value is the color for specified date or `function` taking date as a parameter and returning color for that date",
-      "events": "Marks the date as an event (only for date picker)",
+      "eventColor": "Sets the color for event dot. It can be string (all events will have the same color) or `object` where attribute is the event date and value is boolean/color/array of colors for specified date or `function` taking date as a parameter and returning boolean/color/array of colors for that date",
+      "events": "Array of dates or object defining events or colors or function returning boolean/color/array of colors",
       "locale": "Sets the locale. Accepts a string with a BCP 47 language tag.",
       "firstDayOfWeek": "Sets the first day of the week, starting with 0 for Sunday.",
       "titleDateFormat": "Allows you to customize the format of the date string that appears in the title of the date picker. Called with date (ISO 8601 string) and locale (string) arguments.",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
![image](https://user-images.githubusercontent.com/15625235/47903929-fa53a500-deb6-11e8-8a2c-7e3104c2e15d.png)

## Motivation and Context
fixes #5501

## How Has This Been Tested?
visually, updated snaps

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-date-picker value="2018-01-05" :events="eventsDateArray" :event-color="['red', 'blue']"></v-date-picker>
      <v-date-picker type="month" value="2018-05" :events="eventsMonthArray" :event-color="['red', 'blue']"></v-date-picker>
      <v-date-picker value="2018-01-05" :events="eventsDateObject"></v-date-picker>
      <v-date-picker type="month" value="2018-05" :events="eventsMonthObject"></v-date-picker>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    eventsDateArray: ['2018-01-04', '2018-01-05', '2018-01-07'],
    eventsMonthArray: ['2018-01', '2018-05', '2018-07'],
    eventsDateObject: {'2018-01-03': false, '2018-01-04': true, '2018-01-05': 'red', '2018-01-07': ['blue', 'green', 'black']},
    eventsMonthObject: {'2018-01': false, '2018-03': true, '2018-05': 'red', '2018-07': ['blue', 'green', 'black']},
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
