### PR TITLE
Add missing example translation: Sort by

### DIFF
--- a/packages/docs/src/snippets/ts/create_translation.txt
+++ b/packages/docs/src/snippets/ts/create_translation.txt
@@ -12,6 +12,7 @@ export default {
       sortAscending: ': Sorted ascending. Activate to sort descending.',
       sortNone: ': Not sorted. Activate to sort ascending.',
     },
+    sortBy: 'Sort by',
   },
   dataFooter: {
     itemsPerPageText: 'Items per page:',


### PR DESCRIPTION
Adding missing translation to the example in documentation, which has been added to the general codebase in [this commit](https://github.com/vuetifyjs/vuetify/commit/6c491286b0bbda6d7b29334804094c2327071297), discussed in [this issue](https://github.com/vuetifyjs/vuetify/issues/8083).

## Motivation and Context

When using a custom translation (Czech for example), there is default English label "Sort by".

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
