### PR TITLE
feat(VCalendar): use $vuetify.lang.current as default language

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarWeekly.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarWeekly.ts
@@ -70,7 +70,7 @@ export default CalendarBase.extend({
       const shortOptions = { timeZone: 'UTC', month: 'short' }
 
       return createNativeLocaleFormatter(
-        this.locale,
+        this.currentLocale,
         (_tms, short) => short ? shortOptions : longOptions
       )
     }

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-base.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-base.ts
@@ -1,10 +1,11 @@
 
 // Mixins
 import mixins from '../../../util/mixins'
-import Themeable from '../../../mixins/themeable'
 import Colorable from '../../../mixins/colorable'
-import Times from './times'
+import Localable from '../../../mixins/localable'
 import Mouse from './mouse'
+import Themeable from '../../../mixins/themeable'
+import Times from './times'
 
 // Util
 import props from '../util/props'
@@ -19,8 +20,14 @@ import {
   getEndOfWeek
 } from '../util/timestamp'
 
+export default mixins(
+  Colorable,
+  Localable,
+  Mouse,
+  Themeable,
+  Times
 /* @vue/component */
-export default mixins(Colorable, Themeable, Times, Mouse).extend({
+).extend({
   name: 'calendar-base',
 
   props: props.base,
@@ -51,7 +58,7 @@ export default mixins(Colorable, Themeable, Times, Mouse).extend({
       const options = { timeZone: 'UTC', day: 'numeric' }
 
       return createNativeLocaleFormatter(
-        this.locale,
+        this.currentLocale,
         (_tms, _short) => options
       )
     },
@@ -64,7 +71,7 @@ export default mixins(Colorable, Themeable, Times, Mouse).extend({
       const shortOptions = { timeZone: 'UTC', weekday: 'short' }
 
       return createNativeLocaleFormatter(
-        this.locale,
+        this.currentLocale,
         (_tms, short) => short ? shortOptions : longOptions
       )
     }

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-intervals.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-intervals.ts
@@ -69,7 +69,7 @@ export default CalendarBase.extend({
       const shortHourOptions = { timeZone: 'UTC', hour12: true, hour: 'numeric' }
 
       return createNativeLocaleFormatter(
-        this.locale,
+        this.currentLocale,
         (tms, short) => short ? (tms.minute === 0 ? shortHourOptions : shortOptions) : longOptions
       )
     }

--- a/packages/vuetify/src/components/VCalendar/util/props.ts
+++ b/packages/vuetify/src/components/VCalendar/util/props.ts
@@ -32,10 +32,6 @@ export default {
     dayFormat: {
       type: Function, // VTimestampFormatter,
       default: null
-    },
-    locale: {
-      type: String,
-      default: 'en-us'
     }
   },
   intervals: {


### PR DESCRIPTION
## Description
use the global locale instead of defining it for every calendar component

## Motivation and Context
see https://github.com/vuetifyjs/vuetify/pull/6320

## How Has This Been Tested?
it wasn't 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
