### PR TITLE
docs: remove duplicate word

### DIFF
--- a/packages/docs/src/lang/en/components/Sliders.json
+++ b/packages/docs/src/lang/en/components/Sliders.json
@@ -5,7 +5,7 @@
   "examples": {
     "thumb": {
       "heading": "### Thumb",
-      "desc": "You can display a `thumb-label` while sliding or always. It It can have a custom color by setting `thumb-color` and a custom size with `thumb-size`. With `always-dirty` its color will never change, even when on `min` value."
+      "desc": "You can display a `thumb-label` while sliding or always. It can have a custom color by setting `thumb-color` and a custom size with `thumb-size`. With `always-dirty` its color will never change, even when on `min` value."
     },
     "custom-thumb": {
       "heading": "### Custom Range slider",


### PR DESCRIPTION
## Description
Removed duplication of the word "It" from the en docs for the v-slider component, in the description for "Thumb".

> It It can have a custom color...

changed to

> It can have a custom color...

## Motivation and Context
Proper grammar is important for a professional image.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
