### PR TITLE
fix(translations): Update catalan translations

### DIFF
--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -1,25 +1,25 @@
 export default {
-  close: 'Close',
+  close: 'Tancar',
   dataIterator: {
     noResultsText: 'Sense dades per mostrar',
-    loadingText: 'Loading item...',
+    loadingText: 'Carregant...',
   },
   dataTable: {
     itemsPerPageText: 'Files per pàgina:',
     ariaLabel: {
-      sortDescending: ': Sorted descending. Activate to remove sorting.',
-      sortAscending: ': Sorted ascending. Activate to sort descending.',
-      sortNone: ': Not sorted. Activate to sort ascending.',
+      sortDescending: ': Ordre descendent. Premi per treure la ordenació.',
+      sortAscending: ': Ordre ascendent. Premi per ordenar descendent.',
+      sortNone: ': Sense ordenar. Premi per ordenar ascendent.',
     },
-    sortBy: 'Sort by',
+    sortBy: 'Ordenat per',
   },
   dataFooter: {
     itemsPerPageText: 'Elements per pàgina:',
     itemsPerPageAll: 'Tot',
-    nextPage: 'Pàgina Següent',
-    prevPage: 'Pàgina Anterior',
-    firstPage: 'Pàgina Primera',
-    lastPage: 'Pàgina Darrera',
+    nextPage: 'Pàgina següent',
+    prevPage: 'Pàgina anterior',
+    firstPage: 'Primera pàgina',
+    lastPage: 'Última pàgina',
     pageText: '{0}-{1} de {2}',
   },
   datePicker: {
@@ -28,17 +28,17 @@ export default {
   noDataText: 'Sense dades',
   carousel: {
     prev: 'Visualització prèvia',
-    next: 'Següent visual',
+    next: 'Visualització següent',
     ariaLabel: {
-      delimiter: 'Carousel slide {0} of {1}',
+      delimiter: 'Diapositiva {0} of {1}',
     },
   },
   calendar: {
     moreEvents: '{0} més',
   },
   fileInput: {
-    counter: '{0} files',
-    counterSize: '{0} files ({1} in total)',
+    counter: '{0} fitxers',
+    counterSize: '{0} fitxers ({1} en total)',
   },
   timePicker: {
     am: 'AM',


### PR DESCRIPTION
Update catalan translations were missing.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Update catalan translations were missing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Catalan translations were missing.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
