### PR TITLE
enh(VTreeview): added return-object prop

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -60,6 +60,10 @@ export default mixins(
       default: () => ([])
     } as PropValidator<NodeArray>,
     openAll: Boolean,
+    returnObject: {
+      type: Boolean,
+      default: false // TODO: Should be true in next major
+    },
     value: {
       type: Array,
       default: () => ([])
@@ -102,29 +106,14 @@ export default mixins(
       },
       deep: true
     },
-    active (value: (string | number)[]) {
-      const old = [...this.activeCache]
-      if (!value || deepEqual(old, value)) return
-
-      old.forEach(key => this.updateActive(key, false))
-      value.forEach(key => this.updateActive(key, true))
-      this.emitActive()
+    active (value: (string | number | any)[]) {
+      this.handleNodeCacheWatcher(value, this.activeCache, this.updateActive, this.emitActive)
     },
-    value (value: (string | number)[]) {
-      const old = [...this.selectedCache]
-      if (!value || deepEqual(old, value)) return
-
-      old.forEach(key => this.updateSelected(key, false))
-      value.forEach(key => this.updateSelected(key, true))
-      this.emitSelected()
+    value (value: (string | number | any)[]) {
+      this.handleNodeCacheWatcher(value, this.selectedCache, this.updateSelected, this.emitSelected)
     },
-    open (value: (string | number)[]) {
-      const old = [...this.openCache]
-      if (deepEqual(old, value)) return
-
-      old.forEach(key => this.updateOpen(key, false))
-      value.forEach(key => this.updateOpen(key, true))
-      this.emitOpen()
+    open (value: (string | number | any)[]) {
+      this.handleNodeCacheWatcher(value, this.openCache, this.updateOpen, this.emitOpen)
     }
   },
 
@@ -217,13 +206,26 @@ export default mixins(
       return node
     },
     emitOpen () {
-      this.$emit('update:open', [...this.openCache])
+      this.emitNodeCache('update:open', this.openCache)
     },
     emitSelected () {
-      this.$emit('input', [...this.selectedCache])
+      this.emitNodeCache('input', this.selectedCache)
     },
     emitActive () {
-      this.$emit('update:active', [...this.activeCache])
+      this.emitNodeCache('update:active', this.activeCache)
+    },
+    emitNodeCache (event: string, cache: NodeCache) {
+      this.$emit(event, [...cache].map(key => this.returnObject ? this.nodes[key].item : key))
+    },
+    handleNodeCacheWatcher (value: any[], cache: NodeCache, updateFn: Function, emitFn: Function) {
+      value = this.returnObject ? value.map(v => getObjectValueByPath(v, this.itemKey)) : value
+      const old = [...cache]
+      if (deepEqual(old, value)) return
+
+      old.forEach(key => updateFn(key, false))
+      value.forEach(key => updateFn(key, true))
+
+      emitFn()
     },
     getDescendants (key: string | number, descendants: NodeArray = []) {
       const children = this.nodes[key].children

--- a/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
+++ b/packages/vuetify/test/unit/components/VTreeview/VTreeview.spec.js
@@ -132,7 +132,8 @@ test('VTreeView.ts', ({ mount }) => {
     const wrapper = mount(VTreeview, {
       propsData: {
         items: [{ id: 0, name: 'Root', children: [{ id: 1, name: 'Child' }] }],
-        value: []
+        value: [],
+        selectable: true
       }
     })
 
@@ -146,7 +147,7 @@ test('VTreeView.ts', ({ mount }) => {
     expect(wrapper.find('.v-treeview-node--selected').length).toBe(2)
     expect(wrapper.html()).toMatchSnapshot()
 
-    wrapper.setProps({ value: undefined })
+    wrapper.setProps({ value: [] })
     await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
@@ -409,5 +410,43 @@ test('VTreeView.ts', ({ mount }) => {
     expect(wrapper.html()).toMatchSnapshot()
 
     expect(Object.keys(wrapper.vm.nodes).length).toBe(2)
+  })
+
+  it('should emit objects when return-object prop is used', async () => {
+    const items = [{ id: 0, name: 'Root', children: [{ id: 1, name: 'Child' }] }]
+
+    const wrapper = mount(VTreeview, {
+      propsData: {
+        items,
+        activatable: true,
+        selectable: true,
+        returnObject: true
+      }
+    })
+
+    const active = jest.fn()
+    wrapper.vm.$on('update:active', active)
+    const selected = jest.fn()
+    wrapper.vm.$on('input', selected)
+    const open = jest.fn()
+    wrapper.vm.$on('update:open', open)
+
+    wrapper.find('.v-treeview-node__root')[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(active).toHaveBeenCalledTimes(1)
+    expect(active).toHaveBeenCalledWith([items[0]])
+
+    wrapper.find('.v-treeview-node__checkbox')[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(selected).toHaveBeenCalledTimes(1)
+    expect(selected).toHaveBeenCalledWith([items[0], items[0].children[0]])
+
+    wrapper.find('.v-treeview-node__toggle')[0].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(open).toHaveBeenCalledTimes(1)
+    expect(open).toHaveBeenCalledWith([items[0]])
   })
 })

--- a/packages/vuetify/test/unit/components/VTreeview/__snapshots__/VTreeview.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VTreeview/__snapshots__/VTreeview.spec.js.snap
@@ -533,6 +533,11 @@ exports[`VTreeView.ts should update selection when selected prop changes 1`] = `
       >
         arrow_drop_down
       </i>
+      <i aria-hidden="true"
+         class="v-icon v-treeview-node__checkbox v-icon--link material-icons theme--light"
+      >
+        check_box_outline_blank
+      </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
           Root
@@ -554,6 +559,11 @@ exports[`VTreeView.ts should update selection when selected prop changes 2`] = `
       >
         arrow_drop_down
       </i>
+      <i aria-hidden="true"
+         class="v-icon v-treeview-node__checkbox v-icon--link material-icons theme--light accent--text"
+      >
+        check_box
+      </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
           Root
@@ -563,6 +573,11 @@ exports[`VTreeView.ts should update selection when selected prop changes 2`] = `
     <div class="v-treeview-node__children">
       <div class="v-treeview-node v-treeview-node--leaf v-treeview-node--selected">
         <div class="v-treeview-node__root">
+          <i aria-hidden="true"
+             class="v-icon v-treeview-node__checkbox v-icon--link material-icons theme--light accent--text"
+          >
+            check_box
+          </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
               Child
@@ -579,12 +594,17 @@ exports[`VTreeView.ts should update selection when selected prop changes 2`] = `
 exports[`VTreeView.ts should update selection when selected prop changes 3`] = `
 
 <div class="v-treeview theme--light">
-  <div class="v-treeview-node v-treeview-node--selected">
+  <div class="v-treeview-node">
     <div class="v-treeview-node__root">
       <i aria-hidden="true"
          class="v-icon v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
         arrow_drop_down
+      </i>
+      <i aria-hidden="true"
+         class="v-icon v-treeview-node__checkbox v-icon--link material-icons theme--light"
+      >
+        check_box_outline_blank
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -593,8 +613,13 @@ exports[`VTreeView.ts should update selection when selected prop changes 3`] = `
       </div>
     </div>
     <div class="v-treeview-node__children">
-      <div class="v-treeview-node v-treeview-node--leaf v-treeview-node--selected">
+      <div class="v-treeview-node v-treeview-node--leaf">
         <div class="v-treeview-node__root">
+          <i aria-hidden="true"
+             class="v-icon v-treeview-node__checkbox v-icon--link material-icons theme--light"
+          >
+            check_box_outline_blank
+          </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
               Child


### PR DESCRIPTION
## Description
return-object prop defaults to false and will return the whole node
item object instead of just the key when set to true. this affects
v-model, active.sync and open.sync props.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
solves #5881

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
unit test and playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-treeview :items="items" selectable activatable v-model="asd" return-object :active.sync="zxc" :open.sync="open"></v-treeview>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      asd: [],
      zxc: [],
      open: [],
      items: [
        {
          id: 1,
          name: 'Applications :',
          children: [
            { id: 2, name: 'Calendar : app' },
            { id: 3, name: 'Chrome : app' },
            { id: 4, name: 'Webstorm : app' }
          ]
        },
        {
          id: 5,
          name: 'Documents :',
          children: [
            {
              id: 6,
              name: 'vuetify :',
              children: [
                {
                  id: 7,
                  name: 'src :',
                  children: [
                    { id: 8, name: 'index : ts' },
                    { id: 9, name: 'bootstrap : ts' }
                  ]
                }
              ]
            },
            {
              id: 10,
              name: 'material2 :',
              children: [
                {
                  id: 11,
                  name: 'src :',
                  children: [
                    { id: 12, name: 'v-btn : ts' },
                    { id: 13, name: 'v-card : ts' },
                    { id: 14, name: 'v-window : ts' }
                  ]
                }
              ]
            }
          ]
        },
        {
          id: 15,
          name: 'Downloads :',
          children: [
            { id: 16, name: 'October : pdf' },
            { id: 17, name: 'November : pdf' },
            { id: 18, name: 'Tutorial : html' }
          ]
        },
        {
          id: 19,
          name: 'Videos :',
          children: [
            {
              id: 20,
              name: 'Tutorials :',
              children: [
                { id: 21, name: 'Basic layouts : mp4' },
                { id: 22, name: 'Advanced techniques : mp4' },
                { id: 23, name: 'All about app : dir' }
              ]
            },
            { id: 24, name: 'Intro : mov' },
            { id: 25, name: 'Conference introduction : avi' }
          ]
        }
      ]
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
