### PR TITLE
docs(tables): change TableHeader align:left to align:start

### DIFF
--- a/packages/docs/src/examples/data-tables/complex/crud.vue
+++ b/packages/docs/src/examples/data-tables/complex/crud.vue
@@ -82,7 +82,7 @@
       headers: [
         {
           text: 'Dessert (100g serving)',
-          align: 'left',
+          align: 'start',
           sortable: false,
           value: 'name',
         },

--- a/packages/docs/src/examples/data-tables/complex/edit-dialog.vue
+++ b/packages/docs/src/examples/data-tables/complex/edit-dialog.vue
@@ -70,7 +70,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/custom-filter.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/custom-filter.vue
@@ -119,7 +119,7 @@
         return [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/customize-footer.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/customize-footer.vue
@@ -20,7 +20,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/customize-header.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/customize-header.vue
@@ -16,7 +16,7 @@
       headers: [
         {
           text: 'Dessert (100g serving)',
-          align: 'left',
+          align: 'start',
           value: 'name',
         },
         { text: 'Calories', value: 'calories' },

--- a/packages/docs/src/examples/data-tables/intermediate/customize-rows.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/customize-rows.vue
@@ -17,7 +17,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/expand.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/expand.vue
@@ -31,7 +31,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/paginate.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/paginate.vue
@@ -33,7 +33,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/server.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/server.vue
@@ -22,7 +22,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/simple-checkbox.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/simple-checkbox.vue
@@ -75,7 +75,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/slots.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/slots.vue
@@ -195,7 +195,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/intermediate/sort.vue
+++ b/packages/docs/src/examples/data-tables/intermediate/sort.vue
@@ -23,7 +23,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             value: 'name',
           },
           { text: 'Calories', value: 'calories' },

--- a/packages/docs/src/examples/data-tables/playground.vue
+++ b/packages/docs/src/examples/data-tables/playground.vue
@@ -81,7 +81,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             value: 'name',
           },
           { text: 'Category', value: 'category' },

--- a/packages/docs/src/examples/data-tables/simple/dense.vue
+++ b/packages/docs/src/examples/data-tables/simple/dense.vue
@@ -90,7 +90,7 @@
       headers: [
         {
           text: 'Dessert (100g serving)',
-          align: 'left',
+          align: 'start',
           sortable: false,
           value: 'name',
         },

--- a/packages/docs/src/examples/data-tables/simple/filterable-columns.vue
+++ b/packages/docs/src/examples/data-tables/simple/filterable-columns.vue
@@ -25,7 +25,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             filterable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/simple/footer-props.vue
+++ b/packages/docs/src/examples/data-tables/simple/footer-props.vue
@@ -22,7 +22,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             value: 'name',
           },
           { text: 'Category', value: 'category' },

--- a/packages/docs/src/examples/data-tables/simple/group.vue
+++ b/packages/docs/src/examples/data-tables/simple/group.vue
@@ -16,7 +16,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             value: 'name',
           },
           { text: 'Category', value: 'category' },

--- a/packages/docs/src/examples/data-tables/simple/headerless.vue
+++ b/packages/docs/src/examples/data-tables/simple/headerless.vue
@@ -15,7 +15,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             value: 'name',
           },
           { text: 'Calories', value: 'calories' },

--- a/packages/docs/src/examples/data-tables/simple/multi-sort.vue
+++ b/packages/docs/src/examples/data-tables/simple/multi-sort.vue
@@ -16,7 +16,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/simple/search.vue
+++ b/packages/docs/src/examples/data-tables/simple/search.vue
@@ -27,7 +27,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/simple/select.vue
+++ b/packages/docs/src/examples/data-tables/simple/select.vue
@@ -23,7 +23,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/simple/virtualized.vue
+++ b/packages/docs/src/examples/data-tables/simple/virtualized.vue
@@ -100,7 +100,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },

--- a/packages/docs/src/examples/data-tables/usage.vue
+++ b/packages/docs/src/examples/data-tables/usage.vue
@@ -14,7 +14,7 @@
         headers: [
           {
             text: 'Dessert (100g serving)',
-            align: 'left',
+            align: 'start',
             sortable: false,
             value: 'name',
           },


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Type TableHeader requires either `start`,`center` or `right` as `align` value, in the examples `left` was used. changed all occurrences from `left` to `start`


## How Has This Been Tested?
No testing, it is a change in the documentation example


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
