### PR TITLE
feat(VTextField): hide affixes when neither focused nor dirty

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -73,6 +73,14 @@ export default baseMixins.extend<options>().extend({
     chips: Boolean,
     clearable: Boolean,
     deletableChips: Boolean,
+    displayPrefix: {
+      type: Boolean,
+      default: true,
+    },
+    displaySuffix: {
+      type: Boolean,
+      default: true,
+    },
     dense: Boolean,
     eager: Boolean,
     hideSelected: Boolean,

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -56,6 +56,7 @@
 .v-text-field
   padding-top: $text-field-active-label-height
   margin-top: $input-top-spacing - $text-field-active-label-height
+  overflow: hidden
 
   input
     flex: 1 1 auto

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -55,6 +55,8 @@ export default baseMixins.extend<options>().extend({
       default: '$vuetify.icons.clear',
     },
     counter: [Boolean, Number, String],
+    displayPrefix: Boolean,
+    displaySuffix: Boolean,
     filled: Boolean,
     flat: Boolean,
     fullWidth: Boolean,
@@ -396,12 +398,14 @@ export default baseMixins.extend<options>().extend({
       ])
     },
     genAffix (type: 'prefix' | 'suffix') {
+      const hideMe = type === 'prefix' ? !this.displayPrefix : !this.displaySuffix
+
       return this.$createElement('transition', {
         props: {
           name: type === 'prefix' ? 'slide-x-transition' : 'slide-x-reverse-transition',
         },
       }, [
-        this.hideAffixes ? null : this.$createElement('div', {
+        this.hideAffixes && hideMe ? null : this.$createElement('div', {
           class: `v-text-field__${type}`,
           ref: type,
         }, this[type]),

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -92,7 +92,7 @@ export default baseMixins.extend<options>().extend({
         ...VInput.options.computed.classes.call(this),
         'v-text-field': true,
         'v-text-field--full-width': this.fullWidth,
-        'v-text-field--prefix': this.prefix,
+        'v-text-field--prefix': this.prefix && !this.hideAffixes,
         'v-text-field--single-line': this.isSingle,
         'v-text-field--solo': this.isSolo,
         'v-text-field--solo-inverted': this.soloInverted,
@@ -160,6 +160,9 @@ export default baseMixins.extend<options>().extend({
     labelValue (): boolean {
       return !this.isSingle &&
         Boolean(this.isFocused || this.isLabelActive || this.placeholder)
+    },
+    hideAffixes (): boolean {
+      return !this.isFocused && !this.isDirty
     },
   },
 
@@ -393,6 +396,8 @@ export default baseMixins.extend<options>().extend({
       ])
     },
     genAffix (type: 'prefix' | 'suffix') {
+      if (this.hideAffixes) return null
+
       return this.$createElement('div', {
         class: `v-text-field__${type}`,
         ref: type,

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -396,12 +396,16 @@ export default baseMixins.extend<options>().extend({
       ])
     },
     genAffix (type: 'prefix' | 'suffix') {
-      if (this.hideAffixes) return null
-
-      return this.$createElement('div', {
-        class: `v-text-field__${type}`,
-        ref: type,
-      }, this[type])
+      return this.$createElement('transition', {
+        props: {
+          name: type === 'prefix' ? 'slide-x-transition' : 'slide-x-reverse-transition',
+        },
+      }, [
+        this.hideAffixes ? null : this.$createElement('div', {
+          class: `v-text-field__${type}`,
+          ref: type,
+        }, this[type]),
+      ])
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -428,12 +428,48 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   it('should have prefix and suffix', () => {
     const wrapper = mountFunction({
       propsData: {
+        displayPrefix: true,
+        prefix: '$',
+        displaySuffix: true,
+        suffix: '.com',
+      },
+    })
+
+    expect(wrapper.findAll('.v-text-field__prefix')).toHaveLength(1);
+    expect(wrapper.findAll('.v-text-field__suffix')).toHaveLength(1);
+  })
+
+  it('should have prefix and suffix only when focused/dirty', () => {
+    const wrapper = mountFunction({
+      propsData: {
         prefix: '$',
         suffix: '.com',
       },
     })
 
-    expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapper.findAll('.v-text-field__prefix').wrappers).toHaveLength(0)
+    expect(wrapper.findAll('.v-text-field__suffix').wrappers).toHaveLength(0)
+    expect(wrapper.vm.hideAffixes).toBeTruthy()
+
+    wrapper.vm.focus()
+
+    expect(wrapper.findAll('.v-text-field__prefix').wrappers).toHaveLength(1)
+    expect(wrapper.findAll('.v-text-field__suffix').wrappers).toHaveLength(1)
+    expect(wrapper.vm.hideAffixes).toBeFalsy()
+
+    wrapper.vm.blur()
+
+    expect(wrapper.findAll('.v-text-field__prefix').wrappers).toHaveLength(0)
+    expect(wrapper.findAll('.v-text-field__suffix').wrappers).toHaveLength(0)
+    expect(wrapper.vm.hideAffixes).toBeTruthy()
+
+    wrapper.setProps({
+      value: 'test',
+    })
+
+    expect(wrapper.findAll('.v-text-field__prefix')).toHaveLength(1)
+    expect(wrapper.findAll('.v-text-field__suffix')).toHaveLength(1)
+    expect(wrapper.vm.hideAffixes).toBeFalsy()
   })
 
   it('should use a custom clear callback', async () => {

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -435,8 +435,8 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
       },
     })
 
-    expect(wrapper.findAll('.v-text-field__prefix')).toHaveLength(1);
-    expect(wrapper.findAll('.v-text-field__suffix')).toHaveLength(1);
+    expect(wrapper.findAll('.v-text-field__prefix')).toHaveLength(1)
+    expect(wrapper.findAll('.v-text-field__suffix')).toHaveLength(1)
   })
 
   it('should have prefix and suffix only when focused/dirty', () => {

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -22,13 +22,13 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
         </div>
       </div>
       <div class="v-text-field__slot">
-        <label for="input-155"
+        <label for="input-163"
                class="v-label theme--light"
                style="left: 0px; position: absolute;"
         >
           foo
         </label>
-        <input id="input-155"
+        <input id="input-163"
                type="text"
         >
       </div>
@@ -64,35 +64,6 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
          class="v-icon notranslate append append-outer theme--light"
       >
       </i>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`VTextField.ts should have prefix and suffix 1`] = `
-<div class="v-input theme--light v-text-field v-text-field--prefix">
-  <div class="v-input__control">
-    <div class="v-input__slot">
-      <div class="v-text-field__slot">
-        <div class="v-text-field__prefix">
-          $
-        </div>
-        <input id="input-108"
-               type="text"
-        >
-        <div class="v-text-field__suffix">
-          .com
-        </div>
-      </div>
-    </div>
-    <div class="v-text-field__details">
-      <div class="v-messages theme--light">
-        <span name="message-transition"
-              tag="div"
-              class="v-messages__wrapper"
-        >
-        </span>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Hide prefix/suffix when text field isn't focused or dirty.
- [x] Add a prop to force display affixes
- [x] Add animations
- [x] Fix VSelect etc

## Motivation and Context
Fixes #7872

## How Has This Been Tested?
Markup
- [x] `jest`

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field prefix="$" suffix="%"></v-text-field>
  </v-container>
</template>

<script>
export default {
  data: () => ({
  }),
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
