### PR TITLE
Fix link to component for VFileInput

### DIFF
--- a/packages/docs/src/data/pages/components/FileInputs.json
+++ b/packages/docs/src/data/pages/components/FileInputs.json
@@ -1,7 +1,7 @@
 {
   "title": "header",
   "titleText": "headerText",
-  "file": "components/VAutocomplete",
+  "file": "components/VFileInput",
   "children": [
     {
       "type": "section",


### PR DESCRIPTION
## Description
The link in the docs went to the directory for VAutocomplete instead of VFileInput. I fixed it so it links to the right component directory

## Motivation and Context
While browsing the docs, clicking the link for the source went to the directory for the wrong component.

## How Has This Been Tested?
No, just a documentation/metadata fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
