### PR TITLE
fix(VSelect): fix rendering without attrs

### DIFF
--- a/packages/vuetify/src/components/VSelect/index.js
+++ b/packages/vuetify/src/components/VSelect/index.js
@@ -30,7 +30,7 @@ const wrapper = {
     segmented: Boolean
   },
 
-  render (h, { props, data, slots, parent }) {
+  render (h, { props, data, slots, parent }) { // eslint-disable-line max-statements
     dedupeModelListeners(data)
     const children = rebuildSlots(slots(), h)
 
@@ -53,6 +53,8 @@ const wrapper = {
     if (props.editable) {
       deprecate('<v-select editable>', '<v-overflow-btn editable>', wrapper, parent)
     }
+
+    data.attrs = data.attrs || {}
 
     if (props.combobox || props.tags) {
       data.attrs.multiple = props.tags


### PR DESCRIPTION
## Description
`VSelect` should render without `attrs`.

## Motivation and Context
Fixes #5942.

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<script>
  export default {
    data: () => ({
      items: [
        "1",
        "2",
        "3"
      ]
    }),
    render (h) {
      return h('v-app', [
        h('v-select', {
          props: {
            items: this.items,
            label: 'test',
            itemText: 'name',
            itemValue: 'slug'
          }
        })
      ])
    }
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
