### PR TITLE
fix(VProgressLinear): invalid background position in RTL mode

### DIFF
--- a/packages/vuetify/src/components/VCard/__tests__/VCard.spec.ts
+++ b/packages/vuetify/src/components/VCard/__tests__/VCard.spec.ts
@@ -26,6 +26,11 @@ describe('VCard.vue', () => {
       propsData: {
         loading: true,
       },
+      mocks: {
+        $vuetify: {
+          rtl: false,
+        },
+      },
     })
 
     expect(wrapper.html()).toMatchSnapshot()

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.ts
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.ts
@@ -128,7 +128,7 @@ export default baseMixins.extend({
 
       return {
         opacity: backgroundOpacity,
-        left: convertToUnit(this.normalizedValue, '%'),
+        [this.$vuetify.rtl ? 'right' : 'left']: convertToUnit(this.normalizedValue, '%'),
         width: convertToUnit(this.normalizedBuffer - this.normalizedValue, '%'),
       }
     },

--- a/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.ts
+++ b/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.ts
@@ -83,9 +83,13 @@ describe('VProgressLinear.ts', () => {
       propsData: {
         value: 33,
       },
+      mocks: {
+        $vuetify: {
+          rtl: true,
+        },
+      },
     })
 
-    wrapper.vm.$vuetify.rtl = true
     expect(wrapper.html()).toMatchSnapshot()
   })
 

--- a/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.ts
+++ b/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.ts
@@ -15,6 +15,11 @@ describe('VProgressLinear.ts', () => {
   beforeEach(() => {
     mountFunction = (options = {}) => {
       return mount(VProgressLinear, {
+        mocks: {
+          $vuetify: {
+            rtl: false,
+          },
+        },
         ...options,
       })
     }
@@ -70,6 +75,17 @@ describe('VProgressLinear.ts', () => {
       },
     })
 
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should render component in RTL mode', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        value: 33,
+      },
+    })
+
+    wrapper.vm.$vuetify.rtl = true
     expect(wrapper.html()).toMatchSnapshot()
   })
 

--- a/packages/vuetify/src/components/VProgressLinear/__tests__/__snapshots__/VProgressLinear.spec.ts.snap
+++ b/packages/vuetify/src/components/VProgressLinear/__tests__/__snapshots__/VProgressLinear.spec.ts.snap
@@ -21,6 +21,27 @@ exports[`VProgressLinear.ts should render component and match snapshot 1`] = `
 </div>
 `;
 
+exports[`VProgressLinear.ts should render component in RTL mode 1`] = `
+<div role="progressbar"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="33"
+     class="v-progress-linear theme--light"
+     style="height: 4px;"
+>
+  <div class="v-progress-linear__background primary"
+       style="opacity: 0.3; width: 67%; right: 33%;"
+  >
+  </div>
+  <div class="v-progress-linear__buffer">
+  </div>
+  <div class="v-progress-linear__determinate primary"
+       style="width: 33%;"
+  >
+  </div>
+</div>
+`;
+
 exports[`VProgressLinear.ts should render component with buffer value and match snapshot 1`] = `
 <div role="progressbar"
      aria-valuemin="0"

--- a/packages/vuetify/src/components/VProgressLinear/__tests__/__snapshots__/VProgressLinear.spec.ts.snap
+++ b/packages/vuetify/src/components/VProgressLinear/__tests__/__snapshots__/VProgressLinear.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`VProgressLinear.ts should render component in RTL mode 1`] = `
      style="height: 4px;"
 >
   <div class="v-progress-linear__background primary"
-       style="opacity: 0.3; width: 67%; right: 33%;"
+       style="opacity: 0.3; right: 33%; width: 67%;"
   >
   </div>
   <div class="v-progress-linear__buffer">

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -351,7 +351,10 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it.skip('should render component with async loading and custom progress and match snapshot', () => {
+  it('should render component with async loading and custom progress and match snapshot', () => {
+    Vue.prototype.$vuetify = {
+      rtl: false,
+    }
     const progress = Vue.component('test', {
       render (h) {
         return h(VProgressLinear, {
@@ -370,11 +373,6 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
       },
       slots: {
         progress: [progress],
-      },
-      mocks: {
-        $vuetify: {
-          rtl: false,
-        },
       },
     })
 

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -351,7 +351,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('should render component with async loading and custom progress and match snapshot', () => {
+  it.skip('should render component with async loading and custom progress and match snapshot', () => {
     const progress = Vue.component('test', {
       render (h) {
         return h(VProgressLinear, {
@@ -370,6 +370,11 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
       },
       slots: {
         progress: [progress],
+      },
+      mocks: {
+        $vuetify: {
+          rtl: false,
+        },
       },
     })
 

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -22,13 +22,13 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
         </div>
       </div>
       <div class="v-text-field__slot">
-        <label for="input-148"
+        <label for="input-155"
                class="v-label theme--light"
                style="left: 0px; position: absolute;"
         >
           foo
         </label>
-        <input id="input-148"
+        <input id="input-155"
                type="text"
         >
       </div>
@@ -77,7 +77,7 @@ exports[`VTextField.ts should have prefix and suffix 1`] = `
         <div class="v-text-field__prefix">
           $
         </div>
-        <input id="input-101"
+        <input id="input-108"
                type="text"
         >
         <div class="v-text-field__suffix">

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -22,13 +22,13 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
         </div>
       </div>
       <div class="v-text-field__slot">
-        <label for="input-155"
+        <label for="input-148"
                class="v-label theme--light"
                style="left: 0px; position: absolute;"
         >
           foo
         </label>
-        <input id="input-155"
+        <input id="input-148"
                type="text"
         >
       </div>
@@ -77,7 +77,7 @@ exports[`VTextField.ts should have prefix and suffix 1`] = `
         <div class="v-text-field__prefix">
           $
         </div>
-        <input id="input-108"
+        <input id="input-101"
                type="text"
         >
         <div class="v-text-field__suffix">


### PR DESCRIPTION
## Motivation and Context
fixes #8419

## How Has This Been Tested?
visually, added snapshots

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-btn block @click="$vuetify.rtl = !$vuetify.rtl">{{ $vuetify.rtl ? 'rtl' : 'ltr' }}</v-btn>
    <v-row>
      <v-col cols="12" class="align-self-center text-center my-0 py-0">
        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="100" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="90" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="80" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="70" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="60" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="50" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="40" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="30" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="20" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="10" />
        </v-card>

        <v-card class="pa-2 mx-auto mt-2" width="250">
          <v-progress-linear value="0" />
        </v-card>

      </v-col>
    </v-row>
  </v-container>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
