### PR TITLE
fix(VTextfield): legend position with reverse prop

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -387,6 +387,14 @@
 
       +rtl()
         padding-right: $text-field-outlined-fieldset-padding
+    
+
+    &.v-text-field--reverse fieldset
+      +ltr()
+        padding-right: $text-field-outlined-fieldset-padding
+
+      +rtl()
+        padding-left: $text-field-outlined-fieldset-padding
 
     legend
       line-height: $text-field-outlined-legend-line-height
@@ -398,6 +406,13 @@
 
       +rtl()
         text-align: right
+
+    &.v-text-field--reverse legend
+      +ltr()
+        text-align: right
+
+      +rtl()
+        text-align: left
 
     &.v-text-field--rounded
       legend


### PR DESCRIPTION
fix #10277

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
This PR fixes styling of legend in reverse outlined text field.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue #10277 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->
Visually tested

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field label="Label" value="Value" outlined reverse></v-text-field>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    //
  })
}
</script>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
