### PR TITLE
feat(VAutocomplete): auto-clear autocomplete when search field is empty

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
@@ -193,6 +193,11 @@ export default {
       ) this.activateMenu()
     },
     searchInput (val) {
+      if (val && val.length === 0) {
+        this.lazySearch = undefined
+        this.setMenuIndex(-1)
+        return
+      }
       this.lazySearch = val
     },
     internalSearch (val) {


### PR DESCRIPTION
## Description
Auto-clear autocomplete when search field is empty

## Motivation and Context
Fixes #5917.

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-container fluid>
      <v-layout>
        <v-flex xs3 class="mr-5">
          <v-autocomplete
            label="autocomplete"
            :items="data"
            v-model="autocompleteData"
            @change="displayData"
            @blur="displayData">

          </v-autocomplete>
        </v-flex>
        <v-flex xs3>
          <v-text-field
            label="autocompleteDisplayData"
            tabIndex="-1"
            readonly
            v-model="autocompleteDisplayData">
          </v-text-field>
        </v-flex>
      </v-layout>
      <v-layout>
        <f-vlex xs2>
          <v-text-field
            label="textField">
          </v-text-field>
        </f-vlex>
      </v-layout>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        data: ['Item 1', 'Item 2', 'Item 3'],
        autocompleteData: null,
        autocompleteDisplayData: null
      }
    },
    methods: {
      displayData () {
        this.autocompleteDisplayData = this.autocompleteData
      }
    }
  }
</script>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
