### PR TITLE
[Docs]: Grid > VRow: align property changed to match validator

### DIFF
--- a/packages/docs/src/lang/en/components/Grids.json
+++ b/packages/docs/src/lang/en/components/Grids.json
@@ -119,7 +119,7 @@
       "orderXl": "Changes the order of the component on extra large and greater breakpoints."
     },
     "v-row": {
-      "align": "Applies the [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) css property. Available options are **start**, **center**, **end**, **space-between**, **space-around** and **stretch**.",
+      "align": "Applies the [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) css property. Available options are **start**, **center**, **end**, **baseline** and **stretch**.",
       "alignSm": "Changes the **align-items** property on small and greater breakpoints.",
       "alignMd": "Changes the **align-items** property on medium and greater breakpoints.",
       "alignLg": "Changes the **align-items** property on large and greater breakpoints.",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
As per MDN web docs and component `VRow.ts` alignValidator, `align` property on `v-row` component does not accept `space-between` nor `space-around` options. However, it does accept `baseline`
option. Changes made on documentation to reflect those constraints

## Motivation and Context
   * Why is this change required? What problem does it solve?
I found out about this documentation error trying to apply `align="space-around"` on a `v-row` component. This throws an error by [VRow.ts alignValidator](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VGrid/VRow.ts#L19)

## How Has This Been Tested?
I followed the [Contribution Guide](https://vuetifyjs.com/en/getting-started/contributing) to create a local repo.
Visually tested modifications on the [Grid Page](https://vuetifyjs.com/en/components/grids#api)

## Markup:


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
