### PR TITLE
 feat(VImg): use inherent width from image

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.ts
+++ b/packages/vuetify/src/components/VImg/VImg.ts
@@ -48,7 +48,8 @@ export default VResponsive.extend({
       currentSrc: '', // Set from srcset
       image: null as HTMLImageElement | null,
       isLoading: true,
-      calculatedAspectRatio: undefined as number | undefined
+      calculatedAspectRatio: undefined as number | undefined,
+      naturalWidth: undefined as number | undefined
     }
   },
 
@@ -177,6 +178,7 @@ export default VResponsive.extend({
         const { naturalHeight, naturalWidth } = img
 
         if (naturalHeight || naturalWidth) {
+          this.naturalWidth = naturalWidth
           this.calculatedAspectRatio = naturalWidth / naturalHeight
         } else {
           timeout != null && setTimeout(poll, timeout)
@@ -184,6 +186,13 @@ export default VResponsive.extend({
       }
 
       poll()
+    },
+    genContent () {
+      const content: VNode = VResponsive.options.methods.genContent.call(this)
+      this._b(content.data!, 'div', {
+        style: { width: `${this.naturalWidth}px` }
+      }, false)
+      return content
     },
     __genPlaceholder (): VNode | void {
       if (this.$slots.placeholder) {

--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -78,6 +78,14 @@ declare module 'vue/types/vue' {
     _uid: number
     _isDestroyed: boolean
 
+    /** bindObjectProps */
+    _b (
+      data: VNodeData,
+      tag: string,
+      value: any,
+      asProp: boolean,
+      isSync?: boolean
+    ): VNodeData
     /** bindObjectListeners */
      _g (data: VNodeData, value: {}): VNodeData
   }

--- a/packages/vuetifyjs.com/src/App.vue
+++ b/packages/vuetifyjs.com/src/App.vue
@@ -44,15 +44,15 @@
     mounted () {
       this.getReleases()
 
-      this.snackbar({
-        color: 'store',
-        close: true,
-        id: 'cyber-monday-sale',
-        text: 'Shop now',
-        msg: 'Happy Cyber Monday',
-        to: '/store/',
-        timeout: 0
-      })
+      // this.snackbar({
+      //   color: 'store',
+      //   close: true,
+      //   id: 'cyber-monday-sale',
+      //   text: 'Shop now',
+      //   msg: 'Happy Cyber Monday',
+      //   to: '/store/',
+      //   timeout: 0
+      // })
     },
 
     methods: {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes #5757

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-container grid-list-xl text-xs-center>
      <v-layout align-center justify-center column>
        <v-flex>
          <h1>Some Title (Centered Properly)</h1>
        </v-flex>
        <v-flex>
          <v-img src="https://www.guidedogs.org/wp-content/uploads/2018/01/Mobile.jpg"></v-img>
        </v-flex>
        <v-flex>
          Only works if there is text in the flex???
          <v-img src="https://www.guidedogs.org/wp-content/uploads/2018/01/Mobile.jpg"></v-img>
        </v-flex>
      </v-layout>
    </v-container>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

