### PR TITLE
fix(VTooltip): make tooltip activator visible on SSR initial render

### DIFF
--- a/packages/vuetify/src/components/VTooltip/VTooltip.sass
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.sass
@@ -1,8 +1,6 @@
 @import ./_variables
 
 .v-tooltip
-  display: none
-
   &--attached
     display: inline
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Remove `display: none;` from `.v-tooltip` class.

## Motivation and Context
Upon initial SSR rendering, the activator for a tooltip is contained inside the root of the VTooltip component like so:
```html
<span class="v-tooltip v-tooltip--bottom">
  <div
    class="v-tooltip__content"
    style="left:0px;max-width:auto;opacity:0;top:12px;z-index:0;display:none;"
  ></div>
  <div>ACTIVATOR</div>
</span>
```

Because `v-tooltip` is `display: none;` the activator is not visible.

When JS kicks in the DOM [gets modified by the `beforeMount` of `Detachable`](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/mixins/detachable/index.ts#L61) and the activator gets moved out like so:
```html
<div>ACTIVATOR</div>
<span class="v-tooltip v-tooltip--bottom">
  <div class="v-tooltip__content" style="left:0px;max-width:auto;opacity:0;top:12px;z-index:0;display:none;"></div>
</span>
```

Removing this `display: none;` fix the SSR issue as the activator gets displayed before JS kicks in. Moreover as `tooltip__content` is empty before JS kicks in and also have `display:none;` set, this change shouldn't have any side effect on that front.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
I've tested this by overriding this style on my project that uses Nuxt + Vuetify and checking it fixes the SSR issue. I didn't notice any side effects, tooltips still work as expected.
I've also tested in the playground and it also seems to work without issue.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-tooltip bottom>
      <template v-slot:activator="{ on }">
        <v-btn v-on="on">Hover me</v-btn>
      </template>
      This is a tooltip
    </v-tooltip>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
