### PR TITLE
fix(VAutocomplete): use toLocaleLowerCase when filtering items

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.js
@@ -31,14 +31,7 @@ export default VSelect.extend({
     filter: {
       type: Function,
       default: (item, queryText, itemText) => {
-        const hasValue = val => val != null ? val : ''
-
-        const text = hasValue(itemText)
-        const query = hasValue(queryText)
-
-        return text.toString()
-          .toLowerCase()
-          .indexOf(query.toString().toLowerCase()) > -1
+        return itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
       }
     },
     hideNoData: Boolean,
@@ -90,9 +83,9 @@ export default VSelect.extend({
       return this.getText(this.selectedItem).toString().length
     },
     filteredItems () {
-      if (!this.isSearching || this.noFilter) return this.allItems
+      if (!this.isSearching || this.noFilter || this.internalSearch == null) return this.allItems
 
-      return this.allItems.filter(i => this.filter(i, this.internalSearch, this.getText(i)))
+      return this.allItems.filter(item => this.filter(item, this.internalSearch.toString(), this.getText(item).toString()))
     },
     internalSearch: {
       get () {

--- a/packages/vuetify/src/components/VSelect/VSelectList.js
+++ b/packages/vuetify/src/components/VSelect/VSelectList.js
@@ -125,8 +125,8 @@ export default {
       return `<span class="v-list__tile__mask">${escapeHTML(text)}</span>`
     },
     getMaskedCharacters (text) {
-      const searchInput = (this.searchInput || '').toString().toLowerCase()
-      const index = text.toLowerCase().indexOf(searchInput)
+      const searchInput = (this.searchInput || '').toString().toLocaleLowerCase()
+      const index = text.toLocaleLowerCase().indexOf(searchInput)
 
       if (index < 0) return { start: '', middle: text, end: '' }
 


### PR DESCRIPTION
## Description
Search results with this fix:
"İ" - 'İstanbul', 'izmir'
"i" - 'İstanbul', 'izmir'
"ı" - 'ılgaz', 'Irak'
"I" - 'ılgaz', 'Irak'

## Motivation and Context
fixes #4811

## How Has This Been Tested?
visually

## Markup:
For non-turkish browsers this PR can be verified by changing `toLocaleLowerCase()` to `toLocaleLowerCase('tr')`

<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-autocomplete box :items="['İstanbul', 'izmir', 'ılgaz', 'Irak']" />
    </v-content>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
