### PR TITLE
[Bug] fix(VDataTable): show no-results when custom filter returns zero rows

### DIFF
--- a/packages/vuetify/src/components/VData/VData.ts
+++ b/packages/vuetify/src/components/VData/VData.ts
@@ -23,6 +23,7 @@ export interface DataPagination {
 }
 
 export interface DataProps {
+  originalItemsLength: number
   items: any[]
   pagination: DataPagination
   options: DataOptions
@@ -183,6 +184,7 @@ export default Vue.extend({
         updateOptions: this.updateOptions,
         pagination: this.pagination,
         groupedItems: this.groupedItems,
+        originalItemsLength: this.items.length,
       }
 
       return props

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -183,14 +183,14 @@ export default Themeable.extend({
     genEmptyWrapper (content: VNodeChildren) {
       return this.$createElement('div', content)
     },
-    genEmpty (itemsLength: number) {
-      if (itemsLength <= 0 && this.loading) {
+    genEmpty (originalItemsLength: number, filteredItemsLength: number) {
+      if (originalItemsLength <= 0 && this.loading) {
         const loading = this.$slots['loading'] || this.$vuetify.lang.t(this.loadingText)
         return this.genEmptyWrapper(loading)
-      } else if (itemsLength <= 0 && !this.items.length) {
+      } else if (originalItemsLength <= 0) {
         const noData = this.$slots['no-data'] || this.$vuetify.lang.t(this.noDataText)
         return this.genEmptyWrapper(noData)
-      } else if (itemsLength <= 0 && this.search) {
+      } else if (filteredItemsLength <= 0) {
         const noResults = this.$slots['no-results'] || this.$vuetify.lang.t(this.noResultsText)
         return this.genEmptyWrapper(noResults)
       }
@@ -198,7 +198,7 @@ export default Themeable.extend({
       return null
     },
     genItems (props: DataProps) {
-      const empty = this.genEmpty(props.pagination.itemsLength)
+      const empty = this.genEmpty(props.originalItemsLength, props.pagination.itemsLength)
       if (empty) return [empty]
 
       if (this.$scopedSlots.default) {

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -184,13 +184,13 @@ export default Themeable.extend({
       return this.$createElement('div', content)
     },
     genEmpty (originalItemsLength: number, filteredItemsLength: number) {
-      if (originalItemsLength <= 0 && this.loading) {
+      if (originalItemsLength === 0 && this.loading) {
         const loading = this.$slots['loading'] || this.$vuetify.lang.t(this.loadingText)
         return this.genEmptyWrapper(loading)
-      } else if (originalItemsLength <= 0) {
+      } else if (originalItemsLength === 0) {
         const noData = this.$slots['no-data'] || this.$vuetify.lang.t(this.noDataText)
         return this.genEmptyWrapper(noData)
-      } else if (filteredItemsLength <= 0) {
+      } else if (filteredItemsLength === 0) {
         const noResults = this.$slots['no-results'] || this.$vuetify.lang.t(this.noResultsText)
         return this.genEmptyWrapper(noResults)
       }

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -282,7 +282,7 @@ export default VDataIterator.extend({
       ])
     },
     genItems (items: any[], props: DataProps) {
-      const empty = this.genEmpty(props.pagination.itemsLength)
+      const empty = this.genEmpty(props.originalItemsLength, props.pagination.itemsLength)
       if (empty) return [empty]
 
       return props.groupedItems


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
changed logic around showing empty messages so that it uses original items length and filtered items length instead of relying on `search` prop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #8131

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-data-table
      :headers="headers"
      :items="items"
    />
    <v-data-table
      :headers="headers"
      :items="[]"
    />
    <v-data-table
      :headers="headers"
      :items="[]"
      loading
    />
    <v-data-table
      :headers="headers2"
      :items="items"
      search="ö"
    />
    <v-data-table
      :headers="headers2"
      :items="items"
    />
  </div>
</template>

<script>
export default {
  data: () => ({
    headers: [
      {
        value: 'foo',
        text: 'Foo',
        filter: () => false
      }
    ],
    headers2: [
      {
        value: 'foo',
        text: 'Foo',
      }
    ],
    items: [
      { foo: 1 }
    ]
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
