### PR TITLE
fix(vautocomplete): avoid setting selectedIndex to 0 after delete

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -245,7 +245,7 @@ export default VSelect.extend({
 
       const index = this.selectedItems.length - 1
 
-      if (this.selectedIndex === -1) {
+      if (this.selectedIndex === -1 && index !== 0) {
         this.selectedIndex = index
         return
       }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -141,7 +141,6 @@ describe('VAutocomplete.ts', () => {
     input.trigger('keydown.backspace')
 
     expect(wrapper.vm.internalValue).toBeUndefined()
-    expect(wrapper.vm.selectedIndex).toBe(-1)
   })
 
   it('should not change selectedIndex to 0 when backspace is pressed', () => {

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -141,5 +141,22 @@ describe('VAutocomplete.ts', () => {
     input.trigger('keydown.backspace')
 
     expect(wrapper.vm.internalValue).toBeUndefined()
+    expect(wrapper.vm.selectedIndex).toBe(-1)
+  })
+
+  it('should not change selectedIndex to 0 when backspace is pressed', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['f', 'b'],
+        value: 'f',
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.trigger('focus')
+    input.trigger('keydown.backspace')
+
+    expect(wrapper.vm.selectedIndex).toBe(-1)
   })
 })


### PR DESCRIPTION
fix #10036

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
e2e

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container fluid>
    <v-row>
      <v-col cols="12">
        <v-combobox
          v-model="select"
          :items="items"
          label="Select a favorite activity or create a new one"
        ></v-combobox>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data () {
      return {
        select: 'f',
        items: [
          'f',
          'b',
        ],
      }
    },
  }
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
