### PR TITLE
fix(VDataTable): no-data/no-results text improvements

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -6,7 +6,7 @@
 +theme(v-data-table) using ($material)
   tbody
     tr
-      &:hover:not(.v-data-table__expand-row)
+      &:hover:not(.v-data-table__expand-row):not(.v-data-table__empty-wrapper)
         background: map-deep-get($material, 'table', 'hover')
 
       &.expanded
@@ -24,6 +24,10 @@
 
   .v-data-footer
     border-top: 1px solid rgba(map-get($material, 'fg-color'), map-get($material, 'divider-percent'))
+
+  .v-data-table__empty-wrapper
+    color: map-deep-get($material, 'text', 'disabled')
+    text-align: center
 
 .v-data-table__mobile-row
   display: block

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -260,7 +260,9 @@ export default VDataIterator.extend({
       return children
     },
     genEmptyWrapper (content: VNodeChildrenArrayContents) {
-      return this.$createElement('tr', [
+      return this.$createElement('tr', {
+        staticClass: 'v-data-table__empty-wrapper',
+      }, [
         this.$createElement('td', {
           attrs: {
             colspan: this.computedHeadersLength,

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`VDataTable.ts should render 1`] = `
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="v-data-table__empty-wrapper">
           <td colspan="0">
             No data available
           </td>
@@ -137,7 +137,7 @@ exports[`VDataTable.ts should render loading state 1`] = `
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="v-data-table__empty-wrapper">
           <td colspan="0">
             Loading items...
           </td>
@@ -343,7 +343,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr class="v-data-table__empty-wrapper">
           <td colspan="6">
             Loading items...
           </td>


### PR DESCRIPTION
## Description
1. centers the no data / no results text
2. add disabled style to the text
3. removes hover effect on no data / no results row

## Motivation and Context
fixes #8102

## How Has This Been Tested?
playground, updated snapshots

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table :headers="[{text:'a',value:'a'},{text:'b',value:'b'}]" :items="[]" hide-default-footer></v-data-table>
    <v-data-table search="foo" :headers="[{text:'a',value:'a'},{text:'b',value:'b'}]" :items="[{}, {}]" hide-default-footer></v-data-table>
  </v-container>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
