### PR TITLE
Fixed typo in Autocompletes.json

### DIFF
--- a/packages/docs/src/lang/en/components/Autocompletes.json
+++ b/packages/docs/src/lang/en/components/Autocompletes.json
@@ -39,6 +39,6 @@
     "filter": "The filtering algorithm used when searching. [example](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts#L36)",
     "hideNoData": "Hides the menu when there are no options to show.  Useful for preventing the menu from opening before results are fetched asynchronously.  Also has the effect of opening the menu when the `items` array changes if not already open.",
     "noFilter": "Do not apply filtering when searching. Useful when data is being filtered server side",
-    "searchInput": "Search value. Can be use with `.sync` modifier."
+    "searchInput": "Search value. Can be used with `.sync` modifier."
   }
 }


### PR DESCRIPTION
## Description
Fixes a typo in Autocompletes.json. Specifically the documentation for the `search-input` prop.

## Motivation and Context
Fixes a typo

## How Has This Been Tested?
N/A

## Markup:
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
