### PR TITLE
docs(VButton): remove text prop when using icon

### DIFF
--- a/packages/docs/src/examples/buttons/simple/icon.vue
+++ b/packages/docs/src/examples/buttons/simple/icon.vue
@@ -8,25 +8,25 @@
           </v-col>
 
           <v-col cols="12" sm="3">
-            <v-btn text icon color="pink">
+            <v-btn icon color="pink">
               <v-icon>mdi-heart</v-icon>
             </v-btn>
           </v-col>
 
           <v-col cols="12" sm="3">
-            <v-btn text icon color="indigo">
+            <v-btn icon color="indigo">
               <v-icon>mdi-star</v-icon>
             </v-btn>
           </v-col>
 
           <v-col cols="12" sm="3">
-            <v-btn text icon color="green">
+            <v-btn icon color="green">
               <v-icon>mdi-cached</v-icon>
             </v-btn>
           </v-col>
 
           <v-col cols="12" sm="3">
-            <v-btn text icon color="deep-orange">
+            <v-btn icon color="deep-orange">
               <v-icon>mdi-thumb-up</v-icon>
             </v-btn>
           </v-col>


### PR DESCRIPTION
## Motivation and Context
Removes useless attribute `text` with `icon` on buttons from the documentation, for the icon example. Avoid confusion.

## How Has This Been Tested?
As you can see `icon` and `text icon` provide the same result: https://codepen.io/elfayer/pen/gOpWrXB

## Markup:
<details>

```vue
<div id="app">
  <v-app id="inspire">
    <v-card flat>
      <v-card-text>
        <v-container fluid class="pa-0">
          <v-row>
            <v-col cols="12">
              <v-btn text icon color="pink">
                <v-icon>mdi-heart</v-icon>
              </v-btn>
            </v-col>
            <v-col cols="12">
              <v-btn icon color="pink">
                <v-icon>mdi-heart</v-icon>
              </v-btn>
            </v-col>
          </v-row>
        </v-container>
      </v-card-text>
    </v-card>
  </v-app>
</div>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
