### PR TITLE
docs(Intersect): increase colored dot contrast

### DIFF
--- a/packages/docs/src/examples/intersect/simple/options.vue
+++ b/packages/docs/src/examples/intersect/simple/options.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="d-flex align-center text-center justify-center">
       <v-avatar
-        :color="isIntersecting ? 'success' : 'error'"
+        :color="isIntersecting ? 'green lighten-1' : 'red darken-2'"
         class="mr-3 swing-transition"
         size="32"
       ></v-avatar>

--- a/packages/docs/src/examples/intersect/usage.vue
+++ b/packages/docs/src/examples/intersect/usage.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="d-flex align-center text-center justify-center">
       <v-avatar
-        :color="isIntersecting ? 'success' : 'error'"
+        :color="isIntersecting ? 'green lighten-1' : 'red darken-2'"
         class="mr-3 swing-transition"
         size="32"
       ></v-avatar>


### PR DESCRIPTION
## Description
I have a friend who didn't understand the Intersect colored dot example because he has deuteranomaly color blindness.

## Motivation and Context
To help that friend to understand the example I created this PR to increase the colored dot contrast (lighter green, darker red).

## How Has This Been Tested?
With his eyes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
