### PR TITLE
chore: change excludes options in tsconfig

### DIFF
--- a/packages/vuetify/tsconfig.dist.json
+++ b/packages/vuetify/tsconfig.dist.json
@@ -7,5 +7,10 @@
     "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true
-  }
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.spec.js",
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,8 +63,6 @@
     "emitDecoratorMetadata": true             /* Enables experimental support for emitting type metadata for decorators. */
   },
   "exclude": [
-    "**/*.spec.ts",
-    "**/*.spec.js",
     "node_modules"
   ]
 }


### PR DESCRIPTION
This pr makes ts language service work properly in IDE(Webstorm).

In the old config, both *.spec.ts and *.spec.js are excluded, so in WebStorm the ts language service may get some wired informations, such as `Information:Cannot find parent 'tsconfig.json'`, and type-check does not work properly in some cases.

So, I moved "spect.ts" and 'spec.js' from the root tsconfig.json to `packages/vuetify/tsconfig.dist.json` (which is used for building dist).

**PLEASE NOTE!**
This PR may BREAK some unit tests (mainly type-check errors), and I have not modified these tests.
