### PR TITLE
fix(VSystemBar): set status height

### DIFF
--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.ts
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.ts
@@ -46,8 +46,7 @@ export default mixins(
       if (this.height) {
         return isNaN(parseInt(this.height)) ? this.height : parseInt(this.height)
       }
-
-      return this.window ? 32 : 24
+      return this.status ? 16 : this.window ? 32 : 24
     },
     styles (): object {
       return {


### PR DESCRIPTION
## Description
Sets the computedHeight to 16px when `status` prop is set

## Motivation and Context
documentation states `status` prop reduces the system bar height.

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-system-bar
      status
      color="primary"
    >
      <v-icon>mdi-gmail</v-icon>status
    </v-system-bar>
    <v-system-bar color="green">
      <v-icon>mdi-gmail</v-icon>normal
    </v-system-bar>
    <v-system-bar
      window
      color="orange"
    >
      <v-icon>mdi-gmail</v-icon>window
    </v-system-bar>
  </div>
</template>

<script>
  export default {
    data () {
      return {}
    },
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
