### PR TITLE
fix(VMenu): Update position dynamically

### DIFF
--- a/packages/vuetify/src/components/VTooltip/VTooltip.js
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.js
@@ -132,11 +132,6 @@ export default {
     }
   },
 
-  watch: {
-    positionX: 'updateDimensions',
-    positionY: 'updateDimensions'
-  },
-
   beforeMount () {
     this.$nextTick(() => {
       this.value && this.callActivate()

--- a/packages/vuetify/src/mixins/menuable.js
+++ b/packages/vuetify/src/mixins/menuable.js
@@ -153,7 +153,9 @@ export default Vue.extend({
       if (this.disabled) return
 
       val ? this.callActivate() : this.callDeactivate()
-    }
+    },
+    positionX: 'updateDimensions',
+    positionY: 'updateDimensions'
   },
 
   beforeMount () {

--- a/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
+++ b/packages/vuetify/test/unit/components/VMenu/VMenu.spec.js
@@ -455,4 +455,33 @@ test('VMenu.js', ({ mount, compileToFunctions }) => {
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
+
+  it('should update position dynamically', async () => {
+    const wrapper = mount(VMenu, {
+      propsData: {
+        absolute: true,
+        value: true,
+        positionX: 100,
+        positionY: 200,
+      }
+    })
+
+    const content = wrapper.find('.v-menu__content')[0]
+
+    const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
+
+    // TODO replace with jest fakeTimers when it will support requestAnimationFrame: https://github.com/facebook/jest/pull/7776
+    // See https://github.com/vuetifyjs/vuetify/pull/6330#issuecomment-460083547 for details
+    await sleep(50)
+    expect(content.getAttribute('style')).toMatchSnapshot()
+
+    wrapper.setProps({
+      positionX: 110,
+      positionY: 220
+    })
+    await sleep(50)
+    expect(content.getAttribute('style')).toMatchSnapshot()
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
 })

--- a/packages/vuetify/test/unit/components/VMenu/__snapshots__/VMenu.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VMenu/__snapshots__/VMenu.spec.js.snap
@@ -310,6 +310,10 @@ exports[`VMenu.js should render component with custom transition and match snaps
 
 exports[`VMenu.js should round dimensions 1`] = `"max-height: auto; min-width: 101px; max-width: auto; top: 12px; left: 50px; z-index: 8; display: none; z-index: 8;"`;
 
+exports[`VMenu.js should update position dynamically 1`] = `"max-height: auto; min-width: 0px; max-width: auto; top: 200px; left: 100px; z-index: 8;"`;
+
+exports[`VMenu.js should update position dynamically 2`] = `"max-height: auto; min-width: 0px; max-width: auto; top: 220px; left: 110px; z-index: 8;"`;
+
 exports[`VMenu.js should work 1`] = `
 
 <div class="v-menu">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Moves watchers for `positionX` and `positionY` (added in #5967) from `VTooltip` to `menuable` mixin, so now position of `VMenu` can also be dynamically updated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #4956

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-layout align-center justify-center>
      <v-flex xs4 text-xs-center>

        <div>Click "Open menu". Then click "Change menu position".</div>
        <v-btn @click="openMenu">Open menu</v-btn>
        <v-btn @click="changePosition">Change menu position</v-btn>
        <v-menu
          absolute
          :value="visible"
          :position-x="x"
          :position-y="100"
          :close-on-click="false"
          content-class="pa-2"
        >
          Menu position-x: {{ x }}
        </v-menu>

      </v-flex>
    </v-layout>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      visible: false,
      x: 100,
    }),
    methods: {
      openMenu() {
        this.visible = true;
      },
      changePosition() {
        this.x += 100;
      },
    },
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
