### PR TITLE
fix(VDataTable): header icons should respect type (svg/non-svg)

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeader.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeader.sass
@@ -29,25 +29,24 @@
       cursor: pointer
       outline: 0
 
-      i
-        font-size: 18px
+      .v-icon
         display: inline-block
         opacity: 0
         transition: .3s map-get($transition, 'swing')
 
       &:focus,
       &:hover
-        i
+        .v-icon
           opacity: .6
 
     &.active
       transform: none
 
-      i
+      .v-icon
         opacity: 1
 
       &.desc
-        i
+        .v-icon
           transform: rotate(-180deg)
 
 .v-data-table-header__sort-badge
@@ -76,11 +75,8 @@
     .v-chip
       height: 24px
 
-    .v-chip__close
-      i
-        font-size: 18px
-
-      &.desc i
+    .v-chip__close.desc
+      .v-icon
         transform: rotate(-180deg)
 
 .v-data-table-header-mobile__select

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -251,6 +251,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -266,6 +267,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -281,6 +283,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -296,6 +299,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -311,6 +315,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -440,6 +445,7 @@ exports[`VDataTable.ts should render virtual table 1`] = `
               </span>
               <i aria-hidden="true"
                  class="v-icon material-icons theme--light"
+                 style="font-size: 18px;"
               >
                 $vuetify.icons.sort
               </i>
@@ -455,6 +461,7 @@ exports[`VDataTable.ts should render virtual table 1`] = `
               </span>
               <i aria-hidden="true"
                  class="v-icon material-icons theme--light"
+                 style="font-size: 18px;"
               >
                 $vuetify.icons.sort
               </i>
@@ -470,6 +477,7 @@ exports[`VDataTable.ts should render virtual table 1`] = `
               </span>
               <i aria-hidden="true"
                  class="v-icon material-icons theme--light"
+                 style="font-size: 18px;"
               >
                 $vuetify.icons.sort
               </i>
@@ -485,6 +493,7 @@ exports[`VDataTable.ts should render virtual table 1`] = `
               </span>
               <i aria-hidden="true"
                  class="v-icon material-icons theme--light"
+                 style="font-size: 18px;"
               >
                 $vuetify.icons.sort
               </i>
@@ -500,6 +509,7 @@ exports[`VDataTable.ts should render virtual table 1`] = `
               </span>
               <i aria-hidden="true"
                  class="v-icon material-icons theme--light"
+                 style="font-size: 18px;"
               >
                 $vuetify.icons.sort
               </i>
@@ -724,6 +734,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -739,6 +750,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -754,6 +766,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -769,6 +782,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -784,6 +798,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -904,6 +919,7 @@ exports[`VDataTable.ts should render with data 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -919,6 +935,7 @@ exports[`VDataTable.ts should render with data 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -934,6 +951,7 @@ exports[`VDataTable.ts should render with data 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -949,6 +967,7 @@ exports[`VDataTable.ts should render with data 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -964,6 +983,7 @@ exports[`VDataTable.ts should render with data 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1182,6 +1202,7 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1197,6 +1218,7 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1212,6 +1234,7 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1227,6 +1250,7 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1357,6 +1381,7 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1372,6 +1397,7 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1387,6 +1413,7 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1402,6 +1429,7 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1775,6 +1803,7 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1790,6 +1819,7 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1805,6 +1835,7 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -1820,6 +1851,7 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2140,6 +2172,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2155,6 +2188,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2170,6 +2204,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2185,6 +2220,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2200,6 +2236,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2334,6 +2371,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2349,6 +2387,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2364,6 +2403,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2379,6 +2419,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2394,6 +2435,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2651,6 +2693,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2666,6 +2709,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2681,6 +2725,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2696,6 +2741,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2711,6 +2757,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2978,6 +3025,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -2993,6 +3041,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3008,6 +3057,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3023,6 +3073,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3038,6 +3089,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3312,6 +3364,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3327,6 +3380,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3342,6 +3396,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3357,6 +3412,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>
@@ -3372,6 +3428,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
             </span>
             <i aria-hidden="true"
                class="v-icon material-icons theme--light"
+               style="font-size: 18px;"
             >
               $vuetify.icons.sort
             </i>

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
@@ -25,6 +25,7 @@ exports[`VDataTableHeader.ts desktop should render 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -40,6 +41,7 @@ exports[`VDataTableHeader.ts desktop should render 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -55,6 +57,7 @@ exports[`VDataTableHeader.ts desktop should render 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -70,6 +73,7 @@ exports[`VDataTableHeader.ts desktop should render 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -85,6 +89,7 @@ exports[`VDataTableHeader.ts desktop should render 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -119,6 +124,7 @@ exports[`VDataTableHeader.ts desktop should work with multiSort 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -134,6 +140,7 @@ exports[`VDataTableHeader.ts desktop should work with multiSort 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -149,6 +156,7 @@ exports[`VDataTableHeader.ts desktop should work with multiSort 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -164,6 +172,7 @@ exports[`VDataTableHeader.ts desktop should work with multiSort 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -179,6 +188,7 @@ exports[`VDataTableHeader.ts desktop should work with multiSort 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -219,6 +229,7 @@ exports[`VDataTableHeader.ts desktop should work with showGroupBy 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -237,6 +248,7 @@ exports[`VDataTableHeader.ts desktop should work with showGroupBy 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -255,6 +267,7 @@ exports[`VDataTableHeader.ts desktop should work with showGroupBy 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -273,6 +286,7 @@ exports[`VDataTableHeader.ts desktop should work with showGroupBy 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -291,6 +305,7 @@ exports[`VDataTableHeader.ts desktop should work with showGroupBy 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -328,6 +343,7 @@ exports[`VDataTableHeader.ts desktop should work with sortBy correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -343,6 +359,7 @@ exports[`VDataTableHeader.ts desktop should work with sortBy correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -358,6 +375,7 @@ exports[`VDataTableHeader.ts desktop should work with sortBy correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -373,6 +391,7 @@ exports[`VDataTableHeader.ts desktop should work with sortBy correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -388,6 +407,7 @@ exports[`VDataTableHeader.ts desktop should work with sortBy correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -422,6 +442,7 @@ exports[`VDataTableHeader.ts desktop should work with sortDesc correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -437,6 +458,7 @@ exports[`VDataTableHeader.ts desktop should work with sortDesc correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -452,6 +474,7 @@ exports[`VDataTableHeader.ts desktop should work with sortDesc correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -467,6 +490,7 @@ exports[`VDataTableHeader.ts desktop should work with sortDesc correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -482,6 +506,7 @@ exports[`VDataTableHeader.ts desktop should work with sortDesc correctly 1`] = `
       </span>
       <i aria-hidden="true"
          class="v-icon material-icons theme--light"
+         style="font-size: 18px;"
       >
         $vuetify.icons.sort
       </i>
@@ -623,6 +648,7 @@ exports[`VDataTableHeader.ts mobile should work with multiSort 1`] = `
                       <div class="v-chip__close sortable active desc">
                         <i aria-hidden="true"
                            class="v-icon material-icons theme--light"
+                           style="font-size: 18px;"
                         >
                           $vuetify.icons.sort
                         </i>
@@ -731,6 +757,7 @@ exports[`VDataTableHeader.ts mobile should work with sortBy correctly 1`] = `
                       <div class="v-chip__close sortable active desc">
                         <i aria-hidden="true"
                            class="v-icon material-icons theme--light"
+                           style="font-size: 18px;"
                         >
                           $vuetify.icons.sort
                         </i>
@@ -791,6 +818,7 @@ exports[`VDataTableHeader.ts mobile should work with sortDesc correctly 1`] = `
                       <div class="v-chip__close sortable active asc">
                         <i aria-hidden="true"
                            class="v-icon material-icons theme--light"
+                           style="font-size: 18px;"
                         >
                           $vuetify.icons.sort
                         </i>

--- a/packages/vuetify/src/components/VDataTable/mixins/__tests__/__snapshots__/header.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/mixins/__tests__/__snapshots__/header.spec.ts.snap
@@ -82,6 +82,7 @@ exports[`VDataTable/header.ts should generate sort icon 1`] = `
 
 <i aria-hidden="true"
    class="v-icon mdi mdi-sort theme--light"
+   style="font-size: 18px;"
 >
 </i>
 

--- a/packages/vuetify/src/components/VDataTable/mixins/header.ts
+++ b/packages/vuetify/src/components/VDataTable/mixins/header.ts
@@ -83,7 +83,11 @@ export default mixins<options>().extend({
       })
     },
     genSortIcon () {
-      return this.$createElement(VIcon, [this.sortIcon])
+      return this.$createElement(VIcon, {
+        props: {
+          size: 18
+        }
+      }, [this.sortIcon])
     }
   }
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
header sort icons should respect size and rotate regardless of type

## Motivation and Context
closes #7338

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-data-table fixed-header :headers="headers"></v-data-table>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name'
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' }
        ]
      }
    }
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
