### PR TITLE
feat(VSlideGroup) add steps

### DIFF
--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
@@ -71,6 +71,7 @@ export const BaseSlideGroup = mixins<options &
       default: '$vuetify.icons.prev',
     },
     showArrows: Boolean,
+    steps: Boolean,
   },
 
   data: () => ({
@@ -227,6 +228,8 @@ export const BaseSlideGroup = mixins<options &
             start: (e: TouchEvent) => this.overflowCheck(e, this.onTouchStart),
             move: (e: TouchEvent) => this.overflowCheck(e, this.onTouchMove),
             end: (e: TouchEvent) => this.overflowCheck(e, this.onTouchEnd),
+            left: (e: TouchEvent) => this.calculateStepOffset(e, 'left'),
+            right: (e: TouchEvent) => this.calculateStepOffset(e, 'right'),
           },
         }],
         ref: 'wrapper',
@@ -238,6 +241,30 @@ export const BaseSlideGroup = mixins<options &
         (direction === 'prev' ? -1 : 1) * widths.wrapper
 
       return sign * Math.max(Math.min(newAbosluteOffset, widths.content - widths.wrapper), 0)
+    },
+    calculateStepOffset (e: TouchEvent, direction: 'right' | 'left') {
+      if (!this.isOverflowing || !this.steps) return
+
+      const { content, wrapper } = this.$refs
+      const maxScrollOffset = content.clientWidth - wrapper.clientWidth
+      const oneItemWidth = content.clientWidth / this.internalItemsLength
+      const offsetWithoutRest = this.scrollOffset - (this.scrollOffset % oneItemWidth)
+
+      if (this.$vuetify.rtl) {
+        /* istanbul ignore else */
+        if (direction === 'right' && this.scrollOffset > -maxScrollOffset) {
+          this.scrollOffset = offsetWithoutRest + -oneItemWidth
+        } else if (direction === 'left') {
+          this.scrollOffset = offsetWithoutRest
+        }
+      } else {
+        /* istanbul ignore else */
+        if (direction === 'left' && this.scrollOffset < maxScrollOffset) {
+          this.scrollOffset = offsetWithoutRest + oneItemWidth
+        } else if (direction === 'right') {
+          this.scrollOffset = offsetWithoutRest
+        }
+      }
     },
     onAffixClick (location: 'prev' | 'next') {
       this.$emit(`click:${location}`)


### PR DESCRIPTION
## Description
Steps is a prop that add some dynamic touch scroll

**Without steps prop (default):**
![before](https://user-images.githubusercontent.com/8259014/64557680-0069ac00-d33a-11e9-9dab-b6268c3e8d57.gif)
**With steps prop**
![Screencastfrom09-09-2019072154PM](https://user-images.githubusercontent.com/8259014/64557768-3018b400-d33a-11e9-8156-6c6464f5eb4b.gif)

## How Has This Been Tested?
visually 

## Markup:
on touch screens add ```steps``` prop on VSlideGroup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
