### PR TITLE
docs: prevent content shifting during loading (ssr hydration)

### DIFF
--- a/packages/docs/src/pages/documentation/Page.vue
+++ b/packages/docs/src/pages/documentation/Page.vue
@@ -65,3 +65,12 @@
     }
   }
 </script>
+
+<style scoped>
+  @media (min-width: 1264px) {
+    .v-content:not([data-booted="true"]) {
+      padding-left: 300px !important;
+      padding-right: 210px !important;
+    }
+  }
+</style>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
In server-side rendered html for documentation pages (like [`/buttons`](https://vuetifyjs.com/en/components/buttons)) both left and right navigation drawers are hidden and content is horizantolly centered and has `max-width: 1185px`. (It can be checked by disabling javascript). Here is screenshot:
![image](https://user-images.githubusercontent.com/6505554/51792060-2341b880-21ce-11e9-8984-f4757a32e799.png)

But after ssr hydradation both navigation drawers become visible. Left navigation drawer has width `300px` and right has width `210px`. Because navigation drawers has different widths, after hydradation content is shifting a bit (up to `45px`). Here is screenshot:
![image](https://user-images.githubusercontent.com/6505554/51792071-3bb1d300-21ce-11e9-86c7-68bd03e68b5e.png)

This pr explicitly set horizontal padding for content to match padding after hydration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A little smoother loading of the documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
