### PR TITLE
fix(VTreeview): load initial selection when using return-object

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -157,8 +157,8 @@ export default mixins(
 
   created () {
     this.buildTree(this.items)
-    this.value.forEach(key => this.updateSelected(key, true))
-    this.active.forEach(key => this.updateActive(key, true))
+    this.value.forEach(key => this.updateSelected(this.returnObject ? getObjectValueByPath(key, this.itemKey) : key, true))
+    this.active.forEach(key => this.updateActive(this.returnObject ? getObjectValueByPath(key, this.itemKey) : key, true))
   },
 
   mounted () {
@@ -170,7 +170,7 @@ export default mixins(
     if (this.openAll) {
       this.updateAll(true)
     } else {
-      this.open.forEach(key => this.updateOpen(key, true))
+      this.open.forEach(key => this.updateOpen(this.returnObject ? getObjectValueByPath(key, this.itemKey) : key, true))
       this.emitOpen()
     }
   },

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
@@ -7,16 +7,6 @@ import {
 import VTreeview from '../VTreeview'
 import { ExtractVue } from '../../../util/mixins'
 
-Vue.prototype.$vuetify = {
-  icons: {
-    values: {
-      subgroup: 'arrow_drop_down',
-      checkboxOn: 'check_box',
-      checkboxOff: 'check_box_outline_blank',
-    },
-  },
-}
-
 const singleRootTwoChildren = [
   { id: 0, name: 'Root', children: [{ id: 1, name: 'Child' }, { id: 2, name: 'Child 2' }] },
 ]
@@ -654,6 +644,29 @@ describe('VTreeView.ts', () => { // eslint-disable-line max-statements
           name: 'three',
         },
       ],
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/8709
+  it('should handle initial active/open/selected values when using return-object prop', async () => {
+    const one = { id: '1', name: 'One' }
+    const three = { id: '3', name: 'Three' }
+    const two = { id: '2', name: 'Two', children: [three] }
+
+    const wrapper = mountFunction({
+      propsData: {
+        returnObject: true,
+        selectable: true,
+        activatable: true,
+        items: [one, two],
+        value: [one],
+        open: [two],
+        active: [three],
+      },
     })
 
     await wrapper.vm.$nextTick()

--- a/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeview.spec.ts.snap
+++ b/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeview.spec.ts.snap
@@ -108,6 +108,66 @@ exports[`VTreeView.ts should filter items using custom item filter 2`] = `
 </div>
 `;
 
+exports[`VTreeView.ts should handle initial active/open/selected values when using return-object prop 1`] = `
+<div class="v-treeview theme--light">
+  <div aria-expanded="false"
+       class="v-treeview-node v-treeview-node--leaf v-treeview-node--selected"
+  >
+    <div class="v-treeview-node__root">
+      <i role="button"
+         class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light accent--text"
+      >
+        $checkboxOn
+      </i>
+      <div class="v-treeview-node__content">
+        <div class="v-treeview-node__label">
+          One
+        </div>
+      </div>
+    </div>
+  </div>
+  <div aria-expanded="true"
+       class="v-treeview-node"
+  >
+    <div class="v-treeview-node__root">
+      <i role="button"
+         class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
+      >
+        $subgroup
+      </i>
+      <i role="button"
+         class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light"
+      >
+        $checkboxOff
+      </i>
+      <div class="v-treeview-node__content">
+        <div class="v-treeview-node__label">
+          Two
+        </div>
+      </div>
+    </div>
+    <div class="v-treeview-node__children">
+      <div aria-expanded="false"
+           class="v-treeview-node v-treeview-node--leaf"
+      >
+        <div class="v-treeview-node__root v-treeview-node--active primary--text">
+          <i role="button"
+             class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light"
+          >
+            $checkboxOff
+          </i>
+          <div class="v-treeview-node__content">
+            <div class="v-treeview-node__label">
+              Three
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`VTreeView.ts should handle replacing items with new array of equal length 1`] = `
 <div class="v-treeview theme--light">
   <div aria-expanded="false"
@@ -171,7 +231,7 @@ exports[`VTreeView.ts should load children when expanding 1`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -192,7 +252,7 @@ exports[`VTreeView.ts should load children when expanding 2`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -226,12 +286,12 @@ exports[`VTreeView.ts should load children when selecting, but not render 1`] = 
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <i role="button"
          class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light"
       >
-        check_box_outline_blank
+        $checkboxOff
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -252,12 +312,12 @@ exports[`VTreeView.ts should load children when selecting, but not render 2`] = 
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <i role="button"
          class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light accent--text"
       >
-        check_box
+        $checkboxOn
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -293,7 +353,7 @@ exports[`VTreeView.ts should open all children when using open-all prop 1`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -309,7 +369,7 @@ exports[`VTreeView.ts should open all children when using open-all prop 1`] = `
           <i role="button"
              class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
           >
-            arrow_drop_down
+            $subgroup
           </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
@@ -356,7 +416,7 @@ exports[`VTreeView.ts should react to open changes 1`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -372,7 +432,7 @@ exports[`VTreeView.ts should react to open changes 1`] = `
           <i role="button"
              class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
           >
-            arrow_drop_down
+            $subgroup
           </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
@@ -419,7 +479,7 @@ exports[`VTreeView.ts should react to open changes 2`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -435,7 +495,7 @@ exports[`VTreeView.ts should react to open changes 2`] = `
           <i role="button"
              class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
           >
-            arrow_drop_down
+            $subgroup
           </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
@@ -469,7 +529,7 @@ exports[`VTreeView.ts should react to open changes 3`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -485,7 +545,7 @@ exports[`VTreeView.ts should react to open changes 3`] = `
           <i role="button"
              class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
           >
-            arrow_drop_down
+            $subgroup
           </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
@@ -532,7 +592,7 @@ exports[`VTreeView.ts should react to open changes 4`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -553,7 +613,7 @@ exports[`VTreeView.ts should recalculate tree when loading async children using 
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -657,7 +717,7 @@ exports[`VTreeView.ts should render items 1`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -678,7 +738,7 @@ exports[`VTreeView.ts should render items in dense mode 1`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -816,7 +876,7 @@ exports[`VTreeView.ts should show expand icon when children is empty and load-ch
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -836,12 +896,12 @@ exports[`VTreeView.ts should update selection when selected prop changes 1`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <i role="button"
          class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light"
       >
-        check_box_outline_blank
+        $checkboxOff
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -862,12 +922,12 @@ exports[`VTreeView.ts should update selection when selected prop changes 2`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <i role="button"
          class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light accent--text"
       >
-        check_box
+        $checkboxOn
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -883,7 +943,7 @@ exports[`VTreeView.ts should update selection when selected prop changes 2`] = `
           <i role="button"
              class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light accent--text"
           >
-            check_box
+            $checkboxOn
           </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">
@@ -906,12 +966,12 @@ exports[`VTreeView.ts should update selection when selected prop changes 3`] = `
       <i role="button"
          class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
       >
-        arrow_drop_down
+        $subgroup
       </i>
       <i role="button"
          class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light"
       >
-        check_box_outline_blank
+        $checkboxOff
       </i>
       <div class="v-treeview-node__content">
         <div class="v-treeview-node__label">
@@ -927,7 +987,7 @@ exports[`VTreeView.ts should update selection when selected prop changes 3`] = `
           <i role="button"
              class="v-icon notranslate v-treeview-node__checkbox v-icon--link material-icons theme--light"
           >
-            check_box_outline_blank
+            $checkboxOff
           </i>
           <div class="v-treeview-node__content">
             <div class="v-treeview-node__label">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
the initial loading of active/open/selected items did not take into account `return-object` prop.

## Motivation and Context
closes #8709

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
playground, unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row>
      <v-col cols="12">
      </v-col>
      <v-col cols="12">
        <v-card>
          <v-card-title>Treeview</v-card-title>
          <v-treeview selectable v-model="selection" :items="items" activatable :active.sync="asd" :open.sync="open" return-object></v-treeview>
          <v-card-actions>
            <v-btn color="primary" @click="selection = [{id: '1', name: 'One'}]">Select One</v-btn>
          </v-card-actions>
        </v-card>
      </v-col>
      <v-col cols="12">
        <v-card>
          {{ selection }}
        </v-card>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
const one = {id: '1', name: 'One'}
const three = { id: '3', name: 'Three' }
const two = {id: '2', name: 'Two', children: [three]}

export default {
  data: () => ({
    items: [
      one,
      two,
    ],
    open: [{id: '2', name: 'Two', children: [three]}],
    asd: [{ id: '3', name: 'Three' }],
    selection: [{id: '1', name: 'One'}]
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
