### PR TITLE
fix(VRating): pass in x-small icon size

### DIFF
--- a/packages/vuetify/src/components/VRating/VRating.ts
+++ b/packages/vuetify/src/components/VRating/VRating.ts
@@ -94,24 +94,24 @@ export default mixins(
     iconProps (): object {
       const {
         dark,
-        medium,
         large,
         light,
+        medium,
         small,
         size,
-        xSmall,
         xLarge,
+        xSmall,
       } = this.$props
 
       return {
         dark,
-        medium,
         large,
         light,
+        medium,
         size,
         small,
-        xSmall,
         xLarge,
+        xSmall,
       }
     },
     isHovering (): boolean {

--- a/packages/vuetify/src/components/VRating/VRating.ts
+++ b/packages/vuetify/src/components/VRating/VRating.ts
@@ -99,6 +99,7 @@ export default mixins(
         light,
         small,
         size,
+        xSmall,
         xLarge,
       } = this.$props
 
@@ -109,6 +110,7 @@ export default mixins(
         light,
         size,
         small,
+        xSmall,
         xLarge,
       }
     },


### PR DESCRIPTION
## Description
passes `x-small` size into `v-icon`

## Motivation and Context
fixes #9350 

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<template>
  <v-container fluid>
    <v-row>
      <v-col cols="12">
        <v-rating small></v-rating>
        <v-rating x-small></v-rating>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({}),
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
