### PR TITLE
fix(VDataIterator): add isMobile property to custom item slot scope

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -82,7 +82,7 @@ export default Themeable.extend({
       // https://github.com/vuetifyjs/vuetify/issues/7410
       if (this.$vuetify.breakpoint.width === 0) return false
 
-      return this.$vuetify.breakpoint.width < parseInt(this.mobileBreakPoint, 10)
+      return this.$vuetify.breakpoint.width < parseInt(this.mobileBreakpoint, 10)
     },
   },
 

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -32,6 +32,10 @@ export default Themeable.extend({
       type: Array as PropType<any[]>,
       default: () => [],
     },
+    mobileBreakpoint: {
+      type: Number,
+      default: 600,
+    },
     singleExpand: Boolean,
     loading: [Boolean, String],
     noResultsText: {
@@ -72,6 +76,9 @@ export default Themeable.extend({
     },
     selectableItems (): any[] {
       return this.internalCurrentItems.filter(item => this.isSelectable(item))
+    },
+    isMobile (): boolean {
+      return this.$vuetify.breakpoint.width < this.mobileBreakpoint
     },
   },
 
@@ -192,15 +199,14 @@ export default Themeable.extend({
       this.$emit('item-expanded', { item, value })
     },
     createItemProps (item: any) {
-      const props = {
+      return {
         item,
         select: (v: boolean) => this.select(item, v),
         isSelected: this.isSelected(item),
         expand: (v: boolean) => this.expand(item, v),
         isExpanded: this.isExpanded(item),
+        isMobile: this.isMobile,
       }
-
-      return props
     },
     genEmptyWrapper (content: VNodeChildren) {
       return this.$createElement('div', content)

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -78,6 +78,10 @@ export default Themeable.extend({
       return this.internalCurrentItems.filter(item => this.isSelectable(item))
     },
     isMobile (): boolean {
+      // Guard against SSR render
+      // https://github.com/vuetifyjs/vuetify/issues/7410
+      if (this.$vuetify.breakpoint.width === 0) return false
+
       return this.$vuetify.breakpoint.width < this.mobileBreakpoint
     },
   },

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -33,7 +33,7 @@ export default Themeable.extend({
       default: () => [],
     },
     mobileBreakpoint: {
-      type: Number,
+      type: [Number, String],
       default: 600,
     },
     singleExpand: Boolean,
@@ -82,7 +82,7 @@ export default Themeable.extend({
       // https://github.com/vuetifyjs/vuetify/issues/7410
       if (this.$vuetify.breakpoint.width === 0) return false
 
-      return this.$vuetify.breakpoint.width < this.mobileBreakpoint
+      return this.$vuetify.breakpoint.width < parseInt(this.mobileBreakPoint, 10)
     },
   },
 

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@vue/test-utils'
 import Vue from 'vue'
 import { preset } from '../../../presets/default'
-import {Breakpoint} from "../../../services/breakpoint";
+import { Breakpoint } from "../../../services/breakpoint";
 
 Vue.prototype.$vuetify = {
   icons: {

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@vue/test-utils'
 import Vue from 'vue'
 import { preset } from '../../../presets/default'
-import { Breakpoint } from "../../../services/breakpoint"
+import { Breakpoint } from '../../../services/breakpoint'
 
 Vue.prototype.$vuetify = {
   icons: {

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@vue/test-utils'
 import Vue from 'vue'
 import { preset } from '../../../presets/default'
+import {Breakpoint} from "../../../services/breakpoint";
 
 Vue.prototype.$vuetify = {
   icons: {
@@ -30,6 +31,7 @@ describe('VDataIterator.ts', () => {
       return mount(VDataIterator, {
         mocks: {
           $vuetify: {
+            breakpoint: new Breakpoint(preset),
             lang: new Lang(preset),
             theme: {
               dark: false,

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
@@ -6,8 +6,8 @@ import {
   Wrapper,
 } from '@vue/test-utils'
 import Vue from 'vue'
-import { preset } from '../../../presets/default'
 import { Breakpoint } from '../../../services/breakpoint'
+import { preset } from '../../../presets/default'
 
 Vue.prototype.$vuetify = {
   icons: {

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataIterator.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@vue/test-utils'
 import Vue from 'vue'
 import { preset } from '../../../presets/default'
-import { Breakpoint } from "../../../services/breakpoint";
+import { Breakpoint } from "../../../services/breakpoint"
 
 Vue.prototype.$vuetify = {
   icons: {

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
@@ -202,7 +202,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-21"
+               aria-owns="list-31"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -211,7 +211,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                   10
                 </div>
                 <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                       id="input-21"
+                       id="input-31"
                        readonly="readonly"
                        type="text"
                        aria-readonly="true"
@@ -288,7 +288,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-21"
+               aria-owns="list-31"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -297,7 +297,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                   10
                 </div>
                 <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                       id="input-21"
+                       id="input-31"
                        readonly="readonly"
                        type="text"
                        aria-readonly="true"
@@ -374,7 +374,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-21"
+               aria-owns="list-31"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -383,7 +383,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                   10
                 </div>
                 <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                       id="input-21"
+                       id="input-31"
                        readonly="readonly"
                        type="text"
                        aria-readonly="true"

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
@@ -202,7 +202,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-31"
+               aria-owns="list-21"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -211,7 +211,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                   10
                 </div>
                 <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                       id="input-31"
+                       id="input-21"
                        readonly="readonly"
                        type="text"
                        aria-readonly="true"
@@ -288,7 +288,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-31"
+               aria-owns="list-21"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -297,7 +297,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                   10
                 </div>
                 <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                       id="input-31"
+                       id="input-21"
                        readonly="readonly"
                        type="text"
                        aria-readonly="true"
@@ -374,7 +374,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-31"
+               aria-owns="list-21"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -383,7 +383,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                   10
                 </div>
                 <input aria-label="$vuetify.dataFooter.itemsPerPageText"
-                       id="input-31"
+                       id="input-21"
                        readonly="readonly"
                        type="text"
                        aria-readonly="true"

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -80,10 +80,6 @@ export default VDataIterator.extend({
     showGroupBy: Boolean,
     // TODO: Fix
     // virtualRows: Boolean,
-    mobileBreakpoint: {
-      type: Number,
-      default: 600,
-    },
     height: [Number, String],
     hideDefaultHeader: Boolean,
     caption: String,
@@ -134,13 +130,6 @@ export default VDataIterator.extend({
       return this.isMobile ? undefined : {
         colspan: this.headersLength || this.computedHeaders.length,
       }
-    },
-    isMobile (): boolean {
-      // Guard against SSR render
-      // https://github.com/vuetifyjs/vuetify/issues/7410
-      if (this.$vuetify.breakpoint.width === 0) return false
-
-      return this.$vuetify.breakpoint.width < this.mobileBreakpoint
     },
     columnSorters (): Record<string, DataTableCompareFunction> {
       return this.computedHeaders.reduce<Record<string, DataTableCompareFunction>>((acc, header) => {

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -5455,19 +5455,19 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
       </thead>
       <tbody>
         <div>
-          {"item":{"name":"Frozen Yogurt","calories":159,"fat":6,"carbs":24,"protein":4,"iron":"1%"},"isSelected":false,"isExpanded":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":0}
+          {"item":{"name":"Frozen Yogurt","calories":159,"fat":6,"carbs":24,"protein":4,"iron":"1%"},"isSelected":false,"isExpanded":false,"isMobile":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":0}
         </div>
         <div>
-          {"item":{"name":"Ice cream sandwich","calories":237,"fat":9,"carbs":37,"protein":4.3,"iron":"1%"},"isSelected":false,"isExpanded":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":1}
+          {"item":{"name":"Ice cream sandwich","calories":237,"fat":9,"carbs":37,"protein":4.3,"iron":"1%"},"isSelected":false,"isExpanded":false,"isMobile":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":1}
         </div>
         <div>
-          {"item":{"name":"Eclair","calories":262,"fat":16,"carbs":23,"protein":6,"iron":"7%"},"isSelected":false,"isExpanded":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":2}
+          {"item":{"name":"Eclair","calories":262,"fat":16,"carbs":23,"protein":6,"iron":"7%"},"isSelected":false,"isExpanded":false,"isMobile":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":2}
         </div>
         <div>
-          {"item":{"name":"Cupcake","calories":305,"fat":3.7,"carbs":67,"protein":4.3,"iron":"8%"},"isSelected":false,"isExpanded":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":3}
+          {"item":{"name":"Cupcake","calories":305,"fat":3.7,"carbs":67,"protein":4.3,"iron":"8%"},"isSelected":false,"isExpanded":false,"isMobile":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":3}
         </div>
         <div>
-          {"item":{"name":"Gingerbread","calories":356,"fat":16,"carbs":49,"protein":3.9,"iron":"16%"},"isSelected":false,"isExpanded":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":4}
+          {"item":{"name":"Gingerbread","calories":356,"fat":16,"carbs":49,"protein":3.9,"iron":"16%"},"isSelected":false,"isExpanded":false,"isMobile":false,"headers":[{"text":"Dessert (100g serving)","align":"left","sortable":false,"value":"name"},{"text":"Calories","value":"calories"},{"text":"Fat (g)","value":"fat"},{"text":"Carbs (g)","value":"carbs"},{"text":"Protein (g)","value":"protein"},{"text":"Iron (%)","value":"iron"}],"index":4}
         </div>
       </tbody>
     </table>


### PR DESCRIPTION
Add possibility to customize 'item' slot in DataTable and DataIterator in mobile view by introducing
isMobile property to be available in the scope.

fix #9436

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Custom `item` slots in DataTable render badly on mobiles. Header in table is responsive but the slot is not, which causes it to look really bad (https://codepen.io/AshrafBasry/pen/QWWdeML). The proposed solution is the easiest possible - by adding `isMobile` prop into the scope, we can allow the developer to customize their `item` slot both for normal and mobile view.

## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/9436
https://github.com/vuetifyjs/vuetify/issues/8394

## How Has This Been Tested?
Visually.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table :headers="tableHeaders" :items="tableData">
      <template v-slot:item="{item, isMobile}">
        <tr v-if="!isMobile">
          <td>{{item.col1}}</td>
          <td>{{item.col2}}</td>
          <td>{{item.col3}}</td>
          <td>{{item.col4}}</td>
        </tr>
        <tr v-else>
          <td>Custom mobile view - {{item.col1}}</td>
        </tr>
      </template>
    </v-data-table>

    <v-data-iterator :items="tableData">
      <template v-slot:item="{item, isMobile}">
        <v-card v-if="!isMobile" class="my-2">
          <v-card-title class="subheading font-weight-bold">
            {{item.col1}}
          </v-card-title>
          <v-card-actions>
            <p>Desktop item view</p>
          </v-card-actions>
        </v-card>
        <v-card v-else class="my-2">
          <v-card-title class="subheading font-weight-bold">
            {{item.col1}}
          </v-card-title>
          <v-card-actions>
            <p>Mobile item view</p>
          </v-card-actions>
        </v-card>
      </template>
    </v-data-iterator>
  </v-container>
</template>

<script>
export default {
  data() {
    return {
      tableHeaders: [
          {
            text: 'Col 1',
            sortable: true,
            value: 'col1'
          }, {
            text: 'Col 2',
            sortable: false,
            value: 'col2'
          },{
            text: 'Col 3',
            sortable: false,
            value: 'col3'
          }, {
            text: 'Col 4',
            sortable: false,
            value: 'col4'
          }
        ],
      tableData: [
          {
            col1: 'Data 1',
            col2: "Data 2",
            col3: "Data 3",
            col4: "Data 4",
          },
          {
            col1: 'Data 1',
            col2: "Data 2",
            col3: "Data 3",
            col4: "Data 4",
          },
          {
            col1: 'Data 1',
            col2: "Data 2",
            col3: "Data 3",
            col4: "Data 4",
          },
        ]
    }
  }
}
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
