### PR TITLE
fix(VTextField): incorrectly displayed counter with hide-details=auto

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -82,6 +82,9 @@ export default baseMixins.extend<options>().extend({
     computedId (): string {
       return this.id || `input-${this._uid}`
     },
+    hasDetails (): boolean {
+      return this.messagesToDisplay.length > 0
+    },
     hasHint (): boolean {
       return !this.hasMessages &&
         !!this.hint &&
@@ -126,7 +129,7 @@ export default baseMixins.extend<options>().extend({
       }).filter(message => message !== '')
     },
     showDetails (): boolean {
-      return this.hideDetails === false || (this.hideDetails === 'auto' && this.messagesToDisplay.length > 0)
+      return this.hideDetails === false || (this.hideDetails === 'auto' && this.hasDetails)
     },
   },
 

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -131,6 +131,12 @@ export default baseMixins.extend<options>().extend({
       }
       return (this.internalValue || '').toString().length
     },
+    hasCounter (): boolean {
+      return this.counter !== false && this.counter != null
+    },
+    hasDetails (): boolean {
+      return VInput.options.computed.hasDetails.call(this) || this.hasCounter
+    },
     internalValue: {
       get (): any {
         return this.lazyValue
@@ -301,7 +307,7 @@ export default baseMixins.extend<options>().extend({
       ])
     },
     genCounter () {
-      if (this.counter === false || this.counter == null) return null
+      if (!this.hasCounter) return null
 
       const max = this.counter === true ? this.attrs$.maxlength : this.counter
 
@@ -392,12 +398,10 @@ export default baseMixins.extend<options>().extend({
       })
     },
     genMessages () {
-      if (this.hideDetails === true) return null
+      if (!this.showDetails) return null
 
       const messagesNode = VInput.options.methods.genMessages.call(this)
       const counterNode = this.genCounter()
-
-      if (this.hideDetails === 'auto' && !messagesNode && !counterNode) return null
 
       return this.$createElement('div', {
         staticClass: 'v-text-field__details',

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -715,20 +715,22 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     expect(focus).toHaveBeenCalledTimes(1)
   })
 
-  it('should hide messages if no messages and hide-details is auto', () => {
+  it('should hide messages if no messages and hide-details is auto', async () => {
     const wrapper = mountFunction({
       propsData: {
         hideDetails: 'auto',
       },
     })
 
-    expect(wrapper.vm.genMessages()).toBeNull()
+    expect(wrapper.html()).toMatchSnapshot()
 
     wrapper.setProps({ counter: 7 })
-    expect(wrapper.vm.genMessages()).not.toBeNull()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
 
     wrapper.setProps({ counter: null, errorMessages: 'required' })
-    expect(wrapper.vm.genMessages()).not.toBeNull()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.html()).toMatchSnapshot()
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/8268

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -98,6 +98,74 @@ exports[`VTextField.ts should have prefix and suffix 1`] = `
 </div>
 `;
 
+exports[`VTextField.ts should hide messages if no messages and hide-details is auto 1`] = `
+<div class="v-input v-input--hide-details theme--light v-text-field">
+  <div class="v-input__control">
+    <div class="v-input__slot">
+      <div class="v-text-field__slot">
+        <input id="input-141"
+               type="text"
+        >
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VTextField.ts should hide messages if no messages and hide-details is auto 2`] = `
+<div class="v-input theme--light v-text-field">
+  <div class="v-input__control">
+    <div class="v-input__slot">
+      <div class="v-text-field__slot">
+        <input id="input-141"
+               type="text"
+        >
+      </div>
+    </div>
+    <div class="v-text-field__details">
+      <div class="v-messages theme--light">
+        <span name="message-transition"
+              tag="div"
+              class="v-messages__wrapper"
+        >
+        </span>
+      </div>
+      <div class="v-counter theme--light">
+        0 / 7
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VTextField.ts should hide messages if no messages and hide-details is auto 3`] = `
+<div class="v-input v-input--has-state theme--light v-text-field error--text">
+  <div class="v-input__control">
+    <div class="v-input__slot">
+      <div class="v-text-field__slot">
+        <input id="input-141"
+               type="text"
+        >
+      </div>
+    </div>
+    <div class="v-text-field__details">
+      <div class="v-messages theme--light error--text"
+           role="alert"
+      >
+        <span name="message-transition"
+              tag="div"
+              class="v-messages__wrapper"
+        >
+          <div class="v-messages__message">
+            required
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`VTextField.ts should not display counter when set to false/undefined/null 1`] = `
 <div class="v-input theme--light v-text-field">
   <div class="v-input__control">


### PR DESCRIPTION
## Motivation and Context
fixes #10701

## How Has This Been Tested?
playground, jest 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field
      counter="1024"
      hide-details="auto"
    />
    <v-text-field
      counter="1024"
    />
    <v-text-field
      counter="1024"
      hide-details
    />
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
