### PR TITLE
test(VChipGroup): make coverage 100%

### DIFF
--- a/packages/vuetify/src/components/VChipGroup/__tests__/VChipGroup.spec.ts
+++ b/packages/vuetify/src/components/VChipGroup/__tests__/VChipGroup.spec.ts
@@ -50,4 +50,18 @@ describe('VChipGroup.ts', () => {
     expect(wrapper.classes()).toContain('v-chip-group--column')
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should switch to column', () => {
+    const wrapper = mountFunction()
+
+    expect(wrapper.classes()).not.toContain('v-chip-group--column')
+    expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.setProps({
+      column: true
+    })
+
+    expect(wrapper.classes()).toContain('v-chip-group--column')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VChipGroup/__tests__/__snapshots__/VChipGroup.spec.ts.snap
+++ b/packages/vuetify/src/components/VChipGroup/__tests__/__snapshots__/VChipGroup.spec.ts.snap
@@ -21,3 +21,25 @@ exports[`VChipGroup.ts should render column 1`] = `
 </div>
 
 `;
+
+exports[`VChipGroup.ts should switch to column 1`] = `
+
+<div class="v-item-group v-slide-group theme--light v-chip-group">
+  <div class="v-slide-group__wrapper">
+    <div class="v-slide-group__content">
+    </div>
+  </div>
+</div>
+
+`;
+
+exports[`VChipGroup.ts should switch to column 2`] = `
+
+<div class="v-item-group v-slide-group theme--light v-chip-group v-chip-group--column">
+  <div class="v-slide-group__wrapper">
+    <div class="v-slide-group__content">
+    </div>
+  </div>
+</div>
+
+`;


### PR DESCRIPTION
## Description
Add one more test for VChipGroup.

## Motivation and Context
The coverage was :cry:. It's 100% now.
![default](https://user-images.githubusercontent.com/19504461/52006726-e7fcfd80-24dd-11e9-8b54-f4758ef0e66b.png)


## How Has This Been Tested?
`jest --coverage`

## Markup:
<details>

```vue
<none />
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
