### PR TITLE
fix(VCalendar): missing day-label slot for daily (#11069)

### DIFF
--- a/packages/api-generator/src/maps/v-calendar.js
+++ b/packages/api-generator/src/maps/v-calendar.js
@@ -24,6 +24,10 @@ module.exports = {
         props: VTimestamp,
       },
       {
+        name: 'day-label-header',
+        props: VTimestamp,
+      },
+      {
         name: 'day-month',
         props: VTimestamp,
       },

--- a/packages/docs/src/lang/en/components/Calendars.json
+++ b/packages/docs/src/lang/en/components/Calendars.json
@@ -80,7 +80,8 @@
   "slots": {
     "day-body": "The content that is placed in a `day` view in the scrollable interval container. The day & time object is passed through this slots scope.",
     "day-header": "The content that is placed in a `day` view in the top container. The day & time object is passed through this slots scope.",
-    "day-label": "The content that is placed in the day of the month space in the `week` or `month` view. The day & time object is passed through this slots scope.",
+    "day-label": "The content that is placed in the day of the month space in the `custom-weekly` or `month` view. The day & time object is passed through this slots scope.",
+    "day-label-header": "The content that is placed in the day of the month space in the `week`, `day`, `4day`, or `custom-daily` view. The day & time object is passed through this slots scope.",
     "day-month": "The content that is placed in the month space in the `week` or `month` view. The day & time object is passed through this slots scope.",
     "day": "The content that is placed in a `week` or `month` view. The day & time object is passed through this slots scope.",
     "event": "The content placed in an event. This ignores the `event-name` prop.",

--- a/packages/docs/src/lang/fr-FR/components/Calendars.json
+++ b/packages/docs/src/lang/fr-FR/components/Calendars.json
@@ -73,7 +73,8 @@
   "slots": {
     "day-body": "Le contenu placé dans une vue `day` dans le conteneur d'intervalle défilé. L'objet jour et heure est passé à travers cette portée.",
     "day-header": "Le contenu placé dans une vue `day` dans le conteneur en haut. L'objet jour et heure est passé à travers cette portée.",
-    "day-label": "Le contenu qui est placé dans le jour du mois dans la vue `week` ou `month`. L'objet jour et heure est passé à travers cette portée.",
+    "day-label": "Le contenu qui est placé dans le jour du mois dans la vue `custom-weekly` ou `month`. L'objet jour et heure est passé à travers cette portée.",
+    "day-label-header": "Le contenu qui est placé dans le jour du mois dans la vue `week`, `day`, `4day` ou `custom-daily`. L'objet jour et heure est passé à travers cette portée.",
     "day-month": "Le contenu placé dans l'espace du mois dans la vue `week` ou `month`. L'objet jour et heure est passé à travers cette portée.",
     "day": "Le contenu placé dans une vue `week` ou `month`. L'objet jour et heure est passé à travers cette portée.",
     "interval": "Le contenu placé dans l'espace d'intervalle dans la vue `day`. L'objet jour et heure est passé à travers cette portée."

--- a/packages/docs/src/lang/fr-FR/components/Calendars.json
+++ b/packages/docs/src/lang/fr-FR/components/Calendars.json
@@ -74,7 +74,6 @@
     "day-body": "Le contenu placé dans une vue `day` dans le conteneur d'intervalle défilé. L'objet jour et heure est passé à travers cette portée.",
     "day-header": "Le contenu placé dans une vue `day` dans le conteneur en haut. L'objet jour et heure est passé à travers cette portée.",
     "day-label": "Le contenu qui est placé dans le jour du mois dans la vue `custom-weekly` ou `month`. L'objet jour et heure est passé à travers cette portée.",
-    "day-label-header": "Le contenu qui est placé dans le jour du mois dans la vue `week`, `day`, `4day` ou `custom-daily`. L'objet jour et heure est passé à travers cette portée.",
     "day-month": "Le contenu placé dans l'espace du mois dans la vue `week` ou `month`. L'objet jour et heure est passé à travers cette portée.",
     "day": "Le contenu placé dans une vue `week` ou `month`. L'objet jour et heure est passé à travers cette portée.",
     "interval": "Le contenu placé dans l'espace d'intervalle dans la vue `day`. L'objet jour et heure est passé à travers cette portée."

--- a/packages/docs/src/lang/zh-CN/components/Calendars.json
+++ b/packages/docs/src/lang/zh-CN/components/Calendars.json
@@ -77,7 +77,8 @@
   "slots": {
     "day-body": "放置在可滚动间隔容器的 `day` 视图中的内容。day & time 对象通过此插槽作用域传递。",
     "day-header": "顶部容器中 `day` 视图中放置的内容。day & time 对象通过此插槽作用域传递。",
-    "day-label": "在 `week` 或 `month` 视图中放置在月份的第几天的内容。day & time 对象通过此插槽作用域传递。",
+    "day-label": "在 `custom-weekly` 或 `month` 视图中放置在月份的第几天的内容。day & time 对象通过此插槽作用域传递。",
+    "day-label-header": "在 `week`, `day`, `4day` 或 `custom-daily` 视图中放置在月份的第几天的内容。day & time 对象通过此插槽作用域传递。",
     "day-month": "在 `week` 或 `month` 视图中放置在月份空间的内容。day & time 对象通过此插槽作用域传递。",
     "day": "放置在 `week` 或 `month` 视图中的内容。day & time 对象通过此插槽作用域传递。",
     "interval": "在 `day` 视图中放置在间隔空间中的内容。day & time 对象通过此插槽作用域传递。"

--- a/packages/docs/src/lang/zh-CN/components/Calendars.json
+++ b/packages/docs/src/lang/zh-CN/components/Calendars.json
@@ -78,7 +78,6 @@
     "day-body": "放置在可滚动间隔容器的 `day` 视图中的内容。day & time 对象通过此插槽作用域传递。",
     "day-header": "顶部容器中 `day` 视图中放置的内容。day & time 对象通过此插槽作用域传递。",
     "day-label": "在 `custom-weekly` 或 `month` 视图中放置在月份的第几天的内容。day & time 对象通过此插槽作用域传递。",
-    "day-label-header": "在 `week`, `day`, `4day` 或 `custom-daily` 视图中放置在月份的第几天的内容。day & time 对象通过此插槽作用域传递。",
     "day-month": "在 `week` 或 `month` 视图中放置在月份空间的内容。day & time 对象通过此插槽作用域传递。",
     "day": "放置在 `week` 或 `month` 视图中的内容。day & time 对象通过此插槽作用域传递。",
     "interval": "在 `day` 视图中放置在间隔空间中的内容。day & time 对象通过此插槽作用域传递。"

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -105,9 +105,7 @@ export default CalendarWithIntervals.extend({
     genHeadDayLabel (day: CalendarTimestamp): VNode {
       return this.$createElement('div', {
         staticClass: 'v-calendar-daily_head-day-label',
-      }, [
-        this.genHeadDayButton(day),
-      ])
+      }, getSlot(this, 'day-label-header', day) || [this.genHeadDayButton(day)])
     },
     genHeadDayButton (day: CalendarTimestamp): VNode {
       const color = day.present ? this.color : 'transparent'


### PR DESCRIPTION
fixes #11069

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
resolves #11069

## Motivation and Context
Calendar slots were inconsistent

## How Has This Been Tested?
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
