### PR TITLE
fix(VSimpleTable): fix hover when using tree-shaking

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -32,6 +32,9 @@
 
       &.active
         background: map-deep-get($material, 'table', 'active')
+        
+      &:hover
+        background: map-deep-get($material, 'table', 'hover')
 
 // Block
 .v-data-table


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fixes missing `hover` styling for **VSimpleTable** which was relying on `hover` of **VDataTable**, leading to an issue when not using **VDataTable** with **tree-shaking** enabled.

## Motivation and Context
https://github.com/nuxt-community/vuetify-module/issues/73

## How Has This Been Tested?
Visually when using VSimpleTable in production with treeShaking, `hover` gets fixed with this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.