### PR TITLE
fix(VTextField): prevent TypeError when color is an empty string

### DIFF
--- a/packages/vuetify/src/components/VCounter/VCounter.ts
+++ b/packages/vuetify/src/components/VCounter/VCounter.ts
@@ -5,7 +5,7 @@ import '../../stylus/components/_counters.styl'
 import Themeable, { functionalThemeClasses } from '../../mixins/themeable'
 
 // Types
-import { VNode, RenderContext } from 'vue'
+import { VNode } from 'vue'
 import mixins from '../../util/mixins'
 
 /* @vue/component */
@@ -22,11 +22,11 @@ export default mixins(Themeable).extend({
     max: [Number, String]
   },
 
-  render (h, ctx: RenderContext): VNode {
+  render (h, ctx): VNode {
     const { props } = ctx
     const max = parseInt(props.max, 10)
     const value = parseInt(props.value, 10)
-    const content = max ? `${value} / ${max}` : props.value
+    const content = max ? `${value} / ${max}` : String(props.value)
     const isGreater = max && (value > max)
 
     return h('div', {

--- a/packages/vuetify/src/components/VLabel/VLabel.ts
+++ b/packages/vuetify/src/components/VLabel/VLabel.ts
@@ -6,7 +6,7 @@ import Colorable from '../../mixins/colorable'
 import Themeable, { functionalThemeClasses } from '../../mixins/themeable'
 
 // Types
-import { VNode, RenderContext } from 'vue'
+import { VNode } from 'vue'
 import mixins from '../../util/mixins'
 
 // Helpers
@@ -21,7 +21,7 @@ export default mixins(Themeable).extend({
   props: {
     absolute: Boolean,
     color: {
-      type: [Boolean, String],
+      type: String,
       default: 'primary'
     },
     disabled: Boolean,
@@ -38,7 +38,7 @@ export default mixins(Themeable).extend({
     value: Boolean
   },
 
-  render (h, ctx: RenderContext): VNode {
+  render (h, ctx): VNode {
     const { children, listeners, props } = ctx
     const data = {
       staticClass: 'v-label',

--- a/packages/vuetify/src/components/VRadioGroup/VRadio.js
+++ b/packages/vuetify/src/components/VRadioGroup/VRadio.js
@@ -104,7 +104,7 @@ export default {
           for: this.id
         },
         props: {
-          color: this.radio.validationState || false,
+          color: this.radio.validationState || '',
           dark: this.dark,
           focused: this.hasState,
           light: this.light


### PR DESCRIPTION
fixes #6981

https://github.com/vuetifyjs/vuetify/blob/189cbd20330be6e42ed190ebe3cfd9b26295c51b/packages/vuetify/src/components/VTextField/VTextField.js#L300 is coerced to `true` if VLabel has `Boolean`

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
lol

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

