### PR TITLE
feat(VAutocomplete): highlight masked characters when ignoring diactrics

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -10,6 +10,7 @@ import { keyCodes } from '../../util/helpers'
 
 // Types
 import { PropType } from 'vue'
+import { PropValidator } from 'vue/types/options'
 
 const defaultMenuProps = {
   ...VSelectMenuProps,
@@ -34,7 +35,7 @@ export default VSelect.extend({
     filter: {
       type: Function,
       default: (item: any, queryText: string, itemText: string) => {
-        return itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
+        return itemText.includes(queryText)
       },
     },
     hideNoData: Boolean,
@@ -51,6 +52,10 @@ export default VSelect.extend({
       type: Boolean,
       default: false,
     },
+    sanitizeText: {
+      type: Function,
+      default: (text: string) => text.toLocaleLowerCase(),
+    } as PropValidator<(text: string) => string>,
   },
 
   data () {
@@ -87,7 +92,8 @@ export default VSelect.extend({
     filteredItems (): object[] {
       if (!this.isSearching || this.noFilter || this.internalSearch == null) return this.allItems
 
-      return this.allItems.filter(item => this.filter(item, String(this.internalSearch), String(this.getText(item))))
+      const internalSearch = this.sanitizeText(String(this.internalSearch))
+      return this.allItems.filter(item => this.filter(item, internalSearch, this.sanitizeText(String(this.getText(item)))))
     },
     internalSearch: {
       get (): string | undefined {
@@ -149,6 +155,7 @@ export default VSelect.extend({
           !this.isSearching ||
           !this.filteredItems.length
         ),
+        sanitizeText: this.sanitizeText,
         searchInput: this.internalSearch,
       }
 

--- a/packages/vuetify/src/components/VSelect/VSelectList.ts
+++ b/packages/vuetify/src/components/VSelect/VSelectList.ts
@@ -65,6 +65,10 @@ export default mixins(Colorable, Themeable).extend({
       type: Array,
       default: () => [],
     } as PropValidator<any[]>,
+    sanitizeText: {
+      type: Function,
+      default: (text: string) => text.toLocaleLowerCase(),
+    } as PropValidator<(text: string) => string>,
   },
 
   computed: {
@@ -130,8 +134,8 @@ export default mixins(Colorable, Themeable).extend({
       middle: string
       end: string
     } {
-      const searchInput = (this.searchInput || '').toString().toLocaleLowerCase()
-      const index = text.toLocaleLowerCase().indexOf(searchInput)
+      const searchInput = this.sanitizeText((this.searchInput || '').toString())
+      const index = this.sanitizeText(text).indexOf(searchInput)
 
       if (index < 0) return { start: '', middle: text, end: '' }
 


### PR DESCRIPTION
## Description
Adds prop - function that processes the text before filtering and highlighting masked characters

The prop name needs to be changed (hence the draft), but I don' have a good name atm

## Motivation and Context
fixes #3194 

Also simplifies the filtering function code:
```js
filterSelectInput (item, queryText, itemText) {
  const hasValue = val => val != null ? val : ''
  let text = _.deburr(hasValue(itemText).toString().toLowerCase())
  let query = _.deburr(hasValue(queryText).toString().toLowerCase())
  return text.indexOf(query) > -1;
}
```

vs

```js
deburr: text => _.deburr(text).toLowerCase()
```


## How Has This Been Tested?
No

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-autocomplete
      label="Countries"
      :items="countries"
      :sanitize-text="deburr"
    />
  </v-container>
</template>

<script>
export default {
  methods: {
    deburr: text => text.replace('Î', 'I').replace('É', 'E').toLowerCase()
  },

 data: () => ({
    countries: [
      { "text": "Afghanistan", "value": "AF" },
      { "text": "Afrique du Sud", "value": "ZA" },
      { "text": "Île Bouvet", "value": "BV" },
      { "text": "Antigua-et-Barbuda", "value": "AG" },
      { "text": "Éthiopie", "value": "ET" },
      { "text": "États-Unis", "value": "US" },
    ]
  }),
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
