### PR TITLE
feat(VCard): add support for custom hover elevation

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.ts
+++ b/packages/vuetify/src/components/VCard/VCard.ts
@@ -4,6 +4,9 @@ import '../../stylus/components/_cards.styl'
 // Extensions
 import VSheet from '../VSheet'
 
+// Extensions
+import VHover from '../VHover'
+
 // Mixins
 import Routable from '../../mixins/routable'
 
@@ -26,24 +29,34 @@ export default mixins(
       default: 2
     },
     flat: Boolean,
-    hover: Boolean,
+    hover: [Boolean, String, Number],
     img: String,
     raised: Boolean
   },
+
+  data: () => ({
+    isHovered: false
+  }),
 
   computed: {
     classes (): object {
       return {
         'v-card': true,
-        'v-card--hover': this.hover,
+        'v-card--hover': this.isHoverable,
         ...VSheet.options.computed.classes.call(this)
       }
     },
     computedElevation (): number | string {
+      if (this.isHovered) {
+        return typeof this.hover === 'boolean' ? 8 : Number(this.hover)
+      }
       if (this.flat) return 0
       if (this.raised) return 3
 
       return (VSheet.options.computed as any).computedElevation.call(this)
+    },
+    isHoverable (): boolean {
+      return this.hover != null && this.hover !== false
     },
     styles (): object {
       const style = {
@@ -63,6 +76,17 @@ export default mixins(
 
     data.style = this.styles
 
-    return h(tag, this.setBackgroundColor(this.color, data), this.$slots.default)
+    const card = h(tag, this.setBackgroundColor(this.color, data), this.$slots.default)
+
+    if (!this.isHoverable) return card
+
+    return h(VHover, {
+      props: { value: this.isHovered },
+      on: {
+        input: (val: boolean) => {
+          this.isHovered = val
+        }
+      }
+    }, [card])
   }
 })

--- a/packages/vuetify/test/unit/components/VCard/VCard.spec.js
+++ b/packages/vuetify/test/unit/components/VCard/VCard.spec.js
@@ -54,4 +54,34 @@ test('VCard.vue', ({ mount }) => {
     })
     expect(wrapper.hasStyle('height', '401px')).toBe(true)
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/5815
+  it('should apply the correct elevation on hover', async () => {
+    const wrapper = mount(VCard, {
+      propsData: {
+        hover: true
+      }
+    })
+
+    expect(wrapper.vm.computedElevation).toBe(2)
+
+    wrapper.trigger('mouseenter')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(wrapper.vm.computedElevation).toBe(8)
+
+    wrapper.trigger('mouseleave')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(wrapper.vm.computedElevation).toBe(2)
+
+    wrapper.setProps({ elevation: 12, hover: 2 })
+    expect(wrapper.vm.computedElevation).toBe(12)
+
+    wrapper.trigger('mouseenter')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(wrapper.vm.computedElevation).toBe(2)
+
+    wrapper.trigger('mouseleave')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(wrapper.vm.computedElevation).toBe(12)
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added the ability to specify a custom hover elevation with a default of 8 still applied if boolean true.
<!--- Describe your changes in detail -->

## Motivation and Context
With the introduction of `v-sheet`, `v-card` now implements **elevatable**. Was missing hover functionality that used to exist in css.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
unit
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <boilerplate>
    <v-card elevation="12" hover="0">
          <v-img
            src="https://cdn.vuetifyjs.com/images/cards/desert.jpg"
            aspect-ratio="2.75"
          ></v-img>

          <v-card-title primary-title>
            <div>
              <h3 class="headline mb-0">Kangaroo Valley Safari</h3>
              <div>
                Located two hours south of Sydney in the <br />Southern
                Highlands of New South Wales, ...
              </div>
            </div>
          </v-card-title>

          <v-card-actions>
            <v-btn flat color="orange">Share</v-btn>
            <v-btn flat color="orange">Explore</v-btn>
          </v-card-actions>
        </v-card>
  </boilerplate>
</template>

<script>
  export default {
    data: () => ({
      //
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
