### PR TITLE
fix(VDatePicker): Unwanted form submission on header click.

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
@@ -112,7 +112,7 @@ export default mixins(
       const header = this.$createElement('div', this.setTextColor(color, {
         key: String(this.value)
       }), [this.$createElement('button', {
-        domProp: {
+        domProps: {
             type: 'button'
         },
         on: {

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
@@ -113,7 +113,7 @@ export default mixins(
         key: String(this.value)
       }), [this.$createElement('button', {
         domProps: {
-            type: 'button'
+          type: 'button'
         },
         on: {
           click: () => this.$emit('toggle')

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
@@ -112,6 +112,9 @@ export default mixins(
       const header = this.$createElement('div', this.setTextColor(color, {
         key: String(this.value)
       }), [this.$createElement('button', {
+        domProp: {
+            type: 'button'
+        },
         on: {
           click: () => this.$emit('toggle')
         }

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
@@ -112,7 +112,7 @@ export default mixins(
       const header = this.$createElement('div', this.setTextColor(color, {
         key: String(this.value)
       }), [this.$createElement('button', {
-        domProps: {
+        attrs: {
           type: 'button'
         },
         on: {

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -3099,7 +3099,7 @@ exports[`VDatePicker.js should render disabled picker 1`] = `
         </button>
         <div class="v-date-picker-header__value v-date-picker-header__value--disabled">
           <div>
-            <button>
+            <button type="button">
               May 2013
             </button>
           </div>

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.date.spec.js.snap
@@ -33,7 +33,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="primary--text">
-            <button>
+            <button type="button">
               November 2005
             </button>
           </div>
@@ -404,7 +404,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="orange--text text--darken-1">
-            <button>
+            <button type="button">
               November 2005
             </button>
           </div>
@@ -775,7 +775,7 @@ exports[`VDatePicker.js should match snapshot with dark theme 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               May 2013
             </button>
           </div>
@@ -1157,7 +1157,7 @@ exports[`VDatePicker.js should match snapshot with default settings 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               May 2013
             </button>
           </div>
@@ -1562,7 +1562,7 @@ exports[`VDatePicker.js should render component with min/max props 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               January 2013
             </button>
           </div>
@@ -1960,7 +1960,7 @@ exports[`VDatePicker.js should render component with min/max props 2`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               January 2013
             </button>
           </div>
@@ -2335,7 +2335,7 @@ exports[`VDatePicker.js should render component with min/max props 2`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               2013
             </button>
           </div>
@@ -2526,7 +2526,7 @@ exports[`VDatePicker.js should render component with min/max props 3`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               January 2013
             </button>
           </div>
@@ -2901,7 +2901,7 @@ exports[`VDatePicker.js should render component with min/max props 3`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               2013
             </button>
           </div>
@@ -3513,7 +3513,7 @@ exports[`VDatePicker.js should render readonly picker 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               May 2013
             </button>
           </div>

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePicker.month.spec.js.snap
@@ -164,7 +164,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="primary--text">
-            <button>
+            <button type="button">
               2005
             </button>
           </div>
@@ -342,7 +342,7 @@ exports[`VDatePicker.js should match snapshot with colored picker 2`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="orange--text text--darken-1">
-            <button>
+            <button type="button">
               2005
             </button>
           </div>
@@ -643,7 +643,7 @@ exports[`VDatePicker.js should match snapshot with pick-month prop 1`] = `
         </button>
         <div class="v-date-picker-header__value">
           <div class="accent--text">
-            <button>
+            <button type="button">
               2013
             </button>
           </div>

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
@@ -127,7 +127,7 @@ exports[`VDatePickerHeader.js should render disabled component and match snapsho
   </button>
   <div class="v-date-picker-header__value v-date-picker-header__value--disabled">
     <div>
-      <button>
+      <button type="button">
         November 2005
       </button>
     </div>

--- a/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
+++ b/packages/vuetify/test/unit/components/VDatePicker/__snapshots__/VDatePickerHeader.spec.js.snap
@@ -16,7 +16,7 @@ exports[`VDatePickerHeader.js should render component and match snapshot 1`] = `
   </button>
   <div class="v-date-picker-header__value">
     <div class="accent--text">
-      <button>
+      <button type="button">
         November 2005
       </button>
     </div>
@@ -52,7 +52,7 @@ exports[`VDatePickerHeader.js should render component in RTL mode and match snap
   </button>
   <div class="v-date-picker-header__value">
     <div class="accent--text">
-      <button>
+      <button type="button">
         November 2005
       </button>
     </div>
@@ -88,7 +88,7 @@ exports[`VDatePickerHeader.js should render component with default slot and matc
   </button>
   <div class="v-date-picker-header__value">
     <div class="accent--text">
-      <button>
+      <button type="button">
         <span>
           foo
         </span>
@@ -164,7 +164,7 @@ exports[`VDatePickerHeader.js should render readonly component and match snapsho
   </button>
   <div class="v-date-picker-header__value">
     <div class="accent--text">
-      <button>
+      <button type="button">
         November 2005
       </button>
     </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
If a DatePicker is used within a form, a click on the month in the DatePicker header will cause an unwanted submit of the form. 

My change will correct this behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I would like to create a form where the user can select a date.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
I tested with the existing tests.

## Markup:
https://jsfiddle.net/jkd4rbo8/21/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
