### PR TITLE
simplify contributors onboarding by fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - init: yarn install && yarn run build
+    command: yarn run start
+ports:
+  - port: 8095
+    onOpen: open-preview
+vscode:
+  extensions:
+    - octref.vetur@0.23.0:TEzauMObB6f3i2JqlvrOpA==
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
   <a href="https://cdnjs.com/libraries/vuetify">
     <img src="https://img.shields.io/cdnjs/v/vuetify.svg" alt="CDN">
   </a>
+  <a href="https://gitpod.io/#https://github.com/vuetifyjs/vuetify">
+    <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code">
+  </a>
 </p>
 
 <h2 align="center">Supporting Vuetify</h2>
@@ -430,6 +433,12 @@ Detailed changes for each release are documented in the [release notes](https://
 
 ### Contributing
 Developers interested in contributing should read the [Code of Conduct](./CODE_OF_CONDUCT.md) and the [Contribution Guide](https://vuetifyjs.com/getting-started/contributing).
+
+#### Online one-click setup for Contributing
+
+Contribute to Vuetify, using a fully featured online development environment; cloned repo, pre-installed dependencies, running web server.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 > Please do **not** ask general questions in an issue. Issues are only to report bugs, suggest
   enhancements, or request new features. For general questions and discussions, ask in the [community chat](https://community.vuetifyjs.com/).


### PR DESCRIPTION
Hi! :) 

This Pr simplify contributors onboarding with Gitpod(a free online VS Code like IDE that provides ready to code dev environments). With a single click it will launch a ready to code workspace where:

- the dependencies are pre-installed.
- `yarn run build` finished.
- the webserver running.

so that anyone interested in contributing can start straight away without wasting time on the setup.

This can be tried on my fork via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/vuetify

#### Screenshot:

![image](https://user-images.githubusercontent.com/46004116/76041846-11a41600-5f75-11ea-98fd-45e12e408242.png)

