### PR TITLE
fix(vautocomplete): make focus and blur events fire

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -156,9 +156,10 @@ export default VSelect.extend({
     internalValue: 'setSearch',
     isFocused (val) {
       if (val) {
-        this.$refs.input &&
-          this.$refs.input.select()
+        document.addEventListener('copy', this.onCopy)
+        this.$refs.input && this.$refs.input.select()
       } else {
+        document.removeEventListener('copy', this.onCopy)
         this.updateSelf()
       }
     },
@@ -389,16 +390,6 @@ export default VSelect.extend({
     },
     hasItem (item: any) {
       return this.selectedValues.indexOf(this.getValue(item)) > -1
-    },
-    onFocus () {
-      if (!this.isFocused) {
-        document.addEventListener('copy', this.onCopy)
-      }
-      VTextField.options.methods.onFocus.call(this)
-    },
-    onBlur () {
-      document.removeEventListener('copy', this.onCopy)
-      VSelect.options.methods.onBlur.call(this)
     },
     onCopy (event: ClipboardEvent) {
       if (this.selectedIndex === -1) return


### PR DESCRIPTION
## Description
blur and focus events should fire on `v-autocomplete` and `v-combobox`

## Motivation and Context
resolves #9204

## How Has This Been Tested?
unit | visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container fluid>
    <v-row>
      <v-col cols="12">
        Blur: {{ blur }}
        Focus: {{ focus }}
        <v-combobox
          v-model="combo"
          :items="items"
          label="Combobox"
          @blur="blur++"
          @focus="focus++"
        ></v-combobox>
        <v-autocomplete
          v-model="auto"
          :items="items"
          label="Select a favorite activity or create a new one"
          @blur="blur++"
          @focus="focus++"
        ></v-autocomplete>
      </v-col>
    </v-row>
    <v-row>
      <v-col cols="12">
        <v-autocomplete
          chips
          :items="['Aaa', 'Bbb', 'Ccc', 'Ddd']"
          :value="select1"
          label="1. Chips"
        />
        <v-autocomplete
          multiple
          :items="['Aaa', 'Bbb', 'Ccc', 'Ddd']"
          :value="select2"
          label="2. Multiple"
        />
        <v-autocomplete
          multiple
          chips
          :items="['Aaa', 'Bbb', 'Ccc', 'Ddd']"
          :value="select3"
          label="3. Multiple Chips"
        />
        <v-autocomplete
          solo
          multiple
          chips
          label="Empty autocomplete to paste into"
        />
        <v-combobox
          solo
          multiple
          chips
          :items="['Bbb', 'Ccc']"
          label="Empty combobox to paste into"
        />
        <v-text-field
          solo
          label="Empty text field to paste into"
        />
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      auto: 'Programming',
      combo: 'Programming',
      items: [
        'Programming',
        'Design',
        'Vue',
        'Vuetify',
      ],
      blur: 0,
      focus: 0,
      select1: 'Aaa',
      select2: ['Bbb', 'Ccc'],
      select3: ['Bbb', 'Ccc'],
    }),
  }
</script>

```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
