### PR TITLE
docs(VTabs): correct a mistake in grow documentation

### DIFF
--- a/packages/vuetifyjs.com/src/lang/en/components/Tabs.json
+++ b/packages/vuetifyjs.com/src/lang/en/components/Tabs.json
@@ -53,7 +53,7 @@
   "props": {
     "alignWithTitle": "Make `v-tabs` lined up with the toolbar title",
     "cycle": "Will reset to first or last tab when swiping left or right if at the end of indexes",
-    "grow": "Force `v-tab-item`'s to take up all available space",
+    "grow": "Force `v-tab`'s to take up all available space",
     "hideSlider": "Hide's the generated `v-tabs-slider`",
     "iconsAndText": "Will stack icon and text vertically",
     "prevIcon": "Left pagination icon",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
grow effects `v-tab`, not `v-tab-item`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
to prevent confusion

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
confirmed the side effects of `grow` in codepens from the docs

## Markup:
<!--- Paste markup for testing your change --->
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
