### PR TITLE
docs: add md spec version and links

### DIFF
--- a/packages/docs/src/components/core/Page.vue
+++ b/packages/docs/src/components/core/Page.vue
@@ -13,33 +13,21 @@
         </v-flex>
         <v-spacer />
         <v-flex
-          v-if="structure.mdLink"
+          v-if="structure.mdSpec"
           shrink
         >
-          <v-tooltip left>
-            <v-btn
-              slot="activator"
-              :href="structure.mdLink"
-              icon
-              target="_blank"
-              rel="noopener"
-              class="mt-2"
-              aria-label="Material Design Specification"
-            >
-              <v-icon>mdi-material-design</v-icon>
-            </v-btn>
-            <span>Material Design Specification</span>
-          </v-tooltip>
+          <core-spec-btn
+            :link="structure.mdSpec.link"
+            :version="structure.mdSpec.version"
+          />
         </v-flex>
       </v-layout>
+
       <div
         v-if="structure.titleText"
         class="mb-5"
       >
-        <doc-text
-          v-if="structure.titleText"
-          class="mb-4"
-        >
+        <doc-text class="mb-4">
           {{ structure.titleText }}
         </doc-text>
       </div>

--- a/packages/docs/src/components/core/SpecBtn.vue
+++ b/packages/docs/src/components/core/SpecBtn.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-tooltip left>
+    <v-btn
+      slot="activator"
+      :href="link"
+      icon
+      target="_blank"
+      rel="noopener"
+      class="mt-2"
+      aria-label="Material Design Specification"
+    >
+      <v-badge
+        right
+        overlap
+        color="transparent"
+      >
+        <span
+          v-if="version"
+          slot="badge"
+          class="caption black--text font-weight-black pl-2"
+        >
+          {{ version }}
+        </span>
+        <v-icon>mdi-material-design</v-icon>
+      </v-badge>
+    </v-btn>
+    <span>Material Design Specification</span>
+  </v-tooltip>
+</template>
+
+<script>
+  export default {
+    props: {
+      link: {
+        type: String,
+        default: 'https://material.io/design/'
+      },
+      version: {
+        type: String,
+        default: ''
+      }
+    }
+  }
+</script>

--- a/packages/docs/src/data/pages/components/Autocompletes.json
+++ b/packages/docs/src/data/pages/components/Autocompletes.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/archive/guidelines/components/text-fields.html",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/text-fields.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Banners.json
+++ b/packages/docs/src/data/pages/components/Banners.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/banners.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/banners.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/BottomNavigation.json
+++ b/packages/docs/src/data/pages/components/BottomNavigation.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/bottom-navigation.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/bottom-navigation.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/BottomSheets.json
+++ b/packages/docs/src/data/pages/components/BottomSheets.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/sheets-bottom.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/sheets-bottom.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/ButtonGroups.json
+++ b/packages/docs/src/data/pages/components/ButtonGroups.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/buttons.html#toggle-button",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/buttons.html#toggle-button"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Buttons.json
+++ b/packages/docs/src/data/pages/components/Buttons.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/buttons.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/buttons.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Cards.json
+++ b/packages/docs/src/data/pages/components/Cards.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/cards.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/cards.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/ChipGroups.json
+++ b/packages/docs/src/data/pages/components/ChipGroups.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/chips.html#input-chips",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/chips.html#input-chips"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Chips.json
+++ b/packages/docs/src/data/pages/components/Chips.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/chips.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/chips.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/DataTables.json
+++ b/packages/docs/src/data/pages/components/DataTables.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/data-tables.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/data-tables.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/DatePickers.json
+++ b/packages/docs/src/data/pages/components/DatePickers.json
@@ -1,6 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/pickers.html#pickers-date-pickers"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Dialogs.json
+++ b/packages/docs/src/data/pages/components/Dialogs.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/dialogs.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/dialogs.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Dividers.json
+++ b/packages/docs/src/data/pages/components/Dividers.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/dividers.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/dividers.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/ExpansionPanels.json
+++ b/packages/docs/src/data/pages/components/ExpansionPanels.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/archive/guidelines/components/expansion-panels.html",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/expansion-panels.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/FloatingActionButtons.json
+++ b/packages/docs/src/data/pages/components/FloatingActionButtons.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/buttons-floating-action-button.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/buttons-floating-action-button.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Icons.json
+++ b/packages/docs/src/data/pages/components/Icons.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/iconography/system-icons.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/iconography/system-icons.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Images.json
+++ b/packages/docs/src/data/pages/components/Images.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/communication/imagery.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/communication/imagery.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Lists.json
+++ b/packages/docs/src/data/pages/components/Lists.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/lists.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/lists.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Menus.json
+++ b/packages/docs/src/data/pages/components/Menus.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/menus.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/menus.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/NavigationDrawers.json
+++ b/packages/docs/src/data/pages/components/NavigationDrawers.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/navigation-drawer.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/navigation-drawer.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/OverflowBtns.json
+++ b/packages/docs/src/data/pages/components/OverflowBtns.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/archive/guidelines/components/buttons.html#buttons-dropdown-buttons",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/buttons.html#buttons-dropdown-buttons"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Progress.json
+++ b/packages/docs/src/data/pages/components/Progress.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/progress-indicators.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/progress-indicators.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/SelectionControls.json
+++ b/packages/docs/src/data/pages/components/SelectionControls.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/selection-controls.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/selection-controls.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Sliders.json
+++ b/packages/docs/src/data/pages/components/Sliders.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/sliders.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/sliders.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Snackbars.json
+++ b/packages/docs/src/data/pages/components/Snackbars.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/snackbars.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/snackbars.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Steppers.json
+++ b/packages/docs/src/data/pages/components/Steppers.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/archive/guidelines/components/steppers.html",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/steppers.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Subheaders.json
+++ b/packages/docs/src/data/pages/components/Subheaders.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/archive/guidelines/components/subheaders.html",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/subheaders.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Tabs.json
+++ b/packages/docs/src/data/pages/components/Tabs.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/tabs.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/tabs.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/TextFields.json
+++ b/packages/docs/src/data/pages/components/TextFields.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/text-fields.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/text-fields.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Textarea.json
+++ b/packages/docs/src/data/pages/components/Textarea.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/text-fields.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/text-fields.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/TimePickers.json
+++ b/packages/docs/src/data/pages/components/TimePickers.json
@@ -1,6 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
+  "mdSpec": {
+    "version": "1",
+    "link": "https://material.io/archive/guidelines/components/pickers.html#pickers-time-pickers"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Toolbars.json
+++ b/packages/docs/src/data/pages/components/Toolbars.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/app-bars-top.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/app-bars-top.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/components/Tooltips.json
+++ b/packages/docs/src/data/pages/components/Tooltips.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/components/tooltips.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/components/tooltips.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/AspectRatios.json
+++ b/packages/docs/src/data/pages/framework/AspectRatios.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/layout/spacing-methods.html#containers-aspect-ratios",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/layout/spacing-methods.html#containers-aspect-ratios"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Breakpoints.json
+++ b/packages/docs/src/data/pages/framework/Breakpoints.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/layout/responsive-layout-grid.html#breakpoints",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/layout/responsive-layout-grid.html#breakpoints"
+  },
   "children": [
     {
       "type": "layout-grid"

--- a/packages/docs/src/data/pages/framework/Colors.json
+++ b/packages/docs/src/data/pages/framework/Colors.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/color/the-color-system.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/color/the-color-system.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Elevation.json
+++ b/packages/docs/src/data/pages/framework/Elevation.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/environment/elevation.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/environment/elevation.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Grid.json
+++ b/packages/docs/src/data/pages/framework/Grid.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/layout/responsive-layout-grid.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/layout/responsive-layout-grid.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/GridLists.json
+++ b/packages/docs/src/data/pages/framework/GridLists.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/layout/responsive-layout-grid.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/layout/responsive-layout-grid.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Icons.json
+++ b/packages/docs/src/data/pages/framework/Icons.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/iconography/system-icons.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/iconography/system-icons.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Internationalization.json
+++ b/packages/docs/src/data/pages/framework/Internationalization.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/usability/bidirectionality.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/usability/bidirectionality.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Spacing.json
+++ b/packages/docs/src/data/pages/framework/Spacing.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/layout/spacing-methods.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/layout/spacing-methods.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Transitions.json
+++ b/packages/docs/src/data/pages/framework/Transitions.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/motion/understanding-motion.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/motion/understanding-motion.html"
+  },
   "children": [
     {
       "type": "section",

--- a/packages/docs/src/data/pages/framework/Typography.json
+++ b/packages/docs/src/data/pages/framework/Typography.json
@@ -1,7 +1,10 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "mdLink": "https://material.io/design/typography/the-type-system.html",
+  "mdSpec": {
+    "version": "2",
+    "link": "https://material.io/design/typography/the-type-system.html"
+  },
   "children": [
     {
       "type": "section",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Add spec version as a badge.
Add link to MD specs for pickers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Know which specs version the component is without leaving docs.
Easily navigate to MD specs of a component.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Visually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
