### PR TITLE
Docs(VTextField): outline -> outlined

### DIFF
--- a/packages/docs/src/lang/en/components/TextFields.json
+++ b/packages/docs/src/lang/en/components/TextFields.json
@@ -11,7 +11,7 @@
     },
     "shaped": {
       "header": "### Shaped",
-      "desc": "`shaped` text fields are rounded if they're `outline` and have higher `border-radius` if `filled`."
+      "desc": "`shaped` text fields are rounded if they're `outlined` and have higher `border-radius` if `filled`."
     },
     "disabledAndReadonly": {
       "header": "### Disabled and readonly",
@@ -39,7 +39,7 @@
     },
     "characterCounter": {
       "header": "### Character counter",
-      "desc": "Use a `counter` prop to inform a user of the character limit. The counter does not perform any validation by itself. You will need to pair it with either the internal validation system, or a 3rd party library. You can use it on regular, box or outline text fields."
+      "desc": "Use a `counter` prop to inform a user of the character limit. The counter does not perform any validation by itself. You will need to pair it with either the internal validation system, or a 3rd party library. You can use it on regular, box or outlined text fields."
     },
     "password": {
       "header": "### Password input",
@@ -73,7 +73,7 @@
       "header": "### Solo style",
       "desc": "Text fields can be used with an alternative solo design."
     },
-    "outline": {
+    "outlined": {
       "header": "### Outline style",
       "desc": "Text fields can be used with an alternative outline design."
     },
@@ -117,7 +117,7 @@
     "toggleKeys": "Array of key codes that will toggle the input (if it supports toggling)",
     "type": "Sets input type",
     "value": "Components.Inputs.props.value",
-    "shaped": "Round if `outline` and increase `border-radius` if `filled`. Must be used with either `outline` or `filled`"
+    "shaped": "Round if `outlined` and increase `border-radius` if `filled`. Must be used with either `outlined` or `filled`"
   },
   "slots": {
     "append": "Components.Inputs.slots.append",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->
Just replacing outline with outlined

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Removes old use of outline instead of outlined

## How Has This Been Tested?
none 

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
