### PR TITLE
docs: broken styles in codepen

### DIFF
--- a/packages/docs/src/examples/calendars/complex/events.vue
+++ b/packages/docs/src/examples/calendars/complex/events.vue
@@ -48,18 +48,19 @@
   }
 </script>
 
-<style lang="sass" scoped>
-.my-event
-  overflow: hidden
-  text-overflow: ellipsis
-  white-space: nowrap
-  border-radius: 2px
-  background-color: #1867c0
-  color: #ffffff
-  border: 1px solid #1867c0
-  width: 100%
-  font-size: 12px
-  padding: 3px
-  cursor: pointer
-  margin-bottom: 1px
+<style scoped>
+.my-event {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 2px;
+  background-color: #1867c0;
+  color: #ffffff;
+  border: 1px solid #1867c0;
+  width: 100%;
+  font-size: 12px;
+  padding: 3px;
+  cursor: pointer;
+  margin-bottom: 1px;
+}
 </style>

--- a/packages/docs/src/examples/calendars/simple/weekly.vue
+++ b/packages/docs/src/examples/calendars/simple/weekly.vue
@@ -70,25 +70,27 @@
   }
 </script>
 
-<style lang="sass" scoped>
-.my-event
-  overflow: hidden
-  text-overflow: ellipsis
-  white-space: nowrap
-  border-radius: 2px
-  background-color: #1867c0
-  color: #ffffff
-  border: 1px solid #1867c0
-  font-size: 12px
-  padding: 3px
-  cursor: pointer
-  margin-bottom: 1px
-  left: 4px
-  margin-right: 8px
-  position: relative
+<style scoped>
+.my-event {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 2px;
+  background-color: #1867c0;
+  color: #ffffff;
+  border: 1px solid #1867c0;
+  font-size: 12px;
+  padding: 3px;
+  cursor: pointer;
+  margin-bottom: 1px;
+  left: 4px;
+  margin-right: 8px;
+  position: relative;
+}
 
-  &.with-time
-    position: absolute
-    right: 4px
-    margin-right: 0px
+.my-event.with-time {
+  position: absolute;
+  right: 4px;
+  margin-right: 0px;
+}
 </style>

--- a/packages/docs/src/examples/icons/simple/md.vue
+++ b/packages/docs/src/examples/icons/simple/md.vue
@@ -58,9 +58,10 @@
   </v-container>
 </template>
 
-<style lang="sass">
-.group
-  display: flex
-  flex: 1
-  justify-content: space-around
+<style>
+.group {
+  display: flex;
+  flex: 1;
+  justify-content: space-around;
+}
 </style>

--- a/packages/docs/src/examples/layouts/google-keep.vue
+++ b/packages/docs/src/examples/layouts/google-keep.vue
@@ -146,8 +146,8 @@
   }
 </script>
 
-<style lang="sass">
-#keep
-  .v-navigation-drawer__border
-    display: none
+<style>
+#keep .v-navigation-drawer__border {
+  display: none
+}
 </style>

--- a/packages/docs/src/examples/menus/intermediate/absolute-without-activator.vue
+++ b/packages/docs/src/examples/menus/intermediate/absolute-without-activator.vue
@@ -57,9 +57,10 @@
   }
 </script>
 
-<style lang="sass" scoped>
-.portrait.v-card
-  margin: 0 auto
-  max-width: 600px
-  width: 100%
+<style scoped>
+.portrait.v-card {
+  margin: 0 auto;
+  max-width: 600px;
+  width: 100%;
+}
 </style>

--- a/packages/docs/src/examples/progress-circular/simple/circular-colored.vue
+++ b/packages/docs/src/examples/progress-circular/simple/circular-colored.vue
@@ -27,7 +27,8 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
-.v-progress-circular
-  margin: 1rem
+<style scoped>
+.v-progress-circular {
+  margin: 1rem;
+}
 </style>

--- a/packages/docs/src/examples/progress-circular/simple/circular-indeterminate.vue
+++ b/packages/docs/src/examples/progress-circular/simple/circular-indeterminate.vue
@@ -27,7 +27,8 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
-.v-progress-circular
-  margin: 1rem
+<style scoped>
+.v-progress-circular {
+  margin: 1rem;
+}
 </style>

--- a/packages/docs/src/examples/progress-circular/simple/circular-rotate.vue
+++ b/packages/docs/src/examples/progress-circular/simple/circular-rotate.vue
@@ -64,7 +64,8 @@
   }
 </script>
 
-<style lang="sass" scoped>
-.v-progress-circular
-  margin: 1rem
+<style scoped>
+.v-progress-circular {
+  margin: 1rem;
+}
 </style>

--- a/packages/docs/src/examples/progress-circular/simple/circular-size-and-width.vue
+++ b/packages/docs/src/examples/progress-circular/simple/circular-size-and-width.vue
@@ -33,7 +33,8 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
-.v-progress-circular
-  margin: 1rem
+<style scoped>
+.v-progress-circular {
+  margin: 1rem;
+}
 </style>

--- a/packages/docs/src/examples/progress-circular/usage.vue
+++ b/packages/docs/src/examples/progress-circular/usage.vue
@@ -12,7 +12,8 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
-.v-progress-circular
-  margin: 1rem
+<style scoped>
+.v-progress-circular {
+  margin: 1rem;
+}
 </style>

--- a/packages/docs/src/examples/sliders/simple/editable-numeric-value.vue
+++ b/packages/docs/src/examples/sliders/simple/editable-numeric-value.vue
@@ -85,8 +85,9 @@
   }
 </script>
 
-<style lang="sass">
-.e4
-  width: 400px
-  margin: auto
+<style scoped>
+.e4 {
+  width: 400px;
+  margin: auto;
+}
 </style>


### PR DESCRIPTION
Codepen component removes first 2 spaces from styles which breaks codepen if using sass (for example click the codepen btn on last calendars example)

https://vuetifyjscom-rbididdjsi.now.sh/en/components/calendars
vs
https://next.vuetifyjs.com/en/components/calendars