### PR TITLE
fix(vdata): prevent array value from sort-desc

### DIFF
--- a/packages/vuetify/src/components/VData/VData.ts
+++ b/packages/vuetify/src/components/VData/VData.ts
@@ -219,7 +219,7 @@ export default Vue.extend({
       this.updateOptions({ sortDesc: wrapInArray(sortDesc) })
     },
     'internalOptions.sortDesc' (sortDesc: boolean[], old: boolean[]) {
-      !deepEqual(sortDesc, old) && this.$emit('update:sort-desc', Array.isArray(this.sortDesc) ? sortDesc : sortDesc[0])
+      !deepEqual(sortDesc, old) && this.$emit('update:sort-desc', Array.isArray(sortDesc) ? sortDesc[0] : sortDesc)
     },
     groupBy (groupBy: string | string[]) {
       this.updateOptions({ groupBy: wrapInArray(groupBy) })


### PR DESCRIPTION
VData would emit correct values for the first 3 sorts of a data-table column, followed by emitting
array values for every sort following. VData now correctly removes the array before emitting the
value.

fixes #9267
