### PR TITLE
fix(kitchen): move all FABs to right

### DIFF
--- a/packages/kitchen/src/pan/Buttons.vue
+++ b/packages/kitchen/src/pan/Buttons.vue
@@ -1396,7 +1396,6 @@
         color="success"
         fixed
         bottom
-        left
         right
       >
         <v-icon>mdi-plus</v-icon>

--- a/packages/kitchen/src/pan/Date pickers.vue
+++ b/packages/kitchen/src/pan/Date pickers.vue
@@ -7,7 +7,7 @@
       fab
       fixed
       bottom
-      left
+      right
       @click="() => landscape = !landscape"
     >
       <v-icon small>

--- a/packages/kitchen/src/pan/Month pickers.vue
+++ b/packages/kitchen/src/pan/Month pickers.vue
@@ -7,7 +7,7 @@
       fab
       fixed
       bottom
-      left
+      right
       @click="() => landscape = !landscape"
     >
       <v-icon small>


### PR DESCRIPTION
## Description
Move FABs to right so they won't conflict with drawer (#6212)
![default](https://user-images.githubusercontent.com/19504461/51438190-d6d01780-1cb9-11e9-8e20-9a053f3445ce.png)

## Motivation and Context
Fixes #6212.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
