### PR TITLE
fix(docs): up-next - tabs url

### DIFF
--- a/packages/docs/src/data/pages/components/Steppers.json
+++ b/packages/docs/src/data/pages/components/Steppers.json
@@ -67,7 +67,7 @@
         {
           "type": "up-next",
           "value": [
-            "customization/tabs",
+            "components/tabs",
             "components/buttons",
             "components/windows"
           ]


### PR DESCRIPTION
## Description
up-next url for tabs is not correct:
https://vuetifyjs.com/en/components/steppers#up-next

## How Has This Been Tested?
visually


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
