### PR TITLE
docs: fix grammatical error caused by wrong tense usage

### DIFF
--- a/packages/docs/src/lang/en/components/DataTables.json
+++ b/packages/docs/src/lang/en/components/DataTables.json
@@ -122,7 +122,7 @@
   },
   "slots": {
     "v-data-table": {
-      "body": "Slot to replaces the default table `<tbody>`",
+      "body": "Slot to replace the default table `<tbody>`",
       "body.append": "Appends elements to the end of the default table `<tbody>`",
       "body.prepend": "Prepends elements to the start of the default table `<tbody>`",
       "expanded-item": "Slot to customize expanded rows",


### PR DESCRIPTION

## Description
Fix grammatical error caused by wrong tense usage

## Motivation and Context
Makes the documentation read well

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
