### PR TITLE
fix(VListGroup): convert icon slots to kebab

### DIFF
--- a/packages/vuetify/src/components/VList/VListGroup.ts
+++ b/packages/vuetify/src/components/VList/VListGroup.ts
@@ -125,12 +125,12 @@ export default baseMixins.extend<options>().extend({
     genAppendIcon (): VNode | null {
       const icon = !this.subGroup ? this.appendIcon : false
 
-      if (!icon && !this.$slots.appendIcon) return null
+      if (!icon && !this.$slots['append-icon']) return null
 
       return this.$createElement(VListItemIcon, {
         staticClass: 'v-list-group__header__append-icon',
       }, [
-        this.$slots.appendIcon || this.genIcon(icon),
+        this.$slots['append-icon'] || this.genIcon(icon),
       ])
     },
     genHeader (): VNode {
@@ -178,12 +178,11 @@ export default baseMixins.extend<options>().extend({
           ? '$subgroup'
           : false
 
-      if (!icon && !this.$slots.prependIcon) return null
-
+      if (!icon && !this.$slots['prepend-icon']) return null
       return this.$createElement(VListItemIcon, {
         staticClass: 'v-list-group__header__prepend-icon',
       }, [
-        this.$slots.prependIcon || this.genIcon(icon),
+        this.$slots['prepend-icon'] || this.genIcon(icon),
       ])
     },
     onRouteChange (to: Route) {

--- a/packages/vuetify/src/components/VList/__tests__/VListGroup.spec.ts
+++ b/packages/vuetify/src/components/VList/__tests__/VListGroup.spec.ts
@@ -91,17 +91,16 @@ describe('VListGroup.ts', () => {
   it('should render a custom affix icons', async () => {
     const wrapper = mountFunction({
       slots: {
-        appendIcon: {
+        'append-icon': {
           render: h => h('span', 'foo'),
         },
-        prependIcon: {
+        'prepend-icon': {
           render: h => h('span', 'bar'),
         },
       },
     })
 
-    expect(wrapper.html()).toContain('<span>foo</span>')
-    expect(wrapper.html()).toContain('<span>bar</span>')
+    expect(wrapper.html()).toMatchSnapshot()
   })
 
   it('should respond to keydown.enter on header', () => {

--- a/packages/vuetify/src/components/VList/__tests__/__snapshots__/VListGroup.spec.ts.snap
+++ b/packages/vuetify/src/components/VList/__tests__/__snapshots__/VListGroup.spec.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VListGroup.ts should render a custom affix icons 1`] = `
+<div class="v-list-group">
+  <div tabindex="0"
+       aria-expanded="false"
+       role="button"
+       class="v-list-group__header v-list-item v-list-item--link theme--light"
+  >
+    <div class="v-list-item__icon v-list-group__header__prepend-icon">
+      <span>
+        bar
+      </span>
+    </div>
+    <div class="v-list-item__icon v-list-group__header__append-icon">
+      <span>
+        foo
+      </span>
+    </div>
+  </div>
+  <div class="v-list-group__items"
+       style="display: none;"
+  >
+  </div>
+</div>
+`;
+
 exports[`VListGroup.ts should render component and match snapshot 1`] = `
 <div class="v-list-group">
   <div tabindex="0"


### PR DESCRIPTION
## Description
converts `append-icon` and `prepend-icon` slots to kebab case on `v-list-group`

## Motivation and Context
So they can be used

## How Has This Been Tested?
unit | visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row justify="center">
      <v-card
        class="mx-auto"
        max-width="450"
        tile
      >
        <v-list>
          <v-list-group></v-list-group>
          <v-list-group
            prepend-icon="mdi-star"
            append-icon="mdi-star"
          >
          </v-list-group>
          <v-list-group>
            <template #prepend-icon>
              <v-icon>mdi-star</v-icon>
            </template>
            <template #append-icon>
              <v-icon>mdi-star</v-icon>
            </template>
          </v-list-group>
        </v-list>
      </v-card>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({}),
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
