### PR TITLE
feat(VIcon): add font awesome support

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
+    "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@mdi/js": "^3.8.95",
     "autoprefixer": "^9.6.1",
     "babel-loader": "^8.0.6",

--- a/packages/docs/src/data/pages/components/Icons.json
+++ b/packages/docs/src/data/pages/components/Icons.json
@@ -81,7 +81,8 @@
             "simple/color",
             "intermediate/buttons",
             "intermediate/clickable",
-            "complex/mdi-svg"
+            "complex/mdi-svg",
+            "complex/fa-svg"
           ]
         }
       ]

--- a/packages/docs/src/data/pages/customization/Icons.json
+++ b/packages/docs/src/data/pages/customization/Icons.json
@@ -305,6 +305,22 @@
             {
               "type": "markup",
               "value": "js_vuetify_custom_fa_svg_icons"
+            },
+            {
+              "type": "text",
+              "lang": "customFASvgText2"
+            },
+            {
+              "type": "markup",
+              "value": "vuetify_custom_fa_svg_icons_direct"
+            },
+            {
+              "type": "text",
+              "lang": "customFASvgText3"
+            },
+            {
+              "type": "markup",
+              "value": "vuetify_custom_fa_svg_icons_jsx"
             }
           ]
         }

--- a/packages/docs/src/examples/icons/complex/fa-svg.vue
+++ b/packages/docs/src/examples/icons/complex/fa-svg.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-row
+    align="center"
+    justify="center"
+  >
+    <v-icon>{{ icons.faEdit }}</v-icon>
+    <div class="mx-2"></div>
+    <v-icon>{{ icons.faCoffee }}</v-icon>
+    <div class="mx-2"></div>
+    <v-icon>{{ icons.faInbox }}</v-icon>
+    <div class="mx-2"></div>
+    <v-btn
+      color="primary"
+      depressed
+    >
+      <v-icon left>{{ icons.faComments }}</v-icon>
+      Comment
+    </v-btn>
+  </v-row>
+</template>
+
+<script>
+  import {
+    faEdit,
+    faCoffee,
+    faInbox,
+    faComments,
+  } from '@fortawesome/free-solid-svg-icons'
+
+  export default {
+    data: () => ({
+      icons: {
+        faEdit,
+        faCoffee,
+        faInbox,
+        faComments,
+      },
+    }),
+  }
+</script>

--- a/packages/docs/src/lang/en/components/Icons.json
+++ b/packages/docs/src/lang/en/components/Icons.json
@@ -26,6 +26,10 @@
     "mdi-svg": {
       "heading": "### MDI SVG",
       "desc": "You can manually import only the icons you use when using the [@mdi/js](https://www.npmjs.com/package/@mdi/js) package. If you want to use SVG icons with `VIcon` component, read about using them [here](/customization/icons#install-material-design-icons-js-svg)."
+    },
+    "fa-svg": {
+      "heading": "### Font Awesome Pro SVG",
+      "desc": "You can manualy construct an SVG payload, to use directly with VIcon or other components using VIcon. It's fully compatible with Font Awesome Pro 5 icons, so you can import them manualy from their SVG library to benefit from the tree shaking."
     }
   },
   "props": {

--- a/packages/docs/src/lang/en/customization/Icons.json
+++ b/packages/docs/src/lang/en/customization/Icons.json
@@ -44,5 +44,7 @@
   "usingMissingMaterialIconsText3": "Then you need to register the exact material icons you want.",
   "usingMissingMaterialIconsText4": "Finally you can use the material icons like this.",
   "customFASvg": "### Custom Font Awesome Pro Icons",
-  "customFASvgText1": "You can utilize component icons with Font Awesome Pro to select individual icon weights:"
+  "customFASvgText1": "You can utilize component icons with Font Awesome Pro to select individual icon weights:",
+  "customFASvgText2": "You can also directly pass Font Awesome Pro icons within the slot of the VIcon component. This way you get the benefit of tree-shaking, and you don't need to list all icons in a library prior to their use.",
+  "customFASvgText3": "It's also a perfect way to implement FA icons through JSX like so:"
 }

--- a/packages/docs/src/lang/fr-FR/customization/Icons.json
+++ b/packages/docs/src/lang/fr-FR/customization/Icons.json
@@ -44,5 +44,7 @@
   "usingMissingMaterialIconsText3": "Vous devez alors enregistrer les icônes Material exactes que vous voulez.",
   "usingMissingMaterialIconsText4": "Enfin, vous pouvez utiliser les icônes Material comme ceci.",
   "customFASvg": "### Icônes personnalisées Font Awesome Pro",
-  "customFASvgText1": "Vous pouvez utiliser les icônes des composants avec Font Awesome Pro pour sélectionner des poids d'icônes individuels :"
+  "customFASvgText1": "Vous pouvez utiliser les icônes des composants avec Font Awesome Pro pour sélectionner des poids d'icônes individuels :",
+  "customFASvgText2": "Vous pouvez également passer une icone SVG de Font Awesome Pro directement dans le slot du composent VIcon. De cette manière, vous bénéficierez du tree-shaking, et vous n'aurez également plus besoin de lister les icones dans une library en amont.",
+  "customFASvgText3": "C'est aussi une élégante façon d'implémenter les icones FA au travers de JSX comme suit :"
 }

--- a/packages/docs/src/snippets/js/vuetify_custom_fa_svg_icons_direct.txt
+++ b/packages/docs/src/snippets/js/vuetify_custom_fa_svg_icons_direct.txt
@@ -1,0 +1,17 @@
+<!-- Vue Component -->
+
+<template>
+  <div class="my-component">
+    <v-icon>{{ icon }}</v-icon>
+  </div>
+</template>
+
+<script>
+  import { faBars } from '@fortawesome/free-solid-svg-icons'
+
+  export default {
+    data: {
+      icon: faBars
+    }
+  }
+</script>

--- a/packages/docs/src/snippets/js/vuetify_custom_fa_svg_icons_jsx.txt
+++ b/packages/docs/src/snippets/js/vuetify_custom_fa_svg_icons_jsx.txt
@@ -1,0 +1,13 @@
+<!-- Vue JSX Component -->
+
+import { faBars } from '@fortawesome/free-solid-svg-icons'
+
+export default {
+  render() {
+    return (
+      <div class="my-component">
+        <v-icon>{ faBars }</v-icon>
+      </div>
+    )
+  }
+}

--- a/packages/vuetify/src/components/VIcon/__tests__/VIcon.spec.ts
+++ b/packages/vuetify/src/components/VIcon/__tests__/VIcon.spec.ts
@@ -309,5 +309,42 @@ describe('VIcon', () => {
 
       expect(wrapper.html()).toMatchSnapshot()
     })
+
+    it('should render an svg icon using svg icon definition', async () => {
+      const wrapper = mountFunction({}, {
+        path: 'M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z',
+        viewBox: '0 0 24 24',
+      } as any)
+
+      expect(wrapper.html()).toMatchSnapshot()
+
+      wrapper.setProps({ large: true })
+
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('should render an svg icon using a FontAwesome5 icon definition', async () => {
+      const wrapper = mountFunction({}, {
+        icon: [
+          24,
+          24,
+          [],
+          'f0c9',
+          'M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z',
+        ],
+        iconName: 'test',
+        prefix: 'fas',
+      } as any)
+
+      expect(wrapper.html()).toMatchSnapshot()
+
+      wrapper.setProps({ large: true })
+
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
 })

--- a/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
+++ b/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
@@ -35,6 +35,76 @@ exports[`VIcon for component icon should render an svg icon 2`] = `
 </span>
 `;
 
+exports[`VIcon for component icon should render an svg icon using a FontAwesome5 icon definition 1`] = `
+<span aria-hidden="true"
+      class="v-icon notranslate v-icon--svg theme--light"
+>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewbox="0 0 24 24"
+       height="32"
+       width="32"
+       role="img"
+       aria-hidden="true"
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
+    </path>
+  </svg>
+</span>
+`;
+
+exports[`VIcon for component icon should render an svg icon using a FontAwesome5 icon definition 2`] = `
+<span aria-hidden="true"
+      class="v-icon notranslate v-icon--svg theme--light"
+      style="font-size: 36px; height: 36px; width: 36px;"
+>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewbox="0 0 24 24"
+       height="36px"
+       width="36px"
+       role="img"
+       aria-hidden="true"
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
+    </path>
+  </svg>
+</span>
+`;
+
+exports[`VIcon for component icon should render an svg icon using svg icon definition 1`] = `
+<span aria-hidden="true"
+      class="v-icon notranslate v-icon--svg theme--light"
+>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewbox="0 0 24 24"
+       height="32"
+       width="32"
+       role="img"
+       aria-hidden="true"
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
+    </path>
+  </svg>
+</span>
+`;
+
+exports[`VIcon for component icon should render an svg icon using svg icon definition 2`] = `
+<span aria-hidden="true"
+      class="v-icon notranslate v-icon--svg theme--light"
+      style="font-size: 36px; height: 36px; width: 36px;"
+>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewbox="0 0 24 24"
+       height="36px"
+       width="36px"
+       role="img"
+       aria-hidden="true"
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
+    </path>
+  </svg>
+</span>
+`;
+
 exports[`VIcon for component icon should render component 1`] = `
 <div class="v-icon notranslate test-component v-icon--is-component theme--light"
      aria-hidden="true"

--- a/packages/vuetify/types/services/icons.d.ts
+++ b/packages/vuetify/types/services/icons.d.ts
@@ -27,7 +27,14 @@ export type VuetifyIconComponent = {
   props?: object
 }
 
-export type VuetifyIcon = string | VuetifyIconComponent
+export type VuetifyIconSVG = {
+  path: string
+  viewBox: string
+  name?: string
+  prefix?: string
+}
+
+export type VuetifyIcon = string | VuetifyIconComponent | VuetifyIconSVG
 
 export interface VuetifyIcons {
   complete: VuetifyIcon


### PR DESCRIPTION
## Description
Font Awesome icons does not returns directly an SVG path like MDI, but an object containing more informations. One very useful information is the viewbox size, which was defaulting to 24 within VIcon.

This commit brings a new interface `VuetifyIconSVG` which can be given directly as the slot of VIcon, to handle those cases.

It also add the support for a Font Awesome SVG icon definition object to be passed directly within the VIcon slot (it will internaly be converted to a VuetifyIconSVG).

This changes is fully retro-compatible and does not change the API of VIcon.

## Motivation and Context
It solves the issue #9995, which was not resolved fully by #9996.

## How Has This Been Tested?
Unit test have been added to test the case with :
* a custom path given within a `VuetifyIconSVG` payload
* an icon definition from Font Awesome Pro 5
It has also been tested successfuly within a project with ~50 components.

unit | visually

## Markup:

<details>

```vue
<template>
  <v-row
    align="center"
    justify="center"
  >
    <v-icon>{{ icons.faDogLeashed }}</v-icon>
    <div class="mx-2"></div>
    <v-icon>{{ icons.faTachometer }}</v-icon>
    <div class="mx-2"></div>
    <v-icon>{{ icons.faInbox }}</v-icon>
    <div class="mx-2"></div>
    <v-btn
      color="primary"
      depressed
    >
      <v-icon left>{{ icons.faComments }}</v-icon>
      Comment
    </v-btn>
  </v-row>
</template>

<script>
  import {
    faDogLeashed,
    faTachometer,
    faInbox,
    faComments,
  } from "@fortawesome/pro-light-svg-icons";

  export default {
    data: () => ({
      icons: {
        faDogLeashed,
        faTachometer,
        faInbox,
        faComments,
      },
    }),
  }
</script>
```

</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
