### PR TITLE
fix(VSlider): set value to min if it's less than min (#6604)

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.js
+++ b/packages/vuetify/src/components/VSlider/VSlider.js
@@ -511,7 +511,7 @@ export default VInput.extend({
 
       const newValue = Math.round((value - offset) / this.stepNumeric) * this.stepNumeric + offset
 
-      return parseFloat(Math.min(newValue, this.max).toFixed(decimals))
+      return parseFloat(Math.max(Math.min(newValue, this.max), this.min).toFixed(decimals))
     },
     setInternalValue (value) {
       this.internalValue = value

--- a/packages/vuetify/test/unit/components/VSlider/VSlider.spec.js
+++ b/packages/vuetify/test/unit/components/VSlider/VSlider.spec.js
@@ -355,6 +355,18 @@ test('VSlider.vue', ({ mount }) => {
     expect(wrapper.vm.roundValue(5.667)).toBe(5)
   })
 
+  it('should return a rounded value bounded by min and max', () => {
+    const wrapper = mount(VSlider, {
+      propsData: {
+        min: 5,
+        max: 10
+      }
+    })
+
+    expect(wrapper.vm.roundValue(1)).toBe(5)
+    expect(wrapper.vm.roundValue(15)).toBe(10)
+  })
+
   it('should not update if value matches lazy value', () => {
     const validate = jest.fn()
     const wrapper = mount(VSlider, {


### PR DESCRIPTION

## Description
Forces the slider value to be within the boundaries set by min and max props.

## Motivation and Context
fixes #6604 

## How Has This Been Tested?
Tested visually with the provided playground code.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-layout justify-center wrap>
      <v-flex xs7>
        <v-slider
          v-model="val"
          min="55"
          max="80" />
      </v-flex>
    </v-layout>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      val: 50
    }),
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
