### PR TITLE
fix(getObjectValueByPath): fix getObjectValueByPath

### DIFF
--- a/packages/vuetify/src/util/__tests__/helpers.spec.ts
+++ b/packages/vuetify/src/util/__tests__/helpers.spec.ts
@@ -6,6 +6,7 @@ import {
   convertToUnit,
   getSlotType,
   arrayDiff,
+  getObjectValueByPath,
 } from '../helpers'
 
 describe('helpers', () => {
@@ -111,6 +112,24 @@ describe('helpers', () => {
     expect(deepEqual({ r: [circular] }, { r: [circular] })).toEqual(true)
   })
 
+  it('should get value directly on object if not undefined', () => {
+    const obj = {
+      a: 'foo',
+      'b.a': 'foobar',
+      b: {
+        a: 1,
+      },
+      'c.d': undefined,
+      c: {
+        d: 'bar',
+      },
+    }
+
+    expect(getObjectValueByPath(obj, 'a')).toEqual('foo')
+    expect(getObjectValueByPath(obj, 'b.a')).toEqual('foobar')
+    expect(getObjectValueByPath(obj, 'c.d')).toEqual('bar')
+  })
+
   it('should get nested value', () => {
     const obj = {
       a: {
@@ -166,7 +185,7 @@ describe('helpers', () => {
     expect(getPropertyFromItem(obj, 'c.2.d.x', 'fallback')).toEqual('fallback')
     expect(getPropertyFromItem(obj, o => o.a.b + o.c[0])).toEqual(3)
     expect(getPropertyFromItem(obj, ['c', 2, 'd'])).toEqual('d')
-    expect(getPropertyFromItem(obj, 'x.y')).toEqual('nested')
+    expect(getPropertyFromItem(obj, 'x.y')).toEqual('comp')
     expect(getPropertyFromItem(obj, ['x', 'y'])).toEqual('nested')
     expect(getPropertyFromItem(obj, ['x.y'])).toEqual('comp')
   })

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -214,9 +214,10 @@ export function deepEqual (a: any, b: any): boolean {
   return props.every(p => deepEqual(a[p], b[p]))
 }
 
-export function getObjectValueByPath (obj: object, path: string, fallback?: any): any {
+export function getObjectValueByPath (obj: any, path: string, fallback?: any): any {
   // credit: http://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-with-string-key#comment55278413_6491621
-  if (!path || path.constructor !== String) return fallback
+  if (obj == null || !path || path.constructor !== String) return fallback
+  if (obj[path] !== undefined) return obj[path]
   path = path.replace(/\[(\w+)\]/g, '.$1') // convert indexes to properties
   path = path.replace(/^\./, '') // strip a leading dot
   return getNestedValue(obj, path.split('.'), fallback)

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -216,7 +216,7 @@ export function deepEqual (a: any, b: any): boolean {
 
 export function getObjectValueByPath (obj: any, path: string, fallback?: any): any {
   // credit: http://stackoverflow.com/questions/6491463/accessing-nested-javascript-objects-with-string-key#comment55278413_6491621
-  if (obj == null || !path || path.constructor !== String) return fallback
+  if (obj == null || !path || typeof path !== 'string') return fallback
   if (obj[path] !== undefined) return obj[path]
   path = path.replace(/\[(\w+)\]/g, '.$1') // convert indexes to properties
   path = path.replace(/^\./, '') // strip a leading dot


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Return early if key exists directly on object to improve performance

## Motivation and Context
solves #7302 

## How Has This Been Tested?
playground, unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field v-model="search" label="search"></v-text-field>
    <v-data-table
        :headers="headers"
        :items="moreDesserts"
        :search="search"
      ></v-data-table>
  </v-container>
</template>

<script>
  export default {
    data () {
      return {
        search: '',
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name'
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' }
        ],
        desserts: [
          {
            value: false,
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%'
          },
          {
            value: false,
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%'
          },
          {
            value: false,
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%'
          },
          {
            value: false,
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%'
          },
          {
            value: false,
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%'
          },
          {
            value: false,
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%'
          },
          {
            value: false,
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%'
          },
          {
            value: false,
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%'
          },
          {
            value: false,
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%'
          },
          {
            value: false,
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%'
          }
        ],
        count:0,
      }
    },
    watch: {
      moreDesserts(newList){
        this.count = newList.length
      }
    },
    computed: {
      moreDesserts() {
        let all = []
        for (let i = 0; i < 20000; i++) {
          this.desserts.forEach((c) => {
            all.push({ ...c, name: `${c.name}_${i}` })
          })
        }
        return all
      }
    }
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
