### PR TITLE
docs(icons): remove outdated stylus import

### DIFF
--- a/packages/docs/src/snippets/js/using_missing_material_icons.txt
+++ b/packages/docs/src/snippets/js/using_missing_material_icons.txt
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
-import 'vuetify/src/stylus/app.styl'
 import MaterialIcon from '@/components/MaterialIcon'
 
 function missingMaterialIcons(ids) {


### PR DESCRIPTION
## Description
The docs include an import of the outdated stylus file. Removing this to be aligned with other examples and current version.

## Motivation and Context
Avoid confusion for readers.  
I think the example should still work because all other examples don't have this import.  
I'm not a 100% sure here.

## How Has This Been Tested?
Not tested.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
