### PR TITLE
fix: fix babel-transform-sass-paths

### DIFF
--- a/packages/vuetify/build/babel-transform-sass-paths.js
+++ b/packages/vuetify/build/babel-transform-sass-paths.js
@@ -1,8 +1,6 @@
-var types = require('babel-types');
-var pathLib = require('path');
-var wrapListener = require('babel-plugin-detective/wrap-listener');
+const wrapListener = require('babel-plugin-detective/wrap-listener')
 
-module.exports = wrapListener(listener, 'transform-sass-paths');
+module.exports = wrapListener(listener, 'transform-sass-paths')
 
 function listener(path, file, opts) {
   const regex = /((?:\.\.?\/)+)/gi
@@ -10,8 +8,6 @@ function listener(path, file, opts) {
     const matches = regex.exec(path.node.value)
     if (!matches) return
     const m = matches[0].startsWith('./') ? matches[0].substr(2) : matches[0]
-    const folder = file.hub.file.opts.filename.split('/').slice(2, 3)[0]
-
-    path.node.value = path.node.value.replace(matches[0], `${m}../../../src/components/${folder}/`)
+    path.node.value = path.node.value.replace(matches[0], `${m}../src/`)
   }
 }

--- a/packages/vuetify/build/babel-transform-sass-paths.js
+++ b/packages/vuetify/build/babel-transform-sass-paths.js
@@ -1,13 +1,20 @@
-const wrapListener = require('babel-plugin-detective/wrap-listener')
+var wrapListener = require('babel-plugin-detective/wrap-listener')
 
 module.exports = wrapListener(listener, 'transform-sass-paths')
 
-function listener(path, file, opts) {
-  const regex = /((?:\.\.?\/)+)/gi
+function listener(path, file) {
   if (path.isLiteral() && path.node.value.endsWith('.sass')) {
-    const matches = regex.exec(path.node.value)
-    if (!matches) return
-    const m = matches[0].startsWith('./') ? matches[0].substr(2) : matches[0]
-    path.node.value = path.node.value.replace(matches[0], `${m}../src/`)
+    let tmpPath = path.node.value.split('/')
+    let currentFolder = file.hub.file.opts.filename.split('/').slice(0, -1)
+
+    let relativePath = Array(currentFolder.length).fill('..').concat(currentFolder)
+
+    while (tmpPath[0].startsWith('.') && (tmpPath.shift() === '..')) {
+      relativePath.splice(-1)
+    }
+
+    const finalPath = relativePath.concat(tmpPath).join('/').replace(currentFolder[0], 'src')
+
+    path.node.value = finalPath
   }
 }

--- a/packages/vuetify/build/babel-transform-sass-paths.js
+++ b/packages/vuetify/build/babel-transform-sass-paths.js
@@ -1,20 +1,12 @@
-var wrapListener = require('babel-plugin-detective/wrap-listener')
+const { join, dirname, relative } = require('path')
+const wrapListener = require('babel-plugin-detective/wrap-listener')
 
 module.exports = wrapListener(listener, 'transform-sass-paths')
 
 function listener(path, file) {
   if (path.isLiteral() && path.node.value.endsWith('.sass')) {
-    let tmpPath = path.node.value.split('/')
-    let currentFolder = file.hub.file.opts.filename.split('/').slice(0, -1)
-
-    let relativePath = Array(currentFolder.length).fill('..').concat(currentFolder)
-
-    while (tmpPath[0].startsWith('.') && (tmpPath.shift() === '..')) {
-      relativePath.splice(-1)
-    }
-
-    const finalPath = relativePath.concat(tmpPath).join('/').replace(currentFolder[0], 'src')
-
-    path.node.value = finalPath
+    const from = dirname(file.hub.file.opts.filename)
+    const to = from.replace(from.split('/')[0], 'src')
+    path.node.value = join(relative(from, to), path.node.value)
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes`babel-transform-sass-paths` custom plugin to correctly resolve `.sass` paths when building `es5` & `lib` folders.

This PR fixes the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Before ❌
```js
// vuetify/lib/framework.js
...
import '../src/stylus/app.styl';
import '../../../src/components/undefined/styles/main.sass';
...
```

```js
// vuetify/lib/components/VPicker/VPicker.js
...
import '../../../src/stylus/components/_pickers.styl';
import '../../../../src/components/VPicker/VCard/VCard.sass';
...
```
## After 👍🏼
```js
// vuetify/lib/framework.js
...
import '../src/stylus/app.styl';
import '../src/styles/main.sass';
...
```
```js
// vuetify/lib/components/VPicker/VPicker.js
...
import '../../../src/stylus/components/_pickers.styl';
import '../../../src/components/VCard/VCard.sass';
...
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`next`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
