### PR TITLE
feat(VColorPicker): support percentage widths

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPicker.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPicker.ts
@@ -8,6 +8,9 @@ import VColorPickerCanvas from './VColorPickerCanvas'
 import VColorPickerEdit, { Mode, modes } from './VColorPickerEdit'
 import VColorPickerSwatches from './VColorPickerSwatches'
 
+// Directives
+import { resize } from '../../directives'
+
 // Helpers
 import { VColorPickerColor, parseColor, fromRGBA, extractColor } from './util'
 import mixins from '../../util/mixins'
@@ -19,6 +22,8 @@ import { PropValidator } from 'vue/types/options'
 
 export default mixins(Themeable).extend({
   name: 'v-color-picker',
+
+  directives: { resize },
 
   props: {
     canvasHeight: {
@@ -56,7 +61,14 @@ export default mixins(Themeable).extend({
 
   data: () => ({
     internalValue: fromRGBA({ r: 255, g: 0, b: 0, a: 1 }),
+    elementWidth: 300,
   }),
+
+  computed: {
+    isPercentageWidth (): boolean {
+      return typeof this.width === 'string' && this.width.indexOf('%') > 0
+    },
+  },
 
   watch: {
     value: {
@@ -68,6 +80,9 @@ export default mixins(Themeable).extend({
   },
 
   methods: {
+    calculateWidth () {
+      this.elementWidth = this.$el.getBoundingClientRect().width
+    },
     updateColor (color: VColorPickerColor) {
       this.internalValue = color
       const value = extractColor(this.internalValue, this.value)
@@ -83,7 +98,7 @@ export default mixins(Themeable).extend({
           color: this.internalValue,
           disabled: this.disabled,
           dotSize: this.dotSize,
-          width: this.width,
+          width: this.isPercentageWidth ? this.elementWidth : this.width,
           height: this.canvasHeight,
         },
         on: {
@@ -150,6 +165,12 @@ export default mixins(Themeable).extend({
       props: {
         maxWidth: this.width,
       },
+      directives: this.isPercentageWidth ? [
+        {
+          name: 'resize',
+          value: this.calculateWidth,
+        },
+      ] : undefined,
     }, [
       !this.hideCanvas && this.genCanvas(),
       this.genControls(),

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.ts
@@ -56,6 +56,9 @@ export default Vue.extend({
 
   watch: {
     'color.hue': 'updateCanvas',
+    width () {
+      this.$nextTick(this.updateCanvas)
+    },
   },
 
   mounted () {


### PR DESCRIPTION
## Description
color-picker now supports percentage widths

## Motivation and Context
canvas width has to be set in px, so previously percentage widths did not work

closes #7151

## How Has This Been Tested?
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-color-picker width="100%"/>
  </v-container>
</template>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
