### PR TITLE
fix(VExpansionPanel): Missing coma in SASS

### DIFF
--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass
@@ -96,7 +96,7 @@
       &:not(.v-expansion-panel-header__icon--disable-rotate) .v-icon
         transform: rotate(-180deg)
 
-.v-expansion-panels:not(.v-expansion-panels--accordion)
+.v-expansion-panels:not(.v-expansion-panels--accordion),
 .v-expansion-panels:not(.v-expansion-panels--tile)
   > .v-expansion-panel
     &--active


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
Fixes this warning
```
WARNING on line 99, column 1 of stdin:
This selector doesn't have any properties and won't be rendered.
   ╷
99 │ .v-expansion-panels:not(.v-expansion-panels--accordion)
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵


```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I started getting the above warning after upgrading to 2.2.0
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Warning is fixed after applying this change
## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
