### PR TITLE
docs: kind guide for using missing material icons

### DIFF
--- a/packages/docs/src/data/pages/customization/Icons.json
+++ b/packages/docs/src/data/pages/customization/Icons.json
@@ -304,6 +304,47 @@
       "type": "section",
       "children": [
         {
+          "type": "heading",
+          "lang": "usingMissingMaterialIconsHeader"
+        },
+        {
+          "type": "text",
+          "lang": "usingMissingMaterialIconsText1"
+        },
+        {
+          "type": "markup",
+          "value": "html_using_missing_material_icons_font"
+        },
+        {
+          "type": "text",
+          "lang": "usingMissingMaterialIconsText2"
+        },
+        {
+          "type": "markup",
+          "value": "html_using_missing_material_icons_component"
+        },
+        {
+          "type": "text",
+          "lang": "usingMissingMaterialIconsText3"
+        },
+        {
+          "type": "markup",
+          "value": "js_using_missing_material_icons"
+        },
+        {
+          "type": "text",
+          "lang": "usingMissingMaterialIconsText4"
+        },
+        {
+          "type": "markup",
+          "value": "html_using_missing_material_icons_usage"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "children": [
+        {
           "type": "up-next",
           "value": [
             "components/icons",

--- a/packages/docs/src/lang/en/customization/Icons.json
+++ b/packages/docs/src/lang/en/customization/Icons.json
@@ -38,6 +38,11 @@
   "componentIconsHeader": "## Component icons",
   "componentIconsText1": "Instead of provided icon fonts presets you can use your own component icons. You also can switch icons that are used in Vuetify component with your own.",
   "componentIconsText2": "If you want your SVG icon to inherit colors and scale correctly - be sure add the following css to it:",
+  "usingMissingMaterialIconsHeader": "## Using missing Material Icons",
+  "usingMissingMaterialIconsText1": "Some material icons are missing by default. For example, `person` and `person_outline` are available, but `visibility_outline` isn't, while `visibility` is. To use missing material icons, include the font below (remove another material font if already registerd).",
+  "usingMissingMaterialIconsText2": "You can add your custom component. Let me assume it is **@/components/MaterialIcon.vue**.",
+  "usingMissingMaterialIconsText3": "Then you need to register the exact material icons you want",
+  "usingMissingMaterialIconsText4": "Finally you can use the material icons like this.",
   "customFASvg": "### Custom Font Awesome Pro Icons",
   "customFASvgText1": "You can utilize component icons with Font Awesome Pro to select individual icon weights:"
 }

--- a/packages/docs/src/lang/en/customization/Icons.json
+++ b/packages/docs/src/lang/en/customization/Icons.json
@@ -39,9 +39,9 @@
   "componentIconsText1": "Instead of provided icon fonts presets you can use your own component icons. You also can switch icons that are used in Vuetify component with your own.",
   "componentIconsText2": "If you want your SVG icon to inherit colors and scale correctly - be sure add the following css to it:",
   "usingMissingMaterialIconsHeader": "## Using missing Material Icons",
-  "usingMissingMaterialIconsText1": "Some material icons are missing by default. For example, `person` and `person_outline` are available, but `visibility_outline` isn't, while `visibility` is. To use missing material icons, include the font below (remove another material font if already registerd).",
+  "usingMissingMaterialIconsText1": "Some material icons are missing by default. For example, `person` and `person_outline` are available, but `visibility_outline` isn't, while `visibility` is. To use missing material icons, include the font below (remove another material font if already registered).",
   "usingMissingMaterialIconsText2": "You can add your custom component. Let me assume it is **@/components/MaterialIcon.vue**.",
-  "usingMissingMaterialIconsText3": "Then you need to register the exact material icons you want",
+  "usingMissingMaterialIconsText3": "Then you need to register the exact material icons you want.",
   "usingMissingMaterialIconsText4": "Finally you can use the material icons like this.",
   "customFASvg": "### Custom Font Awesome Pro Icons",
   "customFASvgText1": "You can utilize component icons with Font Awesome Pro to select individual icon weights:"

--- a/packages/docs/src/snippets/html/using_missing_material_icons_component.txt
+++ b/packages/docs/src/snippets/html/using_missing_material_icons_component.txt
@@ -1,0 +1,46 @@
+<template>
+  <i :class="standardClass">{{ parsed.id }}</i>
+</template>
+
+<script>
+export default {
+  props: {
+    name: {
+      type: String
+    }
+  },
+  computed: {
+    parsed() {
+      const check = (customSuffixes, standardSuffix) => {
+        for (let suffix of customSuffixes) {
+          suffix = `_${suffix}`
+          if (this.name.endsWith(suffix)) {
+            return {
+              suffix: standardSuffix,
+              id: this.name.substring(0, this.name.indexOf(suffix))
+            }
+          }
+        }
+        return false
+      }
+
+      return (
+        check(['fill', 'filled'], '') ||
+        check(['outline', 'outlined'], 'outlined') ||
+        check(['two-tone', 'two-toned'], 'two-tone') ||
+        check(['round', 'rounded'], 'round') ||
+        check(['sharp', 'shapened'], 'sharp') || {
+          suffix: '',
+          id: this.name
+        }
+      )
+    },
+    standardClass() {
+      if (this.parsed.suffix) {
+        return `material-icons-${this.parsed.suffix}`
+      }
+      return 'material-icons'
+    }
+  }
+}
+</script>

--- a/packages/docs/src/snippets/html/using_missing_material_icons_font.txt
+++ b/packages/docs/src/snippets/html/using_missing_material_icons_font.txt
@@ -1,0 +1,4 @@
+<link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
+/>

--- a/packages/docs/src/snippets/html/using_missing_material_icons_usage.txt
+++ b/packages/docs/src/snippets/html/using_missing_material_icons_usage.txt
@@ -1,0 +1,14 @@
+<!-- using as a prop. Be careful of double and single quotation. -->
+<v-text-field
+    label="password"
+    :append-icon="
+      pwShow
+        ? '$vuetify.icons.visibility_outline'
+        : '$vuetify.icons.visibility_off_outline'
+    "
+    @click:append="pwShow = !pwShow"
+    :type="pwShow ? 'text' : 'password'"
+  />
+
+<!-- using directly as an icon component -->
+<v-icon>$vuetify.icons.visibility_outline</v-icon>

--- a/packages/docs/src/snippets/js/using_missing_material_icons.txt
+++ b/packages/docs/src/snippets/js/using_missing_material_icons.txt
@@ -1,0 +1,28 @@
+import Vue from 'vue'
+import Vuetify from 'vuetify/lib'
+import 'vuetify/src/stylus/app.styl'
+import MaterialIcon from '@/components/MaterialIcon'
+
+function missingMaterialIcons(ids) {
+  const icons = {}
+  for (const id of ids) {
+    for (const suffix of ['fill', 'outline', 'two-tone', 'round', 'sharp']) {
+      const name = `${id}_${suffix}`
+      icons[name] = {
+        component: MaterialIcon,
+        props: {
+          name
+        }
+      }
+    }
+  }
+  return icons
+}
+
+Vue.use(Vuetify, {
+  // iconfont: 'md',
+  icons: {
+    ...missingMaterialIcons(['visibility', 'visibility_off'])
+    // This will enable 'visibility_outline', 'visibility_off_round' and so on.
+  }
+})


### PR DESCRIPTION
## Description
This PR is identical to #7735, but for `next`. 
I added a kind description of how to use missing material icons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some material icons are missing by default. For example, `person` and `person_outline` are available, but `visibility_outline` isn't while `visibility` is. This has been a known issue for a while, but I personally had a bit embarrassing experience finding how to solve this inconsistency as there wasn't a clear and explicit description. Therefore I thought it would be helpful or at least convenient for other people if I can add some guide that can be easily copied and pasted.

Fixes https://github.com/vuetifyjs/vuetify/issues/4164

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Of course I run docs server on my local machine and found no problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) 
