### PR TITLE
fix(typescript): add missing xl breakpoint

### DIFF
--- a/packages/vuetify/types/services/breakpoint.d.ts
+++ b/packages/vuetify/types/services/breakpoint.d.ts
@@ -8,6 +8,7 @@ export interface VuetifyBreakpointThresholds {
   sm: number
   md: number
   lg: number
+  xl: number
 }
 
 export interface VuetifyBreakpoint {


### PR DESCRIPTION
## Description
Adds the missing `xl` type to the `VuetifyBreakpointThresholds`.

## Motivation and Context
When redefining the breakpoints as stated in the [documentation](https://vuetifyjs.com/en/customization/breakpoints#usage) typescript throws an error:

`Object literal may only specify known properties, and 'xl' does not exist in type 'Partial<VuetifyBreakpointThresholds>'`

## How Has This Been Tested?
manually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
import Vue from "vue";
import Vuetify from "vuetify/lib";

Vue.use(Vuetify);

export default new Vuetify({
  breakpoint: {
    thresholds: {
      xs: 0,
      sm: 1008,
      md: 1280,
      lg: 1440,
      xl: 1920,
    },
  },
});

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
