### PR TITLE
fix: make ripple touchstart event listener use passive option

### DIFF
--- a/packages/vuetify/src/directives/ripple.ts
+++ b/packages/vuetify/src/directives/ripple.ts
@@ -161,7 +161,10 @@ function updateRipple (el: HTMLElement, binding: VNodeDirective, wasEnabled: boo
   }
   if (enabled && !wasEnabled) {
     if (navigator.maxTouchPoints) {
-      el.addEventListener('touchstart', rippleShow, false)
+      el.addEventListener('touchstart', rippleShow, {
+        capture: false,
+        passive: true
+      })
       el.addEventListener('touchend', rippleHide, false)
       el.addEventListener('touchcancel', rippleHide, false)
     } else {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Description, Motivation and Context
I saw that my personal website https://marrec.io, using Vuetify, went from 100% to 93% Lighthouse result for the "Best Practices" section.

![screenshot_4](https://user-images.githubusercontent.com/25272043/52428596-94546a80-2b02-11e9-9599-285415c1e129.png)

Assuming https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners, Google Audits now checks if we're using `passive` option for some event listeners. And if we don't, it's considered as not best practices.

A `wheel` eventListener has already have been updated through #6263 
but after some checks, the file highlighted by Lighthouse Audits is still Vuetify stuff.

It seems then there are other things to care about, like the `touchstart` eventListener of the `ripple` directive, which I'm fixing through this PR.

## How Has This Been Tested?
Didn't actually tested it, but I just followed official Web API docs to update the options of `addEventListener('touchstart')`
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
