### PR TITLE
fix(vdatepicker): fix min date

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -570,6 +570,20 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should round down min date in ISO 8601 format', async () => {
+    const cb = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        value: '2019-01-20',
+        min: '2019-01-06T15:55:56.441Z',
+      },
+    })
+
+    wrapper.vm.$on('input', cb)
+    wrapper.findAll('.v-date-picker-table--date tbody tr+tr td:first-child button').at(0).trigger('click')
+    expect(cb.mock.calls[0][0]).toEqual('2019-01-06')
+  })
+
   it('should emit @input and not emit @change when month is clicked (not reative picker)', async () => {
     const wrapper = mountFunction({
       propsData: {

--- a/packages/vuetify/src/components/VDatePicker/util/isDateAllowed.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/isDateAllowed.ts
@@ -2,6 +2,6 @@ export type AllowedDateFunction = (date: string) => boolean
 
 export default function isDateAllowed (date: string, min: string, max: string, allowedFn: AllowedDateFunction | undefined) {
   return (!allowedFn || allowedFn(date)) &&
-    (!min || date >= min) &&
+    (!min || date >= min.substr(0, 10)) &&
     (!max || date <= max)
 }


### PR DESCRIPTION
fix #9039

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fix min date compare logic (Inclusive)

## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/9039

## How Has This Been Tested?
Visually and added unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    {{ min }}
    <v-date-picker :min="min"></v-date-picker>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    min: '2019-09-28T15:55:56.441Z'
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
