### PR TITLE
fix(VColorPicker): allow null as initial value

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/__tests__/VColorPicker.spec.ts
+++ b/packages/vuetify/src/components/VColorPicker/__tests__/VColorPicker.spec.ts
@@ -137,4 +137,15 @@ describe('VColorPicker.ts', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/9472
+  it('should work correctly when initial value is null', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        value: null,
+      },
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VColorPicker/__tests__/__snapshots__/VColorPicker.spec.ts.snap
+++ b/packages/vuetify/src/components/VColorPicker/__tests__/__snapshots__/VColorPicker.spec.ts.snap
@@ -1630,3 +1630,157 @@ exports[`VColorPicker.ts should show swatches 1`] = `
   </div>
 </div>
 `;
+
+exports[`VColorPicker.ts should work correctly when initial value is null 1`] = `
+<div class="v-color-picker v-sheet theme--light theme--light"
+     style="max-width: 300px;"
+>
+  <div class="v-color-picker__canvas"
+       style="width: 300px; height: 150px;"
+  >
+    <canvas width="300"
+            height="150"
+    >
+    </canvas>
+    <div class="v-color-picker__canvas-dot"
+         style="width: 10px; height: 10px; transform: translate(295px, -5px);"
+    >
+    </div>
+  </div>
+  <div class="v-color-picker__controls">
+    <div class="v-color-picker__preview">
+      <div class="v-color-picker__dot">
+        <div style="background: rgb(255, 0, 0);">
+        </div>
+      </div>
+      <div class="v-color-picker__sliders">
+        <div class="v-input v-color-picker__hue v-input--hide-details theme--light v-input__slider v-color-picker__track">
+          <div class="v-input__control">
+            <div class="v-input__slot">
+              <div class="v-slider v-slider--horizontal theme--light">
+                <input value="0"
+                       id="input-79"
+                       readonly="readonly"
+                       tabindex="-1"
+                >
+                <div class="v-slider__track-container">
+                  <div class="v-slider__track-background primary lighten-3"
+                       style="right: 0px;"
+                  >
+                  </div>
+                  <div class="v-slider__track-fill primary"
+                       style="left: 0px; width: 0%;"
+                  >
+                  </div>
+                </div>
+                <div role="slider"
+                     tabindex="0"
+                     aria-valuemin="0"
+                     aria-valuemax="360"
+                     aria-valuenow="0"
+                     aria-readonly="false"
+                     aria-orientation="horizontal"
+                     class="v-slider__thumb-container grey--text text--lighten-2"
+                     style="left: 0%;"
+                >
+                  <div class="v-slider__thumb grey lighten-2">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="v-input v-color-picker__alpha v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-input__slider v-color-picker__track">
+          <div class="v-input__control">
+            <div class="v-input__slot">
+              <div class="v-slider v-slider--horizontal theme--light">
+                <input value="1"
+                       id="input-80"
+                       readonly="readonly"
+                       tabindex="-1"
+                >
+                <div class="v-slider__track-container">
+                  <div class="v-slider__track-background primary lighten-3"
+                       style="right: 0px;"
+                  >
+                  </div>
+                  <div class="v-slider__track-fill primary"
+                       style="left: 0px; width: 100%;"
+                  >
+                  </div>
+                </div>
+                <div role="slider"
+                     tabindex="0"
+                     aria-valuemin="0"
+                     aria-valuemax="1"
+                     aria-valuenow="1"
+                     aria-readonly="false"
+                     aria-orientation="horizontal"
+                     class="v-slider__thumb-container grey--text text--lighten-2"
+                     style="left: 100%;"
+                >
+                  <div class="v-slider__thumb grey lighten-2">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="v-color-picker__edit">
+      <div class="v-color-picker__input">
+        <input type="number"
+               min="0"
+               max="255"
+               step="1"
+        >
+        <span>
+          R
+        </span>
+      </div>
+      <div class="v-color-picker__input">
+        <input type="number"
+               min="0"
+               max="255"
+               step="1"
+        >
+        <span>
+          G
+        </span>
+      </div>
+      <div class="v-color-picker__input">
+        <input type="number"
+               min="0"
+               max="255"
+               step="1"
+        >
+        <span>
+          B
+        </span>
+      </div>
+      <div class="v-color-picker__input">
+        <input type="number"
+               min="0"
+               max="1"
+               step="0.01"
+        >
+        <span>
+          A
+        </span>
+      </div>
+      <button type="button"
+              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+      >
+        <span class="v-btn__content">
+          <i aria-hidden="true"
+             class="v-icon notranslate material-icons theme--light"
+          >
+            $unfold
+          </i>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/vuetify/src/components/VColorPicker/util/index.ts
+++ b/packages/vuetify/src/components/VColorPicker/util/index.ts
@@ -127,6 +127,8 @@ export function parseColor (color: any, oldColor: VColorPickerColor | null) {
 }
 
 export function extractColor (color: VColorPickerColor, input: any) {
+  if (input == null) return color
+
   if (typeof input === 'string') {
     return input.length === 7 ? color.hex : color.hexa
   }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
fixes issue when initial value is null

## Motivation and Context
closes #9472

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-color-picker v-model="color"></v-color-picker>
     Color: {{color}}
  </v-container>
</template>

<script>
export default {
  data () {
    return {
      color: null
    }
  },
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
