### PR TITLE
fix(VSimpleTable): set max width to 100%

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -41,6 +41,8 @@
 
 // Block
 .v-data-table
+  max-width: 100%
+
   table
     width: 100%
     border-spacing: 0


### PR DESCRIPTION
## Motivation and Context
fixes #8993

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-container class="fill-height">
      <v-data-table
        :headers="new Array(30).fill({ text: 'foo' })"
        :items="[]"
        class="elevation-1"
      ></v-data-table>
    </v-container>
    <v-container class="fill-height">
      <v-data-table
        :headers="[{text: 'foo'}]"
        :items="[]"
        class="elevation-1"
      ></v-data-table>
    </v-container>
  </div>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)

## Other comments

Current solution:
![image](https://user-images.githubusercontent.com/15625235/75602341-cb733080-5af6-11ea-9e76-41946e93cb13.png)


It could be also `width: 100%`:
![image](https://user-images.githubusercontent.com/15625235/75602336-c31af580-5af6-11ea-97c2-0c6506c3b4af.png)

Not sure which is better (the current one is less breaking, EDIT: and more in line with native tables