### PR TITLE
refactor(VSystemBar): remove status prop

### DIFF
--- a/packages/docs/src/lang/en/components/SystemBars.json
+++ b/packages/docs/src/lang/en/components/SystemBars.json
@@ -20,7 +20,6 @@
   },
   "props": {
     "lightsOut": "Reduces the system bar opacity",
-    "status": "Reduces the system bar height",
     "window": "Increases the system bar height"
   }
 }

--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
@@ -21,6 +21,7 @@
 
   .v-icon
     font-size: $system-bar-icon-font-size
+    margin-right: $system-bar-icon-margin-right
 
   &--fixed, &--absolute
     left: 0
@@ -33,10 +34,6 @@
 
   &--absolute
     position: absolute
-
-  &--status
-    .v-icon
-      margin-right: $system-bar-status-icon-margin-right
 
   &--window
     .v-icon

--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.ts
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.ts
@@ -27,7 +27,6 @@ export default mixins(
   props: {
     height: [Number, String],
     lightsOut: Boolean,
-    status: Boolean,
     window: Boolean,
   },
 
@@ -37,7 +36,6 @@ export default mixins(
         'v-system-bar--lights-out': this.lightsOut,
         'v-system-bar--absolute': this.absolute,
         'v-system-bar--fixed': !this.absolute && (this.app || this.fixed),
-        'v-system-bar--status': this.status,
         'v-system-bar--window': this.window,
         ...this.themeClasses,
       }

--- a/packages/vuetify/src/components/VSystemBar/_variables.scss
+++ b/packages/vuetify/src/components/VSystemBar/_variables.scss
@@ -2,6 +2,6 @@ $system-bar-font-size: map-deep-get($headings, 'body-2', 'size') !default;
 $system-bar-font-weight: map-deep-get($headings, 'body-2', 'weight') !default;
 $system-bar-icon-font-size: map-deep-get($headings, 'subtitle-1', 'size') !default;
 $system-bar-padding: 0 8px !default;
-$system-bar-status-icon-margin-right: 4px !default;
+$system-bar-icon-margin-right: 4px !default;
 $system-bar-window-icon-margin-right: 8px !default;
 $system-bar-window-icon-font-size: map-deep-get($headings, 'h6', 'size') !default;


### PR DESCRIPTION
## Description
removes the `status` prop from VSystemBar.

## Motivation and Context
It serves no functional value.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-system-bar color="green">
      <v-icon>mdi-gmail</v-icon>normal
    </v-system-bar>
    <v-system-bar
      window
      color="orange"
    >
      <v-icon>mdi-gmail</v-icon>window
    </v-system-bar>
  </div>
</template>

<script>
  export default {
    data () {
      return {}
    },
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
