### PR TITLE
feat(VTextField): add customizable counter value

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.ts
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.ts
@@ -31,7 +31,7 @@ export default VAutocomplete.extend({
   }),
 
   computed: {
-    counterValue (): number {
+    computedCounterValue (): number {
       return this.multiple
         ? this.selectedItems.length
         : (this.internalSearch || '').toString().length

--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -79,7 +79,7 @@ export default VTextField.extend({
         'v-file-input': true,
       }
     },
-    counterValue (): string {
+    computedCounterValue (): string {
       const fileCount = (this.isMultiple && this.lazyValue)
         ? this.lazyValue.length
         : (this.lazyValue instanceof File) ? 1 : 0
@@ -203,7 +203,7 @@ export default VTextField.extend({
       const length = this.text.length
 
       if (length < 2) return this.text
-      if (this.showSize && !this.counter) return [this.counterValue]
+      if (this.showSize && !this.counter) return [this.computedCounterValue]
       return [this.$vuetify.lang.t(this.counterString, length)]
     },
     genSelections () {

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -147,7 +147,7 @@ export default baseMixins.extend<options>().extend({
     computedOwns (): string {
       return `list-${this._uid}`
     },
-    counterValue (): number {
+    computedCounterValue (): number {
       return this.multiple
         ? this.selectedItems.length
         : (this.getText(this.selectedItems[0]) || '').toString().length

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
@@ -137,7 +137,7 @@ describe('VSelect.ts', () => {
       },
     })
 
-    expect(wrapper.vm.counterValue).toBe(3)
+    expect(wrapper.vm.computedCounterValue).toBe(3)
 
     wrapper.setProps({
       items: [{
@@ -146,7 +146,7 @@ describe('VSelect.ts', () => {
       }],
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.counterValue).toBe(9)
+    expect(wrapper.vm.computedCounterValue).toBe(9)
 
     wrapper.setProps({
       items: ['foo', 'bar', 'baz'],
@@ -154,7 +154,7 @@ describe('VSelect.ts', () => {
       value: ['foo', 'bar'],
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.counterValue).toBe(2)
+    expect(wrapper.vm.computedCounterValue).toBe(2)
   })
 
   it('should emit a single change event', async () => {

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -55,6 +55,7 @@ export default baseMixins.extend<options>().extend({
       default: '$clear',
     },
     counter: [Boolean, Number, String],
+    counterValue: Function,
     filled: Boolean,
     flat: Boolean,
     fullWidth: Boolean,
@@ -107,7 +108,10 @@ export default baseMixins.extend<options>().extend({
         'v-text-field--shaped': this.shaped,
       }
     },
-    counterValue (): number {
+    computedCounterValue (): number {
+      if (typeof this.counterValue === 'function') {
+        return this.counterValue(this.internalValue)
+      }
       return (this.internalValue || '').toString().length
     },
     internalValue: {
@@ -296,7 +300,7 @@ export default baseMixins.extend<options>().extend({
           dark: this.dark,
           light: this.light,
           max,
-          value: this.counterValue,
+          value: this.computedCounterValue,
         },
       })
     },

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -566,15 +566,21 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
     wrapper.setProps({ value: 'foo bar baz' })
 
+    await wrapper.vm.$nextTick()
+
     expect(counter.element.innerHTML).toBe('9 / 25')
 
     wrapper.setProps({ counter: '50' })
+
+    await wrapper.vm.$nextTick()
 
     expect(counter.element.innerHTML).toBe('9 / 50')
 
     wrapper.setProps({
       counterValue: (value?: string): number => (value || '').replace(/ba/g, '').length,
     })
+
+    await wrapper.vm.$nextTick()
 
     expect(counter.element.innerHTML).toBe('7 / 50')
   })

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -549,6 +549,36 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     expect(counter.element.innerHTML).toBe('0 / 50')
   })
 
+  it('should use counter value function', async () => {
+    const wrapper = mountFunction({
+      attrs: {
+        maxlength: 25,
+      },
+      propsData: {
+        counter: true,
+        counterValue: (value?: string): number => (value || '').replace(/\s/g, '').length,
+      },
+    })
+
+    const counter = wrapper.find('.v-counter')
+
+    expect(counter.element.innerHTML).toBe('0 / 25')
+
+    wrapper.setProps({ value: 'foo bar baz' })
+
+    expect(counter.element.innerHTML).toBe('9 / 25')
+
+    wrapper.setProps({ counter: '50' })
+
+    expect(counter.element.innerHTML).toBe('9 / 50')
+
+    wrapper.setProps({
+      counterValue: (value?: string): number => (value || '').replace(/ba/g, '').length,
+    })
+
+    expect(counter.element.innerHTML).toBe('7 / 50')
+  })
+
   it('should set bad input on input', () => {
     const wrapper = mountFunction()
 

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -22,13 +22,13 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
         </div>
       </div>
       <div class="v-text-field__slot">
-        <label for="input-159"
+        <label for="input-131"
                class="v-label theme--light"
                style="left: 0px; position: absolute;"
         >
           foo
         </label>
-        <input id="input-159"
+        <input id="input-131"
                type="text"
         >
       </div>

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -22,13 +22,13 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
         </div>
       </div>
       <div class="v-text-field__slot">
-        <label for="input-127"
+        <label for="input-159"
                class="v-label theme--light"
                style="left: 0px; position: absolute;"
         >
           foo
         </label>
-        <input id="input-127"
+        <input id="input-159"
                type="text"
         >
       </div>


### PR DESCRIPTION
## Description

added customizable counter value via optional function

_I messed up a previous branch #8790, this is the same but recreated_

## Motivation and Context

closes #8788 

## How Has This Been Tested?

unit test

## Markup:

<details>

```vue
<template>
  <v-text-field
    counter
    :counter-length="(value) => (value || '').replace(/\s/g).length"
  ></v-data-table>
</template>
```
</details>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:

- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
