### PR TITLE
chore: restrict vuetify and other libs version to current major

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ For including styles 🎨, you can either place the below styles in your `index.
 
 ```html
 <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
-<link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
 ```
 Or you can import it to your webpack entry point file. This is _usually_ your `main.js` file.
 
@@ -319,14 +319,14 @@ To use Vuetify in your project by directly importing it through CDNs (Content De
 
 ```html
 <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons" rel="stylesheet">
-<link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
 ```
 
 Don't forget to add both Vuetify and the main Vue library to your HTML file before the closing `</body>` tag.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
 ```
 
 ### Community Support

--- a/packages/docs/src/components/doc/Codepen.vue
+++ b/packages/docs/src/components/doc/Codepen.vue
@@ -18,14 +18,14 @@
 
   const cssResources = [
     'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900',
-    'https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css',
+    'https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css',
     'https://fonts.googleapis.com/css?family=Material+Icons',
     `https://cdn.jsdelivr.net/npm/vuetify@${version}/dist/vuetify.min.css`,
   ]
 
   const jsResources = [
     'https://cdn.jsdelivr.net/npm/babel-polyfill/dist/polyfill.min.js',
-    'https://cdn.jsdelivr.net/npm/vue/dist/vue.js',
+    'https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js',
     `https://cdn.jsdelivr.net/npm/vuetify@${version}/dist/vuetify.min.js`,
   ]
 

--- a/packages/docs/src/examples/autocompletes/usage.vue
+++ b/packages/docs/src/examples/autocompletes/usage.vue
@@ -21,6 +21,6 @@
 
 <codepen-resources lang="json">
   {
-    "css": ["https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css"]
+    "css": ["https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css"]
   }
 </codepen-resources>

--- a/packages/docs/src/examples/forms/intermediate/vee-validate.vue
+++ b/packages/docs/src/examples/forms/intermediate/vee-validate.vue
@@ -103,6 +103,6 @@
 
 <codepen-resources lang="json">
   {
-    "js": ["https://cdn.jsdelivr.net/npm/vee-validate@latest/dist/vee-validate.js"]
+    "js": ["https://cdn.jsdelivr.net/npm/vee-validate@2.x/dist/vee-validate.js"]
   }
 </codepen-resources>

--- a/packages/docs/src/examples/windows/playground.vue
+++ b/packages/docs/src/examples/windows/playground.vue
@@ -69,6 +69,6 @@
 
 <codepen-resources lang="json">
   {
-    "css": ["https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css"]
+    "css": ["https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css"]
   }
 </codepen-resources>

--- a/packages/docs/src/examples/windows/simple/reverse.vue
+++ b/packages/docs/src/examples/windows/simple/reverse.vue
@@ -81,6 +81,6 @@
 
 <codepen-resources lang="json">
   {
-    "css": ["https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css"]
+    "css": ["https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css"]
   }
 </codepen-resources>

--- a/packages/docs/src/examples/windows/simple/vertical.vue
+++ b/packages/docs/src/examples/windows/simple/vertical.vue
@@ -81,6 +81,6 @@
 
 <codepen-resources lang="json">
   {
-    "css": ["https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css"]
+    "css": ["https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css"]
   }
 </codepen-resources>

--- a/packages/docs/src/snippets/html/cdn_quickstart.txt
+++ b/packages/docs/src/snippets/html/cdn_quickstart.txt
@@ -2,8 +2,8 @@
 <html>
 <head>
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
 </head>
 <body>
@@ -15,8 +15,8 @@
     </v-app>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
   <script>
     new Vue({
       el: '#app',

--- a/packages/docs/src/snippets/html/fa4_link.txt
+++ b/packages/docs/src/snippets/html/fa4_link.txt
@@ -1,1 +1,1 @@
-<link href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/font-awesome@4.x/css/font-awesome.min.css" rel="stylesheet">

--- a/packages/docs/src/snippets/html/material_design_icons_link.txt
+++ b/packages/docs/src/snippets/html/material_design_icons_link.txt
@@ -1,1 +1,1 @@
-<link href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/packages/docs/src/themes/parallax-starter/index.html
+++ b/packages/docs/src/themes/parallax-starter/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href='https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons' rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
 </head>
 <body>
  <div id="app">
@@ -195,8 +195,8 @@
     </v-content>
   </v-app>
  </div>
- <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
- <script src="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
  <script>
    new Vue({
     el: '#app',

--- a/packages/kitchen/public/index.html
+++ b/packages/kitchen/public/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="See Vuetify components from a high level with multiple variations. Pick a meal (component) and see what it has to offer.">
     <meta name="keywords" content="vuetify kitchen, vuetify components, vuetify overview">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
-    <link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css">
   </head>
   <body>
     <noscript>

--- a/packages/kitchen/src/components/Codepen.vue
+++ b/packages/kitchen/src/components/Codepen.vue
@@ -78,14 +78,14 @@
       cssResources () {
         return [
           'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons',
-          'https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css',
+          'https://cdn.jsdelivr.net/npm/@mdi/font@3.x/css/materialdesignicons.min.css',
           `https://cdn.jsdelivr.net/npm/vuetify@${this.version}/dist/vuetify.min.css`,
         ]
       },
       jsResources () {
         return [
           'https://cdn.jsdelivr.net/npm/babel-polyfill/dist/polyfill.min.js',
-          'https://cdn.jsdelivr.net/npm/vue/dist/vue.js',
+          'https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js',
           `https://cdn.jsdelivr.net/npm/vuetify@${this.version}/dist/vuetify.min.js`,
         ]
       },


### PR DESCRIPTION
## Description
replaces `npm/vuetify/dist` with `npm/vuetify@^2/dist` to avoid breaking apps after releasing next major

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
