### PR TITLE
fix: prevent duplicated theme stylesheet id

### DIFF
--- a/packages/vuetify/src/services/theme/index.ts
+++ b/packages/vuetify/src/services/theme/index.ts
@@ -156,7 +156,7 @@ export class Theme extends Service {
   // Generate the style element
   // if applicable
   private genStyleElement (): void {
-    if (typeof document === 'undefined') return
+    if (typeof document === 'undefined' || document.getElementById('vuetify-theme-stylesheet')) return
 
     /* istanbul ignore next */
     const options = this.options || {}

--- a/packages/vuetify/src/services/theme/index.ts
+++ b/packages/vuetify/src/services/theme/index.ts
@@ -70,7 +70,7 @@ export class Theme extends Service {
   // When setting css, check for element
   // and apply new values
   set css (val: string) {
-    this.checkStyleElement() && (this.styleEl!.innerHTML = val)
+    this.checkOrCreateStyleElement() && (this.styleEl!.innerHTML = val)
   }
 
   set dark (val: boolean) {
@@ -131,13 +131,14 @@ export class Theme extends Service {
   }
 
   // Check for existence of style element
-  private checkStyleElement (): boolean {
+  private checkOrCreateStyleElement (): boolean {
+    this.styleEl = document.getElementById('vuetify-theme-stylesheet') as HTMLStyleElement
+
     /* istanbul ignore next */
     if (this.styleEl) return true
 
     this.genStyleElement() // If doesn't have it, create it
 
-    this.styleEl = document.getElementById('vuetify-theme-stylesheet') as HTMLStyleElement
     return Boolean(this.styleEl)
   }
 
@@ -156,7 +157,7 @@ export class Theme extends Service {
   // Generate the style element
   // if applicable
   private genStyleElement (): void {
-    if (typeof document === 'undefined' || document.getElementById('vuetify-theme-stylesheet')) return
+    if (typeof document === 'undefined') return
 
     /* istanbul ignore next */
     const options = this.options || {}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
When using SSR, `vue-theme-stylesheet` is already in DOM, but there's missing check that make client add an empty `style` tag with a duplicated id. Having two same `id` in DOM is not HTML valid.

Assuming comment here https://github.com/vuetifyjs/vuetify/blob/next/packages/vuetify/src/services/theme/index.ts#L138, I think it's just a check that have been forgotten but already thought.

## How Has This Been Tested?
I checked locally with an SSR project that there was no duplicatd tag with same id anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

