### PR TITLE
fix(VSparkline): fix duplicate id on VSparkline path

### DIFF
--- a/packages/vuetify/src/components/VSparkline/VSparkline.ts
+++ b/packages/vuetify/src/components/VSparkline/VSparkline.ts
@@ -307,7 +307,6 @@ export default mixins<options &
 
       return this.$createElement('path', {
         attrs: {
-          id: this._uid,
           d: genPath(points, this._radius, this.fill, this.parsedHeight),
           fill: this.fill ? `url(#${this._uid})` : 'none',
           stroke: this.fill ? 'none' : `url(#${this._uid})`,

--- a/packages/vuetify/src/components/VSparkline/__tests__/__snapshots__/VSparkline.spec.ts.snap
+++ b/packages/vuetify/src/components/VSparkline/__tests__/__snapshots__/VSparkline.spec.ts.snap
@@ -39,8 +39,7 @@ exports[`VSparkline.ts should position labels correctly 1`] = `
       42
     </text>
   </g>
-  <path id="35"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#35)"
   >
@@ -67,8 +66,7 @@ exports[`VSparkline.ts should render component and match a snapshot 1`] = `
       </stop>
     </linearGradient>
   </defs>
-  <path id="1"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#1)"
   >
@@ -759,8 +757,7 @@ exports[`VSparkline.ts should render component with gradient and match a snapsho
       </stop>
     </linearGradient>
   </defs>
-  <path id="9"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#9)"
   >
@@ -807,8 +804,7 @@ exports[`VSparkline.ts should render component with label size and match a snaps
       42
     </text>
   </g>
-  <path id="33"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#33)"
   >
@@ -835,8 +831,7 @@ exports[`VSparkline.ts should render component with line width and match a snaps
       </stop>
     </linearGradient>
   </defs>
-  <path id="7"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#7)"
   >
@@ -863,8 +858,7 @@ exports[`VSparkline.ts should render component with padding and match a snapshot
       </stop>
     </linearGradient>
   </defs>
-  <path id="3"
-        d="M20 54.99999L150 49.8780487804878S150 49.8780487804878 150 49.8780487804878L280 20.00001"
+  <path d="M20 54.99999L150 49.8780487804878S150 49.8780487804878 150 49.8780487804878L280 20.00001"
         fill="none"
         stroke="url(#3)"
   >
@@ -911,8 +905,7 @@ exports[`VSparkline.ts should render component with string labels and match a sn
       42
     </text>
   </g>
-  <path id="11"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#11)"
   >
@@ -959,8 +952,7 @@ exports[`VSparkline.ts should render component with string labels and match a sn
       43
     </text>
   </g>
-  <path id="11"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#11)"
   >
@@ -1007,8 +999,7 @@ exports[`VSparkline.ts should render component with string labels and match a sn
       baz
     </text>
   </g>
-  <path id="11"
-        d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
+  <path d="M8 66.99999L150 58.36585365853659S150 58.36585365853659 150 58.36585365853659L292 8.00001"
         fill="none"
         stroke="url(#11)"
   >
@@ -1035,8 +1026,7 @@ exports[`VSparkline.ts should render component with trend and equal values and m
       </stop>
     </linearGradient>
   </defs>
-  <path id="31"
-        d="M8 66.99999L150 67L292 67.00001"
+  <path d="M8 66.99999L150 67L292 67.00001"
         fill="none"
         stroke="url(#31)"
   >
@@ -1063,8 +1053,7 @@ exports[`VSparkline.ts should render smooth component and match a snapshot 1`] =
       </stop>
     </linearGradient>
   </defs>
-  <path id="5"
-        d="M8 66.99999L130.03686879378304 59.579687437670394S150 58.36585365853659 168.8494438621337 51.6801625133916L292 8.00001"
+  <path d="M8 66.99999L130.03686879378304 59.579687437670394S150 58.36585365853659 168.8494438621337 51.6801625133916L292 8.00001"
         fill="none"
         stroke="url(#5)"
   >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
This MR removes the `id` property on the SVG `path` element from VSparkline.

## Motivation and Context
VSparkline has a duplicated `id`. It uses the same `id` for it's `path` element and the `linearGradient`.
This creates an issue during SSR rehydration where the path disappear as it can't find the gradient.

## How Has This Been Tested?
This has been tested visually to check it's still renders properly. The snapshots have also been updated.
I haven't been able to link my local Vuetify to a Nuxt project to check removing the duplicated `id` does fix the issue, however it seems very likely it will.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-sparkline
      auto-draw
      :value="[0, 2, 5, 9, 5, 10, 3, 5, 0, 0, 1, 8, 2, 9, 0]"
      :gradient="['#623195', '#9e6dd1']"
      :line-width="2"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
