### PR TITLE
chore: keep aligned with general naming of prop

### DIFF
--- a/packages/docs/src/examples/data-tables/intermediate/sort.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/sort.vue
@@ -4,7 +4,7 @@
       :headers="headers"
       :items="desserts"
       :sort-by.sync="sortBy"
-      :sort-desc.sync="descending"
+      :sort-desc.sync="sortDesc"
       class="elevation-1"
     ></v-data-table>
     <div class="text-center pt-2">
@@ -19,7 +19,7 @@
     data () {
       return {
         sortBy: 'fat',
-        descending: false,
+        sortDesc: false,
         headers: [
           {
             text: 'Dessert (100g serving)',


### PR DESCRIPTION
## Description
Update VDataTable docs to reflect updated naming of `descending` prop.

## Motivation and Context
It might be confusing for users to see description only here while everywhere else sortDesc is used now. especially migrating from 1.5.

Yes, I am that user :P


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
