### PR TITLE
fix(VDataTable): remove hover on empty (no data) wrapper

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -34,7 +34,7 @@
       &.active
         background: map-deep-get($material, 'table', 'active')
 
-      &:hover:not(.v-data-table__expanded__content)
+      &:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper)
         background: map-deep-get($material, 'table', 'hover')
 
 // Block


### PR DESCRIPTION
## Motivation 
Removes unnecessary hover effect on `no data`/`no results` row
https://codepen.io/jkarczm/pen/WNvxwRE

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
```vue
<template>
  <v-container>
    <v-data-table :headers="[{ text: 'Foo' }]" :items="[]" />
    <v-data-table :headers="[{ text: 'Foo' }]" :items="[{}]" search="foo" />
  </v-container>
</template>
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
