### PR TITLE
Doc examples for FileInputs: display-size -> show-size

### DIFF
--- a/packages/docs/src/examples/file-inputs/complex/advanced.vue
+++ b/packages/docs/src/examples/file-inputs/complex/advanced.vue
@@ -8,7 +8,7 @@
     placeholder="Select your files"
     prepend-icon="mdi-paperclip"
     outlined
-    :display-size="1000"
+    :show-size="1000"
   >
     <template v-slot:selection="{ index, text }">
       <v-chip

--- a/packages/docs/src/examples/file-inputs/simple/counter.vue
+++ b/packages/docs/src/examples/file-inputs/simple/counter.vue
@@ -1,3 +1,3 @@
 <template>
-  <v-file-input display-size counter multiple label="File input"></v-file-input>
+  <v-file-input show-size counter multiple label="File input"></v-file-input>
 </template>

--- a/packages/kitchen/src/pan/File Inputs.vue
+++ b/packages/kitchen/src/pan/File Inputs.vue
@@ -30,17 +30,17 @@
 
       <core-title>Size displaying</core-title>
       <core-section>
-        <v-file-input display-size />
+        <v-file-input show-size />
       </core-section>
 
       <core-title>Size displaying & multiple</core-title>
       <core-section>
-        <v-file-input display-size multiple />
+        <v-file-input show-size multiple />
       </core-section>
 
       <core-title>Size displaying & counter</core-title>
       <core-section>
-        <v-file-input display-size multiple counter />
+        <v-file-input show-size multiple counter />
       </core-section>
 
       <core-title>Non-deletable</core-title>
@@ -80,7 +80,7 @@
 
       <core-title>Validation (2 MB limit)</core-title>
       <core-section>
-        <v-file-input display-size :rules="rules" />
+        <v-file-input show-size :rules="rules" />
       </core-section>
     </v-layout>
   </v-container>


### PR DESCRIPTION
Updated 2 examples that were not working as expected, and the kitchen pan file

## Description
Changed the uses of the prop `display-size` to `show-size` in FileInputs examples and in the kitchen pan file.

## Motivation and Context
The examples that were supposed to show the file size were not working in the docs.

## How Has This Been Tested?
Visually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
