### PR TITLE
fix(VPicker): content position in landscape mode

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/_variables.scss
+++ b/packages/vuetify/src/components/VDatePicker/_variables.scss
@@ -2,8 +2,8 @@
 
 $date-picker-years-font-size: 16px !default;
 $date-picker-years-font-weight: 400 !default;
-$date-picker-years-portrait-height: 286px !default;
-$date-picker-years-landscape-height: 286px !default;
+$date-picker-years-portrait-height: 290px !default;
+$date-picker-years-landscape-height: 290px !default;
 $date-picker-years-item-padding: 8px 0 !default;
 $date-picker-years-active-font-size: 26px !default;
 $date-picker-years-active-font-weight: 500 !default;

--- a/packages/vuetify/src/components/VPicker/VPicker.sass
+++ b/packages/vuetify/src/components/VPicker/VPicker.sass
@@ -17,6 +17,7 @@
 
 .v-picker--full-width
   display: flex
+  width: 100%
 
   > .v-picker__body
     margin: initial
@@ -69,10 +70,21 @@
     width: $picker-landscape-title-width
     position: absolute
     top: 0
-    left: 0
     height: 100%
     z-index: 1
 
+    +ltr()
+      left: 0
+
+    +rtl()
+      right: 0
+
   .v-picker__body:not(.v-picker__body--no-title),
   .v-picker__actions:not(.v-picker__actions--no-title)
-    margin-left: $picker-landscape-title-width
+    +ltr()
+      margin-left: $picker-landscape-title-width
+      margin-right: 0
+
+    +rtl()
+      margin-right: $picker-landscape-title-width
+      margin-left: 0


### PR DESCRIPTION
1. sets full-width picker to 100%
2. fixes the years height to be the same as month/date
3. moves picker title in landscape mode to the right side in RTL

## Motivation and Context
fixes #9258

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <div>
      <v-btn @click="$vuetify.rtl = !$vuetify.rtl">rtl: {{ $vuetify.rtl }}</v-btn>
      <v-btn @click="landscape = !landscape">landscape: {{ landscape }}</v-btn>
      <v-btn @click="fullWidth = !fullWidth">full width: {{ fullWidth }}</v-btn>
      <v-btn @click="noTitle = !noTitle">noTitle: {{ noTitle }}</v-btn>
    </div>
    <v-row align="center">
      <v-date-picker
        :full-width="fullWidth"
        :landscape="landscape"
        :no-title="noTitle"
      />
    </v-row>

    <v-btn @click="menu = true">Open menu</v-btn>
    <v-menu
      v-model="menu"
      min-width="600"
      max-width="600"
      :close-on-content-click="false"
    >
      <v-date-picker
        :full-width="fullWidth"
        :landscape="landscape"
        :no-title="noTitle"
      />
    </v-menu>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      landscape: true,
      fullWidth: true,
      noTitle: false,
      menu: false,
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
