### PR TITLE
fix(VTabs): RTL support for VTabs

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTabs.js
+++ b/packages/vuetify/src/components/VTabs/VTabs.js
@@ -90,10 +90,14 @@ export default BaseItemGroup.extend({
       this.nextIconVisible = this.checkNextIcon()
     },
     checkPrevIcon () {
+      if (this.$vuetify.rtl) return this.widths.container > (this.scrollOffset * -1) + this.widths.wrapper
+
       return this.scrollOffset > 0
     },
     checkNextIcon () {
       // Check one scroll ahead to know the width of right-most item
+      if (this.$vuetify.rtl) return this.scrollOffset < 0
+
       return this.widths.container > this.scrollOffset + this.widths.wrapper
     },
     callSlider () {
@@ -195,6 +199,7 @@ export default BaseItemGroup.extend({
       /* istanbul ignore next */
       if (!this.activeTab) return
       if (!this.isOverflowing) return (this.scrollOffset = 0)
+      if (this.$vuetify.rtl) return
 
       const totalWidth = this.widths.wrapper + this.scrollOffset
       const { clientWidth, offsetLeft } = this.activeTab.$el

--- a/packages/vuetify/src/components/VTabs/mixins/tabs-touch.js
+++ b/packages/vuetify/src/components/VTabs/mixins/tabs-touch.js
@@ -10,8 +10,14 @@ export default {
       const clientWidth = this.$refs.wrapper.clientWidth
 
       if (direction === 'prev') {
+        if (this.$vuetify.rtl) {
+          return Math.max(this.scrollOffset - clientWidth, (this.$refs.container.clientWidth - clientWidth) * -1)
+        }
         return Math.max(this.scrollOffset - clientWidth, 0)
       } else {
+        if (this.$vuetify.rtl) {
+          return Math.min(this.scrollOffset + clientWidth, 0)
+        }
         return Math.min(this.scrollOffset + clientWidth, this.$refs.container.clientWidth - clientWidth)
       }
     },
@@ -31,10 +37,18 @@ export default {
       container.style.willChange = null
 
       /* istanbul ignore else */
-      if (this.scrollOffset < 0 || !this.isOverflowing) {
-        this.scrollOffset = 0
-      } else if (this.scrollOffset >= maxScrollOffset) {
-        this.scrollOffset = maxScrollOffset
+      if (this.$vuetify.rtl) {
+        if (this.scrollOffset > 0 || !this.isOverflowing) {
+          this.scrollOffset = 0
+        } else if (this.scrollOffset * -1 >= maxScrollOffset) {
+          this.scrollOffset = maxScrollOffset * -1
+        }
+      } else {
+        if (this.scrollOffset < 0 || !this.isOverflowing) {
+          this.scrollOffset = 0
+        } else if (this.scrollOffset >= maxScrollOffset) {
+          this.scrollOffset = maxScrollOffset
+        }
       }
     }
   }


### PR DESCRIPTION
Fixed few issues with VTabs in RTL mode.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
There are couple of issues with VTabs in RTL mode with pagination. 
Initial tabs positioning not right. Tabs moved towards left onto pagination leaving empty space on right. - fixed
Prev/Next button clicks moving tabs in opposite direction - Fixed
Prev/Next buttons not hiding based on Tab scroll position - Fixed
Position active tab in visible portion of tabs on load - Not fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are using VTabs as menu bar in our application and without this Tabs are not functional/usable in RTL mode.

<!--- If it fixes an open issue, please link to the issue here. -->
There are couple of issues logged. One of them is open and other are closed as no support at that moment or marked as fixed (but not actually fixed).

https://github.com/vuetifyjs/vuetify/issues/6696
https://github.com/vuetifyjs/vuetify/issues/4788
https://github.com/vuetifyjs/vuetify/issues/5329
https://github.com/vuetifyjs/vuetify/issues/6575

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I have used Playground.vue to test this. 
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
None

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// dev/index.js
Vue.use(Vuetify, { rtl: true })

// Paste your FULL Playground.vue here
<template>
  <v-app>
    <v-tabs
      v-model="activeTabIndex"
      dark
      color="cyan"
      show-arrows
    >
      <v-tabs-slider color="yellow" />
      <v-tab
        v-for="i in 15"
        :key="i"
        :href="'#tab-' + i"
      >
        Item {{ i }}
      </v-tab>
      <v-tabs-items>
        <v-tab-item
          v-for="i in 15"
          :id="'tab-' + i"
          :key="i"
        >
          <v-card flat>
            <v-card-text>
              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
              quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
            </v-card-text>
          </v-card>
        </v-tab-item>
      </v-tabs-items>
    </v-tabs>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        activeTabIndex: 'tab-12'
      }
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
