### PR TITLE
fix(progressbar): allow vertical centering of inner content

### DIFF
--- a/packages/vuetify/src/stylus/components/_progress-linear.styl
+++ b/packages/vuetify/src/stylus/components/_progress-linear.styl
@@ -48,6 +48,7 @@
 
   &__content
     width: 100%
+    height: 100%
     position: absolute
     top: 0
     left: 0


### PR DESCRIPTION
## Description
set v-progress-linear__content height to 100%

## Motivation and Context
Fixes #6707

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-card flat width="60%">
      <v-progress-linear color="red lighten-2" background-color="grey lighten-2" height="30" width="60%" value="75">
        <v-layout align-center fill-height>
          <v-flex xs1 text-xs-center>37%</v-flex>
          <v-flex xs11 text-xs-center>vue</v-flex>
        </v-layout>
      </v-progress-linear>
    </v-card>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      valueDeterminate: 50
    })
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
