### PR TITLE
fix(validate): Disable default white color with a dark theme

### DIFF
--- a/packages/vuetify/src/mixins/validatable/index.ts
+++ b/packages/vuetify/src/mixins/validatable/index.ts
@@ -68,12 +68,6 @@ export default mixins(
     computedColor (): string | undefined {
       if (this.disabled) return undefined
       if (this.color) return this.color
-      // It's assumed that if the input is on a
-      // dark background, the user will want to
-      // have a white color. If the entire app
-      // is setup to be dark, then they will
-      // like want to use their primary color
-      if (this.isDark && !this.appIsDark) return 'white'
       else return 'primary'
     },
     hasError (): boolean {


### PR DESCRIPTION
## Description
Disable default white color with a dark theme

## Motivation and Context
The colors for the light and dark themes are set in the configuration file of the framework. Using the white color of the default font with a dark theme does not allow you to adjust the color of individual elements, for example:

For a `v-text-field` element, using the `solo-inverted` parameter with a dark theme, the color of the `append-inner` or `prepend` (including `clear`) icon will always be white. There is no way to change the color of the `clear` icon.

Look:

[Not focused `v-text-field`](https://i.imgur.com/oKN823K.png)
[Focused `v-text-field`](https://i.imgur.com/4oHQts2.png)

## How Has This Been Tested?
Visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<v-text-field
      single-line
      hide-details
      solo-inverted
      flat
      clearable
    >
      <template v-slot:prepend-inner>
        <v-icon color="primary">mdi-magnify</v-icon>
      </template>

      <template v-slot:append>
        <v-icon color="primary">mdi-information-outline</v-icon>
      </template>
    </v-text-field>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
