### PR TITLE
improvement(VDataTable): add canExpand prop that reports whether item can be expanded

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -100,6 +100,9 @@ export default VDataIterator.extend({
       type: Function as PropType<typeof defaultFilter>,
       default: defaultFilter,
     },
+    canExpand: {
+      type: Function as PropType<(item: any) => boolean>,
+    },
   },
 
   data () {
@@ -443,18 +446,25 @@ export default VDataIterator.extend({
 
       if (this.showExpand) {
         const slot = scopedSlots['data-table-expand']
-        scopedSlots['data-table-expand'] = slot ? () => slot(data) : () => this.$createElement(VIcon, {
-          staticClass: 'v-data-table__expand-icon',
-          class: {
-            'v-data-table__expand-icon--active': data.isExpanded,
-          },
-          on: {
-            click: (e: MouseEvent) => {
-              e.stopPropagation()
-              data.expand(!data.isExpanded)
-            },
-          },
-        }, [this.expandIcon])
+        scopedSlots['data-table-expand'] = slot
+          ? () => slot(data)
+          : () => {
+            if (this.canExpand && !this.canExpand(item)) {
+              return null
+            }
+            return this.$createElement(VIcon, {
+              staticClass: 'v-data-table__expand-icon',
+              class: {
+                'v-data-table__expand-icon--active': data.isExpanded,
+              },
+              on: {
+                click: (e: MouseEvent) => {
+                  e.stopPropagation()
+                  data.expand(!data.isExpanded)
+                },
+              },
+            }, [this.expandIcon])
+          }
       }
 
       return this.$createElement(this.isMobile ? MobileRow : Row, {


### PR DESCRIPTION
## Description

This PR adds a prop to VDataTable that controls whether a row is expandable or not. E.g.

```
<v-data-table ... :can-expand="canExpand" />

function canExpand(item: any): boolean {
  return item.values.length > 1
}
```

The code is working as is and I will complete tests and docs if there is an interest in merging this PR.

## Motivation and Context

There is an article that explains how  to do the same using a slot, but it uses custom markup/styling. Given how simple this PR is I decided to give it a try.

https://dev.to/dasdaniel/how-to-create-a-vuelify-data-table-that-has-only-some-expandable-rows-1m9m

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
