### PR TITLE
docs(alerts): fix typo

### DIFF
--- a/packages/docs/src/lang/en/components/Alerts.json
+++ b/packages/docs/src/lang/en/components/Alerts.json
@@ -49,7 +49,7 @@
     }
   },
   "accessibility": {
-    "desc": "By default, `v-alert` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [**alert**](https://www.w3.org/TR/wai-aria/#alert) which denotes that the alert \"is a live region with important and usually time-sensitive, information.\" When using the **dismissible** prop the close icon will recieve a corresponding `aria-label`. This value can be modified by changing either the **close-label** prop or globally through customizing the [Internationalization](/customization/internationalization)'s default value for the _close_ property."
+    "desc": "By default, `v-alert` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [**alert**](https://www.w3.org/TR/wai-aria/#alert) which denotes that the alert \"is a live region with important and usually time-sensitive, information.\" When using the **dismissible** prop the close icon will receive a corresponding `aria-label`. This value can be modified by changing either the **close-label** prop or globally through customizing the [Internationalization](/customization/internationalization)'s default value for the _close_ property."
   },
   "props": {
     "border": "Puts a border on the alert. Accepts **top** | **right** | **bottom** | **left**.",


### PR DESCRIPTION
## Description

Fixes a typo on the [Alert page](https://vuetifyjs.com/en/components/alerts/).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
