### PR TITLE
refactor(VAutocomplete): rename variable name

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
@@ -2,14 +2,14 @@
 import '../../stylus/components/_autocompletes.styl'
 
 // Extensions
-import VSelect, { defaultMenuProps as VSelectMenuProps } from '../VSelect/VSelect'
+import VSelect, { defaultMenuProps as VSelectDefaultMenuProps } from '../VSelect/VSelect'
 import VTextField from '../VTextField/VTextField'
 
 // Utils
 import { keyCodes } from '../../util/helpers'
 
 const defaultMenuProps = {
-  ...VSelectMenuProps,
+  ...VSelectDefaultMenuProps,
   offsetY: true,
   offsetOverflow: true,
   transition: false


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
- rename variable name
    - VSelect default menu props

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The variable name after change is easier to understand purpose 🤔 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
- none

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
