### PR TITLE
fix(elevation): use filter instead of box-shadow

### DIFF
--- a/packages/vuetify/src/stylus/settings/_elevations.styl
+++ b/packages/vuetify/src/stylus/settings/_elevations.styl
@@ -85,9 +85,6 @@ elevation($z, important = false)
   filter: unquote('drop-shadow(' + $shadow-key-umbra[$z] + ')')
               unquote('drop-shadow(' + $shadow-key-penumbra[$z] + ')')
               unquote('drop-shadow(' + $shadow-key-ambient[$z] + ')') (important ? !important : )
-  -webkit-filter: unquote('drop-shadow(' + $shadow-key-umbra[$z] + ')')
-              unquote('drop-shadow(' + $shadow-key-penumbra[$z] + ')')
-              unquote('drop-shadow(' + $shadow-key-ambient[$z] + ')') (important ? !important : )
 
 elevationTransition($duration = 280ms, $easing = cubic-bezier(.4, 0, .2, 1))
   transition: box-shadow $duration $easing

--- a/packages/vuetify/src/stylus/settings/_elevations.styl
+++ b/packages/vuetify/src/stylus/settings/_elevations.styl
@@ -82,9 +82,7 @@ $shadow-key-ambient := 0px 0px 0px 0px $shadow-key-ambient-opacity,
 
 // MIXINS
 elevation($z, important = false)
-  filter: unquote('drop-shadow(' + $shadow-key-umbra[$z] + ')')
-              unquote('drop-shadow(' + $shadow-key-penumbra[$z] + ')')
-              unquote('drop-shadow(' + $shadow-key-ambient[$z] + ')') (important ? !important : )
+  filter: unquote('drop-shadow(' + $shadow-key-umbra[$z] + ')') unquote('drop-shadow(' + $shadow-key-penumbra[$z] + ')') unquote('drop-shadow(' + $shadow-key-ambient[$z] + ')') (important ? !important : )
 
 elevationTransition($duration = 280ms, $easing = cubic-bezier(.4, 0, .2, 1))
   transition: box-shadow $duration $easing

--- a/packages/vuetify/src/stylus/settings/_elevations.styl
+++ b/packages/vuetify/src/stylus/settings/_elevations.styl
@@ -82,9 +82,12 @@ $shadow-key-ambient := 0px 0px 0px 0px $shadow-key-ambient-opacity,
 
 // MIXINS
 elevation($z, important = false)
-  box-shadow: $shadow-key-umbra[$z],
-              $shadow-key-penumbra[$z],
-              $shadow-key-ambient[$z] (important ? !important : )
+  filter: unquote('drop-shadow(' + $shadow-key-umbra[$z] + ')')
+              unquote('drop-shadow(' + $shadow-key-penumbra[$z] + ')')
+              unquote('drop-shadow(' + $shadow-key-ambient[$z] + ')') (important ? !important : )
+  -webkit-filter: unquote('drop-shadow(' + $shadow-key-umbra[$z] + ')')
+              unquote('drop-shadow(' + $shadow-key-penumbra[$z] + ')')
+              unquote('drop-shadow(' + $shadow-key-ambient[$z] + ')') (important ? !important : )
 
 elevationTransition($duration = 280ms, $easing = cubic-bezier(.4, 0, .2, 1))
   transition: box-shadow $duration $easing


### PR DESCRIPTION
BREAKING CHANGE
I don't know whether I should call this BREAKING CHANGE, so i write just in case.

## Description
For now elevation-{n} is not applied to non-box elements like SVG. This commit solves that kind of problems.

## Motivation and Context
For now elevation-{n} is not applied to non-box elements like SVG. This commit solves that kind of problems.

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<div class="elevation-5">example</div>
<svg width="100" height="100" class="elevation-5">
  <circle cx="50" cy="50" r="50"/>
</svg>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
