### PR TITLE
fix(VDatePicker): events alignment on current date

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerTable.sass
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerTable.sass
@@ -77,5 +77,8 @@
 .v-date-picker-table--month .v-date-picker-table__events
   bottom: $date-picker-event-date-bottom
 
+.v-date-picker-table__current .v-date-picker-table__events
+  margin-bottom: -1px
+
 .v-date-picker-table--disabled
   pointer-events: none

--- a/packages/vuetify/src/components/VDatePicker/__tests__/__snapshots__/VDatePickerMonthTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/__snapshots__/VDatePickerMonthTable.spec.ts.snap
@@ -45,7 +45,7 @@ exports[`VDatePickerMonthTable.ts should render component and match snapshot (mu
         </td>
         <td>
           <button type="button"
-                  class="v-btn v-size--default v-btn--outlined theme--light accent--text"
+                  class="v-btn v-size--default v-date-picker-table__current v-btn--outlined theme--light accent--text"
           >
             <div class="v-btn__content">
               May
@@ -170,7 +170,7 @@ exports[`VDatePickerMonthTable.ts should render component and match snapshot 1`]
         </td>
         <td>
           <button type="button"
-                  class="v-btn v-size--default v-btn--outlined theme--light accent--text"
+                  class="v-btn v-size--default v-date-picker-table__current v-btn--outlined theme--light accent--text"
           >
             <div class="v-btn__content">
               May

--- a/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
+++ b/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
@@ -77,6 +77,7 @@ export default mixins(
     genButtonClasses (isAllowed: boolean, isFloating: boolean, isSelected: boolean, isCurrent: boolean) {
       return {
         'v-size--default': !isFloating,
+        'v-date-picker-table__current': isCurrent,
         'v-btn--active': isSelected,
         'v-btn--flat': !isAllowed || this.disabled,
         'v-btn--text': isSelected === isCurrent,


### PR DESCRIPTION

## Motivation and Context
fixes #8182

## How Has This Been Tested?
unit,  playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-date-picker value="2020-01" :events="['2020-11', '2020-12']" show-current="2020-11" type="month"></v-date-picker>
    <v-date-picker value="2020-11-01" :events="['2020-11-05', '2020-11-06']" show-current="2020-11-05" type="date"></v-date-picker>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
