### PR TITLE
fix(vdialog): fix card subtitle positioning in dialog

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -27,6 +27,9 @@
     > .v-card__text
       padding: 0 24px 20px
 
+    > .v-card__subtitle
+      padding: 0px 16px 16px 24px
+
 // Element
 .v-dialog__content
   align-items: center


### PR DESCRIPTION
Currently a custom padding is set for the v-card-title when being used in a v-dialog. This custom
padding was however NOT set for a v-card-subtitle causing it to be wrongly positioned. This commit
fixes the v-card-subtitle positioning.

fix #9468

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This pull request fixes the bug described in #9468, by setting the left-padding of the v-card-subtitle in a v-dialog to the same values of the v-card-title in this scenario.

## Motivation and Context
This change solves the problem described in #9468.

## How Has This Been Tested?
I've tested this visually and by checking the padding-values in the browser's developer tools.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-dialog v-model="showDialog">
      <v-card>
        <v-card-title>This is positioned correctly</v-card-title>
        <v-card-subtitle>This is also positioned correctly now</v-card-subtitle>
        <v-card-text>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in ipsum purus. Vestibulum non diam ultricies, scelerisque ex vel, commodo sem. Phasellus blandit vehicula arcu, in dignissim magna. Nullam et augue sit amet eros dictum feugiat. Nam mi lorem, interdum non elementum vitae, sollicitudin nec mi. Phasellus facilisis enim sit amet porttitor dictum. Sed molestie ex vitae augue convallis blandit. Nulla a dapibus tortor, eu accumsan urna. Fusce varius turpis sed justo pellentesque pulvinar. Morbi eu leo nec ipsum elementum ullamcorper. Pellentesque at urna risus. Aliquam consequat id velit et elementum.
        </v-card-text>
      </v-card>
    </v-dialog>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      showDialog: () => true,
    }),
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
