### PR TITLE
fix(VFileInput): bug in Safari where file is not added

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -161,10 +161,10 @@ export default VTextField.extend({
 
       input.data!.domProps!.value = this.internalFileInput
 
-      // This solves issue in Safari where
-      // nothing happens when you add file
-      // since for some reason Safari does
-      // not emit the input event. (#7941)
+      // This solves an issue in Safari where
+      // nothing happens when adding a file
+      // do to the input event not firing
+      // https://github.com/vuetifyjs/vuetify/issues/7941
       delete input.data!.on!.input
       input.data!.on!.change = this.onInput
 

--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -161,6 +161,13 @@ export default VTextField.extend({
 
       input.data!.domProps!.value = this.internalFileInput
 
+      // This solves issue in Safari where
+      // nothing happens when you add file
+      // since for some reason Safari does
+      // not emit the input event. (#7941)
+      delete input.data!.on!.input
+      input.data!.on!.change = this.onInput
+
       return [this.genSelections(), input]
     },
     genPrependSlot () {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Safari does not seem to emit an input event when selecting a file, even though
from what I can see the HTML spec says both an input and change event should
be emitted.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #7941

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container class="pa-0">
    <v-file-input label="File input" v-model="asd"></v-file-input>
    {{ asd }}
  </v-container>
</template>

<script>
export default {
  data: () => ({
    asd: null,
    mode: 'hex',
    color: '#ff00ff'
  }),
  watch: {
    asd (v) {
      console.log(v)
    }
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
