### PR TITLE
feat(VDataIterator): emit the page-count event from VData

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.ts
@@ -295,6 +295,7 @@ export default Themeable.extend({
           this.internalCurrentItems = v
           this.$emit('current-items', v)
         },
+        'page-count': (v: number) => this.$emit('page-count', v),
       },
       scopedSlots: {
         default: this.genDefaultScopedSlot,


### PR DESCRIPTION
Description

Also emit the page-count event from the inner VData component to update the external pagination on async item changes

This feature is already documented but not implemented at this time

## Motivation and Context

It makes a pagination pageCount update possible if the Iterator items changes in a async matter

## How Has This Been Tested?

No additional tests because I don't find any similar tests in the VDataTable component who already implements this feature

## Markup:
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
