### PR TITLE
feat(VDataTable): add contexmenu:row event for data table

### DIFF
--- a/packages/api-generator/src/maps/v-data-table.js
+++ b/packages/api-generator/src/maps/v-data-table.js
@@ -17,7 +17,16 @@ const TableHeader = {
 }
 
 const DataTableEvents = [
-  { name: 'click:row', source: 'v-data-table', value: 'any, { select: (value: boolean) => void, isSelected: boolean, expand: (value: boolean) => void, isExpanded: boolean }' },
+  {
+    name: 'click:row',
+    source: 'v-data-table',
+    value: 'any, { expand: (value: boolean) => void, headers: TableHeader[], isExpanded: boolean, isMobile: boolean, isSelected: boolean, item: any, select: (value: boolean) => void }',
+  },
+  {
+    name: 'contextmenu:row',
+    source: 'v-data-table',
+    value: 'MouseEvent, { expand: (value: boolean) => void, headers: TableHeader[], isExpanded: boolean, isMobile: boolean, isSelected: boolean, item: any, select: (value: boolean) => void }',
+  },
 ].concat(DataIteratorEvents)
 
 const DataTableHeaderScopedProps = {

--- a/packages/api-generator/src/maps/v-data-table.js
+++ b/packages/api-generator/src/maps/v-data-table.js
@@ -16,16 +16,25 @@ const TableHeader = {
   'sort?': '(a: any, b: any) => number',
 }
 
+const dataString = `{
+  expand: (value: boolean) => void,
+  headers: TableHeader[],
+  isExpanded: boolean,
+  isMobile: boolean,
+  isSelected: boolean,
+  item: any,
+  select: (value: boolean) => void
+}`
 const DataTableEvents = [
   {
     name: 'click:row',
     source: 'v-data-table',
-    value: 'any, { expand: (value: boolean) => void, headers: TableHeader[], isExpanded: boolean, isMobile: boolean, isSelected: boolean, item: any, select: (value: boolean) => void }',
+    value: `any, ${dataString}`,
   },
   {
     name: 'contextmenu:row',
     source: 'v-data-table',
-    value: 'MouseEvent, { expand: (value: boolean) => void, headers: TableHeader[], isExpanded: boolean, isMobile: boolean, isSelected: boolean, item: any, select: (value: boolean) => void }',
+    value: `MouseEvent, ${dataString}`,
   },
 ].concat(DataIteratorEvents)
 

--- a/packages/docs/src/lang/en/components/DataTables.json
+++ b/packages/docs/src/lang/en/components/DataTables.json
@@ -172,7 +172,8 @@
       "save": "Emits when edit-dialog save button is pressed"
     },
     "v-data-table": {
-      "click:row": "Emits when a table row is clicked. The item for the row is included. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`."
+      "click:row": "Emits when a table row is clicked. The item for the row is included. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
+      "contextmenu:row": "Emits when a table row is right-clicked. The item for the row is included. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`."
     },
     "v-simple-checkbox": {
       "click": "Event that is emitted when the component is clicked"

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -461,9 +461,7 @@ export default VDataIterator.extend({
           // TODO: first argument should be the data object
           // but this is a breaking change so it's for v3
           click: () => this.$emit('click:row', item, data),
-          contextmenu: (event: MouseEvent) => {
-            this.$emit('contextmenu:row', event, data)
-          },
+          contextmenu: (event: MouseEvent) => this.$emit('contextmenu:row', event, data),
         },
       })
     },

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -461,6 +461,9 @@ export default VDataIterator.extend({
           // TODO: first argument should be the data object
           // but this is a breaking change so it's for v3
           click: () => this.$emit('click:row', item, data),
+          contextmenu: (event: MouseEvent) => {
+            this.$emit('contextmenu:row', event, data)
+          },
         },
       })
     },

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -348,6 +348,24 @@ describe('VDataTable.ts', () => {
     expect(fn).toHaveBeenCalled()
   })
 
+  it('should emit event when contextmenu is triggered on internally created row', async () => {
+    const fn = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        headers: testHeaders,
+        items: testItems,
+      },
+      listeners: {
+        'contextmenu:row': fn,
+      },
+    })
+
+    wrapper.find('tbody tr').trigger('contextmenu')
+    await wrapper.vm.$nextTick()
+
+    expect(fn).toHaveBeenCalled()
+  })
+
   // https://github.com/vuetifyjs/vuetify/issues/8254
   it('should pass kebab-case footer props correctly', () => {
     const wrapper = mountFunction({

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -423,7 +423,7 @@ exports[`VDataTable.ts should default to first option in itemsPerPageOptions if 
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-409"
+               aria-owns="list-427"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -432,7 +432,7 @@ exports[`VDataTable.ts should default to first option in itemsPerPageOptions if 
                   6
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-409"
+                       id="input-427"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -811,7 +811,7 @@ exports[`VDataTable.ts should handle object when checking if it should default t
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-427"
+               aria-owns="list-445"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -820,7 +820,7 @@ exports[`VDataTable.ts should handle object when checking if it should default t
                   All
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-427"
+                       id="input-445"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -1100,7 +1100,7 @@ exports[`VDataTable.ts should limit page to current page count if not using serv
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-391"
+               aria-owns="list-409"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -1109,7 +1109,7 @@ exports[`VDataTable.ts should limit page to current page count if not using serv
                   5
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-391"
+                       id="input-409"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -1293,7 +1293,7 @@ exports[`VDataTable.ts should not limit page to current item count when using se
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-335"
+               aria-owns="list-353"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -1302,7 +1302,7 @@ exports[`VDataTable.ts should not limit page to current item count when using se
                   5
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-335"
+                       id="input-353"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -1581,7 +1581,7 @@ exports[`VDataTable.ts should not limit page to current item count when using se
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-335"
+               aria-owns="list-353"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -1590,7 +1590,7 @@ exports[`VDataTable.ts should not limit page to current item count when using se
                   5
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-335"
+                       id="input-353"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -1975,7 +1975,7 @@ exports[`VDataTable.ts should not search column with filterable set to false 1`]
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-354"
+               aria-owns="list-372"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -1984,7 +1984,7 @@ exports[`VDataTable.ts should not search column with filterable set to false 1`]
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-354"
+                       id="input-372"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -2178,7 +2178,7 @@ exports[`VDataTable.ts should not search column with filterable set to false 2`]
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-354"
+               aria-owns="list-372"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -2187,7 +2187,7 @@ exports[`VDataTable.ts should not search column with filterable set to false 2`]
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-354"
+                       id="input-372"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -2434,7 +2434,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-373"
+               aria-owns="list-391"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -2443,7 +2443,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-373"
+                       id="input-391"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -2830,7 +2830,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-373"
+               aria-owns="list-391"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -2839,7 +2839,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-373"
+                       id="input-391"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -3096,7 +3096,7 @@ exports[`VDataTable.ts should not select item that is not selectable 1`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-501"
+               aria-owns="list-519"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -3105,7 +3105,7 @@ exports[`VDataTable.ts should not select item that is not selectable 1`] = `
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-501"
+                       id="input-519"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -3195,7 +3195,7 @@ exports[`VDataTable.ts should pass kebab-case footer props correctly 1`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-285"
+               aria-owns="list-303"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -3204,7 +3204,7 @@ exports[`VDataTable.ts should pass kebab-case footer props correctly 1`] = `
                   10
                 </div>
                 <input aria-label="Foo:"
-                       id="input-285"
+                       id="input-303"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -3390,7 +3390,7 @@ exports[`VDataTable.ts should render footer.page-text slot content 1`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-317"
+               aria-owns="list-335"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -3399,7 +3399,7 @@ exports[`VDataTable.ts should render footer.page-text slot content 1`] = `
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-317"
+                       id="input-335"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -3635,7 +3635,7 @@ exports[`VDataTable.ts should render item slot when using group-by function 1`] 
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-571"
+               aria-owns="list-589"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -3644,7 +3644,7 @@ exports[`VDataTable.ts should render item slot when using group-by function 1`] 
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-571"
+                       id="input-589"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -7145,7 +7145,7 @@ exports[`VDataTable.ts should search group-by column 1`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-544"
+               aria-owns="list-562"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -7154,7 +7154,7 @@ exports[`VDataTable.ts should search group-by column 1`] = `
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-544"
+                       id="input-562"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -7290,7 +7290,7 @@ exports[`VDataTable.ts should search group-by column 2`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-544"
+               aria-owns="list-562"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -7299,7 +7299,7 @@ exports[`VDataTable.ts should search group-by column 2`] = `
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-544"
+                       id="input-562"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -7579,7 +7579,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 1`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-619"
+               aria-owns="list-637"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -7588,7 +7588,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 1`] = `
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-619"
+                       id="input-637"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -7868,7 +7868,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 2`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-619"
+               aria-owns="list-637"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -7877,7 +7877,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 2`] = `
                   10
                 </div>
                 <input aria-label="$vuetify.dataTable.itemsPerPageText"
-                       id="input-619"
+                       id="input-637"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
add contextmenu:row event for data table

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves #9382 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit & visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table
      class="elevation-1"
      :headers="headers"
      :items="desserts"
      item-key="name"
      @contextmenu:row="onRowContextmenu"
    />

    <v-menu
      v-model="showMenu"
      :position-x="menuX"
      :position-y="menuY"
      absolute
      offset-y
    >
      <v-list>
        <v-list-item
          v-for="item in items"
          :key="item.title"
          @click=""
        >
          <v-list-item-title>{{ item.title }}</v-list-item-title>
        </v-list-item>
      </v-list>
    </v-menu>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      desserts: [
        {
          name: 'Frozen Yogurt',
          calories: 159,
          fat: 6.0,
          carbs: 24,
          protein: 4.0,
          iron: '1%',
        },
        {
          name: 'Ice cream sandwich',
          calories: 237,
          fat: 9.0,
          carbs: 37,
          protein: 4.3,
          iron: '1%',
        },
        {
          name: 'Eclair',
          calories: 262,
          fat: 16.0,
          carbs: 23,
          protein: 6.0,
          iron: '7%',
        },
        {
          name: 'Cupcake',
          calories: 305,
          fat: 3.7,
          carbs: 67,
          protein: 4.3,
          iron: '8%',
        },
        {
          name: 'Gingerbread',
          calories: 356,
          fat: 16.0,
          carbs: 49,
          protein: 3.9,
          iron: '16%',
        },
        {
          name: 'Jelly bean',
          calories: 375,
          fat: 0.0,
          carbs: 94,
          protein: 0.0,
          iron: '0%',
        },
        {
          name: 'Lollipop',
          calories: 392,
          fat: 0.2,
          carbs: 98,
          protein: 0,
          iron: '2%',
        },
        {
          name: 'Honeycomb',
          calories: 408,
          fat: 3.2,
          carbs: 87,
          protein: 6.5,
          iron: '45%',
        },
        {
          name: 'Donut',
          calories: 452,
          fat: 25.0,
          carbs: 51,
          protein: 4.9,
          iron: '22%',
        },
        {
          name: 'KitKat',
          calories: 518,
          fat: 26.0,
          carbs: 65,
          protein: 7,
          iron: '6%',
        },
      ],
      headers: [
        {
          align: 'start',
          sortable: false,
          text: 'Dessert (100g serving)',
          value: 'name',
        },
        {
          text: 'Calories',
          value: 'calories'
        },
        {
          text: 'Fat (g)',
          value: 'fat'
        },
        {
          text: 'Carbs (g)',
          value: 'carbs'
        },
        {
          text: 'Protein (g)',
          value: 'protein'
        },
        {
          text: 'Iron (%)',
          value: 'iron'
        },
      ],
      items: [],
      menuX: 0,
      menuY: 0,
      showMenu: false,
    }),
    methods: {
      onRowContextmenu (event, data) {
        event.preventDefault()
        this.items = Object.entries(data).map(([key, value]) => {
          return {
            title: `${key}: ${typeof value === 'function' ? value.toString() : JSON.stringify(value)}`
          }
        }).sort((item1, item2) => item1.title.localeCompare(item2.title))
        this.showMenu = false
        this.menuX = event.clientX
        this.menuY = event.clientY
        this.$nextTick(() => {
          this.showMenu = true
        })
      }
    },
  }
</script>
```
</details>

## Docs
<details>

![unknown](https://user-images.githubusercontent.com/1329447/78321133-031f2f00-7520-11ea-8822-03a45bf1b270.png)

 </details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- - [ ] Bug fix (non-breaking change which fixes an issue) -->
- [X] New feature (non-breaking change which adds functionality)
<!-- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better) -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [X] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
