### PR TITLE
refactor(VParallax): update for v2

### DIFF
--- a/packages/vuetify/src/components/VParallax/VParallax.ts
+++ b/packages/vuetify/src/components/VParallax/VParallax.ts
@@ -5,18 +5,20 @@ import './VParallax.sass'
 import Translatable from '../../mixins/translatable'
 
 // Types
-import Vue from 'vue'
 import { VNode, VNodeData } from 'vue/types/vnode'
-import mixins, { ExtractVue } from '../../util/mixins'
+import mixins from '../../util/mixins'
 
-interface options extends Vue {
+const baseMixins = mixins(
+  Translatable
+)
+interface options extends InstanceType<typeof baseMixins> {
   $refs: {
     img: HTMLImageElement
   }
 }
 
 /* @vue/component */
-export default mixins<options & ExtractVue<typeof Translatable>>(Translatable).extend({
+export default baseMixins.extend<options>().extend({
   name: 'v-parallax',
 
   props: {
@@ -45,12 +47,6 @@ export default mixins<options & ExtractVue<typeof Translatable>>(Translatable).e
     }
   },
 
-  watch: {
-    parallax () {
-      this.isBooted = true
-    }
-  },
-
   mounted () {
     this.init()
   },
@@ -70,6 +66,8 @@ export default mixins<options & ExtractVue<typeof Translatable>>(Translatable).e
           this.listeners()
         }, false)
       }
+
+      this.isBooted = true
     },
     objHeight () {
       return this.$refs.img.naturalHeight

--- a/packages/vuetify/src/components/VParallax/__tests__/__snapshots__/VParallax.spec.ts.snap
+++ b/packages/vuetify/src/components/VParallax/__tests__/__snapshots__/VParallax.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`VParallax.ts should use alt tag when supplied 1`] = `
   <div class="v-parallax__image-container">
     <img alt="name"
          class="v-parallax__image"
-         style="display: block; opacity: 0; transform: translate(-50%, 0px);"
+         style="display: block; opacity: 1; transform: translate(-50%, 0px);"
     >
   </div>
   <div class="v-parallax__content">
@@ -42,7 +42,7 @@ exports[`VParallax.ts should use empty alt tag when not supplied 1`] = `
   <div class="v-parallax__image-container">
     <img alt
          class="v-parallax__image"
-         style="display: block; opacity: 0; transform: translate(-50%, 0px);"
+         style="display: block; opacity: 1; transform: translate(-50%, 0px);"
     >
   </div>
   <div class="v-parallax__content">


### PR DESCRIPTION
relied on translate to be called in order to boot, this doesn't occur when image is the same size as
the container

fixes #7010

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
