### PR TITLE
fix(VSelect): make the VSelect height the same of VTextField

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -126,6 +126,13 @@
       text-overflow: ellipsis
       white-space: nowrap
 
+  &.v-input--dense
+    .v-select__selection--comma
+      margin: $select-dense-selections-margin
+
+    .v-chip
+      margin: $select-dense-chip-margin
+
   &__slot
     position: relative
     align-items: center

--- a/packages/vuetify/src/components/VSelect/_variables.scss
+++ b/packages/vuetify/src/components/VSelect/_variables.scss
@@ -1,6 +1,7 @@
 @import '../../styles/styles.sass';
 
 $select-chip-margin: 4px !default;
+$select-dense-chip-margin: 0 4px 0 4px !default;
 $select-selected-chip-opacity: .22 !default;
 $select-prefix-line-height: 20px !default;
 $select-prefix-top: 7px !default;
@@ -11,9 +12,10 @@ $select-chips-selections-padding-top: 42px !default;
 $select-active-icon-flip: true !default;
 $select-chips-dense-selections-padding-top: 40px !default;
 $select-active-chip-opacity: 0.2 !default;
-$select-small-chips-selections-min-height: 32px !default;
+$select-small-chips-selections-min-height: 26px !default;
 $select-chips-box-enclosed-selections-min-height: 68px !default;
 $select-chips-dense-selections-min-height: 40px !default;
 $select-small-chips-dense-selections-min-height: 38px !default;
 $select-selections-line-height: 18px !default;
 $select-selections-margin: 7px 4px 7px 0 !default;
+$select-dense-selections-margin: 5px 4px 3px 0 !default;

--- a/packages/vuetify/src/components/VSelect/_variables.scss
+++ b/packages/vuetify/src/components/VSelect/_variables.scss
@@ -14,7 +14,6 @@ $select-active-chip-opacity: 0.2 !default;
 $select-small-chips-selections-min-height: 32px !default;
 $select-chips-box-enclosed-selections-min-height: 68px !default;
 $select-chips-dense-selections-min-height: 40px !default;
-$select-small-chips-selections-min-height: 56px !default;
 $select-small-chips-dense-selections-min-height: 38px !default;
 $select-selections-line-height: 18px !default;
 $select-selections-margin: 7px 4px 7px 0 !default;

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -86,12 +86,19 @@
   &.v-input--dense
     padding-top: 0
 
-    &:not(.v-text-field--outlined):not(.v-text-field--single-line):not(.v-select)
+    &:not(.v-text-field--outlined)
       input
         padding: $text-field-dense-padding
 
     &[type=text]::-ms-clear
       display: none
+
+    .v-input__prepend-inner,
+    .v-input__append-inner
+      margin-top: $text-field-dense-append-prepend-margin
+
+      .v-input__icon > .v-icon
+        margin-top: $text-field-dense-icon-append-prepend-margin-top
 
   .v-input__prepend-inner,
   .v-input__append-inner

--- a/packages/vuetify/src/components/VTextField/_variables.scss
+++ b/packages/vuetify/src/components/VTextField/_variables.scss
@@ -5,6 +5,8 @@ $text-field-line-height: 20px !default;
 $text-field-padding: 8px 0 8px !default;
 $text-field-dense-padding: 4px 0 2px !default;
 $text-field-append-prepend-margin: 4px !default;
+$text-field-dense-append-prepend-margin: 0px !default;
+$text-field-dense-icon-append-prepend-margin-top: 8px !default;
 $text-field-filled-full-width-outlined-slot-min-height: 56px !default;
 $text-field-filled-full-width-outlined-dense-slot-min-height: 52px !default;
 $text-field-filled-full-width-outlined-single-line-slot-min-height: 40px !default;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Reduced the height of the VSelect in dense mode to match the height of the VTextField.
Fixes #10877 

## Motivation and Context
When in dense mode, the VSelect height is bigger than the VTextField height, resulting in the text and underline of the elements being misaligned when placed side to side. The problem also happens when using a append or prepend inner icon in a VTextField, but the difference is smaller. One of the changes here reverts PR #10694, which fixed the changing height of the VSelect, but it would still be misaligned in relation to the VTextField.

## How Has This Been Tested?
Visually

Before
![Captura de Tela (16)](https://user-images.githubusercontent.com/18455124/77151591-04a71c80-6a75-11ea-8d85-d2704522e32c.png)

After
![Captura de Tela (17)](https://user-images.githubusercontent.com/18455124/77151604-0c66c100-6a75-11ea-84a2-2a3bf3430201.png)

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row class="title">Standard</v-row>
    <v-row>
      <v-col>
        <v-select v-model="select" label="Select" :items="list"></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select_2" label="Empty Select" :items="list"></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select" label="Small Chip Select" :items="list" chips small-chips></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select" label="Chip Select" :items="list" chips></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select_2" label="Empty Chip Select" :items="list" chips></v-select>
      </v-col>
      <v-col>
        <v-autocomplete v-model="values" :items="list" chips label="Chips Autocomplete" multiple></v-autocomplete>
      </v-col>
    </v-row>

    <v-row class="title">Dense</v-row>
    <v-row>
      <v-col>
        <v-select v-model="select" label="Dense Select" :items="list" dense></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select_2" label="Empty Dense Select" :items="list" dense></v-select>
      </v-col>
      <v-col>
        <v-select
          v-model="select"
          label="Small Chip Dense Select"
          :items="list"
          chips
          small-chips
          dense
        ></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select" label="Chip Dense Select" :items="list" chips dense></v-select>
      </v-col>
      <v-col>
        <v-select v-model="select_2" label="Empty Chip Dense Select" :items="list" chips dense></v-select>
      </v-col>
      <v-col>
        <v-autocomplete
          v-model="values"
          :items="list"
          chips
          label="Dense Chips Autocomplete"
          multiple
          dense
        ></v-autocomplete>
      </v-col>
    </v-row>

    <v-row class="title">This row should be aligned</v-row>
    <v-row>
      <v-col>
        <v-text-field dense label="Dense text"></v-text-field>
      </v-col>
      <v-col>
        <v-text-field dense append-icon="place" label="Dense text icon"></v-text-field>
      </v-col>
      <v-col>
        <v-select dense label="Dense empty"></v-select>
      </v-col>
      <v-col>
        <v-select dense label="Dense selected" :items="list" v-model="select"></v-select>
      </v-col>
      <v-col>
        <v-select dense single-line :items="list" label="Dense single-line"></v-select>
      </v-col>
      <v-col>
        <v-select dense small-chips label="Dense small chips" :items="list" v-model="select"></v-select>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
export default {
  data() {
    return {
      list: ["Dense"],
      autocomplete: "A",
      select: "Dense",
      autocomplete_2: null,
      select_2: null,
      values: ["A", "B"]
    };
  }
};
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
