### PR TITLE
fix(VIcon): Dense Font Size Selector

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.sass
+++ b/packages/vuetify/src/components/VIcon/VIcon.sass
@@ -23,6 +23,9 @@
   vertical-align: middle
   user-select: none
 
+  &--dense
+    font-size: $icon-size-dense
+
 .v-icon
   &--right
     margin-left: map-get($grid-gutters, 'md')
@@ -46,7 +49,5 @@
     fill: currentColor
 
   &--dense
-    font-size: $icon-size-dense
-
     &--is-component
       height: $icon-size-dense


### PR DESCRIPTION
## Description
The `dense` prop not working on VIcon.

## Motivation and Context
The Issue
https://codepen.io/dev0x0/pen/rNNzdwp

## How Has This Been Tested?
visually

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
