### PR TITLE
refactor(click-outside): update for v3

### DIFF
--- a/packages/vuetify/src/directives/click-outside/__tests__/click-outside.spec.ts
+++ b/packages/vuetify/src/directives/click-outside/__tests__/click-outside.spec.ts
@@ -24,7 +24,7 @@ function bootstrap (args?: object) {
   }
 }
 
-describe('click-outside.js', () => {
+describe('click-outside.ts', () => {
   it('should register and unregister handler', () => {
     const { registeredHandler, el } = bootstrap()
     expect(window.document.body.addEventListener).toHaveBeenCalledWith('click', registeredHandler, true)

--- a/packages/vuetify/src/directives/click-outside/index.ts
+++ b/packages/vuetify/src/directives/click-outside/index.ts
@@ -1,25 +1,25 @@
-import { VNodeDirective } from 'vue/types/vnode'
+import { DirectiveBinding } from 'vue'
 
 interface ClickOutsideBindingArgs {
   closeConditional?: (e: Event) => boolean
   include?: () => HTMLElement[]
 }
 
-interface ClickOutsideDirective extends VNodeDirective {
-  value?: (e: Event) => void
+interface ClickOutsideDirectiveBinding extends DirectiveBinding {
+  value: (e: Event) => void | undefined
   args?: ClickOutsideBindingArgs
 }
 
-function closeConditional () {
+function defaultCloseConditional () {
   return false
 }
 
-function directive (e: PointerEvent, el: HTMLElement, binding: ClickOutsideDirective): void {
+function directive (e: PointerEvent, el: HTMLElement, binding: ClickOutsideDirectiveBinding): void {
   // Args may not always be supplied
   binding.args = binding.args || {}
 
   // If no closeConditional was supplied assign a default
-  const isActive = (binding.args.closeConditional || closeConditional)
+  const isActive = binding.args.closeConditional || defaultCloseConditional
 
   // The include element callbacks below can be expensive
   // so we should avoid calling them when we're not active.
@@ -58,7 +58,7 @@ export const ClickOutside = {
   // sure that the root element is
   // available, iOS does not support
   // clicks on body
-  inserted (el: HTMLElement, binding: ClickOutsideDirective) {
+  inserted (el: HTMLElement, binding: ClickOutsideDirectiveBinding) {
     const onClick = (e: Event) => directive(e as PointerEvent, el, binding)
     // iOS does not recognize click events on document
     // or body, this is the entire purpose of the v-app
@@ -74,7 +74,7 @@ export const ClickOutside = {
 
     const app = document.querySelector('[data-app]') ||
       document.body // This is only for unit tests
-    app && app.removeEventListener('click', el._clickOutside, true)
+    app.removeEventListener('click', el._clickOutside, true)
     delete el._clickOutside
   },
 }

--- a/packages/vuetify/src/directives/click-outside/index.ts
+++ b/packages/vuetify/src/directives/click-outside/index.ts
@@ -6,7 +6,7 @@ interface ClickOutsideBindingArgs {
 }
 
 interface ClickOutsideDirectiveBinding extends DirectiveBinding {
-  value: (e: Event) => void | undefined
+  value: ((e: Event) => void) | undefined
   args?: ClickOutsideBindingArgs
 }
 


### PR DESCRIPTION
## Description
Update click-outside directive for Vue 3

## Motivation and Context
Upcoming Vuetify 3.0 release

## How Has This Been Tested?
`jest`

## Markup
<details>

```vue
<script>
import { ClickOutside } from '../src/directives/click-outside'
import { defineComponent, withDirectives, h } from 'vue'

export default defineComponent(() => () => withDirectives(h('div', { class: 'test' }), [ [ ClickOutside, { callback: () => alert('a'), closeConditional: () => true } ] ]))
</script>

<style>
  .test {
    width: 100px;
    height: 100px;
    background-color: red;
  }
</style>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
