### PR TITLE
added trailing "`" to string

### DIFF
--- a/packages/vuetifyjs.com/src/lang/en/mixins/Routable.json
+++ b/packages/vuetifyjs.com/src/lang/en/mixins/Routable.json
@@ -1,6 +1,6 @@
 {
   "props": {
-    "activeClass": "Class bound when component is active. **warning** Depending upon the component, this could cause side effects. If you need to add a custom class on top of a default, just do `active-class=\"default-class your-class\"",
+    "activeClass": "Class bound when component is active. **warning** Depending upon the component, this could cause side effects. If you need to add a custom class on top of a default, just do `active-class=\"default-class your-class\"`",
     "append": "Vue Router router-link prop",
     "disabled": "Route item is disabled",
     "exact": "Exactly match the link. Without this, '/' will match every route",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added a trailing `` ` `` to string as it's missing from documentation and results in the following:
![screenshot from 2018-12-13 12-42-17](https://user-images.githubusercontent.com/2579764/49926840-f6636b80-fed5-11e8-8a3d-17312ce4dfbb.png)

## Motivation and Context
The following code was intended to be formatted as code, but the trailing `` ` `` was omitted by accident:
`active-class="default-class your-class"`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
