### PR TITLE
fix(VDatePicker): change clickable area of month/year in header

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.js
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.js
@@ -105,12 +105,13 @@ export default {
     },
     genHeader () {
       const color = !this.disabled && (this.color || 'accent')
-      const header = this.$createElement('strong', this.setTextColor(color, {
-        key: String(this.value),
+      const header = this.$createElement('div', this.setTextColor(color, {
+        key: String(this.value)
+      }), [this.$createElement('button', {
         on: {
           click: () => this.$emit('toggle')
         }
-      }), [this.$slots.default || this.formatter(String(this.value))])
+      }, [this.$slots.default || this.formatter(String(this.value))])])
 
       const transition = this.$createElement('transition', {
         props: {

--- a/packages/vuetify/src/stylus/components/_date-picker-header.styl
+++ b/packages/vuetify/src/stylus/components/_date-picker-header.styl
@@ -3,11 +3,12 @@
 
 v-date-picker-header($material)
   .v-date-picker-header__value:not(.v-date-picker-header__value--disabled)
-    strong:not(:hover)
-      color: $material.text.primary !important
+    button:not(:hover):not(:focus)
+      color: $material.text.primary
 
-  .v-date-picker-header__value--disabled strong
-    color: $material.text.disabled
+  .v-date-picker-header__value--disabled
+    button
+      color: $material.text.disabled
 
 theme(v-date-picker-header, "v-date-picker-header")
 
@@ -33,11 +34,16 @@ theme(v-date-picker-header, "v-date-picker-header")
   position: relative
   overflow: hidden
 
-  strong
-    cursor: pointer
+  div
     transition: $primary-transition
-    display: block
     width: 100%
+
+  button
+    cursor: pointer
+    font-weight: bold
+    outline: none
+    padding: 0.5rem
+    transition: $primary-transition
 
 .v-date-picker-header--disabled
   pointer-events: none

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.date.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.date.spec.js
@@ -318,7 +318,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const button = wrapper.find('.v-date-picker-header strong')[0]
+    const button = wrapper.find('.v-date-picker-header div button')[0]
 
     button.trigger('click')
     expect(wrapper.vm.activePicker).toBe('MONTH')

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.date.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.date.spec.js
@@ -11,7 +11,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
     })
 
     const title = wrapper.find('.v-date-picker-title__date')[0]
-    const header = wrapper.find('.v-date-picker-header__value strong')[0]
+    const header = wrapper.find('.v-date-picker-header__value div')[0]
 
     expect(title.text()).toBe('Tue, Nov 1')
     expect(header.text()).toBe('November 2005')
@@ -302,7 +302,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const [leftButton, rightButton] = wrapper.find('.v-date-picker-header button')
+    const [leftButton, rightButton] = wrapper.find('.v-date-picker-header button.v-btn')
 
     leftButton.trigger('click')
     expect(wrapper.vm.tableDate).toBe('2005-10')
@@ -318,7 +318,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const button = wrapper.find('.v-date-picker-header div button')[0]
+    const button = wrapper.find('.v-date-picker-header__value button')[0]
 
     button.trigger('click')
     expect(wrapper.vm.activePicker).toBe('MONTH')

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.month.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.month.spec.js
@@ -139,7 +139,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const [leftButton, rightButton] = wrapper.find('.v-date-picker-header button')
+    const [leftButton, rightButton] = wrapper.find('.v-date-picker-header button.v-btn')
 
     leftButton.trigger('click')
     expect(wrapper.vm.tableDate).toBe('2004')
@@ -156,7 +156,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const button = wrapper.find('.v-date-picker-header div button')[0]
+    const button = wrapper.find('.v-date-picker-header__value button')[0]
 
     button.trigger('click')
     expect(wrapper.vm.activePicker).toBe('YEAR')

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.month.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePicker.month.spec.js
@@ -156,7 +156,7 @@ test('VDatePicker.js', ({ mount, compileToFunctions }) => {
       }
     })
 
-    const button = wrapper.find('.v-date-picker-header strong')[0]
+    const button = wrapper.find('.v-date-picker-header div button')[0]
 
     button.trigger('click')
     expect(wrapper.vm.activePicker).toBe('YEAR')

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePickerHeader.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePickerHeader.spec.js
@@ -55,7 +55,7 @@ test('VDatePickerHeader.js', ({ mount }) => {
       }
     })
 
-    expect(wrapper.find('.v-date-picker-header__value strong')[0].element.textContent).toBe('2005')
+    expect(wrapper.find('.v-date-picker-header__value div')[0].element.textContent).toBe('2005')
   })
 
   it('should render prev/next icons', () => {
@@ -79,7 +79,7 @@ test('VDatePickerHeader.js', ({ mount }) => {
       }
     })
 
-    expect(wrapper.find('.v-date-picker-header__value strong')[0].element.textContent).toBe('(2005-11)')
+    expect(wrapper.find('.v-date-picker-header__value div')[0].element.textContent).toBe('(2005-11)')
   })
 
   it('should render colored component and match snapshot', () => {
@@ -90,9 +90,9 @@ test('VDatePickerHeader.js', ({ mount }) => {
       }
     })
 
-    const strong = wrapper.find('.v-date-picker-header__value strong')[0]
-    expect(strong.hasClass('green--text')).toBe(true)
-    expect(strong.hasClass('text--lighten-1')).toBe(true)
+    const div = wrapper.find('.v-date-picker-header__value div')[0]
+    expect(div.hasClass('green--text')).toBe(true)
+    expect(div.hasClass('text--lighten-1')).toBe(true)
   })
 
   it('should render component with default slot and match snapshot', () => {
@@ -118,7 +118,7 @@ test('VDatePickerHeader.js', ({ mount }) => {
     const toggle = jest.fn()
     wrapper.vm.$on('toggle', toggle)
 
-    wrapper.find('.v-date-picker-header__value div button')[0].trigger('click')
+    wrapper.find('.v-date-picker-header__value button')[0].trigger('click')
     expect(toggle).toBeCalled()
   })
 
@@ -132,10 +132,10 @@ test('VDatePickerHeader.js', ({ mount }) => {
     const input = jest.fn()
     wrapper.vm.$on('input', input)
 
-    wrapper.find('button')[0].trigger('click')
+    wrapper.find('button.v-btn')[0].trigger('click')
     expect(input).toBeCalledWith('2005-11')
 
-    wrapper.find('button')[1].trigger('click')
+    wrapper.find('button.v-btn')[1].trigger('click')
     expect(input).toBeCalledWith('2006-01')
   })
 
@@ -166,8 +166,8 @@ test('VDatePickerHeader.js', ({ mount }) => {
       value: 2006
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('.v-date-picker-header__value strong')[0].hasClass('tab-transition-enter')).toBe(true)
-    expect(wrapper.find('.v-date-picker-header__value strong')[0].hasClass('tab-transition-enter-active')).toBe(true)
+    expect(wrapper.find('.v-date-picker-header__value div')[0].hasClass('tab-transition-enter')).toBe(true)
+    expect(wrapper.find('.v-date-picker-header__value div')[0].hasClass('tab-transition-enter-active')).toBe(true)
   })
 
   it('should watch value and run reverse transition', async () => {
@@ -181,8 +181,8 @@ test('VDatePickerHeader.js', ({ mount }) => {
       value: 2004
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.find('.v-date-picker-header__value strong')[0].hasClass('tab-reverse-transition-enter')).toBe(true)
-    expect(wrapper.find('.v-date-picker-header__value strong')[0].hasClass('tab-reverse-transition-enter-active')).toBe(true)
+    expect(wrapper.find('.v-date-picker-header__value div')[0].hasClass('tab-reverse-transition-enter')).toBe(true)
+    expect(wrapper.find('.v-date-picker-header__value div')[0].hasClass('tab-reverse-transition-enter-active')).toBe(true)
   })
 
 })

--- a/packages/vuetify/test/unit/components/VDatePicker/VDatePickerHeader.spec.js
+++ b/packages/vuetify/test/unit/components/VDatePicker/VDatePickerHeader.spec.js
@@ -118,7 +118,7 @@ test('VDatePickerHeader.js', ({ mount }) => {
     const toggle = jest.fn()
     wrapper.vm.$on('toggle', toggle)
 
-    wrapper.find('.v-date-picker-header__value strong')[0].trigger('click')
+    wrapper.find('.v-date-picker-header__value div button')[0].trigger('click')
     expect(toggle).toBeCalled()
   })
 

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -32,9 +32,11 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="primary--text">
-            November 2005
-          </strong>
+          <div class="primary--text">
+            <button>
+              November 2005
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"
@@ -401,9 +403,11 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="orange--text text--darken-1">
-            November 2005
-          </strong>
+          <div class="orange--text text--darken-1">
+            <button>
+              November 2005
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"
@@ -770,9 +774,11 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            May 2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              May 2013
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--dark"
@@ -1150,9 +1156,11 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            May 2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              May 2013
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"
@@ -1553,9 +1561,11 @@ exports[`VDatePicker.js should render component with min/max props 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            January 2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              January 2013
+            </button>
+          </div>
         </div>
         <button disabled="disabled"
                 type="button"
@@ -1949,9 +1959,11 @@ exports[`VDatePicker.js should render component with min/max props 2`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            January 2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              January 2013
+            </button>
+          </div>
         </div>
         <button disabled="disabled"
                 type="button"
@@ -2322,9 +2334,11 @@ exports[`VDatePicker.js should render component with min/max props 2`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              2013
+            </button>
+          </div>
         </div>
         <button disabled="disabled"
                 type="button"
@@ -2511,9 +2525,11 @@ exports[`VDatePicker.js should render component with min/max props 3`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            January 2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              January 2013
+            </button>
+          </div>
         </div>
         <button disabled="disabled"
                 type="button"
@@ -2884,9 +2900,11 @@ exports[`VDatePicker.js should render component with min/max props 3`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              2013
+            </button>
+          </div>
         </div>
         <button disabled="disabled"
                 type="button"
@@ -3080,9 +3098,11 @@ exports[`VDatePicker.js should render disabled picker 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value v-date-picker-header__value--disabled">
-          <strong>
-            May 2013
-          </strong>
+          <div>
+            <button>
+              May 2013
+            </button>
+          </div>
         </div>
         <button disabled="disabled"
                 type="button"
@@ -3492,9 +3512,11 @@ exports[`VDatePicker.js should render readonly picker 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            May 2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              May 2013
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
@@ -163,9 +163,11 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="primary--text">
-            2005
-          </strong>
+          <div class="primary--text">
+            <button>
+              2005
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"
@@ -339,9 +341,11 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="orange--text text--darken-1">
-            2005
-          </strong>
+          <div class="orange--text text--darken-1">
+            <button>
+              2005
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"
@@ -638,9 +642,11 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
           </div>
         </button>
         <div class="v-date-picker-header__value">
-          <strong class="accent--text">
-            2013
-          </strong>
+          <div class="accent--text">
+            <button>
+              2013
+            </button>
+          </div>
         </div>
         <button type="button"
                 class="v-btn v-btn--icon theme--light"

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
@@ -15,9 +15,11 @@ exports[`VDatePickerHeader.js should render component and match snapshot 1`] = `
     </div>
   </button>
   <div class="v-date-picker-header__value">
-    <strong class="accent--text">
-      November 2005
-    </strong>
+    <div class="accent--text">
+      <button>
+        November 2005
+      </button>
+    </div>
   </div>
   <button type="button"
           class="v-btn v-btn--icon theme--light"
@@ -49,9 +51,11 @@ exports[`VDatePickerHeader.js should render component in RTL mode and match snap
     </div>
   </button>
   <div class="v-date-picker-header__value">
-    <strong class="accent--text">
-      November 2005
-    </strong>
+    <div class="accent--text">
+      <button>
+        November 2005
+      </button>
+    </div>
   </div>
   <button type="button"
           class="v-btn v-btn--icon theme--light"
@@ -83,11 +87,13 @@ exports[`VDatePickerHeader.js should render component with default slot and matc
     </div>
   </button>
   <div class="v-date-picker-header__value">
-    <strong class="accent--text">
-      <span>
-        foo
-      </span>
-    </strong>
+    <div class="accent--text">
+      <button>
+        <span>
+          foo
+        </span>
+      </button>
+    </div>
   </div>
   <button type="button"
           class="v-btn v-btn--icon theme--light"
@@ -120,9 +126,11 @@ exports[`VDatePickerHeader.js should render disabled component and match snapsho
     </div>
   </button>
   <div class="v-date-picker-header__value v-date-picker-header__value--disabled">
-    <strong>
-      November 2005
-    </strong>
+    <div>
+      <button>
+        November 2005
+      </button>
+    </div>
   </div>
   <button disabled="disabled"
           type="button"
@@ -155,9 +163,11 @@ exports[`VDatePickerHeader.js should render readonly component and match snapsho
     </div>
   </button>
   <div class="v-date-picker-header__value">
-    <strong class="accent--text">
-      November 2005
-    </strong>
+    <div class="accent--text">
+      <button>
+        November 2005
+      </button>
+    </div>
   </div>
   <button type="button"
           class="v-btn v-btn--icon theme--light"


### PR DESCRIPTION
## Description
Makes only header text clickable instead of the whole header

## Motivation and Context
fixes #5725

## How Has This Been Tested?
visually, updated units 

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-content>
      <v-container
        <v-date-picker />
        <v-date-picker color="red" />
        <v-date-picker readonly />
        <v-date-picker color="red" readonly />
        <v-date-picker disabled />
        <v-date-picker color="red" disabled />
      </v-container>
    </v-content>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
