### PR TITLE
docs: correct affix position description

### DIFF
--- a/packages/vuetifyjs.com/src/lang/en/mixins/DataIterable.json
+++ b/packages/vuetifyjs.com/src/lang/en/mixins/DataIterable.json
@@ -21,8 +21,8 @@
     "value": "Selected row items"
   },
   "slots": {
-    "actions-append": "Slot to put custom elements before the actions in the footer.",
-    "actions-prepend": "Slot to put custom elements after the actions in the footer.",
+    "actions-append": "Slot to put custom elements after the actions in the footer.",
+    "actions-prepend": "Slot to put custom elements before the actions in the footer.",
     "footer": "Slot to specify an extra footer",
     "noData": "Displayed when there are no items (takes precedence over `no-results`)",
     "noResults": "Displayed when there are no filtered items"


### PR DESCRIPTION
Use of before and after are mixed up for actions-prepend and actions-append slots for the Data Table.