### PR TITLE
fix(vselect): resolve bug in browsers with event order disparity

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.js
+++ b/packages/vuetify/src/components/VSelect/VSelect.js
@@ -257,11 +257,9 @@ export default VTextField.extend({
   methods: {
     /** @public */
     blur (e) {
+      VTextField.options.methods.blur.call(this, e)
       this.isMenuActive = false
-      this.isFocused = false
-      this.$refs.input && this.$refs.input.blur()
       this.selectedIndex = -1
-      this.onBlur(e)
     },
     /** @public */
     activateMenu () {
@@ -529,9 +527,6 @@ export default VTextField.extend({
     },
     getValue (item) {
       return getPropertyFromItem(item, this.itemValue, this.getText(item))
-    },
-    onBlur (e) {
-      this.$emit('blur', e)
     },
     onChipInput (item) {
       if (this.multiple) this.selectItem(item)

--- a/packages/vuetify/src/components/VTextField/VTextField.js
+++ b/packages/vuetify/src/components/VTextField/VTextField.js
@@ -204,8 +204,13 @@ export default VInput.extend({
       this.onFocus()
     },
     /** @public */
-    blur () {
-      this.$refs.input ? this.$refs.input.blur() : this.onBlur()
+    blur (e) {
+      // https://github.com/vuetifyjs/vuetify/issues/5913
+      // Safari tab order gets broken if called synchronous
+      window.requestAnimationFrame(() => {
+        this.$refs.input && this.$refs.input.blur()
+      })
+      this.onBlur(e)
     },
     clearableCallback () {
       this.internalValue = null
@@ -377,7 +382,7 @@ export default VInput.extend({
       // to persist
       this.internalChange = false
 
-      this.$emit('blur', e)
+      e && this.$emit('blur', e)
     },
     onClick () {
       if (this.isFocused || this.disabled) return

--- a/packages/vuetify/test/unit/components/VTextField/VTextField.spec.js
+++ b/packages/vuetify/test/unit/components/VTextField/VTextField.spec.js
@@ -745,7 +745,7 @@ test('VTextField.js', ({ mount }) => {
     expect(change).toHaveBeenCalledTimes(2)
   })
 
-  it('should have focus and blur methods', () => {
+  it('should have focus and blur methods', async () => {
     const wrapper = mount(VTextField)
     const focus = jest.fn()
     const blur = jest.fn()
@@ -756,6 +756,12 @@ test('VTextField.js', ({ mount }) => {
     expect(focus).toHaveBeenCalledTimes(1)
 
     wrapper.vm.blur()
+
+    // https://github.com/vuetifyjs/vuetify/issues/5913
+    // Blur waits a requestAnimationFrame
+    // to resolve a bug in MAC / Safari
+    await new Promise(resolve => window.requestAnimationFrame(resolve))
+
     expect(blur).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
The ordering of events in Safari/Edge/IE caused our manual blur of the input to break tabbing
through inputs. Additionally resolving duplicate blur events

"fix #10609"

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Fixing tabbing so that it doesn't return to the first focusable element in Safari/Edge/IE (and possibly other browsers). Additionally fixing duplicate blur event. This PR piggy backs off of this PR for 2.0 here: https://github.com/vuetifyjs/vuetify/commit/5fa6a682634a0c159cf7c37897535bc2894131b9 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change is required to fix this open issue: https://github.com/vuetifyjs/vuetify/issues/10609

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
I have updated an existing test, all tests pass, and additionally I was able to test in these environments:
- Chrome Version 80.0.3987.106 (Official Build) (64-bit)
- Firefox Version 73.0
- Microsoft Edge 41.16299.1004.0
- Internet Explorer 11 Version 11.1087.16299.0

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```
<template>
  <div>
    <v-text-field label="First Name"></v-text-field>
    <v-text-field label="Last Name"></v-text-field>
    <v-text-field label="Occupation"></v-text-field>
    <v-autocomplete
      v-model="model"
      :items="states"
      :label="'State'"
      prepend-icon="mdi-city"
    ></v-autocomplete>
    <v-text-field label="City"></v-text-field>
    <v-text-field label="E-mail"></v-text-field>	
  </div>
</template>

<script>
  export default {
    data () {
      return {
        isEditing: false,
        model: null,
        states: [
          'Alabama', 'Alaska', 'American Samoa', 'Arizona',
          'Arkansas', 'California', 'Colorado', 'Connecticut',
          'Delaware', 'District of Columbia', 'Federated States of Micronesia',
          'Florida', 'Georgia', 'Guam', 'Hawaii', 'Idaho',
          'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky',
          'Louisiana', 'Maine', 'Marshall Islands', 'Maryland',
          'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi',
          'Missouri', 'Montana', 'Nebraska', 'Nevada',
          'New Hampshire', 'New Jersey', 'New Mexico', 'New York',
          'North Carolina', 'North Dakota', 'Northern Mariana Islands', 'Ohio',
          'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico',
          'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee',
          'Texas', 'Utah', 'Vermont', 'Virgin Island', 'Virginia',
          'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
        ]
      }
    }
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
