### PR TITLE
fix: fix vue-devtools when using nuxt

### DIFF
--- a/packages/vuetify/src/services/theme/index.ts
+++ b/packages/vuetify/src/services/theme/index.ts
@@ -174,25 +174,18 @@ export class Theme extends Service {
 
   private initNuxt (root: Vue) {
     const options = this.options || {}
-    const metaInfo = {
-      style: [
-        {
-          cssText: this.generatedStyles,
-          type: 'text/css',
-          id: 'vuetify-theme-stylesheet',
-          nonce: options.cspNonce
-        }
-      ]
-    }
-
-    root.$children.push({
-      $children: [],
-      $options: {
-        metaInfo, // TODO: vue-meta 2.0 $meta.getOptions()
-        head: metaInfo
-      },
-      $vnode: { data: {} }
-    } as any)
+    root.$children.push(new Vue({
+      head: {
+        style: [
+          {
+            cssText: this.generatedStyles,
+            type: 'text/css',
+            id: 'vuetify-theme-stylesheet',
+            nonce: options.cspNonce
+          }
+        ]
+      }
+    } as any))
   }
 
   private initSSR (ssrContext?: any) {


### PR DESCRIPTION
## Description
When using Nuxt, Vuetify SSR styles are pushed with a "hack" using `root.$children.push()` with `vue-meta` options. But as it it wasn't a proper Vue instance, it was breaking Vue DevTools, cause `$children` should be only Vue instances.

## Motivation and Context
Not having Vue DevTools working was a pain :D

## How Has This Been Tested?
I tested locally on 2 Nuxt + Vuetify projects and that fixed Vue DevTools.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

