### PR TITLE
fix(VAutocomplete): hide-selected may not show menu

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
@@ -69,10 +69,13 @@ export default {
     computedItems () {
       return this.filteredItems
     },
-    displayedItemsCount () {
+    selectedValues () {
+      return this.selectedItems.map(item => this.getValue(item))
+    },
+    hasDisplayedItems () {
       return this.hideSelected
-        ? this.filteredItems.length - this.selectedItems.length
-        : this.filteredItems.length
+        ? this.filteredItems.some(item => !this.hasItem(item))
+        : this.filteredItems.length > 0
     },
     /**
      * The range of the current input text
@@ -116,7 +119,7 @@ export default {
     menuCanShow () {
       if (!this.isFocused) return false
 
-      return (this.displayedItemsCount > 0) || !this.hideNoData
+      return this.hasDisplayedItems || !this.hideNoData
     },
     $_menuProps () {
       const props = VSelect.computed.$_menuProps.call(this)
@@ -362,6 +365,9 @@ export default {
       )) {
         this.setSearch()
       }
+    },
+    hasItem (item) {
+      return this.selectedValues.indexOf(this.getValue(item)) > -1
     }
   }
 }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.js
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.js
@@ -44,7 +44,7 @@ export default {
     menuCanShow () {
       if (!this.isFocused) return false
 
-      return (this.displayedItemsCount > 0) ||
+      return this.hasDisplayedItems ||
         (!!this.$slots['no-data'] && !this.hideNoData)
     }
   },

--- a/packages/vuetify/test/unit/components/VAutocomplete/VAutocomplete.spec.js
+++ b/packages/vuetify/test/unit/components/VAutocomplete/VAutocomplete.spec.js
@@ -219,7 +219,7 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
   it('should not display menu when tab focused', async () => {
     const wrapper = shallow(VAutocomplete, {
       propsData: {
-        items: [1 ,2],
+        items: [1, 2],
         value: 1
       }
     })
@@ -496,7 +496,7 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     input.element.value = 'foo'
     input.trigger('input')
 
-    wrapper.setProps({ hideSelections: true })
+    wrapper.setProps({ hideSelected: true })
 
     expect(wrapper.vm.genSelections()).toEqual([])
   })
@@ -794,5 +794,27 @@ test('VAutocomplete.js', ({ mount, shallow, compileToFunctions }) => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.internalSearch).toBe(0)
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/4580
+  it('should display menu when hide-no-date and hide-selected are enabled and selected item does not match search', async () => {
+    const wrapper = shallow(VAutocomplete, {
+      propsData: {
+        items: [1, 2],
+        value: 1,
+        hideNoData: true,
+        hideSelected: true,
+      }
+    })
+
+    const input = wrapper.first('input')
+    input.trigger('focus')
+    await wrapper.vm.$nextTick()
+
+    input.element.value = 2
+    input.trigger('input')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.menuCanShow).toBe(true)
   })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Modify `displayedItemsCount` method in VAutocomplete to work correctly with `hide-selected` prop. Previous code (`this.filteredItems.length - this.selectedItems.length`) didn't work if there exists selected item which doesn't match search. Now explicit check is used (thus helpers methods are added — `hasItem` and `selectedValues`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #4580

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
unit & visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <div>Type <code>Cali</code> in VAutocomplete. Expect to see menu with one item (California)</div>
    <v-autocomplete
      v-model="model"
      :items="states"
      chips
      multiple
      hide-no-data
      hide-selected
    />
  </div>
</template>

<script>
  export default {
    data: () => ({
      model: ['Alabama'],
      states: [
        'Alabama', 'Alaska', 'American Samoa', 'Arizona',
        'Arkansas', 'California', 'Colorado', 'Connecticut',
        'Delaware', 'District of Columbia', 'Federated States of Micronesia',
        'Florida', 'Georgia', 'Guam', 'Hawaii', 'Idaho',
        'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky',
        'Louisiana', 'Maine', 'Marshall Islands', 'Maryland',
        'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi',
        'Missouri', 'Montana', 'Nebraska', 'Nevada',
        'New Hampshire', 'New Jersey', 'New Mexico', 'New York',
        'North Carolina', 'North Dakota', 'Northern Mariana Islands', 'Ohio',
        'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico',
        'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee',
        'Texas', 'Utah', 'Vermont', 'Virgin Island', 'Virginia',
        'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
      ]
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 