### PR TITLE
test(VSwitch): Migrate to vue-test-utils

### DIFF
--- a/packages/vuetify/src/components/VSwitch/__tests__/VSwitch.spec.ts
+++ b/packages/vuetify/src/components/VSwitch/__tests__/VSwitch.spec.ts
@@ -37,6 +37,8 @@ describe('VSwitch.js', () => {
 
     wrapper.setProps({ ripple: true })
 
+    await wrapper.vm.$nextTick()
+
     ripple = wrapper.find('.v-input--selection-controls__ripple')
 
     expect(ripple.element._ripple.enabled).toBe(true)

--- a/packages/vuetify/src/components/VSwitch/__tests__/VSwitch.spec.ts
+++ b/packages/vuetify/src/components/VSwitch/__tests__/VSwitch.spec.ts
@@ -53,12 +53,12 @@ describe('VSwitch.js', () => {
     const change = jest.fn()
     wrapper.vm.$on('change', change)
     touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
-    expect(change).toBeCalledWith(true)
+    expect(change).toHaveBeenCalledWith(true)
     expect(change).toHaveBeenCalledTimes(1)
 
     wrapper.setProps({ inputValue: true })
     touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
-    expect(change).toBeCalledWith(false)
+    expect(change).toHaveBeenCalledWith(false)
     expect(change).toHaveBeenCalledTimes(2)
   })
 
@@ -74,17 +74,17 @@ describe('VSwitch.js', () => {
     wrapper.vm.$on('change', change)
 
     input.trigger('keydown.left')
-    expect(change).not.toBeCalled()
+    expect(change).not.toHaveBeenCalled()
 
     input.trigger('keydown.right')
-    expect(change).toBeCalledWith(true)
+    expect(change).toHaveBeenCalledWith(true)
     expect(change).toHaveBeenCalledTimes(1)
 
     input.trigger('keydown.right')
     expect(change).toHaveBeenCalledTimes(1)
 
     input.trigger('keydown.left')
-    expect(change).toBeCalledWith(false)
+    expect(change).toHaveBeenCalledWith(false)
     expect(change).toHaveBeenCalledTimes(2)
   })
 
@@ -98,11 +98,11 @@ describe('VSwitch.js', () => {
     const change = jest.fn()
     wrapper.vm.$on('change', change)
     touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
-    expect(change).not.toBeCalled()
+    expect(change).not.toHaveBeenCalled()
 
     wrapper.setProps({ inputValue: true })
     touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
-    expect(change).not.toBeCalled()
+    expect(change).not.toHaveBeenCalled()
   })
 
   it('should render element with loader and match the snapshot', async () => {

--- a/packages/vuetify/src/components/VSwitch/__tests__/VSwitch.spec.ts
+++ b/packages/vuetify/src/components/VSwitch/__tests__/VSwitch.spec.ts
@@ -1,31 +1,50 @@
-import { test, touch } from '@/test'
-import VSwitch from '@/components/VSwitch'
+// Components
+import VSwitch from '../VSwitch'
 
-test('VSwitch.js', ({ mount }) => {
+// Utilities
+import {
+  mount,
+  Wrapper
+} from '@vue/test-utils'
+import { touch } from '../../../../test'
+
+// Types
+import { ExtractVue } from '../../../util/mixins'
+
+describe('VSwitch.js', () => {
+  type Instance = ExtractVue<typeof VSwitch>
+  let mountFunction: (options?: object) => Wrapper<Instance>
+
+  beforeEach(() => {
+    mountFunction = (options = {}) => {
+      return mount(VSwitch, {
+        ...options
+      })
+    }
+  })
+
   it('should set ripple data attribute based on ripple prop state', async () => {
-    const wrapper = mount(VSwitch, {
+    const wrapper = mountFunction({
       propsData: {
         inputValue: false,
         ripple: false
       }
     })
 
-    let ripple = wrapper.find('.v-input--selection-controls__ripple')
+    let ripple = wrapper.findAll('.v-input--selection-controls__ripple')
 
-    expect(ripple.length).toBe(0)
+    expect(ripple).toHaveLength(0)
 
     wrapper.setProps({ ripple: true })
 
-    ripple = wrapper.first('.v-input--selection-controls__ripple')
-
-    await wrapper.vm.$nextTick()
+    ripple = wrapper.find('.v-input--selection-controls__ripple')
 
     expect(ripple.element._ripple.enabled).toBe(true)
     expect(ripple.element._ripple.centered).toBe(true)
   })
 
   it('should emit change event on swipe', async () => {
-    const wrapper = mount(VSwitch, {
+    const wrapper = mountFunction({
       props: {
         inputValue: false
       }
@@ -33,25 +52,25 @@ test('VSwitch.js', ({ mount }) => {
 
     const change = jest.fn()
     wrapper.vm.$on('change', change)
-    touch(wrapper.first('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
+    touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
     expect(change).toBeCalledWith(true)
     expect(change).toHaveBeenCalledTimes(1)
 
     wrapper.setProps({ inputValue: true })
-    touch(wrapper.first('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
+    touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
     expect(change).toBeCalledWith(false)
     expect(change).toHaveBeenCalledTimes(2)
   })
 
   it('should emit change event on key events', async () => {
-    const wrapper = mount(VSwitch, {
+    const wrapper = mountFunction({
       props: {
         inputValue: false
       }
     })
 
     const change = jest.fn()
-    const input = wrapper.first('input')
+    const input = wrapper.find('input')
     wrapper.vm.$on('change', change)
 
     input.trigger('keydown.left')
@@ -70,7 +89,7 @@ test('VSwitch.js', ({ mount }) => {
   })
 
   it('should not emit change event on swipe when not active', async () => {
-    const wrapper = mount(VSwitch, {
+    const wrapper = mountFunction({
       props: {
         inputValue: false
       }
@@ -78,16 +97,16 @@ test('VSwitch.js', ({ mount }) => {
 
     const change = jest.fn()
     wrapper.vm.$on('change', change)
-    touch(wrapper.first('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
+    touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(-20, 0)
     expect(change).not.toBeCalled()
 
     wrapper.setProps({ inputValue: true })
-    touch(wrapper.first('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
+    touch(wrapper.find('.v-input--selection-controls__ripple')).start(0, 0).end(20, 0)
     expect(change).not.toBeCalled()
   })
 
   it('should render element with loader and match the snapshot', async () => {
-    const wrapper = mount(VSwitch, {
+    const wrapper = mountFunction({
       props: {
         loading: true
       }

--- a/packages/vuetify/src/components/VSwitch/__tests__/__snapshots__/VSwitch.spec.ts.snap
+++ b/packages/vuetify/src/components/VSwitch/__tests__/__snapshots__/VSwitch.spec.ts.snap
@@ -42,8 +42,11 @@ exports[`VSwitch.js should render element with loader and match the snapshot 1`]
       </div>
     </div>
     <div class="v-messages theme--light">
-      <div class="v-messages__wrapper">
-      </div>
+      <span name="message-transition"
+            tag="div"
+            class="v-messages__wrapper"
+      >
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Test was migrated to vue-test-utils:
* test file with vue-test-utils added in components/[component_name]/tests
* test file with avoriaz removed from test/unit/... folder

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requirement for v2

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
unit

## Current issues:
* `.v-input--selection-controls__ripple` is not found while present when logging `wrapper.html()`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
