### PR TITLE
fix(VDataTable): disable header sorting if disable-sort is true

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -230,6 +230,7 @@ export default VDataIterator.extend({
           someItems: this.someItems,
           everyItem: this.everyItem,
           singleSelect: this.singleSelect,
+          disableSort: this.disableSort,
         },
         on: {
           sort: props.sort,

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaderDesktop.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaderDesktop.ts
@@ -40,7 +40,7 @@ export default mixins(header).extend({
           : this.$createElement('span', [header.text])
         )
 
-        if (header.sortable || !header.hasOwnProperty('sortable')) {
+        if (!this.disableSort && (header.sortable || !header.hasOwnProperty('sortable'))) {
           listeners['click'] = () => this.$emit('sort', header.value)
 
           const sortIndex = this.options.sortBy.findIndex(k => k === header.value)

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaderMobile.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaderMobile.ts
@@ -44,6 +44,7 @@ export default mixins(header).extend({
           hideDetails: true,
           multiple: this.options.multiSort,
           value: this.options.multiSort ? this.options.sortBy : this.options.sortBy[0],
+          disabled: this.disableSort,
         },
         on: {
           change: (v: string | string[]) => this.$emit('sort', v),

--- a/packages/vuetify/src/components/VDataTable/mixins/header.ts
+++ b/packages/vuetify/src/components/VDataTable/mixins/header.ts
@@ -59,6 +59,7 @@ export default mixins<options>().extend({
     someItems: Boolean,
     showGroupBy: Boolean,
     singleSelect: Boolean,
+    disableSort: Boolean,
   },
 
   methods: {


### PR DESCRIPTION
## Description
disable clicking on headers to sort when `disable-sort` is active

## Motivation and Context
fix #7657 

## How Has This Been Tested?
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-data-table
    disable-sort
    :headers="headers"
    :items="desserts"
    :items-per-page="5"
    class="elevation-1"
  ></v-data-table>
</template>

<script>
  export default {
    data () {
      return {
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
