### PR TITLE
fix(VSkeletonLoader): remove unnecessary border-radius on skeleton-loader card style

### DIFF
--- a/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.sass
+++ b/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.sass
@@ -209,7 +209,7 @@
     ~ .v-skeleton-loader__card-heading
       border-radius: 0
 
-    &:first-child, &:last-child
+    &::first-child, &::last-child
       border-radius: inherit
 
   &__list-item

--- a/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.sass
+++ b/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.sass
@@ -204,9 +204,13 @@
 
   &__image
     height: $skeleton-loader-image-height
+    border-radius: 0
 
-    &:not(:first-child):not(:last-child)
+    ~ .v-skeleton-loader__card-heading
       border-radius: 0
+
+    &:first-child, &:last-child
+      border-radius: inherit
 
   &__list-item
     height: $skeleton-loader-list-item-height


### PR DESCRIPTION
Remove the border-radius property when a card-heading is following an image in skeleton-loader.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
When rendering `skeleton-loader` type `"card"` a `border-radius` property break the seams between the image and the card-heading. This is more easy to notice on dark theme.

## Motivation and Context
I can't find any open related issue. However, this is related to the addition of 74bc9011152b61b36b636249d38a6b9c367d5e99 that raised the issue #9447.
I don't see why https://github.com/vuetifyjs/vuetify/commit/74bc9011152b61b36b636249d38a6b9c367d5e99#diff-e99f6b3f7c8208735fbabc77e06b7e33R111 was added and what it add to the code. I tried every `skeleton-loader` without this and I can't see any difference.

## How Has This Been Tested?
visually 

## Markup:
<details>

```vue
<template>
  <v-skeleton-loader type="card"></v-skeleton-loader>
</template>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
