### PR TITLE
fix(VSimpleTable): missing bottom border of tbody th

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -24,12 +24,14 @@
 
   tbody
     tr
-      &:not(:last-child) td
-        &:not(.v-data-table__mobile-row)
-          border-bottom: thin solid map-get($material, 'dividers')
+      &:not(:last-child)
+        td,
+        th
+          &:not(.v-data-table__mobile-row)
+            border-bottom: thin solid map-get($material, 'dividers')
 
-        &:last-child
-          border-bottom: thin solid map-get($material, 'dividers')
+          &:last-child
+            border-bottom: thin solid map-get($material, 'dividers')
 
       &.active
         background: map-deep-get($material, 'table', 'active')


### PR DESCRIPTION
## Description
Adds bottom border to `tbody th`

## Motivation and Context
https://codepen.io/jkarczm/pen/bGdpMzB?editors=1000

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-simple-table>
        <tbody>
          <tr v-for="i in 3">
            <th scope="row">TH - has no bottom border</th>
            <td>TD - has bottom border</td>
            <td>TD - has bottom border</td>
          </tr>
        </tbody>
      </v-simple-table>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
