### PR TITLE
fix(VDataTable): fix default table header color

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -20,7 +20,7 @@
         border-bottom: thin solid map-get($material, 'dividers')
 
       th
-        color: map-deep-get($material, 'text', 'primary')
+        color: map-deep-get($material, 'text', 'secondary')
 
   tbody
     tr


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
[#9766](https://github.com/vuetifyjs/vuetify/pull/9766/files#diff-72b8d9f8f633be49d3762ae7ce4f9253L23-R23) introduced a bug causing all headers of data-table to be of primary text color instead of only active or hovered ones.

See: https://vuetifyjs.com/en/components/data-tables#usage

![image](https://user-images.githubusercontent.com/14029371/72071274-662e6a80-3311-11ea-89f9-57685ec1c2b2.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IMO only active or hovered headers should be of primary text color as it used to be before v2.2

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
visually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
