### PR TITLE
fix(VTreeview.sass): center vertically treeview items on IE11

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.sass
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.sass
@@ -61,6 +61,14 @@
     top: 0
     transition: $primary-transition
 
+  // Fix for IE11 where min-height does not work with
+  // align-items: center in flex containers
+  // https://github.com/philipwalton/flexbugs/issues/231
+  &::after
+    content: ''
+    min-height: inherit
+    font-size: 0
+
 .v-treeview-node__children
   transition: all $treeview-transition
 

--- a/packages/vuetify/src/components/VTreeview/VTreeview.sass
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.sass
@@ -66,8 +66,8 @@
   // https://github.com/philipwalton/flexbugs/issues/231
   &::after
     content: ''
-    min-height: inherit
     font-size: 0
+    min-height: inherit
 
 .v-treeview-node__children
   transition: all $treeview-transition


### PR DESCRIPTION
After this fix treeview items are now vertically centered on IE11.

fix #10534

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #10534

On IE11 treeview items are not vertically centered. This PR fixes this issue.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I want to fix the bug which exists only on IE11.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
I have tested the changes visually on different browsers including IE11.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-treeview activatable color="warning" :items="items"></v-treeview>
  </v-container>
</template>

<script>
export default {
  data() {
    return {
      items: [
        {
          id: 1,
          name: "Applications :",
          children: [
            { id: 2, name: "Calendar : app" },
            { id: 3, name: "Chrome : app" },
            { id: 4, name: "Webstorm : app" }
          ]
        },
        {
          id: 5,
          name: "Documents :",
          children: [
            {
              id: 6,
              name: "vuetify :",
              children: [
                {
                  id: 7,
                  name: "src :",
                  children: [
                    { id: 8, name: "index : ts" },
                    { id: 9, name: "bootstrap : ts" }
                  ]
                }
              ]
            },
            {
              id: 10,
              name: "material2 :",
              children: [
                {
                  id: 11,
                  name: "src :",
                  children: [
                    { id: 12, name: "v-btn : ts" },
                    { id: 13, name: "v-card : ts" },
                    { id: 14, name: "v-window : ts" }
                  ]
                }
              ]
            }
          ]
        },
        {
          id: 15,
          name: "Downloads :",
          children: [
            { id: 16, name: "October : pdf" },
            { id: 17, name: "November : pdf" },
            { id: 18, name: "Tutorial : html" }
          ]
        },
        {
          id: 19,
          name: "Videos :",
          children: [
            {
              id: 20,
              name: "Tutorials :",
              children: [
                { id: 21, name: "Basic layouts : mp4" },
                { id: 22, name: "Advanced techniques : mp4" },
                { id: 23, name: "All about app : dir" }
              ]
            },
            { id: 24, name: "Intro : mov" },
            { id: 25, name: "Conference introduction : avi" }
          ]
        }
      ]
    };
  }
};
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
