### PR TITLE
fix(VDataTableHeaderMobile): don't show disabled headers in sort select

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeader.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeader.sass
@@ -66,7 +66,6 @@
 
   .v-select
     margin-bottom: 8px
-    margin-left: 16px
 
     .v-chip
       height: 24px

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaderMobile.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaderMobile.ts
@@ -37,14 +37,16 @@ export default mixins(header).extend({
       }, children)
     },
     genSortSelect () {
+      const sortHeaders = this.headers.filter(h => h.sortable !== false && h.value !== 'data-table-select')
+
       return this.$createElement(VSelect, {
         props: {
           label: 'Sort by',
-          items: this.headers.filter(h => h.value !== 'data-table-select'),
+          items: sortHeaders,
           hideDetails: true,
           multiple: this.options.multiSort,
           value: this.options.multiSort ? this.options.sortBy : this.options.sortBy[0],
-          disabled: this.disableSort,
+          disabled: sortHeaders.length === 0 || this.disableSort,
         },
         on: {
           change: (v: string | string[]) => this.$emit('sort', v),


### PR DESCRIPTION
## Description
hides disabled headers in sort VSelect, hides VSelect if there's no sortable headers at all

Alternatively it can show disabled VSelect if there's no sortable headers @vuetifyjs/core-team ?

## Motivation and Context
fixes #8036 

## How Has This Been Tested?
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table :headers="headers" :items="desserts" :items-per-page="5" class="elevation-1" />
    <v-data-table :headers="headers2" :items="desserts" :items-per-page="5" class="elevation-1" />
  </v-container>
</template>

<script>
export default {
  data: () => ({
    headers: [
      { text: 'Dessert (100g serving)', sortable: false, value: 'name' },
      { text: 'Calories', value: 'calories' },
    ],
    headers2: [
      { text: 'Dessert (100g serving)', sortable: false, value: 'name' },
      { text: 'Calories', sortable: false, value: 'calories' },
    ],
    desserts: [
      { name: 'Frozen Yogurt', calories: 159 },
      { name: 'Ice cream sandwich', calories: 237 },
    ],
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
