### PR TITLE
fix: fix column slot param

### DIFF
--- a/packages/docs/src/examples/data-tables/crud.vue
+++ b/packages/docs/src/examples/data-tables/crud.vue
@@ -52,7 +52,7 @@
         </v-dialog>
       </v-toolbar>
     </template>
-    <template v-slot:item.column.action="{ item }">
+    <template v-slot:item.action="{ item }">
       <v-icon
         small
         class="mr-2"


### PR DESCRIPTION
## Description

Fix v-datatable broken with inline actions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It's a tiny fix, just test it in codepen.

remove "column" in this demo.

https://codepen.io/pen/?&editable=true&editors=101

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
