### PR TITLE
fix(VTreeview): emit opened nodes when using load-children

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -288,7 +288,7 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         on: {
           click: () => {
             if (this.openOnClick && this.hasChildren) {
-              this.open()
+              this.checkChildren().then(() => this.open())
             } else if (this.activatable && !this.disabled) {
               this.isActive = !this.isActive
               this.treeview.updateActive(this.key, this.isActive)

--- a/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewNode.ts
@@ -288,7 +288,7 @@ const VTreeviewNode = baseMixins.extend<options>().extend({
         on: {
           click: () => {
             if (this.openOnClick && this.hasChildren) {
-              this.checkChildren().then(() => this.open())
+              this.checkChildren().then(this.open)
             } else if (this.activatable && !this.disabled) {
               this.isActive = !this.isActive
               this.treeview.updateActive(this.key, this.isActive)

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.ts
@@ -842,4 +842,30 @@ describe('VTreeView.ts', () => { // eslint-disable-line max-statements
 
     expect(input).toHaveBeenCalledTimes(1)
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/9693
+  it('should emit opened node when using open-on-click and load-children', async () => {
+    const open = jest.fn()
+
+    const wrapper = mountFunction({
+      propsData: {
+        items: [{ id: 0, name: 'Root', children: [] }],
+        loadChildren: () => wrapper.setProps({
+          items: [{ id: 0, name: 'Root', children: [{ id: 1, name: 'Child' }] }],
+        }),
+        openOnClick: true,
+      },
+      listeners: {
+        'update:open': open,
+      },
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.find('.v-treeview-node__root').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).toMatchSnapshot()
+    expect(open).toHaveBeenLastCalledWith([0])
+  })
 })

--- a/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeview.spec.ts.snap
+++ b/packages/vuetify/src/components/VTreeview/__tests__/__snapshots__/VTreeview.spec.ts.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VTreeView.ts should emit opened node when using open-on-click and load-children 1`] = `
+<div class="v-treeview theme--light">
+  <div aria-expanded="false"
+       class="v-treeview-node v-treeview-node--click"
+  >
+    <div class="v-treeview-node__root">
+      <button type="button"
+              class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light"
+      >
+        $subgroup
+      </button>
+      <div class="v-treeview-node__content">
+        <div class="v-treeview-node__label">
+          Root
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VTreeView.ts should emit opened node when using open-on-click and load-children 2`] = `
+<div class="v-treeview theme--light">
+  <div aria-expanded="true"
+       class="v-treeview-node v-treeview-node--click"
+  >
+    <div class="v-treeview-node__root">
+      <button type="button"
+              class="v-icon notranslate v-treeview-node__toggle v-icon--link material-icons theme--light v-treeview-node__toggle--open"
+      >
+        $subgroup
+      </button>
+      <div class="v-treeview-node__content">
+        <div class="v-treeview-node__label">
+          Root
+        </div>
+      </div>
+    </div>
+    <div class="v-treeview-node__children">
+      <div aria-expanded="false"
+           class="v-treeview-node v-treeview-node--leaf v-treeview-node--click"
+      >
+        <div class="v-treeview-node__root">
+          <div class="v-treeview-node__level">
+          </div>
+          <div class="v-treeview-node__level">
+          </div>
+          <div class="v-treeview-node__content">
+            <div class="v-treeview-node__label">
+              Child
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`VTreeView.ts should filter items 1`] = `
 <div class="v-treeview theme--light">
   <div aria-expanded="false"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
using load-children together with open-on-click and clicking on
root div of node, treeview was not emitting the newly opened node.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #9693

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
playground, unit test

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-treeview
      :active.sync="active"
      :items="items"
      :load-children="fetchUsers"
      :open.sync="open"
      activatable
      color="warning"
      open-on-click
      transition
    >
      <template v-slot:prepend="{ item }">
        <v-icon v-if="!item.children">mdi-account</v-icon>
      </template>
    </v-treeview>
    <div><b>Opened:</b> {{ open.join(", ") }}</div>
  </v-container>
</template>

<script>
  const pause = ms => new Promise(resolve => setTimeout(resolve, ms))

  export default {
    data: () => ({
      active: [],
      avatar: null,
      open: [],
      users: [],
    }),

    computed: {
      items () {
        return [
          {
            id: 'Folder1',
            name: 'Folder1',
            children: this.users,
          },
        ]
      },
      selected () {
        if (!this.active.length) return undefined

        const id = this.active[0]

        return this.users.find(user => user.id === id)
      },
    },

    watch: {
      selected: 'randomAvatar',
    },

    methods: {
      async fetchUsers (item) {
        // Remove in 6 months and say
        // you've made optimizations! :)
        await pause(1500);
        item.children.push(...([
          {
            id: item.id + "_1",
            name: item.id + "_1",
            children: []
          },
          {
            id: item.id + "_2",
            name: item.id + "_2",
            children: []
          },
          {
            id: item.id + "_3",
            name: item.id + "_3",
            children: []
          }
        ]));
        return;
      }
    }
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
