### PR TITLE
fix(vvirtualscroll): the key of the children is not right

### DIFF
--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.ts
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.ts
@@ -69,13 +69,13 @@ export default Measurable.extend({
       ).map(this.genChild)
     },
     genChild (item: any, index: number) {
-      const firstToRender = this.firstToRender + index
-      const top = convertToUnit(firstToRender * this.__itemHeight)
+      const indexToRender = this.firstToRender + index
+      const top = convertToUnit(indexToRender * this.__itemHeight)
 
       return this.$createElement('div', {
         staticClass: 'v-virtual-scroll__item',
         style: { top },
-        key: index,
+        key: indexToRender,
       }, getSlot(this, 'default', { item, index }))
     },
     getFirst (): number {


### PR DESCRIPTION
The key of the items is not right. It should never change to avoid unnecessary re-renders

## Description
Change key value from the index of the element based on the rendered to the index of the element based on all items

## Motivation and Context
This change will improve the component performance.

## How Has This Been Tested?
Playground example.
See example provided in the section below and test it with browser cache disabled to visually see the issue

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-virtual-scroll height="750px" :items="items" item-height="250">
      <template v-slot="{ item }">
        <div class="item">
          I'm item number {{ item.id }}
          <v-img width="200" height="200" :src="'https://picsum.photos/id/'+ item.id +'/200/200'"></v-img>
        </div>
      </template>
    </v-virtual-scroll>
  </v-container>
</template>

<script>
import VVirtualScroll from '../src/components'

const fillArrayWithNumbers = n => Array.apply(null, Array(n)).map((x, i) => i);
export default {
  data: () => ({
    items: fillArrayWithNumbers(5000).map(i => ({id: i, content: "content-" + i})),
  })
}
</script>

```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
