### PR TITLE
docs: Fix opacity demo for 'text--disabled'

### DIFF
--- a/packages/docs/src/examples/text/opacity.vue
+++ b/packages/docs/src/examples/text/opacity.vue
@@ -2,6 +2,6 @@
   <div>
     <p class="text--primary">High-emphasis has an opacity of 87%.</p>
     <p class="text--secondary">Medium-emphasis text and hint text have opacities of 60%.</p>
-    <p class="text-disabled">Disabled text has an opacity of 37%.</p>
+    <p class="text--disabled">Disabled text has an opacity of 37%.</p>
   </div>
 </template>


### PR DESCRIPTION
Fix missing dash "-" in the text opacity demo for 'text--disabled'