### PR TITLE
fix(colorutils.ts): lookbehind regexp causing FF throw error

### DIFF
--- a/packages/vuetify/src/util/colorUtils.ts
+++ b/packages/vuetify/src/util/colorUtils.ts
@@ -226,8 +226,8 @@ export function parseGradient (
 ) {
   return gradient.replace(/([a-z]+(\s[a-z]+-[1-5])?)(?=$|,)/gi, x => {
     return classToHex(x, colors, currentTheme) || x
-  }).replace(/(?<=rgba\()#[0-9a-f]+(?=,)/gi, x => {
-    return Object.values(HexToRGBA(parseHex(x))).slice(0, 3).join(',')
+  }).replace(/(rgba\()#[0-9a-f]+(?=,)/gi, x => {
+    return 'rgba(' + Object.values(HexToRGBA(parseHex(x.replace(/rgba\(/, '')))).slice(0, 3).join(',')
   })
 }
 


### PR DESCRIPTION
## Description
Firefox wil not load application because of error on regexp with lookbehind part.
Changed code without using lookbehind

fix #11214

## Motivation and Context
Fixes #11214 

## How Has This Been Tested?
unit

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
