### PR TITLE
fix(VDatePicker): set proper tableDate if showCurrent is set

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -128,7 +128,7 @@ export default mixins(
         }
 
         const date = (this.multiple || this.range ? (this.value as string[])[(this.value as string[]).length - 1] : this.value) ||
-          `${now.getFullYear()}-${now.getMonth() + 1}`
+          (typeof this.showCurrent === 'string' ? this.showCurrent : `${now.getFullYear()}-${now.getMonth() + 1}`)
         return sanitizeDateString(date as string, this.type === 'date' ? 'month' : 'year')
       })(),
     }

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -678,4 +678,14 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
     expect(input.mock.calls[1][0]).toEqual(expect.arrayContaining(['2019-01-06']))
     expect(change.mock.calls).toHaveLength(1)
   })
+
+  it('should set proper tableDate', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        showCurrent: '2030-04-04',
+      },
+    })
+
+    expect(wrapper.vm.tableDate).toBe('2030-04')
+  })
 })


### PR DESCRIPTION
## Motivation and Context
fixes #6714

## How Has This Been Tested?
jest, playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-date-picker
      value="2030-05-04"
      show-current="2030-05-20"
    />
    <v-date-picker show-current="2030-05-20" />
    <v-date-picker value="2030-04-04" />
    <v-date-picker />
  </div>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
