### PR TITLE
docs(Icons): add new example

### DIFF
--- a/packages/vuetifyjs.com/src/data/pages/framework/Icons.json
+++ b/packages/vuetifyjs.com/src/data/pages/framework/Icons.json
@@ -220,6 +220,18 @@
         {
           "type": "markup",
           "value": "html_custom_icons_custom_component"
+        },
+        {
+          "type": "heading",
+          "lang": "customFASvg"
+        },
+        {
+          "type": "text",
+          "lang": "customFASvgText1"
+        },
+        {
+          "type": "markup",
+          "value": "js_vuetify_custom_fa_svg_icons"
         }
       ]
     },

--- a/packages/vuetifyjs.com/src/lang/en/framework/Icons.json
+++ b/packages/vuetifyjs.com/src/lang/en/framework/Icons.json
@@ -33,6 +33,6 @@
   "componentIconsHeader": "## Component icons",
   "componentIconsText1": "Instead of provided icon fonts presets you can use your own component icons. You also can switch icons that are used in Vuetify component with your own.",
   "componentIconsText2": "If you want your SVG icon to inherit colors and scale correctly - be sure add the following css to it:",
-  "customFASvg": "### Custom Font AWesome Pro Icons",
+  "customFASvg": "### Custom Font Awesome Pro Icons",
   "customFASvgText1": "You can utilize component icons with Font Awesome Pro to select individual icon weights:"
 }

--- a/packages/vuetifyjs.com/src/lang/en/framework/Icons.json
+++ b/packages/vuetifyjs.com/src/lang/en/framework/Icons.json
@@ -32,5 +32,7 @@
   "customComponentText1": "You can utilize the same icon strings in your own custom components. Any time **$vuetify.icons** is passed in through _v-text_, _v-html_ or as text, `<v-icon>` will look up that specified value. This allows you to create customized solutions that are easy to build and easy to manage.",
   "componentIconsHeader": "## Component icons",
   "componentIconsText1": "Instead of provided icon fonts presets you can use your own component icons. You also can switch icons that are used in Vuetify component with your own.",
-  "componentIconsText2": "If you want your SVG icon to inherit colors and scale correctly - be sure add the following css to it:"
+  "componentIconsText2": "If you want your SVG icon to inherit colors and scale correctly - be sure add the following css to it:",
+  "customFASvg": "### Custom Font AWesome Pro Icons",
+  "customFASvgText1": "You can utilize component icons with Font Awesome Pro to select individual icon weights:"
 }

--- a/packages/vuetifyjs.com/src/snippets/js/vuetify_custom_fa_svg_icons.txt
+++ b/packages/vuetifyjs.com/src/snippets/js/vuetify_custom_fa_svg_icons.txt
@@ -1,0 +1,28 @@
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { faBars } from '@fortawesome/pro-light-svg-icons'
+import { faVuejs } from '@fortawesome/free-brands-svg-icons'
+
+Vue.component('font-awesome-icon', FontAwesomeIcon)
+library.add(faBars, faVuejs)
+
+Vue.use(Vuetify, {
+  icons: {
+    // set menu to light (default is solid)
+    'menu': {
+      component: FontAwesomeIcon,
+      props: {
+        icon: ['fal', 'bars']
+      }
+    },
+    // reusable custom icon
+    'vuejs': {
+      component: FontAwesomeIcon,
+      props: {
+        icon: ['fab', 'vuejs']
+      }
+    }
+  }
+})


### PR DESCRIPTION
Setting icon weights with FA is incredibly easy, but not well documented.

* Add example of setting Font Awesome Pro icon weights using component icons.
* In keeping with the progressive nature of the Icons page, the example is added to the Component Icons section
* For brevity, I did not show advanced features of `vue-fontawesome`

Alternatively, we could add a new section below Component Icons specifically for Font Awesome Pro. This would allow going into more detail about using `faSvg` combined with `component` icons, including the use of additional `props` like `transform` and `mask`.
