### PR TITLE
fix(types): missing currentTheme in Theme interface

### DIFF
--- a/packages/vuetify/types/services/theme.d.ts
+++ b/packages/vuetify/types/services/theme.d.ts
@@ -13,6 +13,7 @@ export interface Theme {
     dark: Partial<VuetifyThemeVariant>
     light: Partial<VuetifyThemeVariant>
   }
+  readonly currentTheme: Partial<VuetifyThemeVariant>
 }
 
 export interface VuetifyThemes {


### PR DESCRIPTION
Do we want `parsedTheme` and `generatedStyles` as well?
Probably not, seems that it's only for internal use


## Motivation and Context
fixes #9546

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
