### PR TITLE
Fix/#9120 VDatePicker range performance

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -372,12 +372,10 @@ export default mixins(
 
       if (this.range && this.value && this.value.length === 2) {
         proxyValue = []
-        const [rangeFrom, rangeTo] = [this.value[0], this.value[1]].map(x => x.substr(0, 10)).sort().map(x => new Date(x))
-        if (this.$data.rangeCache) {
-          const c = this.$data.rangeCache
-          if (c.from.getTime() === rangeFrom.getTime() && c.to.getTime() === rangeTo.getTime()) {
-            proxyValue = c.dates
-          }
+        const [rangeFrom, rangeTo] = [...this.value].map(x => x.substr(0, 10)).sort().map(x => new Date(x))
+        const c = this.$data.rangeCache
+        if (this.$data.rangeCache && c.from.getTime() === rangeFrom.getTime() && c.to.getTime() === rangeTo.getTime()) {
+          proxyValue = c.dates
         } else {
           const diffDays = Math.ceil((rangeTo.getTime() - rangeFrom.getTime()) / 864e5)
           const current = new Date(+rangeFrom)

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -368,26 +368,6 @@ export default mixins(
       })
     },
     genDateTable () {
-      let proxyValue = this.value
-
-      if (this.range && this.value && this.value.length === 2) {
-        proxyValue = []
-        const [rangeFrom, rangeTo] = [...this.value].map(x => x.substr(0, 10)).sort().map(x => new Date(x))
-        const c = this.$data.rangeCache
-        if (this.$data.rangeCache && c.from.getTime() === rangeFrom.getTime() && c.to.getTime() === rangeTo.getTime()) {
-          proxyValue = c.dates
-        } else {
-          const diffDays = Math.ceil((rangeTo.getTime() - rangeFrom.getTime()) / 864e5)
-          const current = new Date(+rangeFrom)
-          proxyValue.push(current.toISOString().substring(0, 10))
-          for (let i = 0; i < diffDays; i++) {
-            current.setDate(current.getDate() + 1)
-            proxyValue.push(current.toISOString().substring(0, 10))
-          }
-          this.$data.rangeCache = { from: rangeFrom, to: rangeTo, dates: proxyValue }
-        }
-      }
-
       return this.$createElement(VDatePickerDateTable, {
         props: {
           allowedDates: this.allowedDates,
@@ -403,11 +383,12 @@ export default mixins(
           locale: this.locale,
           min: this.min,
           max: this.max,
+          range: this.range,
           readonly: this.readonly,
           scrollable: this.scrollable,
           showWeek: this.showWeek,
           tableDate: `${pad(this.tableYear, 4)}-${pad(this.tableMonth + 1)}`,
-          value: proxyValue,
+          value: this.value,
           weekdayFormat: this.weekdayFormat,
         },
         ref: 'table',

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -372,11 +372,21 @@ export default mixins(
 
       if (this.range && this.value && this.value.length === 2) {
         proxyValue = []
-        const [rangeFrom, rangeTo] = [this.value[0], this.value[1]].map(x => new Date(`${x}T00:00:00+00:00`)).sort((a, b) => a > b ? 1 : -1)
-        const diffDays = Math.ceil((rangeTo.getTime() - rangeFrom.getTime()) / (1000 * 60 * 60 * 24))
-        for (let i = 0; i <= diffDays; i++) {
-          const current = new Date(+rangeFrom + i * 864e5)
+        const [rangeFrom, rangeTo] = [this.value[0], this.value[1]].map(x => x.substr(0, 10)).sort().map(x => new Date(x))
+        if (this.$data.rangeCache) {
+          const c = this.$data.rangeCache
+          if (c.from.getTime() === rangeFrom.getTime() && c.to.getTime() === rangeTo.getTime()) {
+            proxyValue = c.dates
+          }
+        } else {
+          const diffDays = Math.ceil((rangeTo.getTime() - rangeFrom.getTime()) / 864e5)
+          const current = new Date(+rangeFrom)
           proxyValue.push(current.toISOString().substring(0, 10))
+          for (let i = 0; i < diffDays; i++) {
+            current.setDate(current.getDate() + 1)
+            proxyValue.push(current.toISOString().substring(0, 10))
+          }
+          this.$data.rangeCache = { from: rangeFrom, to: rangeTo, dates: proxyValue }
         }
       }
 

--- a/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
+++ b/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
@@ -50,7 +50,7 @@ export default mixins(
       type: String,
       required: true,
     },
-    value: [String, Array],
+    value: [String, Array] as PropValidator<string | string[]>,
   },
 
   data: () => ({
@@ -101,7 +101,7 @@ export default mixins(
     },
     genButton (value: string, isFloating: boolean, mouseEventType: string, formatter: DatePickerFormatter) {
       const isAllowed = isDateAllowed(value, this.min, this.max, this.allowedDates)
-      const isSelected = value === this.value || (Array.isArray(this.value) && (this.value.indexOf(value) !== -1 || this.isInRange(value)))
+      const isSelected = this.isSelected(value)
       const isCurrent = value === this.current
       const setColor = isSelected ? this.setBackgroundColor : this.setTextColor
       const color = (isSelected || isCurrent) && (this.color || 'accent')
@@ -193,13 +193,17 @@ export default mixins(
         directives: [touchDirective],
       }, [transition])
     },
-    isInRange (value: string): boolean {
-      if (this.range && this.value.length === 2) {
-        const [from, to] = [...this.value as string[]].sort()
-        return from <= value && value <= to
+    isSelected (value: string): boolean {
+      if (Array.isArray(this.value)) {
+        if (this.range && this.value.length === 2) {
+          const [from, to] = [...this.value].sort()
+          return from <= value && value <= to
+        } else {
+          return this.value.indexOf(value) !== -1
+        }
       }
 
-      return false
+      return value === this.value
     },
   },
 })

--- a/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
+++ b/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
@@ -43,6 +43,7 @@ export default mixins(
     } as any as PropValidator<DateEventColors>,
     min: String,
     max: String,
+    range: Boolean,
     readonly: Boolean,
     scrollable: Boolean,
     tableDate: {
@@ -100,7 +101,7 @@ export default mixins(
     },
     genButton (value: string, isFloating: boolean, mouseEventType: string, formatter: DatePickerFormatter) {
       const isAllowed = isDateAllowed(value, this.min, this.max, this.allowedDates)
-      const isSelected = value === this.value || (Array.isArray(this.value) && this.value.indexOf(value) !== -1)
+      const isSelected = value === this.value || (Array.isArray(this.value) && (this.value.indexOf(value) !== -1 || this.isInRange(value)))
       const isCurrent = value === this.current
       const setColor = isSelected ? this.setBackgroundColor : this.setTextColor
       const color = (isSelected || isCurrent) && (this.color || 'accent')
@@ -191,6 +192,14 @@ export default mixins(
         } : undefined,
         directives: [touchDirective],
       }, [transition])
+    },
+    isInRange (value: string): boolean {
+      if (this.range && this.value.length === 2) {
+        const [from, to] = [...this.value as string[]].sort()
+        return from <= value && value <= to
+      }
+
+      return false
     },
   },
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Check date selection for range in the current month only.
Currently smooth to support range as big as '0000-01-01', '2019-09-20', should be enough.
## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/9120

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-date-picker v-model="dates" range width="290" class="mt-4"></v-date-picker>
    v-model value: {{ dates }}
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      dates: ['0000-01-01', '2019-09-20'],
    })
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
