### PR TITLE
fix centered v-tabs with tooltip for v-tab: set correct margin

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTabs.sass
+++ b/packages/vuetify/src/components/VTabs/VTabs.sass
@@ -127,7 +127,7 @@
     .v-tabs-bar__content > *:first-child:not(.v-tabs-slider-wrapper)
       margin-left: auto
 
-    .v-tabs-slider-wrapper + *
+    .v-tabs-bar__content > .v-tab:first-of-type
       margin-left: auto
 
   +rtl()
@@ -137,7 +137,7 @@
     .v-tabs-bar__content > *:first-child:not(.v-tabs-slider-wrapper)
       margin-right: auto
 
-    .v-tabs-slider-wrapper + *
+    .v-tabs-bar__content > .v-tab:first-of-type
       margin-right: auto
 
 .v-tabs--fixed-tabs > .v-tabs-bar


### PR DESCRIPTION
## Description
v-tabs centered does not align correct if the v-tab elements are wrapped in a tooltip

```css
   .v-tabs-slider-wrapper + *
```
this css selector points to the `span.v-tooltip` instead of the first .v-tab

## Motivation and Context
problem in my current project

## How Has This Been Tested?
i have modified the css to see if it works

## Markup:
<details>

```css
.v-tabs--centered > .v-tabs-bar .v-tabs-bar__content > .v-tab:first-of-type {
  margin-left: auto;
}
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [X ] The PR title is no longer than 64 characters.
- [ X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
