### PR TITLE
fix(VToolbar): styles missing width 100%

### DIFF
--- a/packages/vuetify/src/components/VToolbar/VToolbar.sass
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.sass
@@ -3,6 +3,7 @@
 
 // Block
 .v-toolbar
+  width: 100%
   // Needs increased specificity
   &.v-sheet
     transition: $toolbar-transition


### PR DESCRIPTION
## Description
The width was most likely missing when being converted to sass

## Motivation and Context
Without the width it changes the behavior of `v-toolbar`

## How Has This Been Tested?
none - this is a single line css change

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>

  <v-app>
    <v-content>
      <v-container fluid>
        <v-card>
          <v-card-title>
            <v-toolbar>
              <v-toolbar-title>Title</v-toolbar-title>
            </v-toolbar>
          </v-card-title>
          <v-card-text>Hello world</v-card-text>
        </v-card>
      </v-container>
    </v-content>
  </v-app>
</div>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
