### PR TITLE
refactor: mergeClasses, mergeStyles, mergeListeners

### DIFF
--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -1,0 +1,69 @@
+import { mergeClasses, mergeListeners, mergeStyles } from '../mergeData'
+
+describe('mergeClasses', () => {
+  it('should merge classes', () => {
+    const cUndefined = undefined
+    const cEmptyString = ''
+    const cString = 'foo bar'
+    const cArray = ['foo', 'bar']
+    const cObject = { foo: true, bar: false }
+
+    expect(mergeClasses(cUndefined, cUndefined)).toBeUndefined()
+    expect(mergeClasses(cUndefined, cObject)).toBe(cObject)
+    expect(mergeClasses(cEmptyString, cUndefined)).toBe(cEmptyString)
+    expect(mergeClasses(cUndefined, cObject)).toBe(cObject)
+    expect(mergeClasses(cString, cUndefined)).toBe(cString)
+    expect(mergeClasses(cString, cEmptyString)).toBe(cString)
+    expect(mergeClasses(cString, cString)).toStrictEqual([cString, cString])
+    expect(mergeClasses(cString, cArray)).toStrictEqual([cString, ...cArray])
+    expect(mergeClasses(cString, cObject)).toStrictEqual([cString, cObject])
+    expect(mergeClasses(cArray, cUndefined)).toBe(cArray)
+    expect(mergeClasses(cArray, cEmptyString)).toBe(cArray)
+    expect(mergeClasses(cArray, cString)).toStrictEqual([...cArray, cString])
+    expect(mergeClasses(cArray, cArray)).toStrictEqual([...cArray, ...cArray])
+    expect(mergeClasses(cArray, cObject)).toStrictEqual([...cArray, cObject])
+    expect(mergeClasses(cObject, cUndefined)).toBe(cObject)
+    expect(mergeClasses(cObject, cEmptyString)).toBe(cObject)
+    expect(mergeClasses(cObject, cString)).toStrictEqual([cObject, cString])
+    expect(mergeClasses(cObject, cArray)).toStrictEqual([cObject, ...cArray])
+    expect(mergeClasses(cObject, cObject)).toStrictEqual([cObject, cObject])
+  })
+})
+
+describe('mergeStyles', () => {
+  it('should merge styles', () => {
+    const cUndefined = undefined
+    const cEmptyString = ''
+    const cString = 'foo: bar; fizz-buzz: 10px'
+    const cObject = { foo: 'bar', fizzBuzz: '10px' }
+
+    expect(mergeStyles(cUndefined, cUndefined)).toBeUndefined()
+    expect(mergeStyles(cUndefined, cObject)).toBe(cObject)
+    expect(mergeStyles(cEmptyString, cUndefined)).toBeUndefined()
+    expect(mergeStyles(cUndefined, cObject)).toBe(cObject)
+    expect(mergeStyles(cString, cUndefined)).toBe(cString)
+    expect(mergeStyles(cString, cEmptyString)).toBe(cString)
+    expect(mergeStyles(cString, cString)).toStrictEqual([cObject, cObject])
+    expect(mergeStyles(cString, cObject)).toStrictEqual([cObject, cObject])
+    expect(mergeStyles(cObject, cUndefined)).toBe(cObject)
+    expect(mergeStyles(cObject, cEmptyString)).toBe(cObject)
+    expect(mergeStyles(cObject, cString)).toStrictEqual([cObject, cObject])
+    expect(mergeStyles(cObject, cObject)).toStrictEqual([cObject, cObject])
+  })
+})
+
+describe('mergeListeners', () => {
+  it('should merge styles', () => {
+    const listener1 = () => {}
+    const listener2 = () => {}
+
+    expect(mergeListeners(undefined, undefined)).toBeUndefined()
+    expect(mergeListeners(undefined, { one: listener1 })).toStrictEqual({ one: listener1 })
+    expect(mergeListeners(undefined, { one: [listener1, listener2] })).toStrictEqual({ one: [listener1, listener2] })
+    expect(mergeListeners({ one: listener1 }, undefined)).toStrictEqual({ one: listener1 })
+    expect(mergeListeners({ one: [listener1, listener2] }, undefined)).toStrictEqual({ one: [listener1, listener2] })
+    expect(mergeListeners({ one: listener1 }, { one: listener2 })).toStrictEqual({ one: [listener1, listener2] })
+    expect(mergeListeners({ one: listener1 }, { one: [listener2] })).toStrictEqual({ one: [listener1, listener2] })
+    expect(mergeListeners({ one: [listener1, listener2] }, { one: [listener2] })).toStrictEqual({ one: [listener1, listener2, listener2] })
+  })
+})

--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -53,7 +53,7 @@ describe('mergeStyles', () => {
 })
 
 describe('mergeListeners', () => {
-  it('should merge styles', () => {
+  it('should merge listeners', () => {
     const listener1 = () => {}
     const listener2 = () => {}
 

--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -1,69 +1,80 @@
 import { mergeClasses, mergeListeners, mergeStyles } from '../mergeData'
 
-describe('mergeClasses', () => {
-  it('should merge classes', () => {
-    const cUndefined = undefined
-    const cEmptyString = ''
-    const cString = 'foo bar'
-    const cArray = ['foo', 'bar']
-    const cObject = { foo: true, bar: false }
+function verifyFactory (mergeMethod: (target: any, source: any) => any) {
+  return function verify (target: any, source: any, expected: any) {
+    if (expected === target) {
+      expect(mergeMethod(target, source)).toBe(expected)
+    } else {
+      expect(mergeMethod(target, source)).toStrictEqual(expected)
+    }
+  }
+}
 
-    expect(mergeClasses(cUndefined, cUndefined)).toBeUndefined()
-    expect(mergeClasses(cUndefined, cObject)).toBe(cObject)
-    expect(mergeClasses(cEmptyString, cUndefined)).toBe(cEmptyString)
-    expect(mergeClasses(cUndefined, cObject)).toBe(cObject)
-    expect(mergeClasses(cString, cUndefined)).toBe(cString)
-    expect(mergeClasses(cString, cEmptyString)).toBe(cString)
-    expect(mergeClasses(cString, cString)).toStrictEqual([cString, cString])
-    expect(mergeClasses(cString, cArray)).toStrictEqual([cString, ...cArray])
-    expect(mergeClasses(cString, cObject)).toStrictEqual([cString, cObject])
-    expect(mergeClasses(cArray, cUndefined)).toBe(cArray)
-    expect(mergeClasses(cArray, cEmptyString)).toBe(cArray)
-    expect(mergeClasses(cArray, cString)).toStrictEqual([...cArray, cString])
-    expect(mergeClasses(cArray, cArray)).toStrictEqual([...cArray, ...cArray])
-    expect(mergeClasses(cArray, cObject)).toStrictEqual([...cArray, cObject])
-    expect(mergeClasses(cObject, cUndefined)).toBe(cObject)
-    expect(mergeClasses(cObject, cEmptyString)).toBe(cObject)
-    expect(mergeClasses(cObject, cString)).toStrictEqual([cObject, cString])
-    expect(mergeClasses(cObject, cArray)).toStrictEqual([cObject, ...cArray])
-    expect(mergeClasses(cObject, cObject)).toStrictEqual([cObject, cObject])
-  })
+describe('mergeClasses', () => {
+  const cUndefined = undefined
+  const cEmptyString = ''
+  const cString = 'foo bar'
+  const cArray = ['foo', 'bar']
+  const cObject = { foo: true, bar: false }
+
+  it.each([
+    [cUndefined, cUndefined, cUndefined],
+    [cUndefined, cObject, cObject],
+    [cEmptyString, cUndefined, cEmptyString],
+    [cUndefined, cObject, cObject],
+    [cString, cUndefined, cString],
+    [cString, cEmptyString, cString],
+    [cString, cString, [cString, cString]],
+    [cString, cArray, [cString, ...cArray]],
+    [cString, cObject, [cString, cObject]],
+    [cArray, cUndefined, cArray],
+    [cArray, cEmptyString, cArray],
+    [cArray, cString, [...cArray, cString]],
+    [cArray, cArray, [...cArray, ...cArray]],
+    [cArray, cObject, [...cArray, cObject]],
+    [cObject, cUndefined, cObject],
+    [cObject, cEmptyString, cObject],
+    [cObject, cString, [cObject, cString]],
+    [cObject, cArray, [cObject, ...cArray]],
+    [cObject, cObject, [cObject, cObject]],
+  ])('should merge classes', verifyFactory(mergeClasses))
 })
 
 describe('mergeStyles', () => {
-  it('should merge styles', () => {
-    const cUndefined = undefined
-    const cEmptyString = ''
-    const cString = 'foo: bar; fizz-buzz: 10px; background: var(--background)'
-    const cObject = { foo: 'bar', fizzBuzz: '10px', background: 'var(--background)' }
+  const cUndefined = undefined
+  const cEmptyString = ''
+  const cString = 'foo: bar; fizz-buzz: 10px; background: var(--background)'
+  const cObject = { foo: 'bar', fizzBuzz: '10px', background: 'var(--background)' }
 
-    expect(mergeStyles(cUndefined, cUndefined)).toBeUndefined()
-    expect(mergeStyles(cUndefined, cObject)).toBe(cObject)
-    expect(mergeStyles(cEmptyString, cUndefined)).toBeUndefined()
-    expect(mergeStyles(cUndefined, cObject)).toBe(cObject)
-    expect(mergeStyles(cString, cUndefined)).toBe(cString)
-    expect(mergeStyles(cString, cEmptyString)).toBe(cString)
-    expect(mergeStyles(cString, cString)).toStrictEqual([cObject, cObject])
-    expect(mergeStyles(cString, cObject)).toStrictEqual([cObject, cObject])
-    expect(mergeStyles(cObject, cUndefined)).toBe(cObject)
-    expect(mergeStyles(cObject, cEmptyString)).toBe(cObject)
-    expect(mergeStyles(cObject, cString)).toStrictEqual([cObject, cObject])
-    expect(mergeStyles(cObject, cObject)).toStrictEqual([cObject, cObject])
-  })
+  it.each([
+    [cUndefined, cUndefined, cUndefined],
+    [cUndefined, cObject, cObject],
+    [cEmptyString, cUndefined, cUndefined],
+    [cUndefined, cObject, cObject],
+    [cString, cUndefined, cString],
+    [cString, cEmptyString, cString],
+    [cString, cString, [cObject, cObject]],
+    [cString, cObject, [cObject, cObject]],
+    [cObject, cUndefined, cObject],
+    [cObject, cEmptyString, cObject],
+    [cObject, cString, [cObject, cObject]],
+    [cObject, cObject, [cObject, cObject]],
+  ])('should merge styles', verifyFactory(mergeStyles))
 })
 
 describe('mergeListeners', () => {
-  it('should merge listeners', () => {
-    const listener1 = () => {}
-    const listener2 = () => {}
+  const listener1 = () => {}
+  const listener2 = () => {}
 
-    expect(mergeListeners(undefined, undefined)).toBeUndefined()
-    expect(mergeListeners(undefined, { one: listener1 })).toStrictEqual({ one: listener1 })
-    expect(mergeListeners(undefined, { one: [listener1, listener2] })).toStrictEqual({ one: [listener1, listener2] })
-    expect(mergeListeners({ one: listener1 }, undefined)).toStrictEqual({ one: listener1 })
-    expect(mergeListeners({ one: [listener1, listener2] }, undefined)).toStrictEqual({ one: [listener1, listener2] })
-    expect(mergeListeners({ one: listener1 }, { one: listener2 })).toStrictEqual({ one: [listener1, listener2] })
-    expect(mergeListeners({ one: listener1 }, { one: [listener2] })).toStrictEqual({ one: [listener1, listener2] })
-    expect(mergeListeners({ one: [listener1, listener2] }, { one: [listener2] })).toStrictEqual({ one: [listener1, listener2, listener2] })
-  })
+  it.each([
+    [undefined, undefined, undefined],
+    [undefined, { one: listener1 }, { one: listener1 }],
+    [undefined, { one: [listener1, listener2] }, { one: [listener1, listener2] }],
+    [{ one: listener1 }, undefined, { one: listener1 }],
+    [{ one: [listener1, listener2] }, undefined, { one: [listener1, listener2] }],
+    [{ one: listener1 }, { one: listener2 }, { one: [listener1, listener2] }],
+    [{ one: listener1 }, { one: [listener2] }, { one: [listener1, listener2] }],
+    [{ one: [listener1, listener2] }, { one: [listener2] }, { one: [listener1, listener2, listener2] }],
+    [{ one: [listener1, listener2] }, { two: listener2 }, { one: [listener1, listener2], two: listener2 }],
+  ])('should merge listeners', verifyFactory(mergeListeners))
 })

--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -34,8 +34,8 @@ describe('mergeStyles', () => {
   it('should merge styles', () => {
     const cUndefined = undefined
     const cEmptyString = ''
-    const cString = 'foo: bar; fizz-buzz: 10px'
-    const cObject = { foo: 'bar', fizzBuzz: '10px' }
+    const cString = 'foo: bar; fizz-buzz: 10px; background: var(--background)'
+    const cObject = { foo: 'bar', fizzBuzz: '10px', background: 'var(--background)' }
 
     expect(mergeStyles(cUndefined, cUndefined)).toBeUndefined()
     expect(mergeStyles(cUndefined, cObject)).toBe(cObject)

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -102,13 +102,7 @@ export default function mergeData (): VNodeData {
           mergeTarget[prop] = { ...arguments[i][prop], ...mergeTarget[prop] }
           break
         // Reassignment strategy (no merge)
-        case 'slot':
-        case 'key':
-        case 'ref':
-        case 'tag':
-        case 'show':
-        case 'keepAlive':
-        default:
+        default: // slot, key, ref, tag, show, keepAlive
           if (!mergeTarget[prop]) {
             mergeTarget[prop] = arguments[i][prop]
           }

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -113,7 +113,10 @@ export default function mergeData (): VNodeData {
   return mergeTarget
 }
 
-export function mergeStyles (target: undefined | string | object[] | object, source: undefined | string | object[] | object) {
+export function mergeStyles (
+  target: undefined | string | object[] | object,
+  source: undefined | string | object[] | object
+) {
   if (!target) return source
   if (!source) return target
 

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -5,7 +5,7 @@
  */
 /* eslint-disable max-statements */
 import { VNodeData } from 'vue'
-import { camelize } from './helpers'
+import { camelize, wrapInArray } from './helpers'
 
 const pattern = {
   styleList: /;(?![^(]*\))/g,
@@ -119,15 +119,11 @@ export default function mergeData (): VNodeData {
   return mergeTarget
 }
 
-function arrayize<T> (value: T | T[]): T[] {
-  return Array.isArray(value) ? value : [value]
-}
-
 export function mergeStyles (target: undefined | string | object[] | object, source: undefined | string | object[] | object) {
   if (!target) return source
   if (!source) return target
 
-  target = arrayize(typeof target === 'string' ? parseStyle(target) : target)
+  target = wrapInArray(typeof target === 'string' ? parseStyle(target) : target)
 
   return (target as object[]).concat(typeof source === 'string' ? parseStyle(source) : source)
 }
@@ -136,7 +132,7 @@ export function mergeClasses (target: any, source: any) {
   if (!source) return target
   if (!target) return source
 
-  return target ? arrayize(target).concat(source) : source
+  return target ? wrapInArray(target).concat(source) : source
 }
 
 export function mergeListeners (
@@ -152,8 +148,8 @@ export function mergeListeners (
     // Concat function to array of functions if callback present.
     if (target[event]) {
       // Insert current iteration data in beginning of merged array.
-      target[event] = arrayize(target[event])
-      ;(target[event] as Function[]).push(...arrayize(source[event]))
+      target[event] = wrapInArray(target[event])
+      ;(target[event] as Function[]).push(...wrapInArray(source[event]))
     } else {
       // Straight assign.
       target[event] = source[event]

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -41,7 +41,6 @@ export default function mergeData (): VNodeData {
   const mergeTarget: VNodeData & Dictionary<any> = {}
   let i: number = arguments.length
   let prop: string
-  let event: string
 
   // Allow for variadic argument length.
   while (i--) {
@@ -51,34 +50,15 @@ export default function mergeData (): VNodeData {
       switch (prop) {
         // Array merge strategy (array concatenation)
         case 'class':
-        case 'style':
         case 'directives':
-          if (!arguments[i][prop]) {
-            break
+          if (arguments[i][prop]) {
+            mergeTarget[prop] = mergeClasses(mergeTarget[prop], arguments[i][prop])
           }
-          if (!Array.isArray(mergeTarget[prop])) {
-            mergeTarget[prop] = []
+          break
+        case 'style':
+          if (arguments[i][prop]) {
+            mergeTarget[prop] = mergeStyles(mergeTarget[prop], arguments[i][prop])
           }
-
-          if (prop === 'style') {
-            let style: any[]
-            if (Array.isArray(arguments[i].style)) {
-              style = arguments[i].style
-            } else {
-              style = [arguments[i].style]
-            }
-            for (let j = 0; j < style.length; j++) {
-              const s = style[j]
-              if (typeof s === 'string') {
-                style[j] = parseStyle(s)
-              }
-            }
-            arguments[i].style = style
-          }
-
-          // Repackaging in an array allows Vue runtime
-          // to merge class/style bindings regardless of type.
-          mergeTarget[prop] = mergeTarget[prop].concat(arguments[i][prop])
           break
         // Space delimited string concatenation strategy
         case 'staticClass':
@@ -101,25 +81,8 @@ export default function mergeData (): VNodeData {
         // uses the last given value to assign.
         case 'on':
         case 'nativeOn':
-          if (!arguments[i][prop]) {
-            break
-          }
-          if (!mergeTarget[prop]) {
-            mergeTarget[prop] = {}
-          }
-          const listeners = mergeTarget[prop]!
-          for (event of Object.keys(arguments[i][prop] || {})) {
-            // Concat function to array of functions if callback present.
-            if (listeners[event]) {
-              // Insert current iteration data in beginning of merged array.
-              listeners[event] = Array<Function>().concat( // eslint-disable-line
-                listeners[event],
-                arguments[i][prop][event]
-              )
-            } else {
-              // Straight assign.
-              listeners[event] = arguments[i][prop][event]
-            }
+          if (arguments[i][prop]) {
+            mergeTarget[prop] = mergeListeners(mergeTarget[prop], arguments[i][prop])
           }
           break
         // Object merge strategy
@@ -154,4 +117,48 @@ export default function mergeData (): VNodeData {
   }
 
   return mergeTarget
+}
+
+function arrayize<T> (value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
+}
+
+export function mergeStyles (target: undefined | string | object[] | object, source: undefined | string | object[] | object) {
+  if (!target) return source
+  if (!source) return target
+
+  target = arrayize(typeof target === 'string' ? parseStyle(target) : target)
+
+  return (target as object[]).concat(typeof source === 'string' ? parseStyle(source) : source)
+}
+
+export function mergeClasses (target: any, source: any) {
+  if (!source) return target
+  if (!target) return source
+
+  return target ? arrayize(target).concat(source) : source
+}
+
+export function mergeListeners (
+  target: { [key: string]: Function | Function[] } | undefined,
+  source: { [key: string]: Function | Function[] } | undefined
+) {
+  if (!target) return source
+  if (!source) return target
+
+  let event: string
+
+  for (event of Object.keys(source)) {
+    // Concat function to array of functions if callback present.
+    if (target[event]) {
+      // Insert current iteration data in beginning of merged array.
+      target[event] = arrayize(target[event])
+      ;(target[event] as Function[]).push(...arrayize(source[event]))
+    } else {
+      // Straight assign.
+      target[event] = source[event]
+    }
+  }
+
+  return target
 }


### PR DESCRIPTION
## Description
Provides utilities for merging parts of VNodeData. Sometimes we just want to merge only classes or listeners instead of full data object.
Might be used for instance here: https://github.com/vuetifyjs/vuetify/pull/11126/files#diff-27a9bd669f7e558ec66554510a51c4afR81

## How Has This Been Tested?
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
