### PR TITLE
fix(VTextField): use intersect to recalculate elements width

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -13,6 +13,7 @@ import Loadable from '../../mixins/loadable'
 
 // Directives
 import ripple from '../../directives/ripple'
+import intersect from '../../directives/intersect'
 
 // Utilities
 import { convertToUnit, keyCodes } from '../../util/helpers'
@@ -42,7 +43,7 @@ const dirtyTypes = ['color', 'file', 'time', 'date', 'datetime-local', 'week', '
 export default baseMixins.extend<options>().extend({
   name: 'v-text-field',
 
-  directives: { ripple },
+  directives: { ripple, intersect },
 
   inheritAttrs: false,
 
@@ -84,6 +85,7 @@ export default baseMixins.extend<options>().extend({
     initialValue: null,
     isBooted: false,
     isClearing: false,
+    isVisible: false,
   }),
 
   computed: {
@@ -180,6 +182,13 @@ export default baseMixins.extend<options>().extend({
         this.initialValue = this.lazyValue
       } else if (this.initialValue !== this.lazyValue) {
         this.$emit('change', this.lazyValue)
+      }
+    },
+    isVisible (val) {
+      if (val) {
+        this.setLabelWidth()
+        this.setPrefixWidth()
+        this.setPrependWidth()
       }
     },
     value (val) {
@@ -374,6 +383,14 @@ export default baseMixins.extend<options>().extend({
           focus: this.onFocus,
           keydown: this.onKeyDown,
         }),
+        directives: [
+          {
+            name: 'intersect',
+            value: {
+              handler: this.onObserve,
+            },
+          },
+        ],
         ref: 'input',
       })
     },
@@ -447,6 +464,10 @@ export default baseMixins.extend<options>().extend({
       if (this.hasMouseDown) this.focus()
 
       VInput.options.methods.onMouseUp.call(this, e)
+    },
+    onObserve (entries: IntersectionObserverEntry[], observer: IntersectionObserver, isIntersecting: boolean) {
+      if (this.isVisible) return
+      this.isVisible = isIntersecting
     },
     setLabelWidth () {
       if (!this.outlined || !this.$refs.label) return


### PR DESCRIPTION
fixes #9299

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Use v-intersect directive to recalculate element width after input becomes visible, 

## Motivation and Context
Cause they have zero width on mount in hidden state (inside expansion panel, for example)
https://github.com/vuetifyjs/vuetify/issues/9299

## How Has This Been Tested?
visually

## Markup:
https://codepen.io/djaler/pen/oNNXywM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
