### PR TITLE
docs(VGrid): fix examples for IE11 usage

### DIFF
--- a/packages/docs/src/data/pages/components/Grids.json
+++ b/packages/docs/src/data/pages/components/Grids.json
@@ -27,6 +27,11 @@
         {
           "type": "text",
           "lang": "usageText3"
+        },
+        {
+          "type": "alert",
+          "lang": "usageAlert1",
+          "value": "info"
         }
       ]
     },

--- a/packages/docs/src/data/pages/styles/Flex.json
+++ b/packages/docs/src/data/pages/styles/Flex.json
@@ -101,6 +101,11 @@
           "lang": "alignText1"
         },
         {
+          "type": "alert",
+          "lang": "alignAlert1",
+          "value": "info"
+        },
+        {
           "type": "example",
           "value": "flex-align"
         },

--- a/packages/docs/src/examples/grids/playground.vue
+++ b/packages/docs/src/examples/grids/playground.vue
@@ -6,7 +6,7 @@
           :align="alignment"
           :justify="justify"
           class="grey lighten-5"
-          style="min-height: 300px;"
+          style="height: 300px;"
         >
           <v-card
             v-for="n in 3"

--- a/packages/docs/src/examples/grids/simple/vertical-alignment.vue
+++ b/packages/docs/src/examples/grids/simple/vertical-alignment.vue
@@ -8,7 +8,7 @@
       <v-row
         :align="align"
         no-gutters
-        style="min-height: 150px;"
+        style="height: 150px;"
       >
         <v-col
           v-for="n in 3"
@@ -28,7 +28,7 @@
     <v-container class="grey lighten-5">
       <v-row
         no-gutters
-        style="min-height: 150px;"
+        style="height: 150px;"
       >
         <v-col
           v-for="align in alignments"

--- a/packages/docs/src/lang/en/components/Grids.json
+++ b/packages/docs/src/lang/en/components/Grids.json
@@ -8,6 +8,7 @@
     "`v-col` is a content holder that must be a direct child of `v-row`."
   ],
   "usageText3": "Ensure that you understand the limitations and [bugs around flexbox](https://github.com/philipwalton/flexbugs), such as the inhability to [utilize certain HTML elements as flex containers](https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers).",
+  "usageAlert1": "When using the grid system with IE11 and vertical alignment is important you will need to set an explicit `height` as `min-height` will not suffice.",
   "examples": {
     "usage": {
       "desc": "The Vuetify grid is heavily inspired by the [Bootstrap grid](https://getbootstrap.com/docs/4.0/layout/grid/). It is integrated by using a series of containers, rows, and columns to layout and align content. **If you are new to flexbox**, [Read the CSS Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background) for background, terminology, guidelines, and code snippets."

--- a/packages/docs/src/lang/en/components/Grids.json
+++ b/packages/docs/src/lang/en/components/Grids.json
@@ -8,7 +8,7 @@
     "`v-col` is a content holder that must be a direct child of `v-row`."
   ],
   "usageText3": "Ensure that you understand the limitations and [bugs around flexbox](https://github.com/philipwalton/flexbugs), such as the inhability to [utilize certain HTML elements as flex containers](https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers).",
-  "usageAlert1": "When using the grid system with IE11 and vertical alignment is important you will need to set an explicit `height` as `min-height` will not suffice.",
+  "usageAlert1": "When using the grid system with IE11 you will need to set an explicit `height` as `min-height` will not suffice and cause undesired results.",
   "examples": {
     "usage": {
       "desc": "The Vuetify grid is heavily inspired by the [Bootstrap grid](https://getbootstrap.com/docs/4.0/layout/grid/). It is integrated by using a series of containers, rows, and columns to layout and align content. **If you are new to flexbox**, [Read the CSS Tricks flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/#flexbox-background) for background, terminology, guidelines, and code snippets."

--- a/packages/docs/src/lang/en/styles/Flex.json
+++ b/packages/docs/src/lang/en/styles/Flex.json
@@ -74,6 +74,7 @@
   ],
   "alignHeader": "## Flex align",
   "alignText1": "The `align-items` flex setting can be changed using the flex align classes. This by default will modify the flexbox items on the **x-axis** but is reversed when using `flex-direction: column`, modifying the **y-axis**. Choose from `start`, `end`, `center`, `baseline`, or `stretch` (browser default).",
+  "alignAlert1": "When using flex align with IE11 you will need to set an explicit `height` as `min-height` will not suffice and cause undesired results.",
   "alignText2": "There are also responsive variations for `align-items`.",
   "alignList": [
     "`.align-start`",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
The new grid struggles with vertical alignment if there is no explicit `height` set, `min-height` is not enough, @KaelWD @johnleider maybe this is something we could document as caveat? the bootstrap grid has the same problem. 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually
## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
