### PR TITLE
added carousel keys to create translation snippet documentation

### DIFF
--- a/packages/docs/src/snippets/ts/create_translation.txt
+++ b/packages/docs/src/snippets/ts/create_translation.txt
@@ -10,5 +10,9 @@ export default {
   "dataTable": {
     "rowsPerPageText": "Rows per page:"
   },
-  "noDataText": "No data available"
+  "noDataText": "No data available",
+  "carousel": {
+    "prev": "Previous visual",
+    "next": "Next visual"
+  }
 }


### PR DESCRIPTION
## Description
Added the carousel i18n object to the create-translation snippet

## Motivation and Context
saw it, fixed it

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
