### PR TITLE
Fix missing Material Icons example

### DIFF
--- a/packages/docs/src/snippets/js/using_missing_material_icons.txt
+++ b/packages/docs/src/snippets/js/using_missing_material_icons.txt
@@ -21,7 +21,9 @@ function missingMaterialIcons(ids) {
 Vue.use(Vuetify, {
   // iconfont: 'md',
   icons: {
-    ...missingMaterialIcons(['visibility', 'visibility_off'])
-    // This will enable 'visibility_outline', 'visibility_off_round' and so on.
+    values: {
+      ...missingMaterialIcons(['visibility', 'visibility_off'])
+      // This will enable 'visibility_outline', 'visibility_off_round' and so on.
+    }
   }
 })


### PR DESCRIPTION
The example doesn't work as is. The values object is missing as per the other examples. 

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
