### PR TITLE
fix(VTreeview): respect selection-type when rebuilding tree

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -225,7 +225,7 @@ export default mixins(
         this.nodes[key] = !children.length ? node : this.calculateState(node, this.nodes)
 
         // Don't forget to rebuild cache
-        if (this.nodes[key].isSelected) this.selectedCache.add(key)
+        if (this.nodes[key].isSelected && (this.selectionType === 'independent' || node.children.length === 0)) this.selectedCache.add(key)
         if (this.nodes[key].isActive) this.activeCache.add(key)
         if (this.nodes[key].isOpen) this.openCache.add(key)
 

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
@@ -705,4 +705,47 @@ describe('VTreeView.ts', () => { // eslint-disable-line max-statements
 
     expect(wrapper.vm.nodes['5'].isIndeterminate).toBeUndefined()
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/8720
+  it('should set correct selection when updating items', async () => {
+    const items = [{
+      id: 1,
+      name: 'Foo',
+      children: [
+        { id: 2, name: 'Bar' },
+        { id: 3, name: 'Fizz' },
+        { id: 4, name: 'Buzz' },
+      ],
+    }]
+
+    const input = jest.fn()
+
+    const wrapper = mountFunction({
+      propsData: {
+        items,
+        value: [2, 3, 4],
+        selectionType: 'leaf',
+        selectable: true,
+      },
+      listeners: {
+        input,
+      },
+    })
+
+    wrapper.setProps({
+      items: [{
+        id: 1,
+        name: 'Foo',
+        children: [
+          { id: 2, name: 'Bar' },
+          { id: 3, name: 'Fizz' },
+          { id: 4, name: 'Buzz' },
+        ],
+      }],
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(input).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
when rebuilding the tree we did not take selection-type into account

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #8720

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
playground, unit test

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container grid-list-xl>
    <v-treeview
      v-model="selectedItems"
      :items="items"
      selectable
      open-all
      selection-type="leaf"
    > </v-treeview>
    <v-btn @click="onClicked"> Change Array Set </v-btn>
    <v-col> {{ selectedItems }} </v-col>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      selectedItems: ['C1', 'C2', 'C3', 'C4'],
      items: [
        {
          id: 'PARENT',
          name: "Parent",
          disabled: false,
          children: [
            { id: 'C1', name: "Child 1" },
            { id: 'C2', name: "Child 2" },
            { id: 'C3', name: "Child 3", disabled: true },
            { id: 'C4', name: "Child 4" }
          ]
        }
      ]
    }),
    methods: {
      onClicked() {
        this.items = [
          {
            id: 'PARENT',
            name: "Parent",
            disabled: false,
            children: [
              { id: 'C1', name: "Child 1" },
              { id: 'C2', name: "Child 2" },
              { id: 'C3', name: "Child 3", disabled: false },
              { id: 'C4', name: "Child 4" }
            ]
          }
        ];
      }
    }
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
