### PR TITLE
fix(VDialog/VMenu/VTooltip): hide wrapper element when not attached

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -43,14 +43,11 @@
   z-index: 6
   outline: none
 
-.v-dialog__activator
-  cursor: pointer
-
-  *
-    cursor: pointer
-
 .v-dialog__container
-  display: inline
+  display: none
+
+  &--attached
+    display: inline
 
 // Modifier
 .v-dialog--animated

--- a/packages/vuetify/src/components/VDialog/VDialog.ts
+++ b/packages/vuetify/src/components/VDialog/VDialog.ts
@@ -314,6 +314,12 @@ export default baseMixins.extend({
 
     return h('div', {
       staticClass: 'v-dialog__container',
+      class: {
+        'v-dialog__container--attached':
+          this.attach === '' ||
+          this.attach === true ||
+          this.attach === 'attach',
+      },
       attrs: { role: 'dialog' },
     }, children)
   },

--- a/packages/vuetify/src/components/VMenu/VMenu.sass
+++ b/packages/vuetify/src/components/VMenu/VMenu.sass
@@ -2,15 +2,10 @@
 @import './_variables.scss'
 
 .v-menu
-  display: inline
+  display: none
 
-  &__activator
-    align-items: center
-    cursor: pointer
-    display: flex
-
-    *
-      cursor: pointer
+  &--attached
+    display: inline
 
   &__content
     position: absolute

--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -438,6 +438,12 @@ export default baseMixins.extend({
   render (h): VNode {
     const data = {
       staticClass: 'v-menu',
+      class: {
+        'v-menu--attached':
+          this.attach === '' ||
+          this.attach === true ||
+          this.attach === 'attach',
+      },
       directives: [{
         arg: '500',
         name: 'resize',

--- a/packages/vuetify/src/components/VTooltip/VTooltip.sass
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.sass
@@ -2,7 +2,10 @@
 @import ./_variables
 
 .v-tooltip
-  display: inline
+  display: none
+
+  &--attached
+    display: inline
 
   &__content
     background: $tooltip-background-color
@@ -17,7 +20,7 @@
     width: auto
     opacity: 1
     pointer-events: none
-    
+
     &--fixed
       position: fixed
 

--- a/packages/vuetify/src/components/VTooltip/VTooltip.ts
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.ts
@@ -110,6 +110,10 @@ export default mixins(Colorable, Delayable, Dependent, Detachable, Menuable, Tog
         'v-tooltip--right': this.right,
         'v-tooltip--bottom': this.bottom,
         'v-tooltip--left': this.left,
+        'v-menu--attached':
+          this.attach === '' ||
+          this.attach === true ||
+          this.attach === 'attach',
       }
     },
     computedTransition (): string {

--- a/packages/vuetify/src/components/VTooltip/VTooltip.ts
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.ts
@@ -110,7 +110,7 @@ export default mixins(Colorable, Delayable, Dependent, Detachable, Menuable, Tog
         'v-tooltip--right': this.right,
         'v-tooltip--bottom': this.bottom,
         'v-tooltip--left': this.left,
-        'v-menu--attached':
+        'v-tooltip--attached':
           this.attach === '' ||
           this.attach === true ||
           this.attach === 'attach',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds `display: none` to the root element unless it's attached to itself (because then we'd be hiding the content too)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #6951
The previous commit 97681ce only helps in an inline context

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

