### PR TITLE
vslider: prop decreasing allows max on left and min on right

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.js
+++ b/packages/vuetify/src/components/VSlider/VSlider.js
@@ -32,6 +32,7 @@ export default VInput.extend({
   props: {
     alwaysDirty: Boolean,
     inverseLabel: Boolean,
+    decreasing: Boolean,
     label: String,
     min: {
       type: [Number, String],
@@ -143,8 +144,8 @@ export default VInput.extend({
       return this.step > 0 ? parseFloat(this.step) : 0
     },
     trackFillStyles () {
-      const left = this.$vuetify.rtl ? 'auto' : 0
-      const right = this.$vuetify.rtl ? 0 : 'auto'
+      const left = (this.$vuetify.rtl || this.decreasing) ? 'auto' : 0
+      const right = (this.$vuetify.rtl || this.decreasing) ? 0 : 'auto'
       let width = `${this.inputWidth}%`
 
       if (this.disabled) width = `calc(${this.inputWidth}% - 8px)`
@@ -165,8 +166,8 @@ export default VInput.extend({
     },
     trackStyles () {
       const trackPadding = this.disabled ? `calc(${this.inputWidth}% + 8px)` : `${this.trackPadding}px`
-      const left = this.$vuetify.rtl ? 'auto' : trackPadding
-      const right = this.$vuetify.rtl ? trackPadding : 'auto'
+      const left = (this.$vuetify.rtl || this.decreasing) ? 'auto' : trackPadding
+      const right = (this.$vuetify.rtl || this.decreasing) ? trackPadding : 'auto'
       const width = this.disabled
         ? `calc(${100 - this.inputWidth}% - 8px)`
         : '100%'
@@ -332,7 +333,7 @@ export default VInput.extend({
         },
         style: {
           transition: this.trackTransition,
-          left: `${this.$vuetify.rtl ? 100 - valueWidth : valueWidth}%`
+          left: `${(this.$vuetify.rtl || this.decreasing) ? 100 - valueWidth : valueWidth}%`
         },
         on: {
           touchstart: onDrag,
@@ -462,7 +463,7 @@ export default VInput.extend({
       // It is possible for left to be NaN, force to number
       let left = Math.min(Math.max((clientX - offsetLeft) / trackWidth, 0), 1) || 0
 
-      if (this.$vuetify.rtl) left = 1 - left
+      if (this.$vuetify.rtl || this.decreasing) left = 1 - left
 
       const isInsideTrack = clientX >= offsetLeft - 8 && clientX <= offsetLeft + trackWidth + 8
       const value = parseFloat(this.min) + left * (this.max - this.min)
@@ -482,7 +483,7 @@ export default VInput.extend({
       if ([left, right, down, up].includes(e.keyCode)) {
         this.keyPressed += 1
 
-        const increase = this.$vuetify.rtl ? [left, up] : [right, up]
+        const increase = (this.$vuetify.rtl || this.decreasing) ? [left, up] : [right, up]
         const direction = increase.includes(e.keyCode) ? 1 : -1
         const multiplier = e.shiftKey ? 3 : (e.ctrlKey ? 2 : 1)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

Implementation is very similar to global Vue rtl setting but specific setting is local to the particular v-slider.

## Motivation and Context

1. Needed just one particular slider to have a decreasing mode - max on the left and min on the right

## How Has This Been Tested?

Manual testing only.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] The PR title is no longer than 64 characters.
- [x ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
