### PR TITLE
fix(VCalendar): throw error when no days available

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -204,7 +204,9 @@ export default CalendarWithIntervals.extend({
 
       return this.$createElement('div', data, this.genIntervalLabels())
     },
-    genIntervalLabels (): VNode[] {
+    genIntervalLabels (): VNode[] | null {
+      if (!this.intervals.length) return null
+
       return this.intervals[0].map(this.genIntervalLabel)
     },
     genIntervalLabel (interval: VTimestamp): VNode {

--- a/packages/vuetify/src/components/VCalendar/util/__tests__/__snapshots__/timestamp.spec.ts.snap
+++ b/packages/vuetify/src/components/VCalendar/util/__tests__/__snapshots__/timestamp.spec.ts.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VCalendar/util/timestamp.ts createDayList should handle skips equal to zero 1`] = `
+Array [
+  Object {
+    "date": "2019-04-22",
+    "day": 22,
+    "future": false,
+    "hasDay": true,
+    "hasTime": false,
+    "hour": 0,
+    "minute": 0,
+    "month": 4,
+    "past": true,
+    "present": false,
+    "time": "",
+    "weekday": 1,
+    "year": 2019,
+  },
+  Object {
+    "date": "2019-04-24",
+    "day": 24,
+    "future": false,
+    "hasDay": true,
+    "hasTime": false,
+    "hour": 0,
+    "minute": 0,
+    "month": 4,
+    "past": true,
+    "present": false,
+    "time": "",
+    "weekday": 3,
+    "year": 2019,
+  },
+  Object {
+    "date": "2019-04-26",
+    "day": 26,
+    "future": false,
+    "hasDay": true,
+    "hasTime": false,
+    "hour": 0,
+    "minute": 0,
+    "month": 4,
+    "past": true,
+    "present": false,
+    "time": "",
+    "weekday": 5,
+    "year": 2019,
+  },
+]
+`;
+
 exports[`VCalendar/util/timestamp.ts should create interval list 1`] = `
 Array [
   Object {
@@ -339,56 +389,6 @@ Array [
     "past": false,
     "present": false,
     "time": "00:15",
-    "weekday": 5,
-    "year": 2019,
-  },
-]
-`;
-
-exports[`VCalendar/util/timestamp.ts should handle skips equal to zero 1`] = `
-Array [
-  Object {
-    "date": "2019-04-22",
-    "day": 22,
-    "future": false,
-    "hasDay": true,
-    "hasTime": false,
-    "hour": 0,
-    "minute": 0,
-    "month": 4,
-    "past": true,
-    "present": false,
-    "time": "",
-    "weekday": 1,
-    "year": 2019,
-  },
-  Object {
-    "date": "2019-04-24",
-    "day": 24,
-    "future": false,
-    "hasDay": true,
-    "hasTime": false,
-    "hour": 0,
-    "minute": 0,
-    "month": 4,
-    "past": true,
-    "present": false,
-    "time": "",
-    "weekday": 3,
-    "year": 2019,
-  },
-  Object {
-    "date": "2019-04-26",
-    "day": 26,
-    "future": false,
-    "hasDay": true,
-    "hasTime": false,
-    "hour": 0,
-    "minute": 0,
-    "month": 4,
-    "past": true,
-    "present": false,
-    "time": "",
     "weekday": 5,
     "year": 2019,
   },

--- a/packages/vuetify/src/components/VCalendar/util/__tests__/timestamp.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/util/__tests__/timestamp.spec.ts
@@ -372,71 +372,6 @@ describe('VCalendar/util/timestamp.ts', () => { // eslint-disable-line max-state
     expect(parseTimestamp('2019-03-01').weekday).toBe(5)
   })
 
-  it('should allow first day of week', () => {
-    const weekdays = [1, 2, 3, 4, 5, 6, 0]
-    const skips = getWeekdaySkips(weekdays)
-    const today = parseTimestamp('2019-05-03')
-    const date = parseTimestamp('2019-04-30')
-    const start = getStartOfWeek(date, weekdays, today)
-    const end = getEndOfWeek(date, weekdays, today)
-
-    const days = createDayList(
-      start,
-      end,
-      today,
-      skips,
-      Number.MAX_SAFE_INTEGER
-    )
-
-    expect(days).toEqual([
-      { 'date': '2019-04-29', 'day': 29, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 4, 'past': true, 'present': false, 'time': '', 'weekday': 1, 'year': 2019 },
-      { 'date': '2019-04-30', 'day': 30, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 4, 'past': true, 'present': false, 'time': '', 'weekday': 2, 'year': 2019 },
-      { 'date': '2019-05-01', 'day': 1, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': true, 'present': false, 'time': '', 'weekday': 3, 'year': 2019 },
-      { 'date': '2019-05-02', 'day': 2, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': true, 'present': false, 'time': '', 'weekday': 4, 'year': 2019 },
-      { 'date': '2019-05-03', 'day': 3, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': false, 'present': true, 'time': '', 'weekday': 5, 'year': 2019 },
-      { 'date': '2019-05-04', 'day': 4, 'future': true, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': false, 'present': false, 'time': '', 'weekday': 6, 'year': 2019 },
-      { 'date': '2019-05-05', 'day': 5, 'future': true, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': false, 'present': false, 'time': '', 'weekday': 0, 'year': 2019 },
-    ])
-  })
-
-  it('should return empty array when end is less than start', () => {
-    const weekdays = [1, 2, 3, 4, 5, 6, 0]
-    const skips = getWeekdaySkips(weekdays)
-    const today = parseTimestamp('2019-05-03')
-    const date = parseTimestamp('2019-04-30')
-    const start = getEndOfWeek(date, weekdays, today)
-    const end = getStartOfWeek(date, weekdays, today)
-
-    const days = createDayList(
-      start,
-      end,
-      today,
-      skips,
-      Number.MAX_SAFE_INTEGER
-    )
-
-    expect(days).toEqual([])
-  })
-
-  it('should handle skips equal to zero', () => {
-    const weekdays = [1, 2, 3, 4, 5, 6, 0]
-    const skips = [0, 1, 0, 1, 0, 1, 0]
-    const today = parseTimestamp('2019-04-30')
-    const date = parseTimestamp('2019-04-27')
-    const start = getStartOfWeek(date, weekdays, today)
-    const end = getEndOfWeek(date, weekdays, today)
-
-    const days = createDayList(
-      start,
-      end,
-      today,
-      skips,
-      Number.MAX_SAFE_INTEGER
-    )
-
-    expect(days).toMatchSnapshot()
-  })
-
   it('should create interval list', () => {
     expect(createIntervalList(parseTimestamp('2019-02-08'), 2, 15, 10)).toMatchSnapshot()
     expect(createIntervalList(parseTimestamp('2019-02-08'), 1, 15, 10)).toMatchSnapshot()
@@ -496,12 +431,67 @@ describe('VCalendar/util/timestamp.ts', () => { // eslint-disable-line max-state
     expect(getWeekdaySkips([ 1, 5, 1, 3, 4, 2, 6 ])).toEqual([0, 1, 1, 1, 1, 1, 2])
   })
 
-  it('should create day list', () => {
-    const skips = getWeekdaySkips([ 0, 1, 2, 3, 4, 5, 6 ])
-    const skips1 = getWeekdaySkips([ 1, 1, 1, 1, 1, 1, 0 ])
-    expect(createDayList(parseTimestamp('2019-02-02'), parseTimestamp('2019-02-01'), parseTimestamp('2019-02-02'), skips)).toHaveLength(0)
-    expect(createDayList(parseTimestamp('2019-02-01'), parseTimestamp('2019-02-10'), parseTimestamp('2019-02-02'), skips)).toHaveLength(10)
-    expect(createDayList(parseTimestamp('2019-02-01'), parseTimestamp('2019-02-10'), parseTimestamp('2019-02-02'), skips1)).toHaveLength(3)
+  describe('createDayList', () => {
+    it('should create day list', () => {
+      const skips = getWeekdaySkips([ 0, 1, 2, 3, 4, 5, 6 ])
+      const skips1 = getWeekdaySkips([ 1, 1, 1, 1, 1, 1, 0 ])
+      expect(() => createDayList(parseTimestamp('2019-02-02'), parseTimestamp('2019-02-01'), parseTimestamp('2019-02-02'), skips)).toThrow()
+      expect(createDayList(parseTimestamp('2019-02-01'), parseTimestamp('2019-02-10'), parseTimestamp('2019-02-02'), skips)).toHaveLength(10)
+      expect(createDayList(parseTimestamp('2019-02-01'), parseTimestamp('2019-02-10'), parseTimestamp('2019-02-02'), skips1)).toHaveLength(3)
+    })
+
+    it('should allow first day of week', () => {
+      const weekdays = [1, 2, 3, 4, 5, 6, 0]
+      const skips = getWeekdaySkips(weekdays)
+      const today = parseTimestamp('2019-05-03')
+      const date = parseTimestamp('2019-04-30')
+      const start = getStartOfWeek(date, weekdays, today)
+      const end = getEndOfWeek(date, weekdays, today)
+
+      const days = createDayList(
+        start,
+        end,
+        today,
+        skips,
+        Number.MAX_SAFE_INTEGER
+      )
+
+      expect(days).toEqual([
+        { 'date': '2019-04-29', 'day': 29, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 4, 'past': true, 'present': false, 'time': '', 'weekday': 1, 'year': 2019 },
+        { 'date': '2019-04-30', 'day': 30, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 4, 'past': true, 'present': false, 'time': '', 'weekday': 2, 'year': 2019 },
+        { 'date': '2019-05-01', 'day': 1, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': true, 'present': false, 'time': '', 'weekday': 3, 'year': 2019 },
+        { 'date': '2019-05-02', 'day': 2, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': true, 'present': false, 'time': '', 'weekday': 4, 'year': 2019 },
+        { 'date': '2019-05-03', 'day': 3, 'future': false, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': false, 'present': true, 'time': '', 'weekday': 5, 'year': 2019 },
+        { 'date': '2019-05-04', 'day': 4, 'future': true, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': false, 'present': false, 'time': '', 'weekday': 6, 'year': 2019 },
+        { 'date': '2019-05-05', 'day': 5, 'future': true, 'hasDay': true, 'hasTime': false, 'hour': 0, 'minute': 0, 'month': 5, 'past': false, 'present': false, 'time': '', 'weekday': 0, 'year': 2019 },
+      ])
+    })
+
+    it('should handle skips equal to zero', () => {
+      const weekdays = [1, 2, 3, 4, 5, 6, 0]
+      const skips = [0, 1, 0, 1, 0, 1, 0]
+      const today = parseTimestamp('2019-04-30')
+      const date = parseTimestamp('2019-04-27')
+      const start = getStartOfWeek(date, weekdays, today)
+      const end = getEndOfWeek(date, weekdays, today)
+
+      const days = createDayList(
+        start,
+        end,
+        today,
+        skips,
+        Number.MAX_SAFE_INTEGER
+      )
+
+      expect(days).toMatchSnapshot()
+    })
+
+    it('should throw error if no days are available given specified weekday skips (#7155)', () => {
+      const skips = getWeekdaySkips([1, 2, 3, 4, 5])
+      // 2019-01-12 is a saturday (weekday 6)
+      expect(() => createDayList(parseTimestamp('2019-01-12'), parseTimestamp('2019-01-12'), parseTimestamp('2019-02-01'), skips))
+        .toThrow('No dates found using specified start date, end date, and weekdays.')
+    })
   })
 
   it('should find weekday', () => {

--- a/packages/vuetify/src/components/VCalendar/util/timestamp.ts
+++ b/packages/vuetify/src/components/VCalendar/util/timestamp.ts
@@ -343,8 +343,14 @@ export function getWeekdaySkips (weekdays: number[]): number[] {
   return skips
 }
 
-export function createDayList (start: VTimestamp, end: VTimestamp, now: VTimestamp,
-  weekdaySkips: number[], max = 42, min = 0): VTimestamp[] {
+export function createDayList (
+  start: VTimestamp,
+  end: VTimestamp,
+  now: VTimestamp,
+  weekdaySkips: number[],
+  max = 42,
+  min = 0
+): VTimestamp[] {
   const stop = getDayIdentifier(end)
   const days: VTimestamp[] = []
   let current = copyTimestamp(start)
@@ -352,7 +358,7 @@ export function createDayList (start: VTimestamp, end: VTimestamp, now: VTimesta
   let stopped = currentIdentifier === stop
 
   if (stop < getDayIdentifier(start)) {
-    return days
+    throw new Error('End date is earlier than start date.')
   }
 
   while ((!stopped || days.length < min) && days.length < max) {
@@ -368,6 +374,8 @@ export function createDayList (start: VTimestamp, end: VTimestamp, now: VTimesta
     days.push(day)
     current = relativeDays(current, nextDay, weekdaySkips[current.weekday])
   }
+
+  if (!days.length) throw new Error('No dates found using specified start date, end date, and weekdays.')
 
   return days
 }


### PR DESCRIPTION




<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
there are scenarios where a given start date, end date, and weekdays results
in no days being in range. we should throw a sensible error here instead of
the component just breaking

## Motivation and Context
closes #7155

## How Has This Been Tested?
playground, unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-calendar
    ref="calendar"
    v-model="start"
    :type="type"
    :weekdays="weekdays"
  ></v-calendar>
</template>

<script>
  export default {
    data: () => ({
      start: '2019-01-12',
      type: 'day',
      weekdays: [1, 2, 3, 4, 5],
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
