### PR TITLE
fix(VDatePicker): allow null value for multiple date picker

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -7,19 +7,19 @@ import VDatePickerYears from './VDatePickerYears'
 
 // Mixins
 import Localable from '../../mixins/localable'
-import mixins from '../../util/mixins'
 import Picker from '../../mixins/picker'
 
 // Utils
+import mixins from '../../util/mixins'
+import isDateAllowed from './util/isDateAllowed'
+import { wrapInArray } from '../../util/helpers'
+import { daysInMonth } from '../VCalendar/util/timestamp'
+import { consoleWarn } from '../../util/console'
 import {
   createItemTypeListeners,
   createNativeLocaleFormatter,
   pad,
 } from './util'
-import isDateAllowed from './util/isDateAllowed'
-import { consoleWarn } from '../../util/console'
-import { daysInMonth } from '../VCalendar/util/timestamp'
-import { wrapInArray } from '../../util/helpers'
 
 // Types
 import {

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -279,7 +279,7 @@ export default mixins(
       this.activePicker = type.toUpperCase()
 
       if (this.value && this.value.length) {
-        const output = wrapInArray(this.value)
+        const output = this.multipleValue
           .map((val: string) => sanitizeDateString(val, type))
           .filter(this.isDateAllowed)
         this.$emit('input', this.isMultiple ? output : output[0])

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -151,7 +151,7 @@ export default mixins(
           return this.pickerDate
         }
 
-        const multipleValue = this.value ? wrapInArray(this.value) : []
+        const multipleValue = wrapInArray(this.value)
         const date = ((this.multiple || this.range) ? multipleValue[multipleValue.length - 1] : this.value) ||
           (typeof this.showCurrent === 'string' ? this.showCurrent : `${now.getFullYear()}-${now.getMonth() + 1}`)
         return sanitizeDateString(date as string, this.type === 'date' ? 'month' : 'year')
@@ -161,7 +161,7 @@ export default mixins(
 
   computed: {
     multipleValue (): string[] {
-      return this.value ? wrapInArray(this.value) : []
+      return wrapInArray(this.value)
     },
     isMultiple (): boolean {
       return this.multiple || this.range

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -19,6 +19,7 @@ import {
 import isDateAllowed from './util/isDateAllowed'
 import { consoleWarn } from '../../util/console'
 import { daysInMonth } from '../VCalendar/util/timestamp'
+import { wrapInArray } from '../../util/helpers'
 
 // Types
 import {
@@ -50,7 +51,7 @@ function sanitizeDateString (dateString: string, type: 'date' | 'month' | 'year'
 
 export default mixins(
   Localable,
-  Picker
+  Picker,
 /* @vue/component */
 ).extend({
   name: 'v-date-picker',
@@ -150,7 +151,8 @@ export default mixins(
           return this.pickerDate
         }
 
-        const date = (this.multiple || this.range ? (this.value as string[])[(this.value as string[]).length - 1] : this.value) ||
+        const multipleValue = this.value ? wrapInArray(this.value) : []
+        const date = ((this.multiple || this.range) ? multipleValue[multipleValue.length - 1] : this.value) ||
           (typeof this.showCurrent === 'string' ? this.showCurrent : `${now.getFullYear()}-${now.getMonth() + 1}`)
         return sanitizeDateString(date as string, this.type === 'date' ? 'month' : 'year')
       })(),
@@ -158,17 +160,20 @@ export default mixins(
   },
 
   computed: {
+    multipleValue (): string[] {
+      return this.value ? wrapInArray(this.value) : []
+    },
     isMultiple (): boolean {
       return this.multiple || this.range
     },
     lastValue (): string | null {
-      return this.isMultiple ? (this.value as string[])[(this.value as string[]).length - 1] : (this.value as string | null)
+      return this.isMultiple ? this.multipleValue[this.multipleValue.length - 1] : (this.value as string | null)
     },
     selectedMonths (): string | string[] | undefined {
-      if (!this.value || !this.value.length || this.type === 'month') {
+      if (!this.value || this.type === 'month') {
         return this.value
       } else if (this.isMultiple) {
-        return (this.value as string[]).map(val => val.substr(0, 7))
+        return this.multipleValue.map(val => val.substr(0, 7))
       } else {
         return (this.value as string).substr(0, 7)
       }
@@ -266,7 +271,7 @@ export default mixins(
 
       if (!this.isMultiple && this.value && !this.pickerDate) {
         this.tableDate = sanitizeDateString(this.inputDate, this.type === 'month' ? 'year' : 'month')
-      } else if (this.isMultiple && (this.value as string[]).length && !(oldValue as string[]).length && !this.pickerDate) {
+      } else if (this.isMultiple && this.multipleValue.length && (!oldValue || !(oldValue as string[]).length) && !this.pickerDate) {
         this.tableDate = sanitizeDateString(this.inputDate, this.type === 'month' ? 'year' : 'month')
       }
     },
@@ -274,7 +279,7 @@ export default mixins(
       this.activePicker = type.toUpperCase()
 
       if (this.value && this.value.length) {
-        const output = (this.isMultiple ? (this.value as string[]) : [this.value as string])
+        const output = wrapInArray(this.value)
           .map((val: string) => sanitizeDateString(val, type))
           .filter(this.isDateAllowed)
         this.$emit('input', this.isMultiple ? output : output[0])
@@ -293,11 +298,11 @@ export default mixins(
 
   methods: {
     emitInput (newInput: string) {
-      if (this.range && this.value) {
-        if (this.value.length !== 1) {
+      if (this.range) {
+        if (this.multipleValue.length !== 1) {
           this.$emit('input', [newInput])
         } else {
-          const output = [...this.value, newInput]
+          const output = [this.multipleValue[0], newInput]
           this.$emit('input', output)
           this.$emit('change', output)
         }
@@ -306,9 +311,9 @@ export default mixins(
 
       const output = this.multiple
         ? (
-          (this.value as string[]).indexOf(newInput) === -1
-            ? (this.value as string[]).concat([newInput])
-            : (this.value as string[]).filter(x => x !== newInput)
+          this.multipleValue.indexOf(newInput) === -1
+            ? this.multipleValue.concat([newInput])
+            : this.multipleValue.filter(x => x !== newInput)
         )
         : newInput
 
@@ -364,13 +369,13 @@ export default mixins(
     genPickerTitle () {
       return this.$createElement(VDatePickerTitle, {
         props: {
-          date: this.value ? (this.formatters.titleDate as (value: any) => string)(this.value) : '',
+          date: this.value ? (this.formatters.titleDate as (value: any) => string)(this.isMultiple ? this.multipleValue : this.value) : '',
           disabled: this.disabled,
           readonly: this.readonly,
           selectingYear: this.activePicker === 'YEAR',
-          year: this.formatters.year(this.value ? `${this.inputYear}` : this.tableDate),
+          year: this.formatters.year(this.multipleValue.length ? `${this.inputYear}` : this.tableDate),
           yearIcon: this.yearIcon,
-          value: this.isMultiple ? (this.value as string[])[0] : this.value,
+          value: this.multipleValue[0],
         },
         slot: 'title',
         on: {

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -152,7 +152,7 @@ export default mixins(
         }
 
         const multipleValue = wrapInArray(this.value)
-        const date = ((this.multiple || this.range) ? multipleValue[multipleValue.length - 1] : this.value) ||
+        const date = multipleValue[multipleValue.length - 1] ||
           (typeof this.showCurrent === 'string' ? this.showCurrent : `${now.getFullYear()}-${now.getMonth() + 1}`)
         return sanitizeDateString(date as string, this.type === 'date' ? 'month' : 'year')
       })(),

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -10,8 +10,8 @@ import Localable from '../../mixins/localable'
 import Picker from '../../mixins/picker'
 
 // Utils
-import mixins from '../../util/mixins'
 import isDateAllowed from './util/isDateAllowed'
+import mixins from '../../util/mixins'
 import { wrapInArray } from '../../util/helpers'
 import { daysInMonth } from '../VCalendar/util/timestamp'
 import { consoleWarn } from '../../util/console'

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -213,7 +213,7 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
     expect(cb.mock.calls[0][0]).toHaveLength(3)
     expect(cb.mock.calls[0][0][2]).toBe('2013-05-05')
     expect(cb.mock.calls[0][0]).toEqual(
-      expect.arrayContaining(['2013-05-07', '2013-05-08', '2013-05-05'])
+      expect.arrayContaining(['2013-05-07', '2013-05-08', '2013-05-05']),
     )
   })
 
@@ -714,5 +714,16 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
 
     const buttonOfDay02 = wrapper.findAll('.v-date-picker-table--date tbody button').at(1)
     expect(buttonOfDay02.element.classList.contains('accent')).toBeFalsy()
+  })
+
+  it('should handle date range picker with null value', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        range: true,
+        value: null,
+      },
+    })
+
+    expect(wrapper.find('.v-date-picker-title__date').html()).toMatchSnapshot()
   })
 })

--- a/packages/vuetify/src/components/VDatePicker/__tests__/__snapshots__/VDatePicker.date.spec.ts.snap
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/__snapshots__/VDatePicker.date.spec.ts.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VDatePicker.ts should handle date range picker with null value 1`] = `
+<div class="v-picker__title__btn v-date-picker-title__date v-picker__title__btn--active">
+  <div>
+    &nbsp;
+  </div>
+</div>
+`;
+
 exports[`VDatePicker.ts should match snapshot with colored picker & header 1`] = `
 <div class="v-picker v-card v-picker--date theme--light">
   <div class="v-picker__title orange darken-1">


### PR DESCRIPTION
## Description
Allows null/undefined value for range/multiple date pickers

fix, but deliberately dev branch

## Motivation and Context
fixes #9529

## How Has This Been Tested?
jest, playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-menu
    :close-on-content-click="false"
    max-width="290"
  >
    <template #activator="{ on }">
      <v-text-field
        v-model="value"
        clearable
        :label="JSON.stringify(value)"
        readonly
        v-on="on"
      />
      <v-checkbox
        v-model="isRange"
        label="true = range, false = mutliple"
      />
    </template>
    <v-date-picker
      v-model="value"
      v-bind="{ [isRange ? 'range' : 'multiple']: true }"
    />
  </v-menu>
</template>

<script>
  export default {
    data: () => ({ value: null, isRange: true }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
