### PR TITLE
fix(VTextField/VSelect): don't focus clear icon if dirty

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
@@ -200,6 +200,8 @@ describe('VAutocomplete.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         clearable: true,
+        items: ['foo'],
+        value: 'foo',
       },
     })
 

--- a/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
@@ -248,11 +248,10 @@ exports[`VFileInput.ts should render 1`] = `
       </div>
       <div class="v-input__append-inner">
         <div class="v-input__icon v-input__icon--">
-          <button type="button"
-                  aria-label=" icon"
-                  class="v-icon notranslate v-icon--link material-icons theme--light"
+          <i aria-hidden="true"
+             class="v-icon notranslate material-icons theme--light"
           >
-          </button>
+          </i>
         </div>
       </div>
     </div>
@@ -431,11 +430,10 @@ exports[`VFileInput.ts should render without icon 1`] = `
       </div>
       <div class="v-input__append-inner">
         <div class="v-input__icon v-input__icon--">
-          <button type="button"
-                  aria-label=" icon"
-                  class="v-icon notranslate v-icon--link material-icons theme--light"
+          <i aria-hidden="true"
+             class="v-icon notranslate material-icons theme--light"
           >
-          </button>
+          </i>
         </div>
       </div>
     </div>

--- a/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
@@ -247,7 +247,7 @@ exports[`VFileInput.ts should render 1`] = `
         >
       </div>
       <div class="v-input__append-inner">
-        <div class="v-input__icon v-input__icon--">
+        <div class="v-input__icon">
           <i aria-hidden="true"
              class="v-icon notranslate material-icons theme--light"
           >
@@ -429,7 +429,7 @@ exports[`VFileInput.ts should render without icon 1`] = `
         >
       </div>
       <div class="v-input__append-inner">
-        <div class="v-input__icon v-input__icon--">
+        <div class="v-input__icon">
           <i aria-hidden="true"
              class="v-icon notranslate material-icons theme--light"
           >

--- a/packages/vuetify/src/components/VIcon/VIcon.sass
+++ b/packages/vuetify/src/components/VIcon/VIcon.sass
@@ -8,7 +8,7 @@
   &:focus::after
     opacity: map-deep-get($material, 'states', 'focus')
 
-  &--disabled
+  &.v-icon.v-icon--disabled
     color: map-deep-get($material, 'icons', 'inactive') !important
 
 // Increased specificity to overwrite

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -202,7 +202,7 @@ export default baseMixins.extend<options>().extend({
 
       return this.$createElement('div', {
         staticClass: `v-input__icon`,
-        class: type ? `v-input__icon--${kebabCase(type)}` : '',
+        class: type ? `v-input__icon--${kebabCase(type)}` : undefined,
       }, [
         this.$createElement(
           VIcon,

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -201,7 +201,8 @@ export default baseMixins.extend<options>().extend({
       }
 
       return this.$createElement('div', {
-        staticClass: `v-input__icon v-input__icon--${kebabCase(type)}`,
+        staticClass: `v-input__icon`,
+        class: type ? `v-input__icon--${kebabCase(type)}` : '',
       }, [
         this.$createElement(
           VIcon,

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -419,7 +419,7 @@ export default baseMixins.extend<options>().extend({
 
       icon.children![0].data = mergeData(icon.children![0].data!, {
         attrs: {
-          tabindex: type === 'clear'
+          tabindex: type !== 'append'
             ? undefined
             : (icon.children![0].componentOptions!.listeners && '-1'),
           'aria-hidden': 'true',

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -419,7 +419,9 @@ export default baseMixins.extend<options>().extend({
 
       icon.children![0].data = mergeData(icon.children![0].data!, {
         attrs: {
-          tabindex: icon.children![0].componentOptions!.listeners && '-1',
+          tabindex: type === 'clear'
+            ? undefined
+            : (icon.children![0].componentOptions!.listeners && '-1'),
           'aria-hidden': 'true',
           'aria-label': undefined,
         },

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -298,6 +298,7 @@ export default baseMixins.extend<options>().extend({
     },
     clearableCallback () {
       this.setValue(this.multiple ? [] : undefined)
+      this.setMenuIndex(-1)
       this.$nextTick(() => this.$refs.input && this.$refs.input.focus())
 
       if (this.openOnClear) this.isMenuActive = true

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect4.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect4.spec.ts
@@ -89,6 +89,7 @@ describe('VSelect.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         clearable: true,
+        items: ['foo'],
         value: 'foo',
       },
     })

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
@@ -25,7 +25,6 @@ exports[`VSelect.ts should be clearable with prop, dirty and multi select 1`] = 
           <div class="v-input__icon v-input__icon--clear">
             <button aria-hidden="true"
                     type="button"
-                    tabindex="-1"
                     class="v-icon notranslate v-icon--link material-icons theme--light"
             >
               $clear
@@ -86,7 +85,6 @@ exports[`VSelect.ts should be clearable with prop, dirty and single select 1`] =
           <div class="v-input__icon v-input__icon--clear">
             <button aria-hidden="true"
                     type="button"
-                    tabindex="-1"
                     class="v-icon notranslate v-icon--link material-icons theme--light"
             >
               $clear

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -295,11 +295,12 @@ export default baseMixins.extend<options>().extend({
       if (!this.clearable) return null
 
       const icon = this.isDirty ? 'clear' : ''
+      const cb = this.isDirty ? this.clearableCallback : undefined
 
       return this.genSlot('append', 'inner', [
         this.genIcon(
           icon,
-          this.clearableCallback
+          cb
         ),
       ])
     },


### PR DESCRIPTION


## How Has This Been Tested?
jest, playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-file-input />
    <v-text-field />
    <v-text-field clearable />
    <v-select :items="['foo']" clearable />
    <v-autocomplete :items="['foo']" clearable />
    <v-combobox :items="['foo']" clearable />
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
