### PR TITLE
feat(v-linear-gradient): add new directive

### DIFF
--- a/packages/api-generator/src/map.js
+++ b/packages/api-generator/src/map.js
@@ -290,6 +290,15 @@ module.exports = {
       }
     ]
   },
+  'v-linear-gradient': {
+    options: [
+      {
+        name: 'value',
+        default: 'undefined',
+        type: 'Object'
+      }
+    ]
+  },
   'v-ripple': {
     options: [
       {

--- a/packages/vuetify/src/directives/index.ts
+++ b/packages/vuetify/src/directives/index.ts
@@ -3,13 +3,15 @@ import Resize from './resize'
 import Ripple from './ripple'
 import Scroll from './scroll'
 import Touch from './touch'
+import LinearGradient from './linear-gradient'
 
 export {
   ClickOutside,
   Ripple,
   Resize,
   Scroll,
-  Touch
+  Touch,
+  LinearGradient
 }
 
 export default {
@@ -17,5 +19,6 @@ export default {
   Ripple,
   Resize,
   Scroll,
-  Touch
+  Touch,
+  LinearGradient
 }

--- a/packages/vuetify/src/directives/linear-gradient.ts
+++ b/packages/vuetify/src/directives/linear-gradient.ts
@@ -1,0 +1,31 @@
+import { VNodeDirective } from 'vue/types/vnode'
+
+interface ColorStop {
+  color: string
+  percent?: number
+}
+
+interface LinearGradientDirective extends VNodeDirective {
+  value: {
+    angle: 0
+    stops?: ColorStop[]
+  }
+}
+
+function inserted (el: HTMLElement, binding: LinearGradientDirective) {
+  if (!binding.value) return
+
+  const stops = binding.value.stops ? binding.value.stops.map(stop => stop.percent ? `${stop.color} ${stop.percent}%` : `${stop.color}`) : []
+
+  if (stops.length > 1) {
+    el.style.backgroundImage = `linear-gradient(${binding.value.angle || 0}deg${stops.length > 0 ? ', ' + stops.join(', ') : ''})`
+  } else if (stops.length === 1) {
+    el.style.backgroundColor = binding.value.stops ? binding.value.stops[0].color : null
+  } else {
+    console.error('Cannot create a gradient with 0 color stops!')
+  }
+}
+
+export default {
+  inserted
+}

--- a/packages/vuetify/test/integration/__snapshots__/importFull.spec.js.snap
+++ b/packages/vuetify/test/integration/__snapshots__/importFull.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`full import should register all directives 1`] = `
 Array [
   "ClickOutside",
+  "LinearGradient",
   "Resize",
   "Ripple",
   "Scroll",

--- a/packages/vuetify/test/unit/directives/__snapshots__/linear-gradient.spec.js.snap
+++ b/packages/vuetify/test/unit/directives/__snapshots__/linear-gradient.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VLinearGradient LinearGradient should render element with linear gradient 1`] = `[Function]`;

--- a/packages/vuetify/test/unit/directives/linear-gradient.spec.js
+++ b/packages/vuetify/test/unit/directives/linear-gradient.spec.js
@@ -1,0 +1,41 @@
+import Vue from 'vue'
+import { test } from '@/test'
+import LinearGradient from '@/directives/linear-gradient'
+
+test('VLinearGradient', ({ mount }) => {
+  it('LinearGradient should render element with linear gradient', () => {
+    const testComponent = Vue.component('test', {
+      directives: {
+        LinearGradient
+      },
+      render (h){
+        const data = {
+          directives: [{
+            name: 'linear-gradient',
+            value: {
+              angle: 45,
+              stops: [
+                {
+                  color: "#42f4e5",
+                  percent: 20
+                },
+                {
+                  color: "#409ced"
+                }
+              ]
+            }
+          }],
+          style: {
+            width: "200px",
+            height: "200px"
+          }
+        }
+        return h('div', data)
+      }
+    })
+
+    const wrapper = mount(testComponent)
+
+    expect(wrapper.html).toMatchSnapshot()
+  })
+})

--- a/packages/vuetifyjs.com/src/data/drawerItems.json
+++ b/packages/vuetifyjs.com/src/data/drawerItems.json
@@ -150,7 +150,8 @@
       { "text": "resizing", "to": "resizing" },
       { "text": "ripples", "to": "ripples" },
       { "text": "scrolling", "to": "scrolling" },
-      { "text": "touchSupport", "to": "touch-support" }
+      { "text": "touchSupport", "to": "touch-support" },
+      { "text": "linearGradients", "to": "linear-gradients" }
     ]
   },
   {

--- a/packages/vuetifyjs.com/src/data/pages/directives/LinearGradients.json
+++ b/packages/vuetifyjs.com/src/data/pages/directives/LinearGradients.json
@@ -1,0 +1,37 @@
+{
+  "title": "header",
+  "titleText": "headerText",
+  "children": [
+    {
+      "type": "section",
+      "children": [
+        {
+          "type": "usage",
+          "value": "usage"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "children": [
+        {
+          "type": "api",
+          "value": [ "v-linear-gradient" ]
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "children": [
+        {
+          "type": "up-next",
+          "value": [
+            "framework/colors",
+            "framework/icons",
+            "framework/grid"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/vuetifyjs.com/src/examples/linear-gradients/usage.vue
+++ b/packages/vuetifyjs.com/src/examples/linear-gradients/usage.vue
@@ -1,0 +1,29 @@
+<template>
+  <div v-linear-gradient="gradient" class="demo"></div>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      gradient: {
+        angle: 45,
+        stops: [
+          {
+            color: '#42f4e5',
+            percent: 20
+          },
+          {
+            color: '#409ced'
+          }
+        ]
+      }
+    })
+  }
+</script>
+
+<style>
+.demo {
+  width: 300px;
+  height: 200px;
+}
+</style>

--- a/packages/vuetifyjs.com/src/lang/en/directives/LinearGradients.json
+++ b/packages/vuetifyjs.com/src/lang/en/directives/LinearGradients.json
@@ -1,0 +1,12 @@
+{
+  "header": "# Linear gradient directive",
+  "headerText": "The `v-linear-gradient` directive can be used for making elements with linear gradient background.",
+  "examples": {
+    "usage": {
+      "desc": "Linear gradient with some color stops. You can define color stop percent."
+    }
+  },
+  "options": {
+    "value": "`v-resize=\"gradient\"` Gradient properties."
+  }
+}

--- a/packages/vuetifyjs.com/src/lang/en/meta.json
+++ b/packages/vuetifyjs.com/src/lang/en/meta.json
@@ -454,6 +454,11 @@
     "description": "Resize directive for the Vuetify framework.",
     "keywords": "resize, resize directive, window resize directive"
   },
+  "directives/linear-gradients": {
+    "title": "Linear gradients",
+    "description": "Linear gradient directive for the Vuetify framework.",
+    "keywords": "gradient, linear gradient"
+  },
   "directives/ripples": {
     "title": "Ripple",
     "description": "Ripple directive for the Vuetify framework.",

--- a/packages/vuetifyjs.com/src/lang/en/vuetify/AppDrawer.json
+++ b/packages/vuetifyjs.com/src/lang/en/vuetify/AppDrawer.json
@@ -53,6 +53,7 @@
   "itemGroups": "Item groups",
   "jumbotrons": "Jumbotrons",
   "layout": "Application layout",
+  "linearGradients": "Linear gradients",
   "lists": "Lists",
   "meetTheTeam": "Meet the team",
   "menus": "Menus",


### PR DESCRIPTION
## Description
Add new directive for creating linear gradients

## Motivation and Context
Gradient support

## How Has This Been Tested?
markup

## Markup:
<details>

```vue
<template>
  <div class="demo" v-linear-gradient="gradient"></div>
</template>

<script>
export default {
  data: () => ({
    gradient: {
      angle: 45,
      stops: [
        {
          color: "#42f4e5",
          percent: 20
        },
        {
          color: "#409ced"
        }
      ]
    }
  })
}
</script>


<style>
.demo {
  width: 300px;
  height: 200px
}
</style>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
