### PR TITLE
feat(VDatePicker): pick date range

### DIFF
--- a/packages/docs/src/data/pages/components/DatePickers.json
+++ b/packages/docs/src/data/pages/components/DatePickers.json
@@ -61,6 +61,7 @@
             "intermediate/date-formatting",
             "intermediate/date-formatting-moment-datefns",
             "intermediate/date-multiple",
+            "intermediate/date-range",
             "intermediate/date-birthday",
             "intermediate/date-events",
             "intermediate/month-dialog-and-menu"

--- a/packages/docs/src/examples/date-pickers/intermediate/date-range.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-range.vue
@@ -16,9 +16,8 @@
       dates: ['2019-09-10', '2019-09-20'],
     }),
     computed: {
-      dateRangeText: {
-        set: val => { },
-        get: () => this.dates.join(' ~ '),
+      dateRangeText () {
+        return this.dates.join(' ~ ')
       },
     },
   }

--- a/packages/docs/src/examples/date-pickers/intermediate/date-range.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-range.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-row>
+    <v-col cols="12" sm="6">
+      <v-date-picker v-model="dates" range></v-date-picker>
+    </v-col>
+    <v-col cols="12" sm="6">
+      <v-text-field v-model="dateRangeText" label="Date range" prepend-icon="event" readonly></v-text-field>
+      model: {{ dates }}
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      dates: ['2019-09-10', '2019-09-20'],
+    }),
+    computed: {
+      dateRangeText: {
+        set: val => { },
+        get: () => this.dates.join(' ~ '),
+      },
+    },
+  }
+</script>

--- a/packages/docs/src/lang/en/components/DatePickers.json
+++ b/packages/docs/src/lang/en/components/DatePickers.json
@@ -45,7 +45,7 @@
       "header": "### Date pickers - Mutiple"
     },
     "date-range": {
-      "desc": "Date picker can select date range with the `range` property. When using `range` property date picker expects its model to be an array of length 2 or empty.",
+      "desc": "Date picker can select date range with the `range` prop. When using `range` prop date picker expects its model to be an array of length 2 or empty.",
       "header": "### Date pickers - Range"
     },
     "date-picker-date": {

--- a/packages/docs/src/lang/en/components/DatePickers.json
+++ b/packages/docs/src/lang/en/components/DatePickers.json
@@ -44,6 +44,10 @@
       "desc": "Date picker can now select multiple dates with the `multiple` prop. If using `multiple` then date picker expects its model to be an array.",
       "header": "### Date pickers - Mutiple"
     },
+    "date-range": {
+      "desc": "Date picker can select date range with the `range` property. When using `range` property date picker expects its model to be an array of length 2 or empty.",
+      "header": "### Date pickers - Range"
+    },
     "date-picker-date": {
       "desc": "You can watch the `pickerDate` which is the displayed month/year (depending on the picker type and active view) to perform some action when it changes.",
       "header": "### Date pickers - react to displayed month/year change"
@@ -122,6 +126,7 @@
     "nextIcon": "Sets the icon for next month/year button",
     "pickerDate": "Displayed year/month",
     "prevIcon": "Sets the icon for previous month/year button",
+    "range": "Allow the selection of date range",
     "reactive": "Updates the picker model when changing months/years automatically",
     "readonly": "Makes the picker readonly (doesnt't allow to select new date)",
     "scrollable": "Allows changing displayed month with mouse scroll",

--- a/packages/kitchen/src/pan/Date pickers.vue
+++ b/packages/kitchen/src/pan/Date pickers.vue
@@ -390,13 +390,12 @@
       </core-section>
 
       <core-title>
-        Select range {{ dateRange }}
+        Select range
       </core-title>
       <core-section center>
         <v-date-picker
           v-model="dateRange"
-          select-range
-          multiple
+          range
         />
       </core-section>
     </v-layout>

--- a/packages/kitchen/src/pan/Date pickers.vue
+++ b/packages/kitchen/src/pan/Date pickers.vue
@@ -388,6 +388,17 @@
           />
         </v-layout>
       </core-section>
+
+      <core-title>
+        Select range {{ dateRange }}
+      </core-title>
+      <core-section center>
+        <v-date-picker
+          v-model="dateRange"
+          select-range
+          multiple
+        />
+      </core-section>
     </v-layout>
   </v-container>
 </template>
@@ -402,6 +413,7 @@
       model: '2019-01-16',
       modelMM: '2019-01-16',
       landscape: false,
+      dateRange: [],
     }),
 
     methods: {

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -129,16 +129,16 @@ export default mixins(
   },
 
   computed: {
-    internalMultiple (): boolean {
+    isMultiple (): boolean {
       return this.multiple || this.range
     },
     lastValue (): string | null {
-      return this.internalMultiple ? (this.value as string[])[(this.value as string[]).length - 1] : (this.value as string | null)
+      return this.isMultiple ? (this.value as string[])[(this.value as string[]).length - 1] : (this.value as string | null)
     },
     selectedMonths (): string | string[] | undefined {
       if (!this.value || !this.value.length || this.type === 'month') {
         return this.value
-      } else if (this.internalMultiple) {
+      } else if (this.isMultiple) {
         return (this.value as string[]).map(val => val.substr(0, 7))
       } else {
         return (this.value as string).substr(0, 7)
@@ -178,7 +178,7 @@ export default mixins(
       return {
         year: this.yearFormat || createNativeLocaleFormatter(this.currentLocale, { year: 'numeric', timeZone: 'UTC' }, { length: 4 }),
         titleDate: this.titleDateFormat ||
-          (this.internalMultiple ? this.defaultTitleMultipleDateFormatter : this.defaultTitleDateFormatter),
+          (this.isMultiple ? this.defaultTitleMultipleDateFormatter : this.defaultTitleDateFormatter),
       }
     },
     defaultTitleMultipleDateFormatter (): DatePickerMultipleFormatter {
@@ -235,9 +235,9 @@ export default mixins(
       this.checkMultipleProp()
       this.setInputDate()
 
-      if (!this.internalMultiple && this.value && !this.pickerDate) {
+      if (!this.isMultiple && this.value && !this.pickerDate) {
         this.tableDate = sanitizeDateString(this.inputDate, this.type === 'month' ? 'year' : 'month')
-      } else if (this.internalMultiple && (this.value as string[]).length && !(oldValue as string[]).length && !this.pickerDate) {
+      } else if (this.isMultiple && (this.value as string[]).length && !(oldValue as string[]).length && !this.pickerDate) {
         this.tableDate = sanitizeDateString(this.inputDate, this.type === 'month' ? 'year' : 'month')
       }
     },
@@ -245,10 +245,10 @@ export default mixins(
       this.activePicker = type.toUpperCase()
 
       if (this.value && this.value.length) {
-        const output = (this.internalMultiple ? (this.value as string[]) : [this.value as string])
+        const output = (this.isMultiple ? (this.value as string[]) : [this.value as string])
           .map((val: string) => sanitizeDateString(val, type))
           .filter(this.isDateAllowed)
-        this.$emit('input', this.internalMultiple ? output : output[0])
+        this.$emit('input', this.isMultiple ? output : output[0])
       }
     },
   },
@@ -285,9 +285,9 @@ export default mixins(
     checkMultipleProp () {
       if (this.value == null) return
       const valueType = this.value.constructor.name
-      const expected = this.internalMultiple ? 'Array' : 'String'
+      const expected = this.isMultiple ? 'Array' : 'String'
       if (valueType !== expected) {
-        consoleWarn(`Value must be ${this.internalMultiple ? 'an' : 'a'} ${expected}, got ${valueType}`, this)
+        consoleWarn(`Value must be ${this.isMultiple ? 'an' : 'a'} ${expected}, got ${valueType}`, this)
       }
     },
     isDateAllowed (value: string) {
@@ -301,7 +301,7 @@ export default mixins(
         this.tableDate = `${value}-${pad((this.tableMonth || 0) + 1)}`
       }
       this.activePicker = 'MONTH'
-      if (this.reactive && !this.readonly && !this.internalMultiple && this.isDateAllowed(this.inputDate)) {
+      if (this.reactive && !this.readonly && !this.isMultiple && this.isDateAllowed(this.inputDate)) {
         this.$emit('input', this.inputDate)
       }
     },
@@ -315,7 +315,7 @@ export default mixins(
 
         this.tableDate = value
         this.activePicker = 'DATE'
-        if (this.reactive && !this.readonly && !this.internalMultiple && this.isDateAllowed(this.inputDate)) {
+        if (this.reactive && !this.readonly && !this.isMultiple && this.isDateAllowed(this.inputDate)) {
           this.$emit('input', this.inputDate)
         }
       } else {
@@ -337,7 +337,7 @@ export default mixins(
           selectingYear: this.activePicker === 'YEAR',
           year: this.formatters.year(this.value ? `${this.inputYear}` : this.tableDate),
           yearIcon: this.yearIcon,
-          value: this.internalMultiple ? (this.value as string[])[0] : this.value,
+          value: this.isMultiple ? (this.value as string[])[0] : this.value,
         },
         slot: 'title',
         on: {

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -633,4 +633,26 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
     wrapper.findAll('.v-date-picker-table--date tbody tr+tr td:first-child button').at(0).trigger('dblclick')
     expect(dblclick).toHaveBeenCalledWith('2013-05-05')
   })
+
+  it('should handle date range select', async () => {
+    const cb = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        multiple: true,
+        selectRange: true,
+        value: ['2019-01-01', '2019-01-02'],
+      },
+    })
+
+    wrapper.vm.$on('input', cb)
+    wrapper.findAll('.v-date-picker-table--date tbody tr+tr td:first-child button').at(0).trigger('click')
+    expect(cb.mock.calls[0][0]).toEqual(
+      expect.arrayContaining(['2019-01-06'])
+    )
+
+    wrapper.findAll('.v-date-picker-table--date tbody tr+tr td button').at(2).trigger('click')
+    console.log(JSON.stringify(cb.mock.calls))
+    expect(cb.mock.calls[0][0][0]).toBe('2019-01-06')
+    expect(cb.mock.calls[1][0][0]).toBe('2019-01-08')
+  })
 })

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -638,8 +638,7 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
     const cb = jest.fn()
     const wrapper = mountFunction({
       propsData: {
-        multiple: true,
-        selectRange: true,
+        range: true,
         value: ['2019-01-01', '2019-01-02'],
       },
     })

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -651,7 +651,6 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
     )
 
     wrapper.findAll('.v-date-picker-table--date tbody tr+tr td button').at(2).trigger('click')
-    console.log(JSON.stringify(cb.mock.calls))
     expect(cb.mock.calls[0][0][0]).toBe('2019-01-06')
     expect(cb.mock.calls[1][0][0]).toBe('2019-01-08')
   })


### PR DESCRIPTION
#1646

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Allow datepicker to pick range.
By add new prop "Range", a workaround is provided to handle range picking.

- Value will be kept as an array of size 2 to save [From, To].  New click will clear the array
- Any dates between will be displayed as "selected"
- Can select with both direction (From then To, or To then From)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[#1646 ](https://github.com/vuetifyjs/vuetify/issues/1646)
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually and unit
![VDatePicker](https://user-images.githubusercontent.com/5492274/64489112-cfc63b80-d281-11e9-82f1-dabbf352a69f.gif)

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-date-picker v-model="dates" range width="290" class="mt-4"></v-date-picker>
    v-model value: {{ dates }}
    <v-menu ref="menu" v-model="menu" :close-on-content-click="false" transition="scale-transition" offset-y min-width="290px">
      <template v-slot:activator="{ on }">
        <v-text-field :value="dateRangeText" label="Date range" prepend-icon="event" readonly v-on="on"></v-text-field>
      </template>
      <v-date-picker v-model="dates" range no-title scrollable>
        <div class="flex-grow-1"></div>
        <v-btn text color="primary" @click="$refs.menu.save(dates)">OK</v-btn>
      </v-date-picker>
    </v-menu>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      dates: ['2018-09-15', '2018-09-20'],
      menu: false,
    }),
    computed: {
      dateRangeText () {
        return this.dates.join(' ~ ')
      },
    },
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [x] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
