### PR TITLE
fix(VRipple): add keyboard trigger support

### DIFF
--- a/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
+++ b/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
@@ -10,22 +10,30 @@ import {
 } from '@vue/test-utils'
 
 describe('ripple.ts', () => {
-  it('Ripple with no value should render element with ripple enabled', () => {
-    const testComponent = Vue.component('test', {
-      directives: {
-        Ripple,
-      },
-      render (h) {
-        const data = {
-          directives: [{
-            name: 'ripple',
-          }],
-        }
-        return h('div', data)
-      },
-    })
+  let mountFunction: (options?: object) => Wrapper<Vue>
 
-    const wrapper = mount(testComponent)
+  beforeEach(() => {
+    mountFunction = (options = {}) => {
+      const testComponent = Vue.component('test', {
+        directives: {
+          Ripple,
+        },
+        render (h) {
+          const data = {
+            directives: [{
+              name: 'ripple',
+            }],
+          }
+          return h('div', data)
+        },
+      })
+
+      return mount(testComponent, options)
+    }
+  })
+
+  it('Ripple with no value should render element with ripple enabled', () => {
+    const wrapper = mountFunction()
 
     const div = wrapper.find('div')
     expect(div.element['_ripple'].enabled).toBe(true)
@@ -65,5 +73,56 @@ describe('ripple.ts', () => {
 
     wrapper.setProps({ ripple: true })
     expect(div.element['_ripple'].enabled).toBe(true)
+  })
+
+  it('Ripple should be triggered by the mousedown event', () => {
+    jest.useFakeTimers()
+
+    const wrapper = mountFunction()
+
+    const mousedownEvent = new MouseEvent('mousedown', { detail: 1 })
+    wrapper.element.dispatchEvent(mousedownEvent)
+
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(true)
+
+    const mouseupEvent = new MouseEvent('mouseup', { detail: 1 })
+    wrapper.element.dispatchEvent(mouseupEvent)
+
+    jest.runAllTimers()
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
+  })
+
+  it('Ripple should be triggered by the enter key', () => {
+    jest.useFakeTimers()
+
+    const wrapper = mountFunction()
+
+    const keydownEvent = new KeyboardEvent('keydown', { keyCode: 13 })
+    wrapper.element.dispatchEvent(keydownEvent)
+
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(true)
+
+    const keyupEvent = new KeyboardEvent('keyup')
+    wrapper.element.dispatchEvent(keyupEvent)
+
+    jest.runAllTimers()
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
+  })
+
+  it('Ripple should be triggered by the space key', () => {
+    jest.useFakeTimers()
+
+    const wrapper = mountFunction()
+
+    const keydownEvent = new KeyboardEvent('keydown', { keyCode: 32 })
+    wrapper.element.dispatchEvent(keydownEvent)
+
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(true)
+
+    const keyupEvent = new KeyboardEvent('keyup')
+    wrapper.element.dispatchEvent(keyupEvent)
+
+    jest.runAllTimers()
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
   })
 })

--- a/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
+++ b/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
@@ -38,14 +38,14 @@ describe('ripple.ts', () => {
     jest.useRealTimers()
   })
 
-  it('Ripple with no value should render element with ripple enabled', () => {
+  it('should render element with ripple enabled if no value is passed', () => {
     const wrapper = mountFunction()
 
     const div = wrapper.find('div')
     expect(div.element['_ripple'].enabled).toBe(true)
   })
 
-  it('Ripple should update element property reactively', () => {
+  it('should update element property reactively', () => {
     const testComponent = Vue.component('test', {
       directives: {
         Ripple,
@@ -81,7 +81,7 @@ describe('ripple.ts', () => {
     expect(div.element['_ripple'].enabled).toBe(true)
   })
 
-  it('Ripple should be triggered by the mousedown event', () => {
+  it('should trigger ripple on mousedown', () => {
     const wrapper = mountFunction()
 
     const mousedownEvent = new MouseEvent('mousedown', { detail: 1 })
@@ -96,7 +96,7 @@ describe('ripple.ts', () => {
     expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
   })
 
-  it('Ripple should be triggered by the enter key', () => {
+  it('should trigger ripple on enter key press', () => {
     const wrapper = mountFunction()
 
     const keydownEvent = new KeyboardEvent('keydown', { keyCode: 13 })
@@ -111,7 +111,7 @@ describe('ripple.ts', () => {
     expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
   })
 
-  it('Ripple should be triggered by the space key', () => {
+  it('should trigger ripple on space key press', () => {
     const wrapper = mountFunction()
 
     const keydownEvent = new KeyboardEvent('keydown', { keyCode: 32 })

--- a/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
+++ b/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
@@ -13,6 +13,8 @@ describe('ripple.ts', () => {
   let mountFunction: (options?: object) => Wrapper<Vue>
 
   beforeEach(() => {
+    jest.useFakeTimers()
+
     mountFunction = (options = {}) => {
       const testComponent = Vue.component('test', {
         directives: {
@@ -30,6 +32,10 @@ describe('ripple.ts', () => {
 
       return mount(testComponent, options)
     }
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('Ripple with no value should render element with ripple enabled', () => {
@@ -76,8 +82,6 @@ describe('ripple.ts', () => {
   })
 
   it('Ripple should be triggered by the mousedown event', () => {
-    jest.useFakeTimers()
-
     const wrapper = mountFunction()
 
     const mousedownEvent = new MouseEvent('mousedown', { detail: 1 })
@@ -93,8 +97,6 @@ describe('ripple.ts', () => {
   })
 
   it('Ripple should be triggered by the enter key', () => {
-    jest.useFakeTimers()
-
     const wrapper = mountFunction()
 
     const keydownEvent = new KeyboardEvent('keydown', { keyCode: 13 })
@@ -110,8 +112,6 @@ describe('ripple.ts', () => {
   })
 
   it('Ripple should be triggered by the space key', () => {
-    jest.useFakeTimers()
-
     const wrapper = mountFunction()
 
     const keydownEvent = new KeyboardEvent('keydown', { keyCode: 32 })

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -1,8 +1,12 @@
 // Styles
 import './VRipple.sass'
 
-import { VNode, VNodeDirective } from 'vue'
+// Utilities
+import { keyCodes } from '../../util/helpers'
 import { consoleWarn } from '../../util/console'
+
+// Types
+import { VNode, VNodeDirective } from 'vue'
 
 function transform (el: HTMLElement, value: string) {
   el.style['transform'] = value
@@ -27,12 +31,18 @@ function isKeyboardEvent (e: MouseEvent | TouchEvent | KeyboardEvent): e is Keyb
   return e.constructor.name === 'KeyboardEvent'
 }
 
-const calculate = (e: MouseEvent | TouchEvent | KeyboardEvent, el: HTMLElement, value: RippleOptions = {}) => {
+const calculate = (
+  e: MouseEvent | TouchEvent | KeyboardEvent,
+  el: HTMLElement,
+  value: RippleOptions = {}
+) => {
   let localX = 0
   let localY = 0
+
   if (!isKeyboardEvent(e)) {
     const offset = el.getBoundingClientRect()
     const target = isTouchEvent(e) ? e.touches[e.touches.length - 1] : e
+
     localX = target.clientX - offset.left
     localY = target.clientY - offset.top
   }
@@ -58,7 +68,11 @@ const calculate = (e: MouseEvent | TouchEvent | KeyboardEvent, el: HTMLElement, 
 
 const ripples = {
   /* eslint-disable max-statements */
-  show (e: MouseEvent | TouchEvent | KeyboardEvent, el: HTMLElement, value: RippleOptions = {}) {
+  show (
+    e: MouseEvent | TouchEvent | KeyboardEvent,
+    el: HTMLElement,
+    value: RippleOptions = {}
+  ) {
     if (!el._ripple || !el._ripple.enabled) {
       return
     }
@@ -173,7 +187,7 @@ function rippleHide (e: Event) {
 
 let keyboardRipple = false
 function keyboardRippleShow (e: KeyboardEvent) {
-  if (!keyboardRipple && (e.keyCode === 13 || e.keyCode === 32)) {
+  if (!keyboardRipple && (e.keyCode === keyCodes.enter || e.keyCode === keyCodes.space)) {
     keyboardRipple = true
     rippleShow(e)
   }

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -2,8 +2,8 @@
 import './VRipple.sass'
 
 // Utilities
-import { keyCodes } from '../../util/helpers'
 import { consoleWarn } from '../../util/console'
+import { keyCodes } from '../../util/helpers'
 
 // Types
 import { VNode, VNodeDirective } from 'vue'

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -28,15 +28,13 @@ function isKeyboardEvent (e: MouseEvent | TouchEvent | KeyboardEvent): e is Keyb
 }
 
 const calculate = (e: MouseEvent | TouchEvent | KeyboardEvent, el: HTMLElement, value: RippleOptions = {}) => {
-  let localX, localY
+  let localX = 0
+  let localY = 0
   if (!isKeyboardEvent(e)) {
     const offset = el.getBoundingClientRect()
     const target = isTouchEvent(e) ? e.touches[e.touches.length - 1] : e
     localX = target.clientX - offset.left
     localY = target.clientY - offset.top
-  } else {
-    localX = el.clientWidth / 2
-    localY = el.clientHeight / 2
   }
 
   let radius = 0
@@ -154,7 +152,7 @@ function rippleShow (e: MouseEvent | TouchEvent | KeyboardEvent) {
     // already been registered as touch
     if (element._ripple.isTouch) return
   }
-  value.center = element._ripple.centered
+  value.center = element._ripple.centered || isKeyboardEvent(e)
   if (element._ripple.class) {
     value.class = element._ripple.class
   }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
This PR makes it possible to trigger the ripple effect by pressing the space or enter key on the focused element.

## Motivation and Context
#10285
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
unit | visually
<!--- Please describe how you tested your changes. -->
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-btn color="primary">Primary</v-btn>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    //
  })
}
</script>
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
