### PR TITLE
improvement(VForm): pass all VForm event listeners 

### DIFF
--- a/packages/vuetify/src/components/VForm/VForm.ts
+++ b/packages/vuetify/src/components/VForm/VForm.ts
@@ -130,9 +130,7 @@ export default mixins(
         novalidate: true,
         ...this.attrs$,
       },
-      on: {
-        submit: (e: Event) => this.$emit('submit', e),
-      },
+      on: this.listeners$,
     }, this.$slots.default)
   },
 })

--- a/packages/vuetify/src/components/VForm/__tests__/VForm.spec.ts
+++ b/packages/vuetify/src/components/VForm/__tests__/VForm.spec.ts
@@ -26,7 +26,7 @@ describe('VForm.ts', () => {
   })
 
   // TODO: event not bubbling or something
-  it.skip('should pass on listeners to form element', async () => {
+  it.skip('should pass on save listener to form element', async () => {
     const submit = jest.fn()
     const component = Vue.component('test', {
       render (h) {
@@ -47,6 +47,50 @@ describe('VForm.ts', () => {
     btn.trigger('click')
 
     expect(submit).toHaveBeenCalled()
+  })
+
+  it('should pass on reset listener to form element', async () => {
+    const reset = jest.fn()
+    const component = Vue.component('test', {
+      render (h) {
+        return h(VForm, {
+          on: {
+            reset,
+          },
+        }, [
+          h('button', {
+            attrs: { type: 'reset' },
+          }, ['Reset']),
+        ])
+      },
+    })
+
+    const wrapper = mount(component, { attachToDocument: true })
+
+    const btn = wrapper.find('button')
+
+    btn.trigger('click')
+
+    expect(reset).toHaveBeenCalled()
+  })
+
+  it('should pass on click listener to form element', async () => {
+    const click = jest.fn()
+    const component = Vue.component('test', {
+      render (h) {
+        return h(VForm, {
+          on: {
+            click,
+          },
+        })
+      },
+    })
+
+    const wrapper = mount(component)
+    const form = wrapper.find('form')
+
+    form.trigger('click')
+    expect(click).toHaveBeenCalled()
   })
 
   it('should watch the error bag', async () => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Adds the form reset event listener that proxies the event to parent component.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
I've stumbled upon this while trying to combine a `VForm` component directly with `VeeValidate`'s `ValidationObserver` and the `reset` handler did not work. While I'm sure there are other/better ways to combine these two, it would be nice that the `VForm` component supports emitting the base `form` element reset event.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Created a new unit test.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
