### PR TITLE
fix(Ripple): add ripple property to denote touch enabled

### DIFF
--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -136,6 +136,13 @@ function rippleShow (e: MouseEvent | TouchEvent) {
   if (!element || !element._ripple || element._ripple.touched) return
   if (isTouchEvent(e)) {
     element._ripple.touched = true
+    element._ripple.isTouch = true
+  } else {
+    // It's possible for touch events to fire
+    // as mouse events on Android/iOS, this
+    // will skip the event call if it has
+    // already been registered as touch
+    if (element._ripple.isTouch) return
   }
   value.center = element._ripple.centered
   if (element._ripple.class) {

--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -40,6 +40,7 @@ declare global {
       class?: string
       circle?: boolean
       touched?: boolean
+      isTouch?: boolean
     }
     _onScroll?: {
       callback: EventListenerOrEventListenerObject


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Mouse events can fire with touch on Android/iOS, this sets a ripple prop to allow that to be ignored
on touch devices.
<!--- Describe your changes in detail -->

## Motivation and Context
fixes #7605
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Android/iOS through Browserstack
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div
    v-ripple
    class="text-xs-center elevation-2 pa-5 headline"
  >
    HTML element with v-ripple
  </div>
</template>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
