### PR TITLE
fix(v-menu): allow screen readers to navigate through menu

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
@@ -34,7 +34,8 @@ exports[`VDataFooter.ts should disable last page button if no items 1`] = `
             </div>
           </div>
           <div class="v-menu">
-            <div class="v-menu__content theme--light "
+            <div tabindex="-1"
+                 class="v-menu__content theme--light "
                  style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
             >
             </div>
@@ -135,7 +136,8 @@ exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 
             </div>
           </div>
           <div class="v-menu">
-            <div class="v-menu__content theme--light "
+            <div tabindex="-1"
+                 class="v-menu__content theme--light "
                  style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
             >
             </div>
@@ -232,7 +234,8 @@ exports[`VDataFooter.ts should render in RTL mode 1`] = `
             </div>
           </div>
           <div class="v-menu">
-            <div class="v-menu__content theme--light "
+            <div tabindex="-1"
+                 class="v-menu__content theme--light "
                  style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
             >
             </div>
@@ -329,7 +332,8 @@ exports[`VDataFooter.ts should render with custom itemsPerPage 1`] = `
             </div>
           </div>
           <div class="v-menu">
-            <div class="v-menu__content theme--light "
+            <div tabindex="-1"
+                 class="v-menu__content theme--light "
                  style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
             >
             </div>
@@ -405,7 +409,8 @@ exports[`VDataFooter.ts should show current page if has showCurrentPage 1`] = `
             </div>
           </div>
           <div class="v-menu">
-            <div class="v-menu__content theme--light "
+            <div tabindex="-1"
+                 class="v-menu__content theme--light "
                  style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
             >
             </div>

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
@@ -46,7 +46,8 @@ exports[`VDataIterator.ts should render and match snapshot 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -137,7 +138,8 @@ exports[`VDataIterator.ts should render and match snapshot with data 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -219,7 +221,8 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -301,7 +304,8 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -383,7 +387,8 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -244,7 +244,8 @@ exports[`VDataTable.ts should limit page to current page count if not using serv
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -438,7 +439,8 @@ exports[`VDataTable.ts should not limit page to current item count when using se
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -727,7 +729,8 @@ exports[`VDataTable.ts should not limit page to current item count when using se
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -1121,7 +1124,8 @@ exports[`VDataTable.ts should not search column with filterable set to false 1`]
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -1324,7 +1328,8 @@ exports[`VDataTable.ts should not search column with filterable set to false 2`]
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -1580,7 +1585,8 @@ exports[`VDataTable.ts should not search column with filterable set to false and
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -1976,7 +1982,8 @@ exports[`VDataTable.ts should not search column with filterable set to false and
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -2075,7 +2082,8 @@ exports[`VDataTable.ts should pass kebab-case footer props correctly 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -2174,7 +2182,8 @@ exports[`VDataTable.ts should render 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -2270,7 +2279,8 @@ exports[`VDataTable.ts should render footer.page-text slot content 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -2398,7 +2408,8 @@ exports[`VDataTable.ts should render loading state 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -2604,7 +2615,8 @@ exports[`VDataTable.ts should render loading state 2`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -2795,7 +2807,8 @@ exports[`VDataTable.ts should render with body slot 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -3084,7 +3097,8 @@ exports[`VDataTable.ts should render with data 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -3268,7 +3282,8 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -3695,7 +3710,8 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -4068,7 +4084,8 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -4272,7 +4289,8 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -4586,7 +4604,8 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -4921,7 +4940,8 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -5256,7 +5276,8 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>
@@ -5618,7 +5639,8 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
               </div>
             </div>
             <div class="v-menu">
-              <div class="v-menu__content theme--light "
+              <div tabindex="-1"
+                   class="v-menu__content theme--light "
                    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
               >
               </div>

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
@@ -554,7 +554,8 @@ exports[`VDataTableHeader.ts mobile should render 1`] = `
                 </div>
               </div>
               <div class="v-menu">
-                <div class="v-menu__content theme--light "
+                <div tabindex="-1"
+                     class="v-menu__content theme--light "
                      style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
                 >
                 </div>
@@ -617,7 +618,8 @@ exports[`VDataTableHeader.ts mobile should render with data-table-select header 
                 </div>
               </div>
               <div class="v-menu">
-                <div class="v-menu__content theme--light "
+                <div tabindex="-1"
+                     class="v-menu__content theme--light "
                      style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
                 >
                 </div>
@@ -682,7 +684,8 @@ exports[`VDataTableHeader.ts mobile should work with multiSort 1`] = `
                 </div>
               </div>
               <div class="v-menu">
-                <div class="v-menu__content theme--light "
+                <div tabindex="-1"
+                     class="v-menu__content theme--light "
                      style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
                 >
                 </div>
@@ -734,7 +737,8 @@ exports[`VDataTableHeader.ts mobile should work with showGroupBy 1`] = `
                 </div>
               </div>
               <div class="v-menu">
-                <div class="v-menu__content theme--light "
+                <div tabindex="-1"
+                     class="v-menu__content theme--light "
                      style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
                 >
                 </div>
@@ -799,7 +803,8 @@ exports[`VDataTableHeader.ts mobile should work with sortBy correctly 1`] = `
                 </div>
               </div>
               <div class="v-menu">
-                <div class="v-menu__content theme--light "
+                <div tabindex="-1"
+                     class="v-menu__content theme--light "
                      style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
                 >
                 </div>
@@ -864,7 +869,8 @@ exports[`VDataTableHeader.ts mobile should work with sortDesc correctly 1`] = `
                 </div>
               </div>
               <div class="v-menu">
-                <div class="v-menu__content theme--light "
+                <div tabindex="-1"
+                     class="v-menu__content theme--light "
                      style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
                 >
                 </div>

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VEditDialog.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VEditDialog.spec.ts.snap
@@ -7,6 +7,7 @@ exports[`VEditDialog.ts should render 1`] = `
     </span>
   </div>
   <div role="menu"
+       tabindex="-1"
        class="v-menu__content theme--light v-small-dialog__menu-content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top right; z-index: 0; display: none;"
   >
@@ -50,6 +51,7 @@ exports[`VEditDialog.ts should render custom button texts 1`] = `
     </span>
   </div>
   <div role="menu"
+       tabindex="-1"
        class="v-menu__content theme--light v-small-dialog__menu-content"
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top right; z-index: 0; display: none;"
   >

--- a/packages/vuetify/src/components/VMenu/VMenu.sass
+++ b/packages/vuetify/src/components/VMenu/VMenu.sass
@@ -72,3 +72,7 @@
       opacity: 1
       transform: none !important
       pointer-events: auto
+
+.v-menu__content
+  &:focus
+    outline: none

--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -202,6 +202,7 @@ export default baseMixins.extend({
           if (this.$refs.content) {
             this.calculatedTopAuto = this.calcTopAuto()
             this.auto && (this.$refs.content.scrollTop = this.calcScrollPosition())
+            this.$refs.content.focus()
           }
         })
       })
@@ -307,6 +308,7 @@ export default baseMixins.extend({
         attrs: {
           ...this.getScopeIdAttrs(),
           role: 'role' in this.$attrs ? this.$attrs.role : 'menu',
+          tabIndex: -1,
         },
         staticClass: 'v-menu__content',
         class: {

--- a/packages/vuetify/src/components/VMenu/__tests__/__snapshots__/VMenu.spec.ts.snap
+++ b/packages/vuetify/src/components/VMenu/__tests__/__snapshots__/VMenu.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`VMenu.ts should work 1`] = `
   <button>
   </button>
   <div role="menu"
+       tabindex="-1"
        class="v-menu__content theme--light menuable__content__active "
        style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none; z-index: 8;"
   >

--- a/packages/vuetify/src/components/VOverflowBtn/__tests__/__snapshots__/VOverflowBtn.spec.ts.snap
+++ b/packages/vuetify/src/components/VOverflowBtn/__tests__/__snapshots__/VOverflowBtn.spec.ts.snap
@@ -30,7 +30,8 @@ exports[`VOverflowBtn.js should use default autocomplete selections 1`] = `
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light v-autocomplete__content"
+        <div tabindex="-1"
+             class="v-menu__content theme--light v-autocomplete__content"
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>
@@ -79,7 +80,8 @@ exports[`VOverflowBtn.js should use default autocomplete selections 2`] = `
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light v-autocomplete__content"
+        <div tabindex="-1"
+             class="v-menu__content theme--light v-autocomplete__content"
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect.spec.ts.snap
@@ -236,7 +236,8 @@ exports[`VSelect.ts should render v-select correctly when not using scope slot 1
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>
@@ -283,7 +284,8 @@ exports[`VSelect.ts should render v-select correctly when not using v-list-item 
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>
@@ -330,7 +332,8 @@ exports[`VSelect.ts should render v-select correctly when using v-list-item in i
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
@@ -40,7 +40,8 @@ exports[`VSelect.ts should be clearable with prop, dirty and multi select 1`] = 
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>
@@ -99,7 +100,8 @@ exports[`VSelect.ts should be clearable with prop, dirty and single select 1`] =
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>
@@ -149,7 +151,8 @@ exports[`VSelect.ts should use scoped slot for selection generation 1`] = `
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect3.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect3.spec.ts.snap
@@ -31,7 +31,8 @@ exports[`VSelect.ts should add color to selected index 1`] = `
         </div>
       </div>
       <div class="v-menu">
-        <div class="v-menu__content theme--light "
+        <div tabindex="-1"
+             class="v-menu__content theme--light "
              style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 0; display: none;"
         >
         </div>


### PR DESCRIPTION
Screen readers need to have focus somewhere in the popup element to allow keyboard navigation through its elements

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Focus is set on the menu every time it pops up.

## Motivation and Context
Screen reader behavior using up/down keys:
BEFORE
(there's no way to get to the menu items with keyboard when screen reader is on)
![g1](https://user-images.githubusercontent.com/1068657/68807920-98776080-061d-11ea-80f6-e8e6935555a3.gif)

AFTER
(up/down keys allow to navigate through menu items)
![g2](https://user-images.githubusercontent.com/1068657/68807939-9f05d800-061d-11ea-8089-fd4318c461f4.gif)


## How Has This Been Tested?
visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-menu offset-y>
      <template v-slot:activator="{ on, attrs }">
        <v-btn color="primary" dark v-bind="attrs" v-on="on">Dropdown</v-btn>
      </template>
      <v-list>
        <v-list-item v-for="(item, index) in items" :key="index" @click="onClicked(index)">
          <v-list-item-title>{{ item.title }}</v-list-item-title>
        </v-list-item>
      </v-list>
    </v-menu>
    
    <v-btn>Button 2</v-btn>
    <v-btn>Button 3</v-btn>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    items: [
      { title: "Click Me 1" },
      { title: "Click Me 2" },
      { title: "Click Me 3" }
    ]
  }),
  methods: {
    onClicked(index) {
      alert(`Clicked ${index}`)
    },
  }
};
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
