### PR TITLE
refactor(typography): reorder subtitle-1 and 2

### DIFF
--- a/packages/vuetify/src/styles/elements/_typography.sass
+++ b/packages/vuetify/src/styles/elements/_typography.sass
@@ -41,19 +41,19 @@
     letter-spacing: map-deep-get($headings, 'h6', 'letter-spacing') !important
     font-family: map-deep-get($headings, 'h6', 'font-family') !important
 
-  .subtitle-1
-    font-size: map-deep-get($headings, 'subtitle-1', 'size') !important
-    font-weight: map-deep-get($headings, 'subtitle-1', 'weight')
-    letter-spacing: map-deep-get($headings, 'subtitle-1', 'letter-spacing') !important
-    line-height: map-deep-get($headings, 'subtitle-1', 'line-height')
-    font-family: map-deep-get($headings, 'subtitle-1', 'font-family') !important
-
   .subtitle-2
     font-size: map-deep-get($headings, 'subtitle-2', 'size') !important
     font-weight: map-deep-get($headings, 'subtitle-2', 'weight')
     letter-spacing: map-deep-get($headings, 'subtitle-2', 'letter-spacing') !important
     line-height: map-deep-get($headings, 'subtitle-2', 'line-height')
     font-family: map-deep-get($headings, 'subtitle-2', 'font-family') !important
+
+  .subtitle-1
+    font-size: map-deep-get($headings, 'subtitle-1', 'size') !important
+    font-weight: map-deep-get($headings, 'subtitle-1', 'weight')
+    letter-spacing: map-deep-get($headings, 'subtitle-1', 'letter-spacing') !important
+    line-height: map-deep-get($headings, 'subtitle-1', 'line-height')
+    font-family: map-deep-get($headings, 'subtitle-1', 'font-family') !important
 
   .body-2
     font-size: map-deep-get($headings, 'body-2', 'size') !important


### PR DESCRIPTION
## Description

Following the pattern of how the classes are arranged, everything is sorted descendingly except for `.subtitle-1` and `.subtitle-2`.

## Motivation and Context

The patterns should be consistent.

## How Has This Been Tested?

none

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
