### PR TITLE
fix(VDataTable): default to first itemsPerPage option

### DIFF
--- a/packages/vuetify/src/components/VData/VData.ts
+++ b/packages/vuetify/src/components/VData/VData.ts
@@ -217,8 +217,11 @@ export default Vue.extend({
     itemsPerPage (itemsPerPage: number) {
       this.updateOptions({ itemsPerPage })
     },
-    'internalOptions.itemsPerPage' (itemsPerPage: number) {
-      this.$emit('update:items-per-page', itemsPerPage)
+    'internalOptions.itemsPerPage': {
+      handler (itemsPerPage: number) {
+        this.$emit('update:items-per-page', itemsPerPage)
+      },
+      immediate: true,
     },
     sortBy (sortBy: string | string[]) {
       this.updateOptions({ sortBy: wrapInArray(sortBy) })

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -63,7 +63,7 @@ export default Themeable.extend({
     someItems (): boolean {
       return this.internalCurrentItems.some((i: any) => this.isSelected(i))
     },
-    sanitizedFooterProps (): object {
+    sanitizedFooterProps (): Record<string, any> {
       return camelizeObjectKeys(this.footerProps)
     },
   },

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -144,8 +144,17 @@ export default VDataIterator.extend({
     headersWithoutCustomFilters (): TableHeader[] {
       return this.computedHeaders.filter(header => !header.filter)
     },
-    sanitizedHeaderProps (): object {
+    sanitizedHeaderProps (): Record<string, any> {
       return camelizeObjectKeys(this.headerProps)
+    },
+    computedItemsPerPage (): number {
+      const itemsPerPage = this.options && this.options.itemsPerPage ? this.options.itemsPerPage : this.itemsPerPage
+      if (this.sanitizedFooterProps.itemsPerPageOptions && !this.sanitizedFooterProps.itemsPerPageOptions.includes(itemsPerPage)) {
+        const firstOption = this.sanitizedFooterProps.itemsPerPageOptions[0]
+        return typeof firstOption === 'object' ? firstOption.value : firstOption
+      }
+
+      return itemsPerPage
     },
   },
 
@@ -533,6 +542,7 @@ export default VDataIterator.extend({
         ...this.$props,
         customFilter: this.customFilterWithColumns,
         customSort: this.customSortWithHeaders,
+        itemsPerPage: this.computedItemsPerPage,
       },
       on: {
         'update:options': (v: DataOptions, old: DataOptions) => {

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -398,4 +398,28 @@ describe('VDataTable.ts', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/8184
+  it('should default to first option in itemsPerPageOptions if it does not include itemsPerPage', async () => {
+    const itemsPerPage = jest.fn()
+    const options = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        headers: testHeaders,
+        items: testItems,
+        footerProps: {
+          itemsPerPageOptions: [5, 6],
+        },
+      },
+      listeners: {
+        'update:items-per-page': itemsPerPage,
+        'update:options': options,
+      },
+    })
+
+    expect(itemsPerPage).toHaveBeenCalledWith(5)
+    expect(options).toHaveBeenCalledWith(expect.objectContaining({
+      itemsPerPage: 5,
+    }))
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
default to first itemsPerPage option if itemsPerPage is not found in list of options

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #8184

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
playground, unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-data-table
      :headers="headers"
      :items="items"
      class="elevation-1"
      :footer-props="{itemsPerPageOptions: [{text: 'five', value: 5},6,7]}"
    ></v-data-table>

    <v-data-table
      :headers="headers"
      :items="items"
      class="elevation-1"
      :items-per-page.sync="itemsPerPage"
      :footer-props="{itemsPerPageOptions: [{text: 'five', value: 5},6,7]}"
    ></v-data-table>

    {{ itemsPerPage }}
    <v-data-table
      :headers="headers"
      :items="items"
      class="elevation-1"
      :options.sync="options"
      :footer-props="{itemsPerPageOptions: [{text: 'five', value: 5},6,7]}"
    ></v-data-table>
    {{ options }}

    <v-data-table
      :headers="headers"
      :items="items"
      class="elevation-1"
      :footer-props="{itemsPerPageOptions: [5,6,7]}"
    ></v-data-table>

    <v-data-table
      :headers="headers"
      :items="items"
      class="elevation-1"
      :items-per-page="3"
      hide-default-footer
    ></v-data-table>
  </div>
</template>

<script>
export default {
  data: () => ({
    options: {
      itemsPerPage: 6
    },
    itemsPerPage: 6,
    headers: [
      {
        text: 'Dessert (100g serving)',
        align: 'left',
        sortable: false,
        value: 'name',
      },
      { text: 'Calories', value: 'calories' },
      { text: 'Fat (g)', value: 'fat' },
      { text: 'Carbs (g)', value: 'carbs' },
      { text: 'Protein (g)', value: 'protein' },
      { text: 'Iron (%)', value: 'iron' },
    ],
    items: [
        {
          name: 'Frozen Yogurt',
          calories: 159,
          fat: 6.0,
          carbs: 24,
          protein: 4.0,
          iron: '1%',
        },
        {
          name: 'Ice cream sandwich',
          calories: 237,
          fat: 9.0,
          carbs: 37,
          protein: 4.3,
          iron: '1%',
        },
        {
          name: 'Eclair',
          calories: 262,
          fat: 16.0,
          carbs: 23,
          protein: 6.0,
          iron: '7%',
        },
        {
          name: 'Cupcake',
          calories: 305,
          fat: 3.7,
          carbs: 67,
          protein: 4.3,
          iron: '8%',
        },
        {
          name: 'Gingerbread',
          calories: 356,
          fat: 16.0,
          carbs: 49,
          protein: 3.9,
          iron: '16%',
        },
        {
          name: 'Jelly bean',
          calories: 375,
          fat: 0.0,
          carbs: 94,
          protein: 0.0,
          iron: '0%',
        },
        {
          name: 'Lollipop',
          calories: 392,
          fat: 0.2,
          carbs: 98,
          protein: 0,
          iron: '2%',
        },
        {
          name: 'Honeycomb',
          calories: 408,
          fat: 3.2,
          carbs: 87,
          protein: 6.5,
          iron: '45%',
        },
        {
          name: 'Donut',
          calories: 452,
          fat: 25.0,
          carbs: 51,
          protein: 4.9,
          iron: '22%',
        },
        {
          name: 'KitKat',
          calories: 518,
          fat: 26.0,
          carbs: 65,
          protein: 7,
          iron: '6%',
        },
      ]
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
