### PR TITLE
fix(VStepper): fix the behaviour of the VStepper style on RTL

### DIFF
--- a/packages/vuetify/src/components/VStepper/VStepper.sass
+++ b/packages/vuetify/src/components/VStepper/VStepper.sass
@@ -52,7 +52,11 @@
 
   &--vertical
     .v-stepper__content:not(:last-child)
-      border-left: 1px solid rgba(map-get($material, 'fg-color'), map-get($material, 'divider-percent'))
+      +ltr()
+        border-left: 1px solid rgba(map-get($material, 'fg-color'), map-get($material, 'divider-percent'))
+
+      +rtl()
+        border-right: 1px solid rgba(map-get($material, 'fg-color'), map-get($material, 'divider-percent'))
 
 .v-stepper
   border-radius: $stepper-border-radius
@@ -170,9 +174,13 @@
     padding-bottom: $stepper-vertical-padding-bottom
 
     .v-stepper__content
-      margin: $stepper-vertical-content-margin
       padding: $stepper-vertical-content-padding
       width: auto
+      +ltr()
+        margin: $stepper-vertical-content-ltr-margin
+
+      +rtl()
+        margin: $stepper-vertical-content-rtl-margin
 
     .v-stepper__step
       padding: $stepper-vertical-step-padding

--- a/packages/vuetify/src/components/VStepper/_variables.scss
+++ b/packages/vuetify/src/components/VStepper/_variables.scss
@@ -21,7 +21,8 @@ $stepper-step-step-icon-font-size: map-deep-get($headings, 'h6', 'size') !defaul
 $stepper-step-step-margin: 8px !default;
 $stepper-step-step-min-width: 24px !default;
 $stepper-step-step-width: 24px !default;
-$stepper-vertical-content-margin: -8px -36px -16px 36px !default;
+$stepper-vertical-content-ltr-margin: -8px -36px -16px 36px !default;
+$stepper-vertical-content-rtl-margin: -8px 36px -16px -36px !default;
 $stepper-vertical-content-padding: 16px 60px 16px 23px !default;
 $stepper-vertical-padding-bottom: 36px !default;
 $stepper-vertical-step-padding: 24px 24px 16px !default;


### PR DESCRIPTION
Added a right border on RLT for the VStepper component and also fixed its margins

fix #10098

## Description
A new variable was created to hold the margins on RTL mode, and so, the old $stepper-vertical-content-margin was renamed to $stepper-vertical-content-ltr-margin

## Motivation and Context
Fixes: https://github.com/vuetifyjs/vuetify/issues/10098

## How Has This Been Tested?
unit and visually tested

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-layout column>
      <v-stepper
        v-model="e6"
        vertical
      >
        <v-stepper-step
          :complete="e6 > 1"
          step="1"
        >
          Select an app
          <small>Summarize if needed</small>
        </v-stepper-step>

        <v-stepper-content step="1">
          <v-card
            color="grey lighten-1"
            class="mb-12"
            height="200px"
          ></v-card>
          <v-btn
            color="primary"
            @click="e6 = 2"
          >Continue</v-btn>
          <v-btn text>Cancel</v-btn>
        </v-stepper-content>

        <v-stepper-step
          :complete="e6 > 2"
          step="2"
        >Configure analytics for this app</v-stepper-step>

        <v-stepper-content step="2">
          <v-card
            color="grey lighten-1"
            class="mb-12"
            height="200px"
          ></v-card>
          <v-btn
            color="primary"
            @click="e6 = 3"
          >Continue</v-btn>
          <v-btn text>Cancel</v-btn>
        </v-stepper-content>

        <v-stepper-step
          :complete="e6 > 3"
          step="3"
        >Select an ad format and name ad unit</v-stepper-step>

        <v-stepper-content step="3">
          <v-card
            color="grey lighten-1"
            class="mb-12"
            height="200px"
          ></v-card>
          <v-btn
            color="primary"
            @click="e6 = 4"
          >Continue</v-btn>
          <v-btn text>Cancel</v-btn>
        </v-stepper-content>

        <v-stepper-step step="4">View setup instructions</v-stepper-step>
        <v-stepper-content step="4">
          <v-card
            color="grey lighten-1"
            class="mb-12"
            height="200px"
          ></v-card>
          <v-btn
            color="primary"
            @click="e6 = 1"
          >Continue</v-btn>
          <v-btn text>Cancel</v-btn>
        </v-stepper-content>
      </v-stepper>
    </v-layout>
  </v-container>
</template>

<script>
export default {
  name: "Steppers",

  data: () => ({
    e6: 1
  })
};
</script>

<style scoped>
.center {
  align-self: center;
}
</style>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
