### PR TITLE
fix(VTimePicker): show 12 hr time in title in ampm mode

### DIFF
--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.ts
@@ -338,7 +338,8 @@ export default mixins(
     genPickerTitle () {
       return this.$createElement(VTimePickerTitle, {
         props: {
-          ampm: this.ampmInTitle && this.isAmPm,
+          ampm: this.isAmPm,
+          ampmReadonly: this.isAmPm && !this.ampmInTitle,
           disabled: this.disabled,
           hour: this.inputHour,
           minute: this.inputMinute,

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.sass
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.sass
@@ -1,4 +1,5 @@
 @import './_variables.scss'
+@import '../VPicker/_variables.scss'
 
 .v-time-picker-title
   color: $time-picker-title-color
@@ -33,6 +34,10 @@
 
   div:only-child
     flex-direction: row
+
+  &--readonly
+    .v-picker__title__btn.v-picker__title__btn--active
+      opacity: $picker-inactive-btn-opacity
 
 .v-picker__title--landscape
   .v-time-picker-title

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.ts
@@ -18,6 +18,7 @@ export default mixins(
 
   props: {
     ampm: Boolean,
+    ampmReadonly: Boolean,
     disabled: Boolean,
     hour: Number,
     minute: Number,
@@ -58,9 +59,12 @@ export default mixins(
     genAmPm () {
       return this.$createElement('div', {
         staticClass: 'v-time-picker-title__ampm',
+        class: {
+          'v-time-picker-title__ampm--readonly': this.ampmReadonly,
+        },
       }, [
-        this.genPickerButton('period', 'am', this.$vuetify.lang.t('$vuetify.timePicker.am'), this.disabled || this.readonly),
-        this.genPickerButton('period', 'pm', this.$vuetify.lang.t('$vuetify.timePicker.pm'), this.disabled || this.readonly),
+        (!this.ampmReadonly || this.period === 'am') ? this.genPickerButton('period', 'am', this.$vuetify.lang.t('$vuetify.timePicker.am'), this.disabled || this.readonly) : null,
+        (!this.ampmReadonly || this.period === 'pm') ? this.genPickerButton('period', 'pm', this.$vuetify.lang.t('$vuetify.timePicker.pm'), this.disabled || this.readonly) : null,
       ])
     },
   },

--- a/packages/vuetify/src/components/VTimePicker/__tests__/__snapshots__/VTimePicker.spec.ts.snap
+++ b/packages/vuetify/src/components/VTimePicker/__tests__/__snapshots__/VTimePicker.spec.ts.snap
@@ -6,13 +6,18 @@ exports[`VTimePicker.ts should accept a date object for a value 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          00
+          12
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -132,7 +137,7 @@ exports[`VTimePicker.ts should accept a date object for a value. with useSeconds
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          00
+          12
         </div>
         <span>
           :
@@ -145,6 +150,11 @@ exports[`VTimePicker.ts should accept a date object for a value. with useSeconds
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -264,13 +274,18 @@ exports[`VTimePicker.ts should accept a value 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn">
           12
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -390,7 +405,7 @@ exports[`VTimePicker.ts should accept a value. with useSeconds 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
@@ -403,6 +418,11 @@ exports[`VTimePicker.ts should accept a value. with useSeconds 1`] = `
         </span>
         <div class="v-picker__title__btn">
           34
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -522,13 +542,18 @@ exports[`VTimePicker.ts should change am/pm when updated from model 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          21
+          9
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          PM
         </div>
       </div>
     </div>
@@ -648,7 +673,7 @@ exports[`VTimePicker.ts should change am/pm when updated from model. with useSec
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          21
+          9
         </div>
         <span>
           :
@@ -661,6 +686,11 @@ exports[`VTimePicker.ts should change am/pm when updated from model. with useSec
         </span>
         <div class="v-picker__title__btn">
           12
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          PM
         </div>
       </div>
     </div>
@@ -780,13 +810,18 @@ exports[`VTimePicker.ts should render colored time picker 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -906,13 +941,18 @@ exports[`VTimePicker.ts should render colored time picker, header 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -1032,7 +1072,7 @@ exports[`VTimePicker.ts should render colored time picker, header. with useSecon
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
@@ -1045,6 +1085,11 @@ exports[`VTimePicker.ts should render colored time picker, header. with useSecon
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -1164,7 +1209,7 @@ exports[`VTimePicker.ts should render colored time picker. with useSeconds 1`] =
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
@@ -1177,6 +1222,11 @@ exports[`VTimePicker.ts should render colored time picker. with useSeconds 1`] =
         </span>
         <div class="v-picker__title__btn">
           00
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -1303,6 +1353,11 @@ exports[`VTimePicker.ts should render dark time picker 1`] = `
         </span>
         <div class="v-picker__title__btn">
           --
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -1437,6 +1492,11 @@ exports[`VTimePicker.ts should render dark time picker. with useSeconds 1`] = `
           --
         </div>
       </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
+        </div>
+      </div>
     </div>
   </div>
   <div class="v-picker__body theme--dark"
@@ -1554,13 +1614,18 @@ exports[`VTimePicker.ts should render disabled component 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active v-picker__title__btn--readonly">
-          09
+          9
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn v-picker__title__btn--readonly">
           12
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active v-picker__title__btn--readonly">
+          AM
         </div>
       </div>
     </div>
@@ -1680,7 +1745,7 @@ exports[`VTimePicker.ts should render disabled component. with useSeconds 1`] = 
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active v-picker__title__btn--readonly">
-          09
+          9
         </div>
         <span>
           :
@@ -1693,6 +1758,11 @@ exports[`VTimePicker.ts should render disabled component. with useSeconds 1`] = 
         </span>
         <div class="v-picker__title__btn v-picker__title__btn--readonly">
           34
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active v-picker__title__btn--readonly">
+          AM
         </div>
       </div>
     </div>
@@ -1812,13 +1882,18 @@ exports[`VTimePicker.ts should render landscape component 1`] = `
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
         </span>
         <div class="v-picker__title__btn">
           12
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>
@@ -1938,7 +2013,7 @@ exports[`VTimePicker.ts should render landscape component. with useSeconds 1`] =
     <div class="v-time-picker-title">
       <div class="v-time-picker-title__time">
         <div class="v-picker__title__btn v-picker__title__btn--active">
-          09
+          9
         </div>
         <span>
           :
@@ -1951,6 +2026,11 @@ exports[`VTimePicker.ts should render landscape component. with useSeconds 1`] =
         </span>
         <div class="v-picker__title__btn">
           34
+        </div>
+      </div>
+      <div class="v-time-picker-title__ampm v-time-picker-title__ampm--readonly">
+        <div class="v-picker__title__btn v-picker__title__btn--active">
+          AM
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/15625235/73284596-668e9700-4227-11ea-978a-03ba0e86b4ed.png)


### After

![image](https://user-images.githubusercontent.com/15625235/73284547-5676b780-4227-11ea-95cf-434cfde35ee8.png)


## Motivation and Context
fixes #9572

## How Has This Been Tested?
unit, playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-time-picker></v-time-picker>
    <v-time-picker ampm-in-title></v-time-picker>
    <v-time-picker format="24hr"></v-time-picker>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
