### PR TITLE
fix(VTimePicker): AM/PM farsi translation and margins in RTL mode

### DIFF
--- a/packages/vuetify/src/components/VTimePicker/VTimePickerClock.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerClock.ts
@@ -7,6 +7,7 @@ import Themeable from '../../mixins/themeable'
 // Types
 import mixins, { ExtractVue } from '../../util/mixins'
 import Vue, { VNode, PropType } from 'vue'
+import { PropValidator } from 'vue/types/options'
 
 interface Point {
   x: number
@@ -42,7 +43,7 @@ export default mixins<options &
     format: {
       type: Function,
       default: (val: string | number) => val,
-    },
+    } as PropValidator<(val: string | number) => string | number>,
     max: {
       type: Number,
       required: true,

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.sass
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.sass
@@ -23,8 +23,13 @@
   display: flex
   flex-direction: column
   font-size: $time-picker-ampm-title-font-size
-  margin: $time-picker-ampm-title-margin
   text-transform: uppercase
+
+  +ltr()
+    margin: $time-picker-ampm-title-margin-ltr
+
+  +rtl()
+    margin: $time-picker-ampm-title-margin-rtl
 
   div:only-child
     flex-direction: row

--- a/packages/vuetify/src/components/VTimePicker/_variables.scss
+++ b/packages/vuetify/src/components/VTimePicker/_variables.scss
@@ -3,7 +3,11 @@
 $time-picker-title-color: map-get($shades, 'white') !default;
 $time-picker-title-btn-height: 70px !default;
 $time-picker-landscape-title-btn-height: 55px !default;
-$time-picker-ampm-title-margin: 8px 0 6px 8px !default;
+$time-picker-ampm-title-margin-start: 8px !default;
+$time-picker-ampm-title-margin-bottom: 6px !default;
+$time-picker-ampm-title-margin: 0 0 $time-picker-ampm-title-margin-bottom $time-picker-ampm-title-margin-start !default;  // TODO: remove in 3.0
+$time-picker-ampm-title-margin-ltr: $time-picker-ampm-title-margin !default;
+$time-picker-ampm-title-margin-rtl: 0 $time-picker-ampm-title-margin-start $time-picker-ampm-title-margin-bottom 0 !default;
 $time-picker-ampm-title-font-size: 16px !default;
 $time-picker-landscape-ampm-title-margin: 16px 0 0 !default;
 $time-picker-number-font-size: 16px !default;

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -42,7 +42,7 @@ export default {
     counterSize: '{0} پرونده ({1} در کل)',
   },
   timePicker: {
-    am: 'AM',
-    pm: 'PM',
+    am: 'قبل از ظهر',
+    pm: 'بعد از ظهر',
   },
 }


### PR DESCRIPTION
## Motivation and Context
Fixes few issues from https://github.com/vuetifyjs/vuetify/issues/6757:
- margins of am/pm in title
- Farsi translations of am/pm
- typing of VTimePickerTItle.format prop

![image](https://user-images.githubusercontent.com/15625235/73542459-56fd9100-4467-11ea-80e4-876deb38a608.png)


## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container fluid style="width: 314px">
    <v-btn block @click="$vuetify.rtl = !$vuetify.rtl">RTL: {{ $vuetify.rtl }}</v-btn>
    <v-time-picker />
    <v-time-picker format="24hr" />
    <v-time-picker ampm-in-title />
    <v-time-picker format="24hr" ampm-in-title />
  </v-container>
</template>

<script>
  import Vue from 'vue';
  import { fa } from '../src/locale'
  export default Vue.extend({
    created () {
      this.$vuetify.lang.locales.en = fa
    }
  })
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
