### PR TITLE
fix(VList): missing rtl styles

### DIFF
--- a/packages/vuetify/src/components/VList/VList.sass
+++ b/packages/vuetify/src/components/VList/VList.sass
@@ -68,7 +68,6 @@
     border-radius: 4px
 
 .v-list--shaped
-  padding-right: 8px
   +list-shaped($list-item-min-height)
 
   &.v-list--two-line
@@ -77,9 +76,10 @@
   &.v-list--three-line
     +list-shaped($list-item-three-line-min-height)
 
+  +ltr()
+    padding-right: 8px
   +rtl()
     padding-left: 8px
-    padding-right: 0
 
 .v-list--rounded
   padding: 8px

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -74,10 +74,16 @@
     margin-top: 8px
 
     &:first-child
-      margin-left: $list-item-avatar-horizontal-margin-x
+      +ltr()
+        margin-left: $list-item-avatar-horizontal-margin-x
+      +rtl()
+        margin-right: $list-item-avatar-horizontal-margin-x
 
     &:last-child
-      margin-left: $list-item-avatar-horizontal-margin-x
+      +ltr()
+        margin-left: $list-item-avatar-horizontal-margin-x
+      +rtl()
+        margin-right: $list-item-avatar-horizontal-margin-x
 
 .v-list-item__content
   align-items: center
@@ -104,7 +110,10 @@
 .v-list-item__avatar,
 .v-list-item__icon
   &:last-of-type:not(:only-child)
-    margin-left: 16px
+    +ltr()
+      margin-left: 16px
+    +rtl()
+      margin-right: 16px
 
 .v-list-item__avatar
   &:first-child

--- a/packages/vuetify/src/components/VList/_mixins.sass
+++ b/packages/vuetify/src/components/VList/_mixins.sass
@@ -2,8 +2,12 @@
   .v-list-item,
   .v-list-item:before,
   .v-ripple__container
-    border-bottom-right-radius: #{$size * 0.6666666666666667} !important
-    border-top-right-radius: #{$size * 0.6666666666666667} !important
+    +ltr()
+      border-bottom-right-radius: #{$size * 0.6666666666666667} !important
+      border-top-right-radius: #{$size * 0.6666666666666667} !important
+    +rtl()
+      border-bottom-left-radius: #{$size * 0.6666666666666667} !important
+      border-top-left-radius: #{$size * 0.6666666666666667} !important
 
 @mixin list-rounded($size)
   .v-list-item,


### PR DESCRIPTION
## Motivation and Context
fixes #8403
fixes #8378


## How Has This Been Tested?
visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-btn block @click="$vuetify.rtl = !$vuetify.rtl">{{ $vuetify.rtl ? 'rtl' : 'ltr' }}</v-btn>
    <v-list shaped style="width: 180px">
      <v-list-item to="/page1">
        <v-list-item-icon>
          <v-icon>mdi-view-dashboard</v-icon>
        </v-list-item-icon>
        <v-list-item-content>
          <v-list-item-title>Test</v-list-item-title>
        </v-list-item-content>
        <v-list-item-icon>
          <v-icon>mdi-view-dashboard</v-icon>
        </v-list-item-icon>
      </v-list-item>
    </v-list>
  </v-container>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
