### PR TITLE
fix(VSlider): label is not disabled in readonly slider

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.sass
+++ b/packages/vuetify/src/components/VSlider/VSlider.sass
@@ -262,11 +262,11 @@
   .v-slider__tick
     opacity: 1
 
-.v-slider--readonly
-  pointer-events: none
-
 // Input
 .v-input__slider
+  &.v-input--is-readonly .v-input__slot
+    pointer-events: none
+
   .v-input__slot .v-label
     margin-left: 0
     margin-right: 12px


### PR DESCRIPTION
## Motivation and Context
fixes #9660

## How Has This Been Tested?
playground

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-slider 
      :value="30" 
      prepend-icon="storage" 
      :messages="['Message']" 
      append-icon="storage" 
      label="Slider" 
      @click:append="alert" 
      @click:prepend="alert" 
      readonly 
    />
    <v-range-slider 
      :value="[30,70]" 
      prepend-icon="storage" 
      :messages="['Message']" 
      append-icon="storage" 
      label="Slider" 
      @click:append="alert" 
      @click:prepend="alert" 
      readonly 
    />

  </v-container>
</template>

<script>
export default {
  methods: {
    alert: () => alert('clicked')
  }
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
