### PR TITLE
fix(ripple): ensure _ripple data is not undefined

### DIFF
--- a/packages/vuetify/src/directives/ripple.ts
+++ b/packages/vuetify/src/directives/ripple.ts
@@ -145,7 +145,11 @@ function rippleHide (e: Event) {
   const element = e.currentTarget as HTMLElement | null
   if (!element) return
 
-  window.setTimeout(() => { element._ripple!.touched = false })
+  window.setTimeout(() => {
+    if (element._ripple) {
+      element._ripple.touched = false
+    }
+  })
   ripple.hide(element)
 }
 


### PR DESCRIPTION
## Description
Instead of assuming `element._ripple` won't be undefined/null (which it could be), verify that this is the case.

## Motivation and Context
Deleting a `v-btn` on click results in a console error "Cannot set property 'touched' of undefined at ripple.ts:148". This occurs when the ripple directive's unbind() function is called before rippleHide()'s setTimeout finishes.

Steps to reproduce ([codepen](https://codepen.io/anon/pen/zeaJZp)):
1. Open browser devtools console
2. Click on the "delete me" button in the test page
3. Observe the error message in the console

## How Has This Been Tested?
visually (added the undefined guard manually to a vuetify build)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
