### PR TITLE
docs: removed hard coded colors to work with dark theme

### DIFF
--- a/packages/docs/src/examples/cards/complex/weather.vue
+++ b/packages/docs/src/examples/cards/complex/weather.vue
@@ -1,7 +1,6 @@
 <template>
   <v-card
     class="mx-auto"
-    color="#F9F9F9"
     max-width="400"
   >
     <v-list-item two-line>

--- a/packages/docs/src/examples/chips/complex/photos.vue
+++ b/packages/docs/src/examples/chips/complex/photos.vue
@@ -1,7 +1,6 @@
 <template>
   <v-card
     class="mx-auto"
-    color="white"
     max-width="500"
   >
     <v-toolbar

--- a/packages/docs/src/examples/data-tables/intermediate/expand.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/expand.vue
@@ -10,7 +10,7 @@
     class="elevation-1"
   >
     <template v-slot:top>
-      <v-toolbar flat color="white">
+      <v-toolbar flat>
         <v-toolbar-title>Expandable Table</v-toolbar-title>
         <v-spacer></v-spacer>
         <v-switch v-model="singleExpand" label="Single expand" class="mt-2"></v-switch>


### PR DESCRIPTION
## Description
Hard coded colors used in 

https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/examples/data-tables/intermediate/expand.vue

https://github.com/vuetifyjs/vuetify/tree/master/packages/docs/src/examples/cards/complex/weather.vue

https://github.com/vuetifyjs/vuetify/tree/master/packages/docs/src/examples/chips/complex/photos.vue

Causing components to appear white in dark theme

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
