### PR TITLE
fix(VSparkline): negative values, labels being cut off

### DIFF
--- a/packages/docs/src/examples/sparklines/playground.vue
+++ b/packages/docs/src/examples/sparklines/playground.vue
@@ -5,23 +5,33 @@
       :gradient="gradient"
       :smooth="radius || false"
       :padding="padding"
-      :line-width="width"
+      :line-width="lineWidth"
       :stroke-linecap="lineCap"
       :gradient-direction="gradientDirection"
       :fill="fill"
       :type="type"
       :auto-line-width="autoLineWidth"
       auto-draw
+      :show-labels="showLabels"
+      :label-size="labelSize"
     ></v-sparkline>
 
     <v-divider></v-divider>
 
     <v-layout wrap>
-      <v-flex
-        xs12
-        md6
-      >
+      <v-flex xs12>
         <v-layout fill-height align-center>
+          <v-subheader class="pl-0">Type</v-subheader>
+          <v-btn-toggle v-model="type" mandatory>
+            <v-btn small text value="bar">bar</v-btn>
+            <v-btn small text value="trend">trend</v-btn>
+          </v-btn-toggle>
+        </v-layout>
+      </v-flex>
+
+      <v-flex xs6>
+        <v-layout fill-height align-center>
+          <v-subheader class="pl-0">Gradient</v-subheader>
           <v-item-group v-model="gradient" mandatory>
             <v-layout>
               <v-item
@@ -49,16 +59,46 @@
         </v-layout>
       </v-flex>
 
-      <v-flex
-        xs12
-        md6
-      >
+      <v-flex xs6>
+        <v-layout fill-height align-center>
+          <v-subheader class="pl-0">Gradient direction</v-subheader>
+          <v-btn-toggle v-model="gradientDirection" mandatory>
+            <v-btn small text value="top">top</v-btn>
+            <v-btn small text value="right">right</v-btn>
+            <v-btn small text value="left">left</v-btn>
+            <v-btn small text value="bottom">bottom</v-btn>
+          </v-btn-toggle>
+        </v-layout>
+      </v-flex>
+
+      <v-flex xs12>
         <v-slider
-          v-model="width"
-          label="Width"
+          v-model="lineWidth"
+          label="Line width"
           min="0.1"
           max="10"
           step="0.1"
+          thumb-label
+          :disabled="autoLineWidth"
+        ></v-slider>
+      </v-flex>
+
+      <v-flex xs12>
+        <v-slider
+          v-model="radius"
+          label="Radius"
+          min="0"
+          max="16"
+          thumb-label
+        ></v-slider>
+      </v-flex>
+
+      <v-flex xs12>
+        <v-slider
+          v-model="padding"
+          label="Padding"
+          min="0"
+          max="16"
           thumb-label
         ></v-slider>
       </v-flex>
@@ -66,68 +106,30 @@
       <v-flex xs6>
         <v-layout fill-height align-center>
           <v-subheader class="pl-0">Linecap</v-subheader>
-          <v-btn-toggle v-model="lineCap" mandatory>
-            <v-btn text value="butt">butt</v-btn>
-            <v-btn text value="round">round</v-btn>
-            <v-btn text value="square">square</v-btn>
-          </v-btn-toggle>
-        </v-layout>
-
-        <v-layout fill-height align-center>
-          <v-subheader class="pl-0">Gradient direction</v-subheader>
-          <v-btn-toggle v-model="gradientDirection" mandatory>
-            <v-btn text value="top">top</v-btn>
-            <v-btn text value="right">right</v-btn>
-            <v-btn text value="left">left</v-btn>
-            <v-btn text value="bottom">bottom</v-btn>
+          <v-btn-toggle v-model="lineCap" mandatory :disabled="type !== 'trend'">
+            <v-btn small text value="butt">butt</v-btn>
+            <v-btn small text value="round">round</v-btn>
+            <v-btn small text value="square">square</v-btn>
           </v-btn-toggle>
         </v-layout>
       </v-flex>
 
-      <v-flex
-        xs12
-        md6
-      >
-        <v-slider
-          v-model="radius"
-          label="Radius"
-          min="0"
-          max="25"
-          thumb-label
-        ></v-slider>
-      </v-flex>
-
-      <v-flex
-        xs12
-        md6
-        offset-md6
-      >
-        <v-slider
-          v-model="padding"
-          label="Padding"
-          min="0"
-          max="25"
-          thumb-label
-        ></v-slider>
-      </v-flex>
-
-      <v-flex xs6 offset-md6>
-        <v-layout fill-height align-center>
-          <v-subheader class="pl-0">Type</v-subheader>
-          <v-btn-toggle v-model="type" mandatory>
-            <v-btn text value="bar">bar</v-btn>
-            <v-btn text value="trend">trend</v-btn>
-          </v-btn-toggle>
-        </v-layout>
-      </v-flex>
-
-      <v-flex
-        xs12
-      >
+      <v-flex xs6>
         <v-layout row wrap justify-space-around>
-          <v-switch v-model="fill" label="Fill"></v-switch>
-          <v-switch v-model="autoLineWidth" label="autoLineWidth"></v-switch>
+          <v-switch v-model="showLabels" label="Show labels"></v-switch>
+          <v-switch v-model="fill" label="Fill" :disabled="type !== 'trend'"></v-switch>
+          <v-switch v-model="autoLineWidth" label="Auto-line-width" :disabled="type !== 'bar'"></v-switch>
         </v-layout>
+      </v-flex>
+
+      <v-flex xs12 v-if="showLabels">
+        <v-slider
+          v-model="labelSize"
+          label="Label size"
+          min="1"
+          max="20"
+          thumb-label
+        ></v-slider>
       </v-flex>
     </v-layout>
   </v-container>
@@ -145,12 +147,14 @@
 
   export default {
     data: () => ({
-      width: 2,
+      showLabels: false,
+      lineWidth: 2,
+      labelSize: 7,
       radius: 10,
       padding: 8,
       lineCap: 'round',
       gradient: gradients[5],
-      value: [0, 2, 5, 9, 5, 10, 3, 5, 0, 0, 1, 8, 2, 9, 0],
+      value: [0, 2, 5, 9, 5, 10, 3, 5, -4, -10, 1, 8, 2, 9, 0],
       gradientDirection: 'top',
       gradients,
       fill: false,

--- a/packages/docs/src/lang/en/components/Sparklines.json
+++ b/packages/docs/src/lang/en/components/Sparklines.json
@@ -32,12 +32,14 @@
     "fill": "Using the **fill** property allows you to better customize the look and feel of your sparkline.",
     "gradient": "An array of colors to use as a linear-gradient",
     "gradientDirection": "The direction the gradient should run",
+    "height": "Height of the SVG trendline or bars",
     "labels": "An array of string labels that correspond to the same index as its data counterpart",
     "labelSize": "The label font size",
     "lineWidth": "The thickness of the line, in px",
     "padding": "Low `smooth` or high `line-width` values may result in cropping, increase padding to compensate",
     "showLabels": "Show labels below each data point",
     "smooth": "Number of px to use as a corner radius. `true` defaults to 8, `false` is 0",
-    "type": "Choose between a trendline or bars"
+    "type": "Choose between a trendline or bars",
+    "width": "Width of the SVG trendline or bars"
   }
 }

--- a/packages/vuetify/src/components/VSparkline/VSparkline.ts
+++ b/packages/vuetify/src/components/VSparkline/VSparkline.ts
@@ -3,7 +3,7 @@ import Colorable from '../../mixins/colorable'
 
 // Utilities
 import mixins, { ExtractVue } from '../../util/mixins'
-import { genPoints } from './helpers/core'
+import { genPoints, genBars } from './helpers/core'
 import { genPath } from './helpers/path'
 
 // Types
@@ -30,6 +30,13 @@ export interface Point {
   value: number
 }
 
+export interface Bar {
+  x: number
+  y: number
+  height: number
+  value: number
+}
+
 export interface BarText {
   points: Point[]
   boundary: Boundary
@@ -52,6 +59,8 @@ export default mixins<options &
   Colorable
 ).extend({
   name: 'VSparkline',
+
+  inheritAttrs: false,
 
   props: {
     autoDraw: Boolean,
@@ -135,25 +144,46 @@ export default mixins<options &
     parsedWidth (): number {
       return Number(this.width)
     },
-    totalBars (): number {
+    parsedHeight (): number {
+      return parseInt(this.height, 10)
+    },
+    parsedLabelSize (): number {
+      return parseInt(this.labelSize, 10) || 7
+    },
+    totalHeight (): number {
+      let height = this.parsedHeight
+
+      if (this.hasLabels) height += parseInt(this.labelSize, 10) * 1.5
+
+      return height
+    },
+    totalWidth (): number {
+      let width = this.parsedWidth
+      if (this.type === 'bar') width = Math.max(this.value.length * this._lineWidth, width)
+
+      return width
+    },
+    totalValues (): number {
       return this.value.length
     },
     _lineWidth (): number {
       if (this.autoLineWidth && this.type !== 'trend') {
-        const totalPadding = this.parsedPadding * (this.totalBars + 1)
-        return (this.parsedWidth - totalPadding) / this.totalBars
+        const totalPadding = this.parsedPadding * (this.totalValues + 1)
+        return (this.parsedWidth - totalPadding) / this.totalValues
       } else {
-        return Number(this.lineWidth) || 4
+        return parseFloat(this.lineWidth) || 4
       }
     },
     boundary (): Boundary {
-      const height = Number(this.height)
+      if (this.type === 'bar') return { minX: 0, maxX: this.totalWidth, minY: 0, maxY: this.parsedHeight }
+
+      const padding = this.parsedPadding
 
       return {
-        minX: this.parsedPadding,
-        minY: this.parsedPadding,
-        maxX: this.parsedWidth - this.parsedPadding,
-        maxY: height - this.parsedPadding,
+        minX: padding,
+        maxX: this.totalWidth - padding,
+        minY: padding,
+        maxY: this.parsedHeight - padding,
       }
     },
     hasLabels (): boolean {
@@ -165,7 +195,7 @@ export default mixins<options &
     },
     parsedLabels (): SparklineText[] {
       const labels = []
-      const points = this.points
+      const points = this._values
       const len = points.length
 
       for (let i = 0; labels.length < len; i++) {
@@ -173,24 +203,32 @@ export default mixins<options &
         let value = this.labels[i]
 
         if (!value) {
-          value = item === Object(item)
+          value = typeof item === 'object'
             ? item.value
             : item
         }
 
         labels.push({
-          ...item,
+          x: item.x,
           value: String(value),
         })
       }
 
       return labels
     },
-    points (): Point[] {
-      return genPoints(this.value.slice(), this.boundary, this.type)
+    normalizedValues (): number[] {
+      return this.value.map(item => (typeof item === 'number' ? item : item.value))
+    },
+    _values (): Point[] | Bar[] {
+      return this.type === 'trend' ? genPoints(this.normalizedValues, this.boundary) : genBars(this.normalizedValues, this.boundary)
     },
     textY (): number {
-      return this.boundary.maxY + 6
+      let y = this.parsedHeight
+      if (this.type === 'trend') y -= 4
+      return y
+    },
+    _radius (): number {
+      return this.smooth === true ? 8 : Number(this.smooth)
     },
   },
 
@@ -266,76 +304,54 @@ export default mixins<options &
         },
       }, children)
     },
-    genLabels () {
-      if (!this.hasLabels) return undefined
-
-      return this.genG(this.parsedLabels.map(this.genText))
-    },
     genPath () {
-      const radius = this.smooth === true ? 8 : Number(this.smooth)
+      const points = genPoints(this.normalizedValues, this.boundary)
 
       return this.$createElement('path', {
         attrs: {
           id: this._uid,
-          d: genPath(this.points.slice(), radius, this.fill, Number(this.height)),
+          d: genPath(points, this._radius, this.fill, this.parsedHeight),
           fill: this.fill ? `url(#${this._uid})` : 'none',
           stroke: this.fill ? 'none' : `url(#${this._uid})`,
         },
         ref: 'path',
       })
     },
+    genLabels (offsetX: number) {
+      const children = this.parsedLabels.map((item, i) => (
+        this.$createElement('text', {
+          attrs: {
+            x: item.x + offsetX + this._lineWidth / 2,
+            y: this.textY + (this.parsedLabelSize * 0.75),
+            'font-size': Number(this.labelSize) || 7,
+          },
+        }, [this.genLabel(item, i)])
+      ))
+
+      return this.genG(children)
+    },
     genLabel (item: SparklineText, index: number) {
       return this.$scopedSlots.label
         ? this.$scopedSlots.label({ index, value: item.value })
         : item.value
     },
-    genText (item: SparklineText, index: number) {
-      return this.$createElement('text', {
-        attrs: {
-          x: item.x,
-          y: this.textY,
-        },
-      }, [this.genLabel(item, index)])
-    },
-    genBar () {
-      if (!this.value || this.totalBars < 2) return undefined as never
-      const { width, height, parsedPadding, _lineWidth } = this
-      const viewWidth = width || this.totalBars * parsedPadding * 2
-      const viewHeight = height || 75
-      const boundary: Boundary = {
-        minX: parsedPadding,
-        minY: parsedPadding,
-        maxX: Number(viewWidth) - parsedPadding,
-        maxY: Number(viewHeight) - parsedPadding,
-      }
-      const props = {
-        ...this.$props,
-      }
+    genBars () {
+      if (!this.value || this.totalValues < 2) return undefined as never
 
-      props.points = genPoints(this.value, boundary, this.type)
-
-      const totalWidth = boundary.maxX / (props.points.length - 1)
-
-      props.boundary = boundary
-      props.lineWidth = _lineWidth || (totalWidth - Number(parsedPadding || 5))
-      props.offsetX = 0
-      if (!this.autoLineWidth) {
-        props.offsetX = ((boundary.maxX / this.totalBars) / 2) - boundary.minX
-      }
+      const bars = genBars(this.normalizedValues, this.boundary)
+      const offsetX = (Math.abs(bars[0].x - bars[1].x) - this._lineWidth) / 2
 
       return this.$createElement('svg', {
         attrs: {
-          width: '100%',
-          height: '25%',
-          viewBox: `0 0 ${viewWidth} ${viewHeight}`,
+          display: 'block',
+          viewBox: `0 0 ${this.totalWidth} ${this.totalHeight}`,
         },
       }, [
         this.genGradient(),
-        this.genClipPath(props.offsetX, props.lineWidth, 'sparkline-bar-' + this._uid),
-        this.hasLabels ? this.genBarLabels(props as BarText) : undefined as never,
+        this.genClipPath(bars, offsetX, this._lineWidth, 'sparkline-bar-' + this._uid),
+        this.hasLabels ? this.genLabels(offsetX) : undefined as never,
         this.$createElement('g', {
           attrs: {
-            transform: `scale(1,-1) translate(0,-${boundary.maxY})`,
             'clip-path': `url(#sparkline-bar-${this._uid}-clip)`,
             fill: `url(#${this._uid})`,
           },
@@ -344,39 +360,29 @@ export default mixins<options &
             attrs: {
               x: 0,
               y: 0,
-              width: viewWidth,
-              height: viewHeight,
+              width: this.totalWidth,
+              height: this.height,
             },
           }),
         ]),
       ])
     },
-    genClipPath (offsetX: number, lineWidth: number, id: string) {
-      const negative = Math.min(...this.points.map(x => x.value)) < 0
-
-      const { maxY } = this.boundary
+    genClipPath (bars: Bar[], offsetX: number, lineWidth: number, id: string) {
       const rounding = typeof this.smooth === 'number'
         ? this.smooth
         : this.smooth ? 2 : 0
-
-      const zero = genPoints([ 0, ...this.value ], this.boundary, this.type)[0].y
 
       return this.$createElement('clipPath', {
         attrs: {
           id: `${id}-clip`,
         },
-      }, this.points.map(item => {
-        let height = 0
-
-        if (negative && item.value > 0) height = zero - item.y
-        else if (!negative || item.value < 0) height = maxY - item.y
-
+      }, bars.map(item => {
         return this.$createElement('rect', {
           attrs: {
             x: item.x + offsetX,
-            y: negative ? item.value < 0 ? zero - (maxY - item.y) : zero : 0,
+            y: item.y,
             width: lineWidth,
-            height: Math.max(height, 0),
+            height: item.height,
             rx: rounding,
             ry: rounding,
           },
@@ -385,7 +391,7 @@ export default mixins<options &
             attrs: {
               attributeName: 'height',
               from: 0,
-              to: maxY - item.y,
+              to: item.height,
               dur: `${this.autoDrawDuration}ms`,
               fill: 'freeze',
             },
@@ -393,42 +399,25 @@ export default mixins<options &
         ])
       }))
     },
-    genBarLabels (props: BarText): VNode {
-      const offsetX = props.offsetX || 0
-
-      const children = this.parsedLabels.map((item, i) => (
-        this.$createElement('text', {
-          attrs: {
-            x: item.x + offsetX + this._lineWidth / 2,
-            y: props.boundary.maxY + (Number(this.labelSize) || 7),
-            'font-size': Number(this.labelSize) || 7,
-          },
-        }, [this.genLabel(item, i)])
-      ))
-
-      return this.genG(children)
-    },
     genTrend () {
       return this.$createElement('svg', this.setTextColor(this.color, {
         attrs: {
+          ...this.$attrs,
+          display: 'block',
           'stroke-width': this._lineWidth || 1,
-          width: '100%',
-          height: '25%',
-          viewBox: `0 0 ${this.width} ${this.height}`,
+          viewBox: `0 0 ${this.width} ${this.totalHeight}`,
         },
       }), [
         this.genGradient(),
-        this.genLabels(),
+        this.hasLabels && this.genLabels(-2),
         this.genPath(),
       ])
     },
   },
 
   render (h): VNode {
-    if (this.totalBars < 2) return undefined as never
+    if (this.totalValues < 2) return undefined as never
 
-    return this.type === 'trend'
-      ? this.genTrend()
-      : this.genBar()
+    return this.type === 'trend' ? this.genTrend() : this.genBars()
   },
 })

--- a/packages/vuetify/src/components/VSparkline/__tests__/__snapshots__/VSparkline.spec.ts.snap
+++ b/packages/vuetify/src/components/VSparkline/__tests__/__snapshots__/VSparkline.spec.ts.snap
@@ -2,9 +2,8 @@
 
 exports[`VSparkline.ts should render component and match a snapshot 1`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
+<svg display="block"
+     stroke-width="4"
      viewbox="0 0 300 75"
      class="primary--text"
 >
@@ -22,7 +21,7 @@ exports[`VSparkline.ts should render component and match a snapshot 1`] = `
     </linearGradient>
   </defs>
   <path id="1"
-        d="M8 65.62789697674418L150 57.395348837209305S150 57.395348837209305 150 57.395348837209305L292 9.372103023255814"
+        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#1)"
   >
@@ -33,8 +32,7 @@ exports[`VSparkline.ts should render component and match a snapshot 1`] = `
 
 exports[`VSparkline.ts should render component with bars and auto-line-width and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -51,33 +49,32 @@ exports[`VSparkline.ts should render component with bars and auto-line-width and
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-21-clip">
-    <rect x="8"
-          y="0"
+    <rect x="5.333333333333336"
+          y="71.34146341463415"
           width="89.33333333333333"
-          height="1.3721030232558178"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="105.33333333333333"
-          y="0"
+    <rect x="105.33333333333334"
+          y="60.36585365853659"
           width="89.33333333333333"
-          height="9.604651162790695"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="202.66666666666666"
-          y="0"
+    <rect x="205.33333333333334"
+          y="-3.6585365853658516"
           width="89.33333333333333"
-          height="57.62789697674418"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-21-clip)"
+  <g clip-path="url(#sparkline-bar-21-clip)"
      fill="url(#21)"
   >
     <rect x="0"
@@ -93,8 +90,7 @@ exports[`VSparkline.ts should render component with bars and auto-line-width and
 
 exports[`VSparkline.ts should render component with bars and auto-line-width with custom padding and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -111,33 +107,32 @@ exports[`VSparkline.ts should render component with bars and auto-line-width wit
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-27-clip">
-    <rect x="12"
-          y="0"
+    <rect x="8"
+          y="71.34146341463415"
           width="84"
-          height="1.1860565116279105"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
     <rect x="108"
-          y="0"
+          y="60.36585365853659"
           width="84"
-          height="8.302325581395351"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="204"
-          y="0"
+    <rect x="208"
+          y="-3.6585365853658516"
           width="84"
-          height="49.813943488372104"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-63)"
-     clip-path="url(#sparkline-bar-27-clip)"
+  <g clip-path="url(#sparkline-bar-27-clip)"
      fill="url(#27)"
   >
     <rect x="0"
@@ -153,9 +148,8 @@ exports[`VSparkline.ts should render component with bars and auto-line-width wit
 
 exports[`VSparkline.ts should render component with bars and custom label size and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
-     viewbox="0 0 300 75"
+<svg display="block"
+     viewbox="0 0 300 97.5"
 >
   <defs>
     <linearGradient id="29"
@@ -171,53 +165,52 @@ exports[`VSparkline.ts should render component with bars and custom label size a
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-29-clip">
-    <rect x="48.666666666666664"
-          y="0"
+    <rect x="48"
+          y="71.34146341463415"
           width="4"
-          height="1.3721030232558178"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="146"
-          y="0"
+    <rect x="148"
+          y="60.36585365853659"
           width="4"
-          height="9.604651162790695"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="243.33333333333331"
-          y="0"
+    <rect x="248"
+          y="-3.6585365853658516"
           width="4"
-          height="57.62789697674418"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
   <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
-    <text x="50.666666666666664"
-          y="82"
+    <text x="50"
+          y="86.25"
           font-size="15"
     >
       Value 1
     </text>
-    <text x="148"
-          y="82"
+    <text x="150"
+          y="86.25"
           font-size="15"
     >
       Value 2
     </text>
-    <text x="245.33333333333331"
-          y="82"
+    <text x="250"
+          y="86.25"
           font-size="15"
     >
       Value 3
     </text>
   </g>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-29-clip)"
+  <g clip-path="url(#sparkline-bar-29-clip)"
      fill="url(#29)"
   >
     <rect x="0"
@@ -233,8 +226,7 @@ exports[`VSparkline.ts should render component with bars and custom label size a
 
 exports[`VSparkline.ts should render component with bars and custom padding and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -252,32 +244,31 @@ exports[`VSparkline.ts should render component with bars and custom padding and 
   </defs>
   <clipPath id="sparkline-bar-25-clip">
     <rect x="48"
-          y="0"
+          y="71.34146341463415"
           width="4"
-          height="1.1860565116279105"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="144"
-          y="0"
+    <rect x="148"
+          y="60.36585365853659"
           width="4"
-          height="8.302325581395351"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="240"
-          y="0"
+    <rect x="248"
+          y="-3.6585365853658516"
           width="4"
-          height="49.813943488372104"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-63)"
-     clip-path="url(#sparkline-bar-25-clip)"
+  <g clip-path="url(#sparkline-bar-25-clip)"
      fill="url(#25)"
   >
     <rect x="0"
@@ -293,8 +284,7 @@ exports[`VSparkline.ts should render component with bars and custom padding and 
 
 exports[`VSparkline.ts should render component with bars and gradient and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -319,33 +309,32 @@ exports[`VSparkline.ts should render component with bars and gradient and match 
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-17-clip">
-    <rect x="48.666666666666664"
-          y="0"
+    <rect x="48"
+          y="71.34146341463415"
           width="4"
-          height="1.3721030232558178"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="146"
-          y="0"
+    <rect x="148"
+          y="60.36585365853659"
           width="4"
-          height="9.604651162790695"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="243.33333333333331"
-          y="0"
+    <rect x="248"
+          y="-3.6585365853658516"
           width="4"
-          height="57.62789697674418"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-17-clip)"
+  <g clip-path="url(#sparkline-bar-17-clip)"
      fill="url(#17)"
   >
     <rect x="0"
@@ -361,9 +350,8 @@ exports[`VSparkline.ts should render component with bars and gradient and match 
 
 exports[`VSparkline.ts should render component with bars and labels and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
-     viewbox="0 0 300 75"
+<svg display="block"
+     viewbox="0 0 300 85.5"
 >
   <defs>
     <linearGradient id="19"
@@ -379,53 +367,52 @@ exports[`VSparkline.ts should render component with bars and labels and match a 
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-19-clip">
-    <rect x="48.666666666666664"
-          y="0"
+    <rect x="48"
+          y="71.34146341463415"
           width="4"
-          height="1.3721030232558178"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="146"
-          y="0"
+    <rect x="148"
+          y="60.36585365853659"
           width="4"
-          height="9.604651162790695"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="243.33333333333331"
-          y="0"
+    <rect x="248"
+          y="-3.6585365853658516"
           width="4"
-          height="57.62789697674418"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
   <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
-    <text x="50.666666666666664"
-          y="74"
+    <text x="50"
+          y="80.25"
           font-size="7"
     >
       Value 1
     </text>
-    <text x="148"
-          y="74"
+    <text x="150"
+          y="80.25"
           font-size="7"
     >
       Value 2
     </text>
-    <text x="245.33333333333331"
-          y="74"
+    <text x="250"
+          y="80.25"
           font-size="7"
     >
       Value 3
     </text>
   </g>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-19-clip)"
+  <g clip-path="url(#sparkline-bar-19-clip)"
      fill="url(#19)"
   >
     <rect x="0"
@@ -441,8 +428,7 @@ exports[`VSparkline.ts should render component with bars and labels and match a 
 
 exports[`VSparkline.ts should render component with bars and line width and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -459,33 +445,32 @@ exports[`VSparkline.ts should render component with bars and line width and matc
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-23-clip">
-    <rect x="48.666666666666664"
-          y="0"
+    <rect x="46"
+          y="71.34146341463415"
           width="8"
-          height="1.3721030232558178"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
     <rect x="146"
-          y="0"
+          y="60.36585365853659"
           width="8"
-          height="9.604651162790695"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="243.33333333333331"
-          y="0"
+    <rect x="246"
+          y="-3.6585365853658516"
           width="8"
-          height="57.62789697674418"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-23-clip)"
+  <g clip-path="url(#sparkline-bar-23-clip)"
      fill="url(#23)"
   >
     <rect x="0"
@@ -501,8 +486,7 @@ exports[`VSparkline.ts should render component with bars and line width and matc
 
 exports[`VSparkline.ts should render component with bars and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -519,33 +503,32 @@ exports[`VSparkline.ts should render component with bars and match a snapshot 1`
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-13-clip">
-    <rect x="48.666666666666664"
-          y="0"
+    <rect x="48"
+          y="71.34146341463415"
           width="4"
-          height="1.3721030232558178"
+          height="1.829268292682927"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="146"
-          y="0"
+    <rect x="148"
+          y="60.36585365853659"
           width="4"
-          height="9.604651162790695"
+          height="12.804878048780488"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="243.33333333333331"
-          y="0"
+    <rect x="248"
+          y="-3.6585365853658516"
           width="4"
-          height="57.62789697674418"
+          height="76.82926829268293"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-13-clip)"
+  <g clip-path="url(#sparkline-bar-13-clip)"
      fill="url(#13)"
   >
     <rect x="0"
@@ -561,8 +544,7 @@ exports[`VSparkline.ts should render component with bars and match a snapshot 1`
 
 exports[`VSparkline.ts should render component with bars and negative and match a snapshot 1`] = `
 
-<svg width="100%"
-     height="25%"
+<svg display="block"
      viewbox="0 0 300 75"
 >
   <defs>
@@ -579,41 +561,40 @@ exports[`VSparkline.ts should render component with bars and negative and match 
     </linearGradient>
   </defs>
   <clipPath id="sparkline-bar-15-clip">
-    <rect x="36.5"
-          y="63.06664666666666"
+    <rect x="35.5"
+          y="73.25581395348837"
           width="4"
-          height="1.3111211111111203"
+          height="1.744186046511628"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="109.5"
-          y="64.37776777777778"
+    <rect x="110.5"
+          y="71.51162790697674"
           width="4"
-          height="1.311101111111114"
+          height="1.744186046511628"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="182.5"
-          y="64.37776777777778"
+    <rect x="185.5"
+          y="61.04651162790697"
           width="4"
-          height="9.177767777777774"
+          height="12.209302325581396"
           rx="0"
           ry="0"
     >
     </rect>
-    <rect x="255.5"
-          y="64.37776777777778"
+    <rect x="260.5"
+          y="0"
           width="4"
-          height="55.06664666666667"
+          height="73.25581395348837"
           rx="0"
           ry="0"
     >
     </rect>
   </clipPath>
-  <g transform="scale(1,-1) translate(0,-67)"
-     clip-path="url(#sparkline-bar-15-clip)"
+  <g clip-path="url(#sparkline-bar-15-clip)"
      fill="url(#15)"
   >
     <rect x="0"
@@ -629,9 +610,8 @@ exports[`VSparkline.ts should render component with bars and negative and match 
 
 exports[`VSparkline.ts should render component with gradient and match a snapshot 1`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
+<svg display="block"
+     stroke-width="4"
      viewbox="0 0 300 75"
      class="primary--text"
 >
@@ -657,7 +637,7 @@ exports[`VSparkline.ts should render component with gradient and match a snapsho
     </linearGradient>
   </defs>
   <path id="9"
-        d="M8 65.62789697674418L150 57.395348837209305S150 57.395348837209305 150 57.395348837209305L292 9.372103023255814"
+        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#9)"
   >
@@ -668,9 +648,8 @@ exports[`VSparkline.ts should render component with gradient and match a snapsho
 
 exports[`VSparkline.ts should render component with line width and match a snapshot 1`] = `
 
-<svg stroke-width="42"
-     width="100%"
-     height="25%"
+<svg display="block"
+     stroke-width="42"
      viewbox="0 0 300 75"
      class="primary--text"
 >
@@ -688,7 +667,7 @@ exports[`VSparkline.ts should render component with line width and match a snaps
     </linearGradient>
   </defs>
   <path id="7"
-        d="M8 65.62789697674418L150 57.395348837209305S150 57.395348837209305 150 57.395348837209305L292 9.372103023255814"
+        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#7)"
   >
@@ -699,9 +678,8 @@ exports[`VSparkline.ts should render component with line width and match a snaps
 
 exports[`VSparkline.ts should render component with padding and match a snapshot 1`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
+<svg display="block"
+     stroke-width="4"
      viewbox="0 0 300 75"
      class="primary--text"
 >
@@ -719,7 +697,7 @@ exports[`VSparkline.ts should render component with padding and match a snapshot
     </linearGradient>
   </defs>
   <path id="3"
-        d="M20 54.186036511627904L150 49.30232558139535S150 49.30232558139535 150 49.30232558139535L280 20.813963488372092"
+        d="M20 54.99999L150 49.8780487804878S150 49.8780487804878 150 49.8780487804878L280 20.00001"
         fill="none"
         stroke="url(#3)"
   >
@@ -730,10 +708,9 @@ exports[`VSparkline.ts should render component with padding and match a snapshot
 
 exports[`VSparkline.ts should render component with string labels and match a snapshot 1`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
-     viewbox="0 0 300 75"
+<svg display="block"
+     stroke-width="4"
+     viewbox="0 0 300 85.5"
      class="primary--text"
 >
   <defs>
@@ -751,23 +728,26 @@ exports[`VSparkline.ts should render component with string labels and match a sn
   </defs>
   <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
     <text x="8"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       1
     </text>
     <text x="150"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       7
     </text>
     <text x="292"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       42
     </text>
   </g>
   <path id="11"
-        d="M8 65.62789697674418L150 57.395348837209305S150 57.395348837209305 150 57.395348837209305L292 9.372103023255814"
+        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#11)"
   >
@@ -778,10 +758,9 @@ exports[`VSparkline.ts should render component with string labels and match a sn
 
 exports[`VSparkline.ts should render component with string labels and match a snapshot 2`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
-     viewbox="0 0 300 75"
+<svg display="block"
+     stroke-width="4"
+     viewbox="0 0 300 85.5"
      class="primary--text"
 >
   <defs>
@@ -799,23 +778,26 @@ exports[`VSparkline.ts should render component with string labels and match a sn
   </defs>
   <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
     <text x="8"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       2
     </text>
     <text x="150"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       8
     </text>
     <text x="292"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       43
     </text>
   </g>
   <path id="11"
-        d="M8 65.62789697674418L150 57.395348837209305S150 57.395348837209305 150 57.395348837209305L292 9.372103023255814"
+        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#11)"
   >
@@ -826,10 +808,9 @@ exports[`VSparkline.ts should render component with string labels and match a sn
 
 exports[`VSparkline.ts should render component with string labels and match a snapshot 3`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
-     viewbox="0 0 300 75"
+<svg display="block"
+     stroke-width="4"
+     viewbox="0 0 300 85.5"
      class="primary--text"
 >
   <defs>
@@ -847,23 +828,26 @@ exports[`VSparkline.ts should render component with string labels and match a sn
   </defs>
   <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
     <text x="8"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       foo
     </text>
     <text x="150"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       bar
     </text>
     <text x="292"
-          y="73"
+          y="76.25"
+          font-size="7"
     >
       baz
     </text>
   </g>
   <path id="11"
-        d="M8 65.62789697674418L150 57.395348837209305S150 57.395348837209305 150 57.395348837209305L292 9.372103023255814"
+        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#11)"
   >
@@ -874,9 +858,8 @@ exports[`VSparkline.ts should render component with string labels and match a sn
 
 exports[`VSparkline.ts should render smooth component and match a snapshot 1`] = `
 
-<svg stroke-width="4"
-     width="100%"
-     height="25%"
+<svg display="block"
+     stroke-width="4"
      viewbox="0 0 300 75"
      class="primary--text"
 >
@@ -894,7 +877,7 @@ exports[`VSparkline.ts should render smooth component and match a snapshot 1`] =
     </linearGradient>
   </defs>
   <path id="5"
-        d="M8 65.62789697674418L130.03352731272736 58.55291889055212S150 57.395348837209305 168.94587032678325 50.98800948606565L292 9.372103023255814"
+        d="M8 66.99999L130.03686879378304 59.579687437670394S150 58.36585365853659 168.8494438621337 51.6801625133916L292 8.00001"
         fill="none"
         stroke="url(#5)"
   >

--- a/packages/vuetify/src/components/VSparkline/helpers/core.ts
+++ b/packages/vuetify/src/components/VSparkline/helpers/core.ts
@@ -1,31 +1,51 @@
-import { SparklineItem, Boundary, Point } from '../VSparkline'
+import { Point, Boundary, Bar } from '../VSparkline'
 
 export function genPoints (
-  points: SparklineItem[],
-  boundary: Boundary,
-  type: String
+  values: number[],
+  boundary: Boundary
 ): Point[] {
-  const { minX, minY, maxX, maxY } = boundary
-  const normalisedPoints = points.map(
-    item => (typeof item === 'number' ? item : item.value)
-  )
-  const totalPoints = normalisedPoints.length
-  const maxValue = Math.max(...normalisedPoints) + 1
-  let minValue = Math.min(...normalisedPoints)
+  const { minX, maxX, minY, maxY } = boundary
+  const totalValues = values.length
+  const maxValue = Math.max(...values)
+  const minValue = Math.min(...values)
 
-  if (minValue) minValue -= 1
-  let gridX = (maxX - minX) / (totalPoints - 1)
-  if (type === 'bar') gridX = maxX / totalPoints
+  const gridX = (maxX - minX) / (totalValues - 1)
   const gridY = (maxY - minY) / (maxValue - minValue)
 
-  return normalisedPoints.map((value, index) => {
+  return values.map((value, index) => {
     return {
       x: minX + index * gridX,
       y:
         maxY -
         (value - minValue) * gridY +
-        +(index === totalPoints - 1) * 0.00001 -
+        +(index === totalValues - 1) * 0.00001 -
         +(index === 0) * 0.00001,
+      value,
+    }
+  })
+}
+
+export function genBars (
+  values: number[],
+  boundary: Boundary
+): Bar[] {
+  const { minX, maxX, minY, maxY } = boundary
+  const totalValues = values.length
+  const maxValue = Math.max(...values)
+  const minValue = Math.min(...values)
+
+  const gridX = maxX / totalValues
+  const gridY = (maxY - minY) / (maxValue - minValue)
+  const horizonY = maxY - Math.abs(minValue * gridY)
+
+  return values.map((value, index) => {
+    const height = Math.abs(gridY * value)
+
+    return {
+      x: minX + index * gridX,
+      y: horizonY - height +
+        +(value < 0) * height,
+      height,
       value,
     }
   })


### PR DESCRIPTION
## Description
negative values were not displayed correctly in bars. labels were also being cut off in certain scenarios. refactored the generation and displaying of bars to make it a bit less confusing.

## Motivation and Context
because

## How Has This Been Tested?
playground, unit tests

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-sparkline
    :value="value"
    :type="type"
  ></v-sparkline>
</template>

<script>
  export default {
    data: () => ({
      value: [-5, 5],
      type: 'bar',
    }),
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
