### PR TITLE
fix(VBreadcrumbs): v-for key error when two items have identical texts

### DIFF
--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.ts
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.ts
@@ -85,12 +85,15 @@ export default mixins(
     genItems () {
       const items = []
       const hasSlot = !!this.$scopedSlots.item
+      const keys = []
 
       for (let i = 0; i < this.items.length; i++) {
         const item = this.items[i]
 
+        keys.push(item.text)
+
         if (hasSlot) items.push(this.$scopedSlots.item!({ item }))
-        else items.push(this.$createElement(VBreadcrumbsItem, { key: item.text, props: item }, [item.text]))
+        else items.push(this.$createElement(VBreadcrumbsItem, { key: keys.join('.'), props: item }, [item.text]))
 
         if (i < this.items.length - 1) items.push(this.genDivider())
       }

--- a/packages/vuetify/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
+++ b/packages/vuetify/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
@@ -37,7 +37,7 @@ test('VBreadcrumbs.js', ({ mount, compileToFunctions }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it.only('should not complain about identical keys', () => {
+  it('should not complain about identical keys', () => {
     const { render } = compileToFunctions(`
       <v-breadcrumbs :items="items"></v-breadcrumbs>
     `)

--- a/packages/vuetify/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
+++ b/packages/vuetify/test/unit/components/VBreadcrumbs/VBreadcrumbs.spec.js
@@ -37,6 +37,28 @@ test('VBreadcrumbs.js', ({ mount, compileToFunctions }) => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it.only('should not complain about identical keys', () => {
+    const { render } = compileToFunctions(`
+      <v-breadcrumbs :items="items"></v-breadcrumbs>
+    `)
+
+    const component = Vue.component('test', {
+      components: {
+        VBreadcrumbs, VBreadcrumbsItem
+      },
+      data: () => ({
+        items: [
+          { text: 'a' },
+          { text: 'a' }
+        ]
+      }),
+      render
+    })
+    const wrapper = mount(component)
+
+    expect(`Duplicate keys detected: 'a'`).not.toHaveBeenWarned()
+  })
+
   it('should use slot to render items if present', () => {
     const { render } = compileToFunctions(`
       <v-breadcrumbs :items="items">


### PR DESCRIPTION
## Description
Allows breadcrumbs with identical texts

## Motivation and Context
closes #5454

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
playground, test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-breadcrumbs :items="items" divider=">"></v-breadcrumbs>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
    items: [
      {
        text: 'Dashboard',
        disabled: false,
        href: 'breadcrumbs_dashboard'
      },
      {
        text: 'Link 1',
        disabled: false,
        href: 'breadcrumbs_link_1'
      },
      {
        text: 'Dashboard',
        disabled: true,
        href: 'breadcrumbs_link_2'
      }
    ]
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
