### PR TITLE
fix(WindowItem): calculate height on leave

### DIFF
--- a/packages/vuetify/src/components/VWindow/VWindowItem.ts
+++ b/packages/vuetify/src/components/VWindow/VWindowItem.ts
@@ -90,7 +90,7 @@ export default mixins<options & ExtractVue<[typeof Bootable]>>(
     onBeforeEnter () {
       this.windowGroup.isActive = true
     },
-    onBeforeLeave (el: HTMLElement) {
+    onLeave (el: HTMLElement) {
       this.windowGroup.internalHeight = convertToUnit(el.clientHeight)
     },
     onEnterCancelled () {
@@ -131,7 +131,7 @@ export default mixins<options & ExtractVue<[typeof Bootable]>>(
       on: {
         afterEnter: this.onAfterEnter,
         beforeEnter: this.onBeforeEnter,
-        beforeLeave: this.onBeforeLeave,
+        leave: this.onLeave,
         enter: this.onEnter,
         enterCancelled: this.onEnterCancelled
       }

--- a/packages/vuetify/test/unit/components/VWindow/VWindowItem.spec.js
+++ b/packages/vuetify/test/unit/components/VWindow/VWindowItem.spec.js
@@ -28,8 +28,8 @@ test('VWindowItem.ts', ({ mount }) => {
     expect(wrapper.vm.internalHeight).toBe(undefined)
     expect(wrapper.vm.isActive).toBe(false)
 
-    // Before leave
-    item.vm.onBeforeLeave(el)
+    // Leave
+    item.vm.onLeave(el)
     expect(wrapper.vm.internalHeight).toBe('0px')
 
     // Canceling


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for doumentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
beforeLeave was causing issues, possibly due to some rendering black magic going on, not sure.
<!--- Describe your changes in detail -->

## Motivation and Context
Window was scrolling to incorrect location when changing tabs.

fixes #5582
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div id="app">
  <v-app>
    <v-content>
      <v-container grid-list-xl>
        <v-tabs
	      v-model="active1"
	      fixed-tabs>
          <v-tab
	        ripple
	      >
	        First
	      </v-tab>
          <v-tab
	        ripple
	      >
	        Second
	      </v-tab>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 Next and previous buttons work correct
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active1 = parseInt(1)">Next card</v-btn>
               </v-container>
             </v-tab-item>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">

                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active1 = parseInt(0)">Previous Card</v-btn>
               </v-container>
             </v-tab-item>
        </v-tabs>
        <v-tabs
	      v-model="active2"
	      fixed-tabs>
          <v-tab
	        ripple
	      >
	        First
	      </v-tab>
          <v-tab
	        ripple
	      >
	        Second
	      </v-tab>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 Next button works correct, previous causes screen scrool down instantly
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active2 = parseInt(1)">Next card</v-btn>
               </v-container>
             </v-tab-item>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active2 = parseInt(0)">Previous Card</v-btn>
               </v-container>
             </v-tab-item>
        </v-tabs>
        <v-tabs
	      v-model="active3"
	      fixed-tabs>
          <v-tab
	        ripple
	      >
	        First
	      </v-tab>
          <v-tab
	        ripple
	      >
	        Second
	      </v-tab>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 Next button works correct, previous causes screen scrool down instantly
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active3 = parseInt(1)">Next card</v-btn>
               </v-container>
             </v-tab-item>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active3 = parseInt(0)">Previous Card</v-btn>
               </v-container>
             </v-tab-item>
        </v-tabs>
        <v-tabs
	      v-model="active4"
	      fixed-tabs>
          <v-tab
	        ripple
	      >
	        First
	      </v-tab>
          <v-tab
	        ripple
	      >
	        Second
	      </v-tab>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 Next button works correct, previous causes screen scrool down instantly
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active4 = parseInt(1)">Next card</v-btn>
               </v-container>
             </v-tab-item>
           <v-tab-item
		      >
             <v-container>
               <v-card height="400px">
                 </v-card>
               <v-btn color="indigo darken-3" outline @click="active4 = parseInt(0)">Previous Card</v-btn>
               </v-container>
             </v-tab-item>
        </v-tabs>
      </v-container>
    </v-content>
  </v-app>
</div>
</template>

<script>
  export default {
   data: () => ({
    active1: 0,
    active2: 0,
    active3: 0,
    active4: 0,
  })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
