### PR TITLE
fix(ripple): allow getComputedStyle to return null

### DIFF
--- a/packages/vuetify/src/directives/ripple.ts
+++ b/packages/vuetify/src/directives/ripple.ts
@@ -72,7 +72,7 @@ const ripple = {
     el.appendChild(container)
 
     const computed = window.getComputedStyle(el)
-    if (computed.position === 'static') {
+    if (computed && computed.position === 'static') {
       el.style.position = 'relative'
       el.dataset.previousPosition = 'static'
     }
@@ -200,7 +200,8 @@ function directive (el: HTMLElement, binding: VNodeDirective, node: VNode) {
 
   // warn if an inline element is used, waiting for el to be in the DOM first
   node.context && node.context.$nextTick(() => {
-    if (window.getComputedStyle(el).display === 'inline') {
+    const computed = window.getComputedStyle(el)
+    if (computed && computed.display === 'inline') {
       const context = (node as any).fnOptions ? [(node as any).fnOptions, node.context] : [node.componentInstance]
       consoleWarn('v-ripple can only be used on block-level elements', ...context)
     }


### PR DESCRIPTION
The function window.getComputedStyle was returning null under certain conditions on Firefox before version 62, see https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#Browser_compatibility.

## Motivation and Context
JS Error on Firefox.

## How Has This Been Tested?
Bug only happens on old Firefox versions. Is this something you want to explicitly test?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
