### PR TITLE
Changed year in caption for v1.5 Release

### DIFF
--- a/packages/docs/src/lang/en/getting-started/Roadmap.json
+++ b/packages/docs/src/lang/en/getting-started/Roadmap.json
@@ -62,7 +62,7 @@
       "type": "release",
       "complete": false,
       "title": "v1.5 Release",
-      "caption": "February 2018",
+      "caption": "February 2019",
       "text": "Add new component `v-calendar`. Improve functionality of `v-sparkline` with a **bar** variant and fill. Improve `v-treeview` and prepare for LTS.",
       "value": true
     },


### PR DESCRIPTION
The caption for the release of v1.5 incorrectly said "February 2018" instead of "February 2019".

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Change the caption for the item "v1.5 Release" from "February 2018" to "February 2019"

## Motivation and Context
The listed year was incorrect.

## How Has This Been Tested?
Just visually.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
