### PR TITLE
Docs: Removes v-card-media + correctes a typo

### DIFF
--- a/packages/docs/src/lang/en/components/Cards.json
+++ b/packages/docs/src/lang/en/components/Cards.json
@@ -3,7 +3,7 @@
   "headerText": "The `v-card` component is a versatile component that can be used for anything from a panel to a static image. The **card** component has numerous helper components to make markup as easy as possible. Components that have no listed options use **Vue's** functional component option for faster rendering and serve as markup sugar to make building easier.",
   "examples": {
     "usage": {
-      "desc": "A card has 4 basic components, `v-card-media`, `v-card-title`, `v-card-text` and `v-card-actions`."
+      "desc": "A card has 3 basic components, `v-card-title`, `v-card-text` and `v-card-actions`."
     },
     "mediaWithText": {
       "header": "### Media with text",
@@ -11,7 +11,7 @@
     },
     "horizontal": {
       "header": "### Horizontal cards",
-      "desc": "Using `v-flex`, you can create customized horizontal cards. Use the `contain` property to shrink the `v-card-media` to fit inside the container, instead of covering."
+      "desc": "Using `v-flex`, you can create customized horizontal cards. Use the `contain` property to shrink the `v-img` to fit inside the container, instead of covering."
     },
     "grids": {
       "header": "### Grids",
@@ -26,7 +26,7 @@
       "desc": "The `v-card` component has multiple children components that help you build complex examples without having to worry about spacing. This example is comprised of the `v-card-title`, `v-card-text` and `v-card-actions` components."
     }
   },
-  "cardMediaWarning": "`v-card-media` is deprecated used `v-img` instead.",
+  "cardMediaWarning": "`v-card-media` is deprecated, use `v-img` instead.",
   "props": {
     "contain": "Change the background-size to contain.",
     "flat": "Removes card box shadow",


### PR DESCRIPTION
Removes v-card-media as mentioned in issue #6579.
Corrects a typo in the warning.