### PR TITLE
feat: added color and opacity props to overlayable mixin

### DIFF
--- a/packages/docs/src/lang/en/components/BottomSheets.json
+++ b/packages/docs/src/lang/en/components/BottomSheets.json
@@ -28,7 +28,6 @@
   },
   "props": {
     "eager": "Mixins.Bootable.props.eager",
-    "hideOverlay": "Components.Dialogs.props.hideOverlay",
     "inset": "Reduces the sheet content maximum width to 70%.",
     "internalActivator": "Components.Dialogs.props.internalActivator",
     "openOnHover": "Components.Dialogs.props.openOnHover",

--- a/packages/docs/src/lang/en/components/Dialogs.json
+++ b/packages/docs/src/lang/en/components/Dialogs.json
@@ -49,7 +49,6 @@
     "dark": "Mixins.Themeable.props.dark",
     "fullWidth": "Forces the dialog to expand 100% of available width.",
     "fullscreen": "Changes layout for fullscreen display.",
-    "hideOverlay": "Hides the display of the overlay.",
     "internalActivator": "Detaches the menu content inside of the component as opposed to the document.",
     "eager": "Mixins.Bootable.props.eager",
     "light": "Mixins.Themeable.props.light",

--- a/packages/docs/src/lang/en/components/NavigationDrawers.json
+++ b/packages/docs/src/lang/en/components/NavigationDrawers.json
@@ -51,7 +51,6 @@
     "expandOnHover": "Collapses the drawer to a **mini-variant** until hovering with the mouse",
     "fixed": "Mixins.Positionable.props.fixed",
     "floating": "A floating drawer has no visible container (no border-right)",
-    "hideOverlay": "Hide the display of the overlay",
     "height": "Sets the height of the navigation drawer",
     "miniVariantWidth": "Designates the width assigned when the `mini` prop is turned on",
     "miniVariant": "Condenses navigation drawer width, also accepts the **.sync** modifier. With this, the drawer will re-open when clicking it",

--- a/packages/docs/src/lang/en/mixins/Overlayable.json
+++ b/packages/docs/src/lang/en/mixins/Overlayable.json
@@ -1,0 +1,7 @@
+{
+  "props": {
+    "hideOverlay": "Hides the display of the overlay.",
+    "overlayColor": "Sets the overlay color.",
+    "overlayOpacity": "Sets the overlay opacity."
+  }
+}

--- a/packages/vuetify/src/mixins/overlayable/index.ts
+++ b/packages/vuetify/src/mixins/overlayable/index.ts
@@ -29,6 +29,8 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
 
   props: {
     hideOverlay: Boolean,
+    overlayColor: String,
+    overlayOpacity: [Number, String],
   },
 
   data () {
@@ -54,6 +56,8 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
         propsData: {
           absolute: this.absolute,
           value: false,
+          color: this.overlayColor,
+          opacity: this.overlayOpacity,
         },
       })
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added overlay-color and overlay-opacity props to overlayable mixin
Added overlayable translation strings file in english

## Motivation and Context
There was no way to control the opacity or color of the overlay on VBottomSheet, VDialog and
VNavigationDrawer components.  
The overlayable mixin was apparently only used for the hide-overlay prop.

Fixes #8301

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<v-dialog
    v-model="dialog"
    overlay-opacity="0.9"
    overlay-color="red"
> ... </v-dialog>

<v-bottom-sheet
    v-model="sheet"
    overlay-opacity="1"
    overlay-color="green"
> ... </v-bottom-sheet>

<v-navigation-drawer
    v-model="drawer"
    overlay-opacity="0.5"
    overlay-color="blue"
    absolute
    temporary
> ... </v-navigation-drawer>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
