### PR TITLE
docs(kitchen): use VAutocomplete on the Home page

### DIFF
--- a/packages/kitchen/src/views/Home.vue
+++ b/packages/kitchen/src/views/Home.vue
@@ -12,11 +12,11 @@
           <h2 class="display-3 mb-5">
             What'll it be?
           </h2>
-          <v-select
+          <v-autocomplete
             v-model="meal"
             :items="meals"
             label="Meals"
-            solo-inverted
+            solo
           />
           <v-btn
             :to="meal"


### PR DESCRIPTION
## Description
Use `VAutocomplete` on the home page.

## Motivation and Context
It's much more convenient to use with big component list:
![default](https://user-images.githubusercontent.com/19504461/51696964-cb615100-2017-11e9-82a4-ff5d2fe3294f.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
