### PR TITLE
docs: data-tables simple search append-icon wrong props

### DIFF
--- a/packages/docs/src/examples/data-tables/simple/search.vue
+++ b/packages/docs/src/examples/data-tables/simple/search.vue
@@ -5,7 +5,7 @@
       <v-spacer></v-spacer>
       <v-text-field
         v-model="search"
-        append-icon="search"
+        append-icon="mdi-magnify"
         label="Search"
         single-line
         hide-details


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
In the documentation, for the search section at the data-tables components, they are a wrong append-icon props documented

## Motivation and Context
the search icon doesn't show off. when i try the example.

## How Has This Been Tested?
Read the commit file or the doc


## Types of changes
- [x] Edit the append-icon props. remove `search`, and add `mdi-magnify`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
