### PR TITLE
Fix #5481: use correct color for prefix in disabled VTextField

### DIFF
--- a/packages/vuetify/src/stylus/components/_text-fields.styl
+++ b/packages/vuetify/src/stylus/components/_text-fields.styl
@@ -19,6 +19,10 @@ v-text-field($material)
         transparent 4px
       ) 1 repeat
 
+    .v-text-field__prefix,
+    .v-text-field__suffix
+      color: $material.text.disabled
+
   &__prefix,
   &__suffix
     color: $material.text.secondary


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Use `$material.text.disabled` color for prefix and suffix in disabled VTextField

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #5481

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-text-field
    disabled
    prefix="P"
    suffix="S"
    label="Label"
    value="Value"
  ></v-text-field>
</template>

<script>
  export default {}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 