### PR TITLE
fix(VCarousel): prev/next buttons were too small

### DIFF
--- a/packages/vuetify/src/components/VWindow/VWindow.sass
+++ b/packages/vuetify/src/components/VWindow/VWindow.sass
@@ -18,13 +18,8 @@
     top: calc(50% - 20px)
     z-index: 1
 
-    .v-btn
-      margin: 0
-      height: auto
-      width: auto
-
-      &:hover
-        background: none
+    .v-btn:hover
+      background: none
 
   &__prev
     left: 0

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -141,6 +141,7 @@ export default BaseItemGroup.extend({
         this.$createElement(VBtn, {
           props: {
             icon: true,
+            small: true,
           },
           attrs: {
             'aria-label': this.$vuetify.lang.t(`$vuetify.carousel.${direction}`),
@@ -153,7 +154,7 @@ export default BaseItemGroup.extend({
           },
         }, [
           this.$createElement(VIcon, {
-            props: { size: 40 },
+            props: { large: true },
           }, icon),
         ]),
       ])


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
increased size of buttons

## Motivation and Context
prev/next buttons were too small

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-carousel>
    <v-carousel-item
      v-for="(color, i) in colors"
      :key="color"
    >
      <v-sheet
        :color="color"
        height="100%"
        tile
      >
        <v-layout
          align-center
          fill-height
          justify-center
        >
          <div class="display-3">Slide {{ i + 1 }}</div>
        </v-layout>
      </v-sheet>
    </v-carousel-item>
  </v-carousel>
</template>

<script>
  export default {
    data () {
      return {
        colors: [
          'primary',
          'secondary',
          'yellow darken-2',
          'red',
          'orange',
        ],
      }
    },
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
