### PR TITLE
fix(VDialog, VMenu): improve keyboard navigation

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.js
+++ b/packages/vuetify/src/components/VDialog/VDialog.js
@@ -12,7 +12,7 @@ import Toggleable from '../../mixins/toggleable'
 import ClickOutside from '../../directives/click-outside'
 
 // Helpers
-import { getZIndex, convertToUnit, getSlotType } from '../../util/helpers'
+import { convertToUnit, keyCodes, getSlotType } from '../../util/helpers'
 import ThemeProvider from '../../util/ThemeProvider'
 import { consoleError } from '../../util/console'
 
@@ -149,9 +149,7 @@ export default {
       // If the dialog content contains
       // the click event, or if the
       // dialog is not active
-      if (this.$refs.content.contains(e.target) ||
-        !this.isActive
-      ) return false
+      if (!this.isActive || this.$refs.content.contains(e.target)) return false
 
       // If we made it here, the click is outside
       // and is active. If persistent, and the
@@ -166,7 +164,7 @@ export default {
 
       // close dialog if !persistent, clicked outside and we're the topmost dialog.
       // Since this should only be called in a capture event (bottom up), we shouldn't need to stop propagation
-      return getZIndex(this.$refs.content) >= this.getMaxZIndex()
+      return this.activeZIndex >= this.getMaxZIndex()
     },
     hideScroll () {
       if (this.fullscreen) {
@@ -178,16 +176,37 @@ export default {
     show () {
       !this.fullscreen && !this.hideOverlay && this.genOverlay()
       this.$refs.content.focus()
-      this.$listeners.keydown && this.bind()
+      this.bind()
     },
     bind () {
-      window.addEventListener('keydown', this.onKeydown)
+      this.$listeners.keydown && window.addEventListener('keydown', this.onKeydown)
+      window.addEventListener('focusin', this.onFocusin)
     },
     unbind () {
       window.removeEventListener('keydown', this.onKeydown)
+      window.removeEventListener('focusin', this.onFocusin)
     },
     onKeydown (e) {
       this.$emit('keydown', e)
+    },
+    onFocusin (e) {
+      const { target } = event
+
+      if (
+        // It isn't the document or the dialog body
+        ![document, this.$refs.content].includes(target) &&
+        // It isn't inside the dialog body
+        !this.$refs.content.contains(target) &&
+        // We're the topmost dialog
+        this.activeZIndex >= this.getMaxZIndex() &&
+        // It isn't inside a dependent element (like a menu)
+        !this.getOpenDependentElements().some(el => el.contains(target))
+        // So we must have focused something outside the dialog and its children
+      ) {
+        // Find and focus the first available element inside the dialog
+        const focusable = this.$refs.content.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+        focusable.length && focusable[0].focus()
+      }
     },
     genActivator () {
       if (!this.hasActivator) return null
@@ -223,7 +242,7 @@ export default {
       directives: [
         {
           name: 'click-outside',
-          value: () => (this.isActive = false),
+          value: () => { this.isActive = false },
           args: {
             closeConditional: this.closeConditional,
             include: this.getOpenDependentElements

--- a/packages/vuetify/src/components/VDialog/VDialog.js
+++ b/packages/vuetify/src/components/VDialog/VDialog.js
@@ -179,14 +179,19 @@ export default {
       this.bind()
     },
     bind () {
-      this.$listeners.keydown && window.addEventListener('keydown', this.onKeydown)
       window.addEventListener('focusin', this.onFocusin)
     },
     unbind () {
-      window.removeEventListener('keydown', this.onKeydown)
       window.removeEventListener('focusin', this.onFocusin)
     },
     onKeydown (e) {
+      if (e.keyCode === keyCodes.esc && !this.getOpenDependents().length) {
+        if (!this.persistent) {
+          this.isActive = false
+        } else if (!this.noClickAnimation) {
+          this.animateClick()
+        }
+      }
       this.$emit('keydown', e)
     },
     onFocusin (e) {
@@ -279,6 +284,9 @@ export default {
       attrs: {
         tabIndex: '-1',
         ...this.getScopeIdAttrs()
+      },
+      on: {
+        keydown: this.onKeydown
       },
       style: { zIndex: this.activeZIndex },
       ref: 'content'

--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -197,8 +197,10 @@ export default Vue.extend({
         })
       })
     },
-    closeConditional () {
-      return this.isActive && this.closeOnClick
+    closeConditional (e) {
+      return this.isActive &&
+        this.closeOnClick &&
+        !this.$refs.content.contains(e.target)
     },
     onResize () {
       if (!this.isActive) return

--- a/packages/vuetify/src/components/VMenu/mixins/menu-generators.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-generators.js
@@ -49,7 +49,7 @@ export default {
       // Do not add click outside for hover menu
       const directives = !this.openOnHover && this.closeOnClick ? [{
         name: 'click-outside',
-        value: () => (this.isActive = false),
+        value: () => { this.isActive = false },
         args: {
           closeConditional: this.closeConditional,
           include: () => [this.$el, ...this.getOpenDependentElements()]
@@ -82,7 +82,8 @@ export default {
             e.stopPropagation()
             if (e.target.getAttribute('disabled')) return
             if (this.closeOnContentClick) this.isActive = false
-          }
+          },
+          keydown: this.onKeyDown
         }
       }
 

--- a/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
@@ -43,6 +43,8 @@ export default {
       if (e.keyCode === keyCodes.esc) {
         // Wait for dependent elements to close first
         setTimeout(() => { this.isActive = false })
+        const activator = this.getActivator()
+        this.$nextTick(() => activator && activator.focus())
       } else if (e.keyCode === keyCodes.tab) {
         setTimeout(() => {
           if (!this.$refs.content.contains(document.activeElement)) {

--- a/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
+++ b/packages/vuetify/src/components/VMenu/mixins/menu-keyable.js
@@ -41,7 +41,8 @@ export default {
   methods: {
     onKeyDown (e) {
       if (e.keyCode === keyCodes.esc) {
-        this.isActive = false
+        // Wait for dependent elements to close first
+        setTimeout(() => { this.isActive = false })
       } else if (e.keyCode === keyCodes.tab) {
         setTimeout(() => {
           if (!this.$refs.content.contains(document.activeElement)) {

--- a/packages/vuetify/src/directives/click-outside.ts
+++ b/packages/vuetify/src/directives/click-outside.ts
@@ -45,32 +45,11 @@ function directive (e: PointerEvent, el: HTMLElement, binding: ClickOutsideDirec
   // Check if it's a click outside our elements, and then if our callback returns true.
   // Non-toggleable components should take action in their callback and return falsy.
   // Toggleable can return true if it wants to deactivate.
-  // Note that, because we're in the capture phase, this callback will occure before
+  // Note that, because we're in the capture phase, this callback will occur before
   // the bubbling click event on any outside elements.
-  !clickedInEls(e, elements) && setTimeout(() => {
+  !elements.some(el => el.contains(e.target as Node)) && setTimeout(() => {
     isActive(e) && binding.value && binding.value(e)
   }, 0)
-}
-
-function clickedInEls (e: PointerEvent, elements: HTMLElement[]): boolean {
-  // Get position of click
-  const { clientX: x, clientY: y } = e
-  // Loop over all included elements to see if click was in any of them
-  for (const el of elements) {
-    if (clickedInEl(el, x, y)) return true
-  }
-
-  return false
-}
-
-function clickedInEl (el: HTMLElement, x: number, y: number): boolean {
-  // Get bounding rect for element
-  // (we're in capturing event and we want to check for multiple elements,
-  //  so can't use target.)
-  const b = el.getBoundingClientRect()
-  // Check if the click was in the element's bounding rect
-
-  return x >= b.left && x <= b.right && y >= b.top && y <= b.bottom
 }
 
 export default {

--- a/packages/vuetify/src/mixins/dependent.ts
+++ b/packages/vuetify/src/mixins/dependent.ts
@@ -7,6 +7,7 @@ interface options extends Vue {
   $refs: {
     content: HTMLElement
   }
+  overlay?: HTMLElement
 }
 
 interface DependentInstance extends Vue {
@@ -70,6 +71,7 @@ export default mixins<options>().extend({
     getClickableDependentElements (): HTMLElement[] {
       const result = [this.$el]
       if (this.$refs.content) result.push(this.$refs.content)
+      if (this.overlay) result.push(this.overlay)
       result.push(...this.getOpenDependentElements())
 
       return result

--- a/packages/vuetify/src/mixins/returnable.ts
+++ b/packages/vuetify/src/mixins/returnable.ts
@@ -26,7 +26,9 @@ export default Vue.extend({
   methods: {
     save (value: any) {
       this.originalValue = value
-      this.isActive = false
+      setTimeout(() => {
+        this.isActive = false
+      })
     }
   }
 })

--- a/packages/vuetify/test/unit/components/VDialog/VDialog.spec.js
+++ b/packages/vuetify/test/unit/components/VDialog/VDialog.spec.js
@@ -178,20 +178,13 @@ test('VDialog.js', ({ mount, compileToFunctions }) => {
 
   it('should emit keydown event', async () => {
     const keydown = jest.fn()
-    const component = {
-      render: h => h(VDialog, {
-        props: {
-          value: true
-        },
-        on: {
-          keydown
-        }
-      })
-    }
-    const wrapper = mount(component)
+    const wrapper = mount(VDialog, {
+      propsData: { value: true }
+    })
+    wrapper.vm.$on('keydown', keydown)
 
     await wrapper.vm.$nextTick()
-    window.dispatchEvent(new Event('keydown'))
+    wrapper.vm.$refs.content.dispatchEvent(new Event('keydown'))
     expect(keydown).toBeCalled()
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()

--- a/packages/vuetify/test/unit/directives/click-outside.spec.js
+++ b/packages/vuetify/test/unit/directives/click-outside.spec.js
@@ -4,14 +4,7 @@ import ClickOutside from '@/directives/click-outside'
 
 function bootstrap (args) {
   let registeredHandler
-  const el = {
-    getBoundingClientRect: () => ({
-      top: 100,
-      bottom: 200,
-      left: 100,
-      right: 200
-    })
-  }
+  const el = document.createElement('div')
 
   const binding = {
     value: jest.fn(),
@@ -43,7 +36,7 @@ test('click-outside.js', () => {
 
   it('should call the callback when closeConditional returns true', async () => {
     const { registeredHandler, callback } = bootstrap({ closeConditional: () => true })
-    const event = { clientX: 5, clientY: 20}
+    const event = { target: document.createElement('div') }
 
     registeredHandler(event)
     await new Promise(resolve => setTimeout(resolve))
@@ -51,43 +44,36 @@ test('click-outside.js', () => {
   })
 
   it('should not call the callback when closeConditional returns false', async () => {
-    const { registeredHandler, callback } = bootstrap({ closeConditional: () => false })
+    const { registeredHandler, callback, el } = bootstrap({ closeConditional: () => false })
 
-    registeredHandler({ clientX: 5, clientY: 20})
+    registeredHandler({ target: el })
     await new Promise(resolve => setTimeout(resolve))
     expect(callback).not.toBeCalled()
   })
 
   it('should not call the callback when closeConditional is not provided', async () => {
-    const { registeredHandler, callback } = bootstrap()
+    const { registeredHandler, callback, el } = bootstrap()
 
-    registeredHandler({ clientX: 5, clientY: 20})
+    registeredHandler({ target: el })
     await new Promise(resolve => setTimeout(resolve))
     expect(callback).not.toBeCalled()
   })
 
   it('should not call the callback when clicked in element', async () => {
-    const { registeredHandler, callback } = bootstrap({ closeConditional: () => true })
+    const { registeredHandler, callback, el } = bootstrap({ closeConditional: () => true })
 
-    registeredHandler({ clientX: 105, clientY: 120})
+    registeredHandler({ target: el })
     await new Promise(resolve => setTimeout(resolve))
     expect(callback).not.toBeCalledWith()
   })
 
   it('should not call the callback when clicked in elements', async () => {
-    const { registeredHandler, callback } = bootstrap({
+    const { registeredHandler, callback, el } = bootstrap({
       closeConditional: () => true,
-      include: () => [{
-        getBoundingClientRect: () => ({
-          top: 1100,
-          bottom: 1200,
-          left: 1100,
-          right: 1200
-        })
-      }]
+      include: () => [el]
     })
 
-    registeredHandler({ clientX: 1105, clientY: 1120})
+    registeredHandler({ target: document.createElement('div') })
     await new Promise(resolve => setTimeout(resolve))
     expect(callback).not.toBeCalledWith()
   })
@@ -95,11 +81,11 @@ test('click-outside.js', () => {
   it('should not call the callback when event is not fired by user action', async () => {
     const { registeredHandler, callback } = bootstrap({ closeConditional: () => true })
 
-    registeredHandler({ clientX: 5, clientY: 20, isTrusted: false })
+    registeredHandler({ isTrusted: false })
     await new Promise(resolve => setTimeout(resolve))
     expect(callback).not.toBeCalledWith()
 
-    registeredHandler({ clientX: 5, clientY: 20, pointerType: false })
+    registeredHandler({ pointerType: false })
     await new Promise(resolve => setTimeout(resolve))
     expect(callback).not.toBeCalledWith()
   })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
These are all somewhat related and are just here for testing, can be rebased onto master. 

The big one is #2538, the tab key can no longer escape from dialogs. The others got in the way of this working properly with nested dialogs and menus so I fixed them at the same time.

Builds on #1932
@Webifi If you could take a look at my click-outside changes that'd be cool

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR greatly improves use of dialogs with just the keyboard, it is now possible to navigate and close deeply nested dialogs and menus. 

fixes #2538
fixes #5200
fixes #6352
and some other bugs that I found during

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-dialog content-class="first">
        <v-btn slot="activator">dialog</v-btn>
        <v-card>
          <v-card-text>
            <v-text-field label="Input in dialog"></v-text-field>
            <v-text-field label="Input in dialog"></v-text-field>
            <v-text-field label="Input in dialog"></v-text-field>
            <v-dialog content-class="second">
              <v-btn slot="activator">nested dialog</v-btn>
              <v-card>
                <v-card-text>
                  <v-text-field label="Input in nested dialog"></v-text-field>
                  <v-text-field label="Input in nested dialog"></v-text-field>
                  <v-text-field label="Input in nested dialog"></v-text-field>
                </v-card-text>
              </v-card>
            </v-dialog>
            <v-menu :close-on-content-click="false" offset-y>
              <v-btn slot="activator">nested menu</v-btn>
              <v-card>
                <v-card-text>
                  <v-dialog>
                    <v-btn slot="activator">nested dialog</v-btn>
                    <v-card>
                      <v-card-text>
                        <v-text-field label="Input in dialog in menu in dialog"></v-text-field>
                        <v-text-field label="Input in dialog in menu in dialog"></v-text-field>
                        <v-text-field label="Input in dialog in menu in dialog"></v-text-field>
                      </v-card-text>
                    </v-card>
                  </v-dialog>
                </v-card-text>
              </v-card>
            </v-menu>
          </v-card-text>
        </v-card>
      </v-dialog>

      <v-menu :close-on-content-click="false" offset-y>
        <v-btn slot="activator">menu</v-btn>
        <v-card>
          <v-card-text>
            <v-dialog>
              <v-btn slot="activator">nested dialog</v-btn>
              <v-card>
                <v-card-text>
                  <v-text-field label="Input in dialog in menu"></v-text-field>
                  <v-text-field label="Input in dialog in menu"></v-text-field>
                  <v-text-field label="Input in dialog in menu"></v-text-field>
                </v-card-text>
              </v-card>
            </v-dialog>
          </v-card-text>
        </v-card>
      </v-menu>

      <v-text-field label="Input outside dialog"></v-text-field>
      <v-text-field label="Input outside dialog"></v-text-field>

      <input type="text" style="border: 1px solid black">

      <!--<v-menu v-for="i in 100" :key="i"></v-menu>-->
    </v-container>
  </v-app>
</template>
```
</details>

<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-btn @click="dialog = true">Open Dialog</v-btn>
      <v-dialog v-model="dialog">
        <v-card>
          <v-card-title class="headline">
            Dialog with v-time-picker inside
          </v-card-title>
          <v-card-text>
            <v-menu
              ref="timeframeStartMenu"
              class="mr-2"
              :close-on-content-click="false"
              v-model="timeframeStartMenu"
              :return-value.sync="timeframeStart"
              :nudge-right="40"
              offset-y
              lazy
            >
              <v-text-field
                slot="activator"
                v-model="timeframeStart"
                label="From"
                prepend-icon="access_time"
                readonly
              ></v-text-field>
              <v-time-picker
                v-model="timeframeStart"
                format="24hr"
                full-width
                @change="$refs.timeframeStartMenu.save(timeframeStart)"
              ></v-time-picker>
            </v-menu>
          </v-card-text>
        </v-card>
      </v-dialog>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      dialog: false,
      timeframeStart: '09:00',
      timeframeStartMenu: false,
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
