### PR TITLE
docs(ALaCarte) Typo correction "secnarios" -> "scenarios"

### DIFF
--- a/packages/vuetifyjs.com/src/lang/en/framework/ALaCarte.json
+++ b/packages/vuetifyjs.com/src/lang/en/framework/ALaCarte.json
@@ -16,7 +16,7 @@
   "loaderText1": "Keeping track of all the components you're using can be a real chore, so we wrote a webpack loader to help you. [**vuetify-loader**](https://github.com/vuetifyjs/vuetify-loader) will automatically import all the vuetify components you use, where you use them.\nThis will also make code-splitting more effective, as webpack will only load the components required for that chunk to be displayed.",
   "loaderText2": "Now any Vuetify component used in a template will be automatically added to an in-component import like above.",
   "loaderLimitationsHeader": "## Limitations",
-  "loaderLimitationsText1": "When using the `vuetify-loader`, there are a few secnarios which will require manual importing of components.",
+  "loaderLimitationsText1": "When using the `vuetify-loader`, there are a few scenarios which will require manual importing of components.",
   "loaderLimitationsDynamicHeader": "## Dynamic components",
   "loaderLimitationsDynamicText1": "`v-data-iterator` can use any component via the **content-tag** prop. This component must be registered [globally](#global-import):",
   "loaderLimitationsDynamicText2": "Dynamic components used with `<component :is=\"\">` can be registered [locally](#local-import):",


### PR DESCRIPTION
Skipping template since it's just a typo if that is OK.