### PR TITLE
chore: throw if vuetify is not bootstrapped properly

### DIFF
--- a/packages/vuetify/src/components/VApp/VApp.ts
+++ b/packages/vuetify/src/components/VApp/VApp.ts
@@ -34,6 +34,12 @@ export default mixins(
     },
   },
 
+  beforeCreate () {
+    if (!this.$vuetify || (this.$vuetify === this.$root)) {
+      throw new Error('Vuetify is not properly initialized, see https://vuetifyjs.com/getting-started/quick-start#bootstrapping-the-vuetify-object')
+    }
+  },
+
   render (h) {
     const wrapper = h('div', { staticClass: 'v-application--wrap' }, this.$slots.default)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15625235/61821821-72546780-ae58-11e9-85de-78492f39e955.png)

I've tried `consoleError` as well but imho the message wasn't visible enough

## How Has This Been Tested?
replace `vuetify` with `v: vuetify` in dev/index.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
