### PR TITLE
fix(VSelect): don't emit change event when clicked on the selected item 

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.js
+++ b/packages/vuetify/src/components/VSelect/VSelect.js
@@ -693,8 +693,8 @@ export default VTextField.extend({
       this.selectedItems = selectedItems
     },
     setValue (value) {
+      value !== this.internalValue && this.$emit('change', value)
       this.internalValue = value
-      this.$emit('change', value)
     }
   }
 })

--- a/packages/vuetify/test/unit/components/VSelect/VSelect.spec.js
+++ b/packages/vuetify/test/unit/components/VSelect/VSelect.spec.js
@@ -538,4 +538,23 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     expect(change.mock.calls).toEqual([['foo']])
   })
+
+  it('should not emit change event when clicked on the selecterd item', async () => {
+    const wrapper = mount(VSelect, {
+      propsData: {
+        items: ['foo', 'bar']
+      }
+    })
+
+    const change = jest.fn()
+    wrapper.vm.$on('change', change)
+
+    wrapper.vm.selectItem('foo')
+    await wrapper.vm.$nextTick()
+
+    wrapper.vm.selectItem('foo')
+    await wrapper.vm.$nextTick()
+
+    expect(change.mock.calls.length).toBe(1);
+  })
 })

--- a/packages/vuetify/test/unit/components/VSelect/VSelect.spec.js
+++ b/packages/vuetify/test/unit/components/VSelect/VSelect.spec.js
@@ -539,7 +539,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
     expect(change.mock.calls).toEqual([['foo']])
   })
 
-  it('should not emit change event when clicked on the selecterd item', async () => {
+  it('should not emit change event when clicked on the selected item', async () => {
     const wrapper = mount(VSelect, {
       propsData: {
         items: ['foo', 'bar']

--- a/packages/vuetify/test/unit/components/VSelect/VSelect3.spec.js
+++ b/packages/vuetify/test/unit/components/VSelect/VSelect3.spec.js
@@ -164,7 +164,7 @@ test('VSelect', ({ mount, compileToFunctions }) => {
 
     wrapper.vm.$on('change', change)
 
-    wrapper.setProps({ value: 'foo' })
+    wrapper.setProps({ value: 'bar' })
 
     expect(change).not.toBeCalled()
 


### PR DESCRIPTION
## Description
Don't emit change event when clicked on the selected item 

## Motivation and Context
#6052

## How Has This Been Tested?
`jest`

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-select
      :items="types"
      label="Types"
      v-model="type"
      @change="onchange"
      hide-details
    ></v-select>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    types:["type1","type2","type3","type4"],
    type:"type1"
  }),
  methods: {
  	onchange(){
    	alert(this.type)
    }
  }
}
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
