### PR TITLE
fix(sparkline): stop-color and fill not using material colors

### DIFF
--- a/packages/vuetify/src/components/VSparkline/VSparkline.ts
+++ b/packages/vuetify/src/components/VSparkline/VSparkline.ts
@@ -275,7 +275,7 @@ export default mixins<options &
         this.$createElement('stop', {
           attrs: {
             offset: index / len,
-            'stop-color': color || this.color || 'currentColor',
+            'stop-color': color || 'currentColor',
           },
         })
       )
@@ -298,7 +298,7 @@ export default mixins<options &
           fontSize: '8',
           textAnchor: 'middle',
           dominantBaseline: 'mathematical',
-          fill: this.color || 'currentColor',
+          fill: 'currentColor',
         } as object, // TODO: TS 3.5 is too eager with the array type here
       }, children)
     },

--- a/packages/vuetify/src/components/VSparkline/__tests__/__snapshots__/VSparkline.spec.ts.snap
+++ b/packages/vuetify/src/components/VSparkline/__tests__/__snapshots__/VSparkline.spec.ts.snap
@@ -14,12 +14,12 @@ exports[`VSparkline.ts should position labels correctly 1`] = `
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
   </defs>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="8"
           y="76.25"
           font-size="7"
@@ -62,7 +62,7 @@ exports[`VSparkline.ts should render component and match a snapshot 1`] = `
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -88,7 +88,7 @@ exports[`VSparkline.ts should render component with bars and auto-line-width and
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -144,7 +144,7 @@ exports[`VSparkline.ts should render component with bars and auto-line-width wit
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -200,7 +200,7 @@ exports[`VSparkline.ts should render component with bars and correct bar lengths
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -248,7 +248,7 @@ exports[`VSparkline.ts should render component with bars and correct bar lengths
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -296,7 +296,7 @@ exports[`VSparkline.ts should render component with bars and custom label size a
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -327,7 +327,7 @@ exports[`VSparkline.ts should render component with bars and custom label size a
     >
     </rect>
   </clipPath>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="50"
           y="86.25"
           font-size="15"
@@ -372,7 +372,7 @@ exports[`VSparkline.ts should render component with bars and custom padding and 
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -492,7 +492,7 @@ exports[`VSparkline.ts should render component with bars and labels and match a 
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -523,7 +523,7 @@ exports[`VSparkline.ts should render component with bars and labels and match a 
     >
     </rect>
   </clipPath>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="50"
           y="80.25"
           font-size="7"
@@ -568,7 +568,7 @@ exports[`VSparkline.ts should render component with bars and line width and matc
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -624,7 +624,7 @@ exports[`VSparkline.ts should render component with bars and match a snapshot 1`
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -680,7 +680,7 @@ exports[`VSparkline.ts should render component with bars and negative and match 
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -782,12 +782,12 @@ exports[`VSparkline.ts should render component with label size and match a snaps
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
   </defs>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="8"
           y="81.5"
           font-size="14"
@@ -830,7 +830,7 @@ exports[`VSparkline.ts should render component with line width and match a snaps
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -858,7 +858,7 @@ exports[`VSparkline.ts should render component with padding and match a snapshot
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -886,12 +886,12 @@ exports[`VSparkline.ts should render component with string labels and match a sn
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
   </defs>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="8"
           y="76.25"
           font-size="7"
@@ -934,12 +934,12 @@ exports[`VSparkline.ts should render component with string labels and match a sn
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
   </defs>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="8"
           y="76.25"
           font-size="7"
@@ -982,12 +982,12 @@ exports[`VSparkline.ts should render component with string labels and match a sn
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
   </defs>
-  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: primary;">
+  <g style="font-size: 8; text-anchor: middle; dominant-baseline: mathematical; fill: currentColor;">
     <text x="8"
           y="76.25"
           font-size="7"
@@ -1030,7 +1030,7 @@ exports[`VSparkline.ts should render component with trend and equal values and m
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>
@@ -1058,7 +1058,7 @@ exports[`VSparkline.ts should render smooth component and match a snapshot 1`] =
                     y2="0"
     >
       <stop offset="0"
-            stop-color="primary"
+            stop-color="currentColor"
       >
       </stop>
     </linearGradient>


### PR DESCRIPTION
## Description
This makes sure that material colors also work for the stop-color and fill properties, which are the reason this didn't work. As the `<svg>` tag has a `color` class applied:

https://github.com/vuetifyjs/vuetify/blob/f57b7a7c6247e1b496ae87a1e4b4c014a7dcdc1d/packages/vuetify/src/components/VSparkline/VSparkline.ts#L400-L402

using `currentColor` will always work, as the color will simply propagate downwards.

Another option would be to translate the color to some hex value, as such:
```typescript
parsedColor (): string {
  if (isCssColor(this.color)) {
    return this.color
  } else {
    const parsedTheme = (this.$vuetify.theme as Theme & { parsedTheme: VuetifyParsedTheme}).parsedTheme
    const colorParts = this.color.split(' ')
    if (colorParts.length === 1) {
      return parsedTheme[this.color].base
    } else {
      const modifierColorParts = colorParts[1].split('-')
      return parsedTheme[colorParts[0]][modifierColorParts[0] + modifierColorParts[1]]
    }
  }
},
```
but I think this is not very neat and brings unnecessary overhead.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
fixes #6387

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-sparkline
      :value="value"
      color="primary lighten-1"
      height="100"
      padding="24"
      stroke-linecap="round"
      smooth
    >
      <template v-slot:label="item">
        ${{ item.value }}
      </template>
    </v-sparkline>

  </v-container>
</template>

<script>
  export default {
    data: () => ({
      value: [
        423,
        446,
        675,
        510,
        590,
        610,
        760,
      ],
    })
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
