### PR TITLE
fix(VDataTable): include rows that exclusively match custom filters

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -50,12 +50,19 @@ function searchTableItems (
   customFilter: DataTableFilterFunction
 ) {
   search = typeof search === 'string' ? search.trim() : null
+
+  // If the `search` property is empty and there are no custom filters in use, there is nothing to do.
   if (!(search && headersWithoutCustomFilters.length) && !headersWithCustomFilters.length) return items
 
-  return items.filter(item =>
-    (headersWithCustomFilters.length && headersWithCustomFilters.every(filterFn(item, search, defaultFilter))) ||
-    (search && headersWithoutCustomFilters.some(filterFn(item, search, customFilter)))
-  )
+  return items.filter(item => {
+    // Headers with custom filters are evaluated whether or not a search term has been provided.
+    if (headersWithCustomFilters.length && headersWithCustomFilters.every(filterFn(item, search, defaultFilter))) {
+      return true
+    }
+
+    // Otherwise, the `search` property is used to filter columns without a custom filter.
+    return (search && headersWithoutCustomFilters.some(filterFn(item, search, customFilter)))
+  })
 }
 
 /* @vue/component */

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -49,17 +49,13 @@ function searchTableItems (
   headersWithoutCustomFilters: DataTableHeader[],
   customFilter: DataTableFilterFunction
 ) {
-  let filtered = items
   search = typeof search === 'string' ? search.trim() : null
-  if (search && headersWithoutCustomFilters.length) {
-    filtered = items.filter(item => headersWithoutCustomFilters.some(filterFn(item, search, customFilter)))
-  }
+  if (!(search && headersWithoutCustomFilters.length) && !headersWithCustomFilters.length) return items
 
-  if (headersWithCustomFilters.length) {
-    filtered = filtered.filter(item => headersWithCustomFilters.every(filterFn(item, search, defaultFilter)))
-  }
-
-  return filtered
+  return items.filter(item =>
+    (headersWithCustomFilters.length && headersWithCustomFilters.every(filterFn(item, search, defaultFilter))) ||
+    (search && headersWithoutCustomFilters.some(filterFn(item, search, customFilter)))
+  )
 }
 
 /* @vue/component */

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -856,4 +856,37 @@ describe('VDataTable.ts', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/11179
+  it('should return rows from columns that exclusively match custom filters', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: testItems,
+        headers: [
+          {
+            text: 'Dessert (100g serving)',
+            align: 'left',
+            filter: (value, search) => {
+              if (!search) return true
+              return value === search
+            },
+            value: 'name',
+          },
+          { text: 'Calories', value: 'calories' },
+          { text: 'Fat (g)', value: 'fat' },
+          { text: 'Carbs (g)', value: 'carbs' },
+          { text: 'Protein (g)', value: 'protein' },
+          { text: 'Iron (%)', value: 'iron' },
+        ],
+      },
+    })
+
+    wrapper.setProps({ search: 'eclair' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(0)
+
+    wrapper.setProps({ search: 'Eclair' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Currently, if a custom filter is used on a header config, it won't evaluate on any `search` term that exclusively match this custom filter. The term must match one or more columns that fall under `headersWithoutCustomFilters`.

Closes #9887 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Behaviour is inconsistent since the custom filter will be evaluated up until the point that a search term is entered. Once a term is entered, even if the term matches the custom filter, the row is excluded from the results if none of the other columns match.

A simple example is provided in the Codepen in the linked issue: by adding a custom filter with a case-sensitive search for Dessert Name, the ability to search is lost.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
- Tested in our own project which uses Vuetify
- Playground reproduction (below)
- Added a unit test verifying the Codepen/playground reproduction

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-data-table
    :headers="headers"
    :items="desserts"
    :search="search"
    item-key="name"
  >
    <template v-slot:top>
      <v-text-field v-model="search" label="Search (EXACT MATCH)" class="mx-4"></v-text-field>
    </template>
  </v-data-table>
</template>

<script>
  export default {
    data: () => ({
      search: '',
      headers: [
        {
          text: 'Dessert (100g serving)',
          align: 'left',
          sortable: false,
          value: 'name',
          filter: (value, search) => {
            if (!search) return true
            return value === search
          }
        },
        { text: 'Calories', value: 'calories' },
        { text: 'Fat (g)', value: 'fat' },
        { text: 'Carbs (g)', value: 'carbs' },
        { text: 'Protein (g)', value: 'protein' },
        { text: 'Iron (%)', value: 'iron' }
      ],
      desserts: [
        {
          value: false,
          name: 'Frozen Yogurt',
          calories: 159,
          fat: 6.0,
          carbs: 24,
          protein: 4.0,
          iron: '1%',
          brands: [
            {
              name: 'Blue Bell',
              calories: 237,
              fat: 9.0,
              carbs: 37,
              protein: 4.3,
              iron: '1%'
            },
            {
              name: 'Tilamook',
              calories: 262,
              fat: 16.0,
              carbs: 23,
              protein: 6.0,
              iron: '7%'
            }
          ]
        },
        {
          value: false,
          name: 'Ice cream sandwich',
          calories: 237,
          fat: 9.0,
          carbs: 37,
          protein: 4.3,
          iron: '1%'
        },
        {
          value: false,
          name: 'Eclair',
          calories: 262,
          fat: 16.0,
          carbs: 23,
          protein: 6.0,
          iron: '7%'
        },
        {
          value: false,
          name: 'Cupcake',
          calories: 305,
          fat: 3.7,
          carbs: 67,
          protein: 4.3,
          iron: '8%'
        },
        {
          value: false,
          name: 'Gingerbread',
          calories: 356,
          fat: 16.0,
          carbs: 49,
          protein: 3.9,
          iron: '16%'
        },
        {
          value: false,
          name: 'Jelly bean',
          calories: 375,
          fat: 0.0,
          carbs: 94,
          protein: 0.0,
          iron: '0%'
        },
        {
          value: false,
          name: 'Lollipop',
          calories: 392,
          fat: 0.2,
          carbs: 98,
          protein: 0,
          iron: '2%'
        },
        {
          value: false,
          name: 'Honeycomb',
          calories: 408,
          fat: 3.2,
          carbs: 87,
          protein: 6.5,
          iron: '45%'
        },
        {
          value: false,
          name: 'Donut',
          calories: 452,
          fat: 25.0,
          carbs: 51,
          protein: 4.9,
          iron: '22%'
        },
        {
          value: false,
          name: 'KitKat',
          calories: 518,
          fat: 26.0,
          carbs: 65,
          protein: 7,
          iron: '6%'
        }
      ]
    })
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
