### PR TITLE
test(VSnackbar): Migrate to vue-test-utils

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/__tests__/VSnackbar.spec.ts
+++ b/packages/vuetify/src/components/VSnackbar/__tests__/VSnackbar.spec.ts
@@ -1,49 +1,69 @@
-import { test } from '@/test'
-import VSnackbar from '@/components/VSnackbar'
+// Components
+import VSnackbar from '../VSnackbar'
 
-test('VSnackbar.vue', ({ mount }) => {
+// Utilities
+import {
+  mount,
+  Wrapper
+} from '@vue/test-utils'
+
+// Types
+import { ExtractVue } from '../../../util/mixins'
+
+describe('VSnackbar.ts', () => {
+  type Instance = ExtractVue<typeof VSnackbar>
+  let mountFunction: (options?: object) => Wrapper<Instance>
+
+  beforeEach(() => {
+    mountFunction = (options = {}) => {
+      return mount(VSnackbar, {
+        ...options
+      })
+    }
+  })
+
   it('should have a v-snack class', () => {
-    const wrapper = mount(VSnackbar, {
+    const wrapper = mountFunction({
       propsData: {
         value: true
       }
     })
 
-    expect(wrapper.hasClass('v-snack')).toBe(true)
+    expect(wrapper.classes()).toContain('v-snack')
   })
 
   it('should have a v-snack__wrapper with a color class', () => {
-    const wrapper = mount(VSnackbar, {
+    const wrapper = mountFunction({
       propsData: {
         value: true,
         color: 'orange lighten-2'
       }
     })
 
-    expect(wrapper.find('.v-snack__wrapper.orange')).toHaveLength(1)
-    expect(wrapper.find('.v-snack__wrapper.lighten-2')).toHaveLength(1)
+    expect(wrapper.findAll('.v-snack__wrapper.orange')).toHaveLength(1)
+    expect(wrapper.findAll('.v-snack__wrapper.lighten-2')).toHaveLength(1)
   })
 
   it('should have a v-snack__content class only when active', async () => {
-    const wrapper = mount(VSnackbar, {
+    const wrapper = mountFunction({
       propsData: {
         value: false,
         timeout: 1000
       }
     })
 
-    expect(wrapper.find('div .v-snack__content')).toHaveLength(0)
+    expect(wrapper.findAll('div .v-snack__content')).toHaveLength(0)
 
     wrapper.setProps({ value: true })
 
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.find('div .v-snack__content')).toHaveLength(1)
+    expect(wrapper.findAll('div .v-snack__content')).toHaveLength(1)
   })
 
   it('should timeout correctly', async () => {
     jest.useFakeTimers()
-    const wrapper = mount(VSnackbar, {
+    const wrapper = mountFunction({
       propsData: {
         value: false,
         timeout: 3141
@@ -52,9 +72,9 @@ test('VSnackbar.vue', ({ mount }) => {
 
     const value = jest.fn()
 
-    wrapper.instance().$on('input', value)
+    wrapper.vm.$on('input', value)
     wrapper.setProps({ value: true })
-    wrapper.update()
+    // wrapper.update()
 
     await wrapper.vm.$nextTick()
 
@@ -65,13 +85,13 @@ test('VSnackbar.vue', ({ mount }) => {
 
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.data().isActive).toBe(false)
-    expect(value).toBeCalledWith(false)
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(value).toHaveBeenCalledWith(false)
   })
 
   it('should timeout correctly when initial value is true', async () => {
     jest.useFakeTimers()
-    const wrapper = mount(VSnackbar, {
+    const wrapper = mountFunction({
       propsData: {
         value: true,
         timeout: 3141
@@ -80,7 +100,7 @@ test('VSnackbar.vue', ({ mount }) => {
 
     const value = jest.fn()
 
-    wrapper.instance().$on('input', value)
+    wrapper.vm.$on('input', value)
 
     await wrapper.vm.$nextTick()
 
@@ -91,7 +111,7 @@ test('VSnackbar.vue', ({ mount }) => {
 
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.data().isActive).toBe(false)
-    expect(value).toBeCalledWith(false)
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(value).toHaveBeenCalledWith(false)
   })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Test for VSnackbar was migrated to vue-test-utils:
* test file with vue-test-utils added in components/[component_name]/__tests__
* test file with avoriaz removed from test/unit/... folder

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requirements of vuetify 2.0

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
unit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
