### PR TITLE
fix(VTextField): use intersect to recalculate elements width

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -9,6 +9,7 @@ import VCounter from '../VCounter'
 import VLabel from '../VLabel'
 
 // Mixins
+import Intersectable from '../../mixins/intersectable'
 import Loadable from '../../mixins/loadable'
 
 // Directives
@@ -24,7 +25,14 @@ import { VNode } from 'vue/types'
 
 const baseMixins = mixins(
   VInput,
-  Loadable
+  Intersectable({
+    onVisible: [
+      'setLabelWidth',
+      'setPrefixWidth',
+      'setPrependWidth',
+    ],
+  }),
+  Loadable,
 )
 interface options extends InstanceType<typeof baseMixins> {
   $refs: {

--- a/packages/vuetify/src/mixins/intersectable/__tests__/intersectable.spec.ts
+++ b/packages/vuetify/src/mixins/intersectable/__tests__/intersectable.spec.ts
@@ -1,0 +1,39 @@
+import intersectable from '../index'
+
+import {
+  mount,
+  Wrapper,
+} from '@vue/test-utils'
+import { ComponentOptions } from 'vue'
+
+describe('intersectable.ts', () => {
+  let mountFunction: (options?: ComponentOptions<any>) => Wrapper<any>
+
+  beforeEach(() => {
+    mountFunction = (options?: ComponentOptions<any>) => {
+      return mount({
+        render: h => h('div'),
+        ...options,
+      })
+    }
+  })
+
+  it('should call callbacks when element is intersected', () => {
+    const callback = jest.fn()
+
+    const wrapper = mountFunction({
+      mixins: [intersectable({ onVisible: ['callback'] })],
+      methods: { callback },
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+
+    wrapper.vm.onObserve([] as IntersectionObserverEntry[], null as any as IntersectionObserver, false)
+
+    expect(callback).not.toHaveBeenCalled()
+
+    wrapper.vm.onObserve([] as IntersectionObserverEntry[], null as any as IntersectionObserver, true)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/vuetify/src/mixins/intersectable/index.ts
+++ b/packages/vuetify/src/mixins/intersectable/index.ts
@@ -1,0 +1,49 @@
+// Directives
+import Intersect from '../../directives/intersect'
+
+// Utilities
+import { consoleWarn } from '../../util/console'
+
+// Types
+import Vue from 'vue'
+
+export default function intersectable (options: { onVisible: string[] }) {
+  if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+    // do nothing because intersection observer is not available
+    return Vue.extend({ name: 'intersectable' })
+  }
+
+  return Vue.extend({
+    name: 'intersectable',
+
+    mounted () {
+      Intersect.inserted(this.$el as HTMLElement, {
+        name: 'intersect',
+        value: {
+          handler: this.onObserve,
+        },
+      })
+    },
+
+    destroyed () {
+      Intersect.unbind(this.$el as HTMLElement)
+    },
+
+    methods: {
+      onObserve (entries: IntersectionObserverEntry[], observer: IntersectionObserver, isIntersecting: boolean) {
+        if (!isIntersecting) return
+
+        for (let i = 0, length = options.onVisible.length; i < length; i++) {
+          const callback = (this as any)[options.onVisible[i]]
+
+          if (typeof callback === 'function') {
+            callback()
+            continue
+          }
+
+          consoleWarn(options.onVisible[i] + ' method is not available on the instance but referenced in intersectable mixin options')
+        }
+      },
+    },
+  })
+}


### PR DESCRIPTION
fixes #9299

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Use IntersectionObserver (if it available) to recalculate element width after input becomes visible, 

## Motivation and Context
Cause they have zero width on mount in hidden state (inside expansion panel, for example)
https://github.com/vuetifyjs/vuetify/issues/9299

## How Has This Been Tested?
visually

## Markup:
https://codepen.io/djaler/pen/oNNXywM

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
