### PR TITLE
fix: allow empty children array to behave as leaf on VTreeView

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -258,7 +258,7 @@ export default baseMixins.extend<options>().extend({
           click: () => {
             if (this.disabled) return
 
-            if (this.openOnClick && this.children) {
+            if (this.openOnClick && (this.children && this.children.length > 0) {
               this.open()
             } else if (this.activatable) {
               this.isActive = !this.isActive


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

## Description
Instead of checking for property children, we also check that it has elements inside of the array. 

## Motivation and Context
Activatable and open-on-click are not behaving correctly together. I'm facing a fully recursive structure that comes with empty array and I cannot retrieve the active leave because of that

## How Has This Been Tested?
visually

## Markup:
<details>

```
            if (this.openOnClick && (this.children && this.children.length > 0) {
              this.open()
            } else if (this.activatable) {
              this.isActive = !this.isActive
              this.treeview.updateActive(this.key, this.isActive)
              this.treeview.emitActive()
            }
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
