### PR TITLE
fix(VSlideGroup): hide arrows

### DIFF
--- a/packages/vuetify/src/components/VChipGroup/__tests__/__snapshots__/VChipGroup.spec.ts.snap
+++ b/packages/vuetify/src/components/VChipGroup/__tests__/__snapshots__/VChipGroup.spec.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`VChipGroup.ts should have a v-chip-group class 1`] = `
 <div class="v-item-group theme--light v-slide-group v-chip-group">
-  <div class="v-slide-group__prev v-slide-group__prev--disabled">
-  </div>
   <div class="v-slide-group__wrapper">
     <div class="v-slide-group__content">
     </div>
@@ -13,8 +11,6 @@ exports[`VChipGroup.ts should have a v-chip-group class 1`] = `
 
 exports[`VChipGroup.ts should render column 1`] = `
 <div class="v-item-group theme--light v-slide-group v-chip-group v-chip-group--column">
-  <div class="v-slide-group__prev v-slide-group__prev--disabled">
-  </div>
   <div class="v-slide-group__wrapper">
     <div class="v-slide-group__content">
     </div>
@@ -24,8 +20,6 @@ exports[`VChipGroup.ts should render column 1`] = `
 
 exports[`VChipGroup.ts should switch to column 1`] = `
 <div class="v-item-group theme--light v-slide-group v-chip-group">
-  <div class="v-slide-group__prev v-slide-group__prev--disabled">
-  </div>
   <div class="v-slide-group__wrapper">
     <div class="v-slide-group__content">
     </div>
@@ -35,8 +29,6 @@ exports[`VChipGroup.ts should switch to column 1`] = `
 
 exports[`VChipGroup.ts should switch to column 2`] = `
 <div class="v-item-group theme--light v-slide-group v-chip-group v-chip-group--column">
-  <div class="v-slide-group__prev v-slide-group__prev--disabled">
-  </div>
   <div class="v-slide-group__wrapper">
     <div class="v-slide-group__content">
     </div>

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.sass
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.sass
@@ -44,9 +44,3 @@
   display: flex
   flex: 1 1 auto
   overflow: hidden
-
-// Modifiers
-.v-slide-group__next,
-.v-slide-group__prev
-  &--disabled
-    pointer-events: none

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
@@ -144,7 +144,7 @@ export const BaseSlideGroup = mixins<options &
 
   methods: {
     genNext (): VNode | null {
-      if (!this.hasAffixes) return null
+      if (!this.hasNext) return null
 
       const slot = this.$scopedSlots.next
         ? this.$scopedSlots.next({})
@@ -152,9 +152,6 @@ export const BaseSlideGroup = mixins<options &
 
       return this.$createElement('div', {
         staticClass: 'v-slide-group__next',
-        class: {
-          'v-slide-group__next--disabled': !this.hasNext,
-        },
         on: {
           click: () => this.onAffixClick('next'),
         },
@@ -201,15 +198,14 @@ export const BaseSlideGroup = mixins<options &
     },
     // Always generate prev for scrollable hint
     genPrev (): VNode | null {
+      if (!this.hasPrev) return null
+
       const slot = this.$scopedSlots.prev
         ? this.$scopedSlots.prev({})
         : this.$slots.prev || this.__cachedPrev
 
       return this.$createElement('div', {
         staticClass: 'v-slide-group__prev',
-        class: {
-          'v-slide-group__prev--disabled': !this.hasPrev,
-        },
         on: {
           click: () => this.onAffixClick('prev'),
         },

--- a/packages/vuetify/src/components/VTabs/__tests__/__snapshots__/VTabs.spec.ts.snap
+++ b/packages/vuetify/src/components/VTabs/__tests__/__snapshots__/VTabs.spec.ts.snap
@@ -5,8 +5,6 @@ exports[`VTabs.ts should render generic elements in the tab container 1`] = `
   <div role="tablist"
        class="v-item-group theme--light v-slide-group v-tabs-bar primary--text"
   >
-    <div class="v-slide-group__prev v-slide-group__prev--disabled">
-    </div>
     <div class="v-slide-group__wrapper">
       <div class="v-slide-group__content v-tabs-bar__content">
         <div class="test-element">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Hide prev/next buttons in order to save space.

## Motivation and Context
Fixes #8875

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-slide-group center-active>
      <v-slide-item
        v-for="n in 25"
        :key="n"
        v-slot:default="{ active, toggle }"
      >
        <v-btn
          class="mx-2"
          :input-value="active"
          active-class="purple white--text"
          depressed
          rounded
          @click="toggle"
        >
          Options {{ n }}
        </v-btn>
      </v-slide-item>
    </v-slide-group>
  </div>
</template>

<script>
export default {
  data: () => ({
  }),
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
