### PR TITLE
Change text of data footer for case of 1 row per page (#9133)

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -137,7 +137,9 @@ export default Vue.extend({
 
         children = this.$scopedSlots['page-text']
           ? [this.$scopedSlots['page-text']!({ pageStart, pageStop, itemsLength })]
-          : [this.$vuetify.lang.t('$vuetify.dataIterator.pageText', pageStart, pageStop, itemsLength)]
+          : pageStart == pageStop
+            ? [this.$vuetify.lang.t('$vuetify.dataIterator.singlePageText', pageStart, itemsLength)]
+            : [this.$vuetify.lang.t('$vuetify.dataIterator.pageText', pageStart, pageStop, itemsLength)]
       }
 
       return this.$createElement('div', {

--- a/packages/vuetify/src/locale/af.ts
+++ b/packages/vuetify/src/locale/af.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} van {2}',
+    singlePageText: '{0} van {1}',
     noResultsText: 'Geen ooreenstemmende resultate is gevind nie',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/ar.ts
+++ b/packages/vuetify/src/locale/ar.ts
@@ -2,6 +2,7 @@ export default {
   close: 'إغلاق',
   dataIterator: {
     pageText: '{0}-{1} من {2}',
+    singlePageText: '{0} من {1}',
     noResultsText: 'لا توجد سجلات مطابقة',
     loadingText: 'تحميل العنصر...',
   },

--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} de {2}',
+    singlePageText: '{0} de {1}',
     noResultsText: 'Sense dades per mostrar',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Schließen',
   dataIterator: {
     pageText: '{0}-{1} von {2}',
+    singlePageText: '{0} von {1}',
     noResultsText: 'Keine Elemente gefunden',
     loadingText: 'Lade Elemente...',
   },

--- a/packages/vuetify/src/locale/el.ts
+++ b/packages/vuetify/src/locale/el.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} από {2}',
+    singlePageText: '{0} από {1}',
     noResultsText: 'Δε βρέθηκαν αποτελέσματα',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/en.ts
+++ b/packages/vuetify/src/locale/en.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} of {2}',
+    singlePageText: '{0} of {1}',
     noResultsText: 'No matching records found',
     loadingText: 'Loading items...',
   },

--- a/packages/vuetify/src/locale/es.ts
+++ b/packages/vuetify/src/locale/es.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Cerrar',
   dataIterator: {
     pageText: '{0}-{1} de {2}',
+    singlePageText: '{0} de {1}',
     noResultsText: 'Ningún elemento coincide con la búsqueda',
     loadingText: 'Cargando...',
   },

--- a/packages/vuetify/src/locale/et.ts
+++ b/packages/vuetify/src/locale/et.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Sulge',
   dataIterator: {
     pageText: '{0}-{1} {2}st',
+    singlePageText: '{0} {1}st',
     noResultsText: 'Vastavaid kirjeid ei leitud',
     loadingText: 'Andmeid laaditakse...',
   },

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -2,6 +2,7 @@ export default {
   close: 'بستن',
   dataIterator: {
     pageText: '{0} تا {1} از {2}',
+    singlePageText: '{0} از {1}',
     noResultsText: 'نتیجه‌ای یافت نشد',
     loadingText: 'در حال بارگذاری...',
   },

--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Fermer',
   dataIterator: {
     pageText: '{0}-{1} de {2}',
+    singlePageText: '{0} de {1}',
     noResultsText: 'Aucun enregistrement correspondant trouvé',
     loadingText: "Chargement de l'élément...",
   },

--- a/packages/vuetify/src/locale/he.ts
+++ b/packages/vuetify/src/locale/he.ts
@@ -2,6 +2,7 @@ export default {
   close: 'סגור',
   dataIterator: {
     pageText: '{0}-{1} מתוך {2}',
+    singlePageText: '{0} מתוך {1}',
     noResultsText: 'לא נמצאו תוצאות מתאימות',
     loadingText: 'טוען פריט...',
   },

--- a/packages/vuetify/src/locale/hr.ts
+++ b/packages/vuetify/src/locale/hr.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} od {2}',
+    singlePageText: '{0} od {1}',
     noResultsText: 'Nisu pronađeni odgovarajući zapisi',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} / {2}',
+    singlePageText: '{0} / {1}',
     noResultsText: 'Nincs egyező találat',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/id.ts
+++ b/packages/vuetify/src/locale/id.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Tutup',
   dataIterator: {
     pageText: '{0}-{1} dari {2}',
+    singlePageText: '{0} dari {1}',
     noResultsText: 'Tidak ditemukan catatan yang cocok',
     loadingText: 'Memuat data...',
   },

--- a/packages/vuetify/src/locale/it.ts
+++ b/packages/vuetify/src/locale/it.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Chiudi',
   dataIterator: {
     pageText: '{0}-{1} di {2}',
+    singlePageText: '{0} di {1}',
     noResultsText: 'Nessun risultato trovato',
     loadingText: 'Caricamento in corso...',
   },

--- a/packages/vuetify/src/locale/ja.ts
+++ b/packages/vuetify/src/locale/ja.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} 件目 / {2}件',
+    singlePageText: '{0} 件目 / {1}件',
     noResultsText: '検索結果が見つかりません。',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/ko.ts
+++ b/packages/vuetify/src/locale/ko.ts
@@ -2,6 +2,7 @@ export default {
   close: '닫기',
   dataIterator: {
     pageText: '{2} 중 {0}-{1}',
+    singlePageText: '{1} 중 {0}',
     noResultsText: '일치하는 항목이 없습니다.',
     loadingText: '불러오는 중...',
   },

--- a/packages/vuetify/src/locale/lv.ts
+++ b/packages/vuetify/src/locale/lv.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Aizvērt',
   dataIterator: {
     pageText: '{0}-{1} no {2}',
+    singlePageText: '{0} no {1}',
     noResultsText: 'Nekas netika atrasts',
     loadingText: 'Ielādē...',
   },

--- a/packages/vuetify/src/locale/nl.ts
+++ b/packages/vuetify/src/locale/nl.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Sluiten',
   dataIterator: {
     pageText: '{0}-{1} van {2}',
+    singlePageText: '{0} van {1}',
     noResultsText: 'Geen overeenkomende resultaten gevonden',
     loadingText: 'Items aan het laden...',
   },

--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Lukk',
   dataIterator: {
     pageText: '{0}-{1} av {2}',
+    singlePageText: '{0} av {1}',
     noResultsText: 'Fant ingen matchende elementer.',
     loadingText: 'Laster elementer...',
   },

--- a/packages/vuetify/src/locale/pl.ts
+++ b/packages/vuetify/src/locale/pl.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Zamknij',
   dataIterator: {
     pageText: '{0}-{1} z {2}',
+    singlePageText: '{0} z {1}',
     noResultsText: 'Nie znaleziono danych odpowiadających wyszukiwaniu',
     loadingText: 'Wczytywanie danych...',
   },

--- a/packages/vuetify/src/locale/pt.ts
+++ b/packages/vuetify/src/locale/pt.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Fechar',
   dataIterator: {
     pageText: '{0}-{1} de {2}',
+    singlePageText: '{0} de {1}',
     noResultsText: 'Nenhum dado encontrado',
     loadingText: 'Carregando itens...',
   },

--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} din {2}',
+    singlePageText: '{0} din {1}',
     noResultsText: 'Nu au fost găsite înregistrări care să se potrivească',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/ru.ts
+++ b/packages/vuetify/src/locale/ru.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Закрыть',
   dataIterator: {
     pageText: '{0}-{1} из {2}',
+    singlePageText: '{0} из {1}',
     noResultsText: 'Не найдено подходящих записей',
     loadingText: 'Запись загружается...',
   },

--- a/packages/vuetify/src/locale/sl.ts
+++ b/packages/vuetify/src/locale/sl.ts
@@ -1,7 +1,7 @@
 export default {
   close: 'Zapri',
   dataIterator: {
-    pageText: '{0}-{1} od {2}',
+    pageText: '{0} od {1}',
     noResultsText: 'Ni iskanega zapisa',
     loadingText: 'Nalaganje...',
   },

--- a/packages/vuetify/src/locale/sr-Cyrl.ts
+++ b/packages/vuetify/src/locale/sr-Cyrl.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} од {2}',
+    singlePageText: '{0} од {1}',
     noResultsText: 'Ни један запис није пронађен',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/th.ts
+++ b/packages/vuetify/src/locale/th.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} จาก {2}',
+    singlePageText: '{0} จาก {1}',
     noResultsText: 'ไม่พบข้อมูลที่ค้นหา',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} de {2}',
+    signlePageText: '{0} de {2}',
     noResultsText: 'Eşleşen Veri Bulunamadı',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/uk.ts
+++ b/packages/vuetify/src/locale/uk.ts
@@ -2,6 +2,7 @@ export default {
   close: 'Close',
   dataIterator: {
     pageText: '{0}-{1} з {2}',
+    singlePageText: '{0} з {1}',
     noResultsText: 'В результаті пошуку нічого не знайдено',
     loadingText: 'Loading item...',
   },

--- a/packages/vuetify/src/locale/zh-Hans.ts
+++ b/packages/vuetify/src/locale/zh-Hans.ts
@@ -2,6 +2,7 @@ export default {
   close: '关闭',
   dataIterator: {
     pageText: '{0}-{1} 共 {2}',
+    singlePageText: '{0} 共 {1}',
     noResultsText: '没有符合条件的结果',
     loadingText: '加载中……',
   },

--- a/packages/vuetify/src/locale/zh-Hant.ts
+++ b/packages/vuetify/src/locale/zh-Hant.ts
@@ -2,6 +2,7 @@ export default {
   close: '關閉',
   dataIterator: {
     pageText: '{2} 條中的 {0}~{1} 條',
+    singlePageText: '{1} 條中的 {0} 條',
     noResultsText: '沒有符合條件的結果',
     loadingText: '讀取中...',
   },


### PR DESCRIPTION
## Description
This is an idea of how we might accomplish what I described in #9133.

## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/9133

## How Has This Been Tested?
None.

## Markup:
```vue
<template>
  <v-data-iterator
    :items="[{ id: '1', text: 'foo'}, {id: '2', text: 'bar'}]"
    :item-key="id"
    :rows-per-page-items="[1]"
    :pagination-sync="{ pagination: rowsPerPage: 1 }"
   :content-tag="v-layout"
  >
    <template #item="{ item }">
      <div>{{ item.name }}</div>
    </template>
  </v-data-iterator>
</template>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
