### PR TITLE
fix(vcarousel delimiter aria-label): a11y carousel delimiters

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -135,6 +135,9 @@ export default VWindow.extend({
       for (let i = 0; i < length; i++) {
         const child = this.$createElement(VBtn, {
           staticClass: 'v-carousel__controls__item',
+          attrs: {
+            'aria-label': this.$vuetify.lang.t('$vuetify.carousel.ariaLabel.delimiter', i + 1, length),
+          },
           props: {
             icon: true,
             small: true,

--- a/packages/vuetify/src/components/VCarousel/__tests__/VCarousel.spec.ts
+++ b/packages/vuetify/src/components/VCarousel/__tests__/VCarousel.spec.ts
@@ -85,6 +85,10 @@ describe('VCarousel.ts', () => {
 
     expect(items).toHaveLength(3)
 
+    items.wrappers.forEach(item => {
+      expect(item.attributes()['aria-label']).toBeDefined()
+    })
+
     items.at(1).trigger('click')
 
     expect(wrapper.vm.internalIndex).toBe(1)

--- a/packages/vuetify/src/locale/af.ts
+++ b/packages/vuetify/src/locale/af.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Vorige visuele',
     next: 'Volgende visuele',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} meer',

--- a/packages/vuetify/src/locale/ar.ts
+++ b/packages/vuetify/src/locale/ar.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'البصري السابق',
     next: 'البصري التالي',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} أكثر',

--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Visualització prèvia',
     next: 'Següent visual',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} més',

--- a/packages/vuetify/src/locale/cs.ts
+++ b/packages/vuetify/src/locale/cs.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Předchozí obrázek',
     next: 'Další obrázek',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} dalších',

--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Vorheriges Bild',
     next: 'Nächstes Bild',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} mehr',

--- a/packages/vuetify/src/locale/el.ts
+++ b/packages/vuetify/src/locale/el.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'הקודם חזותי',
     next: 'הבא חזותי',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} ακόμη',

--- a/packages/vuetify/src/locale/en.ts
+++ b/packages/vuetify/src/locale/en.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Previous visual',
     next: 'Next visual',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} more',

--- a/packages/vuetify/src/locale/es.ts
+++ b/packages/vuetify/src/locale/es.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Visual anterior',
     next: 'Visual siguiente',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} más',

--- a/packages/vuetify/src/locale/et.ts
+++ b/packages/vuetify/src/locale/et.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Eelmine visuaalne',
     next: 'Järgmine visuaalne',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} veel',

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'اسلاید قبلی',
     next: 'اسلاید بعدی',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{بیشتر {0',

--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Visuel précédent',
     next: 'Visuel suivant',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} plus',

--- a/packages/vuetify/src/locale/he.ts
+++ b/packages/vuetify/src/locale/he.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'מצג קודם',
     next: 'מצג הבא',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} נוספים',

--- a/packages/vuetify/src/locale/hr.ts
+++ b/packages/vuetify/src/locale/hr.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Prethodno',
     next: 'Sljedeće',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Još {0}',

--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Korábbi vizuális',
     next: 'Következő vizuális',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} további',

--- a/packages/vuetify/src/locale/id.ts
+++ b/packages/vuetify/src/locale/id.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Visual sebelumnya',
     next: 'Visual selanjutnya',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} lagi',

--- a/packages/vuetify/src/locale/it.ts
+++ b/packages/vuetify/src/locale/it.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Vista precedente',
     next: 'Prossima vista',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} di più',

--- a/packages/vuetify/src/locale/ja.ts
+++ b/packages/vuetify/src/locale/ja.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: '前のビジュアル',
     next: '次のビジュアル',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'さらに{0}',

--- a/packages/vuetify/src/locale/ko.ts
+++ b/packages/vuetify/src/locale/ko.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: '이전 화면',
     next: '다음 화면',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} 더보기',

--- a/packages/vuetify/src/locale/lt.ts
+++ b/packages/vuetify/src/locale/lt.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Ankstesnioji skaidrė',
     next: 'Kita skaidrė',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Daugiau {0}',

--- a/packages/vuetify/src/locale/lv.ts
+++ b/packages/vuetify/src/locale/lv.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Iepriekšējais slaids',
     next: 'Nākamais slaids',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Vēl {0}',

--- a/packages/vuetify/src/locale/nl.ts
+++ b/packages/vuetify/src/locale/nl.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Vorig beeld',
     next: 'Volgend beeld',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} meer',

--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Forrige bilde',
     next: 'Neste bilde',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} mer',

--- a/packages/vuetify/src/locale/pl.ts
+++ b/packages/vuetify/src/locale/pl.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Poprzedni obraz',
     next: 'Następny obraz',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} więcej',

--- a/packages/vuetify/src/locale/pt.ts
+++ b/packages/vuetify/src/locale/pt.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Visão anterior',
     next: 'Próxima visão',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Mais {0}',

--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Anterior vizual',
     next: 'Următorul vizual',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} mai mult',

--- a/packages/vuetify/src/locale/ru.ts
+++ b/packages/vuetify/src/locale/ru.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Предыдущий визуальный',
     next: 'Следующий визуальный',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Еще {0}',

--- a/packages/vuetify/src/locale/sl.ts
+++ b/packages/vuetify/src/locale/sl.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Prejšnji prikaz',
     next: 'Naslednji prikaz',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Še {0}',

--- a/packages/vuetify/src/locale/sr-Cyrl.ts
+++ b/packages/vuetify/src/locale/sr-Cyrl.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Превиоус висуал',
     next: 'Нект висуал',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} море',

--- a/packages/vuetify/src/locale/sv.ts
+++ b/packages/vuetify/src/locale/sv.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Föregående vy',
     next: 'Nästa vy',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} fler',

--- a/packages/vuetify/src/locale/th.ts
+++ b/packages/vuetify/src/locale/th.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'ภาพก่อนหน้า',
     next: 'ภาพต่อไป',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'อีก {0}',

--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Önceki görsel',
     next: 'Sonraki görsel',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '{0} tane daha',

--- a/packages/vuetify/src/locale/uk.ts
+++ b/packages/vuetify/src/locale/uk.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: 'Попередній візуальний',
     next: 'Наступний візуальнийa',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: 'Ще {0}',

--- a/packages/vuetify/src/locale/zh-Hans.ts
+++ b/packages/vuetify/src/locale/zh-Hans.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: '上一张',
     next: '下一张',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '还有 {0} 项',

--- a/packages/vuetify/src/locale/zh-Hant.ts
+++ b/packages/vuetify/src/locale/zh-Hant.ts
@@ -29,6 +29,9 @@ export default {
   carousel: {
     prev: '上一張',
     next: '下一張',
+    ariaLabel: {
+      delimiter: 'Carousel slide {0} of {1}',
+    },
   },
   calendar: {
     moreEvents: '還有其他 {0} 項',


### PR DESCRIPTION
It is an a11y violation to have no aria-labels on clickable UI elements such as the carousel
navigation buttons. Adding aria-labels will support a screen reader

fix #7996

## Description
Added an aria-label attribute for VCarousel delimiter buttons so that screen readers have something to dictate. Ideally there should be a locale string added and translated to support languages other than English.

## Motivation and Context
Fixes issue: https://github.com/vuetifyjs/vuetify/issues/7996

## How Has This Been Tested?
Added expect to delimiter unit test in VCarousel.spec.ts
Manually/visually (manually inspecting the DOM)

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-carousel>
    <v-carousel-item
      v-for="(color, i) in colors"
      :key="color"
    >
      <v-sheet
        :color="color"
        height="100%"
        tile
      >
        <v-row
          class="fill-height"
          align="center"
          justify="center"
        >
          <div class="display-3">Slide {{ i + 1 }}</div>
        </v-row>
      </v-sheet>
    </v-carousel-item>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    colors: [
      'primary',
      'secondary',
      'yellow darken-2',
      'red',
      'orange',
    ],
  })
}
</script>

```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
