### PR TITLE
fix(VSwitch): thumb position in inset v-switch in RTL mode

### DIFF
--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -17,16 +17,6 @@
       color: map-deep-get($material, 'selection-controls', 'track', 'disabled') !important
 
 .v-input--switch
-  +rtl()
-    .v-input--selection-controls__ripple
-      left: auto
-      right: $switch-ripple-x
-
-    &.v-input--is-dirty
-      .v-input--selection-controls__ripple,
-      .v-input--switch__thumb
-        transform: translate(-$switch-dirty-offset-x, 0)
-
   &__track,
   &__thumb
     background-color: currentColor
@@ -58,16 +48,29 @@
     width: 38px
 
   .v-input--selection-controls__ripple
-    left: $switch-ripple-x
     top: $switch-ripple-top
 
   &.v-input--is-dirty
     &.v-input--is-disabled
       opacity: $switch-disabled-opacity
 
-    .v-input--selection-controls__ripple,
-    .v-input--switch__thumb
-      transform: translate($switch-dirty-offset-x, 0)
+  +ltr()
+    .v-input--selection-controls__ripple
+      left: $switch-ripple-x
+
+    &.v-input--is-dirty
+      .v-input--selection-controls__ripple,
+      .v-input--switch__thumb
+        transform: translate($switch-dirty-offset-x, 0)
+
+  +rtl()
+    .v-input--selection-controls__ripple
+      right: $switch-ripple-x
+
+    &.v-input--is-dirty
+      .v-input--selection-controls__ripple,
+      .v-input--switch__thumb
+        transform: translate(-$switch-dirty-offset-x, 0)
 
   &:not(&--flat):not(&--inset)
     .v-input--switch__thumb
@@ -84,3 +87,23 @@
       left: -4px
       opacity: .32
       top: calc(50% - 14px)
+
+    +ltr()
+      .v-input--selection-controls__ripple,
+      .v-input--switch__thumb
+        transform: translate(0, 0) !important
+
+      &.v-input--is-dirty
+        .v-input--selection-controls__ripple,
+        .v-input--switch__thumb
+          transform: translate(20px, 0) !important
+
+    +rtl()
+      .v-input--selection-controls__ripple,
+      .v-input--switch__thumb
+        transform: translate(-6px, 0) !important
+
+      &.v-input--is-dirty
+        .v-input--selection-controls__ripple,
+        .v-input--switch__thumb
+          transform: translate(-26px, 0) !important

--- a/packages/vuetify/src/components/VSwitch/_variables.sass
+++ b/packages/vuetify/src/components/VSwitch/_variables.sass
@@ -11,4 +11,4 @@ $switch-thumb-width: 20px
 $switch-thumb-height: 20px
 $switch-thumb-top: calc(50% - 10px)
 $switch-thumb-elevation: 4
-$switch-dirty-offset-x: 18px
+$switch-dirty-offset-x: 20px


### PR DESCRIPTION
## Motivation and Context
fixes #8130
and minor bug (2px offset) for normal `v-switch`

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container grid-list-xl>
    <v-btn block @click="$vuetify.rtl = !$vuetify.rtl">Toggle rtl</v-btn>
    <v-switch inset :input-value="false"></v-switch>
    <v-switch inset :input-value="true"></v-switch>
    <v-switch :input-value="false"></v-switch>
    <v-switch :input-value="true"></v-switch>
  </v-container>
</template>

<style>
.theme--light.v-input--switch .v-input--switch__thumb,
.theme--light.v-input--switch .v-input--switch__thumb.accent--text {
    color: rgba(255, 255, 255, 0.5) !important;
}
</style>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
