### PR TITLE
feat(VDatatable) : SASS variable for header text color

### DIFF
--- a/.czrc
+++ b/.czrc
@@ -1,0 +1,1 @@
+{ "path": "cz-conventional-changelog" }

--- a/packages/vuetify/dev/router.js
+++ b/packages/vuetify/dev/router.js
@@ -1,11 +1,12 @@
 import Vue from 'vue'
 import Router from 'vue-router'
-
+import P from './Playground.vue'
 Vue.use(Router)
-
+/*
 const component1 = {
   template: `<div class="title">Page 1</div>`,
 }
+*/
 const component2 = {
   template: `<div class="title">Page 2</div>`,
 }
@@ -15,7 +16,7 @@ const router = new Router({
     {
       path: '/page1',
       name: 'Page 1',
-      component: component1,
+      component: P,
     },
     {
       path: '/page2',

--- a/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-events.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-events.spec.ts
@@ -111,7 +111,7 @@ describe('calendar-with-events.ts', () => {
     expect(wrapper.vm.eventNameFunction).toBeDefined()
     expect(typeof wrapper.vm.eventNameFunction).toBe('function')
     expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12' }, input: { Conference: 'Conference' } })).toBe('Conference')
-    expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12', hour: 8, minute: 30, hasTime: true }, input: { Conference: 'Conference' } })).toBe('<strong>8:30 AM</strong> Conference')
+    expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12', hour: 8, minute: 30, hasTime: true }, input: { Conference: 'Conference' } })).toBe('<strong>8:30</strong> Conference')
   })
 
   it('should format time', async () => {
@@ -122,10 +122,10 @@ describe('calendar-with-events.ts', () => {
 
     const wrapper = mount(Mock)
 
-    expect(wrapper.vm.formatTime(testData1, true)).toBe('8:30 AM')
-    expect(wrapper.vm.formatTime(testData2, true)).toBe('5:45 PM')
-    expect(wrapper.vm.formatTime(testData3, true)).toBe('9:05 AM')
-    expect(wrapper.vm.formatTime(testData4, true)).toBe('3 PM')
+    expect(wrapper.vm.formatTime(testData1, true)).toBe('8:30')
+    expect(wrapper.vm.formatTime(testData2, true)).toBe('17:45')
+    expect(wrapper.vm.formatTime(testData3, true)).toBe('9:05')
+    expect(wrapper.vm.formatTime(testData4, true)).toBe('15')
   })
 
   it('should get events map', async () => {


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
SASS variable for header :
```
'table': (
      'header': (
        'text-color': rgba(map-get($shades, 'black'), 0.6),
        'text-color-active': rgba(map-get($shades, 'black'), 0.87),
        'text-color-disabled': rgba(map-get($shades, 'black'), 0.38)
      )
...
```
fix #10952

## Motivation and Context
I need customize header text color without change global text color

## How Has This Been Tested?
With playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table
    :headers="headers"
    :items="desserts"
    :items-per-page="5"
    class="elevation-1"
  ></v-data-table>
  </v-container>
</template>

<script>
 export default {
    data () {
      return {
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] The PR title is no longer than 64 characters.
- [x ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
