### PR TITLE
docs: add activator slot attrs to doc examples

### DIFF
--- a/packages/docs/src/examples/app-bars/complex/menu.vue
+++ b/packages/docs/src/examples/app-bars/complex/menu.vue
@@ -35,10 +35,11 @@
         bottom
         left
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-btn
             icon
             color="yellow"
+            v-bind="attrs"
             v-on="on"
           >
             <v-icon>mdi-dots-vertical</v-icon>

--- a/packages/docs/src/examples/app-bars/simple/dense.vue
+++ b/packages/docs/src/examples/app-bars/simple/dense.vue
@@ -23,8 +23,12 @@
         left
         bottom
       >
-        <template v-slot:activator="{ on }">
-          <v-btn icon v-on="on">
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            icon
+            v-bind="attrs"
+            v-on="on"
+          >
             <v-icon>mdi-dots-vertical</v-icon>
           </v-btn>
         </template>

--- a/packages/docs/src/examples/autocompletes/intermediate/slots.vue
+++ b/packages/docs/src/examples/autocompletes/intermediate/slots.vue
@@ -26,9 +26,10 @@
             left
             transition="slide-y-transition"
           >
-            <template v-slot:activator="{ on }">
+            <template v-slot:activator="{ on, attrs }">
               <v-btn
                 icon
+                v-bind="attrs"
                 v-on="on"
               >
                 <v-icon>mdi-dots-vertical</v-icon>

--- a/packages/docs/src/examples/bottom-sheets/complex/open-in-list.vue
+++ b/packages/docs/src/examples/bottom-sheets/complex/open-in-list.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-bottom-sheet v-model="sheet">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="purple"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Open In

--- a/packages/docs/src/examples/bottom-sheets/complex/player.vue
+++ b/packages/docs/src/examples/bottom-sheets/complex/player.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-bottom-sheet inset>
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="red"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Open Player

--- a/packages/docs/src/examples/bottom-sheets/simple/inset.vue
+++ b/packages/docs/src/examples/bottom-sheets/simple/inset.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-bottom-sheet v-model="sheet" inset>
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="orange"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Open Inset

--- a/packages/docs/src/examples/bottom-sheets/simple/persistent.vue
+++ b/packages/docs/src/examples/bottom-sheets/simple/persistent.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-bottom-sheet v-model="sheet" persistent>
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="green"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Open Persistent

--- a/packages/docs/src/examples/calendars/complex/events.vue
+++ b/packages/docs/src/examples/calendars/complex/events.vue
@@ -15,10 +15,11 @@
           <v-toolbar-title>{{ title }}</v-toolbar-title>
           <v-spacer></v-spacer>
           <v-menu bottom right>
-            <template v-slot:activator="{ on }">
+            <template v-slot:activator="{ on, attrs }">
               <v-btn
                 outlined
                 color="grey darken-2"
+                v-bind="attrs"
                 v-on="on"
               >
                 <span>{{ typeToLabel[type] }}</span>

--- a/packages/docs/src/examples/calendars/playground.vue
+++ b/packages/docs/src/examples/calendars/playground.vue
@@ -73,7 +73,7 @@
         min-width="290px"
         offset-y
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="start"
             class="mt-3"
@@ -83,6 +83,7 @@
             readonly
             outlined
             hide-details
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>
@@ -119,7 +120,7 @@
         min-width="290px"
         offset-y
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="end"
             class="mt-3"
@@ -129,6 +130,7 @@
             readonly
             outlined
             hide-details
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>
@@ -164,7 +166,7 @@
         min-width="290px"
         offset-y
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="now"
             class="mt-3"
@@ -174,6 +176,7 @@
             readonly
             outlined
             hide-details
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/data-iterators/filter.vue
+++ b/packages/docs/src/examples/data-iterators/filter.vue
@@ -94,12 +94,13 @@
         <v-row class="mt-2" align="center" justify="center">
           <span class="grey--text">Items per page</span>
           <v-menu offset-y>
-            <template v-slot:activator="{ on }">
+            <template v-slot:activator="{ on, attrs }">
               <v-btn
                 dark
                 text
                 color="primary"
                 class="ml-2"
+                v-bind="attrs"
                 v-on="on"
               >
                 {{ itemsPerPage }}

--- a/packages/docs/src/examples/data-tables/complex/crud.vue
+++ b/packages/docs/src/examples/data-tables/complex/crud.vue
@@ -15,8 +15,14 @@
         ></v-divider>
         <v-spacer></v-spacer>
         <v-dialog v-model="dialog" max-width="500px">
-          <template v-slot:activator="{ on }">
-            <v-btn color="primary" dark class="mb-2" v-on="on">New Item</v-btn>
+          <template v-slot:activator="{ on, attrs }">
+            <v-btn
+              color="primary"
+              dark
+              class="mb-2"
+              v-bind="attrs"
+              v-on="on"
+            >New Item</v-btn>
           </template>
           <v-card>
             <v-card-title>

--- a/packages/docs/src/examples/date-pickers/intermediate/date-birthday.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-birthday.vue
@@ -7,12 +7,13 @@
     offset-y
     min-width="290px"
   >
-    <template v-slot:activator="{ on }">
+    <template v-slot:activator="{ on, attrs }">
       <v-text-field
         v-model="date"
         label="Birthday date"
         prepend-icon="event"
         readonly
+        v-bind="attrs"
         v-on="on"
       ></v-text-field>
     </template>

--- a/packages/docs/src/examples/date-pickers/intermediate/date-dialog-and-menu.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-dialog-and-menu.vue
@@ -62,12 +62,13 @@
         offset-y
         min-width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="date"
             label="Picker without buttons"
             prepend-icon="event"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/date-pickers/intermediate/date-dialog-and-menu.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-dialog-and-menu.vue
@@ -10,12 +10,13 @@
         offset-y
         min-width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="date"
             label="Picker in menu"
             prepend-icon="event"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>
@@ -35,12 +36,13 @@
         persistent
         width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="date"
             label="Picker in dialog"
             prepend-icon="event"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/date-pickers/intermediate/date-formatting-moment-datefns.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-formatting-moment-datefns.vue
@@ -7,12 +7,13 @@
           :close-on-content-click="false"
           max-width="290"
         >
-          <template v-slot:activator="{ on }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
               :value="computedDateFormattedMomentjs"
               clearable
               label="Formatted with Moment.js"
               readonly
+              v-bind="attrs"
               v-on="on"
               @click:clear="date = null"
             ></v-text-field>
@@ -30,12 +31,13 @@
           :close-on-content-click="false"
           max-width="290"
         >
-          <template v-slot:activator="{ on }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
               :value="computedDateFormattedDatefns"
               clearable
               label="Formatted with datefns"
               readonly
+              v-bind="attrs"
               v-on="on"
               @click:clear="date = null"
             ></v-text-field>

--- a/packages/docs/src/examples/date-pickers/intermediate/date-formatting.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-formatting.vue
@@ -11,13 +11,14 @@
           max-width="290px"
           min-width="290px"
         >
-          <template v-slot:activator="{ on }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
               v-model="dateFormatted"
               label="Date"
               hint="MM/DD/YYYY format"
               persistent-hint
               prepend-icon="event"
+              v-bind="attrs"
               @blur="date = parseDate(dateFormatted)"
               v-on="on"
             ></v-text-field>
@@ -36,7 +37,7 @@
           max-width="290px"
           min-width="290px"
         >
-          <template v-slot:activator="{ on }">
+          <template v-slot:activator="{ on, attrs }">
             <v-text-field
               v-model="computedDateFormatted"
               label="Date (read only text field)"
@@ -44,6 +45,7 @@
               persistent-hint
               prepend-icon="event"
               readonly
+              v-bind="attrs"
               v-on="on"
             ></v-text-field>
           </template>

--- a/packages/docs/src/examples/date-pickers/intermediate/date-multiple.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/date-multiple.vue
@@ -16,7 +16,7 @@
         offset-y
         min-width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-combobox
             v-model="dates"
             multiple
@@ -25,6 +25,7 @@
             label="Multiple picker in menu"
             prepend-icon="event"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-combobox>
         </template>

--- a/packages/docs/src/examples/date-pickers/intermediate/month-dialog-and-menu.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/month-dialog-and-menu.vue
@@ -42,12 +42,13 @@
         persistent
         width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="date"
             label="Picker in dialog"
             prepend-icon="event"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/date-pickers/intermediate/month-dialog-and-menu.vue
+++ b/packages/docs/src/examples/date-pickers/intermediate/month-dialog-and-menu.vue
@@ -11,12 +11,13 @@
         max-width="290px"
         min-width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="date"
             label="Picker in menu"
             prepend-icon="event"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/dialogs/complex/advanced.vue
+++ b/packages/docs/src/examples/dialogs/complex/advanced.vue
@@ -31,9 +31,10 @@
         bottom
         offset-y
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-btn
             class="ma-2"
+            v-bind="attrs"
             v-on="on"
           >A Menu</v-btn>
         </template>
@@ -83,10 +84,11 @@
               right
               offset-y
             >
-              <template v-slot:activator="{ on }">
+              <template v-slot:activator="{ on, attrs }">
                 <v-btn
                   dark
                   icon
+                  v-bind="attrs"
                   v-on="on"
                 >
                   <v-icon>mdi-dots-vertical</v-icon>
@@ -113,9 +115,10 @@
               Open Dialog 2
             </v-btn>
             <v-tooltip right>
-              <template v-slot:activator="{ on }">
+              <template v-slot:activator="{ on, attrs }">
                 <v-btn
                   class="ma-2"
+                  v-bind="attrs"
                   v-on="on"
                 >Tool Tip Activator</v-btn>
               </template>
@@ -224,9 +227,10 @@
               bottom
               left
             >
-              <template v-slot:activator="{ on }">
+              <template v-slot:activator="{ on, attrs }">
                 <v-btn
                   icon
+                  v-bind="attrs"
                   v-on="on"
                 >
                   <v-icon>mdi-dots-vertical</v-icon>

--- a/packages/docs/src/examples/dialogs/intermediate/form.vue
+++ b/packages/docs/src/examples/dialogs/intermediate/form.vue
@@ -1,8 +1,15 @@
 <template>
   <v-row justify="center">
     <v-dialog v-model="dialog" persistent max-width="600px">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Open Dialog</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >
+          Open Dialog
+        </v-btn>
       </template>
       <v-card>
         <v-card-title>

--- a/packages/docs/src/examples/dialogs/intermediate/fullscreen.vue
+++ b/packages/docs/src/examples/dialogs/intermediate/fullscreen.vue
@@ -1,8 +1,15 @@
 <template>
   <v-row justify="center">
     <v-dialog v-model="dialog" fullscreen hide-overlay transition="dialog-bottom-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Open Dialog</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >
+          Open Dialog
+        </v-btn>
       </template>
       <v-card>
         <v-toolbar dark color="primary">

--- a/packages/docs/src/examples/dialogs/simple/modal.vue
+++ b/packages/docs/src/examples/dialogs/simple/modal.vue
@@ -1,8 +1,15 @@
 <template>
   <v-row justify="center">
     <v-dialog v-model="dialog" persistent max-width="290">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Open Dialog</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >
+          Open Dialog
+        </v-btn>
       </template>
       <v-card>
         <v-card-title class="headline">Use Google's location service?</v-card-title>

--- a/packages/docs/src/examples/dialogs/simple/overflowed.vue
+++ b/packages/docs/src/examples/dialogs/simple/overflowed.vue
@@ -1,8 +1,15 @@
 <template>
   <v-row justify="center">
     <v-dialog v-model="dialog" width="600px">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Open Dialog</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >
+          Open Dialog
+        </v-btn>
       </template>
       <v-card>
         <v-card-title>

--- a/packages/docs/src/examples/dialogs/simple/scrollable.vue
+++ b/packages/docs/src/examples/dialogs/simple/scrollable.vue
@@ -1,8 +1,15 @@
 <template>
   <v-row justify="center">
     <v-dialog v-model="dialog" scrollable max-width="300px">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Open Dialog</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >
+          Open Dialog
+        </v-btn>
       </template>
       <v-card>
         <v-card-title>Select Country</v-card-title>

--- a/packages/docs/src/examples/dialogs/usage.vue
+++ b/packages/docs/src/examples/dialogs/usage.vue
@@ -4,10 +4,11 @@
       v-model="dialog"
       width="500"
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="red lighten-2"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Click Me

--- a/packages/docs/src/examples/expansion-panels/complex/advanced.vue
+++ b/packages/docs/src/examples/expansion-panels/complex/advanced.vue
@@ -138,12 +138,13 @@
               offset-y
               min-width="290px"
             >
-              <template v-slot:activator="{ on }">
+              <template v-slot:activator="{ on, attrs }">
                 <v-text-field
                   v-model="trip.start"
                   label="Start date"
                   prepend-icon="event"
                   readonly
+                  v-bind="attrs"
                   v-on="on"
                 ></v-text-field>
               </template>
@@ -175,12 +176,13 @@
               offset-y
               min-width="290px"
             >
-              <template v-slot:activator="{ on }">
+              <template v-slot:activator="{ on, attrs }">
                 <v-text-field
                   v-model="trip.end"
                   label="End date"
                   prepend-icon="event"
                   readonly
+                  v-bind="attrs"
                   v-on="on"
                 ></v-text-field>
               </template>

--- a/packages/docs/src/examples/menus/intermediate/menus.vue
+++ b/packages/docs/src/examples/menus/intermediate/menus.vue
@@ -8,10 +8,11 @@
           <v-spacer></v-spacer>
 
           <v-menu bottom left>
-            <template v-slot:activator="{ on }">
+            <template v-slot:activator="{ on, attrs }">
               <v-btn
                 dark
                 icon
+                v-bind="attrs"
                 v-on="on"
               >
                 <v-icon>mdi-dots-vertical</v-icon>

--- a/packages/docs/src/examples/menus/intermediate/popover.vue
+++ b/packages/docs/src/examples/menus/intermediate/popover.vue
@@ -6,10 +6,11 @@
       :nudge-width="200"
       offset-x
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="indigo"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Menu as Popover

--- a/packages/docs/src/examples/menus/playground.vue
+++ b/packages/docs/src/examples/menus/playground.vue
@@ -21,10 +21,11 @@
       :offset-x="offsetX"
       :offset-y="offsetY"
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/simple/absolute.vue
+++ b/packages/docs/src/examples/menus/simple/absolute.vue
@@ -9,12 +9,13 @@
       offset-y
       style="max-width: 600px"
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-card
           class="portrait"
           img="https://cdn.vuetifyjs.com/images/cards/girl.jpg"
           height="300"
           width="600"
+          v-bind="attrs"
           v-on="on"
         ></v-card>
       </template>

--- a/packages/docs/src/examples/menus/simple/close-on-click.vue
+++ b/packages/docs/src/examples/menus/simple/close-on-click.vue
@@ -2,10 +2,11 @@
   <div class="text-center">
     <v-switch v-model="closeOnClick" label="Close on click"></v-switch>
     <v-menu top :close-on-click="closeOnClick">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/simple/close-on-content-click.vue
+++ b/packages/docs/src/examples/menus/simple/close-on-content-click.vue
@@ -2,10 +2,11 @@
   <div class="text-center">
     <v-switch v-model="closeOnContentClick" label="Close on content click"></v-switch>
     <v-menu top :close-on-content-click="closeOnContentClick">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/simple/custom-transition.vue
+++ b/packages/docs/src/examples/menus/simple/custom-transition.vue
@@ -5,10 +5,11 @@
       origin="center center"
       transition="scale-transition"
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Scale Transition
@@ -31,11 +32,12 @@
       bottom
       right
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           class="deep-orange"
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Slide X Transition
@@ -57,11 +59,12 @@
       transition="slide-y-transition"
       bottom
     >
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           class="purple"
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Slide Y Transition

--- a/packages/docs/src/examples/menus/simple/disabled.vue
+++ b/packages/docs/src/examples/menus/simple/disabled.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu disabled top offset-y>
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/simple/hover.vue
+++ b/packages/docs/src/examples/menus/simple/hover.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu open-on-hover top offset-y>
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/simple/menu-activator-tooltip.vue
+++ b/packages/docs/src/examples/menus/simple/menu-activator-tooltip.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="text-center">
     <v-menu>
-      <template v-slot:activator="{ on: menu }">
+      <template v-slot:activator="{ on: menu, attrs }">
         <v-tooltip bottom>
           <template v-slot:activator="{ on: tooltip }">
             <v-btn
               color="primary"
               dark
+              v-bind="attrs"
               v-on="{ ...tooltip, ...menu }"
             >Dropdown w/ Tooltip</v-btn>
           </template>

--- a/packages/docs/src/examples/menus/simple/offset-x.vue
+++ b/packages/docs/src/examples/menus/simple/offset-x.vue
@@ -2,10 +2,11 @@
   <div class="text-center">
     <v-switch v-model="offset" label="X offset"></v-switch>
     <v-menu top :offset-x="offset">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/simple/offset-y.vue
+++ b/packages/docs/src/examples/menus/simple/offset-y.vue
@@ -2,10 +2,11 @@
   <div class="text-center">
     <v-switch v-model="offset" label="Y offset"></v-switch>
     <v-menu top :offset-y="offset">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/menus/usage.vue
+++ b/packages/docs/src/examples/menus/usage.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu offset-y>
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           color="primary"
           dark
+          v-bind="attrs"
           v-on="on"
         >
           Dropdown

--- a/packages/docs/src/examples/tabs/complex/overflow-to-menu.vue
+++ b/packages/docs/src/examples/tabs/complex/overflow-to-menu.vue
@@ -38,10 +38,11 @@
             bottom
             left
           >
-            <template v-slot:activator="{ on }">
+            <template v-slot:activator="{ on, attrs }">
               <v-btn
                 text
                 class="align-self-center mr-4"
+                v-bind="attrs"
                 v-on="on"
               >
                 more

--- a/packages/docs/src/examples/text-fields/complex/custom-validation.vue
+++ b/packages/docs/src/examples/text-fields/complex/custom-validation.vue
@@ -68,10 +68,11 @@
               v-if="formHasErrors"
               left
             >
-              <template v-slot:activator="{ on }">
+              <template v-slot:activator="{ on, attrs }">
                 <v-btn
                   icon
                   class="my-0"
+                  v-bind="attrs"
                   @click="resetForm"
                   v-on="on"
                 >

--- a/packages/docs/src/examples/text-fields/intermediate/icon-slots.vue
+++ b/packages/docs/src/examples/text-fields/intermediate/icon-slots.vue
@@ -36,8 +36,11 @@
                 style="top: -12px"
                 offset-y
               >
-                <template v-slot:activator="{ on }">
-                  <v-btn v-on="on">
+                <template v-slot:activator="{ on, attrs }">
+                  <v-btn
+                    v-bind="attrs"
+                    v-on="on"
+                  >
                     <v-icon left>mdi-menu</v-icon>
                     Menu
                   </v-btn>

--- a/packages/docs/src/examples/time-pickers/intermediate/dialog-and-menu.vue
+++ b/packages/docs/src/examples/time-pickers/intermediate/dialog-and-menu.vue
@@ -39,12 +39,13 @@
         persistent
         width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="time"
             label="Picker in dialog"
             prepend-icon="access_time"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/time-pickers/intermediate/dialog-and-menu.vue
+++ b/packages/docs/src/examples/time-pickers/intermediate/dialog-and-menu.vue
@@ -12,12 +12,13 @@
         max-width="290px"
         min-width="290px"
       >
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs }">
           <v-text-field
             v-model="time"
             label="Picker in menu"
             prepend-icon="access_time"
             readonly
+            v-bind="attrs"
             v-on="on"
           ></v-text-field>
         </template>

--- a/packages/docs/src/examples/tooltips/alignment.vue
+++ b/packages/docs/src/examples/tooltips/alignment.vue
@@ -1,29 +1,49 @@
 <template>
   <div class="text-center">
     <v-tooltip left>
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Left</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >Left</v-btn>
       </template>
       <span>Left tooltip</span>
     </v-tooltip>
 
     <v-tooltip top>
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Top</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >Top</v-btn>
       </template>
       <span>Top tooltip</span>
     </v-tooltip>
 
     <v-tooltip bottom>
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Bottom</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >Bottom</v-btn>
       </template>
       <span>Bottom tooltip</span>
     </v-tooltip>
 
     <v-tooltip right>
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Right</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >Right</v-btn>
       </template>
       <span>Right tooltip</span>
     </v-tooltip>

--- a/packages/docs/src/examples/tooltips/usage.vue
+++ b/packages/docs/src/examples/tooltips/usage.vue
@@ -1,22 +1,32 @@
 <template>
   <div class="text-center d-flex align-center">
     <v-tooltip bottom>
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" dark v-on="on">Button</v-btn>
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >Button</v-btn>
       </template>
       <span>Tooltip</span>
     </v-tooltip>
 
     <v-tooltip bottom>
-      <template v-slot:activator="{ on }">
-        <v-icon color="primary" dark v-on="on">mdi-home</v-icon>
+      <template v-slot:activator="{ on, attrs }">
+        <v-icon
+          color="primary"
+          dark
+          v-bind="attrs"
+          v-on="on"
+        >mdi-home</v-icon>
       </template>
       <span>Tooltip</span>
     </v-tooltip>
 
     <v-tooltip bottom>
-      <template v-slot:activator="{ on }">
-        <span v-on="on">This text has a tooltip</span>
+      <template v-slot:activator="{ on, attrs }">
+        <span v-bind="attrs" v-on="on">This text has a tooltip</span>
       </template>
       <span>Tooltip</span>
     </v-tooltip>

--- a/packages/docs/src/examples/tooltips/visibility.vue
+++ b/packages/docs/src/examples/tooltips/visibility.vue
@@ -10,8 +10,8 @@
 
       <v-col cols="12" class="mt-12">
         <v-tooltip v-model="show" top>
-          <template v-slot:activator="{ on }">
-            <v-btn icon v-on="on">
+          <template v-slot:activator="{ on, attrs }">
+            <v-btn icon v-bind="attrs" v-on="on">
               <v-icon color="grey lighten-1">mdi-cart</v-icon>
             </v-btn>
           </template>

--- a/packages/docs/src/examples/transitions/custom-origin.vue
+++ b/packages/docs/src/examples/transitions/custom-origin.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu transition="scale-transition" origin="center center">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           dark
           color="primary"
+          v-bind="attrs"
           v-on="on"
         >
           Scale Transition

--- a/packages/docs/src/examples/transitions/fab-transition.vue
+++ b/packages/docs/src/examples/transitions/fab-transition.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu transition="fab-transition">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           dark
           color="primary"
+          v-bind="attrs"
           v-on="on"
         >
           Fab Transition

--- a/packages/docs/src/examples/transitions/fade-transition.vue
+++ b/packages/docs/src/examples/transitions/fade-transition.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu transition="fade-transition">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           dark
           color="primary"
+          v-bind="attrs"
           v-on="on"
         >
           Fade Transition

--- a/packages/docs/src/examples/transitions/scale-transition.vue
+++ b/packages/docs/src/examples/transitions/scale-transition.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="text-center">
     <v-menu transition="scale-transition">
-      <template v-slot:activator="{ on }">
+      <template v-slot:activator="{ on, attrs }">
         <v-btn
           dark
           color="primary"
+          v-bind="attrs"
           v-on="on"
         >
           Scale Transition

--- a/packages/docs/src/examples/transitions/scroll-x-transitions.vue
+++ b/packages/docs/src/examples/transitions/scroll-x-transitions.vue
@@ -3,8 +3,13 @@
     justify="center"
   >
     <v-menu transition="scroll-x-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Scroll X Transition
         </v-btn>
       </template>
@@ -18,8 +23,13 @@
     <div class="mx-4 hidden-sm-and-down"></div>
 
     <v-menu transition="scroll-x-reverse-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="secondary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="secondary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Scroll X Reverse Transition
         </v-btn>
       </template>

--- a/packages/docs/src/examples/transitions/scroll-y-transitions.vue
+++ b/packages/docs/src/examples/transitions/scroll-y-transitions.vue
@@ -3,8 +3,13 @@
     justify="center"
   >
     <v-menu transition="scroll-y-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Scroll Y Transition
         </v-btn>
       </template>
@@ -18,8 +23,13 @@
     <div class="mx-4 hidden-sm-and-down"></div>
 
     <v-menu transition="scroll-y-reverse-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="secondary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="secondary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Scroll Y Reverse Transition
         </v-btn>
       </template>

--- a/packages/docs/src/examples/transitions/slide-x-transitions.vue
+++ b/packages/docs/src/examples/transitions/slide-x-transitions.vue
@@ -3,8 +3,13 @@
     justify="center"
   >
     <v-menu transition="slide-x-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Slide X Transition
         </v-btn>
       </template>
@@ -18,8 +23,13 @@
     <div class="mx-4 hidden-sm-and-down"></div>
 
     <v-menu transition="slide-x-reverse-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="secondary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="secondary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Slide X Reverse Transition
         </v-btn>
       </template>

--- a/packages/docs/src/examples/transitions/slide-y-transitions.vue
+++ b/packages/docs/src/examples/transitions/slide-y-transitions.vue
@@ -3,8 +3,13 @@
     justify="center"
   >
     <v-menu transition="slide-y-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Slide Y Transition
         </v-btn>
       </template>
@@ -18,8 +23,13 @@
     <div class="mx-4 hidden-sm-and-down"></div>
 
     <v-menu transition="slide-y-reverse-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="secondary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="secondary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Slide Y Reverse Transition
         </v-btn>
       </template>

--- a/packages/docs/src/examples/transitions/usage.vue
+++ b/packages/docs/src/examples/transitions/usage.vue
@@ -1,8 +1,13 @@
 <template>
   <v-row justify="center">
     <v-menu transition="slide-x-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="primary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="primary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Slide X Transition
         </v-btn>
       </template>
@@ -20,8 +25,13 @@
     <div class="mx-6 hidden-sm-and-down"></div>
 
     <v-menu transition="scroll-y-transition">
-      <template v-slot:activator="{ on }">
-        <v-btn color="secondary" class="ma-2" v-on="on">
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          color="secondary"
+          class="ma-2"
+          v-bind="attrs"
+          v-on="on"
+        >
           Scroll Y Transition
         </v-btn>
       </template>

--- a/packages/docs/src/usages/bottom-sheets.vue
+++ b/packages/docs/src/usages/bottom-sheets.vue
@@ -5,10 +5,11 @@
       justify="center"
     >
       <v-bottom-sheet v-model="sheet" v-bind="attrs">
-        <template v-slot:activator="{ on }">
+        <template v-slot:activator="{ on, attrs: activatorAttrs }">
           <v-btn
             color="purple"
             dark
+            v-bind="activatorAttrs"
             v-on="on"
           >
             Open Playground


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
Adds `v-bind="attrs"` to activator buttons in the doc examples for the following components:

- VMenu
- VTimePicker
- VDatePicker
- VDialog

## Motivation and Context
resolves #11390

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
NVDA

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
