### PR TITLE
fix(vselect): height changing on select in dense mode

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -7,6 +7,9 @@
   .v-select__selection--disabled
     color: map-deep-get($material, 'text', 'disabled')
 
+  .v-select__selection--dense
+    margin: 0px 4px 0px
+
 .v-select
   position: relative // For **attach** prop
 

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -379,6 +379,7 @@ export default baseMixins.extend<options>().extend({
         staticClass: 'v-select__selection v-select__selection--comma',
         class: {
           'v-select__selection--disabled': isDisabled,
+          'v-select__selection--dense': this.dense,
         },
         key: JSON.stringify(this.getValue(item)),
       }), `${this.getText(item)}${last ? '' : ', '}`)


### PR DESCRIPTION
The VSelect element creates a v-select__selection div that has a margin. When in dense mode, that
margin causes the overall size of the element to change. This fix adds a v-select__selection--dense
class that removes the margin. See https://codepen.io/rsaleri/pen/rNVMvXG for bug reproduction

fix #10635



## Motivation and Context
Fixes [v-select dense input bug](https://github.com/vuetifyjs/vuetify/issues/10635)

## How Has This Been Tested?
Visually tested using sandbox


```vue
<template>
  <v-container>

    <v-row>
      <v-col>
        <v-select
          label="dialog"
          :items="list"
          v-model="select"
        ></v-select>
      </v-col>
      <v-col>
        <v-autocomplete
          label="autocomplete"
          :items="list"
          v-model="autocomplete"
        ></v-autocomplete>
      </v-col>
      <v-col>
        <v-select
          label="dialog 2"
          :items="list"
          v-model="select_2"
          dense
        ></v-select>
      </v-col>
      <v-col>
        <v-autocomplete
          label="autocomplete 2"
          :items="list"
          v-model="autocomplete_2"
          dense
        ></v-autocomplete>
      </v-col>
    </v-row>

  </v-container>
</template>

<script>
export default {
    data() {
        return {
            list: [
                'element 1',
                'element 2',
                'element 3',
                'element 4',
                'element 5',
                'element 6',
            ],
            autocomplete: 'element 1',
            select: 'element 1',
            autocomplete_2: null,
            select_2: null
        };
    }
}
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
