### PR TITLE
fix(#6962): Fix race conditions in VWindowItem.ts during transition.

### DIFF
--- a/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
+++ b/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
@@ -17,7 +17,6 @@ export type GroupableInstance = InstanceType<typeof Groupable> & {
   id?: string
   to?: any
   value?: any
-  beforeChange?: (v: boolean) => void // Callback before setting isActive
  }
 
 export const BaseItemGroup = mixins(
@@ -169,12 +168,7 @@ export const BaseItemGroup = mixins(
     updateItem (item: GroupableInstance, index: number) {
       const value = this.getValue(item, index)
 
-      var val = this.toggleMethod(value)
-      // Trigger callback only if value changed.
-      if (val !== item.isActive && item.beforeChange) {
-        item.beforeChange(val)
-      }
-      item.isActive = val
+      item.isActive = this.toggleMethod(value)
     },
     updateItemsState () {
       if (this.mandatory &&

--- a/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
+++ b/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
@@ -17,6 +17,7 @@ export type GroupableInstance = InstanceType<typeof Groupable> & {
   id?: string
   to?: any
   value?: any
+  beforeChange?: (v: boolean) => void // Callback before setting isActive
  }
 
 export const BaseItemGroup = mixins(
@@ -168,7 +169,12 @@ export const BaseItemGroup = mixins(
     updateItem (item: GroupableInstance, index: number) {
       const value = this.getValue(item, index)
 
-      item.isActive = this.toggleMethod(value)
+      var val = this.toggleMethod(value)
+      // Trigger callback only if value changed.
+      if (val !== item.isActive && item.beforeChange) {
+        item.beforeChange(val)
+      }
+      item.isActive = val
     },
     updateItemsState () {
       if (this.mandatory &&

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -60,7 +60,7 @@ export default BaseItemGroup.extend({
     return {
       changedByDelimiters: false,
       internalHeight: undefined as undefined | string,
-      activeWindows: 0 as number,
+      transitionCount: 0, // Number of windows in transition state.
       isBooted: false,
       isReverse: false,
     }
@@ -68,7 +68,7 @@ export default BaseItemGroup.extend({
 
   computed: {
     isActive (): boolean {
-      return this.activeWindows > 0
+      return this.transitionCount > 0
     },
     classes (): object {
       return {

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -60,13 +60,16 @@ export default BaseItemGroup.extend({
     return {
       changedByDelimiters: false,
       internalHeight: undefined as undefined | string,
-      isActive: false,
+      activeWindows: 0 as number,
       isBooted: false,
       isReverse: false,
     }
   },
 
   computed: {
+    isActive (): boolean {
+      return this.activeWindows > 0
+    },
     classes (): object {
       return {
         ...BaseItemGroup.options.computed.classes.call(this),

--- a/packages/vuetify/src/components/VWindow/VWindowItem.ts
+++ b/packages/vuetify/src/components/VWindow/VWindowItem.ts
@@ -93,11 +93,12 @@ export default baseMixins.extend<options>().extend(
         return
       }
 
-      // This function must be called in all path of the transition.
+      // Finalize transition state.
       this.inTransition = false
       if (this.windowGroup.activeWindows > 0) {
         this.windowGroup.activeWindows--
 
+        // Remove container height if we are out of transition.
         if (this.windowGroup.activeWindows === 0) {
           this.windowGroup.internalHeight = undefined
         }
@@ -117,7 +118,7 @@ export default baseMixins.extend<options>().extend(
       this.windowGroup.activeWindows++
     },
     onTransitionCancelled () {
-      this.onAfterTransition() // Same path as normal transition end.
+      this.onAfterTransition() // This should have the same path as normal transition end.
     },
     onEnter (el: HTMLElement) {
       if (!this.inTransition) {
@@ -125,7 +126,7 @@ export default baseMixins.extend<options>().extend(
       }
 
       this.$nextTick(() => {
-        // If cancelled, we should terminate early since transition end event may not fire.
+        // Do not set height if no transition or cancelled.
         if (!this.computedTransition || !this.inTransition) {
           return
         }
@@ -142,15 +143,17 @@ export default baseMixins.extend<options>().extend(
         name: this.computedTransition,
       },
       on: {
-        // Same handler for enter/leave windows.
+        // Handlers for enter windows.
         beforeEnter: this.onBeforeTransition,
         afterEnter: this.onAfterTransition,
         enterCancelled: this.onTransitionCancelled,
 
+        // Handlers for leave windows.
         beforeLeave: this.onBeforeTransition,
         afterLeave: this.onAfterTransition,
         leaveCancelled: this.onTransitionCancelled,
 
+        // Enter handler for height transition.
         enter: this.onEnter,
       },
     }, [this.genWindowItem()])

--- a/packages/vuetify/src/components/VWindow/VWindowItem.ts
+++ b/packages/vuetify/src/components/VWindow/VWindowItem.ts
@@ -95,11 +95,11 @@ export default baseMixins.extend<options>().extend(
 
       // Finalize transition state.
       this.inTransition = false
-      if (this.windowGroup.activeWindows > 0) {
-        this.windowGroup.activeWindows--
+      if (this.windowGroup.transitionCount > 0) {
+        this.windowGroup.transitionCount--
 
         // Remove container height if we are out of transition.
-        if (this.windowGroup.activeWindows === 0) {
+        if (this.windowGroup.transitionCount === 0) {
           this.windowGroup.internalHeight = undefined
         }
       }
@@ -111,11 +111,11 @@ export default baseMixins.extend<options>().extend(
 
       // Initialize transition state here.
       this.inTransition = true
-      if (this.windowGroup.activeWindows === 0) {
+      if (this.windowGroup.transitionCount === 0) {
         // Set initial height for height transition.
         this.windowGroup.internalHeight = convertToUnit(this.windowGroup.$el.clientHeight)
       }
-      this.windowGroup.activeWindows++
+      this.windowGroup.transitionCount++
     },
     onTransitionCancelled () {
       this.onAfterTransition() // This should have the same path as normal transition end.

--- a/packages/vuetify/src/components/VWindow/VWindowItem.ts
+++ b/packages/vuetify/src/components/VWindow/VWindowItem.ts
@@ -53,7 +53,6 @@ export default baseMixins.extend<options>().extend(
     return {
       isActive: false,
       inTransition: false,
-      initialHeight: undefined as string | undefined,
     }
   },
 
@@ -89,13 +88,6 @@ export default baseMixins.extend<options>().extend(
         on: this.$listeners,
       }, this.showLazyContent(this.genDefaultSlot()))
     },
-    beforeChange (val: boolean) {
-      if (this.windowGroup.$el) {
-        // Cache initial height before any transition event. Both enter/leave window will
-        // have the initial value becuase we don't know which one will enter first.
-        this.initialHeight = convertToUnit(this.windowGroup.$el.clientHeight)
-      }
-    },
     onAfterTransition () {
       if (!this.inTransition) {
         return
@@ -119,7 +111,8 @@ export default baseMixins.extend<options>().extend(
       // Initialize transition state here.
       this.inTransition = true
       if (this.windowGroup.activeWindows === 0) {
-        this.windowGroup.internalHeight = this.initialHeight
+        // Set initial height for height transition.
+        this.windowGroup.internalHeight = convertToUnit(this.windowGroup.$el.clientHeight)
       }
       this.windowGroup.activeWindows++
     },

--- a/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
+++ b/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
@@ -66,7 +66,6 @@ describe('VWindowItem.ts', () => {
 
     // After enter
     item.vm.onAfterTransition()
-    await new Promise(resolve => window.requestAnimationFrame(resolve))
     expect(wrapper.vm.internalHeight).toBeUndefined()
     expect(wrapper.vm.isActive).toBeFalsy()
 
@@ -75,14 +74,13 @@ describe('VWindowItem.ts', () => {
     item.vm.onEnter(el)
     item.vm.onTransitionCancelled()
 
-    expect(item.vm.wasCancelled).toBeTruthy()
+    expect(item.vm.inTransition).toBeFalsy()
     expect(wrapper.vm.isActive).toBeFalsy()
 
     // Normal path.
     item.vm.onBeforeTransition()
     expect(wrapper.vm.isActive).toBeTruthy()
     item.vm.onAfterTransition()
-    await new Promise(resolve => window.requestAnimationFrame(resolve))
 
     expect(wrapper.vm.isActive).toBeFalsy()
   })

--- a/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
+++ b/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
@@ -146,4 +146,36 @@ describe('VWindowItem.ts', () => {
 
     expect(heightChanged).toHaveBeenCalledTimes(1)
   })
+
+  it('should increase and decrease transition count correctly', () => {
+    const wrapper = mount(VWindow, {
+      slots: {
+        default: [VWindowItem, VWindowItem, VWindowItem],
+      },
+    })
+
+    const items = wrapper.vm.items
+    expect(items).toHaveLength(3)
+
+    expect(wrapper.vm.transitionCount).toBe(0)
+    expect(wrapper.vm.isActive).toBeFalsy()
+    items[0].onBeforeTransition()
+    expect(wrapper.vm.transitionCount).toBe(1)
+    expect(wrapper.vm.isActive).toBeTruthy()
+    items[1].onBeforeTransition()
+    expect(wrapper.vm.transitionCount).toBe(2)
+    expect(wrapper.vm.isActive).toBeTruthy()
+    items[0].onTransitionCancelled()
+    expect(wrapper.vm.transitionCount).toBe(1)
+    expect(wrapper.vm.isActive).toBeTruthy()
+    items[2].onBeforeTransition()
+    expect(wrapper.vm.transitionCount).toBe(2)
+    expect(wrapper.vm.isActive).toBeTruthy()
+    items[1].onAfterTransition()
+    expect(wrapper.vm.transitionCount).toBe(1)
+    expect(wrapper.vm.isActive).toBeTruthy()
+    items[2].onAfterTransition()
+    expect(wrapper.vm.transitionCount).toBe(0)
+    expect(wrapper.vm.isActive).toBeFalsy()
+  })
 })

--- a/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
+++ b/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
@@ -54,15 +54,16 @@ describe('VWindowItem.ts', () => {
     const item = wrapper.find(VWindowItem.options)
     // Before enter
     expect(wrapper.vm.isActive).toBeFalsy()
+    expect(wrapper.vm.internalHeight).toBeUndefined()
     item.vm.onBeforeTransition()
     expect(wrapper.vm.isActive).toBeTruthy()
+    expect(wrapper.vm.internalHeight).toBe('0px')
 
     // Enter
-    const el = document.createElement('div')
-    expect(wrapper.vm.internalHeight).toBeUndefined()
+    const el = { clientHeight: 50 }
     item.vm.onEnter(el)
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.internalHeight).toBe('0px')
+    expect(wrapper.vm.internalHeight).toBe('50px')
 
     // After enter
     item.vm.onAfterTransition()
@@ -135,7 +136,6 @@ describe('VWindowItem.ts', () => {
     const item = wrapper.find(VWindowItem.options)
     expect(wrapper.vm.computedTransition).toBeFalsy()
 
-    item.vm.beforeChange(true)
     item.vm.onBeforeTransition()
     expect(wrapper.vm.isActive).toBeTruthy()
     expect(heightChanged).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
From time to time, the transition state of the VWindow container is
not finished and the height will be fixed. This change fixed this
problem.

FINDINGS:

- If transitionend fired before nextTick(), then done() is never
  going to be invoked.
- onEnter() itself may be re-entered during transiton. Then the
  state is messed up.
- onBeforeLeave() may be called after cancel, then the height
  is stuck.
- onBeforeEnter() may be re-entered after first call. Calling
  this multiple times also wrongly reset transition state.

SOLUTION:

- Put correct guards on each event handler. Check of isActive and
  wasCancelled accordingly for each event to prevent re-entrant.
- Put a timer in onEnter() to ensure done() is always invoked and
  deactivate() after timeout if anything goes wrong.

TESTS:

- Add log instrumentations for observation.
- Test quickly switching tabs and see container always deactivate.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [x] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
