### PR TITLE
fix(VDatePickerDateTable): remove '日' character from date picker table

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerDateTable.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerDateTable.ts
@@ -27,7 +27,7 @@ export default mixins(
 
   computed: {
     formatter (): DatePickerFormatter {
-      return this.format || createNativeLocaleFormatter(this.currentLocale, { day: 'numeric', timeZone: 'UTC' }, { start: 8, length: 2 })
+      return this.format || createNativeLocaleFormatter('en', { day: 'numeric', timeZone: 'UTC' }, { start: 8, length: 2 })
     },
     weekdayFormatter (): DatePickerFormatter | undefined {
       return this.weekdayFormat || createNativeLocaleFormatter(this.currentLocale, { weekday: 'narrow', timeZone: 'UTC' })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
The date picker table shows days with '日' character
when locale is 'ja' or 'zh-*', but it is unnatural.

I change it to show days without anything.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
make the v-date-picker better

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
e2e

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue

<template>
  <v-container>
    <v-date-picker v-model="picker"></v-date-picker>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    picker: new Date().toISOString().substr(0, 10)
  })
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [x] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
