### PR TITLE
fix(VCarousel): Always respect original internal height of VWindow.

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -64,7 +64,6 @@ export default VWindow.extend({
   data () {
     return {
       internalHeight: this.height,
-      noHeightReset: true,
       slideTimeout: undefined as number | undefined,
     }
   },

--- a/packages/vuetify/src/components/VCarousel/VCarouselItem.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarouselItem.ts
@@ -49,9 +49,5 @@ export default baseMixins.extend({
 
       return this.$createElement(tag, data, this.showLazyContent(this.genDefaultSlot()))
     },
-    onBeforeEnter () { /* noop */ },
-    onEnter () { /* noop */ },
-    onAfterEnter () { /* noop */ },
-    onEnterCancelled () { /* noop */ },
   },
 })

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -59,8 +59,8 @@ export default BaseItemGroup.extend({
   data () {
     return {
       changedByDelimiters: false,
-      internalHeight: undefined as undefined | string,
-      noHeightReset: false,
+      internalHeight: undefined as undefined | string, // This can be fixed by child class.
+      transitionHeight: undefined as undefined | string, // Intermediate height during transition.
       transitionCount: 0, // Number of windows in transition state.
       isBooted: false,
       isReverse: false,
@@ -130,7 +130,7 @@ export default BaseItemGroup.extend({
           'v-window__container--is-active': this.isActive,
         },
         style: {
-          height: this.internalHeight,
+          height: this.internalHeight || this.transitionHeight,
         },
       }, children)
     },

--- a/packages/vuetify/src/components/VWindow/VWindowItem.ts
+++ b/packages/vuetify/src/components/VWindow/VWindowItem.ts
@@ -98,13 +98,9 @@ export default baseMixins.extend<options>().extend(
       if (this.windowGroup.transitionCount > 0) {
         this.windowGroup.transitionCount--
 
-        // Remove container height if we are out of transition
-        // and window group allows its height to be modified
-        if (
-          this.windowGroup.transitionCount === 0 &&
-          !this.windowGroup.noHeightReset
-        ) {
-          this.windowGroup.internalHeight = undefined
+        // Remove container height if we are out of transition.
+        if (this.windowGroup.transitionCount === 0) {
+          this.windowGroup.transitionHeight = undefined
         }
       }
     },
@@ -117,7 +113,7 @@ export default baseMixins.extend<options>().extend(
       this.inTransition = true
       if (this.windowGroup.transitionCount === 0) {
         // Set initial height for height transition.
-        this.windowGroup.internalHeight = convertToUnit(this.windowGroup.$el.clientHeight)
+        this.windowGroup.transitionHeight = convertToUnit(this.windowGroup.$el.clientHeight)
       }
       this.windowGroup.transitionCount++
     },
@@ -136,7 +132,7 @@ export default baseMixins.extend<options>().extend(
         }
 
         // Set transition target height.
-        this.windowGroup.internalHeight = convertToUnit(el.clientHeight)
+        this.windowGroup.transitionHeight = convertToUnit(el.clientHeight)
       })
     },
   },

--- a/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
+++ b/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
@@ -54,20 +54,20 @@ describe('VWindowItem.ts', () => {
     const item = wrapper.find(VWindowItem.options)
     // Before enter
     expect(wrapper.vm.isActive).toBeFalsy()
-    expect(wrapper.vm.internalHeight).toBeUndefined()
+    expect(wrapper.vm.transitionHeight).toBeUndefined()
     item.vm.onBeforeTransition()
     expect(wrapper.vm.isActive).toBeTruthy()
-    expect(wrapper.vm.internalHeight).toBe('0px')
+    expect(wrapper.vm.transitionHeight).toBe('0px')
 
     // Enter
     const el = { clientHeight: 50 }
     item.vm.onEnter(el)
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.internalHeight).toBe('50px')
+    expect(wrapper.vm.transitionHeight).toBe('50px')
 
     // After enter
     item.vm.onAfterTransition()
-    expect(wrapper.vm.internalHeight).toBeUndefined()
+    expect(wrapper.vm.transitionHeight).toBeUndefined()
     expect(wrapper.vm.isActive).toBeFalsy()
 
     // Canceling
@@ -121,7 +121,7 @@ describe('VWindowItem.ts', () => {
         reverseTransition: false,
       },
       watch: {
-        internalHeight: heightChanged,
+        transitionHeight: heightChanged,
       },
       slots: {
         default: [VWindowItem],


### PR DESCRIPTION
## Description

Add an intermediate height to overwrite component internal height if internalHeight is undefined.
This change makes VWindow universally respect internalHeight if set without special flags.

## Motivation and Context

Improve VWindow.

## How Has This Been Tested?

Test on v-tabs and v-carousel docs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)
