### PR TITLE
fix(VDatePicker): display proper year when model is null

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.js
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.js
@@ -297,7 +297,7 @@ export default {
         props: {
           date: this.value ? this.formatters.titleDate(this.value) : '',
           selectingYear: this.activePicker === 'YEAR',
-          year: this.formatters.year(`${this.inputYear}`),
+          year: this.formatters.year(this.value ? `${this.inputYear}` : this.tableDate),
           yearIcon: this.yearIcon,
           value: this.multiple ? this.value[0] : this.value
         },

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.date.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.date.spec.js
@@ -17,6 +17,19 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     expect(header.text()).toBe('November 2005')
   })
 
+  it('should display the correct year when model is null', () => {
+    const wrapper = mount(VDatePicker, {
+      propsData: {
+        value: null,
+        pickerDate: '2013-01'
+      }
+    })
+
+    const year = wrapper.find('.v-date-picker-title__year')[0]
+
+    expect(year.text()).toBe('2013')
+  })
+
   it('should match snapshot with default settings', () => {
     const wrapper = mount(VDatePicker, {
       propsData: {


### PR DESCRIPTION
## Motivation and Context
fixes #5663

## How Has This Been Tested?
visually, unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-date-picker
        v-model="date1"
      ></v-date-picker>
      <v-date-picker
        v-model="date2"
      ></v-date-picker>
      <v-date-picker
        v-model="date1"
        :picker-date.sync="pickerDate"
      ></v-date-picker>
      <v-date-picker
        v-model="date2"
        :picker-date.sync="pickerDate"
      ></v-date-picker>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    date1: null,
    date2: '2015-05',
    pickerDate: '2013-05'
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
