### PR TITLE
fix(VTextField): dense filled & outlined

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -216,7 +216,8 @@
         min-height: 44px
 
       &.v-text-field--single-line,
-      &.v-text-field--outlined
+      &.v-text-field--outlined,
+      &.v-text-field--outlined.v-text-field--filled
         > .v-input__control > .v-input__slot
           min-height: 40px
 
@@ -228,6 +229,10 @@
     &.v-input--dense
       input
         margin-top: 20px
+
+      &.v-text-field--outlined
+        input
+          margin-top: 0
 
     &.v-text-field--single-line
       input


### PR DESCRIPTION
## Description
Fix dense text fields when it outlined and filled

## Motivation and Context
fixes #9256 

## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<v-text-field outlined filled dense label="TextField"></v-text-field>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
