### PR TITLE
fix(docs): add link to release notes in front page message

### DIFF
--- a/packages/docs/src/components/core/Toolbar.vue
+++ b/packages/docs/src/components/core/Toolbar.vue
@@ -69,7 +69,7 @@
         white
         text--primary
       >
-        Looking for the&nbsp;<a class="primary--text font-weight-bold" href="https://v15.vuetifyjs.com" aria-label="v1.5 documentation">v1.5 documentation</a>?
+        You can find the 2.0 upgrade guide&nbsp;<a class="primary--text font-weight-bold" href="https://github.com/vuetifyjs/vuetify/releases/tag/v2.0.0">here</a>. Maybe you're looking for the&nbsp;<a class="primary--text font-weight-bold" href="https://v15.vuetifyjs.com" aria-label="v1.5 documentation">v1.5 documentation</a>?
       </v-layout>
     </template>
   </v-app-bar>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
adds message for users wanting to find the upgrade guide / release notes.

## Motivation and Context
I found it strange that we don't link to release notes from the docs.

## How Has This Been Tested?
running locally

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
