### PR TITLE
fix(VDataIterator): emit two item-selected events in single-select mode

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -154,6 +154,11 @@ export default Themeable.extend({
       if (value) selection[key] = item
       else delete selection[key]
 
+      if (this.singleSelect && emit) {
+        const keys = Object.keys(this.selection)
+        const old = keys.length && getObjectValueByPath(this.selection[keys[0]], this.itemKey)
+        old && old !== key && this.$emit('item-selected', { item: this.selection[old], value: false })
+      }
       this.selection = selection
       emit && this.$emit('item-selected', { item, value })
     },

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -550,4 +550,30 @@ describe('VDataTable.ts', () => {
 
     expect(itemsPerPage).toHaveBeenCalledWith(-1)
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/8477
+  it('should emit two item-selected events when using single-select prop and selecting new item', async () => {
+    const itemSelected = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        headers: testHeaders,
+        itemKey: 'name',
+        items: testItems.slice(0, 2),
+        value: [testItems[0]],
+        showSelect: true,
+        singleSelect: true,
+      },
+      listeners: {
+        'item-selected': itemSelected,
+      },
+    })
+
+    const checkbox = wrapper.findAll('.v-data-table__checkbox').at(1)
+    checkbox.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(itemSelected).toHaveBeenCalledTimes(2)
+    expect(itemSelected).toHaveBeenCalledWith({ item: testItems[0], value: false })
+    expect(itemSelected).toHaveBeenCalledWith({ item: testItems[1], value: true })
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
bug where in single-select mode we did not emit a 'deselect' item-select event for previously selected item when selecting a new one.

## Motivation and Context
closes #8477

## How Has This Been Tested?
playground, unit test

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-data-table :headers="header" :items="people" single-select show-select @item-selected="itemSelected">
      <template v-slot:item.libelle="{ item }">
        <td class="text-xs">{{ item.libelle }}</td>
      </template>
    </v-data-table>
  </div>
</template>

<script>
export default {
  data: () => ({
    header: [
      {
        value: 'name',
        text: 'Name'
      }
    ],
    people: [
      {
        id: 1,
        name: 'John D.'
      },
      {
        id: 2,
        name: 'Jack M.'
      }
    ]
  }),
  methods: {
    itemSelected(item) {
      console.log('Item : ' + item.item.name + ' value : ' + item.value)
    }
  }
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
