### PR TITLE
fix(VMenu): prevent scroll on keydown

### DIFF
--- a/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
@@ -36,13 +36,6 @@ export default {
 
   methods: {
     onKeyDown (e) {
-      if ([
-        keyCodes.down,
-        keyCodes.up,
-        keyCodes.enter
-      ].includes(e.keyCode)
-      ) e.preventDefault()
-
       if ([keyCodes.esc, keyCodes.tab].includes(e.keyCode)) {
         return this.isActive = false
       }
@@ -50,6 +43,13 @@ export default {
       this.changeListIndex(e)
     },
     changeListIndex (e) {
+      if ([
+        keyCodes.down,
+        keyCodes.up,
+        keyCodes.enter
+      ].includes(e.keyCode)
+      ) e.preventDefault()
+
       // For infinite scroll and autocomplete, re-evaluate children
       this.getTiles()
 

--- a/packages/vuetify/test/unit/components/VSelect/VSelect2.spec.js
+++ b/packages/vuetify/test/unit/components/VSelect/VSelect2.spec.js
@@ -241,7 +241,7 @@ test('VSelect2', ({ mount, compileToFunctions }) => {
 
   })
 
-  it.only('should react to different key down', async () => {
+  it('should react to different key down', async () => {
     const wrapper = mount(VSelect)
     const blur = jest.fn()
     wrapper.vm.$on('blur', blur)

--- a/packages/vuetify/test/unit/components/VSelect/VSelect2.spec.js
+++ b/packages/vuetify/test/unit/components/VSelect/VSelect2.spec.js
@@ -241,18 +241,22 @@ test('VSelect2', ({ mount, compileToFunctions }) => {
 
   })
 
-  it('should react to different key down', async () => {
+  it.only('should react to different key down', async () => {
     const wrapper = mount(VSelect)
     const blur = jest.fn()
     wrapper.vm.$on('blur', blur)
 
-    wrapper.vm.onKeyDown({ keyCode: 9 })
+    const event = new Event('keydown')
+    event.keyCode = 9
+
+    wrapper.vm.onKeyDown(event)
 
     expect(blur).toBeCalled()
     expect(wrapper.vm.isMenuActive).toBe(false)
 
     for (let keyCode of [13, 32, 38, 40]) {
-      wrapper.vm.onKeyDown({ keyCode })
+      event.keyCode = keyCode
+      wrapper.vm.onKeyDown(event)
       expect(wrapper.vm.isMenuActive).toBe(true)
 
       wrapper.vm.isMenuActive = false


### PR DESCRIPTION
fixes #5714
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
move preventDefault invocation to more appropriate location
<!--- Describe your changes in detail -->

## Motivation and Context
Since v1.2 selects have maintained control over keydown. Move default prevent to **changeListIndex** as it is always called when pertaining to keyboard navigation in menus.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <div id="app" style="min-height: 400vh;">
  <v-app id="inspire">
    <v-card>
      <v-container
        fluid
        grid-list-xl
      >
        <v-layout
          align-center
          wrap
        >
          <v-flex xs12 sm6>
            <v-select
              v-model="value"
              :items="items"
              attach
              chips
              label="Chips"
              multiple
            ></v-select>
          </v-flex>
          <v-flex xs12 sm6>
            <v-select
              v-model="value"
              :items="items"
              box
              chips
              label="Chips"
              multiple
            ></v-select>
          </v-flex>
          <v-flex xs12 sm6>
            <v-select
              v-model="value"
              :items="items"
              chips
              label="Chips"
              multiple
              outline
            ></v-select>
          </v-flex>
          <v-flex xs12 sm6>
            <v-select
              v-model="value"
              :items="items"
              chips
              label="Chips"
              multiple
              solo
            ></v-select>
          </v-flex>
        </v-layout>
      </v-container>
    </v-card>
  </v-app>
</div>
</template>

<script>
export default {
  data: () => ({
    items: ['foo', 'bar', 'fizz', 'buzz'],
    value: ['foo', 'bar', 'fizz', 'buzz']
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
