### PR TITLE
fix(VDialog): add/remove overlay and scroll when fullscreen is changed

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.js
+++ b/packages/vuetify/src/components/VDialog/VDialog.js
@@ -91,14 +91,22 @@ export default {
     isActive (val) {
       if (val) {
         this.show()
+        this.hideScroll()
       } else {
         this.removeOverlay()
         this.unbind()
       }
     },
     fullscreen (val) {
-      if (val) this.hideScroll()
-      else this.showScroll()
+      if (!this.isActive) return
+
+      if (val) {
+        this.hideScroll()
+        this.removeOverlay(false)
+      } else {
+        this.showScroll()
+        this.genOverlay()
+      }
     }
   },
 
@@ -154,7 +162,6 @@ export default {
     },
     show () {
       !this.fullscreen && !this.hideOverlay && this.genOverlay()
-      this.fullscreen && this.hideScroll()
       this.$refs.content.focus()
       this.$listeners.keydown && this.bind()
     },

--- a/packages/vuetify/src/mixins/overlayable.js
+++ b/packages/vuetify/src/mixins/overlayable.js
@@ -67,9 +67,10 @@ export default {
 
       return true
     },
-    removeOverlay () {
+    /** removeOverlay(false) will not restore the scollbar afterwards */
+    removeOverlay (showScroll = true) {
       if (!this.overlay) {
-        return this.showScroll()
+        return showScroll && this.showScroll()
       }
 
       this.overlay.classList.remove('v-overlay--active')
@@ -81,7 +82,7 @@ export default {
             this.overlay.parentNode.removeChild(this.overlay)
           }
           this.overlay = null
-          this.showScroll()
+          showScroll && this.showScroll()
         } catch (e) { console.log(e) }
 
         clearTimeout(this.overlayTimeout)


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #2201

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-btn primary dark v-on:click.stop="dialog = true">Open Dialog</v-btn>
      <pre>{{ dialog }}</pre>
      <div style="height: 1000px"></div>
      <v-dialog
          v-model="dialog"
          :fullscreen="is_mobile"
          :transition="is_mobile ? 'dialog-bottom-transition' : 'scale-transition'"
          v-resize="onResize"
          width="80%"
      >
        <v-card>
          <v-toolbar dark class="primary">
            <v-btn icon @click.native="dialog = false" dark>
              <v-icon>close</v-icon>
            </v-btn>
            <v-toolbar-title>Settings</v-toolbar-title>
            <v-spacer></v-spacer>
            <v-toolbar-items>
              <v-btn dark flat @click.native="dialog = false">Save</v-btn>
            </v-toolbar-items>
          </v-toolbar>
          <v-card-title primary-title>
            <div>
              <h3 class="headline mb-0">Kangaroo Valley Safari</h3>
              <div>Located two hours south of Sydney in the <br>Southern Highlands of New South Wales, ...</div>
            </div>
          </v-card-title>
          <v-card-actions>
            <v-btn flat class="orange--text">Share</v-btn>
            <v-btn flat class="orange--text">Explore</v-btn>
          </v-card-actions>
        </v-card>
      </v-dialog>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      is_mobile: false,
      dialog: false
    }),
    methods : {
      onResize (event) {
        this.is_mobile = window.innerWidth < 600;
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)