### PR TITLE
fix(Theme): fix vue-meta theme on page navigation

### DIFF
--- a/packages/vuetify/src/services/theme/__tests__/__snapshots__/theme.spec.ts.snap
+++ b/packages/vuetify/src/services/theme/__tests__/__snapshots__/theme.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Theme.ts should add fake child element for vue-meta with ssr support 1`] = `
+exports[`Theme.ts should add fake child element for vue-meta support 1`] = `
 Object {
   "style": Array [
     Object {

--- a/packages/vuetify/src/services/theme/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/services/theme/__tests__/theme.spec.ts
@@ -183,17 +183,9 @@ describe('Theme.ts', () => {
     expect(ssrContext.head).toMatchSnapshot()
   })
 
-  it('should add fake child element for vue-meta with ssr support', () => {
+  it('should add fake child element for vue-meta support', () => {
     const theme = new Theme(mock)
     ;(instance as any).$meta = {}
-
-    // $isServer is read only but need to be set for test purpose : https://github.com/vuejs/vue/issues/9232#issuecomment-477914392
-    Object.setPrototypeOf(
-      instance,
-      new Proxy(Object.getPrototypeOf(instance), {
-        get: (target, key, receiver) => key === '$isServer' ? true : Reflect.get(target, key, receiver),
-      })
-    )
 
     expect(instance.$children).toHaveLength(0)
 
@@ -205,7 +197,7 @@ describe('Theme.ts', () => {
     const head = options.head
 
     expect(head).toBeTruthy()
-    expect(head).toMatchSnapshot()
+    expect(head()).toMatchSnapshot()
   })
 
   it('should react to theme changes', async () => {

--- a/packages/vuetify/src/services/theme/index.ts
+++ b/packages/vuetify/src/services/theme/index.ts
@@ -110,10 +110,10 @@ export class Theme extends Service {
     if (this.disabled) return
 
     /* istanbul ignore else */
-    if (ssrContext) {
-      this.initSSR(ssrContext)
-    } else if (root.$isServer && (root as any).$meta) {
+    if ((root as any).$meta) {
       this.initVueMeta(root)
+    } else if (ssrContext) {
+      this.initSSR(ssrContext)
     }
 
     this.initTheme()
@@ -178,15 +178,17 @@ export class Theme extends Service {
   private initVueMeta (root: Vue) {
     const options = this.options || {}
     root.$children.push(new Vue({
-      head: {
-        style: [
-          {
-            cssText: this.generatedStyles,
-            type: 'text/css',
-            id: 'vuetify-theme-stylesheet',
-            nonce: options.cspNonce,
-          },
-        ],
+      head: () => {
+        return {
+          style: [
+            {
+              cssText: this.generatedStyles,
+              type: 'text/css',
+              id: 'vuetify-theme-stylesheet',
+              nonce: options.cspNonce,
+            },
+          ],
+        }
       },
     } as any))
   }


### PR DESCRIPTION
## Description

1) Reverts #8079 as it breaks in more cases than the ones it was aiming to fix. 

> We still need to find a solution to not have duplicated stylesheet in SPA projects that uses VueMeta.
2) Makes `head` a function instead of object for VueMeta theme to fix theme when navigating pages

## Motivation and Context
#7879 
https://github.com/nuxt-community/vuetify-module/issues/91
https://github.com/nuxt-community/vuetify-module/issues/63

This PR *should* fix these 3 issues.

## How Has This Been Tested?
Jest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.