### PR TITLE
fix(VFileInput): unindent input when icon is empty

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -160,11 +160,11 @@ export default VTextField.extend({
       return [this.genSelections(), input]
     },
     genPrependSlot () {
+      if (!this.prependIcon) return null
+
       const icon = this.genIcon('prepend', () => {
         this.$refs.input.click()
       })
-
-      icon.data!.attrs = { tabindex: 0 }
 
       return this.genSlot('prepend', 'outer', [icon])
     },

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
@@ -181,4 +181,14 @@ describe('VFileInput.ts', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should render without icon', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        prependIcon: '',
+      },
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
@@ -182,6 +182,7 @@ describe('VFileInput.ts', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  // https://github.com/vuetifyjs/vuetify/issues/8049
   it('should render without icon', () => {
     const wrapper = mountFunction({
       propsData: {

--- a/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
@@ -3,9 +3,7 @@
 exports[`VFileInput.ts should be unclearable 1`] = `
 <div class="v-input v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -40,9 +38,7 @@ exports[`VFileInput.ts should be unclearable 1`] = `
 exports[`VFileInput.ts should display file size 1`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -87,9 +83,7 @@ exports[`VFileInput.ts should display file size 1`] = `
 exports[`VFileInput.ts should display file size 2`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -134,9 +128,7 @@ exports[`VFileInput.ts should display file size 2`] = `
 exports[`VFileInput.ts should display total size in counter 1`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -184,9 +176,7 @@ exports[`VFileInput.ts should display total size in counter 1`] = `
 exports[`VFileInput.ts should display total size in counter 2`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -234,9 +224,7 @@ exports[`VFileInput.ts should display total size in counter 2`] = `
 exports[`VFileInput.ts should render 1`] = `
 <div class="v-input v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -279,9 +267,7 @@ exports[`VFileInput.ts should render 1`] = `
 exports[`VFileInput.ts should render chips 1`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -330,9 +316,7 @@ exports[`VFileInput.ts should render chips 1`] = `
 exports[`VFileInput.ts should render counter 1`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -380,9 +364,7 @@ exports[`VFileInput.ts should render counter 1`] = `
 exports[`VFileInput.ts should render small chips 1`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty v-input--is-readonly theme--light v-text-field v-file-input">
   <div class="v-input__prepend-outer">
-    <div tabindex="0"
-         class="v-input__icon v-input__icon--prepend"
-    >
+    <div class="v-input__icon v-input__icon--prepend">
       <i role="button"
          class="v-icon notranslate v-icon--link material-icons theme--light"
       >
@@ -411,6 +393,40 @@ exports[`VFileInput.ts should render small chips 1`] = `
              class="v-icon notranslate v-icon--link material-icons theme--light"
           >
             $vuetify.icons.clear
+          </i>
+        </div>
+      </div>
+    </div>
+    <div class="v-text-field__details">
+      <div class="v-messages theme--light">
+        <span name="message-transition"
+              tag="div"
+              class="v-messages__wrapper"
+        >
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VFileInput.ts should render without icon 1`] = `
+<div class="v-input v-input--is-readonly theme--light v-text-field v-file-input">
+  <div class="v-input__control">
+    <div class="v-input__slot">
+      <div class="v-text-field__slot">
+        <div class="v-file-input__text">
+        </div>
+        <input id="input-83"
+               readonly="readonly"
+               type="file"
+        >
+      </div>
+      <div class="v-input__append-inner">
+        <div class="v-input__icon v-input__icon--">
+          <i role="button"
+             class="v-icon notranslate v-icon--link material-icons theme--light"
+          >
           </i>
         </div>
       </div>


### PR DESCRIPTION
## Description
also removes tab index from icon, it allowed to tab the icon but enter/space didn't do anything, without it it's still clickable

## Motivation and Context
fixes #8049

## How Has This Been Tested?
playground, unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-file-input prepend-icon="" />
    <v-file-input />
    <v-file-input prepend-icon="mdi-home" />
  </v-container>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
