### PR TITLE
docs(VDataTable): improve expand documentation

### DIFF
--- a/packages/docs/src/examples/data-tables/expand.vue
+++ b/packages/docs/src/examples/data-tables/expand.vue
@@ -1,31 +1,42 @@
 <template>
-  <v-data-table
-    :headers="headers"
-    :items="desserts"
-    item-key="name"
-  >
-    <template slot="items" slot-scope="props">
-      <tr @click="props.expanded = !props.expanded">
-        <td>{{ props.item.name }}</td>
-        <td class="text-xs-right">{{ props.item.calories }}</td>
-        <td class="text-xs-right">{{ props.item.fat }}</td>
-        <td class="text-xs-right">{{ props.item.carbs }}</td>
-        <td class="text-xs-right">{{ props.item.protein }}</td>
-        <td class="text-xs-right">{{ props.item.iron }}</td>
-      </tr>
-    </template>
-    <template slot="expand" slot-scope="props">
-      <v-card flat>
-        <v-card-text>Peek-a-boo!</v-card-text>
-      </v-card>
-    </template>
-  </v-data-table>
+  <div>
+    <v-toolbar flat color="white">
+      <v-toolbar-title>Expandable Table</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-btn color="primary" dark @click="expand = !expand">
+         {{ expand ? 'Close' : 'Keep' }} other rows
+      </v-btn>
+    </v-toolbar>
+    <v-data-table
+      :headers="headers"
+      :items="desserts"
+      item-key="name"
+      :expand="expand"
+    >
+      <template slot="items" slot-scope="props">
+        <tr @click="props.expanded = !props.expanded">
+          <td>{{ props.item.name }}</td>
+          <td class="text-xs-right">{{ props.item.calories }}</td>
+          <td class="text-xs-right">{{ props.item.fat }}</td>
+          <td class="text-xs-right">{{ props.item.carbs }}</td>
+          <td class="text-xs-right">{{ props.item.protein }}</td>
+          <td class="text-xs-right">{{ props.item.iron }}</td>
+        </tr>
+      </template>
+      <template slot="expand" slot-scope="props">
+        <v-card flat>
+          <v-card-text>Peek-a-boo!</v-card-text>
+        </v-card>
+      </template>
+    </v-data-table>
+  </div>
 </template>
 
 <script>
   export default {
     data () {
       return {
+        expand: false,
         headers: [
           {
             text: 'Dessert (100g serving)',

--- a/packages/docs/src/examples/data-tables/expand.vue
+++ b/packages/docs/src/examples/data-tables/expand.vue
@@ -4,14 +4,14 @@
       <v-toolbar-title>Expandable Table</v-toolbar-title>
       <v-spacer></v-spacer>
       <v-btn color="primary" dark @click="expand = !expand">
-         {{ expand ? 'Close' : 'Keep' }} other rows
+        {{ expand ? 'Close' : 'Keep' }} other rows
       </v-btn>
     </v-toolbar>
     <v-data-table
       :headers="headers"
       :items="desserts"
-      item-key="name"
       :expand="expand"
+      item-key="name"
     >
       <template slot="items" slot-scope="props">
         <tr @click="props.expanded = !props.expanded">

--- a/packages/docs/src/lang/en/components/DataTables.json
+++ b/packages/docs/src/lang/en/components/DataTables.json
@@ -27,7 +27,7 @@
     },
     "expand": {
       "header": "### Slot: expand",
-      "desc": "The `v-data-table` component also supports expandable rows using the `expand` slot. You can use the prop `expand` to prevent expanded rows from closing when clicking on another row."
+      "desc": "The `v-data-table` component also supports expandable rows using the `expand` slot. By default expanding a row closes all remaining rows. You can use the prop `expand` on `v-data-table` to prevent expanded rows from closing when clicking on another row."
     },
     "pageText": {
       "header": "### Slot: pageText",

--- a/packages/docs/src/lang/es-MX/components/DataTables.json
+++ b/packages/docs/src/lang/es-MX/components/DataTables.json
@@ -28,7 +28,7 @@
     },
     "expand": {
       "header": "Slot: expand",
-      "desc": "El componente `v-data-table` también soporta filas expandibles utilizando el slot `expand`. Puedes usar la prop `expand` para prevenir que las filas expandidas se cierren al hacer click en una fila distinta."
+      "desc": "El componente `v-data-table` también soporta filas expandibles utilizando el slot `expand`. Por defecto, cuando una fila se expande el resto se cierran. Puedes usar la prop `expand` en `v-data-table` para evitar que las filas expandidas se cierren al hacer click en una fila distinta."
     },
     "pageText": {
       "header": "Slot: page-text",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description

In the documentation for `data-table`, i modified the `expand` explanation and example.

* Add `expand` prop to the example. Users can toggle this prop.
* Rephrase text to make clearer the distinction between `expand` slot and `expand` prop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Documentation for `v-data-table` includes an example for `expand` slot but not for `expand` prop. Also, both the slot and the prop have the same name which can be confusing. The explanation could be easier to understand if more **space** and context is added between both concepts.

## How Has This Been Tested?
This [codepen works](https://codepen.io/anon/pen/REmpLy?&editable=true&editors=101)

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-toolbar flat color="white">
      <v-toolbar-title>Expandable Table</v-toolbar-title>
      <v-spacer></v-spacer>
      <v-btn color="primary" dark @click="expand = !expand">
         {{ expand ? 'Close' : 'Keep' }} other rows
      </v-btn>
    </v-toolbar>
    <v-data-table
      :headers="headers"
      :items="desserts"
      item-key="name"
      :expand="expand"
    >
      <template slot="items" slot-scope="props">
        <tr @click="props.expanded = !props.expanded">
          <td>{{ props.item.name }}</td>
          <td class="text-xs-right">{{ props.item.calories }}</td>
          <td class="text-xs-right">{{ props.item.fat }}</td>
          <td class="text-xs-right">{{ props.item.carbs }}</td>
          <td class="text-xs-right">{{ props.item.protein }}</td>
          <td class="text-xs-right">{{ props.item.iron }}</td>
        </tr>
      </template>
      <template slot="expand" slot-scope="props">
        <v-card flat>
          <v-card-text>Peek-a-boo!</v-card-text>
        </v-card>
      </template>
    </v-data-table>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        expand: false,
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name'
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' }
        ],
        desserts: [
          {
            value: false,
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%'
          },
          {
            value: false,
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%'
          },
          {
            value: false,
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%'
          },
          {
            value: false,
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%'
          },
          {
            value: false,
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%'
          },
          {
            value: false,
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%'
          },
          {
            value: false,
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%'
          },
          {
            value: false,
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%'
          },
          {
            value: false,
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%'
          },
          {
            value: false,
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%'
          }
        ]
      }
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 