### PR TITLE
fix(v-ripple): skip mouse events if triggered by touch

### DIFF
--- a/packages/vuetify/src/directives/ripple.ts
+++ b/packages/vuetify/src/directives/ripple.ts
@@ -130,7 +130,10 @@ function isRippleEnabled (value: any): value is true {
 function rippleShow (e: MouseEvent | TouchEvent) {
   const value: RippleOptions = {}
   const element = e.currentTarget as HTMLElement
-  if (!element) return
+  if (!element || element._ripple!.touched) return
+  if (isTouchEvent(e)) {
+    element._ripple!.touched = true
+  }
   value.center = element._ripple!.centered
   if (element._ripple!.class) {
     value.class = element._ripple!.class
@@ -139,7 +142,11 @@ function rippleShow (e: MouseEvent | TouchEvent) {
 }
 
 function rippleHide (e: Event) {
-  ripple.hide(e.currentTarget as HTMLElement | null)
+  const element = e.currentTarget as HTMLElement | null
+  if (!element) return
+
+  window.setTimeout(() => { element._ripple!.touched = false })
+  ripple.hide(element)
 }
 
 function updateRipple (el: HTMLElement, binding: VNodeDirective, wasEnabled: boolean) {
@@ -160,17 +167,15 @@ function updateRipple (el: HTMLElement, binding: VNodeDirective, wasEnabled: boo
     el._ripple.circle = value.circle
   }
   if (enabled && !wasEnabled) {
-    if (navigator.maxTouchPoints) {
-      el.addEventListener('touchstart', rippleShow, { passive: true })
-      el.addEventListener('touchend', rippleHide, { passive: true })
-      el.addEventListener('touchcancel', rippleHide, { passive: true })
-    } else {
-      el.addEventListener('mousedown', rippleShow)
-      el.addEventListener('mouseup', rippleHide)
-      el.addEventListener('mouseleave', rippleHide)
-      // Anchor tags can be dragged, causes other hides to fail - #1537
-      el.addEventListener('dragstart', rippleHide, { passive: true })
-    }
+    el.addEventListener('touchstart', rippleShow, { passive: true })
+    el.addEventListener('touchend', rippleHide, { passive: true })
+    el.addEventListener('touchcancel', rippleHide)
+
+    el.addEventListener('mousedown', rippleShow)
+    el.addEventListener('mouseup', rippleHide)
+    el.addEventListener('mouseleave', rippleHide)
+    // Anchor tags can be dragged, causes other hides to fail - #1537
+    el.addEventListener('dragstart', rippleHide, { passive: true })
   } else if (!enabled && wasEnabled) {
     removeListeners(el)
   }

--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -38,6 +38,7 @@ declare global {
       centered?: boolean
       class?: string
       circle?: boolean
+      touched?: boolean
     }
     _onScroll?: {
       callback: EventListenerOrEventListenerObject


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Always bind touch events, and skip the fake mouse events if ripple was triggered by a touch

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #6418

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-card ripple>
        <v-card-text>
          ripple
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

