### PR TITLE
fix(VDataFooter): disable last page button if there's no items

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -190,7 +190,7 @@ export default Vue.extend({
 
         after.push(this.genIcon(
           this.onLastPage,
-          this.options.page === this.pagination.pageCount || this.options.itemsPerPage === -1,
+          this.options.page >= this.pagination.pageCount || this.options.itemsPerPage === -1,
           this.$vuetify.lang.t('$vuetify.dataFooter.lastPage'),
           this.$vuetify.rtl ? this.firstIcon : this.lastIcon
         ))

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataFooter.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataFooter.spec.ts
@@ -173,4 +173,26 @@ describe('VDataFooter.ts', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should disable last page button if no items', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        options: {
+          page: 1,
+          itemsPerPage: 10,
+        },
+        pagination: {
+          page: 1,
+          itemsPerPage: 10,
+          pageStart: 0,
+          pageStop: 0,
+          pageCount: 0,
+          itemsLength: 0,
+        },
+        showFirstLastPage: true,
+      },
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
@@ -1,5 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VDataFooter.ts should disable last page button if no items 1`] = `
+<div class="v-data-footer">
+  <div class="v-data-footer__select">
+    Items per page:
+    <div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
+      <div class="v-input__control">
+        <div role="button"
+             aria-haspopup="listbox"
+             aria-expanded="false"
+             aria-owns="list-65"
+             class="v-input__slot"
+        >
+          <div class="v-select__slot">
+            <div class="v-select__selections">
+              <div class="v-select__selection v-select__selection--comma">
+                10
+              </div>
+              <input aria-label="$vuetify.dataFooter.itemsPerPageText"
+                     id="input-65"
+                     readonly="readonly"
+                     type="text"
+                     aria-readonly="true"
+              >
+            </div>
+            <div class="v-input__append-inner">
+              <div class="v-input__icon v-input__icon--append">
+                <i aria-hidden="true"
+                   class="v-icon notranslate mdi mdi-menu-down theme--light"
+                >
+                </i>
+              </div>
+            </div>
+          </div>
+          <div class="v-menu">
+            <div class="v-menu__content theme--light "
+                 style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
+            >
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="v-data-footer__pagination">
+    –
+  </div>
+  <div class="v-data-footer__icons-before">
+    <button type="button"
+            disabled="disabled"
+            class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+            aria-label="First page"
+    >
+      <span class="v-btn__content">
+        <i aria-hidden="true"
+           class="v-icon notranslate mdi mdi-page-first theme--light"
+        >
+        </i>
+      </span>
+    </button>
+    <button type="button"
+            disabled="disabled"
+            class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+            aria-label="Previous page"
+    >
+      <span class="v-btn__content">
+        <i aria-hidden="true"
+           class="v-icon notranslate mdi mdi-chevron-left theme--light"
+        >
+        </i>
+      </span>
+    </button>
+  </div>
+  <div class="v-data-footer__icons-after">
+    <button type="button"
+            disabled="disabled"
+            class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+            aria-label="Next page"
+    >
+      <span class="v-btn__content">
+        <i aria-hidden="true"
+           class="v-icon notranslate mdi mdi-chevron-right theme--light"
+        >
+        </i>
+      </span>
+    </button>
+    <button type="button"
+            disabled="disabled"
+            class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+            aria-label="Last page"
+    >
+      <span class="v-btn__content">
+        <i aria-hidden="true"
+           class="v-icon notranslate mdi mdi-page-last theme--light"
+        >
+        </i>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 1`] = `
 <div class="v-data-footer">
   <div class="v-data-footer__select">


### PR DESCRIPTION
## Motivation and Context
fixes #8577

## How Has This Been Tested?
visually, jest

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-data-table
      :headers="[]"
      :items="[]"
      :footer-props="{showFirstLastPage: true}"
    ></v-data-table>

    <v-data-table
      :headers="[{value:'foo'}]"
      :items="[{foo: 'foo'}]"
      :footer-props="{showFirstLastPage: true}"
    ></v-data-table>

    <v-data-table
      :headers="[{value:'foo'}]"
      :items-per-page="2"
      :items="[{foo: 'foo'},{foo: 'foo'},{foo: 'foo'},{foo: 'foo'}]"
      :footer-props="{showFirstLastPage: true}"
    ></v-data-table>

    <v-data-table
      :headers="[{value:'foo'}]"
      :items-per-page="2"
      :items="[{foo: 'foo'},{foo: 'foo'}]"
      :footer-props="{showFirstLastPage: true}"
    ></v-data-table>
  </div>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
