### PR TITLE
docs: fix icons used in google contacts demo layout

### DIFF
--- a/packages/docs/src/layouts/layouts/demos/google-contacts.vue
+++ b/packages/docs/src/layouts/layouts/demos/google-contacts.vue
@@ -93,7 +93,7 @@
         flat
         solo-inverted
         hide-details
-        prepend-inner-icon="search"
+        prepend-inner-icon="mdi-magnify"
         label="Search"
         class="hidden-sm-and-down"
       />
@@ -260,21 +260,21 @@
       dialog: false,
       drawer: null,
       items: [
-        { icon: 'contacts', text: 'Contacts' },
-        { icon: 'history', text: 'Frequently contacted' },
-        { icon: 'content_copy', text: 'Duplicates' },
+        { icon: 'mdi-contacts', text: 'Contacts' },
+        { icon: 'mdi-history', text: 'Frequently contacted' },
+        { icon: 'mdi-content-copy', text: 'Duplicates' },
         {
-          icon: 'keyboard_arrow_up',
-          'icon-alt': 'keyboard_arrow_down',
+          icon: 'mdi-chevron-up',
+          'icon-alt': 'mdi-chevron-down',
           text: 'Labels',
           model: true,
           children: [
-            { icon: 'add', text: 'Create label' },
+            { icon: 'mdi-plus', text: 'Create label' },
           ],
         },
         {
-          icon: 'keyboard_arrow_up',
-          'icon-alt': 'keyboard_arrow_down',
+          icon: 'mdi-chevron-up',
+          'icon-alt': 'mdi-chevron-down',
           text: 'More',
           model: false,
           children: [
@@ -285,11 +285,11 @@
             { text: 'Other contacts' },
           ],
         },
-        { icon: 'settings', text: 'Settings' },
-        { icon: 'chat_bubble', text: 'Send feedback' },
-        { icon: 'help', text: 'Help' },
-        { icon: 'phonelink', text: 'App downloads' },
-        { icon: 'keyboard', text: 'Go to the old version' },
+        { icon: 'mdi-settings', text: 'Settings' },
+        { icon: 'mdi-message', text: 'Send feedback' },
+        { icon: 'mdi-help-circle', text: 'Help' },
+        { icon: 'mdi-cellphone-link', text: 'App downloads' },
+        { icon: 'mdi-keyboard', text: 'Go to the old version' },
       ],
     }),
   }


### PR DESCRIPTION
## Description
Change the icons used in the Google Contacts demo layout to use the proper mdi icons.

## Motivation and Context
Icons being used in the demo are not compatible with a freshly created vuetify app.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
visually

## Markup:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
