### PR TITLE
Add missing '>' to activator example in migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -350,7 +350,7 @@ All event names has been changed from camelCase to kebab-case:
 <!-- v2.0 -->
 
 <v-dialog>
-  <template v-slot:activator="{ on }"
+  <template v-slot:activator="{ on }">
     <v-btn v-on="on">...</v-btn>
   </template>
 </v-dialog>


### PR DESCRIPTION
## Description
Add missing '>' to activator example in migration guide

## Motivation and Context
The migration guide is missing the closing > for the new activator slot syntax which may be confusing to those who have not seen the syntax before. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
