### PR TITLE
Make VTimePicker select hours after having selected minutes

### DIFF
--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.ts
@@ -213,6 +213,8 @@ export default mixins(
         this.selecting = selectingTimes.minute
       } else if (this.useSeconds && this.selecting === selectingTimes.minute) {
         this.selecting = selectingTimes.second
+      } else {
+        this.selecting = selectingTimes.hour
       }
 
       if (this.inputHour === this.lazyInputHour &&

--- a/packages/vuetify/test/unit/components/VTimePicker/VTimePicker.spec.js
+++ b/packages/vuetify/test/unit/components/VTimePicker/VTimePicker.spec.js
@@ -325,9 +325,9 @@ test('VTimePicker.js', ({ mount }) => {
       expect(wrapper.vm.selectingMinute).toBe(true)
       expect(wrapper.vm.selectingSecond).toBe(false)
       clock.$emit('change')
-      expect(wrapper.vm.selecting).toBe(useSecondsValue ? selectingTimes.second : selectingTimes.minute)
-      expect(wrapper.vm.selectingHour).toBe(false)
-      expect(wrapper.vm.selectingMinute).toBe(!useSecondsValue)
+      expect(wrapper.vm.selecting).toBe(useSecondsValue ? selectingTimes.second : selectingTimes.hour)
+      expect(wrapper.vm.selectingHour).toBe(!useSecondsValue)
+      expect(wrapper.vm.selectingMinute).toBe(false)
       expect(wrapper.vm.selectingSecond).toBe(useSecondsValue)
     })
 


### PR DESCRIPTION
After selecting minutes (or seconds if enabled), the TimePicker stayed in minutes (seconds) selection.
When used inside a VMenu the TimePicker would open in minute-mode when the Menu is re-opened unless destroyed on close.
When used with the `no-title` prop there is not even a way to switch back to hour selection.

With this fix, the `v-model` on `VMenu` and `v-if` on `VTimePicker` is not required anymore.

This fixes vuetifyjs/vuetify#4502

## How Has This Been Tested?
The changes have been tested visually and unit tests updated

## Markup:
<details>

```vue
<template>
  <v-app id="inspire">
    <v-layout row wrap>
      <v-flex xs11 sm5>
        <v-menu
          ref="menu"
          :close-on-content-click="false"
          :nudge-right="40"
          :return-value.sync="time"
          lazy
          transition="scale-transition"
          offset-y
          full-width
          max-width="290px"
          min-width="290px"
        >
          <v-text-field
            slot="activator"
            v-model="time"
            label="Picker in menu"
            prepend-icon="access_time"
            readonly
          ></v-text-field>
          <v-time-picker
            v-model="time"
            full-width
            @change="$refs.menu.save(time)"
          ></v-time-picker>
        </v-menu>
      </v-flex>
      <v-spacer></v-spacer>
      <v-flex xs11 sm5>
        <v-dialog
          ref="dialog"
          v-model="modal2"
          :return-value.sync="time"
          persistent
          lazy
          full-width
          width="290px"
        >
          <v-text-field
            slot="activator"
            v-model="time"
            label="Picker in dialog"
            prepend-icon="access_time"
            readonly
          ></v-text-field>
          <v-time-picker
            v-model="time"
            full-width
          >
            <v-spacer></v-spacer>
            <v-btn flat color="primary" @click="modal2 = false">Cancel</v-btn>
            <v-btn flat color="primary" @click="$refs.dialog.save(time)">OK</v-btn>
          </v-time-picker>
        </v-dialog>
      </v-flex>
    </v-layout>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      time: null,
      modal2: false
    })
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
