### PR TITLE
docs: more spacings in playground

### DIFF
--- a/packages/docs/src/examples/spacing/playground.vue
+++ b/packages/docs/src/examples/spacing/playground.vue
@@ -27,7 +27,7 @@
             div() -
 
         v-select(
-          :items="sizes.slice(1)"
+          :items="paddingSizes.slice(1)"
           :label="$t('Styles.Spacing.size')"
           v-model="paddingSize"
         )
@@ -48,7 +48,7 @@
             div() -
 
         v-select(
-          :items="sizes"
+          :items="marginSizes"
           :label="$t('Styles.Spacing.size')"
           v-model="marginSize"
         )
@@ -74,7 +74,12 @@
   export default {
     data: () => ({
       directions: ['t', 'b', 'l', 'r', 's', 'e', 'x', 'y', 'a'],
-      sizes: ['auto', '0', '1', '2', '3', '4', '5'],
+      paddingSizes: ['auto', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
+      marginSizes: [
+        'auto',
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12',
+        'n1', 'n2', 'n3', 'n4', 'n5', 'n6', 'n7', 'n8', 'n9', 'n10', 'n11', 'n12',
+      ],
       paddingDirection: 'a',
       paddingSize: '2',
       marginDirection: 'a',


### PR DESCRIPTION
## Motivation and Context
MIssing spacing values in playgroun (6-12, negative margins)

## How Has This Been Tested?
https://vuetifyjscom-wguujrtcta.now.sh/en/styles/spacing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
