### PR TITLE
[Bug] fix(VDataTable): fix header column widths not being respected

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -197,9 +197,6 @@ export default VDataIterator.extend({
           class: {
             divider: header.divider,
           },
-          style: {
-            width: header.width,
-          },
         })
       }))
     },

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaderDesktop.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaderDesktop.ts
@@ -24,7 +24,11 @@ export default mixins(header).extend({
         scope: 'col',
         'aria-label': header.text || '',
         'aria-sort': 'none',
+      }
+
+      const styles = {
         width: header.width,
+        minWidth: header.width,
       }
 
       const classes = [
@@ -77,6 +81,7 @@ export default mixins(header).extend({
       return this.$createElement('th', {
         attrs,
         class: classes,
+        style: styles,
         on: listeners,
       }, children)
     },

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -2706,9 +2706,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>
-        <col class
-             style="width: 1px;"
-        >
+        <col class>
         <col class>
         <col class>
         <col class>
@@ -2722,8 +2720,8 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
               scope="col"
               aria-label
               aria-sort="none"
-              width="1px"
               class="text-start"
+              style="width: 1px; min-width: 1px;"
           >
             <span>
             </span>
@@ -3043,9 +3041,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>
-        <col class
-             style="width: 1px;"
-        >
+        <col class>
         <col class>
         <col class>
         <col class>
@@ -3059,8 +3055,8 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
               scope="col"
               aria-label
               aria-sort="none"
-              width="1px"
               class="text-start"
+              style="width: 1px; min-width: 1px;"
           >
             <span>
             </span>
@@ -3380,9 +3376,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>
-        <col class
-             style="width: 1px;"
-        >
+        <col class>
         <col class>
         <col class>
         <col class>
@@ -3396,8 +3390,8 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
               scope="col"
               aria-label
               aria-sort="none"
-              width="1px"
               class="text-start"
+              style="width: 1px; min-width: 1px;"
           >
             <div class="v-data-table__checkbox v-simple-checkbox">
               <div class="v-input--selection-controls__ripple">


### PR DESCRIPTION
## Description
setting both width and min-width as styles on header row was the only
way I could get a consistent result

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #5072, #7623

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table
      :headers="headers"
      :items="items"
      :items-per-page="5"
      class="elevation-1"
      show-select
    ></v-data-table>
  </v-container>
</template>

<script>
export default {
  data: () => ({
     headers: [
      { text: 'Firstname', value: 'firstname', width: '300px' },
      { text: 'Lastname', value: 'lastname' },
      { text: 'Starship Name', value: 'starship', width:'400px' },
      { text: 'Nationality', value: 'nationality' },
      { text: 'Hobbies', value: 'hobbies' },
       { text: 'Likes', value: 'likes' },
       { text: 'Dislikes', value: 'dislikes' },
    ],
    items: [
      { firstname: 'Jean-Luc', lastname: 'Picard', rank: 'Captain', starship: 'Enterprise NCC1701D', nationality: 'French', hobbies: 'Archaeology', likes:'Wine', dislikes:'Borg' }
    ]
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
