### PR TITLE
VEditDialog: Accept props from Menuable to allow nudging popup

### DIFF
--- a/packages/docs/src/lang/en/components/DataTables.json
+++ b/packages/docs/src/lang/en/components/DataTables.json
@@ -104,7 +104,12 @@
       "eager": "Mixins.Bootable.props.eager",
       "large": "Attaches a submit and cancel button to the dialog",
       "saveText": "Sets the default text for the save button when using the **large** prop",
-      "transition": "Mixins.Transitionable.props.transition"
+      "transition": "Mixins.Transitionable.props.transition",
+      "nudgeBottom": "Mixins.Menuable.props.nudgeBottom",
+      "nudgeLeft": "Mixins.Menuable.props.nudgeLeft",
+      "nudgeRight": "Mixins.Menuable.props.nudgeRight",
+      "nudgeTop": "Mixins.Menuable.props.nudgeTop",
+      "nudgeWidth": "Mixins.Menuable.props.nudgeWidth"
     },
     "v-data-table": {
       "calculateWidths": "Enables calculation of column widths. `widths` property will be available in select scoped slots",

--- a/packages/vuetify/src/components/VDataTable/VEditDialog.ts
+++ b/packages/vuetify/src/components/VDataTable/VEditDialog.ts
@@ -26,6 +26,26 @@ export default mixins(Returnable, Themeable).extend({
     },
     large: Boolean,
     eager: Boolean,
+    nudgeBottom: {
+      type: [Number, String],
+      default: 0,
+    },
+    nudgeLeft: {
+      type: [Number, String],
+      default: 0,
+    },
+    nudgeRight: {
+      type: [Number, String],
+      default: 0,
+    },
+    nudgeTop: {
+      type: [Number, String],
+      default: 0,
+    },
+    nudgeWidth: {
+      type: [Number, String],
+      default: 0,
+    },
     persistent: Boolean,
     saveText: {
       default: 'Save',
@@ -116,6 +136,11 @@ export default mixins(Returnable, Themeable).extend({
         eager: this.eager,
         light: this.light,
         dark: this.dark,
+        nudgeBottom: this.nudgeBottom,
+        nudgeLeft: this.nudgeLeft,
+        nudgeRight: this.nudgeRight,
+        nudgeTop: this.nudgeTop,
+        nudgeWidth: this.nudgeWidth,
       },
       on: {
         input: (val: boolean) => (this.isActive = val),


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
This change allows passing `nudge-bottom`, `nudge-right`, etc. to `VEditDialog` to allow adjusting the position of the popup dialog. 
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Allow for more precise control over how the `VEditDialog` popup is positioned. This allows for more remarkable user experiences where the edit dialog can more intuitively appear with the edit field exactly where the display text was. See the gif below.

**Before**
![Kapture 2020-03-30 at 17 52 13](https://user-images.githubusercontent.com/379169/77965563-41fa7e00-72af-11ea-95a6-2f87c99ef013.gif)

**After**
![Kapture 2020-03-30 at 17 56 59](https://user-images.githubusercontent.com/379169/77965833-e1b80c00-72af-11ea-926d-e753c0f74161.gif)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Visually tested with Playground.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table
      :headers="headers"
      :items="desserts"
    >
      <template v-slot:item.name="props">
        <v-edit-dialog
          transition="slide-x-transition"
          nudge-left="32"
          nudge-top="17"
          :return-value.sync="props.item.name"
          @save="save"
          @cancel="cancel"
          @open="open"
          @close="close"
        > {{ props.item.name }}
          <template v-slot:input>
            <div class="editor">
              <input
                v-model="props.item.name"
                type="text"
              >
            </div>
          </template>
        </v-edit-dialog>
      </template>
      <template v-slot:item.iron="props">
        <v-edit-dialog
          :return-value.sync="props.item.iron"
          large
          persistent
          @save="save"
          @cancel="cancel"
          @open="open"
          @close="close"
        >
          <div>{{ props.item.iron }}</div>
          <template v-slot:input>
            <div class="mt-4 title">Update Iron</div>
          </template>
          <template v-slot:input>
            <v-text-field
              v-model="props.item.iron"
              :rules="[max25chars]"
              label="Edit"
              single-line
              counter
              autofocus
            ></v-text-field>
          </template>
        </v-edit-dialog>
      </template>
    </v-data-table>

    <v-snackbar v-model="snack" :timeout="3000" :color="snackColor">
      {{ snackText }}
      <v-btn text @click="snack = false">Close</v-btn>
    </v-snackbar>
  </v-container>
</template>

<script>
  export default {
    data () {
      return {
        snack: false,
        snackColor: '',
        snackText: '',
        max25chars: v => v.length <= 25 || 'Input too long!',
        pagination: {},
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
    methods: {
      save () {
        this.snack = true
        this.snackColor = 'success'
        this.snackText = 'Data saved'
      },
      cancel () {
        this.snack = true
        this.snackColor = 'error'
        this.snackText = 'Canceled'
      },
      open () {
        this.snack = true
        this.snackColor = 'info'
        this.snackText = 'Dialog opened'
      },
      close () {
        console.log('Dialog closed')
      },
    },
  }
</script>

<style lang="scss" scoped>
.editor {
  padding: 16px;

  input {
    outline: none;
    font-size: 14px;
  }
}
</style>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
