### PR TITLE
docs(text): add text emphasis / opacity examples

### DIFF
--- a/packages/docs/src/components/style/Font.vue
+++ b/packages/docs/src/components/style/Font.vue
@@ -72,6 +72,9 @@
             ['font-italic font-weight-light', 'Light italic'],
             ['font-italic font-weight-medium', 'Medium italic'],
             ['font-italic font-weight-bold', 'Bold italic'],
+            ['text--primary', '87% opacity'],
+            ['text--secondary', '60% opacity'],
+            ['text--disabled', '38% opacity']
           ],
         },
       ],

--- a/packages/docs/src/components/style/Font.vue
+++ b/packages/docs/src/components/style/Font.vue
@@ -72,9 +72,6 @@
             ['font-italic font-weight-light', 'Light italic'],
             ['font-italic font-weight-medium', 'Medium italic'],
             ['font-italic font-weight-bold', 'Bold italic'],
-            ['text--primary', '87% opacity'],
-            ['text--secondary', '60% opacity'],
-            ['text--disabled', '38% opacity']
           ],
         },
       ],

--- a/packages/docs/src/data/pages/styles/Text.json
+++ b/packages/docs/src/data/pages/styles/Text.json
@@ -99,6 +99,23 @@
       "children": [
         {
           "type": "heading",
+          "lang": "opacityHeader"
+        },
+        {
+          "type": "text",
+          "lang": "opacityText1"
+        },
+        {
+          "type": "example",
+          "value": "opacity"
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "children": [
+        {
+          "type": "heading",
           "lang": "rtlHeader"
         },
         {

--- a/packages/docs/src/examples/text/opacity.vue
+++ b/packages/docs/src/examples/text/opacity.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <p class="text--primary">High-emphasis has an opacity of 87%.</p>
+    <p class="text--secondary">Medium-emphasis text and hint text have opacities of 60%.</p>
+    <p class="text-disabled">Disabled text has an opacity of 37%.</p>
+  </div>
+</template>

--- a/packages/docs/src/lang/en/styles/Text.json
+++ b/packages/docs/src/lang/en/styles/Text.json
@@ -12,6 +12,8 @@
   "transformText2": "Text breaking and the removal of `text-transform` is also possible. In the first example, the `text-transform: uppercase` custom class is overwritten and allows the text casing to remain. In the second example, we break up a longer word to fit the available space.`",
   "weightsHeader": "## Font weights and italics",
   "weightsText1": "Material design, by default, supports **100, 300, 400, 500, 700, 900** font weights and italicized text.",
+  "opacityHeader": "## Text opacity",
+  "opacityText1": "Opacity helper classes allow you to easily adjust the emphasis of text. `text--primary` has the same opacity as default text. `text--secondary` is used for hints and helper text. De-emphasise text with `text--disabled`.",
   "rtlHeader": "## RTL Alignment",
   "rtlText1": "When using [RTL](/customization/rtl), you may want to keep the alignment regardless of the **rtl** designation. This can be achieved using text alignment helper classes in the following format: `text-<breakpoint>-<direction>`, where breakpoint can be `sm`, `md`, `lg`, or `xl` and direction can be `left` or `right`. You may also want alignment to respond to rtl which can be done using directions `start` and `end`."
 }


### PR DESCRIPTION
## Description
Added examples of `text--primary`, `text--secondary`, and `text--disabled` to Styles and Weights section of Typography. 

<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
These classes provide support for the text emphasis guidelines in MD2. There was no existing documentation for this feature of Vuetify, though the classes are used in several examples.

I made this change to Typography over Text because the style of examples are more user-friendly in Typography.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] The PR title is no longer than 64 characters.
- [*] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [*] My code follows the code style of this project.
- [*] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
