### PR TITLE
fix(VDatePicker): range not working with month picker

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -415,6 +415,7 @@ export default mixins(
           locale: this.locale,
           min: this.minMonth,
           max: this.maxMonth,
+          range: true,
           readonly: this.readonly && this.type === 'month',
           scrollable: this.scrollable,
           value: this.selectedMonths,

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -415,7 +415,7 @@ export default mixins(
           locale: this.locale,
           min: this.minMonth,
           max: this.maxMonth,
-          range: true,
+          range: this.range,
           readonly: this.readonly && this.type === 'month',
           scrollable: this.scrollable,
           value: this.selectedMonths,

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
@@ -298,12 +298,12 @@ describe('VDatePicker.ts', () => {
     })
 
     wrapper.vm.$on('input', cb)
-    wrapper.findAll('.v-date-picker-table--month tbody tr:first-child td:nth-child(3) button').at(0).trigger('click')
+    wrapper.find('.v-date-picker-table--month tbody tr:first-child td:nth-child(3) button').trigger('click')
     expect(cb.mock.calls[0][0]).toEqual(
       expect.arrayContaining(['2019-03'])
     )
 
-    wrapper.findAll('.v-date-picker-table--month tbody tr:first-child+tr+tr td:nth-child(2) button').at(0).trigger('click')
+    wrapper.find('.v-date-picker-table--month tbody tr:first-child+tr+tr td:nth-child(2) button').trigger('click')
     expect(cb.mock.calls[0][0][0]).toBe('2019-03')
     expect(cb.mock.calls[1][0][0]).toBe('2019-08')
   })

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
@@ -286,4 +286,25 @@ describe('VDatePicker.ts', () => {
     wrapper.findAll('.v-date-picker-table--month tbody tr+tr td:first-child button').at(0).trigger('dblclick')
     expect(dblclick).toHaveBeenCalledWith('2013-04')
   })
+
+  it('should handle date range select', async () => {
+    const cb = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        range: true,
+        type: 'month',
+        value: [],
+      },
+    })
+
+    wrapper.vm.$on('input', cb)
+    wrapper.findAll('.v-date-picker-table--month tbody tr:first-child td:nth-child(3) button').at(0).trigger('click')
+    expect(cb.mock.calls[0][0]).toEqual(
+      expect.arrayContaining(['2019-03'])
+    )
+
+    wrapper.findAll('.v-date-picker-table--month tbody tr:first-child+tr+tr td:nth-child(2) button').at(0).trigger('click')
+    expect(cb.mock.calls[0][0][0]).toBe('2019-03')
+    expect(cb.mock.calls[1][0][0]).toBe('2019-08')
+  })
 })


### PR DESCRIPTION
## Motivation and Context
fixes #9885

## How Has This Been Tested?
playground, unit

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-date-picker v-model="dates" range type="month"></v-date-picker>
</template>

<script>
export default {
  data: () => ({
    dates: ['2019-09', '2019-11'],
  }),
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
