### PR TITLE
fix(VTreeview): independent children should be selectable when parent is disabled

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.sass
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.sass
@@ -13,7 +13,6 @@
     +active-states($material)
 
   .v-treeview-node--disabled
-    .v-treeview-node__toggle--disabled,
     > .v-treeview-node__root > .v-treeview-node__content
       color: map-deep-get($material, 'text', 'disabled') !important
 

--- a/packages/vuetify/src/components/VTreeview/VTreeview.sass
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.sass
@@ -13,16 +13,11 @@
     +active-states($material)
 
   .v-treeview-node--disabled
-    color: map-deep-get($material, 'text', 'disabled')
-
-    .v-treeview-node__toggle,
-    .v-treeview-node__checkbox
+    .v-treeview-node__toggle--disabled,
+    > .v-treeview-node__root > .v-treeview-node__content
       color: map-deep-get($material, 'text', 'disabled') !important
 
 .v-treeview-node
-  &--disabled
-    pointer-events: none
-
   &.v-treeview-node--shaped
     +treeview-shaped($treeview-node-height, $treeview-node-shaped-margin)
 

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -75,11 +75,6 @@ export default mixins(
       default: false, // TODO: Should be true in next major
     },
     search: String,
-    selectionType: {
-      type: String as PropType<'leaf' | 'independent'>,
-      default: 'leaf',
-      validator: (v: string) => ['leaf', 'independent'].includes(v),
-    },
     value: {
       type: Array as PropType<NodeArray>,
       default: () => ([]),

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -411,6 +411,7 @@ export default mixins(
     const children: VNodeChildrenArrayContents = this.items.length
       ? this.items.map(item => {
         const genChild = VTreeviewNode.options.methods.genChild.bind(this)
+
         return genChild(item, getObjectValueByPath(item, this.itemDisabled))
       })
       /* istanbul ignore next */

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -409,7 +409,10 @@ export default mixins(
 
   render (h): VNode {
     const children: VNodeChildrenArrayContents = this.items.length
-      ? this.items.map(VTreeviewNode.options.methods.genChild.bind(this))
+      ? this.items.map(item => {
+        const genChild = VTreeviewNode.options.methods.genChild.bind(this)
+        return genChild(item, getObjectValueByPath(item, this.itemDisabled))
+      })
       /* istanbul ignore next */
       : this.$slots.default! // TODO: remove type annotation with TS 3.2
 

--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -117,7 +117,7 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
   }),
 
   computed: {
-    disabled (): string {
+    disabled (): boolean {
       return getObjectValueByPath(this.item, this.itemDisabled)
     },
     key (): string {
@@ -146,6 +146,9 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
     },
     hasChildren (): boolean {
       return !!this.children && (!!this.children.length || !!this.loadChildren)
+    },
+    isLeafSelectionAndDisabled (): boolean {
+      return this.disabled && this.selectionType === 'leaf'
     },
   },
 
@@ -218,12 +221,12 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         class: {
           'v-treeview-node__toggle--open': this.isOpen,
           'v-treeview-node__toggle--loading': this.isLoading,
-          'v-treeview-node__toggle--disabled': this.disabled && this.selectionType === 'leaf',
+          'v-treeview-node__toggle--disabled': this.isLeafSelectionAndDisabled,
         },
         slot: 'prepend',
         on: {
           click: (e: MouseEvent) => {
-            if (this.disabled && this.selectionType === 'leaf') {
+            if (this.isLeafSelectionAndDisabled) {
               return
             }
 
@@ -290,7 +293,7 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         },
         on: {
           click: () => {
-            if (this.disabled && this.selectionType === 'leaf') {
+            if (this.isLeafSelectionAndDisabled) {
               return
             }
 

--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -119,8 +119,10 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
 
   computed: {
     disabled (): boolean {
-      return getObjectValueByPath(this.item, this.itemDisabled) ||
+      return (
+        getObjectValueByPath(this.item, this.itemDisabled) ||
         (this.parentIsDisabled && this.selectionType === 'leaf')
+      )
     },
     key (): string {
       return getObjectValueByPath(this.item, this.itemKey)

--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -81,6 +81,11 @@ export const VTreeviewNodeProps = {
   },
   shaped: Boolean,
   transition: Boolean,
+  selectionType: {
+    type: String as PropType<'leaf' | 'independent'>,
+    default: 'leaf',
+    validator: (v: string) => ['leaf', 'independent'].includes(v),
+  },
 }
 
 /* @vue/component */
@@ -213,11 +218,14 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         class: {
           'v-treeview-node__toggle--open': this.isOpen,
           'v-treeview-node__toggle--loading': this.isLoading,
+          'v-treeview-node__toggle--disabled': this.disabled && this.selectionType === 'leaf',
         },
         slot: 'prepend',
         on: {
           click: (e: MouseEvent) => {
-            if (this.disabled) return
+            if (this.disabled && this.selectionType === 'leaf') {
+              return
+            }
 
             e.stopPropagation()
 
@@ -233,6 +241,7 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         staticClass: 'v-treeview-node__checkbox',
         props: {
           color: this.isSelected || this.isIndeterminate ? this.selectedColor : undefined,
+          disabled: this.disabled,
         },
         on: {
           click: (e: MouseEvent) => {
@@ -281,11 +290,13 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         },
         on: {
           click: () => {
-            if (this.disabled) return
+            if (this.disabled && this.selectionType === 'leaf') {
+              return
+            }
 
             if (this.openOnClick && this.hasChildren) {
               this.open()
-            } else if (this.activatable) {
+            } else if (this.activatable && !this.disabled) {
               this.isActive = !this.isActive
               this.treeview.updateActive(this.key, this.isActive)
               this.treeview.emitActive()
@@ -319,6 +330,7 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
           rounded: this.rounded,
           shaped: this.shaped,
           level: this.level + 1,
+          selectionType: this.selectionType,
         },
         scopedSlots: this.$scopedSlots,
       })

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
@@ -800,4 +800,46 @@ describe('VTreeView.ts', () => { // eslint-disable-line max-statements
 
     expect(input).toHaveBeenLastCalledWith([2])
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/10990
+  // https://github.com/vuetifyjs/vuetify/issues/10770
+  it('should not disable children of disabled parent when in independent mode', async () => {
+    const items = [{
+      id: 1,
+      name: 'Foo',
+      disabled: true,
+      children: [
+        { id: 2, name: 'Bar' },
+        { id: 3, name: 'Fizz', disabled: true },
+        { id: 4, name: 'Buzz' },
+      ],
+    }]
+
+    const input = jest.fn()
+
+    const wrapper = mountFunction({
+      propsData: {
+        items,
+        value: [],
+        open: [1],
+        selectionType: 'independent',
+        selectable: true,
+      },
+      listeners: {
+        input,
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    wrapper.findAll('.v-treeview-node__checkbox').at(1).trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(input).toHaveBeenLastCalledWith([2])
+
+    wrapper.findAll('.v-treeview-node__checkbox').at(2).trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(input).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeviewNode.spec.ts.snap
+++ b/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeviewNode.spec.ts.snap
@@ -72,7 +72,7 @@ exports[`VTreeViewNode.ts should render disabled item 1`] = `
 >
   <div class="v-treeview-node__root">
     <button type="button"
-            class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--disabled"
+            class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
     >
       arrow_drop_down
     </button>

--- a/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeviewNode.spec.ts.snap
+++ b/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeviewNode.spec.ts.snap
@@ -72,7 +72,7 @@ exports[`VTreeViewNode.ts should render disabled item 1`] = `
 >
   <div class="v-treeview-node__root">
     <button type="button"
-            class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
+            class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--disabled"
     >
       arrow_drop_down
     </button>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
it was not possible to select children of disabled parents in independent mode

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #10770, closes #10990

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
playground, unit test

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-treeview
      open-on-click
      :items="tree"
      item-text="text"
      item-key="id"
      selectable
      :value="selected"
      selection-type="independent"
      item-disabled="item_disabled"
    ></v-treeview>
    <hr/>
    <v-treeview
      open-on-click
      :items="tree"
      item-text="text"
      item-key="id"
      selectable
      :value="selected2"
      item-disabled="item_disabled"
    ></v-treeview>
    <v-treeview
        v-model="selected3"
        activatable
        selectable
        selection-type="independent"
        :active.sync="selected3"
        hoverable
        return-object
        dense
        open-all
        open-on-click
        :items="items"
        :search="search"
        :open.sync="open"
        item-disabled="disabled"
      >
        <template v-slot:prepend="{ item }">
          <v-icon
            v-if="item.children"
            v-text="`mdi-${item.id === 1 ? 'home-variant' : 'folder-network'}`"
          ></v-icon>
        </template>
      </v-treeview>
    </v-container>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      items: [
        {
          id: 2,
          name: 'Electronics',
          disabled:true,
          children: [
            {
              id: 201,
              name: 'John',
              disabled:false,
            },
            {
              id: 202,
              name: 'Kael',
              disabled:false,
            },

          ],
        },
        {
          id: 3,
          name: 'Administrators',
          children: [
            {
              id: 301,
              name: 'Ranee',
            },
            {
              id: 302,
              name: 'Rachel',
            },
          ],
        },
       ],
      open: [],
      search: null,
      selected3: [],
      selected: [1,3,8],
      selected2: [1,3,8],
      tree: [
        {text: 'Foo', id: '1', item_disabled:false, children: []},
        {text: 'Bar', id: '2', item_disabled:true, children: [
          {text: 'Select', id: '3', item_disabled:false, children: []},
          {text: 'One of', id: '4', item_disabled:false, children: []},
          {text: 'These', id: '5', item_disabled:false, children: []},
        ]},
        {text: 'Lorem', id: '6', item_disabled:false, children: [
          {text: 'Ipsum', id: '7', item_disabled:false, children: []},
          {text: 'Dolor', id: '8', item_disabled:false, children: []},
        ]},

      ]
    })
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
