### PR TITLE
fix(VCheckbox): use correct unchecked checkbox icon using FA4

### DIFF
--- a/packages/vuetify/src/services/icons/__tests__/__snapshots__/icons.spec.ts.snap
+++ b/packages/vuetify/src/services/icons/__tests__/__snapshots__/icons.spec.ts.snap
@@ -42,7 +42,7 @@ exports[`Icons.ts should use a custom iconfont preset 1`] = `
 Object {
   "cancel": "fa fa-times-circle",
   "checkboxIndeterminate": "fa fa-minus-square",
-  "checkboxOff": "fa fa-square-o",
+  "checkboxOff": "far fa-square",
   "checkboxOn": "fa fa-check-square",
   "clear": "fa fa-times-circle",
   "close": "fa fa-times",

--- a/packages/vuetify/src/services/icons/presets/fa4.ts
+++ b/packages/vuetify/src/services/icons/presets/fa4.ts
@@ -13,7 +13,7 @@ const icons: VuetifyIcons = {
   prev: 'fa fa-chevron-left',
   next: 'fa fa-chevron-right',
   checkboxOn: 'fa fa-check-square',
-  checkboxOff: 'fa fa-square-o', // note 'far'
+  checkboxOff: 'far fa-square', // note 'far'
   checkboxIndeterminate: 'fa fa-minus-square',
   delimiter: 'fa fa-circle', // for carousel
   sort: 'fa fa-sort-up',


### PR DESCRIPTION
## Description
Use correct icon: `far fa-square` instead of `fa fa-square-o`.

## Motivation and Context
Fixes #8998

## How Has This Been Tested?
Updated snapshot.

## Markup:
https://codepen.io/leftclickben/pen/rNBZQOa

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
