### PR TITLE
docs(vcard): fix typo and make example sentence more clear

### DIFF
--- a/packages/docs/src/examples/cards/complex/loading.vue
+++ b/packages/docs/src/examples/cards/complex/loading.vue
@@ -32,7 +32,7 @@
         $ • Italian, Cafe
       </div>
 
-      <div>Small plates, salads & sandwiches an inteimate setting with 12 indoor seats plus patio seating.</div>
+      <div>Small plates, salads & sandwiches - an intimate setting with 12 indoor seats plus patio seating.</div>
     </v-card-text>
 
     <v-divider class="mx-4"></v-divider>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

## Description
There was an unfortunate typo in the docs, and the sentence itself was a little confusing. Just cleaning that up.

## Motivation and Context
Doesn't necessarily solve a problem, but helps the docs to be more clear and more professional.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] The PR title is no longer than 64 characters.
- [x ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ x] My code follows the code style of this project.
- [ x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
