### PR TITLE
feat(valert): make VAlert routable

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.sass
+++ b/packages/vuetify/src/components/VAlert/VAlert.sass
@@ -15,6 +15,7 @@
   margin-bottom: $alert-margin
   padding: $alert-padding
   position: relative
+  text-decoration: none
   +elevationTransition()
 
   &:not(.v-sheet--tile)
@@ -137,6 +138,24 @@
   .v-alert__border
     border-width: $alert-dense-border-width
 
+.v-alert--link
+  cursor: pointer
+
+  &:focus:before
+    opacity: 0.08
+
+  &:before
+    background: currentColor
+    bottom: 0
+    content: ''
+    left: 0
+    opacity: 0
+    pointer-events: none
+    position: absolute
+    right: 0
+    top: 0
+    transition: .2s opacity map-get($transition, 'fast-in-slow-out')
+    
 .v-alert--outlined
   background: transparent !important
   border: $alert-outline !important

--- a/packages/vuetify/src/components/VAlert/VAlert.ts
+++ b/packages/vuetify/src/components/VAlert/VAlert.ts
@@ -9,6 +9,7 @@ import VBtn from '../VBtn'
 import VIcon from '../VIcon'
 
 // Mixins
+import Routable from '../../mixins/routable'
 import Toggleable from '../../mixins/toggleable'
 import Themeable from '../../mixins/themeable'
 import Transitionable from '../../mixins/transitionable'
@@ -24,6 +25,7 @@ import { VNode } from 'vue/types'
 /* @vue/component */
 export default mixins(
   VSheet,
+  Routable,
   Toggleable,
   Transitionable
 ).extend({
@@ -55,6 +57,7 @@ export default mixins(
         return typeof val === 'string' || val === false
       },
     },
+    link: Boolean,
     outlined: Boolean,
     prominent: Boolean,
     text: Boolean,
@@ -127,9 +130,11 @@ export default mixins(
     },
     classes (): object {
       const classes: Record<string, boolean> = {
+        ...Routable.options.computed.classes.call(this),
         ...VSheet.options.computed.classes.call(this),
         'v-alert--border': Boolean(this.border),
         'v-alert--dense': this.dense,
+        'v-alert--link': this.isClickable,
         'v-alert--outlined': this.outlined,
         'v-alert--prominent': this.prominent,
         'v-alert--text': this.text,
@@ -205,25 +210,21 @@ export default mixins(
       }, this.$slots.default)
     },
     genAlert (): VNode {
-      let data: VNodeData = {
-        staticClass: 'v-alert',
-        attrs: {
-          role: 'alert',
-        },
-        class: this.classes,
-        style: this.styles,
-        directives: [{
-          name: 'show',
-          value: this.isActive,
-        }],
-      }
+      const { tag, data } = this.generateRouteLink()
+
+      data.staticClass = 'v-alert'
+      data.attrs!.role = 'alert'
+      data.directives!.push({
+        name: 'show',
+        value: this.isActive,
+      })
 
       if (!this.coloredBorder) {
         const setColor = this.hasText ? this.setTextColor : this.setBackgroundColor
-        data = setColor(this.computedColor, data)
+        return this.$createElement(tag, setColor(this.computedColor, data), [this.genWrapper()])
       }
 
-      return this.$createElement('div', data, [this.genWrapper()])
+      return this.$createElement(tag, data, [this.genWrapper()])
     },
     /** @public */
     toggle () {

--- a/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.ts
+++ b/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.ts
@@ -178,4 +178,20 @@ describe('VAlert.ts', () => {
 
     expect(wrapper.vm.isActive).toBe(false)
   })
+
+  it('should have --link class when href/to prop present or link prop is used', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        href: '/home',
+      },
+    })
+
+    expect(wrapper.classes('v-alert--link')).toBe(true)
+
+    wrapper.setProps({ href: undefined, to: '/foo' })
+    expect(wrapper.classes('v-alert--link')).toBe(true)
+
+    wrapper.setProps({ to: undefined, link: true })
+    expect(wrapper.classes('v-alert--link')).toBe(true)
+  })
 })


### PR DESCRIPTION
Enables VAlert to be routeable

## Description
Added the Routable mixin , and changed the necessary to make it work. added some tests too.
This is my first contribution, so it probably needs some work, please point me in the  right direction :)

## Motivation and Context
fixes #9254 , my own feature request. 
I want to use this in my own project, though I think it can be a nice general feature without negative effect.

## How Has This Been Tested?
Made some tests, they pass.  Used the changes locally and works as expected.

## Markup:
<details>

```vue
<template>
  <v-container fluid>
    <v-alert to="/new-message">You Have a new message</v-alert>
  </v-container>
</template>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
