### PR TITLE
added check for componentOptions existing on slot fixes #6901

### DIFF
--- a/packages/vuetify/src/components/VSpeedDial/VSpeedDial.js
+++ b/packages/vuetify/src/components/VSpeedDial/VSpeedDial.js
@@ -65,7 +65,7 @@ export default {
     if (this.isActive) {
       let btnCount = 0
       children = (this.$slots.default || []).map((b, i) => {
-        if (b.tag && b.componentOptions.Ctor.options.name === 'v-btn') {
+        if (b.tag && typeof b.componentOptions !== 'undefined' && b.componentOptions.Ctor.options.name === 'v-btn') {
           btnCount++
           return h('div', {
             style: {


### PR DESCRIPTION
## Description
Adding a `typeof !== 'undefined'` check so only slots with `componentOptions` will be adding an animation.

## Motivation and Context
it fixes #6901 

## How Has This Been Tested?
I've tested this in my project with the same code as the issues codepen: https://codepen.io/anon/pen/BENVJK?editors=1111

and with the playground as documented below

## Markup:

<details>
Playground.vue

```
<template>
  <v-app>
    <child>
      <div slot="speedDialAfter">
        test
      </div>
    </child>
  </v-app>
</template>

<script>
  import Child from './Child.vue';
  export default {
    components: {Child},
    data: () => ({
    })
  }
</script>


```
Child.vue

```
<template>
  <div>
    <v-fab-transition>
      <v-speed-dial
          v-model="fab"
          :top="true"
          :right="true"
          :open-on-hover="true"
          direction="bottom"
          transition="slide-y-reverse-transition"
      >
        <v-btn slot="activator" color="accent" dark fab hover v-model="fab">
          <v-icon>view_headline</v-icon>
          <v-icon>close</v-icon>
        </v-btn>
        <v-tooltip left>
          <v-btn
              fab
              dark
              small
              color="red"
              slot="activator"
          >
            <v-icon>delete</v-icon>
          </v-btn>
          <span>delete</span>
        </v-tooltip>
        <slot name="speedDialAfter"></slot>
      </v-speed-dial>
    </v-fab-transition>
  </div>
</template>

<script>
  export default {
    name: 'child',
    data: () => ({
      fab: null
    })
  }
</script>

```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 

No documentation needed
