### PR TITLE
fix(VDataTable): remove unnecessary colspan in mobile view

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -120,8 +120,10 @@ export default VDataIterator.extend({
 
       return headers
     },
-    computedHeadersLength (): number {
-      return this.headersLength || this.computedHeaders.length
+    colspanAttrs (): object | undefined {
+      return this.isMobile ? undefined : {
+        colspan: this.headersLength || this.computedHeaders.length,
+      }
     },
     isMobile (): boolean {
       return this.$vuetify.breakpoint.width < this.mobileBreakpoint
@@ -214,9 +216,7 @@ export default VDataIterator.extend({
 
       const th = this.$createElement('th', {
         staticClass: 'column',
-        attrs: {
-          colspan: this.computedHeadersLength,
-        },
+        attrs: this.colspanAttrs,
       }, [progress])
 
       const tr = this.$createElement('tr', {
@@ -264,9 +264,7 @@ export default VDataIterator.extend({
         staticClass: 'v-data-table__empty-wrapper',
       }, [
         this.$createElement('td', {
-          attrs: {
-            colspan: this.computedHeadersLength,
-          },
+          attrs: this.colspanAttrs,
         }, content),
       ])
     },
@@ -331,9 +329,7 @@ export default VDataIterator.extend({
 
         const column = this.$createElement('td', {
           staticClass: 'text-start',
-          attrs: {
-            colspan: this.computedHeadersLength,
-          },
+          attrs: this.colspanAttrs,
         }, [toggle, `${props.options.groupBy[0]}: ${group}`, remove])
 
         children.unshift(this.$createElement('template', { slot: 'column.header' }, [column]))

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaderMobile.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaderMobile.ts
@@ -83,11 +83,7 @@ export default mixins(header).extend({
 
     children.push(this.genSortSelect())
 
-    const th = h('th', {
-      attrs: {
-        colspan: this.headers.length,
-      },
-    }, [h('div', { staticClass: 'v-data-table-header-mobile__wrapper' }, children)])
+    const th = h('th', [h('div', { staticClass: 'v-data-table-header-mobile__wrapper' }, children)])
 
     const tr = h('tr', [th])
 

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
@@ -509,7 +509,7 @@ exports[`VDataTableHeader.ts desktop should work with sortDesc correctly 1`] = `
 exports[`VDataTableHeader.ts mobile should render 1`] = `
 <thead class="v-data-table-header v-data-table-header-mobile">
   <tr>
-    <th colspan="6">
+    <th>
       <div class="v-data-table-header-mobile__wrapper">
         <div class="v-input v-input--hide-details theme--light v-text-field v-select">
           <div class="v-input__control">
@@ -561,7 +561,7 @@ exports[`VDataTableHeader.ts mobile should render 1`] = `
 exports[`VDataTableHeader.ts mobile should render with data-table-select header 1`] = `
 <thead class="v-data-table-header v-data-table-header-mobile">
   <tr>
-    <th colspan="7">
+    <th>
       <div class="v-data-table-header-mobile__wrapper">
         <div class="v-data-table-header-mobile__select">
           <div class="v-data-table__checkbox v-simple-checkbox">
@@ -624,7 +624,7 @@ exports[`VDataTableHeader.ts mobile should render with data-table-select header 
 exports[`VDataTableHeader.ts mobile should work with multiSort 1`] = `
 <thead class="v-data-table-header v-data-table-header-mobile">
   <tr>
-    <th colspan="6">
+    <th>
       <div class="v-data-table-header-mobile__wrapper">
         <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
           <div class="v-input__control">
@@ -689,7 +689,7 @@ exports[`VDataTableHeader.ts mobile should work with multiSort 1`] = `
 exports[`VDataTableHeader.ts mobile should work with showGroupBy 1`] = `
 <thead class="v-data-table-header v-data-table-header-mobile">
   <tr>
-    <th colspan="6">
+    <th>
       <div class="v-data-table-header-mobile__wrapper">
         <div class="v-input v-input--hide-details theme--light v-text-field v-select">
           <div class="v-input__control">
@@ -741,7 +741,7 @@ exports[`VDataTableHeader.ts mobile should work with showGroupBy 1`] = `
 exports[`VDataTableHeader.ts mobile should work with sortBy correctly 1`] = `
 <thead class="v-data-table-header v-data-table-header-mobile">
   <tr>
-    <th colspan="6">
+    <th>
       <div class="v-data-table-header-mobile__wrapper">
         <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
           <div class="v-input__control">
@@ -806,7 +806,7 @@ exports[`VDataTableHeader.ts mobile should work with sortBy correctly 1`] = `
 exports[`VDataTableHeader.ts mobile should work with sortDesc correctly 1`] = `
 <thead class="v-data-table-header v-data-table-header-mobile">
   <tr>
-    <th colspan="6">
+    <th>
       <div class="v-data-table-header-mobile__wrapper">
         <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
           <div class="v-input__control">


### PR DESCRIPTION
## Motivation and Context
colspan just seems unnecessary in mobile mode

## How Has This Been Tested?
visually, updated snapshots

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table
      :headers="headers"
      :items="desserts"
      :expanded.sync="expanded"
      show-select
      item-key="name"
      show-expand
      class="elevation-1"
    >
      <template v-slot:expanded-item="{ headers }">
        <td>
          <div style="width: 200px; height: 10px; background: red" />
        </td>
      </template>
    </v-data-table>
  </v-container>
</template>

<script>
  export default {
    data () {
      return {
        expanded: [],
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
          },
        ],
      }
    },
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
