### PR TITLE
fix(VDataFooter): better handle custom item options

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -63,24 +63,10 @@ export default Vue.extend({
         this.pagination.pageStop < 0
     },
     computedItemsPerPageOptions (): any[] {
-      const itemsPerPageOptions = this.itemsPerPageOptions.map(option => {
+      return this.itemsPerPageOptions.map(option => {
         if (typeof option === 'object') return option
         else return this.genItemsPerPageOption(option)
       })
-
-      const customItemsPerPage = !itemsPerPageOptions.find(option => option.value === this.options.itemsPerPage)
-
-      if (customItemsPerPage) {
-        itemsPerPageOptions.push(this.genItemsPerPageOption(this.options.itemsPerPage))
-
-        itemsPerPageOptions.sort((a, b) => {
-          if (a.value === -1) return 1
-          else if (b.value === -1) return -1
-          else return a.value - b.value
-        })
-      }
-
-      return itemsPerPageOptions
     },
   },
 
@@ -110,6 +96,14 @@ export default Vue.extend({
       }
     },
     genItemsPerPageSelect () {
+      let value = this.options.itemsPerPage
+      const computedIPPO = this.computedItemsPerPageOptions
+
+      if (
+        computedIPPO.length > 0 &&
+        !computedIPPO.find(ippo => ippo.value === value)
+      ) value = this.computedItemsPerPageOptions[0]
+
       return this.$createElement('div', {
         staticClass: 'v-data-footer__select',
       }, [
@@ -121,7 +115,7 @@ export default Vue.extend({
           props: {
             disabled: this.disableItemsPerPage,
             items: this.computedItemsPerPageOptions,
-            value: this.options.itemsPerPage,
+            value,
             hideDetails: true,
             auto: true,
             minWidth: '75px',

--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -102,7 +102,7 @@ export default Vue.extend({
       if (
         computedIPPO.length > 0 &&
         !computedIPPO.find(ippo => ippo.value === value)
-      ) value = this.computedItemsPerPageOptions[0]
+      ) value = computedIPPO[0]
 
       return this.$createElement('div', {
         staticClass: 'v-data-footer__select',
@@ -114,7 +114,7 @@ export default Vue.extend({
           },
           props: {
             disabled: this.disableItemsPerPage,
-            items: this.computedItemsPerPageOptions,
+            items: computedIPPO,
             value,
             hideDetails: true,
             auto: true,

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataFooter.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataFooter.spec.ts
@@ -40,28 +40,10 @@ describe('VDataFooter.ts', () => {
     }
   })
 
-  it('should render and match snapshot', () => {
-    const wrapper = mountFunction({
-      propsData: {
-        options: {
-          page: 4,
-        },
-        pagination: {
-          page: 4,
-          pageStart: 1,
-          pageStop: 10,
-          pageCount: 10,
-          itemsLength: 100,
-        },
-      },
-    })
-
-    expect(wrapper.html()).toMatchSnapshot()
-  })
-
   it('should render with custom itemsPerPage', () => {
     const wrapper = mountFunction({
       propsData: {
+        itemsPerPageOptions: [100],
         options: {
           page: 4,
           itemsPerPage: 100,

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
@@ -1,77 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VDataFooter.ts should render and match snapshot 1`] = `
-<div class="v-data-footer">
-  <div class="v-data-footer__select">
-    Items per page:
-    <div class="v-input v-input--hide-details theme--light v-text-field v-select">
-      <div class="v-input__control">
-        <div role="button"
-             aria-haspopup="listbox"
-             aria-expanded="false"
-             aria-owns="list-2"
-             class="v-input__slot"
-        >
-          <div class="v-select__slot">
-            <div class="v-select__selections">
-              <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                     id="input-2"
-                     readonly="readonly"
-                     type="text"
-                     aria-readonly="true"
-              >
-            </div>
-            <div class="v-input__append-inner">
-              <div class="v-input__icon v-input__icon--append">
-                <i aria-hidden="true"
-                   class="v-icon notranslate mdi mdi-menu-down theme--light"
-                >
-                </i>
-              </div>
-            </div>
-          </div>
-          <div class="v-menu">
-            <div class="v-menu__content theme--light "
-                 style="max-height: 300px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
-            >
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="v-data-footer__pagination">
-    2-10 of 100
-  </div>
-  <div class="v-data-footer__icons-before">
-    <button type="button"
-            class="v-btn v-btn--fab v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
-            aria-label="Previous page"
-    >
-      <span class="v-btn__content">
-        <i aria-hidden="true"
-           class="v-icon notranslate mdi mdi-chevron-left theme--light"
-        >
-        </i>
-      </span>
-    </button>
-  </div>
-  <div class="v-data-footer__icons-after">
-    <button type="button"
-            class="v-btn v-btn--fab v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
-            aria-label="Next page"
-    >
-      <span class="v-btn__content">
-        <i aria-hidden="true"
-           class="v-icon notranslate mdi mdi-chevron-right theme--light"
-        >
-        </i>
-      </span>
-    </button>
-  </div>
-</div>
-`;
-
 exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 1`] = `
 <div class="v-data-footer">
   <div class="v-data-footer__select">
@@ -81,7 +9,7 @@ exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 
         <div role="button"
              aria-haspopup="listbox"
              aria-expanded="false"
-             aria-owns="list-39"
+             aria-owns="list-28"
              class="v-input__slot"
         >
           <div class="v-select__slot">
@@ -90,7 +18,7 @@ exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 
                 10
               </div>
               <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                     id="input-39"
+                     id="input-28"
                      readonly="readonly"
                      type="text"
                      aria-readonly="true"
@@ -178,7 +106,7 @@ exports[`VDataFooter.ts should render in RTL mode 1`] = `
         <div role="button"
              aria-haspopup="listbox"
              aria-expanded="false"
-             aria-owns="list-24"
+             aria-owns="list-13"
              class="v-input__slot"
         >
           <div class="v-select__slot">
@@ -187,7 +115,7 @@ exports[`VDataFooter.ts should render in RTL mode 1`] = `
                 10
               </div>
               <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                     id="input-24"
+                     id="input-13"
                      readonly="readonly"
                      type="text"
                      aria-readonly="true"
@@ -275,7 +203,7 @@ exports[`VDataFooter.ts should render with custom itemsPerPage 1`] = `
         <div role="button"
              aria-haspopup="listbox"
              aria-expanded="false"
-             aria-owns="list-13"
+             aria-owns="list-2"
              class="v-input__slot"
         >
           <div class="v-select__slot">
@@ -284,7 +212,7 @@ exports[`VDataFooter.ts should render with custom itemsPerPage 1`] = `
                 100
               </div>
               <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                     id="input-13"
+                     id="input-2"
                      readonly="readonly"
                      type="text"
                      aria-readonly="true"
@@ -351,7 +279,7 @@ exports[`VDataFooter.ts should show current page if has showCurrentPage 1`] = `
         <div role="button"
              aria-haspopup="listbox"
              aria-expanded="false"
-             aria-owns="list-65"
+             aria-owns="list-54"
              class="v-input__slot"
         >
           <div class="v-select__slot">
@@ -360,7 +288,7 @@ exports[`VDataFooter.ts should show current page if has showCurrentPage 1`] = `
                 10
               </div>
               <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                     id="input-65"
+                     id="input-54"
                      readonly="readonly"
                      type="text"
                      aria-readonly="true"


### PR DESCRIPTION
fixes #8026

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
When providing custom itemsPerPageOptions, if the current item did not exist in the options, it was pushed into the array. This means if no options are provided, 10 is the default and was being pushed into the array.

Now the system simply determines if the provided itemsPerPage exists in the items and if not, the first item is selected.
<!--- Describe your changes in detail -->

## Motivation and Context
itemsPerPage has a default value of 10, which consequently was getting pushed into the footers items array because it was a value that did not exist within the provided list. This causes issues when adding custom itemsPerPageOptions that does not contain the value 10, (or whatever value is defined for the options).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest / visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-5 pa-5">
    <v-data-table
      :headers="headers"
      :items="desserts"
      :options.sync="options"
      :server-items-length="totalDesserts"
      :loading="loading"
      class="elevation-1"
      :footer-props="footerProps"
    ></v-data-table>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        totalDesserts: 0,
        desserts: [],
        loading: true,
        footerProps: { itemsPerPageOptions : [5, 15, -1] },
        // footerProps: { itemsPerPageOptions : [50, 60, 70] },
        options: {
          // itemsPerPage: -1,
          // itemsPerPage: 60,
        },
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
      }
    },
    watch: {
      options: {
        handler () {
          this.getDataFromApi()
            .then(data => {
              this.desserts = data.items
              this.totalDesserts = data.total
            })
        },
        deep: true,
      },
    },
    mounted () {
      this.getDataFromApi()
        .then(data => {
          this.desserts = data.items
          this.totalDesserts = data.total
        })
    },
    methods: {
      getDataFromApi () {
        this.loading = true
        return new Promise((resolve, reject) => {
          const { sortBy, descending, page, itemsPerPage } = this.options

          let items = this.getDesserts()
          const total = items.length

          if (this.options.sortBy) {
            items = items.sort((a, b) => {
              const sortA = a[sortBy]
              const sortB = b[sortBy]

              if (descending) {
                if (sortA < sortB) return 1
                if (sortA > sortB) return -1
                return 0
              } else {
                if (sortA < sortB) return -1
                if (sortA > sortB) return 1
                return 0
              }
            })
          }

          if (itemsPerPage > 0) {
            items = items.slice((page - 1) * itemsPerPage, page * itemsPerPage)
          }

          setTimeout(() => {
            this.loading = false
            resolve({
              items,
              total,
            })
          }, 1000)
        })
      },
      getDesserts () {
        return [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ]
      },
    },
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
