### PR TITLE
fix(VTextarea): recalculate height on model update

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -89,7 +89,6 @@ export default baseMixins.extend<options>().extend({
     prefixWidth: 0,
     prependWidth: 0,
     initialValue: null,
-    internalChange: false,
     isBooted: false,
     isClearing: false
   }),
@@ -398,11 +397,6 @@ export default baseMixins.extend<options>().extend({
     },
     onBlur (e?: Event) {
       this.isFocused = false
-      // Reset internalChange state
-      // to allow external change
-      // to persist
-      this.internalChange = false
-
       this.$emit('blur', e)
     },
     onClick () {
@@ -424,13 +418,10 @@ export default baseMixins.extend<options>().extend({
     },
     onInput (e: Event) {
       const target = e.target as HTMLInputElement
-      this.internalChange = true
       this.internalValue = target.value
       this.badInput = target.validity && target.validity.badInput
     },
     onKeyDown (e: KeyboardEvent) {
-      this.internalChange = true
-
       if (e.keyCode === keyCodes.enter) this.$emit('change', this.internalValue)
 
       this.$emit('keydown', e)

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -396,20 +396,6 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     expect(wrapper.vm.$refs.input.value).toBe('0')
   })
 
-  it('should reset internal change on blur and keydown', async () => {
-    const wrapper = mountFunction()
-
-    wrapper.setProps({ value: 'foo' })
-    wrapper.vm.internalChange = true
-    expect(wrapper.vm.internalChange).toBe(true)
-    wrapper.vm.onBlur()
-    expect(wrapper.vm.internalChange).toBe(false)
-
-    wrapper.find('input').trigger('keydown')
-
-    expect(wrapper.vm.internalChange).toBe(true)
-  })
-
   it('should autofocus', async () => {
     const wrapper = mountFunction({
       attachToDocument: true,
@@ -536,19 +522,6 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     })
 
     expect(wrapper.find('.v-input__icon--append-outer .v-icon').element.innerHTML).toBe('search')
-  })
-
-  // TODO: revisit this, it seems correct in practice because of onBlur()
-  it.skip('should reset internal change', async () => {
-    const wrapper = mountFunction()
-
-    wrapper.setData({ internalChange: true })
-
-    expect(wrapper.vm.internalChange).toBe(true)
-
-    wrapper.setProps({ value: 'foo' })
-
-    expect(wrapper.vm.internalChange).toBe(false)
   })
 
   it('should have correct max value', async () => {

--- a/packages/vuetify/src/components/VTextarea/VTextarea.ts
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.ts
@@ -57,7 +57,7 @@ export default baseMixins.extend({
 
   watch: {
     lazyValue () {
-      !this.internalChange && this.autoGrow && this.$nextTick(this.calculateInputHeight)
+      this.autoGrow && this.$nextTick(this.calculateInputHeight)
     }
   },
 
@@ -100,7 +100,6 @@ export default baseMixins.extend({
         e.stopPropagation()
       }
 
-      this.internalChange = true
       this.$emit('keydown', e)
     }
   }


### PR DESCRIPTION
## Description
`internalChange` was used only for masks. Change my mind

## Motivation and Context
fixes #4683
fixes #6978

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-content>
      <v-container>
        <v-textarea
          auto-grow
          v-model="message"
          @keydown.prevent.enter="message = ''"
          :rows="1"
        ></v-textarea>
      </v-container>
    </v-content>
  </v-app>
</template>

<script>
export default {
  data: () => ({
    message: Array(40).fill('aaaaa ').join('')
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
