### PR TITLE
fix(VIcon): svg icon style when using the prominent prop

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -141,11 +141,11 @@ const VIcon = mixins(
       const fontSize = this.getSize()
       const wrapperData = {
         ...this.getDefaultData(),
-        style: !fontSize ? undefined : {
+        style: fontSize ? {
           fontSize,
           height: fontSize,
           width: fontSize,
-        },
+        } : undefined,
       }
       wrapperData.class['v-icon--svg'] = true
       this.applyColors(wrapperData)

--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -138,38 +138,38 @@ const VIcon = mixins(
       return h(this.tag, data, newChildren)
     },
     renderSvgIcon (icon: string, h: CreateElement): VNode {
-      const data = this.getDefaultData()
-      data.class['v-icon--svg'] = true
-
-      data.attrs = {
-        xmlns: 'http://www.w3.org/2000/svg',
-        viewBox: '0 0 24 24',
-        height: '24',
-        width: '24',
-        role: 'img',
-        'aria-hidden': !this.attrs$['aria-label'],
-        'aria-label': this.attrs$['aria-label'],
-      }
-
       const fontSize = this.getSize()
-      if (fontSize) {
-        data.style = {
+      const wrapperData = {
+        ...this.getDefaultData(),
+        style: !fontSize ? undefined : {
           fontSize,
           height: fontSize,
           width: fontSize,
-        }
-        data.attrs.height = fontSize
-        data.attrs.width = fontSize
+        },
+      }
+      wrapperData.class['v-icon--svg'] = true
+      this.applyColors(wrapperData)
+
+      const svgData: VNodeData = {
+        attrs: {
+          xmlns: 'http://www.w3.org/2000/svg',
+          viewBox: '0 0 24 24',
+          height: fontSize || '32',
+          width: fontSize || '32',
+          role: 'img',
+          'aria-hidden': !this.attrs$['aria-label'],
+          'aria-label': this.attrs$['aria-label'],
+        },
       }
 
-      this.applyColors(data)
-
-      return h('svg', data, [
-        h('path', {
-          attrs: {
-            d: icon,
-          },
-        }),
+      return h('span', wrapperData, [
+        h('svg', svgData, [
+          h('path', {
+            attrs: {
+              d: icon,
+            },
+          }),
+        ]),
       ])
     },
     renderSvgIconComponent (

--- a/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
+++ b/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
@@ -1,32 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VIcon for component icon should render an svg icon 1`] = `
-<svg xmlns="http://www.w3.org/2000/svg"
-     viewbox="0 0 24 24"
-     height="24"
-     width="24"
-     role="img"
-     aria-hidden="true"
-     class="v-icon notranslate v-icon--svg theme--light"
+<span aria-hidden="true"
+      class="v-icon notranslate v-icon--svg theme--light"
 >
-  <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
-  </path>
-</svg>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewbox="0 0 24 24"
+       height="32"
+       width="32"
+       role="img"
+       aria-hidden="true"
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
+    </path>
+  </svg>
+</span>
 `;
 
 exports[`VIcon for component icon should render an svg icon 2`] = `
-<svg xmlns="http://www.w3.org/2000/svg"
-     viewbox="0 0 24 24"
-     height="36px"
-     width="36px"
-     role="img"
-     aria-hidden="true"
-     class="v-icon notranslate v-icon--svg theme--light"
-     style="font-size: 36px; height: 36px; width: 36px;"
+<span aria-hidden="true"
+      class="v-icon notranslate v-icon--svg theme--light"
+      style="font-size: 36px; height: 36px; width: 36px;"
 >
-  <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
-  </path>
-</svg>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewbox="0 0 24 24"
+       height="36px"
+       width="36px"
+       role="img"
+       aria-hidden="true"
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
+    </path>
+  </svg>
+</span>
 `;
 
 exports[`VIcon for component icon should render component 1`] = `


### PR DESCRIPTION


## Description
Fixes SVG icon style for prominent VAlert cound't be applied on SVG. This commit fixes the issue by wrapping the SVG with a span element. Relevant classes are applied to the wrapper.

fix #9670

## How Has This Been Tested?
Tested visually. Updated snapshots.

## Markup:
Steps to reproduce from #9670:
https://codepen.io/janvennemann/pen/gOOdpvq
How it should look:  https://codepen.io/janvennemann/pen/xxxaGmY

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
