### PR TITLE
fix: v-list-tile-title cut badge

### DIFF
--- a/packages/vuetify/src/stylus/components/_lists.styl
+++ b/packages/vuetify/src/stylus/components/_lists.styl
@@ -82,10 +82,13 @@ rtl(v-list-rtl, "v-list")
       width: 100%
 
     &__title
-      height: 24px
+      min-height: 24px
       line-height: 24px
       position: relative
       text-align: left
+
+      > .v-badge
+        margin-top: 16px
 
     &__sub-title
       font-size: $list-sub-title-font-size


### PR DESCRIPTION
This fix is made because of issue #7117

## Description
Any v-badge inside v-list-tile-title now has margin-top to create additional space for badge circle. Also v-list-tile-title now has max-height instead of height to contain v-badge with new additional margin

## Motivation and Context
This is fix for issue https://github.com/vuetifyjs/vuetify/issues/7117

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
