### PR TITLE
feat(VTimePicker): emit click:xxx events

### DIFF
--- a/packages/api-generator/src/map.js
+++ b/packages/api-generator/src/map.js
@@ -1148,6 +1148,22 @@ module.exports = {
       {
         name: 'input',
         value: 'string'
+      },
+      {
+        name: 'change',
+        value: 'string'
+      },
+      {
+        name: 'click:hour',
+        value: 'string'
+      },
+      {
+        name: 'click:minute',
+        value: 'string'
+      },
+      {
+        name: 'click:second',
+        value: 'string'
       }
     ]
   },

--- a/packages/docs/src/examples/time-pickers/timeDialogAndMenu.vue
+++ b/packages/docs/src/examples/time-pickers/timeDialogAndMenu.vue
@@ -25,7 +25,7 @@
           v-if="menu2"
           v-model="time"
           full-width
-          @change="$refs.menu.save(time)"
+          @click:minute="$refs.menu.save(time)"
         ></v-time-picker>
       </v-menu>
     </v-flex>

--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.ts
@@ -18,7 +18,12 @@ const rangeHours24 = createRange(24)
 const rangeHours12am = createRange(12)
 const rangeHours12pm = rangeHours12am.map(v => v + 12)
 const range60 = createRange(60)
-const selectingTimes = { hour: 1, minute: 2, second: 3 }
+const selectingTimes: {
+  hour: 1
+  minute: 2
+  second: 3
+} = { hour: 1, minute: 2, second: 3 }
+const selectingNames = { 1: 'hour', 2: 'minute', 3: 'second' }
 export { selectingTimes }
 
 type Period = 'am' | 'pm'
@@ -58,7 +63,7 @@ export default mixins(
       lazyInputMinute: null as number | null,
       lazyInputSecond: null as number | null,
       period: 'am' as Period,
-      selecting: selectingTimes.hour
+      selecting: selectingTimes.hour as 1 | 2 | 3
     }
   },
 
@@ -206,7 +211,9 @@ export default mixins(
       }
       this.emitValue()
     },
-    onChange () {
+    onChange (value: number) {
+      this.$emit(`click:${selectingNames[this.selecting]}`, value)
+
       const emitChange = this.selecting === (this.useSeconds ? selectingTimes.second : selectingTimes.minute)
 
       if (this.selecting === selectingTimes.hour) {
@@ -220,14 +227,14 @@ export default mixins(
         (!this.useSeconds || this.inputSecond === this.lazyInputSecond)
       ) return
 
-      const value = this.genValue()
-      if (value === null) return
+      const time = this.genValue()
+      if (time === null) return
 
       this.lazyInputHour = this.inputHour
       this.lazyInputMinute = this.inputMinute
       this.useSeconds && (this.lazyInputSecond = this.inputSecond)
 
-      emitChange && this.$emit('change', value)
+      emitChange && this.$emit('change', time)
     },
     firstAllowed (type: 'hour' | 'minute' | 'second', value: number) {
       const allowedFn = type === 'hour' ? this.isAllowedHourCb : (type === 'minute' ? this.isAllowedMinuteCb : this.isAllowedSecondCb)
@@ -302,7 +309,7 @@ export default mixins(
           selecting: this.selecting
         },
         on: {
-          'update:selecting': (value: number) => (this.selecting = value),
+          'update:selecting': (value: 1 | 2 | 3) => (this.selecting = value),
           'update:period': this.setPeriod
         },
         ref: 'title',

--- a/packages/vuetify/test/unit/components/VTimePicker/VTimePicker.spec.js
+++ b/packages/vuetify/test/unit/components/VTimePicker/VTimePicker.spec.js
@@ -331,6 +331,45 @@ test('VTimePicker.js', ({ mount }) => {
       expect(wrapper.vm.selectingSecond).toBe(useSecondsValue)
     })
 
+    it('should emit click:XXX event on change' + useSecondsDesc, () => {
+      const wrapper = mount(VTimePicker, {
+        propsData: {
+          value: '01:23:45pm',
+          format: 'ampm',
+          useSeconds: useSecondsValue
+        }
+      })
+
+      const clock = wrapper.vm.$refs.clock
+      const clickHour = jest.fn()
+      const clickMinute = jest.fn()
+      const clickSecond = jest.fn()
+
+      wrapper.vm.$on('click:hour', clickHour)
+      wrapper.vm.$on('click:minute', clickMinute)
+      wrapper.vm.$on('click:second', clickSecond)
+
+      clock.$emit('change', 1)
+      expect(clickHour).toHaveBeenCalledTimes(1)
+      expect(clickHour).toBeCalledWith(1)
+      expect(clickMinute).toHaveBeenCalledTimes(0)
+      expect(clickSecond).toHaveBeenCalledTimes(0)
+
+      clock.$emit('change', 59)
+      expect(clickHour).toHaveBeenCalledTimes(1)
+      expect(clickMinute).toHaveBeenCalledTimes(1)
+      expect(clickMinute).toBeCalledWith(59)
+      expect(clickSecond).toHaveBeenCalledTimes(0)
+
+      if (useSecondsValue) {
+        clock.$emit('change', 45)
+        expect(clickHour).toHaveBeenCalledTimes(1)
+        expect(clickMinute).toHaveBeenCalledTimes(1)
+        expect(clickSecond).toHaveBeenCalledTimes(1)
+        expect(clickSecond).toBeCalledWith(45)
+      }
+    })
+
     it('should change selecting when clicked in title' + useSecondsDesc, () => {
       const wrapper = mount(VTimePicker, {
         propsData: {


### PR DESCRIPTION
## Description
Adds `click:hour`, `click:minute` and `click:second` events

## Motivation and Context
fixes #6163

## How Has This Been Tested?
jest, visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-menu v-model="menu" ref="menu" :close-on-content-click="false" :return-value.sync="time" offset-y max-width="290px" min-width="290px">
        <v-text-field slot="activator" v-model="time" label="Picker in menu" readonly />
        <v-time-picker v-if="menu" v-model="time" full-width @click:minute="$refs.menu.save(time)" />
      </v-menu>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    menu: false,
    time: '21:37'
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
