### PR TITLE
fix(VTreeview): bug when removing and adding children

### DIFF
--- a/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
+++ b/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
@@ -343,4 +343,49 @@ test('VTreeView.ts', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
     expect(wrapper.find('.v-treeview-node__toggle').length).toBe(1)
   })
+
+  it.only('should remove old nodes', async () => {
+    const wrapper = mount(VTreeview, {
+      propsData: {
+        items: [
+          {
+            id: 1,
+            name: 'one'
+          },
+          {
+            id: 2,
+            name: 'two'
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.setProps({ items: [
+      {
+        id: 1,
+        name: 'one'
+      }
+    ] })
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.setProps({ items: [
+      {
+        id: 1,
+        name: 'one'
+      },
+      {
+        id: 3,
+        name: 'three'
+      }
+    ] })
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
+
+    expect(Object.keys(wrapper.vm.nodes).length).toBe(2)
+  })
 })

--- a/packages/vuetify/test/unit/components/VTreeview/__snapshots__/VTreeview.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VTreeview/__snapshots__/VTreeview.spec.js.snap
@@ -358,6 +358,72 @@ exports[`VTreeView.ts should react to open changes 4`] = `
 
 `;
 
+exports[`VTreeView.ts should remove old nodes 1`] = `
+
+<div class="v-treeview theme--light">
+  <div class="v-treeview-node v-treeview-node--leaf">
+    <div class="v-treeview-node__root">
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
+          one
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="v-treeview-node v-treeview-node--leaf">
+    <div class="v-treeview-node__root">
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
+          two
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
+exports[`VTreeView.ts should remove old nodes 2`] = `
+
+<div class="v-treeview theme--light">
+  <div class="v-treeview-node v-treeview-node--leaf">
+    <div class="v-treeview-node__root">
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
+          one
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
+exports[`VTreeView.ts should remove old nodes 3`] = `
+
+<div class="v-treeview theme--light">
+  <div class="v-treeview-node v-treeview-node--leaf">
+    <div class="v-treeview-node__root">
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
+          one
+        </label>
+      </div>
+    </div>
+  </div>
+  <div class="v-treeview-node v-treeview-node--leaf">
+    <div class="v-treeview-node__root">
+      <div class="v-treeview-node__content">
+        <label class="v-treeview-node__label">
+          three
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+
+`;
+
 exports[`VTreeView.ts should render items 1`] = `
 
 <div class="v-treeview theme--light">


### PR DESCRIPTION
## Description
There was a bug when removing a child, and then adding another one,
where the internal state would keep the removed child and not trigger
a rebuild of tree since the number of nodes was still the same

## Motivation and Context
fixes #5719

## How Has This Been Tested?
manually and added unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-btn @click="addNode($event)">Add to Applications</v-btn>
    <v-btn @click="removeNode($event)">Remove from Applications</v-btn>
    <v-treeview activatable :items="items"></v-treeview>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    items: [
      {
        id: 1,
        name: 'Applications :',
        children: [
          { id: 2, name: 'Calendar : app' },
          { id: 3, name: 'Chrome : app' },
          { id: 4, name: 'Webstorm : app' }
        ]
      },
      {
      id: 5,
      name: 'Documents :',
      children: [
        {
          id: 6,
          name: 'vuetify :',
          children: [
            {
              id: 7,
              name: 'src :',
              children: [
                { id: 8, name: 'index : ts' },
                { id: 9, name: 'bootstrap : ts' }
              ]
            }
          ]
        },
        {
          id: 10,
          name: 'material2 :',
          children: [
            {
              id: 11,
              name: 'src :',
              children: [
                { id: 12, name: 'v-btn : ts' },
                { id: 13, name: 'v-card : ts' },
                { id: 14, name: 'v-window : ts' }
              ]
            }
          ]
        }
      ]
    },
      {
        id: 15,
        name: 'Downloads :',
        children: [
          { id: 16, name: 'October : pdf' },
          { id: 17, name: 'November : pdf' },
          { id: 18, name: 'Tutorial : html' }
        ]
      },
      {
        id: 19,
        name: 'Videos :',
        children: [
          {
            id: 20,
            name: 'Tutorials :',
            children: [
              { id: 21, name: 'Basic layouts : mp4' },
              { id: 22, name: 'Advanced techniques : mp4' },
              { id: 23, name: 'All about app : dir' }
            ]
          },
          { id: 24, name: 'Intro : mov' },
          { id: 25, name: 'Conference introduction : avi' }
        ]
      }
    ],
    maxId: 1000,
    clickCount: 0
  }),
  methods: {
    addNode(e) {
      this.items[0].children.push({ id: this.maxId + this.clickCount, name: 'Test: app ' + this.clickCount });
      this.clickCount++;
    },
    removeNode(e) {
      // this.$set(this.items[0].children, "length", this.items[0].children.length - 1);
      // this.items[0].children.splice(this.items[0].children.length - 1)
      // this.clickCount--
      this.items[0].children = this.items[0].children.filter(c => c.id !== this.maxId + this.clickCount - 1)
    }
  }
}
</script>

<style>
</style>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
