### PR TITLE
fix(VPagination): render all items before mounted hook

### DIFF
--- a/packages/vuetify/src/components/VPagination/VPagination.ts
+++ b/packages/vuetify/src/components/VPagination/VPagination.ts
@@ -65,7 +65,7 @@ export default mixins(Colorable, Themeable).extend({
         ? this.maxButtons
         : totalVisible || this.maxButtons
 
-      if (this.length <= maxLength || maxLength < 1) {
+      if (this.length <= maxLength || maxLength < 0) {
         return this.range(1, this.length)
       }
 

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
@@ -244,12 +244,22 @@ describe('VPagination.ts', () => {
     expect(wrapper.vm.items).toHaveLength(10)
   })
 
-  it('should return length when maxButtons is less than 1', () => {
+  it('should return length when maxButtons is less than 0', () => {
     const wrapper = mountFunction({
       data: () => ({ maxButtons: -3 }),
       propsData: { length: 4 },
     })
 
     expect(wrapper.vm.items).toEqual([1, 2, 3, 4])
+  })
+
+  it('should return 2 items before mounted hook', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        length: 50,
+      },
+    })
+
+    expect(wrapper.vm.items).toHaveLength(2)
   })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

Fixed a bug that pagination renders all items before vue component mounting since v2.0.15.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is a lot of rendering costs and pagination width is so large before mounted hook.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
