### PR TITLE
feat(v-dialog): adds click:outside call

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.ts
+++ b/packages/vuetify/src/components/VDialog/VDialog.ts
@@ -160,6 +160,8 @@ export default baseMixins.extend({
       // If we made it here, the click is outside
       // and is active. If persistent, and the
       // click is on the overlay, animate
+      this.$emit('click:outside')
+
       if (this.persistent) {
         if (!this.noClickAnimation &&
           this.overlay === target

--- a/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.ts
+++ b/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.ts
@@ -6,6 +6,7 @@ import {
   mount,
   Wrapper
 } from '@vue/test-utils'
+import { compileToFunctions } from 'vue-template-compiler'
 
 describe('VDialog.ts', () => {
   type Instance = InstanceType<typeof VDialog>
@@ -261,5 +262,27 @@ describe('VDialog.ts', () => {
     const dialog = wrapper3.find(VDialog)
     expect(wrapper2.element.style.display).toBe('inline-block')
     expect(dialog.vm.hasActivator).toBe(true)
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/5533
+  it('should emit click:outside', async () => {
+    const input = jest.fn()
+    const clickOutside = jest.fn()
+    const wrapper = mountFunction({
+      slots: {
+        activator: ['<span>activator</span>']
+      }
+    })
+
+    wrapper.vm.$on('input', input)
+    wrapper.vm.$on('click:outside', clickOutside)
+
+    expect(wrapper.vm.isActive).toBe(false)
+    wrapper.find('.v-dialog__activator').trigger('click')
+    expect(wrapper.vm.isActive).toBe(true)
+    await wrapper.vm.$nextTick()
+    expect(input).toHaveBeenCalledWith(true)
+    wrapper.vm.closeConditional(new Event('click'))
+    expect(clickOutside).toHaveBeenCalled()
   })
 })

--- a/packages/vuetify/src/components/VForm/__tests__/VForm.spec.ts
+++ b/packages/vuetify/src/components/VForm/__tests__/VForm.spec.ts
@@ -81,6 +81,7 @@ describe('VForm.ts', () => {
   })
 
   // TODO: Figure out how to test this with the updated v-form
+  /*
   it.skip('should only watch children if not lazy', async () => {
     const wrapper = mountFunction({
       propsData: {
@@ -110,6 +111,7 @@ describe('VForm.ts', () => {
 
     expect(Object.keys(wrapper.vm.errorBag)).toHaveLength(1)
   })
+  */
 
   it('should emit input when calling validate on lazy-validated form', async () => {
     const wrapper = mountFunction({


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for doumentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Adds an emitter which emits `click:outside` when the `closeConditional()` gets called.

Duplicate of this PR: #5593 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #5533 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
A new unit test has been created to check if `click:outside` has been called.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div id="app">
    <v-app>
      <v-content>
        <v-container grid-list-xl>
          <v-layout row justify-center>
            <v-dialog
              v-model="open"
              persistent
              @click:outside="callback"
              width="300"
            >
              <v-btn slot="activator"> Open </v-btn>
              <v-card>
                My Dialog Content
              </v-card>
            </v-dialog>
            <v-dialog
              v-model="areYouSureDialog"
              persistent
              width="300"
            >
              <v-card>
                <v-flex>
                  Are you sure?
                </v-flex>
                <v-flex>
                  <v-btn @click="closeBoth"> Yes </v-btn>
                  <v-btn @click="areYouSureDialog = false"> No </v-btn>
                </v-flex>
              </v-card>
            </v-dialog>
          </v-layout>
        </v-container>
      </v-content>
    </v-app>
  </div>
</template>

<script>
export default {
  name: 'app',
  components: {
  },
  methods: {
    callback() {
      this.areYouSureDialog = true;
    },
    closeBoth() {
      this.open = false;
      this.areYouSureDialog = false;
    }
  },
  data: () => ({
    open: false,
    areYouSureDialog: false
  })
}
</script>

<style lang="scss" scoped>
#app {
  font-family: 'Avenir', Helvetica, Arial, sans-serif;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  text-align: center;
  color: #2c3e50;
  margin-top: 60px;
}
</style>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
