### PR TITLE
fix (VBadge) correct styles for overlap format

### DIFF
--- a/packages/vuetify/src/components/VBadge/VBadge.sass
+++ b/packages/vuetify/src/components/VBadge/VBadge.sass
@@ -34,22 +34,27 @@
 
   &--overlap
     .v-badge__badge
-      top: -8px
+      top: 0
+      transform-origin: 100% 0
 
       +ltr()
-        right: -8px
+        right: 0
+        transform: translate(50%, -50%)
 
       +rtl()
-        left: -8px
+        left: 0
+        transform: translate(-50%, -50%)
 
     &.v-badge--left
       .v-badge__badge
         +ltr()
-          left: -8px
+          left: 0
+          transform: translate(-50%, -50%)
           right: initial
 
         +rtl()
-          right: -8px
+          right: 0
+          transform: translate(50%, -50%)
           left: initial
 
     &.v-badge--bottom


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
