### PR TITLE
fix(VTextField): prefix position with outline and single-line

### DIFF
--- a/packages/vuetify/src/stylus/components/_text-fields.styl
+++ b/packages/vuetify/src/stylus/components/_text-fields.styl
@@ -323,6 +323,13 @@ rtl(v-text-field-rtl, "v-text-field")
         margin-top: 22px
         transition: $primary-transition
 
+    &.v-text-field--single-line
+      .v-text-field__prefix
+        margin-top: 0px
+        padding-top: 8px
+        padding-bottom: 8px
+        line-height: 20px
+
     &.v-input--is-focused, &.v-input--has-state
       & > .v-input__control > .v-input__slot
         border: 2px solid currentColor


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Handle TextField prefix style in case of outline and single-line

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #5752 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-container fluid>
      <v-text-field
        label="Amount"
        value="20"
        prefix="Dollar"
        outline
        single-line
      />
    </v-container>
  </v-app>
</template>

<script>
export default {
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
