### PR TITLE
feat(VParallax): add alt tag by default

### DIFF
--- a/packages/vuetify/src/components/VParallax/VParallax.ts
+++ b/packages/vuetify/src/components/VParallax/VParallax.ts
@@ -20,7 +20,10 @@ export default mixins<options & ExtractVue<typeof Translatable>>(Translatable).e
   name: 'v-parallax',
 
   props: {
-    alt: String,
+    alt: {
+      type: String,
+      default: ''
+    },
     height: {
       type: [String, Number],
       default: 500
@@ -78,12 +81,11 @@ export default mixins<options & ExtractVue<typeof Translatable>>(Translatable).e
       staticClass: 'v-parallax__image',
       style: this.styles,
       attrs: {
-        src: this.src
+        src: this.src,
+        alt: this.alt
       },
       ref: 'img'
     }
-
-    if (this.alt) imgData.attrs!.alt = this.alt
 
     const container = h('div', {
       staticClass: 'v-parallax__image-container'

--- a/packages/vuetify/test/unit/components/VParallax/VParallax.spec.js
+++ b/packages/vuetify/test/unit/components/VParallax/VParallax.spec.js
@@ -22,4 +22,14 @@ test('VParallax.js', ({ mount }) => {
     expect(img.getAttribute('alt')).toBe('name')
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should use empty alt tag when not supplied', async () => {
+    const wrapper = mount(VParallax, {
+      attachToDocument: true,
+    })
+
+    const img = wrapper.find('img')[0]
+    expect(img.getAttribute('alt')).toBe('')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/test/unit/components/VParallax/__snapshots__/VParallax.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VParallax/__snapshots__/VParallax.spec.js.snap
@@ -6,7 +6,8 @@ exports[`VParallax.js should render 1`] = `
      style="height: 500px;"
 >
   <div class="v-parallax__image-container">
-    <img class="v-parallax__image"
+    <img alt
+         class="v-parallax__image"
          style="display: block; opacity: 0;"
     >
   </div>
@@ -23,6 +24,23 @@ exports[`VParallax.js should use alt tag when supplied 1`] = `
 >
   <div class="v-parallax__image-container">
     <img alt="name"
+         class="v-parallax__image"
+         style="display: block; opacity: 0;"
+    >
+  </div>
+  <div class="v-parallax__content">
+  </div>
+</div>
+
+`;
+
+exports[`VParallax.js should use empty alt tag when not supplied 1`] = `
+
+<div class="v-parallax"
+     style="height: 500px;"
+>
+  <div class="v-parallax__image-container">
+    <img alt
          class="v-parallax__image"
          style="display: block; opacity: 0;"
     >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for doumentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Adds an empty alt tag to the `v-parallax` component if no alt tag is supplied.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`v-parallax` component does not come with an empty alt tag by default.

Providing an empty alt tag yourself is also not possible.

For example, if you have: `<v-parallax alt="" src="header.jpg" />` the resulting HTML will omit the alt tag completely.

Why this is necessary: (taken from reference 1)
```
Images with only visual value should have an empty alt attribute set on them.  Omitting the alt attribute makes most screen readers read out the entire image URL and providing an alt attribute when the image is for visual purposes only is just as useless.
```

References: 
- [https://davidwalsh.name/accessibility-tip-empty-alt-attributes](https://davidwalsh.name/accessibility-tip-empty-alt-attributes)
- [https://www.w3.org/TR/WCAG20-TECHS/H67.html](https://www.w3.org/TR/WCAG20-TECHS/H67.html)

Since the images in parallax designs are usually for visual purposes only, it makes sense to add an empty alt tag by default.

## How Has This Been Tested?
unit
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
