### PR TITLE
fix(VAutocomplete): check for inital search input prop

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -373,7 +373,7 @@ export default VSelect.extend({
             this.multiple ||
             this.hasSlot
           )
-            ? this.internalSearch ? this.internalSearch : null
+            ? this.internalSearch || null
             : this.getText(this.selectedItem)
         }
       })

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -373,7 +373,7 @@ export default VSelect.extend({
             this.multiple ||
             this.hasSlot
           )
-            ? null
+            ? this.internalSearch ? this.internalSearch : null
             : this.getText(this.selectedItem)
         }
       })

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
@@ -65,6 +65,17 @@ describe('VAutocomplete.ts', () => {
     expect(update).toHaveBeenCalledWith('test')
   })
 
+  it('should set intial search value', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        searchInput: 'foo',
+        items: ['foo', 'bar', 'fizz', 'buzz'],
+      },
+    })
+
+    expect(wrapper.vm.internalSearch).toBe('foo')
+  })
+
   it('should filter autocomplete search results', async () => {
     const wrapper = mountFunction({
       propsData: { items: ['foo', 'bar'] },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fix #9757

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Check for internalSeach value instead of directly replacing it will null

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit | visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div id="app">
    <v-app>
      <v-content>
        <v-container>
          <v-autocomplete
            :search-input.sync="search"
            :items="items"
          />
        </v-container>
      </v-content>
    </v-app>
  </div>
</template>

<script>
  export default {
    data: () => ({
      search: 'foo',
      items: ['foo', 'bar', 'fizz', 'buzz'],
    }),
  }
</script>
```

```vue
<template>
  <div id="app">
    <v-app>
      <v-content>
        <v-container>
          <v-autocomplete
            :search-input.sync="search"
          />
        </v-container>
      </v-content>
    </v-app>
  </div>
</template>

<script>
  export default {
    data: () => ({
      search: 'foo',
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
