### PR TITLE
docs: fix incorrect official MD icon page

### DIFF
--- a/packages/docs/src/lang/en/components/Icons.json
+++ b/packages/docs/src/lang/en/components/Icons.json
@@ -1,6 +1,6 @@
 {
   "heading": "# Icons",
-  "headingText": "The `v-icon` component provides a large set of glyphs to provide context to various aspects of your application. For a list of all available icons, visit the official [Material Design Icons](https://materialdesignicons.com/) page. To use any of these icons simply use the `mdi-` prefix followed by the icon name.",
+  "headingText": "The `v-icon` component provides a large set of glyphs to provide context to various aspects of your application. For a list of all available icons, visit the official [Material Design Icons](https://material.io/resources/icons/?style=baseline) page. To use any of these icons simply use the `mdi-` prefix followed by the icon name.",
   "usageText": "Icons come in two themes (light and dark), and five different sizes (x-small, small, medium (default), large, and x-large).",
   "examples": {
     "font-awesome": {


### PR DESCRIPTION
The previously linked page is not the official material design icons page. It's a community maintained page which lists both community icons and third party icons. It's not a bad page to occasionally use, but the third party icons make the 'For a list of all available icons' very confusing (when the link goes to a page with with unofficial not-included icons).