### PR TITLE
docs(zh-cn): add translation in `introduction` chapter

### DIFF
--- a/packages/docs/src/lang/zh-CN/introduction/LongTermSupport.json
+++ b/packages/docs/src/lang/zh-CN/introduction/LongTermSupport.json
@@ -2,6 +2,7 @@
   "heading": "# 长期支持",
   "headingText": "作为一个组件框架，我们知道许多使用 Vuetify 的项目都有开发周期，这是升级到最新版本的阻力。为了给开发人员和业务人员带来安心，我们提供了 **长期支持** 最新的 _重大_ 版本。这意味着在每个 _重大_ 发行版中，您都可以放心地知道，在一个新的主要发行版之后的 **12 个月** 内，你现有的版本将会获得针对关键的 bug 和安全漏洞进行更新。",
   "2header": "## Vuetify 2.0",
+  "2text": "这是基于 Material Design 2 规范的最新 LTS 版本。它包含了许多对v1.5版本的改进，拥有最新的功能和 bug 修复，是推荐使用的版本。这个版本正在被积极的维护，并且已经有了未来开发方向的 [路线图](/introduction/roadmap)。",
   "2features": [
     "**7 个新组件**",
     "**完成对 MD2 Specification 的升级**",
@@ -11,7 +12,7 @@
   ],
   "2upgrade": "准备从 v1.5 更新到此版本？请查阅可用的 [upgrade guide](https://github.com/vuetifyjs/vuetify/releases/tag/v2.0.0#user-content-upgrade-guide)。",
   "15header": "## Vuetify 1.5 LTS",
-  "15text": "这是基于 Material Design 1 specification 的最新 LTS 版本。LTS代表长期支持——这意味着支持 12个月，直到 2020年7月，提供免费的安全更新和关键的 bug 修复。",
+  "15text": "这是基于 Material Design 1 规范的最新 LTS 版本。LTS代表长期支持——这意味着支持 12个月，直到 2020年7月，提供免费的安全更新和关键的 bug 修复。",
   "15text2": "准备更新到 v1.5？请查阅可用的更新指南：",
   "15versions": [
     "[Vuetify v1.5](https://github.com/vuetifyjs/vuetify/releases/tag/v1.5.0)",

--- a/packages/docs/src/lang/zh-CN/introduction/WhyVuetify.json
+++ b/packages/docs/src/lang/zh-CN/introduction/WhyVuetify.json
@@ -4,6 +4,7 @@
   "community": "社区",
   "communityCaption": "准备好享受 Vue 生态系统中最活跃的社区之一吧。被一个问题困住了？马上寻求帮助。找到一个bug？想谈谈 Firebase 吗？创造了一些令人惊叹的东西吗？来让我们知道吧！了解其他人在 [awesome-vuetify](https://github.com/vuetifyjs/awesome-vuetify) 存储库上构建了什么。",
   "communityHeader": "## 开发者支持",
+  "communityText": "使用Vuetify进行开发意味着你永远不会孤立无援。在官方的 [Discord 群组](https://community.vuetifyjs.com) 可以快速获得开发团队与其他社区成员地帮助，并有机会与世界各地的优秀开发者交流，以帮助您取得成功。需要帮助并且乐于赞助本项目吗？成为 [赞助者](https://github.com/sponsors/johnleider) ，您就能访问非公开的技术支持渠道或是 [咨询](/professional-support/consulting) 项目作者。",
   "comparisonHeader": "## 对比其它框架",
   "comparisonText": "自2014年发布以来，[Vue.js](https://vuejs.org/) 已经成为世界上最流行的 JavaScript 框架之一。这种流行的原因之一是组件的广泛使用，它使开发人员能够创建在整个应用程序中使用和重用的简洁模块。UI 库是这些组件的集合，它们根据特定的样式指南来实现，并提供构建丰富 web 应用程序所需的工具。以下是 2019 年 Vue 最佳组件库的精简列表:",
   "continuous": "持续",


### PR DESCRIPTION
## Description
add `2text` in `zh-CN/introduction/LongTermSupport.json`
add `communityText` in `zh-CN/introduction/WhyVuetify.json`

## Motivation and Context
There are **some contents not localized in Chinese** in vuetify documentation. And there are also some rough translation.
I guess if I have time I would like to modify these translations to make them more suitable for Chinese language understanding

## How Has This Been Tested?

## Markup:

## Types of changes
- [x] Documentation

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
