### PR TITLE
Fix bug disabling expandOnHover during mouseover

### DIFF
--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
@@ -296,7 +296,14 @@ export default baseMixins.extend({
 
       if (val !== this.isActive) this.isActive = val
     },
-    expandOnHover: 'updateMiniVariant',
+    expandOnHover (val) {
+      if (!val && this.isMouseover) {
+        // updateMiniVariant will be trigger updateMiniVariant
+        this.isMouseover = false
+        return
+      }
+      this.updateMiniVariant(val)
+    },
     isMouseover (val) {
       this.updateMiniVariant(!val)
     },


### PR DESCRIPTION
## Description
If expandOnHover is enabled and you disable it during a mouse-over (isMouseOver == true), the content will not expand, this is true only in the first time (because isMouseOver is initialized with false)

## How Has This Been Tested?
Add a button who toogle  expandOnHover inside of your navigation drawer, and play around. First time works fine, second time, you see the content will not expand.

Try to play around with the Pin/Unpin only the first time the main content is expanded.
https://codepen.io/xguiga/pen/PoPYQvQ

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
