### PR TITLE
fix(VSlider): wrong tick labels positions in RTL mode

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.sass
+++ b/packages/vuetify/src/components/VSlider/VSlider.sass
@@ -150,14 +150,14 @@
         transform: translateX(0%)
 
       +rtl()
-        transform: translateX(100%)
+        transform: translateX(0%)
 
     &:last-child .v-slider__tick-label
       +ltr()
         transform: translateX(-100%)
 
       +rtl()
-        transform: translateX(0%)
+        transform: translateX(100%)
 
     .v-slider__tick-label
       top: 8px

--- a/packages/vuetify/src/components/VSlider/VSlider.ts
+++ b/packages/vuetify/src/components/VSlider/VSlider.ts
@@ -314,13 +314,12 @@ export default mixins<options &
 
       const tickSize = parseFloat(this.tickSize)
       const range = createRange(this.numTicks + 1)
-      const direction = this.vertical ? 'bottom' : 'left'
-      const offsetDirection = this.vertical ? 'right' : 'top'
+      const direction = this.vertical ? 'bottom' : (this.$vuetify.rtl ? 'right' : 'left')
+      const offsetDirection = this.vertical ? (this.$vuetify.rtl ? 'left' : 'right') : 'top'
 
       if (this.vertical) range.reverse()
 
-      const ticks = range.map(i => {
-        const index = this.$vuetify.rtl ? this.maxValue - i : i
+      const ticks = range.map(index => {
         const children = []
 
         if (this.tickLabels[index]) {
@@ -329,11 +328,11 @@ export default mixins<options &
           }, this.tickLabels[index]))
         }
 
-        const width = i * (100 / this.numTicks)
+        const width = index * (100 / this.numTicks)
         const filled = this.$vuetify.rtl ? (100 - this.inputWidth) < width : width < this.inputWidth
 
         return this.$createElement('span', {
-          key: i,
+          key: index,
           staticClass: 'v-slider__tick',
           class: {
             'v-slider__tick--filled': filled,


### PR DESCRIPTION
## Motivation and Context
fixes #11028

## How Has This Been Tested?
playground
## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-btn block @click="$vuetify.rtl = !$vuetify.rtl">{{ $vuetify.rtl ? 'rtl' : 'ltr' }}</v-btn>
    <v-range-slider
      v-model="v"
      :tick-labels="['Winter', 'Spring', 'Summer', 'Fall']"
      min="0"
      max="6"
      step="2"
      ticks="always"
      tick-size="4"
    />
    <v-range-slider
      v-model="v"
      min="0"
      max="50"
      step="2"
      ticks="always"
      tick-size="4"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({ v: [2, 4] }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
