### PR TITLE
fix(VMenu): hover stuck open when mouse exits page

### DIFF
--- a/packages/vuetify/src/mixins/menuable.js
+++ b/packages/vuetify/src/mixins/menuable.js
@@ -329,7 +329,7 @@ export default Vue.extend({
     },
     startTransition () {
       return new Promise(resolve => requestAnimationFrame(() => {
-        this.isContentActive = true
+        this.isContentActive = this.hasJustFocused = this.isActive
         resolve()
       }))
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
It's possible for a mouseLeaveEvent to finish closing a menu before the corresponding mouseEnterEvent's animation frame has run, resulting in a stuck open menu. I have added some logic to double check at and make sure the menu is still active at the time the animation frame runs. 

In this situation, isActive has been reset to false between the time runDelay(open) was called and when we were provisioned this animation frame, sync up hasJustFocused to false and do a no-op assign to isContentActive which doesn't trigger the watcher. Tried to minimize branching to match project style.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a fix for https://github.com/vuetifyjs/vuetify/issues/5843, the issue is fully documented over there including related codepen.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
I have tested the hover functionality of v-menu and v-tooltip, including edge cases such as right clicking the mouse and exiting the page, and both are now working correctly.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-app>
      <v-toolbar app>
        <v-menu open-on-hover top offset-y>
          <v-btn
            slot="activator"
            color="primary"
          >
            Dropdown
          </v-btn>
          <v-list>
            <v-list-tile>
              <v-list-tile-title>List Item</v-list-tile-title>
            </v-list-tile>
          </v-list>
        </v-menu>
      </v-toolbar>
      <v-content app>
        <v-tooltip bottom>
          <span slot="activator">This text has a tooltip</span>
          <span>Tooltip</span>
        </v-tooltip>
      </v-content>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
    })
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
