### PR TITLE
fix(VAppBar): fix elevation issue when extended

### DIFF
--- a/packages/vuetify/src/components/VAppBar/VAppBar.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.ts
@@ -172,6 +172,10 @@ export default baseMixins.extend({
       return this.bottom ? scrollOffScreen : -scrollOffScreen
     },
     hideShadow (): boolean {
+      if (this.elevateOnScroll && this.isExtended) {
+        return this.currentScroll < this.computedScrollThreshold
+      }
+
       if (this.elevateOnScroll) {
         return this.currentScroll === 0 ||
           this.computedTransform < 0

--- a/packages/vuetify/src/components/VAppBar/__tests__/VAppBar.spec.ts
+++ b/packages/vuetify/src/components/VAppBar/__tests__/VAppBar.spec.ts
@@ -248,4 +248,32 @@ describe('AppBar.ts', () => {
     expect(wrapper.vm.computedTransform).toBe(0)
     expect(wrapper.vm.hideShadow).toBe(false)
   })
+
+  it('should show shadow when hide-on-scroll and elevate-on-scroll and extended are all true', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        hideOnScroll: true,
+        elevateOnScroll: true,
+        extended: true,
+      },
+    })
+
+    expect(wrapper.vm.computedTransform).toBe(0)
+    expect(wrapper.vm.hideShadow).toBe(true)
+
+    await scrollWindow(1000)
+
+    expect(wrapper.vm.computedTransform).toBe(-64)
+    expect(wrapper.vm.hideShadow).toBe(false)
+
+    await scrollWindow(600)
+
+    expect(wrapper.vm.computedTransform).toBe(0)
+    expect(wrapper.vm.hideShadow).toBe(false)
+
+    await scrollWindow(0)
+
+    expect(wrapper.vm.computedTransform).toBe(0)
+    expect(wrapper.vm.hideShadow).toBe(true)
+  })
 })


### PR DESCRIPTION
When using **hide-on-scroll** in combination with **extended**, **elevate-on-scroll** would not work
as expected.

fixes #8516

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
When using **hide-on-scroll** in combination with **extended**, **elevate-on-scroll** would not work as expected.


## Motivation and Context
fixes #8516

## How Has This Been Tested?
Unit tests
Visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <div>
      <v-row justify="center">
        <v-col cols="3" md="2">
          <v-switch v-model="elevateOnScroll" label="Elevate-on-scroll"></v-switch>
        </v-col>
        <v-col cols="3" md="2">
          <v-switch v-model="hideOnScroll" label="Hide-on-scroll"></v-switch>
        </v-col>

        <v-col cols="3" md="2">
          <v-switch v-model="extended" label="Extended"></v-switch>
        </v-col>
      </v-row>
      <v-card class="overflow-hidden">
        <v-app-bar
          absolute
          scroll-target="#playground-example"
          :color="color"
          :elevate-on-scroll="elevateOnScroll"
          :hide-on-scroll="hideOnScroll"
          :fade-on-scroll="fadeOnScroll"
          :fade-img-on-scroll="fadeImgOnScroll"
          :inverted-scroll="invertedScroll"
          :collapse="collapse"
          :collapse-on-scroll="collapseOnScroll"
          :shrink-on-scroll="shrinkOnScroll"
          :extended="extended"
        >
          <v-app-bar-nav-icon></v-app-bar-nav-icon>

          <template v-slot:extension>This text is in the "extension" slot</template>

          <v-toolbar-title>Title</v-toolbar-title>

          <v-spacer></v-spacer>

          <v-btn icon>
            <v-icon>search</v-icon>
          </v-btn>
        </v-app-bar>

        <v-sheet id="playground-example" class="overflow-y-auto" max-height="600">
          <v-container style="height: 1500px;"></v-container>
        </v-sheet>
      </v-card>
    </div>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    elevateOnScroll: true,
    hideOnScroll: true,
    extended: true,
    color: "white"
  })
};
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
