### PR TITLE
fix: Fix elevation 0 not being accepted #iss9157

### DIFF
--- a/packages/vuetify/src/mixins/elevatable.ts
+++ b/packages/vuetify/src/mixins/elevatable.ts
@@ -12,7 +12,7 @@ export default Vue.extend({
       return this.elevation
     },
     elevationClasses (): Record<string, boolean> {
-      if (!this.computedElevation) return {}
+      if (!this.computedElevation && this.computedElevation !== 0) return {}
 
       return { [`elevation-${this.computedElevation}`]: true }
     }


### PR DESCRIPTION
## Description
The elevationClasses computed property on the elevate mixin was not considering valued zero elevations, thus, it was not possible to set this value on a component like the VCard.

## Motivation and Context
This PR solves issue #9157 

## How Has This Been Tested?
unit tested, but no testing was added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
