### PR TITLE
Fix japanese translation of DataTable

### DIFF
--- a/packages/docs/src/lang/ja-JP/components/DataTables.json
+++ b/packages/docs/src/lang/ja-JP/components/DataTables.json
@@ -3,7 +3,7 @@
   "headerText": "`v-data-table` コンポーネントは表形式のデータを表示するために使われます。ソート、検索、ページネーション、インライン編集、ヘッダーツールチップ、行の選択 などの機能を含んでいます。",
   "components": ["v-data-table', 'v-edit-dialog"],
   "examples": {
-    "standard": {
+    "usage": {
       "header": "基本的な使い方",
       "desc": "基本的な Data table は付加的な機能を含まないデータを格納します。 `hide-actions` prop を使用することで、ページネーションを制御するテーブルアクションの表示を外すことができます。"
     },


### PR DESCRIPTION
## Description
Fix japanese translation of DataTable

## Motivation and Context
Issue: https://github.com/vuetifyjs/vuetify/issues/7597
Make same with the property of en
https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/lang/en/components/DataTables.json#L5

## How Has This Been Tested?
none

## Markup:
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
