### PR TITLE
revert: chore: move css reset to packages

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -99,7 +99,6 @@
     "postcss-loader": "^3.0.0",
     "pug": "^2.0.4",
     "pug-loader": "^2.4.0",
-    "ress": "^2.0.4",
     "rimraf": "^2.6.3",
     "sass": "^1.22.7",
     "sass-loader": "^7.1.0",

--- a/packages/vuetify/src/styles/generic/_index.scss
+++ b/packages/vuetify/src/styles/generic/_index.scss
@@ -1,5 +1,5 @@
-@import './reset.scss';
 @import './animations.scss';
 @import './colors.scss';
+@import './reset.scss';
 @import './elevation.scss';
 @import './transitions.scss';

--- a/packages/vuetify/src/styles/generic/_reset.scss
+++ b/packages/vuetify/src/styles/generic/_reset.scss
@@ -1,1 +1,331 @@
-@import '~ress/dist/ress.min.css'
+/* ! ress.css • v1.1.1 - MIT License - github.com/filipelinhares/ress */
+
+/* # =================================================================
+   # Global selectors
+   # ================================================================= */
+
+   html {
+    box-sizing: border-box;
+    overflow-y: scroll; /* All browsers without overlaying scrollbars */
+    -webkit-text-size-adjust: 100%; /* iOS 8+ */
+  }
+
+  *,
+  ::before,
+  ::after {
+    box-sizing: inherit;
+  }
+
+  ::before,
+  ::after {
+    text-decoration: inherit; /* Inherit text-decoration and vertical align to ::before and ::after pseudo elements */
+    vertical-align: inherit;
+  }
+
+  /* Remove margin, padding of all elements and set background-no-repeat as default */
+  * {
+    background-repeat: no-repeat; /* Set `background-repeat: no-repeat` to all elements */
+    padding: 0; /* Reset `padding` and `margin` of all elements */
+    margin: 0;
+  }
+
+  /* # =================================================================
+     # General elements
+     # ================================================================= */
+
+  /* Add the correct display in iOS 4-7.*/
+  audio:not([controls]) {
+    display: none;
+    height: 0;
+  }
+
+  hr {
+    overflow: visible; /* Show the overflow in Edge and IE */
+  }
+
+  /*
+  * Correct `block` display not defined for any HTML5 element in IE 8/9
+  * Correct `block` display not defined for `details` or `summary` in IE 10/11
+  * and Firefox
+  * Correct `block` display not defined for `main` in IE 11
+  */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  main,
+  menu,
+  nav,
+  section,
+  summary {
+    display: block;
+  }
+
+  summary {
+    display: list-item; /* Add the correct display in all browsers */
+  }
+
+  small {
+    font-size: 80%; /* Set font-size to 80% in `small` elements */
+  }
+
+  [hidden],
+  template {
+    display: none; /* Add the correct display in IE */
+  }
+
+  abbr[title] {
+    border-bottom: 1px dotted; /* Add a bordered underline effect in all browsers */
+    text-decoration: none; /* Remove text decoration in Firefox 40+ */
+  }
+
+  a {
+    background-color: transparent; /* Remove the gray background on active links in IE 10 */
+    -webkit-text-decoration-skip: objects; /* Remove gaps in links underline in iOS 8+ and Safari 8+ */
+  }
+
+  a:active,
+  a:hover {
+    outline-width: 0; /* Remove the outline when hovering in all browsers */
+  }
+
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: monospace, monospace; /* Specify the font family of code elements */
+  }
+
+  b,
+  strong {
+    font-weight: bolder; /* Correct style set to `bold` in Edge 12+, Safari 6.2+, and Chrome 18+ */
+  }
+
+  dfn {
+    font-style: italic; /* Address styling not present in Safari and Chrome */
+  }
+
+  /* Address styling not present in IE 8/9 */
+  mark {
+    background-color: #ff0;
+    color: #000;
+  }
+
+  /* https://gist.github.com/unruthless/413930 */
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  /* # =================================================================
+     # Forms
+     # ================================================================= */
+
+  input {
+    border-radius: 0;
+  }
+
+  /* Apply cursor pointer to button elements */
+  button,
+  [type="button"],
+  [type="reset"],
+  [type="submit"],
+  [role="button"] {
+    cursor: pointer;
+  }
+
+  /* Replace pointer cursor in disabled elements */
+  [disabled] {
+    cursor: default;
+  }
+
+  [type="number"] {
+    width: auto; /* Firefox 36+ */
+  }
+
+  [type="search"] {
+    -webkit-appearance: textfield; /* Safari 8+ */
+  }
+
+  [type="search"]::-webkit-search-cancel-button,
+  [type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none; /* Safari 8 */
+  }
+
+  textarea {
+    overflow: auto; /* Internet Explorer 11+ */
+    resize: vertical; /* Specify textarea resizability */
+  }
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font: inherit; /* Specify font inheritance of form elements */
+  }
+
+  optgroup {
+    font-weight: bold; /* Restore the font weight unset by the previous rule. */
+  }
+
+  button {
+    overflow: visible; /* Address `overflow` set to `hidden` in IE 8/9/10/11 */
+  }
+
+  /* Remove inner padding and border in Firefox 4+ */
+  button::-moz-focus-inner,
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    border-style: 0;
+    padding: 0;
+  }
+
+  /* Replace focus style removed in the border reset above */
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    outline: 0;
+    border: 0;
+  }
+
+  button,
+  html [type="button"], /* Prevent a WebKit bug where (2) destroys native `audio` and `video`controls in Android 4 */
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button; /* Correct the inability to style clickable types in iOS */
+  }
+
+  button,
+  select {
+    text-transform: none; /* Firefox 40+, Internet Explorer 11- */
+  }
+
+  /* Remove the default button styling in all browsers */
+  button,
+  input,
+  select,
+  textarea {
+    background-color: transparent;
+    border-style: none;
+    color: inherit;
+  }
+
+  /* Style select like a standard input */
+  select {
+    -moz-appearance: none; /* Firefox 36+ */
+    -webkit-appearance: none; /* Chrome 41+ */
+  }
+
+  select::-ms-expand {
+    display: none; /* Internet Explorer 11+ */
+  }
+
+  select::-ms-value {
+    color: currentColor; /* Internet Explorer 11+ */
+  }
+
+  legend {
+    border: 0; /* Correct `color` not being inherited in IE 8/9/10/11 */
+    color: inherit; /* Correct the color inheritance from `fieldset` elements in IE */
+    display: table; /* Correct the text wrapping in Edge and IE */
+    max-width: 100%; /* Correct the text wrapping in Edge and IE */
+    white-space: normal; /* Correct the text wrapping in Edge and IE */
+  }
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* Correct the inability to style clickable types in iOS and Safari */
+    font: inherit; /* Change font properties to `inherit` in Chrome and Safari */
+  }
+
+  [type="search"] {
+    -webkit-appearance: textfield; /* Correct the odd appearance in Chrome and Safari */
+    outline-offset: -2px; /* Correct the outline style in Safari */
+  }
+
+  /* # =================================================================
+     # Specify media element style
+     # ================================================================= */
+
+  img {
+    border-style: none; /* Remove border when inside `a` element in IE 8/9/10 */
+  }
+
+  /* Add the correct vertical alignment in Chrome, Firefox, and Opera */
+  progress {
+    vertical-align: baseline;
+  }
+
+  svg:not(:root) {
+    overflow: hidden; /* Internet Explorer 11- */
+  }
+
+  audio,
+  canvas,
+  progress,
+  video {
+    display: inline-block; /* Internet Explorer 11+, Windows Phone 8.1+ */
+  }
+
+  /* # =================================================================
+     # Acessibility
+     # ================================================================= */
+
+  /* Hide content from screens but not screenreaders */
+  @media screen {
+    [hidden~="screen"] {
+      display: inherit;
+    }
+    [hidden~="screen"]:not(:active):not(:focus):not(:target) {
+      position: absolute !important;
+      clip: rect(0 0 0 0) !important;
+    }
+  }
+
+  /* Specify the progress cursor of updating elements */
+  [aria-busy="true"] {
+    cursor: progress;
+  }
+
+  /* Specify the pointer cursor of trigger elements */
+  [aria-controls] {
+    cursor: pointer;
+  }
+
+  /* Specify the unstyled cursor of disabled, not-editable, or otherwise inoperable elements */
+  [aria-disabled] {
+    cursor: default;
+  }
+
+  /* # =================================================================
+     # Selection
+     # ================================================================= */
+
+  /* Specify text selection background color and omit drop shadow */
+
+  ::-moz-selection {
+    background-color: #b3d4fc; /* Required when declaring ::selection */
+    color: #000;
+    text-shadow: none;
+  }
+
+  ::selection {
+    background-color: #b3d4fc; /* Required when declaring ::selection */
+    color: #000;
+    text-shadow: none;
+  }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11346,11 +11346,6 @@ resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0:
   dependencies:
     path-parse "^1.0.6"
 
-ress@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/ress/-/ress-2.0.4.tgz#ec80a066f1e0107353143405ad8c1cc4a48b195e"
-  integrity sha512-Fn9ugfCVPYn+8haQnen0rfm3gaX92Wk3SRpCNvrrpVvW6Iu1IKPU+UjsmVS8hYgweCBEr0x3nJd+TM+PXVaCoQ==
-
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"


### PR DESCRIPTION
This reverts commit f70de6036fa0136f

fixes #11276 

Probably there's solution other that reverting but ain't nobody got time for this

## How Has This Been Tested?
wasn't

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
