### PR TITLE
fix(kitchen): edit link should point to next instead of master

### DIFF
--- a/packages/kitchen/src/App.vue
+++ b/packages/kitchen/src/App.vue
@@ -101,7 +101,7 @@
     }),
     computed: {
       href () {
-        return `https://github.com/vuetifyjs/vuetify/tree/master/packages/kitchen/src/pan/${this.$route.params.component}.vue`
+        return `https://github.com/vuetifyjs/vuetify/tree/next/packages/kitchen/src/pan/${this.$route.params.component}.vue`  // TODO: set branch back to master before v2.0 release
       }
     }
   }


### PR DESCRIPTION
## Description
Fix edit link. It should point to `next` branch until v2.0 is released. **Revert before v2.0 release!!1**

## Motivation and Context
Fix edit link

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
