### PR TITLE
fix(vbtn): fix VBtn custom loader content overflow

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -135,7 +135,7 @@
   height: 100%
   justify-content: center
   left: 0
-  position: absolute
+  position: relative
   top: 0
   width: 100%
 
@@ -241,7 +241,7 @@
   transition: none
 
   .v-btn__content
-    opacity: 0
+    display: none
 
 .v-btn--outlined
   border: $btn-outline-border-width solid currentColor


### PR DESCRIPTION
## Description
Custom loader content overflows when it grows bigger than it's parent

## Motivation and Context
fixes #9672

Fix VBtn custom loader content overflow issue by allowing custom content to expand it's parent (VBtn)

## How Has This Been Tested?
visually

## Reproduction link:
From the reported issue #9672 https://codepen.io/janvennemann/pen/gOOdpvq

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)

## Notes:
I'm not sure if: 
- `.v-btn__content` depends on `opacity` for some animations
- something relies on `.v-btn__loader` to be absolutely positioned
Pointers will be appreciated :) 