### PR TITLE
docs(v-expansion-panels): incorrect documentation for the value prop

### DIFF
--- a/packages/docs/src/lang/en/components/ExpansionPanels.json
+++ b/packages/docs/src/lang/en/components/ExpansionPanels.json
@@ -52,7 +52,7 @@
       "inset": "Makes the expansion-panel open with a inset style",
       "popout": "Makes the expansion-panel open with an popout style",
       "readonly": "Makes the entire expansion-panel read only.",
-      "value": "Controls the opened/closed state of content in the expansion-panel. Corresponds to a zero-based index of the currently opened content. If `expand` prop is used then it is an array of booleans where the index corresponds to the index of the content."
+      "value": "Controls the opened/closed state of content in the expansion-panel. Corresponds to a zero-based index of the currently opened content. If the `multiple` prop (previously `expand` in 1.5.x) is used then it is an array of numbers where each entry corresponds to the index of the opened content.  The index order is not relevant."
     },
     "v-expansion-panel": {
       "disabled": "Disables the expansion-panel content",


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

While migrating from 1.5.x to 2.x I noticed a behavioral change with v-expansion-panels.  The
documentation for the value prop is incorrect.  It says its an array (of booleans, not integers) for
when the 'expand' prop is used.  'expand' is now deprecated and has been replaced with 'multiple'


## Motivation and Context

To ease the path of migration from 1.5.x to 2.0, for those that use v-expansion-panels.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

1. ```yarn build dev```
1. Visit the documentation server
1. Search for v-expansion-panels
1. Verify the text for the value prop has been updated and is correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
