### PR TITLE
feat(v-scroll): add self modifier to target the bound element

### DIFF
--- a/packages/api-generator/src/maps/v-scroll.js
+++ b/packages/api-generator/src/maps/v-scroll.js
@@ -7,6 +7,11 @@ module.exports = {
         type: 'string',
       },
       {
+        name: 'arg:self',
+        default: false,
+        type: 'boolean',
+      },
+      {
         name: 'value',
         default: '(): {}',
         type: 'Function',

--- a/packages/docs/src/data/pages/directives/Scrolling.pug
+++ b/packages/docs/src/data/pages/directives/Scrolling.pug
@@ -3,7 +3,8 @@ api(:value=`[
   'v-scroll'
 ]`)
 examples(:value=`[
-  'options'
+  'options',
+  { file: 'simple/self', newIn: 'v2.3' }
 ]`)
 
 up-next(:value=`[

--- a/packages/docs/src/examples/scrolling/simple/self.vue
+++ b/packages/docs/src/examples/scrolling/simple/self.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-card
+    v-scroll.self="onScroll"
+    class="overflow-y-auto"
+    max-height="400"
+  >
+    <v-banner
+      class="justify-center headline font-weight-light"
+      sticky
+    >
+      Scroll Me - Method invoked
+
+      <span
+        class="font-weight-bold"
+        v-text="scrollInvoked"
+      ></span>
+
+      times
+    </v-banner>
+
+    <v-card-text>
+      <div
+        v-for="n in 12"
+        :key="n"
+        class="mb-4"
+      >
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Modi commodi earum tenetur. Asperiores dolorem placeat ab nobis iusto culpa, autem molestias molestiae quidem pariatur. Debitis beatae expedita nam facere perspiciatis. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellendus ducimus cupiditate rerum officiis consequuntur laborum doloremque quaerat ipsa voluptates, nobis nam quis nulla ullam at corporis, similique ratione quasi illo!
+      </div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      scrollInvoked: 0,
+    }),
+
+    methods: {
+      onScroll () {
+        this.scrollInvoked++
+      },
+    },
+  }
+</script>

--- a/packages/docs/src/lang/en/directives/Scrolling.json
+++ b/packages/docs/src/lang/en/directives/Scrolling.json
@@ -1,6 +1,6 @@
 {
   "heading": "# Scrolling directive",
-  "headingText": "The `v-scroll` directive allows you to provide callbacks when the window or a specifically defined element are scrolled.",
+  "headingText": "The `v-scroll` directive allows you to provide callbacks when a specified target is scrolled.",
   "examples": {
     "usage": {
       "desc": "The default behavior is to bind to the window. If no additional configuration options are needed, you can simply pass your callback function.",
@@ -10,10 +10,15 @@
       "heading": "### Scroll with options",
       "desc": "For a more fine tuned approach, you can designate the target to bind the scroll event listener.",
       "uninverted": true
+    },
+    "self": {
+      "heading": "### Watching bound element",
+      "desc": "`v-scroll` targets the `window` by default but can also watch the element it's being bound to. In the following example we use the **self** modifier, `v-scroll.self`, to watch the [`v-card`](/components/cards) element specifically. This causes the method `onScroll` to invoke as you scroll the card contents; incrementing the counter."
     }
   },
   "options": {
     "arg:target": "`v-scroll:#target=\"callback\"` The target watched for scroll changes. Defaults to window but can be changed to any valid id selector.",
+    "arg:self": "`v-scroll.self=\"callback\"` Binds to the element that the the directive is attached.",
     "value": "`v-scroll=\"callback\"` The function to invoke on target scroll"
   }
 }

--- a/packages/vuetify/src/directives/scroll/__tests__/scroll.spec.ts
+++ b/packages/vuetify/src/directives/scroll/__tests__/scroll.spec.ts
@@ -1,39 +1,130 @@
 // Directives
 import Scroll from '../'
+import { DirectiveBinding } from 'vue/types/options'
 
 describe('scroll.ts', () => {
-  it('shoud bind event on inserted (selector)', () => {
-    const value = () => {}
-    const options = {}
-    const targetElement = { addEventListener: jest.fn(), removeEventListener: jest.fn() }
-    const el = {}
+  const { inserted, unbind } = Scroll
 
-    jest.spyOn(window.document, 'querySelector').mockImplementation(selector => selector === '.selector' ? targetElement : undefined)
+  let binding
+  let el
+  let options
+  let passive
+  let vnode
 
-    Scroll.inserted(el as HTMLElement, { value, arg: '.selector' } as any, null, null)
-    expect(targetElement.addEventListener).toHaveBeenCalledWith('scroll', value, { passive: true })
-    Scroll.unbind(el as HTMLElement, null, null, null)
-    expect(targetElement.removeEventListener).toHaveBeenCalledWith('scroll', value, { passive: true })
-
-    Scroll.inserted(el as HTMLElement, { value, arg: '.selector', options } as any, null, null)
-    expect(targetElement.addEventListener).toHaveBeenCalledWith('scroll', value, options)
-    Scroll.unbind(el as HTMLElement, null, null, null)
-    expect(targetElement.removeEventListener).toHaveBeenCalledWith('scroll', value, options)
+  beforeEach(() => {
+    vnode = null as any
+    options = { passive: true }
+    binding = {
+      value: jest.fn(),
+      modifiers: {},
+      arg: null,
+    } as DirectiveBinding
+    el = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }
   })
 
-  it('shoud bind event on inserted (window)', () => {
-    const value = () => {}
-    jest.spyOn(window, 'addEventListener')
-    jest.spyOn(window, 'removeEventListener')
-    const el = {}
+  it('should work with no provided scroll target (window)', () => {
+    const spyOnWindowAddListener = jest.spyOn(window, 'addEventListener')
+    const spyOnWindowRemoveListener = jest.spyOn(window, 'removeEventListener')
 
-    Scroll.inserted(el as HTMLElement, { value } as any, null, null)
-    expect(window.addEventListener).toHaveBeenCalledWith('scroll', value, { passive: true })
-    Scroll.unbind(el as HTMLElement, null, null, null)
-    expect(window.removeEventListener).toHaveBeenCalledWith('scroll', value, { passive: true })
+    inserted(el, binding, vnode, vnode)
+
+    expect(spyOnWindowAddListener).toHaveBeenCalledWith('scroll', binding.value, options)
+    expect(el._onScroll).toEqual({
+      handler: binding.value,
+      options,
+      target: window,
+    })
+
+    unbind(el, binding, vnode, vnode)
+
+    expect(spyOnWindowRemoveListener).toHaveBeenCalledWith('scroll', binding.value, options)
+    expect(el._onScroll).toBeUndefined()
   })
 
-  it('should not fail when unbinding element without _onScroll', () => {
-    Scroll.unbind({} as HTMLElement, null, null, null)
+  it('should work with a provided valid querySelector string', () => {
+    // Query selector searches the document
+    const target = document.createElement('div')
+    const spyOnFooAddListener = jest.spyOn(target, 'addEventListener')
+    const spyOnFooRemoveListener = jest.spyOn(target, 'removeEventListener')
+
+    target.id = 'foo'
+    document.body.appendChild(target)
+
+    binding.arg = '#bar'
+
+    // Binds nothing if element not found
+    inserted(el, binding, vnode, vnode)
+
+    expect(spyOnFooAddListener).not.toHaveBeenCalled()
+    expect(el._onScroll).toBeUndefined()
+
+    binding.arg = '#foo'
+
+    inserted(el, binding, vnode, vnode)
+
+    expect(spyOnFooAddListener).toHaveBeenCalledWith('scroll', binding.value, options)
+    expect(el._onScroll).toEqual({
+      handler: binding.value,
+      options,
+      target,
+    })
+
+    unbind(el, binding, vnode, vnode)
+
+    expect(spyOnFooRemoveListener).toHaveBeenCalledWith('scroll', binding.value, options)
+    expect(el._onScroll).toBeUndefined()
+
+    document.body.removeChild(target)
+  })
+
+  it('should work with the self modifier', () => {
+    binding.modifiers = { self: true }
+
+    inserted(el, binding, vnode, vnode)
+
+    expect(el.addEventListener).toHaveBeenCalledWith('scroll', binding.value, options)
+    expect(el._onScroll).toEqual({
+      handler: binding.value,
+      options,
+      target: undefined,
+    })
+
+    unbind(el, binding, vnode, vnode)
+
+    expect(el.removeEventListener).toHaveBeenCalledWith('scroll', binding.value, options)
+    expect(el._onScroll).toBeUndefined()
+  })
+
+  it('should not remove listeners if no _onScroll property present', () => {
+    unbind(el, binding, vnode, vnode)
+
+    expect(el.removeEventListener).not.toHaveBeenCalled()
+  })
+
+  it('should accept an object for the value with handler and/or options', () => {
+    const handler = binding.value
+
+    binding.value = { handler }
+
+    inserted(el, binding, vnode, vnode)
+
+    expect(el._onScroll).toEqual({
+      handler,
+      target: window,
+      options: {},
+    })
+
+    binding.value = { handler, options: { passive: false } }
+
+    inserted(el, binding, vnode, vnode)
+
+    expect(el._onScroll).toEqual({
+      handler,
+      target: window,
+      options: { passive: false },
+    })
   })
 })

--- a/packages/vuetify/src/directives/scroll/index.ts
+++ b/packages/vuetify/src/directives/scroll/index.ts
@@ -1,33 +1,49 @@
 import { VNodeDirective } from 'vue/types/vnode'
 import { DirectiveOptions } from 'vue'
 
-interface ScrollVNodeDirective extends VNodeDirective {
+interface ScrollVNodeDirective extends Omit<VNodeDirective, 'modifiers'> {
   arg: string
-  value: EventListenerOrEventListenerObject
-  options?: boolean | AddEventListenerOptions
+  value: EventListener | {
+    handler: EventListener
+    options?: boolean | AddEventListenerOptions
+  }
+  modifiers?: {
+    self?: boolean
+  }
 }
 
 function inserted (el: HTMLElement, binding: ScrollVNodeDirective) {
-  const callback = binding.value
-  const options = binding.options || { passive: true }
-  const target = binding.arg ? document.querySelector(binding.arg) : window
+  const { self = false } = binding.modifiers || {}
+  const value = binding.value
+  // Add fallback to value
+  const { handler, options = {} } = typeof value === 'object'
+    ? value
+    : { handler: value, options: { passive: true } }
+
+  const target = self
+    ? el
+    : binding.arg
+      ? document.querySelector(binding.arg)
+      : window
+
   if (!target) return
 
-  target.addEventListener('scroll', callback, options)
+  target.addEventListener('scroll', handler, options)
 
   el._onScroll = {
-    callback,
+    handler,
     options,
-    target,
+    // Don't reference self
+    target: self ? undefined : target,
   }
 }
 
 function unbind (el: HTMLElement) {
   if (!el._onScroll) return
 
-  const { callback, options, target } = el._onScroll
+  const { handler, options, target = el } = el._onScroll
 
-  target.removeEventListener('scroll', callback, options)
+  target.removeEventListener('scroll', handler, options)
   delete el._onScroll
 }
 

--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -50,9 +50,9 @@ declare global {
       observer: MutationObserver
     }
     _onScroll?: {
-      callback: EventListenerOrEventListenerObject
+      handler: EventListenerOrEventListenerObject
       options: boolean | AddEventListenerOptions
-      target: EventTarget
+      target?: EventTarget
     }
     _touchHandlers?: {
       [_uid: number]: TouchStoredHandlers


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
* Custom options should now work and accept an object containing a **handler** and/or **options** keys:
```vue
<template>
  <div
    v-scroll="{
      handler: onScroll, 
      options: { passive: false }
    }"
  />
</template>
```

* A new modifier, **self**, which automatically targets the binding element. This was cumbersome to accomplish prior:
```vue
<template>
  <!-- v2.2 -->
  <div  
    id="foo"
    v-scroll:#foo="onScroll"
  />

  <!-- v2.3 -->
  <div  v-scroll.self="onScroll" />
</template>
```

<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Currently you must use `querySelector` to target the binding element. This became an issue when wanting to utilize the scroll directive for the upcoming [v-virtual-scroll](https://github.com/vuetifyjs/vuetify/pull/10944) components.

With this implemented, there are components (part of another PR), that could be updated to use this instead of manually:

https://github.com/vuetifyjs/vuetify/blob/b03b507fc811ce4657a8cdbc3993ed58932cbab6/packages/vuetify/src/components/VDataTable/VVirtualTable.ts#L96
https://github.com/vuetifyjs/vuetify/blob/4a3d39b4cf1305be9fc97e45a1020b105322af14/packages/vuetify/src/components/VSelect/VSelect.ts#L253
* 
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
jest / visually
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div
    v-scroll="onScrollWindow"
    class="ma-12 pa-12"
    style="min-height: 300vh;"
  >
    <v-card
      v-scroll.self="onScroll"
      max-height="300"
      class="overflow-y-auto"
    >
      <v-sheet
        id="sheet"
        v-scroll:#sheet="onQueryScroll"
        height="100vh"
        class="overflow-y-auto"
      >
        <v-responsive height="200vh">
          Hello
        </v-responsive>
      </v-sheet>
    </v-card>
  </div>
</template>

<script>
  export default {
    methods: {
      onScroll () {
        console.log('On scroll self')
      },
      onScrollWindow () {
        console.log('On scroll window')
      },
      onQueryScroll () {
        console.log('On scroll querySelector')
      },
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
