### PR TITLE
fix(VResponsive): tweak styles to work with Firefox

### DIFF
--- a/packages/vuetify/src/components/VResponsive/VResponsive.sass
+++ b/packages/vuetify/src/components/VResponsive/VResponsive.sass
@@ -11,6 +11,9 @@
     flex: 1 0 0px
     max-width: 100%
 
+  &__sizer ~ &__content
+    margin-left: -100%
+
   &__sizer
     transition: padding-bottom 0.2s map-get($transition, 'swing')
-    flex: 0 0 0px
+    flex: 1 0 0px


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->

Alternate method of enforcing aspect ratio which works around buggy behavior in Firefox.

This is yet another attempt at fixing the issue. Unfortunately the previous fix, #10027 had unexpected regressions due to how it changed the DOM structure.

This fix is purely CSS, so it should be less prone to unexpected behavior. Can confirm it does not have the issues from #10094.

It seems the bug in Firefox is isolated to giving `flex: 0 0 0px` to the sizer element. Allowing it to have a size avoids the bug in Firefox, and the negative margin pulls the content back into the correct place. According to the flex spec, you should be able to use `visibility: collapse` on the sizer element to get this same result without the negative margin, [but the MDN documentation points out that Chrome and Safari don't implement this correctly](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items#Collapsed_items). As such, the negative margin is the better alternative.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #9659. @KaelWD @johnleider 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

Visually tested in Chrome, Firefox, and Safari. **Has not been tested in IE11 or Edge.**

Confirmed everything looks sane on the Card, Image, and Aspect Ratios documentation pages.

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
<div id="app">
  <v-app id="inspire">
    <div>
      <v-text-field v-model="aspectRatio"></v-text-field>
      <v-card>
        <v-responsive :aspect-ratio="aspectRatio">
          <v-card-text>
            This card has the above aspect ratio
          </v-card-text>
        </v-responsive>
      </v-card>
    </div>
  </v-app>
</div>
</template>

<script>
new Vue({
  el: '#app',
  vuetify: new Vuetify(),
  data () { 
    return {
      aspectRatio: 16/9
    }
  }
})
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
