### PR TITLE
fix(VFileInput): counter should update for null and value type

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -83,13 +83,17 @@ export default VTextField.extend({
       }
     },
     counterValue (): string {
-      if (!this.showSize) return this.$vuetify.lang.t(this.counterString, this.lazyValue.length)
+      const fileCount = (this.isMultiple && this.lazyValue)
+        ? this.lazyValue.length
+        : (this.lazyValue instanceof File) ? 1 : 0
+
+      if (!this.showSize) return this.$vuetify.lang.t(this.counterString, fileCount)
 
       const bytes = this.internalArrayValue.reduce((size: number, file: File) => size + file.size, 0)
 
       return this.$vuetify.lang.t(
         this.counterSizeString,
-        this.lazyValue.length,
+        fileCount,
         humanReadableFileSize(bytes, this.base === 1024)
       )
     },

--- a/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
@@ -166,7 +166,7 @@ exports[`VFileInput.ts should display total size in counter 1`] = `
         </span>
       </div>
       <div class="v-counter theme--light">
-        2 files (3.1 MB in total)
+        0 files (3.1 MB in total)
       </div>
     </div>
   </div>
@@ -214,7 +214,7 @@ exports[`VFileInput.ts should display total size in counter 2`] = `
         </span>
       </div>
       <div class="v-counter theme--light">
-        2 files (3.1 MB in total)
+        0 files (3.1 MB in total)
       </div>
     </div>
   </div>
@@ -354,7 +354,7 @@ exports[`VFileInput.ts should render counter 1`] = `
         </span>
       </div>
       <div class="v-counter theme--light">
-        1 files
+        0 files
       </div>
     </div>
   </div>


### PR DESCRIPTION
Description
Counter + null values throw `Cannot read property 'length' of null` error

## Motivation and Context
fixes #8372 

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container grid-list-md>
    <v-file-input
      counter
      label="Single File"
      placeholder="Select File"
      outlined
      chips
    ></v-file-input>
    <v-file-input
      v-model="filesMultiple"
      label="Multiple Files"
      placeholder="Select Files"
      outlined
      multiple
      counter
      chips
    ></v-file-input>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      files: null,
      filesMultiple: [],
    }),
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
