### PR TITLE
fix(lang): process all keys regardless of $vuetify prefix

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -104,13 +104,15 @@ export default Vue.extend({
         !computedIPPO.find(ippo => ippo.value === value)
       ) value = computedIPPO[0]
 
+      const itemsPerPageText = this.$vuetify.lang.t(this.itemsPerPageText)
+
       return this.$createElement('div', {
         staticClass: 'v-data-footer__select',
       }, [
-        this.$vuetify.lang.t(this.itemsPerPageText),
+        itemsPerPageText,
         this.$createElement(VSelect, {
           attrs: {
-            'aria-label': this.itemsPerPageText,
+            'aria-label': itemsPerPageText,
           },
           props: {
             disabled: this.disableItemsPerPage,

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 
               <div class="v-select__selection v-select__selection--comma">
                 10
               </div>
-              <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+              <input aria-label="Items per page:"
                      id="input-28"
                      readonly="readonly"
                      type="text"
@@ -114,7 +114,7 @@ exports[`VDataFooter.ts should render in RTL mode 1`] = `
               <div class="v-select__selection v-select__selection--comma">
                 10
               </div>
-              <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+              <input aria-label="Items per page:"
                      id="input-13"
                      readonly="readonly"
                      type="text"
@@ -211,7 +211,7 @@ exports[`VDataFooter.ts should render with custom itemsPerPage 1`] = `
               <div class="v-select__selection v-select__selection--comma">
                 100
               </div>
-              <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+              <input aria-label="Items per page:"
                      id="input-2"
                      readonly="readonly"
                      type="text"
@@ -287,7 +287,7 @@ exports[`VDataFooter.ts should show current page if has showCurrentPage 1`] = `
               <div class="v-select__selection v-select__selection--comma">
                 10
               </div>
-              <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+              <input aria-label="Items per page:"
                      id="input-54"
                      readonly="readonly"
                      type="text"

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`VDataIterator.ts should render and match snapshot 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+                <input aria-label="Items per page:"
                        id="input-4"
                        readonly="readonly"
                        type="text"
@@ -120,7 +120,7 @@ exports[`VDataIterator.ts should render and match snapshot with data 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+                <input aria-label="Items per page:"
                        id="input-18"
                        readonly="readonly"
                        type="text"
@@ -202,7 +202,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+                <input aria-label="Items per page:"
                        id="input-31"
                        readonly="readonly"
                        type="text"
@@ -284,7 +284,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+                <input aria-label="Items per page:"
                        id="input-31"
                        readonly="readonly"
                        type="text"
@@ -366,7 +366,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+                <input aria-label="Items per page:"
                        id="input-31"
                        readonly="readonly"
                        type="text"

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -353,7 +353,7 @@ describe('VDataTable.ts', () => {
         headers: [],
         items: [],
         footerProps: {
-          'items-per-page-text': 'Foo:',
+          'items-per-page-text': '$vuetify.dataIterator.loadingText',
         },
       },
     })

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`VDataTable.ts should pass kebab-case footer props correctly 1`] = `
   </div>
   <div class="v-data-footer">
     <div class="v-data-footer__select">
-      Foo:
+      Loading items...
       <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
         <div class="v-input__control">
           <div role="button"
@@ -35,7 +35,7 @@ exports[`VDataTable.ts should pass kebab-case footer props correctly 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="Foo:"
+                <input aria-label="Loading items..."
                        id="input-311"
                        readonly="readonly"
                        type="text"
@@ -134,7 +134,7 @@ exports[`VDataTable.ts should render 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-6"
                        readonly="readonly"
                        type="text"
@@ -260,7 +260,7 @@ exports[`VDataTable.ts should render loading state 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-256"
                        readonly="readonly"
                        type="text"
@@ -466,7 +466,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   10
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-276"
                        readonly="readonly"
                        type="text"
@@ -946,7 +946,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-47"
                        readonly="readonly"
                        type="text"
@@ -1235,7 +1235,7 @@ exports[`VDataTable.ts should render with data 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-26"
                        readonly="readonly"
                        type="text"
@@ -1419,7 +1419,7 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-239"
                        readonly="readonly"
                        type="text"
@@ -1846,7 +1846,7 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-161"
                        readonly="readonly"
                        type="text"
@@ -2219,7 +2219,7 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-218"
                        readonly="readonly"
                        type="text"
@@ -2423,7 +2423,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-183"
                        readonly="readonly"
                        type="text"
@@ -2737,7 +2737,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-120"
                        readonly="readonly"
                        type="text"
@@ -3072,7 +3072,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-72"
                        readonly="readonly"
                        type="text"
@@ -3407,7 +3407,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-72"
                        readonly="readonly"
                        type="text"
@@ -3769,7 +3769,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
                 <div class="v-select__selection v-select__selection--comma">
                   5
                 </div>
-                <input aria-label="$vuetify.dataTable.itemsPerPageText"
+                <input aria-label="Rows per page:"
                        id="input-98"
                        readonly="readonly"
                        type="text"

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -29,8 +29,10 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
             lang: new Lang({
               locales: {
                 en: {
-                  datePicker: {
-                    itemsSelected: 'i has {0} items',
+                  $vuetify: {
+                    datePicker: {
+                      itemsSelected: 'i has {0} items',
+                    },
                   },
                 },
               },

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
@@ -29,8 +29,10 @@ describe('VDatePicker.ts', () => {
             lang: new Lang({
               locales: {
                 en: {
-                  datePicker: {
-                    itemsSelected: 'i has {0} items',
+                  $vuetify: {
+                    datePicker: {
+                      itemsSelected: 'i has {0} items',
+                    },
                   },
                 },
               },

--- a/packages/vuetify/src/services/lang/__tests__/lang.spec.ts
+++ b/packages/vuetify/src/services/lang/__tests__/lang.spec.ts
@@ -9,22 +9,18 @@ describe('$vuetify.lang', () => {
   })
 
   it('should fall back to en', () => {
-    Object.assign(lang.locales.en, { foo: 'bar', bar: 'baz' })
+    lang.locales.en = Object.assign({}, lang.locales.en, { foo: 'bar', bar: 'baz' })
     lang.locales.foreign = { foo: 'foreignBar' }
     lang.current = 'foreign'
 
-    expect(lang.t('$vuetify.foo')).toBe('foreignBar')
+    expect(lang.t('foo')).toBe('foreignBar')
 
-    expect(lang.t('$vuetify.bar')).toBe('baz')
+    expect(lang.t('bar')).toBe('baz')
     expect('Translation key "bar" not found, falling back to default').toHaveBeenTipped()
 
-    expect(lang.t('$vuetify.baz')).toBe('$vuetify.baz')
+    expect(lang.t('baz')).toBe('baz')
     expect('Translation key "baz" not found, falling back to default').toHaveBeenTipped()
     expect('Translation key "baz" not found in fallback').toHaveBeenWarned()
-  })
-
-  it('should ignore unprefixed strings', () => {
-    expect(lang.t('foo.bar.baz')).toBe('foo.bar.baz')
   })
 
   it('should use a different default', () => {
@@ -35,7 +31,7 @@ describe('$vuetify.lang', () => {
       },
     })
 
-    expect(lang.t('$vuetify.foo')).toBe('foreignBar')
+    expect(lang.t('foo')).toBe('foreignBar')
   })
 
   it('should use a custom translator', () => {
@@ -46,5 +42,20 @@ describe('$vuetify.lang', () => {
     lang.t('$vuetify.foobar', 'fizzbuzz')
 
     expect(translator).toHaveBeenCalledWith('$vuetify.foobar', 'fizzbuzz')
+  })
+
+  it('should override default message', () => {
+    lang = new Lang({
+      current: 'foreign',
+      locales: {
+        foreign: {
+          $vuetify: {
+            dataTable: { sortBy: 'foobar' },
+          },
+        },
+      },
+    })
+
+    expect(lang.t('$vuetify.dataTable.sortBy')).toBe('foobar')
   })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
It was not possible to provide custom keys outside of the $vuetify property in the lang options. This uncovered improperly structured locales provided for some tests in the v-data-table suite. Updated a test that used a string literal for **itemsPerPageText** to require an explicit key as it is the only language string that was working as such. Also properly hooked up **aria-label**'s text in the v-data-footer.

## Motivation and Context
fixes #8402

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-data-table
    :headers="headers"
    :items="desserts"
    :items-per-page="5"
    class="elevation-1"
  ></v-data-table>
</template>

<script>
  export default {
    data () {
      return {
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
