### PR TITLE
fix(VSelect): add scopeId to VSelectList

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.js
+++ b/packages/vuetify/src/components/VSelect/VSelect.js
@@ -157,7 +157,11 @@ export default {
       return this.selectedItems.length > 0
     },
     listData () {
+      const scopeId = this.$vnode && this.$vnode.context.$options._scopeId
       return {
+        attrs: scopeId ? {
+          [scopeId]: true
+        } : null,
         props: {
           action: this.multiple && !this.isHidingSelected,
           color: this.color,


### PR DESCRIPTION
## Motivation and Context
fixes #5568

## Comments
Markup works without the fix, but this is because the `.application` gets the `data-v` attribute. If `<v-select>` is in another .vue file then then `<v-select-list>` won't be a child of the component's root so this is where the fix starts working, but you can see the it gets the proper `data-v` attr

It would be better to add `data-v` to the `.v-menu__content` but I couldn't figure out the smart way of doing this

## How Has This Been Tested?
visually 

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-select :items="['a']" />
    </v-container>
  </v-app>
</template>

<style scoped>
  >>> .v-list__tile__title {
    border: 4px solid red;
  }
</style>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
