### PR TITLE
feat(VParallax): add srcset attribute

### DIFF
--- a/packages/vuetify/src/components/VParallax/VParallax.ts
+++ b/packages/vuetify/src/components/VParallax/VParallax.ts
@@ -31,6 +31,7 @@ export default baseMixins.extend<options>().extend({
       default: 500,
     },
     src: String,
+    srcset: String,
   },
 
   data: () => ({
@@ -80,6 +81,7 @@ export default baseMixins.extend<options>().extend({
       style: this.styles,
       attrs: {
         src: this.src,
+        srcset: this.srcset,
         alt: this.alt,
       },
       ref: 'img',


### PR DESCRIPTION
## Description
Added "srcset" attribute to v-parallax component. It defines multiple sizes of the same image, allowing the browser to select the appropriate image source.

## Motivation and Context
Implements #1535 feature request

## How Has This Been Tested?
Visually tested

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
