### PR TITLE
feat(vicon): add font awesome duotone support fix #8398

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -24,7 +24,7 @@ enum SIZE_MAP {
 }
 
 function isFontAwesome5 (iconType: string): boolean {
-  return ['fas', 'far', 'fal', 'fab'].some(val => iconType.includes(val))
+  return ['fas', 'far', 'fal', 'fab', 'fad'].some(val => iconType.includes(val))
 }
 
 function isSvgPath (icon: string): boolean {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Add support for Font Awesome duotone icons

## Motivation and Context
fix #8398 

## How Has This Been Tested?
I was not able to test this as i don't have a Font Awesome Pro license, but judging by the other types of Font Awesome icons it shouldn't require more than this. Would love if someone could test it for me.


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.

