### PR TITLE
refactor(styles): use variables instead of hard-coded colors

### DIFF
--- a/packages/vuetify/src/components/VTooltip/_variables.sass
+++ b/packages/vuetify/src/components/VTooltip/_variables.sass
@@ -1,4 +1,4 @@
 $tooltip-background-color: rgba(map-get($grey, 'darken-2'), 0.9) !default
-$tooltip-text-color: #FFFFFF !default
+$tooltip-text-color: map-get($shades, 'white') !default
 $tooltip-border-radius: 4px !default
 $tooltip-font-size: 14px !default

--- a/packages/vuetify/src/styles/base/_variables.scss
+++ b/packages/vuetify/src/styles/base/_variables.scss
@@ -216,7 +216,7 @@ $button-floating-small-width: 40px !default;
 $button-floating-large-width: 72px !default;
 $button-floating-small-icon-width: 18px !default;
 $button-floating-large-icon-width: 30px !default;
-$button-outline-color: rgba(#000, 0.12) !default;
+$button-outline-color: rgba(mag-get($shades, 'black'), 0.12) !default;
 
 /** Cards */
 $card-border-radius: 2px !default;
@@ -318,7 +318,7 @@ $navigation-drawer-item-font-weight: map-get($font-weights, 'medium') !default;
 $navigation-drawer-group-item-font-weight: map-get($font-weights, 'regular') !default;
 
 /** Snackbars */
-$snackbar-color: #fff !default;
+$snackbar-color: map-get($shades, 'white') !default;
 $snackbar-background-color: #323232 !default;
 $snackbar-corner-offset: 24px !default;
 

--- a/packages/vuetify/src/stylus/components/_bottom-navs.styl
+++ b/packages/vuetify/src/stylus/components/_bottom-navs.styl
@@ -11,7 +11,7 @@ theme(v-bottom-nav, "v-bottom-nav")
 
 .v-item-group.v-bottom-nav
   bottom: 0
-  box-shadow: 0 3px 14px 2px rgba(#000, .12)
+  box-shadow: 0 3px 14px 2px rgba($shades.black, .12)
   display: flex
   left: 0
   justify-content: center

--- a/packages/vuetify/src/stylus/components/_date-picker-table.styl
+++ b/packages/vuetify/src/stylus/components/_date-picker-table.styl
@@ -36,7 +36,7 @@ theme(v-date-picker-table, "v-date-picker-table")
     font-size: 12px
 
     &.v-btn--active
-      color: #fff
+      color: $shades.white
 
 .v-date-picker-table--month
   td

--- a/packages/vuetify/src/stylus/components/_parallax.styl
+++ b/packages/vuetify/src/stylus/components/_parallax.styl
@@ -27,7 +27,7 @@
     z-index: 1
 
   &__content
-    color: #FFFFFF
+    color: $shades.white
     height: 100%
     z-index: 2
     position: relative

--- a/packages/vuetify/src/stylus/components/_pickers.styl
+++ b/packages/vuetify/src/stylus/components/_pickers.styl
@@ -25,7 +25,7 @@ theme(v-picker-body, 'v-picker__body')
   display: flex
 
 .v-picker__title
-  color: #fff
+  color: $shades.white
   border-top-left-radius: $card-border-radius
   border-top-right-radius: $card-border-radius
   padding: 16px

--- a/packages/vuetify/src/stylus/components/_sliders.styl
+++ b/packages/vuetify/src/stylus/components/_sliders.styl
@@ -236,7 +236,7 @@ rtl(v-slider-rtl, "v-input--slider")
     align-items: center
     justify-content: center
     font-size: 12px
-    color: #fff
+    color: $shades.white
     width: 32px
     height: 32px
     border-radius: 50% 50% 0

--- a/packages/vuetify/src/stylus/components/_time-picker-clock.styl
+++ b/packages/vuetify/src/stylus/components/_time-picker-clock.styl
@@ -120,7 +120,7 @@ theme(v-time-picker-clock, "v-time-picker-clock")
     width: $time-picker-indicator-size
 
   &--active
-    color: #fff
+    color: $shades.white
     cursor: default
     z-index: 2
 

--- a/packages/vuetify/src/stylus/components/_time-picker-title.styl
+++ b/packages/vuetify/src/stylus/components/_time-picker-title.styl
@@ -1,7 +1,7 @@
 @import '../bootstrap'
 
 .v-time-picker-title
-  color: #fff
+  color: $shades.white
   display: flex
   line-height: 1
   justify-content: flex-end

--- a/packages/vuetify/src/stylus/elements/_code.styl
+++ b/packages/vuetify/src/stylus/elements/_code.styl
@@ -17,4 +17,4 @@ code
 
 kbd
   background: $grey.darken-2
-  color: #fff
+  color: $shades.white

--- a/packages/vuetify/src/stylus/settings/_theme.styl
+++ b/packages/vuetify/src/stylus/settings/_theme.styl
@@ -100,13 +100,13 @@ $material-light := {
   active-icon-percent: .54
   inactive-icon-percent: .38
   calendar: {
-    background-color: #fff
+    background-color: $shades.white
     outside-background-color: #f7f7f7
-    line-color: #e0e0e0
+    line-color: $grey.lighten-2
     interval-color: $grey.darken-3
     interval-line-color: $grey.lighten-2
-    text-color: #000
-    past-color: rgba(#000, .38)
+    text-color: $shades.black
+    past-color: rgba($shades.black, .38)
   }
 }
 
@@ -209,8 +209,8 @@ $material-dark := {
     line-color: $grey.base
     interval-color: $grey.lighten-3
     interval-line-color: $grey.darken-2
-    text-color: #fff
-    past-color: rgba(#fff, .50)
+    text-color: $shades.white
+    past-color: rgba($shades.white, .50)
   }
 }
 

--- a/packages/vuetify/src/stylus/settings/_variables.styl
+++ b/packages/vuetify/src/stylus/settings/_variables.styl
@@ -295,7 +295,7 @@ $navigation-drawer-item-font-weight := $font-weights.medium
 $navigation-drawer-group-item-font-weight := $font-weights.regular
 
 // Snackbar
-$snackbar-color := #fff
+$snackbar-color := $shades.white
 $snackbar-background-color := #323232
 $snackbar-corner-offset := 24px
 


### PR DESCRIPTION
## Description
Use variables instead of hard-coded colors in styles

## Motivation and Context
Fixes #6437

## How Has This Been Tested?
none

## Markup:
<details>

```vue
none
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
