### PR TITLE
fix(expand-transition): use a proper FLIP animation w/ offsetHeight

### DIFF
--- a/packages/vuetify/src/components/transitions/expand-transition.js
+++ b/packages/vuetify/src/components/transitions/expand-transition.js
@@ -2,34 +2,54 @@ export default function (expandedParentClass = '') {
   return {
     enter (el) {
       el._parent = el.parentNode
+      const initialStyle = el._initialStyle = {
+        transition: el.style.transition,
+        visibility: el.style.visibility,
+        overflow: el.style.overflow,
+        height: el.style.height
+      }
 
-      // Get height that is to be scrolled
+      el.style.setProperty('transition', 'none', 'important')
+      el.style.visibility = 'hidden'
+      const height = `${el.offsetHeight}px`
+      el.style.visibility = initialStyle.visibility
       el.style.overflow = 'hidden'
       el.style.height = 0
+      void el.offsetHeight // force reflow
+      el.style.transition = initialStyle.transition
+
       expandedParentClass && el._parent.classList.add(expandedParentClass)
 
       requestAnimationFrame(() => {
-        el.style.height = el.scrollHeight
-          ? `${el.scrollHeight}px`
-          : 'auto'
+        el.style.height = height
       })
     },
 
     afterEnter (el) {
-      el.style.overflow = null
-      el.style.height = null
+      resetStyles(el)
     },
 
     leave (el) {
-      // Set height before we transition to 0
+      el._initialStyle = {
+        overflow: el.style.overflow,
+        height: el.style.height
+      }
+
       el.style.overflow = 'hidden'
-      el.style.height = `${el.scrollHeight}px`
+      el.style.height = `${el.offsetHeight}px`
 
       requestAnimationFrame(() => el.style.height = 0)
     },
 
     afterLeave (el) {
       expandedParentClass && el._parent && el._parent.classList.remove(expandedParentClass)
+      resetStyles(el)
     }
   }
+}
+
+function resetStyles (el) {
+  el.style.overflow = el._initialStyle.overflow
+  el.style.height = el._initialStyle.height
+  delete el._initialStyle
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #5607
also fixes an unreported bug caused by the use of `scrollHeight`, remove the inline style to see it

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-img
        :aspect-ratio="16/9"
        max-width="600"
        src="https://cdn.vuetifyjs.com/images/cards/kitchen.png"
      >
        <v-expand-transition>
          <div
            v-if="show"
            class="d-flex transition-fast-in-fast-out orange darken-2 v-card--reveal display-3 white--text"
            style="height: 100%"
          >
            $14.99
          </div>
        </v-expand-transition>
      </v-img>
      <v-switch v-model="show"></v-switch>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      show: false
    })
  }
</script>

<style>
  .v-card--reveal {
    align-items: center;
    bottom: 0;
    justify-content: center;
    opacity: .5;
    position: absolute;
    width: 100%;
  }
</style>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

