### PR TITLE
Export `lighten` and `darken` functions

### DIFF
--- a/packages/vuetify/src/services/theme/utils.ts
+++ b/packages/vuetify/src/services/theme/utils.ts
@@ -128,13 +128,13 @@ export function genVariations (name: string, value: ColorInt): Record<string, st
   return values
 }
 
-function lighten (value: ColorInt, amount: number): ColorInt {
+export function lighten (value: ColorInt, amount: number): ColorInt {
   const lab = LAB.fromXYZ(sRGB.toXYZ(value))
   lab[0] = lab[0] + amount * 10
   return sRGB.fromXYZ(LAB.toXYZ(lab))
 }
 
-function darken (value: ColorInt, amount: number): ColorInt {
+export function darken (value: ColorInt, amount: number): ColorInt {
   const lab = LAB.fromXYZ(sRGB.toXYZ(value))
   lab[0] = lab[0] - amount * 10
   return sRGB.fromXYZ(LAB.toXYZ(lab))


### PR DESCRIPTION
## Description
Very simple. Exporting two helper functions (`lighten` and `darken`) from `services/theme/utils`.

## Motivation and Context
I use these functions in my app -- user can input their own color theme, and then I uses these functions to lighten/darken their inputs in various places in the UI. (There are many color choices users make, more than the standard `primary`, `secondary`, `info`, etc will allow, therefore I keep my own color state and need to call these function directly.)

Currently, I have to duplicate these functions to make use of them. I.e. In my app I have this code:

```javascript
import * as sRGB from 'vuetify/es5/util/color/transformSRGB'
import * as LAB from 'vuetify/es5/util/color/transformCIELAB'

function lighten(value, amount) {
  const lab = LAB.fromXYZ(sRGB.toXYZ(value))
  lab[0] = lab[0] + amount * 10
  return sRGB.fromXYZ(LAB.toXYZ(lab))
}

function darken(value, amount) {
  const lab = LAB.fromXYZ(sRGB.toXYZ(value))
  lab[0] = lab[0] - amount * 10
  return sRGB.fromXYZ(LAB.toXYZ(lab))
}
```

However, I would love to just do this instead:

```javascript
import { lighten, darken } from 'vuetify/es5/services/theme/utils'
```

Please consider. Thank you for the wonderful library.