### PR TITLE
feat(VBtn): add retainFocusOnClick property

### DIFF
--- a/packages/docs/src/lang/en/components/Buttons.json
+++ b/packages/docs/src/lang/en/components/Buttons.json
@@ -70,7 +70,8 @@
       "rounded": "Applies a large border radius on the button.",
       "text": "Makes the background transparent.",
       "type": "Set the button's **type** attribute",
-      "value": "Mixins.Groupable.props.value"
+      "value": "Mixins.Groupable.props.value",
+      "retainFocusOnClick": "Don't blur on click."
     },
     "v-btn-toggle": {
       "rounded": "Applies a large border radius on the buttons."

--- a/packages/vuetify/src/components/VBtn/VBtn.ts
+++ b/packages/vuetify/src/components/VBtn/VBtn.ts
@@ -54,6 +54,7 @@ export default baseMixins.extend<options>().extend({
     icon: Boolean,
     loading: Boolean,
     outlined: Boolean,
+    retainFocusOnClick: Boolean,
     rounded: Boolean,
     tag: {
       type: String,
@@ -151,6 +152,7 @@ export default baseMixins.extend<options>().extend({
 
   methods: {
     click (e: MouseEvent): void {
+      !this.retainFocusOnClick && !this.fab && e.detail && this.$el.blur()
       this.$emit('click', e)
 
       this.btnToggle && this.toggle()

--- a/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.ts
+++ b/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.ts
@@ -285,4 +285,24 @@ describe('VBtn.ts', () => {
     })
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should retain focus when clicked', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        retainFocusOnClick: true,
+      },
+    })
+    const event = new MouseEvent('click', { detail: 1 })
+    const blur = jest.fn()
+
+    wrapper.element.blur = blur
+    wrapper.element.dispatchEvent(event)
+
+    expect(blur).not.toHaveBeenCalled()
+
+    wrapper.setProps({ retainFocusOnClick: false })
+    wrapper.element.dispatchEvent(event)
+
+    expect(blur).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Add `retainFocusOnClick` prop.

## Motivation and Context
@johnleider asked.

## How Has This Been Tested?
`jest` + visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container fluid>
    <v-btn>Button</v-btn>
  </v-container>
</template>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
