### PR TITLE
Update v-data-table.js -> headers (align: end->right)

### DIFF
--- a/packages/api-generator/src/maps/v-data-table.js
+++ b/packages/api-generator/src/maps/v-data-table.js
@@ -6,7 +6,7 @@ const { DataFooterPageTextScopedProps } = require('./v-data-footer')
 const TableHeader = {
   text: 'string',
   value: 'string',
-  'align?': '\'start\' | \'center\' | \'end\'',
+  'align?': '\'start\' | \'center\' | \'right\'',
   'sortable?': 'boolean',
   'filterable?': 'boolean',
   'divider?': 'boolean',


### PR DESCRIPTION
Value `end` and applied css class `text-end` does not work. Value `right` and then applied css class `text-right` will align text right.