### PR TITLE
fix(VTextField): make label clickable

### DIFF
--- a/packages/vuetify/src/stylus/components/_text-fields.styl
+++ b/packages/vuetify/src/stylus/components/_text-fields.styl
@@ -150,7 +150,6 @@ rtl(v-text-field-rtl, "v-text-field")
     top: 6px // equal to the margin top of icons
     transform-origin: top left
     white-space: nowrap
-    pointer-events: none
 
     &--active
       max-width: 133%


### PR DESCRIPTION
## Description
Remove `pointer-events: none` to make label clickable.

## Motivation and Context
Fixes #5914.

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-form>
      <v-container>
        <v-layout row wrap>
          <v-flex xs12 sm6>
            <v-text-field
              label="Links in hints are clickable (see below)"
              hint="<a href='http://google.com' target='top'>google.com</a>"
              persistent-hint
            >
            </v-text-field>
          </v-flex>

          <v-flex xs12 sm6>
            <v-text-field
              label="Your product or service"
              value="Links in labels are not clickable (see above)"
              box
            >
              <template slot="label"><a href='https://google.com' target="top">google.com</a></template>
            </v-text-field>
          </v-flex>
        </v-layout>
      </v-container>
    </v-form>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
    })
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
