### PR TITLE
fix(VTimePicker) Center Picker Clock 

### DIFF
--- a/packages/vuetify/src/components/VPicker/VPicker.sass
+++ b/packages/vuetify/src/components/VPicker/VPicker.sass
@@ -52,6 +52,7 @@
   display: flex
   flex-direction: column
   align-items: center
+  margin: 0 auto
 
   > div
     width: 100%


### PR DESCRIPTION
## Description
make time picker clock in center when using seconds and am/pm in title

**Before:**
![clock_before](https://user-images.githubusercontent.com/8259014/65389993-f6d93e80-dd52-11e9-82b6-6deb3ee21805.png)

**After:**
![clock_after](https://user-images.githubusercontent.com/8259014/65389999-ffca1000-dd52-11e9-86cc-41083fc00c97.png)

## Motivation and Context
:guitar: 

## How Has This Been Tested?
visually

## Markup:
```vue
<v-time-picker
      v-model="picker"
      ampm-in-title
      use-seconds
></v-time-picker>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)