### PR TITLE
fix(VOverlay): keep open on background tabs

### DIFF
--- a/packages/vuetify/src/mixins/overlayable/index.ts
+++ b/packages/vuetify/src/mixins/overlayable/index.ts
@@ -87,7 +87,7 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
         this.overlay.zIndex = getZIndex(this.$el)
       }
 
-      this.overlay.value = true               
+      this.overlay.value = true
     },
     genOverlay () {
       this.hideScroll()
@@ -101,7 +101,7 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
           this.declareOverlay()
         })
       } else {
-        this.declareOverlay()                             
+        this.declareOverlay()
       }
 
       return true
@@ -114,7 +114,7 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
             !this.overlay ||
             !this.overlay.$el ||
             !this.overlay.$el.parentNode ||
-            this.overlay.value && !document.hidden
+            (this.overlay.value && !document.hidden)
           ) return
 
           this.overlay.$el.parentNode.removeChild(this.overlay.$el)

--- a/packages/vuetify/src/mixins/overlayable/index.ts
+++ b/packages/vuetify/src/mixins/overlayable/index.ts
@@ -78,24 +78,31 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
 
       this.overlay = overlay
     },
+    declareOverlay () {
+      if (!this.overlay) return
+
+      if (this.activeZIndex !== undefined) {
+        this.overlay.zIndex = String(this.activeZIndex - 1)
+      } else if (this.$el) {
+        this.overlay.zIndex = getZIndex(this.$el)
+      }
+
+      this.overlay.value = true               
+    },
     genOverlay () {
       this.hideScroll()
 
       if (this.hideOverlay) return
 
       if (!this.overlay) this.createOverlay()
-                                    
-      this.overlay.value = true
 
-      requestAnimationFrame(() => {
-        if (!this.overlay) return
-
-        if (this.activeZIndex !== undefined) {
-          this.overlay.zIndex = String(this.activeZIndex - 1)
-        } else if (this.$el) {
-          this.overlay.zIndex = getZIndex(this.$el)
-        }
-      })
+      if (!document.hidden) {
+        requestAnimationFrame(() => {
+          this.declareOverlay()
+        })
+      } else {
+        this.declareOverlay()                             
+      }
 
       return true
     },
@@ -107,7 +114,7 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
             !this.overlay ||
             !this.overlay.$el ||
             !this.overlay.$el.parentNode ||
-            this.overlay.value
+            this.overlay.value && !document.hidden
           ) return
 
           this.overlay.$el.parentNode.removeChild(this.overlay.$el)

--- a/packages/vuetify/src/mixins/overlayable/index.ts
+++ b/packages/vuetify/src/mixins/overlayable/index.ts
@@ -97,9 +97,7 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
       if (!this.overlay) this.createOverlay()
 
       if (!document.hidden) {
-        requestAnimationFrame(() => {
-          this.declareOverlay()
-        })
+        requestAnimationFrame(this.declareOverlay())
       } else {
         this.declareOverlay()
       }

--- a/packages/vuetify/src/mixins/overlayable/index.ts
+++ b/packages/vuetify/src/mixins/overlayable/index.ts
@@ -84,6 +84,8 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
       if (this.hideOverlay) return
 
       if (!this.overlay) this.createOverlay()
+                                    
+      this.overlay.value = true
 
       requestAnimationFrame(() => {
         if (!this.overlay) return
@@ -93,8 +95,6 @@ export default Vue.extend<Vue & Toggleable & Stackable & options>().extend({
         } else if (this.$el) {
           this.overlay.zIndex = getZIndex(this.$el)
         }
-
-        this.overlay.value = true
       })
 
       return true


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Most modern browsers restrict requestAnimationFrame when the tab is inactive. My understanding is that since the requestAnimationFrame is delayed, the when the overlay attempts to remove itself with the event listener the check to destroy the overlay returns from the event listener because the requestAnimationFrame sets this.overlay.value to true.

## Motivation and Context
Fixes #8625 
VOverlay components were not being removed when in a background tab if the dialog was initiated in the background. Our service would display a "Timeout" dialog on all tabs when their session was nearing expiry and this overlay would not be removed on background tabs when logged out or session refreshed.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Visually

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<div id="app">
  <v-app>
    <v-content>
      <v-container>
        <v-btn @click="dial = true">Open</v-btn>
        <v-dialog v-model="dial" persistent>
          <v-card>
            <v-card-title>hello</v-card-title>
          </v-card>
        </v-dialog>
      </v-container>
    </v-content>
  </v-app>
</div>

<script>
new Vue({
  el: '#app',
  vuetify: new Vuetify(),
  data: () => ({
    dial: true
  }),
  created() {
    setTimeout(()=>{
      this.dial = false;
    }, 500);
  }
})
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
