### PR TITLE
fix(VCalendar): proper week height in month view on Firefox

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarWeekly.sass
+++ b/packages/vuetify/src/components/VCalendar/VCalendarWeekly.sass
@@ -28,6 +28,7 @@
   height: 100%
   display: flex
   flex-direction: column
+  min-height: 0
 
 .v-calendar-weekly__head
   display: flex
@@ -48,6 +49,7 @@
   display: flex
   flex: 1
   height: 0
+  min-height: 0
 
 .v-calendar-weekly__day
   flex: 1

--- a/packages/vuetify/src/components/VCalendar/VCalendarWeekly.sass
+++ b/packages/vuetify/src/components/VCalendar/VCalendarWeekly.sass
@@ -28,6 +28,7 @@
   height: 100%
   display: flex
   flex-direction: column
+  // https://github.com/vuetifyjs/vuetify/issues/8319
   min-height: 0
 
 .v-calendar-weekly__head
@@ -49,6 +50,7 @@
   display: flex
   flex: 1
   height: 0
+  // https://github.com/vuetifyjs/vuetify/issues/8319
   min-height: 0
 
 .v-calendar-weekly__day


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
As per specification, flex child elements should have `min-height:0` (min-width for rows) to
prevent element overflow. See https://bugzilla.mozilla.org/show_bug.cgi?id=1114904

Without this properties, the `v-calendar-weekly__week` expands to include all event elements and calendar overflows parent element. In cases where there are a lot of events, and `event-more="true"` is set, `updateEventVisibility` method in the `calendar-with-events` mixin can't properly hide events.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #8319

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-sheet height="600">
    <v-calendar
      v-model="focus"
      color="primary"
      :events="events"
      :event-margin-bottom="3"
      :now="today"
      type="month"
    ></v-calendar>
  </v-sheet>
</template>

<script>
export default {
  data: () => ({
    today: "2019-01-08",
    focus: "2019-01-08",
    events: [
      {
        name: "event 1",
        start: "2019-01-14 18:00",
        end: "2019-01-14 19:00",
        color: "#4285F4"
      },
      {
        name: "event 2",
        start: "2019-01-14 18:00",
        end: "2019-01-14 19:00",
        color: "#4285F4"
      },
      {
        name: "event 5",
        start: "2019-01-14 18:00",
        end: "2019-01-14 19:00",
        color: "#4285F4"
      },
      {
        name: "event 3",
        start: "2019-01-14 18:30",
        end: "2019-01-14 20:30",
        color: "#4285F4"
      },
      {
        name: "event 4",
        start: "2019-01-14 19:00",
        end: "2019-01-14 20:00",
        color: "#4285F4"
      },
      {
        name: "event 6",
        start: "2019-01-14 21:00",
        end: "2019-01-14 23:00",
        color: "#4285F4"
      },
      {
        name: "event 7",
        start: "2019-01-14 22:00",
        end: "2019-01-14 23:00",
        color: "#4285F4"
      },
      {
        name: "event 8",
        start: "2019-01-14 22:00",
        end: "2019-01-14 23:00",
        color: "#4285F4"
      },
      {
        name: "event 9",
        start: "2019-01-14 22:00",
        end: "2019-01-15 23:00",
        color: "#4285F4"
      },
      {
        name: "event 10",
        start: "2019-01-14 22:00",
        end: "2019-01-15 23:00",
        color: "#4285F4"
      }
    ]
  })
};
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
