### PR TITLE
docs: update branch path logic

### DIFF
--- a/packages/docs/src/components/core/FileBtn.vue
+++ b/packages/docs/src/components/core/FileBtn.vue
@@ -2,7 +2,7 @@
   <v-tooltip left bottom>
     <template #activator="{ on }">
       <v-btn
-        :href="`https://github.com/vuetifyjs/vuetify/tree/master/packages/vuetify/src/${link}`"
+        :href="`https://github.com/vuetifyjs/vuetify/tree/${branch}/packages/vuetify/src/${link}`"
         icon
         target="_blank"
         rel="noopener"
@@ -22,6 +22,10 @@
       link: {
         type: String,
         default: '',
+      },
+      branch: {
+        type: String,
+        default: 'master',
       },
     },
   }

--- a/packages/docs/src/components/core/Page.vue
+++ b/packages/docs/src/components/core/Page.vue
@@ -16,7 +16,7 @@
           v-if="structure.file"
           shrink
         >
-          <core-file-btn :link="structure.file" />
+          <core-file-btn :link="structure.file" :branch="branch" />
         </v-flex>
         <v-flex
           v-if="structure.mdSpec"
@@ -45,7 +45,7 @@
         :value="child"
       />
 
-      <doc-contribution />
+      <doc-contribution :branch="branch" />
     </template>
   </v-container>
   <not-found v-else />
@@ -65,6 +65,7 @@
 
     data: () => ({
       timeout: null,
+      branch: null,
     }),
 
     computed: {
@@ -81,6 +82,9 @@
 
     mounted () {
       this.init()
+
+      const branch = (window) ? window.location.hostname.split(',')[0] : 'master'
+      this.branch = ['master', 'dev', 'next'].includes(branch) ? branch : 'master'
     },
 
     methods: {

--- a/packages/docs/src/components/doc/Contribution.vue
+++ b/packages/docs/src/components/doc/Contribution.vue
@@ -23,6 +23,12 @@
   import { parseLink } from '@/util/helpers'
 
   export default {
+    props: {
+      branch: {
+        type: String,
+        default: 'master',
+      },
+    },
     computed: {
       ...mapGetters('documentation', [
         'namespace',
@@ -40,11 +46,11 @@
       },
       contributionLanguageLink () {
         const file = `${this.params.namespace}/${this.page}.json`
-        return `https://github.com/vuetifyjs/vuetify/tree/master/packages/docs/src/lang/${this.params.lang}/${file}`
+        return `https://github.com/vuetifyjs/vuetify/tree/${this.branch}/packages/docs/src/lang/${this.params.lang}/${file}`
       },
       contributionPageLink () {
         const file = `${this.params.namespace}/${this.page}.json`
-        return `https://github.com/vuetifyjs/vuetify/tree/master/packages/docs/src/data/pages/${file}`
+        return `https://github.com/vuetifyjs/vuetify/tree/${this.branch}/packages/docs/src/data/pages/${file}`
       },
     },
 

--- a/packages/docs/src/components/doc/Example.vue
+++ b/packages/docs/src/components/doc/Example.vue
@@ -165,7 +165,7 @@
       loading: true,
       parsed: undefined,
       selected: 'template',
-      branch: process.env.NODE_ENV === 'production' ? 'master' : 'dev',
+      branch: undefined,
     }),
 
     computed: {
@@ -209,6 +209,9 @@
         /* webpackMode: "lazy-once" */
         `!raw-loader!../../examples/${this.file}.vue`
       ).then(comp => this.boot(comp.default))
+
+      const branch = (window) ? window.location.hostname.split(',')[0] : 'master'
+      this.branch = ['master', 'dev', 'next'].includes(branch) ? branch : 'master'
     },
 
     methods: {

--- a/packages/docs/src/components/doc/Markup.vue
+++ b/packages/docs/src/components/doc/Markup.vue
@@ -11,7 +11,7 @@
       class="v-markup__edit"
     >
       <a
-        :href="`https://github.com/vuetifyjs/vuetify/tree/master/packages/docs/src/snippets/${file}`"
+        :href="href"
         target="_blank"
         rel="noopener"
         title="Edit code"
@@ -76,6 +76,7 @@
       code: null,
       copied: false,
       language: vm.lang,
+      branch: null,
     }),
 
     computed: {
@@ -87,10 +88,7 @@
         return `${folder}/${file}.txt`
       },
       href () {
-        const branch = process.env.NODE_ENV === 'production' ? 'master' : 'dev'
-        const href = `https://github.com/vuetifyjs/vuetify/tree/${branch}/packages/docs/src/snippets`
-
-        return `${href}/${this.file}`
+        return `https://github.com/vuetifyjs/vuetify/tree/${this.branch}/packages/docs/src/snippets/${this.file}`
       },
       id () {
         if (this.value === 'markup') return
@@ -100,6 +98,8 @@
 
     mounted () {
       this.$nextTick(this.init)
+      const branch = (window) ? window.location.hostname.split(',')[0] : 'master'
+      this.branch = ['master', 'dev', 'next'].includes(branch) ? branch : 'master'
     },
 
     methods: {


### PR DESCRIPTION
## Description
Updated hard coded branch pathing (for things like "open in github")
Allows for dynamic pathing between master/dev/next

## Motivation and Context
removes some hardcoded links
current process with process.env doesn't work on live sites as they are always prod, also excluded next.

## How Has This Been Tested?
visually

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `next`).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
