### PR TITLE
fix(VPagination): max length

### DIFF
--- a/packages/vuetify/src/components/VPagination/VPagination.ts
+++ b/packages/vuetify/src/components/VPagination/VPagination.ts
@@ -61,11 +61,14 @@ export default mixins(Colorable, Themeable).extend({
 
     items (): (string | number)[] {
       const totalVisible = parseInt(this.totalVisible, 10)
-      const maxLength = totalVisible > this.maxButtons
-        ? this.maxButtons
-        : totalVisible || this.maxButtons
 
-      if (this.length <= maxLength || maxLength < 1) {
+      const maxLength = Math.min(
+        Math.max(0, totalVisible) || this.length,
+        Math.max(0, this.maxButtons) || this.length,
+        this.length
+      )
+
+      if (this.length <= maxLength) {
         return this.range(1, this.length)
       }
 

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
@@ -247,16 +247,30 @@ describe('VPagination.ts', () => {
   it('should never show more than the number of total visible buttons', () => {
     const wrapper = mountFunction({
       data: () => ({
-        maxButtons: 0
+        maxButtons: 0,
       }),
 
       propsData: {
-        length: 40,
-        totalVisible: 10,
+        length: 5,
+        totalVisible: undefined,
       },
     })
 
-    expect(wrapper.vm.items).toEqual([1, 2, 3, 4, 5, "...", 37, 38, 39, 40])
+    expect(wrapper.vm.items).toHaveLength(5)
+
+    wrapper.setProps({ length: 40 })
+
+    wrapper.setData({ maxButtons: 0 })
+    wrapper.setProps({ totalVisible: 10 })
+    expect(wrapper.vm.items).toHaveLength(10)
+
+    wrapper.setData({ maxButtons: 11 })
+    wrapper.setProps({ totalVisible: undefined })
+    expect(wrapper.vm.items).toHaveLength(11)
+
+    wrapper.setData({ maxButtons: 12 })
+    wrapper.setProps({ totalVisible: 13 })
+    expect(wrapper.vm.items).toHaveLength(12)
   })
 
   it('should return length when maxButtons is less than 1', () => {

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
@@ -244,6 +244,21 @@ describe('VPagination.ts', () => {
     expect(wrapper.vm.items).toHaveLength(10)
   })
 
+  it('should never show more than the number of total visible buttons', () => {
+    const wrapper = mountFunction({
+      data: () => ({
+        maxButtons: 0
+      }),
+
+      propsData: {
+        length: 40,
+        totalVisible: 10,
+      },
+    })
+
+    expect(wrapper.vm.items).toEqual([1, 2, 3, 4, 5, "...", 37, 38, 39, 40])
+  })
+
   it('should return length when maxButtons is less than 1', () => {
     const wrapper = mountFunction({
       data: () => ({ maxButtons: -3 }),


### PR DESCRIPTION
Fix calculation of max pagination length.

## Description
Pagination should not show more pages than was setted in totalVisible. 

## Motivation and Context
I have over 74000 pages and now VPagination render them all before maxButtons is calculated, it cause some performance issues. 

## How Has This Been Tested?
unit

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
