### PR TITLE
Fix issue width get's ignored with scrollable dialogs

### DIFF
--- a/packages/vuetify/src/stylus/components/_dialogs.styl
+++ b/packages/vuetify/src/stylus/components/_dialogs.styl
@@ -70,7 +70,6 @@
   &--scrollable,
   &--scrollable > form
     display: flex
-    flex: 1 1 0px
 
     > .v-card
       display: flex
@@ -85,3 +84,6 @@
       > .v-card__text
         overflow-y: auto
         backface-visibility: hidden
+
+  &--scrollable > form
+    flex: 1 1 0px

--- a/packages/vuetify/src/stylus/components/_dialogs.styl
+++ b/packages/vuetify/src/stylus/components/_dialogs.styl
@@ -84,6 +84,3 @@
       > .v-card__text
         overflow-y: auto
         backface-visibility: hidden
-
-  &--scrollable > form
-    flex: 1 1 0px


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
When `flex: 1 1 0px` get's applied to a scrollable dialog it takes up the full width, so change it so it only gets applied to the form that's nested within a scrollable dialog
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6479 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually
## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
