### PR TITLE
fix(VEditDialog): fix editability of VEditDialog

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VEditDialog.sass
+++ b/packages/vuetify/src/components/VDataTable/VEditDialog.sass
@@ -12,7 +12,6 @@
     cursor: pointer
     &__content
       height: 100%
-      padding: 0 16px
 
   &__content
     padding: 0 16px

--- a/packages/vuetify/src/components/VDataTable/VEditDialog.sass
+++ b/packages/vuetify/src/components/VDataTable/VEditDialog.sass
@@ -10,7 +10,9 @@
 
   &__activator
     cursor: pointer
-    height: 100%
+    &__content
+      height: 100%
+      padding: 0 16px
 
   &__content
     padding: 0 16px

--- a/packages/vuetify/src/components/VDataTable/VEditDialog.sass
+++ b/packages/vuetify/src/components/VDataTable/VEditDialog.sass
@@ -11,7 +11,7 @@
   &__activator
     cursor: pointer
     &__content
-      height: 100%
+      display: inline-block
 
   &__content
     padding: 0 16px

--- a/packages/vuetify/src/components/VDataTable/VEditDialog.ts
+++ b/packages/vuetify/src/components/VDataTable/VEditDialog.ts
@@ -122,10 +122,14 @@ export default mixins(Returnable, Themeable).extend({
       },
       scopedSlots: {
         activator: ({ on }) => {
-          return h('span', {
+          return h('div', {
             staticClass: 'v-small-dialog__activator',
             on,
-          }, this.$slots.default)
+          }, [
+            h('span', {
+              staticClass: 'v-small-dialog__activator__content',
+            }, this.$slots.default),
+          ])
         },
       },
     }, [

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VEditDialog.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VEditDialog.spec.ts.snap
@@ -2,8 +2,10 @@
 
 exports[`VEditDialog.ts should render 1`] = `
 <div class="v-menu v-small-dialog v-menu--inline theme--light">
-  <span class="v-small-dialog__activator">
-  </span>
+  <div class="v-small-dialog__activator">
+    <span class="v-small-dialog__activator__content">
+    </span>
+  </div>
   <div role="menu"
        class="v-menu__content theme--light v-small-dialog__menu-content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top right; z-index: 0; display: none;"
@@ -43,8 +45,10 @@ exports[`VEditDialog.ts should render button 1`] = `
 
 exports[`VEditDialog.ts should render custom button texts 1`] = `
 <div class="v-menu v-small-dialog v-menu--inline theme--light">
-  <span class="v-small-dialog__activator">
-  </span>
+  <div class="v-small-dialog__activator">
+    <span class="v-small-dialog__activator__content">
+    </span>
+  </div>
   <div role="menu"
        class="v-menu__content theme--light v-small-dialog__menu-content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top right; z-index: 0; display: none;"


### PR DESCRIPTION

## Description
Fix editability of VEditDialog with empty content
Wrap with `<div>` tag to keep activation region instead of single `<span>` tag

## Motivation and Context
Fixes #8465 

## How Has This Been Tested?
- tweak unit test
- visually



## Markup:
<details>

```vue
<template>
<v-card max-width=400>

  <v-container>
    <v-data-table
        :headers="headers"
        :items="desserts"
      >
        <template v-slot:item.name="props">
          <v-edit-dialog
            :return-value.sync="props.item.name"
          > {{ props.item.name }}
            <template v-slot:input>
              <v-text-field
                v-model="props.item.name"
                :rules="[max25chars]"
                label="Edit"
                single-line
                counter
              ></v-text-field>
            </template>
          </v-edit-dialog>
        </template>
        <template v-slot:item.iron="props">
          <v-edit-dialog
            :return-value.sync="props.item.iron"
            large
            persistent
            @save="save"
            @cancel="cancel"
            @open="open"
            @close="close"
          >
            <div>{{ props.item.iron }}</div>
            <template v-slot:input>
              <div class="mt-4 title">Update Iron</div>
            </template>
            <template v-slot:input>
              <v-text-field
                v-model="props.item.iron"
                :rules="[max25chars]"
                label="Edit"
                single-line
                counter
                autofocus
              ></v-text-field>
            </template>
          </v-edit-dialog>
        </template>
      </v-data-table>
  </v-container>
</v-card>
</template>

<script>
import {VDataTable} from '../src/components/VDataTable';
export default {
  components: {
    VDataTable,
  },
  data: () => ({
    //
       snack: false,
      snackColor: '',
      snackText: '',
      max25chars: v => v.length <= 25 || 'Input too long!',
      pagination: {},
      headers: [
        {
          text: 'Dessert (100g serving)',
          align: 'left',
          sortable: false,
          value: 'name',
        },
        { text: 'Comment', value: 'comment' },
      ],
      desserts: [
        {
          name: '',
          comment: '<- cannot be edit',
        },
        {
          name: 'Inline-editable text',
          comment: '<- editable'
        },
      ],
  })
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:

- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.

