### PR TITLE
Add missing example translation: pageText

### DIFF
--- a/packages/docs/src/snippets/ts/create_translation.txt
+++ b/packages/docs/src/snippets/ts/create_translation.txt
@@ -15,6 +15,7 @@ export default {
     sortBy: 'Sort by',
   },
   dataFooter: {
+    pageText: '{0}-{1} of {2}',
     itemsPerPageText: 'Items per page:',
     itemsPerPageAll: 'All',
     nextPage: 'Next page',


### PR DESCRIPTION
## Description
This undocumented translation results in `[Vuetify] Translation key "dataFooter.pageText" not found, falling back to default` notice in the console and default English text being displayed when using custom language.
Similar to previous MR https://github.com/vuetifyjs/vuetify/pull/9558

## Motivation and Context
When using a custom translation (Czech for example), there is default English label "of", and notice in the console.

## How Has This Been Tested?
I've added the translation to my `vuetify.cs.js` and the table paging now has correct label.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
