### PR TITLE
fix(VBottomNav): correct inactive colors

### DIFF
--- a/packages/vuetify/src/components/VBottomNav/VBottomNav.ts
+++ b/packages/vuetify/src/components/VBottomNav/VBottomNav.ts
@@ -5,6 +5,7 @@ import '../../stylus/components/_bottom-navs.styl'
 import Applicationable from '../../mixins/applicationable'
 import ButtonGroup from '../../mixins/button-group'
 import Colorable from '../../mixins/colorable'
+import Themeable from '../../mixins/themeable'
 
 // Util
 import mixins from '../../util/mixins'
@@ -18,7 +19,8 @@ export default mixins(
     'height',
     'value'
   ]),
-  Colorable
+  Colorable,
+  Themeable
   /* @vue/component */
 ).extend({
   name: 'v-bottom-nav',

--- a/packages/vuetify/src/stylus/components/_bottom-navs.styl
+++ b/packages/vuetify/src/stylus/components/_bottom-navs.styl
@@ -4,6 +4,9 @@
 v-bottom-nav($material)
   background-color: $material.cards
 
+  .v-btn:not(.v-btn--active)
+    color: $material.text.secondary !important
+
 theme(v-bottom-nav, "v-bottom-nav")
 
 .v-item-group.v-bottom-nav
@@ -37,7 +40,6 @@ theme(v-bottom-nav, "v-bottom-nav")
     min-width: 80px
     padding: 8px 12px 10px
     text-transform: none
-    opacity: .5
     width: 100%
     // https://github.com/vuetifyjs/vuetify/issues/4643
     flex-shrink: 1
@@ -57,7 +59,6 @@ theme(v-bottom-nav, "v-bottom-nav")
         line-height: 1
 
     &--active
-      opacity: 1
       padding-top: 6px
 
       &:before
@@ -68,9 +69,6 @@ theme(v-bottom-nav, "v-bottom-nav")
 
         .v-icon
           transform: none
-
-    &:not(.v-btn--active)
-      filter: grayscale(100%)
 
   &--shift
     .v-btn__content
@@ -90,5 +88,5 @@ theme(v-bottom-nav, "v-bottom-nav")
     .v-icon
       transform: scale(1, 1) translate(0, 8px)
 
-    span
+    > span:not(.v-badge)
       color: transparent

--- a/packages/vuetifyjs.com/src/examples/bottom-navigation/colorAndShift.vue
+++ b/packages/vuetifyjs.com/src/examples/bottom-navigation/colorAndShift.vue
@@ -5,6 +5,7 @@
       :color="color"
       :value="true"
       absolute
+      dark
       shift
     >
       <v-btn dark>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
resolves #2685

Changed inactive styles for `v-btn` when used inside of `v-bottom-nav`. 

- Converted styles to match`v-tabs` spec
   - https://material.io/archive/guidelines/components/tabs.html
- Added **Themeable** mixin. 
  - User no longer has to explicitly define **dark** or **light** on `v-btn`. 
- Can now use `v-badge` when using the **shift** prop
<!--- Describe your changes in detail -->

## Motivation and Context
There is no defined color on the spec pages for `v-bottom-nav`:
- https://material.io/design/components/bottom-navigation.html
- https://material.io/archive/guidelines/components/bottom-navigation.html

The current implementation doesn't closely resemble the pictures.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <boilerplate>
    <div id="app">
      <v-app id="inspire">
        <v-card height="200px">
          <div class="headline text-xs-center pa-5">Active: {{ e1 }}</div>
          <v-bottom-nav
            :value="true"
            :active.sync="e1"
            absolute
            color="transparent">
            <v-btn
              flat
              color="teal"
              value="recent">
              <span>Recent</span>
              <v-icon>history</v-icon>
            </v-btn>
            <v-btn
              flat
              color="teal"
              value="favorites">
              <span>Favorites</span>
              <v-icon>favorite</v-icon>
            </v-btn>
            <v-btn
              flat
              color="teal"
              value="nearby">
              <span>Nearby</span>
              <v-badge
                right
                color="red">
                <span slot="badge">!</span>
                <v-icon>shopping_cart</v-icon>
              </v-badge>
            </v-btn>
          </v-bottom-nav>
        </v-card>
        <v-card
          height="200px"
          class="mt-5">
          <v-bottom-nav
            :active.sync="bottomNav"
            :color="color"
            :value="true"
            absolute
            dark
            shift
          >
            <v-btn>
              <span>Video</span>
              <v-icon>ondemand_video</v-icon>
            </v-btn>

            <v-btn>
              <span>Music</span>
              <v-badge color="red">
                <span slot="badge">!</span>
                <v-icon>music_note</v-icon>
              </v-badge>
            </v-btn>

            <v-btn>
              <span>Book</span>
              <v-icon>book</v-icon>
            </v-btn>

            <v-btn>
              <span>Image</span>
              <v-icon>image</v-icon>
            </v-btn>
          </v-bottom-nav>
        </v-card>
      </v-app>
    </div>
  </boilerplate>
</template>

<script>
export default {
  data: () => ({
    e1: 'recent',
    bottomNav: 3
  }),

  computed: {
    color () {
      switch (this.bottomNav) {
        case 0: return 'blue-grey'
        case 1: return 'teal'
        case 2: return 'brown'
        case 3: return 'indigo'
      }
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
