### PR TITLE
fix(VMenu): calculate left in a same way for auto and non-auto menu

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -98,9 +98,7 @@ export default Vue.extend({
     calculatedLeft () {
       const menuWidth = Math.max(this.dimensions.content.width, parseFloat(this.calculatedMinWidth))
 
-      if (!this.auto) return this.calcLeft(menuWidth)
-
-      return `${this.calcXOverflow(this.calcLeftAuto(), menuWidth)}px`
+      return this.calcLeft(menuWidth)
     },
     calculatedMaxHeight () {
       return this.auto ? '200px' : convertToUnit(this.maxHeight)
@@ -118,9 +116,7 @@ export default Vue.extend({
       }
 
       const minWidth = Math.min(
-        this.dimensions.activator.width +
-        this.nudgeWidth +
-        (this.auto ? 16 : 0),
+        this.dimensions.activator.width + this.nudgeWidth,
         Math.max(this.pageWidth - 24, 0)
       )
 


### PR DESCRIPTION
## Description
removes left calculations specific for menu with `auto` prop

## Motivation and Context
fixes #6518

## How Has This Been Tested?
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-autocomplete menu-props="auto"></v-autocomplete>
      </v-container>
    </v-content>
  </v-app>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
