### PR TITLE
refactor(VExpansionPanel): add `aria-expanded` attribute

### DIFF
--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelContent.ts
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelContent.ts
@@ -146,7 +146,8 @@ export default mixins<options &
       staticClass: 'v-expansion-panel__container',
       class: this.containerClasses,
       attrs: {
-        tabindex: this.isReadonly || this.isDisabled ? null : 0
+        tabindex: this.isReadonly || this.isDisabled ? null : 0,
+        'aria-expanded': this.isActive
       },
       on: {
         keydown: this.onKeydown

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelContent.ts
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelContent.ts
@@ -147,7 +147,7 @@ export default mixins<options &
       class: this.containerClasses,
       attrs: {
         tabindex: this.isReadonly || this.isDisabled ? null : 0,
-        'aria-expanded': this.isActive
+        'aria-expanded': Boolean(this.isActive)
       },
       on: {
         keydown: this.onKeydown

--- a/packages/vuetify/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanel.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanel.spec.js.snap
@@ -33,6 +33,7 @@ exports[`VExpansionPanel.js should render an expanded component and match snapsh
 <ul class="v-expansion-panel theme--light">
   <li tabindex="0"
       class="v-expansion-panel__container v-expansion-panel__container--active"
+      aria-expanded="true"
   >
     <div class="v-expansion-panel__header">
       <div>
@@ -89,6 +90,7 @@ exports[`VExpansionPanel.js should render component and match snapshot 2`] = `
 <ul class="v-expansion-panel theme--light">
   <li tabindex="0"
       class="v-expansion-panel__container v-expansion-panel__container--active"
+      aria-expanded="true"
   >
     <div class="v-expansion-panel__header">
       <div>

--- a/packages/vuetify/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanelContent.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanelContent.spec.js.snap
@@ -74,7 +74,7 @@ exports[`VExpansionPanelContent.js should toggle panel on header click 1`] = `
 
 <li tabindex="0"
     class="v-expansion-panel__container v-expansion-panel__container--active"
-    aria-expanded="15"
+    aria-expanded="true"
 >
   <div class="v-expansion-panel__header">
     <span>

--- a/packages/vuetify/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanelContent.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VExpansionPanel/__snapshots__/VExpansionPanelContent.spec.js.snap
@@ -74,6 +74,7 @@ exports[`VExpansionPanelContent.js should toggle panel on header click 1`] = `
 
 <li tabindex="0"
     class="v-expansion-panel__container v-expansion-panel__container--active"
+    aria-expanded="15"
 >
   <div class="v-expansion-panel__header">
     <span>


### PR DESCRIPTION
## Description
Add `aria-expanded` attribute when `VExpansionPanel` is expanded.

## Motivation and Context
Fixes #5879.

## How Has This Been Tested?
jest

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-expansion-panel>
      <v-expansion-panel-content
        v-for="(item,i) in 5"
        :key="i"
      >
        <div slot="header">Item</div>
        <v-card>
          <v-card-text>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</v-card-text>
        </v-card>
      </v-expansion-panel-content>
    </v-expansion-panel>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
    })
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
