### PR TITLE
fix(VTreeview): open-all not working with some item keys

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -30,11 +30,7 @@ type NodeState = {
   isSelected: boolean
   isIndeterminate: boolean
   isOpen: boolean
-}
-
-function ston (s: string | number) {
-  const n = Number(s)
-  return !isNaN(n) ? n : s
+  item: any
 }
 
 export default mixins(
@@ -139,7 +135,7 @@ export default mixins(
     }
 
     if (this.openAll) {
-      Object.keys(this.nodes).forEach(key => this.updateOpen(ston(key), true))
+      Object.keys(this.nodes).forEach(key => this.updateOpen(getObjectValueByPath(this.nodes[key].item, this.itemKey), true))
     } else {
       this.open.forEach(key => this.updateOpen(key, true))
     }
@@ -160,7 +156,8 @@ export default mixins(
         const node: any = {
           vnode: oldNode.vnode,
           parent,
-          children: children.map((c: any) => getObjectValueByPath(c, this.itemKey))
+          children: children.map((c: any) => getObjectValueByPath(c, this.itemKey)),
+          item
         }
 
         this.buildTree(children, key)
@@ -274,36 +271,37 @@ export default mixins(
     updateSelected (key: string | number, isSelected: boolean) {
       if (!this.nodes.hasOwnProperty(key)) return
 
-      const changed: Record<string | number, boolean> = {}
+      const changed = new Map()
 
       const descendants = [key, ...this.getDescendants(key)]
       descendants.forEach(descendant => {
         this.nodes[descendant].isSelected = isSelected
         this.nodes[descendant].isIndeterminate = false
-        changed[descendant] = isSelected
+        changed.set(descendant, isSelected)
       })
 
       const parents = this.getParents(key)
       parents.forEach(parent => {
         this.nodes[parent] = this.calculateState(this.nodes[parent], this.nodes)
-        changed[parent] = this.nodes[parent].isSelected
+        changed.set(parent, this.nodes[parent].isSelected)
       })
 
       const all = [key, ...descendants, ...parents]
       all.forEach(this.updateVnodeState)
 
-      Object.keys(changed).forEach(k => {
-        changed[k] === true ? this.selectedCache.add(ston(k)) : this.selectedCache.delete(ston(k))
-      })
+      for (const [key, value] of changed.entries()) {
+        value === true ? this.selectedCache.add(key) : this.selectedCache.delete(key)
+      }
     },
     updateOpen (key: string | number, isOpen: boolean) {
       if (!this.nodes.hasOwnProperty(key)) return
 
       const node = this.nodes[key]
+      const children = getObjectValueByPath(node.item, this.itemChildren)
 
-      if (node.children && !node.children.length && node.vnode && !node.vnode.hasLoaded) {
+      if (children && !children.length && node.vnode && !node.vnode.hasLoaded) {
         node.vnode.checkChildren().then(() => this.updateOpen(key, isOpen))
-      } else {
+      } else if (children && children.length) {
         node.isOpen = isOpen
 
         node.isOpen ? this.openCache.add(key) : this.openCache.delete(key)

--- a/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
+++ b/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
@@ -3,7 +3,7 @@ import { test } from '@/test'
 import VTreeview from '@/components/VTreeview/VTreeview'
 
 const singleRootTwoChildren = [
-  { id: 0, name: 'Root', children: [{ id: 1, name: 'Child' }, { id: 2, name: 'Child 2'}]}
+  { id: 0, name: 'Root', children: [{ id: 1, name: 'Child' }, { id: 2, name: 'Child 2' }] }
 ]
 
 const threeLevels = [
@@ -36,12 +36,12 @@ test('VTreeView.ts', ({ mount }) => {
     await wrapper.vm.$nextTick()
 
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn).toHaveBeenCalledWith([0, 1, 2, 3])
+    expect(fn).toHaveBeenCalledWith([0, 1, 3, 2])
     expect(wrapper.html()).toMatchSnapshot()
   })
 
   it('should load children when expanding', async () => {
-    const loadChildren = (item) => {
+    const loadChildren = item => {
       item.children = [{ id: 1, name: 'Child' }]
     }
 
@@ -61,7 +61,7 @@ test('VTreeView.ts', ({ mount }) => {
   })
 
   it('should load children when selecting, but not render', async () => {
-    const loadChildren = (item) => {
+    const loadChildren = item => {
       item.children = [{ id: 1, name: 'Child' }]
     }
 
@@ -175,7 +175,7 @@ test('VTreeView.ts', ({ mount }) => {
     const fn = jest.fn()
 
     wrapper.vm.$on('update:open', fn)
-    wrapper.setProps({ open: [0, 1]})
+    wrapper.setProps({ open: [0, 1] })
 
     await wrapper.vm.$nextTick()
 
@@ -281,7 +281,7 @@ test('VTreeView.ts', ({ mount }) => {
 
     wrapper.setProps({ value: [0], items: singleRootTwoChildren })
     await wrapper.vm.$nextTick()
-    expect(value).toHaveBeenCalledWith([0, 1, 2, 3])
+    expect(value).toHaveBeenCalledWith([0, 1, 3, 2])
   })
 
   it('should accept string value for id', async () => {
@@ -289,7 +289,7 @@ test('VTreeView.ts', ({ mount }) => {
       propsData: { itemKey: 'name' }
     })
 
-    wrapper.setProps({ items: [{ name: 'Foobar' }]})
+    wrapper.setProps({ items: [{ name: 'Foobar' }] })
 
     await wrapper.vm.$nextTick()
 
@@ -301,7 +301,7 @@ test('VTreeView.ts', ({ mount }) => {
   })
 
   it('should warn developer when using non-scoped slots', () => {
-    const wrapper = mount(VTreeview, {
+    mount(VTreeview, {
       slots: {
         prepend: [{ render: h => h('div') }],
         append: [{ render: h => h('div') }]
@@ -319,7 +319,7 @@ test('VTreeView.ts', ({ mount }) => {
             text: 'root',
             children: []
           }
-        ],
+        ]
       }
     })
 
@@ -336,7 +336,7 @@ test('VTreeView.ts', ({ mount }) => {
             text: 'root',
             children: []
           }
-        ],
+        ]
       }
     })
 


### PR DESCRIPTION
## Description
VTreeview tried to cast all item keys to numbers, which caused issues
when using a string such as 012 as a key.

## Motivation and Context
fixes #5711

## How Has This Been Tested?
manually & unit tests

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-treeview activatable :items="items" open-all></v-treeview>
    <v-treeview selectable activatable :items="items2" open-all :active.sync="active"></v-treeview>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    active: [13],
    items: [
      {
        id: "11",
        name: "First",
      },
      {
        //id: "12", works
        id: "012", //does not work
        name: 'Second',
        children: [
          {id: "013", name: "Third"}, // Ignored as this is a leaf node
          {id: "014", name: "Fourth"}, // Ignored as this is a leaf node
          {id: "015", name: "Fifth"} // Ignored as this is a leaf node
        ]
      }
    ],
    items2: [
      {
        id: 11,
        name: "First",
      },
      {
        //id: "12", works
        id: 12, //does not work
        name: 'Second',
        children: [
          {id: 13, name: "Third"}, // Ignored as this is a leaf node
          {id: 14, name: "Fourth"}, // Ignored as this is a leaf node
          {id: 15, name: "Fifth"} // Ignored as this is a leaf node
        ]
      }
    ]
  })
}
</script>

<style>
</style>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
