### PR TITLE
fix(VFileInput): replace hardcoded string boundary with computed

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -240,7 +240,8 @@ export default VTextField.extend({
     },
     truncateText (str: string) {
       if (str.length < Number(this.truncateLength)) return str
-      return `${str.slice(0, 10)}…${str.slice(-10)}`
+      const charsKeepOneSide = Math.floor((this.truncateLength - 1) / 2)
+      return `${str.slice(0, charsKeepOneSide)}…${str.slice(-charsKeepOneSide)}`
     },
   },
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
instead of hardcoding the number of chars taken from head and tail of user input to be 10, computed the number of chars to keep based on the `truncate-length` field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
undesired input truncation when `truncate-length` is smaller than default value 22
<!--- If it fixes an open issue, please link to the issue here. -->
#9026

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
