### PR TITLE
fix(v-messages): increase line-height of inputs messages

### DIFF
--- a/packages/vuetify/src/stylus/components/_messages.styl
+++ b/packages/vuetify/src/stylus/components/_messages.styl
@@ -19,7 +19,7 @@ rtl(v-messages-rtl, "v-messages")
   position: relative
 
   &__message
-    line-height: 1
+    line-height: 1.1
     word-break: break-word
     overflow-wrap: break-word
     word-wrap: break-word

--- a/packages/vuetify/src/stylus/components/_messages.styl
+++ b/packages/vuetify/src/stylus/components/_messages.styl
@@ -19,7 +19,7 @@ rtl(v-messages-rtl, "v-messages")
   position: relative
 
   &__message
-    line-height: 1.1
+    line-height: normal
     word-break: break-word
     overflow-wrap: break-word
     word-wrap: break-word


### PR DESCRIPTION
## Description
There is a problem with letters like "qygjp" being cropped in input hints or error messages. While line-height: 1 seems like a potentially reasonable value, it happens to be not enough. I think it should be left for the browser to decide what line-height should be applied to display this element correctly.

## Motivation and Context
![image](https://user-images.githubusercontent.com/7119479/55221338-83260100-5209-11e9-9193-ad3dd17c9643.png)

## How Has This Been Tested?
visually in chrome, firefox, safari (all up to date)

## Markup:

```vue
<template>
  <v-app>
    <v-container fluid>
      <v-flex
        md12
        xs12
      >
        <v-text-field
          v-model="test"
          persistent-hint
          error-messages="qygjp"
          hint="qygjp"
        />
      </v-flex>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      test: ''
    })
  }
</script>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
