### PR TITLE
docs(i18n): add shorter snippet for custom i18n

### DIFF
--- a/packages/docs/src/lang/en/customization/Internationalization.json
+++ b/packages/docs/src/lang/en/customization/Internationalization.json
@@ -6,7 +6,7 @@
   "availableLocalesText": "Currently Vuetify provides translations in the following languages:",
   "alertInfo": "Vuetify provides only a basic translation function `t`. It is recommended for more advanced internationalization functions to make use of Vuetifys integration with [vue-i18n](#vue-i-18-n)",
   "createTranslation": "## Create a translation",
-  "createTranslationText": "To create your own translation, use the code below or copy and rename the file `vuetify/src/locale/en.ts` to your project and make your changes.",
+  "createTranslationText": "To create your own translation, use the code below. You will inherit Vuetify's translations, but also can add your own. Alternatively, you can copy and paste the content of `vuetify/src/locale/en.ts`, but it'll require manual file syncing during updates.",
   "customComponents": "## Custom components",
   "customComponentsText": "If you are building custom Vuetify components that need to hook into the internationalization engine, you can use the `t` function which is part of the `$vuetify.lang` API.",
   "api": {

--- a/packages/docs/src/snippets/ts/create_translation.txt
+++ b/packages/docs/src/snippets/ts/create_translation.txt
@@ -1,4 +1,5 @@
-import { en } from "vuetify/src/locale";
+import { en } from 'vuetify/src/locale'
+
 export default {
   ...en,
 

--- a/packages/docs/src/snippets/ts/create_translation.txt
+++ b/packages/docs/src/snippets/ts/create_translation.txt
@@ -1,4 +1,11 @@
 import { en } from "vuetify/src/locale";
 export default {
-  ...en
+  ...en,
+
+  key1: "key 1 internationalization",
+  key2: "key 2 internationalization",
+
+  namespace: {
+    key3: "key 3 internationalization"
+  }
 }

--- a/packages/docs/src/snippets/ts/create_translation.txt
+++ b/packages/docs/src/snippets/ts/create_translation.txt
@@ -1,37 +1,4 @@
+import { en } from "vuetify/src/locale";
 export default {
-  close: 'Close',
-  dataIterator: {
-    pageText: '{0}-{1} of {2}',
-    noResultsText: 'No matching records found',
-    loadingText: 'Loading items...',
-  },
-  dataTable: {
-    itemsPerPageText: 'Rows per page:',
-    ariaLabel: {
-      sortDescending: ': Sorted descending. Activate to remove sorting.',
-      sortAscending: ': Sorted ascending. Activate to sort descending.',
-      sortNone: ': Not sorted. Activate to sort ascending.',
-    },
-    sortBy: 'Sort by',
-  },
-  dataFooter: {
-    pageText: '{0}-{1} of {2}',
-    itemsPerPageText: 'Items per page:',
-    itemsPerPageAll: 'All',
-    nextPage: 'Next page',
-    prevPage: 'Previous page',
-    firstPage: 'First page',
-    lastPage: 'Last page',
-  },
-  datePicker: {
-    itemsSelected: '{0} selected',
-  },
-  noDataText: 'No data available',
-  carousel: {
-    prev: 'Previous visual',
-    next: 'Next visual',
-  },
-  calendar: {
-    moreEvents: '{0} more',
-  },
+  ...en
 }


### PR DESCRIPTION
## Description
Use shorter and less error-prone snippet for custom i18n.

## Motivation and Context
Current snippet suggests to copy-paste file's content, while it's better to inherit properties, so you won't need to manually check and sync copied content during updates.

## How Has This Been Tested?
N/A

## Markup:
N/A

## Types of changes
- [x] Documentation

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
