### PR TITLE
fix: ignore click outside if component is being destroyed

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.ts
+++ b/packages/vuetify/src/components/VDialog/VDialog.ts
@@ -154,7 +154,7 @@ export default baseMixins.extend({
       // If the dialog content contains
       // the click event, or if the
       // dialog is not active
-      if (!this.isActive || this.$refs.content.contains(target)) return false
+      if (this._isDestroyed || !this.isActive || this.$refs.content.contains(target)) return false
 
       // If we made it here, the click is outside
       // and is active. If persistent, and the

--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -253,6 +253,7 @@ export default baseMixins.extend({
       const target = e.target as HTMLElement
 
       return this.isActive &&
+        !this._isDestroyed &&
         this.closeOnClick &&
         !this.$refs.content.contains(target)
     },

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
@@ -300,7 +300,7 @@ export default baseMixins.extend({
       }
     },
     closeConditional () {
-      return this.isActive && this.reactsToClick
+      return this.isActive && !this._isDestroyed && this.reactsToClick
     },
     genAppend () {
       return this.genPosition('append')

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -305,6 +305,8 @@ export default baseMixins.extend<options>().extend({
     },
     closeConditional (e: Event) {
       return (
+        !this._isDestroyed &&
+
         // Click originates from outside the menu content
         this.content &&
         !this.content.contains(e.target) &&


### PR DESCRIPTION
fixes #6976

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="text-center">
    <v-menu offset-y v-if="$route.name === 'Page 1'">
      <template v-slot:activator="{ on }">
        <v-btn
          color="primary"
          dark
          v-on="on"
        >
          Dropdown
        </v-btn>
      </template>
      <v-list>
        <v-list-item
          v-for="(item, index) in items"
          :key="index"
          @click=""
        >
          <v-list-item-title>{{ item.title }}</v-list-item-title>
        </v-list-item>
      </v-list>
    </v-menu>
    <v-btn to="/page2">go</v-btn>
    <v-btn to="/page1">go</v-btn>
  </div>
</template>

<script>
  export default {
    data: () => ({
      items: [
        { title: 'Click Me' },
        { title: 'Click Me' },
        { title: 'Click Me' },
        { title: 'Click Me 2' },
      ],
    }),
  }
</script>

```
</details>

