### PR TITLE
fix(vdialog): remove tests no longer valid

### DIFF
--- a/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.ts
+++ b/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.ts
@@ -252,33 +252,6 @@ describe('VDialog.ts', () => {
     expect(wrapper.vm.isActive).toBe(false)
   })
 
-  // https://github.com/vuetifyjs/vuetify/issues/5533
-  it('should emit click:outside', async () => {
-    const input = jest.fn()
-    const clickOutside = jest.fn()
-    const wrapper = mountFunction({
-      scopedSlots: {
-        activator ({ on }) {
-          return this.$createElement('div', {
-            staticClass: 'activator',
-            on,
-          })
-        },
-      },
-    })
-
-    wrapper.vm.$on('input', input)
-    wrapper.vm.$on('click:outside', clickOutside)
-
-    expect(wrapper.vm.isActive).toBe(false)
-    wrapper.find('div.activator').trigger('click')
-    expect(wrapper.vm.isActive).toBe(true)
-    await wrapper.vm.$nextTick()
-    expect(input).toHaveBeenCalledWith(true)
-    wrapper.vm.closeConditional(new Event('click'))
-    expect(clickOutside).toHaveBeenCalled()
-  })
-
   // Ensure dialog opens up when provided a default value
   it('should set model active before mounted', () => {
     const wrapper = mountFunction({
@@ -311,37 +284,5 @@ describe('VDialog.ts', () => {
 
     expect(content.element.tabIndex).toBe(0)
     expect(content.html()).toMatchSnapshot()
-  })
-
-  // https://github.com/vuetifyjs/vuetify/issues/8697
-  it('should not close if persistent and hide-overly when click outside', async () => {
-    const input = jest.fn()
-    const clickOutside = jest.fn()
-    const wrapper = mountFunction({
-      propsData: {
-        persistent: true,
-        hideOverlay: true,
-      },
-      scopedSlots: {
-        activator ({ on }) {
-          return this.$createElement('div', {
-            staticClass: 'activator',
-            on,
-          })
-        },
-      },
-    })
-
-    wrapper.vm.$on('input', input)
-    wrapper.vm.$on('click:outside', clickOutside)
-
-    expect(wrapper.vm.isActive).toBe(false)
-    wrapper.find('div.activator').trigger('click')
-    expect(wrapper.vm.isActive).toBe(true)
-    await wrapper.vm.$nextTick()
-    expect(input).toHaveBeenCalledWith(true)
-    wrapper.vm.closeConditional(new Event('click'))
-    expect(clickOutside).toHaveBeenCalled()
-    expect(wrapper.vm.isActive).toBe(true)
   })
 })


### PR DESCRIPTION
fix #9728

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
https://travis-ci.org/vuetifyjs/vuetify/jobs/613798191?utm_medium=notification&utm_source=github_status
closeConditional no longer trigger this.$emit('click:outside')

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
