### PR TITLE
fix(goTo): allow standalone call

### DIFF
--- a/packages/docs/src/data/pages/framework/Scroll.json
+++ b/packages/docs/src/data/pages/framework/Scroll.json
@@ -25,6 +25,23 @@
       "children": [
         {
           "type": "heading",
+          "lang": "routerHeading"
+        },
+        {
+          "type": "text",
+          "lang": "routerText1"
+        },
+        {
+          "type": "markup",
+          "value": "js_import_goto_router"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "children": [
+        {
+          "type": "heading",
           "lang": "firstHeader"
         },
         {

--- a/packages/docs/src/lang/en-US/framework/Scroll.json
+++ b/packages/docs/src/lang/en-US/framework/Scroll.json
@@ -11,6 +11,8 @@
     }
   },
   "components": [ "$vuetify" ],
+  "routerHeading": "## Using with router",
+  "routerText1": "The **goTo** function can be individually imported and invoked anywhere. This is particularly useful when hooking up toe [vue-router](https://router.vuejs.org/).",
   "functions": {
     "goTo": "Scroll to target location, using provided options"
   }

--- a/packages/docs/src/snippets/js/import_goto_router.txt
+++ b/packages/docs/src/snippets/js/import_goto_router.txt
@@ -1,0 +1,19 @@
+import Router from 'vue-router'
+import goTo from 'vuetify/lib/components/Vuetify/goTo'
+
+export default new Router({
+  scrollBehavior: (to, from, savedPosition) => {
+    let scrollTo = 0
+
+    if (to.hash) {
+      scrollTo = to.hash
+    } else if (savedPosition) {
+      scrollTo = savedPosition.y
+    }
+
+    return goTo(scrollTo)
+  },
+  routes: [
+    //
+  ]
+})

--- a/packages/vuetify/src/components/Vuetify/goTo/index.ts
+++ b/packages/vuetify/src/components/Vuetify/goTo/index.ts
@@ -14,7 +14,7 @@ interface GoToSettings {
   appOffset: boolean
 }
 
-export default function goTo (this: Vue, _target: GoToTarget, _settings: Partial<GoToSettings> = {}): Promise<number> {
+export default function goTo (_target: GoToTarget, _settings: Partial<GoToSettings> = {}): Promise<number> {
   const settings: GoToSettings = {
     container: (document.scrollingElement as HTMLElement | null) || document.body || document.documentElement,
     duration: 500,
@@ -29,8 +29,8 @@ export default function goTo (this: Vue, _target: GoToTarget, _settings: Partial
     const isDrawer = container.classList.contains('v-navigation-drawer')
     const isClipped = container.classList.contains('v-navigation-drawer--clipped')
 
-    settings.offset += this.$vuetify.application.bar
-    if (!isDrawer || isClipped) settings.offset += this.$vuetify.application.top
+    settings.offset += Vue.prototype.$vuetify.application.bar
+    if (!isDrawer || isClipped) settings.offset += Vue.prototype.$vuetify.application.top
   }
 
   const startTime = performance.now()


### PR DESCRIPTION
## Description
allows `goTo()` call instead of `this.$vuetify.goTo()`

## Motivation and Context
Allows to use goTo in vue-router

## How Has This Been Tested?
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-toolbar app>Toolbar</v-toolbar>
    <v-content>
      <v-btn @click="goTo">Scroll</v-btn>
      <div style="height: 3000px"></div>
      <div id="target" style="height: 100px; border-top: 4px solid green; background: red"></div>
      <div style="height: 3000px"></div>
    </v-content>
  </v-app>
</template>

<script>
import goTo from '../src/components/Vuetify/goTo'

export default {
  methods: {
    goTo () {
      goTo('#target')
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
