### PR TITLE
feat(VDivider): Add a11y attributes

### DIFF
--- a/packages/vuetify/src/components/VDivider/VDivider.ts
+++ b/packages/vuetify/src/components/VDivider/VDivider.ts
@@ -16,6 +16,11 @@ export default Themeable.extend({
   },
 
   render (h): VNode {
+    // WAI-ARIA attributes
+    let orientation
+    if (!this.$attrs.role || this.$attrs.role === 'separator') {
+      orientation = this.vertical ? 'vertical' : 'horizontal'
+    }
     return h('hr', {
       class: {
         'v-divider': true,
@@ -23,7 +28,11 @@ export default Themeable.extend({
         'v-divider--vertical': this.vertical,
         ...this.themeClasses,
       },
-      attrs: this.$attrs,
+      attrs: {
+        role: 'separator',
+        'aria-orientation': orientation,
+        ...this.$attrs,
+      },
       on: this.$listeners,
     })
   },

--- a/packages/vuetify/src/components/VDivider/__tests__/VDivider.spec.ts
+++ b/packages/vuetify/src/components/VDivider/__tests__/VDivider.spec.ts
@@ -63,4 +63,40 @@ describe('VDivider', () => {
 
     expect(wrapper.classes('v-divider--vertical')).toBe(true)
   })
+
+  it('should have separator role by default', () => {
+    const wrapper = mountFunction()
+
+    expect(wrapper.attributes('role')).toBe('separator')
+  })
+
+  it('should have aria-orientation horizontal by default', () => {
+    const wrapper = mountFunction()
+
+    expect(wrapper.attributes('aria-orientation')).toBe('horizontal')
+  })
+
+  it('should have aria-orientation vertical if vertical prop is set', () => {
+    const wrapper = mountFunction({
+      propsData: { vertical: true },
+    })
+
+    expect(wrapper.attributes('aria-orientation')).toBe('vertical')
+  })
+
+  it('should have presentation role if set in attrs', () => {
+    const wrapper = mountFunction({
+      attrs: { role: 'presentation' },
+    })
+
+    expect(wrapper.attributes('role')).toBe('presentation')
+  })
+
+  it('should have no aria-orientation if presentation role is set in attrs', () => {
+    const wrapper = mountFunction({
+      attrs: { role: 'presentation' },
+    })
+
+    expect(wrapper.attributes('aria-orientation')).toBeUndefined()
+  })
 })

--- a/packages/vuetify/src/components/VDivider/__tests__/__snapshots__/VDivider.spec.ts.snap
+++ b/packages/vuetify/src/components/VDivider/__tests__/__snapshots__/VDivider.spec.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`VDivider should render component and match snapshot 1`] = `
 
-<hr class="v-divider theme--light">
+<hr role="separator"
+    aria-orientation="horizontal"
+    class="v-divider theme--light"
+>
 
 `;

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelectList.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelectList.spec.ts.snap
@@ -114,7 +114,10 @@ exports[`VSelectList.ts should generate children 1`] = `
     <div class="v-subheader theme--light">
       true
     </div>
-    <hr class="v-divider theme--light">
+    <hr role="separator"
+        aria-orientation="horizontal"
+        class="v-divider theme--light"
+    >
     <div tabindex="0"
          aria-selected="false"
          aria-labelledby="foo-list-item-14"


### PR DESCRIPTION
Adding WAI-ARIA accessibility attributes (role and orientation) to the `VDivider` component.

## Description
This is the 2nd PR in a 3-PR bundle (see #7707 and #7709) looking to add an "Accessibility Considerations" section to the standard UI Components documentation pages. This PR adds the recommended WAI-ARIA roles to the `VDivider` component.

## Motivation and Context

Bring the `VDivider` component into compliance with the [WAI-ARIA recommendations for `<hr>` elements](https://www.w3.org/TR/wai-aria/#separator).

## How Has This Been Tested?

5 unit tests added to `src/components/VDivider/__tests__/VDivider.spec.ts`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`next`).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (see following PR) 
