### PR TITLE
docs(Selects): add info about header and divider items

### DIFF
--- a/packages/docs/src/lang/en/components/Selects.json
+++ b/packages/docs/src/lang/en/components/Selects.json
@@ -61,7 +61,7 @@
     "hideSelected": "Do not display in the select menu items that are already selected",
     "itemColor": "Sets color of selected items",
     "itemDisabled": "Set property of **items**'s disabled value",
-    "items": "Can be an array of objects or array of strings. When using objects, will look for a text and value field. This can be changed using the **item-text** and **item-value** props.",
+    "items": "Can be an array of objects or array of strings. When using objects, will look for a text and value field. This can be changed using the **item-text** and **item-value** props.  Objects that have a **header** or **divider** property are considered special cases and generate a list header or divider; these items are not selectable.",
     "itemText": "Set property of **items**'s text value",
     "itemValue": "Set property of **items**'s value - **must be primitive**. Dot notation is supported",
     "menuProps": "Pass props through to the `v-menu` component. Accepts either a string for boolean props `menu-props=\"auto, overflowY\"`, or an object `:menu-props=\"{ auto: true, overflowY: true }\"`",


### PR DESCRIPTION
docs(Selects): document the special handling of objects with header and divider properties

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added documentation regarding the treatment of items objects that have a **header** or **divider** property.


## Motivation and Context
Documents the existing treatment of objects that contain a **header** or **divider** property.  This is important because
* It enabled users to make use of this feature in their code in the knowledge that it is a documented feature
* It prevents users getting unexpected behavior when their objects contain one of these special properties

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
