### PR TITLE
fix(VTextarea): make height of 1 row equal to v-text-field

### DIFF
--- a/packages/vuetify/src/components/VTextarea/VTextarea.sass
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.sass
@@ -13,7 +13,7 @@
     max-width: 100%
     min-height: 32px
     outline: none
-    padding: 7px 0 8px
+    padding: 7px 0
     width: 100%
 
   .v-text-field__prefix


### PR DESCRIPTION
## Description
The padding of VTextarea caused a VTextarea with one row to be 1px taller than a VTextField.  This pull request fixes the 1px difference.

## Motivation and Context
When a VTextarea with one row is placed next to a VTextarea on the same row the 1px difference is noticeable. [This Codepen demonstrates the problem](https://codepen.io/logikgate/pen/QWwGoev)

## How Has This Been Tested?
Visually tested

## Markup:
[This Codepen demonstrates the problem](https://codepen.io/logikgate/pen/QWwGoev)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
