### PR TITLE
fix missing dark prop for v-select component

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.js
+++ b/packages/vuetify/src/components/VSelect/VSelect.js
@@ -165,6 +165,7 @@ export default {
         props: {
           action: this.multiple && !this.isHidingSelected,
           color: this.color,
+          dark: this.dark,
           dense: this.dense,
           hideSelected: this.hideSelected,
           items: this.virtualizedItems,


### PR DESCRIPTION
## Description

When setting VSelect dark prop to true, it does not pass it to VSelectList and this pull request fixes that.

### Screenshot

<img height="334" alt="before" src="https://user-images.githubusercontent.com/8221099/49425087-8bc87680-f7d7-11e8-849b-87f6495f2037.png"> <img height="334" alt="after" src="https://user-images.githubusercontent.com/8221099/49425096-95ea7500-f7d7-11e8-83c6-74e7d5756155.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
