### PR TITLE
Turkish translate

### DIFF
--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -1,17 +1,17 @@
 export default {
-  close: 'Close',
+  close: 'Kapat',
   dataIterator: {
-    noResultsText: 'Eşleşen Veri Bulunamadı',
-    loadingText: 'Loading item...',
+    noResultsText: 'Eşleşen veri bulunamadı',
+    loadingText: 'Yükleniyor... Lütfen bekleyin.',
   },
   dataTable: {
     itemsPerPageText: 'Sayfa başına satır:',
     ariaLabel: {
-      sortDescending: ': Sorted descending. Activate to remove sorting.',
-      sortAscending: ': Sorted ascending. Activate to sort descending.',
-      sortNone: ': Not sorted. Activate to sort ascending.',
+      sortDescending: ': Z den A ya sıralı. Sıralamayı kaldırmak için etkinleştir.',
+      sortAscending: ': A dan Z ye sıralı. Z den A ya sıralamak için etkinleştir.',
+      sortNone: ': Sıralı değil. A dan Z ye sıralamak için etkinleştir.',
     },
-    sortBy: 'Sort by',
+    sortBy: 'Sırala',
   },
   dataFooter: {
     itemsPerPageText: 'Sayfa başına satır:',
@@ -20,12 +20,12 @@ export default {
     prevPage: 'Önceki sayfa',
     firstPage: 'İlk sayfa',
     lastPage: 'Son sayfa',
-    pageText: '{0}-{1} de {2}',
+    pageText: '{0} - {1} arası, Toplam: {2} kayıt',
   },
   datePicker: {
-    itemsSelected: '{0} seçildi',
+    itemsSelected: '{0} öge seçildi',
   },
-  noDataText: 'Uygun veri yok',
+  noDataText: 'Bu görünümde veri yok.',
   carousel: {
     prev: 'Önceki görsel',
     next: 'Sonraki görsel',
@@ -34,8 +34,8 @@ export default {
     moreEvents: '{0} tane daha',
   },
   fileInput: {
-    counter: '{0} files',
-    counterSize: '{0} files ({1} in total)',
+    counter: '{0} dosya',
+    counterSize: '{0} dosya (toplamda {1})',
   },
   timePicker: {
     am: 'AM',


### PR DESCRIPTION
Full turkish language update of current release

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
I translated fully the tr.ts
<!--- Describe your changes in detail -->

## Motivation and Context
There was a lot of translation missing.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on my last project.
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [x] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
