### PR TITLE
fix: ignore click outside if component is being destroyed

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.js
+++ b/packages/vuetify/src/components/VDialog/VDialog.js
@@ -144,7 +144,7 @@ export default {
       // If the dialog content contains
       // the click event, or if the
       // dialog is not active
-      if (!this.isActive || this.$refs.content.contains(e.target)) return false
+      if (this._isDestroyed || !this.isActive || this.$refs.content.contains(e.target)) return false
 
       // If we made it here, the click is outside
       // and is active. If persistent, and the

--- a/packages/vuetify/src/components/VMenu/VMenu.js
+++ b/packages/vuetify/src/components/VMenu/VMenu.js
@@ -199,6 +199,7 @@ export default Vue.extend({
     },
     closeConditional (e) {
       return this.isActive &&
+        !this._isDestroyed &&
         this.closeOnClick &&
         !this.$refs.content.contains(e.target)
     },

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
@@ -256,7 +256,7 @@ export default mixins(
       }
     },
     closeConditional () {
-      return this.isActive && this.reactsToClick
+      return this.isActive && !this._isDestroyed && this.reactsToClick
     },
     genDirectives () {
       const directives = [{

--- a/packages/vuetify/src/components/VSelect/VSelect.js
+++ b/packages/vuetify/src/components/VSelect/VSelect.js
@@ -275,6 +275,8 @@ export default VTextField.extend({
     },
     closeConditional (e) {
       return (
+        !this._isDestroyed &&
+
         // Click originates from outside the menu content
         !!this.content &&
         !this.content.contains(e.target) &&


### PR DESCRIPTION
fixes #6976

(cherry picked from commit f7682aff65ad104cee012e6ea436b9bb0e8a3813)

Backport of #8470

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="text-center">
    <v-menu offset-y v-if="$route.name === 'Page 1'">
      <template v-slot:activator="{ on }">
        <v-btn
          color="primary"
          dark
          v-on="on"
        >
          Dropdown
        </v-btn>
      </template>
      <v-list>
        <v-list-item
          v-for="(item, index) in items"
          :key="index"
          @click=""
        >
          <v-list-item-title>{{ item.title }}</v-list-item-title>
        </v-list-item>
      </v-list>
    </v-menu>
    <v-btn to="/page2">go</v-btn>
    <v-btn to="/page1">go</v-btn>
  </div>
</template>

<script>
  export default {
    data: () => ({
      items: [
        { title: 'Click Me' },
        { title: 'Click Me' },
        { title: 'Click Me' },
        { title: 'Click Me 2' },
      ],
    }),
  }
</script>

```
</details>

This is cool btw: https://git.wiki.kernel.org/index.php/GitFaq#How_to_manually_resolve_conflicts_when_Git_failed_to_detect_rename.3F