### PR TITLE
fix(component): fix "item-key" in v-data-table

### DIFF
--- a/packages/vuetify/src/components/VDataTable/mixins/body.js
+++ b/packages/vuetify/src/components/VDataTable/mixins/body.js
@@ -33,6 +33,9 @@ export default {
 
       return this.genTR([transition], { class: 'v-datatable__expand-row' })
     },
+    getItemKeyOrDefault (props, defalutVal) {
+      return this.itemKey ? getObjectValueByPath(props.item, this.itemKey) : defalutVal
+    },
     genFilteredItems () {
       if (!this.$scopedSlots.items) {
         return null
@@ -42,15 +45,19 @@ export default {
       for (let index = 0, len = this.filteredItems.length; index < len; ++index) {
         const item = this.filteredItems[index]
         const props = this.createProps(item, index)
-        const row = this.$scopedSlots.items(props)
+        let row = this.$scopedSlots.items(props)
 
-        rows.push(this.hasTag(row, 'td')
-          ? this.genTR(row, {
-            key: this.itemKey ? getObjectValueByPath(props.item, this.itemKey) : index,
+        if (this.hasTag(row, 'td')) {
+          row = this.genTR(row, {
+            key: this.getItemKeyOrDefault(props, index),
             attrs: { active: this.isSelected(item) }
           })
-          : row)
-
+        } else if (row.length === 1 && !row[0].key) {
+          row[0].key = this.getItemKeyOrDefault(props, index)
+        } else {
+          // reach cases of bad usage
+        }
+        rows.push(row)
         if (this.$scopedSlots.expand) {
           const expandRow = this.genExpandedRow(props)
           rows.push(expandRow)

--- a/packages/vuetify/test/unit/components/VDataTable/VDataTable.spec.js
+++ b/packages/vuetify/test/unit/components/VDataTable/VDataTable.spec.js
@@ -456,4 +456,24 @@ test('VDataTable.vue', ({ mount, compileToFunctions }) => {
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
+
+  it('item-key should also be applied when users try to control the whole row in items slot', async () => {
+    const data = dataTableNestedTestData()
+    const component = Vue.component('test', {
+      render (h) {
+        return h(VDataTable, {
+          props: data.propsData,
+          scopedSlots: {
+            items: props => {
+              return [h('tr', {class: 'custom-item-class'}, [props.item.nested.value.name])]
+            }
+          }
+        })
+      }
+    })
+    const wrapper = mount(component)
+    expect(wrapper.find('tr.custom-item-class').map(w => w.vNode.key)).toEqual([0, 1, 2])
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
make sure "item-key" also applied when users try to control the whole item row
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

while "item-key" is declared in v-data-table, the key is only automatically applied when "td" is used in the "items" scoped slot. When "tr" (or even "div") is used to control the whole row, the key is not applied to the row as "item-key" itself implies.

This should be regarded as a bug, as the code behavior and the spec is inconsistent. This sometimes will result in problems which usually happen when "key" is missing but desired(strange UI). 

In the following "markup" section, I provided a simplified demo from my program. The problem I encounter is if I delete one row which shouldn't have a leading icon and then add it back via the autocomplete list, the newly added item will somehow have the icon appended. If I explicitly add ":key=xxx" on the "tr", the problem is gone.

*Sorry that the playground I provided cannot reproduce my problem, it only demonstrates my operation. The real component where I encounter this problem has a more complicated structure and behavior with "expand" scoped slot.*

My solution is to first judge whether component users are trying to control the whole row, if yes and if the key is not set, the code will set the key based on "item-key".

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
tested manually, and tested with unit test
## Markup:
<!--- Paste markup for testing your change --->
```vue
<template>
  <v-app>
    <v-data-table
      :headers="headers"
      :items="itemsShownInTable"
      item-key="name"
      class="elevation-1"
    >
      <template v-slot:items="props">
        <tr>
          <td>
            <div style="display:flex; align-items:center;">
              <v-checkbox hide-details v-if="props.item.calories < 300"
                class="my-3"
                color="#339999">
              </v-checkbox>
              <v-tooltip right v-else>
                <template v-slot:activator="{ on }">
                  <v-icon  v-on="on" color='#f4b142'>error</v-icon>
                  <v-checkbox hide-details 
                    class="my-3" disabled
                    color="#339999">
                  </v-checkbox>
                </template>
                some hint here
              </v-tooltip>
              {{ props.item.name }}
            </div>
          </td>
          <td class="text-xs-left">{{ props.item.calories }}</td>
          <td class="text-xs-left">{{ props.item.fat }}</td>
          <td class="text-xs-left">{{ props.item.carbs }}</td>
          <td class="text-xs-left">{{ props.item.protein }}</td>
          <td class="text-xs-left">{{ props.item.iron }}</td>
          <td class="text-xs-left">
            <v-icon small @click="removeItem(props.item)" >delete</v-icon>
          </td>
        </tr>
      </template>
    </v-data-table>
    <v-autocomplete
      v-bind:value="selected"
      v-on:input="onSelect"
      :items="deletedFromTable"
      hide-no-data
      item-text="name"
      chips
      return-object
      dense
    >
    </v-autocomplete>
  </v-app>
</template>
<script>
  export default {
    data: () => ({
        selected: [],
        deletedFromTable: [],
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name'
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
          { text: '', value: '' }
        ],
        desserts: [
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%'
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%'
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%'
          }
        ]
      }),
    computed: {
      itemsShownInTable: function() {
        return this.desserts.filter(function(d) {
          return this.deletedFromTable.indexOf(d) === -1
        }, this)
      }
    },
    methods: {
      removeItem: function(item) {
        this.deletedFromTable.push(item)
      },
      onSelect: function($event) {
        let idx = this.deletedFromTable.indexOf($event)
        if (idx !== -1) {
          this.$nextTick(function() {
            this.selected = []
            this.deletedFromTable.splice(idx, 1)
          })
        }
      }
    }
  }
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
