### PR TITLE
fix(validatable): reset `valid` flag on `resetValidation`

### DIFF
--- a/packages/vuetify/src/mixins/validatable.js
+++ b/packages/vuetify/src/mixins/validatable.js
@@ -176,7 +176,7 @@ export default {
     },
     /** @public */
     resetValidation () {
-      this.valid = false
+      this.validate()
       this.isResetting = true
     },
     /** @public */

--- a/packages/vuetify/src/mixins/validatable.js
+++ b/packages/vuetify/src/mixins/validatable.js
@@ -176,6 +176,7 @@ export default {
     },
     /** @public */
     resetValidation () {
+      this.valid = false
       this.isResetting = true
     },
     /** @public */

--- a/packages/vuetify/test/unit/mixins/validatable.spec.js
+++ b/packages/vuetify/test/unit/mixins/validatable.spec.js
@@ -35,6 +35,20 @@ test('validatable.js', ({ mount }) => {
     expect(wrapper.vm.isResetting).toBe(true)
   })
 
+  it('should reset valid flag on resetValidation', () => {
+    const wrapper = mount(Mock, {
+      data: {
+        valid: true
+      }
+    })
+
+    expect(wrapper.vm.valid).toBe(true)
+
+    wrapper.vm.resetValidation()
+
+    expect(wrapper.vm.valid).toBe(false)
+  })
+
   it('should manually validate', () => {
     const wrapper = mount(Mock)
 

--- a/packages/vuetify/test/unit/mixins/validatable.spec.js
+++ b/packages/vuetify/test/unit/mixins/validatable.spec.js
@@ -37,11 +37,14 @@ test('validatable.js', ({ mount }) => {
 
   it('should reset valid flag on resetValidation', () => {
     const wrapper = mount(Mock, {
-      data: {
-        valid: true
+      propsData: {
+        rules: [() => false]
       }
     })
 
+    expect(wrapper.vm.valid).toBe(false)
+
+    wrapper.setData({ valid: true })
     expect(wrapper.vm.valid).toBe(true)
 
     wrapper.vm.resetValidation()


### PR DESCRIPTION
## Description
Reset `valid` flag on `resetValidation`

## Motivation and Context
Fixes #5877.

## How Has This Been Tested?
`jest`

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-form>
      <v-container>
        <v-layout row wrap>
          <v-flex xs12 sm6>
            <v-text-field
              v-model="email"
              ref="email"
              :rules="[rules.required, rules.email]"
              label="E-mail"
            ></v-text-field>
          </v-flex>
          <v-flex xs12 sm6>
            <v-btn @click="resetVal">Reset validation</v-btn>
          </v-flex>
        </v-layout>
      </v-container>
    </v-form>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        email: '',
        rules: {
          required: value => !!value || 'Required.',
          email: value => {
            const pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
            return pattern.test(value) || 'Invalid e-mail.'
          }
        }
      }
    },
    methods: {
      resetVal () {
        this.$refs.email.resetValidation();
      }
    }
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
