### PR TITLE
fix(VDialog): don't apply tabindex if dialog is not active

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.ts
+++ b/packages/vuetify/src/components/VDialog/VDialog.ts
@@ -276,7 +276,7 @@ export default baseMixins.extend({
       class: this.contentClasses,
       attrs: {
         role: 'document',
-        tabindex: 0,
+        tabindex: this.isActive ? 0 : undefined,
         ...this.getScopeIdAttrs(),
       },
       on: {

--- a/packages/vuetify/src/components/VDialog/__tests__/__snapshots__/VDialog.spec.ts.snap
+++ b/packages/vuetify/src/components/VDialog/__tests__/__snapshots__/VDialog.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`VDialog.ts should render a disabled component and match snapshot 1`] = 
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -32,7 +31,6 @@ exports[`VDialog.ts should render a fullscreen component and match snapshot 1`] 
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -50,7 +48,6 @@ exports[`VDialog.ts should render a persistent component and match snapshot 1`] 
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -68,7 +65,6 @@ exports[`VDialog.ts should render a scrollable component and match snapshot 1`] 
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -86,7 +82,6 @@ exports[`VDialog.ts should render component and match snapshot 1`] = `
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -104,7 +99,6 @@ exports[`VDialog.ts should render component with custom origin and match snapsho
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -122,7 +116,6 @@ exports[`VDialog.ts should render component with custom transition and match sna
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -140,7 +133,6 @@ exports[`VDialog.ts should render component with custom width (max-width) and ma
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >
@@ -158,7 +150,6 @@ exports[`VDialog.ts should render component with custom width and match snapshot
      style="display: block;"
 >
   <div role="document"
-       tabindex="0"
        class="v-dialog__content"
        style="z-index: 0;"
   >


### PR DESCRIPTION
## Motivation and Context
https://codepen.io/jkarczm/pen/ZEzLggz

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-btn>Click me and then press tab</v-btn>
    <v-dialog>
      <template #activator="{ on }">
        <v-btn v-on="on">Open dialog</v-btn>
      </template>
      Contents
    </v-dialog>
  </v-container>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
