### PR TITLE
feat(VSlideGroup): emit events near start/end

### DIFF
--- a/packages/api-generator/src/helpers/variables.js
+++ b/packages/api-generator/src/helpers/variables.js
@@ -287,13 +287,32 @@ const VCalendarDay = {
   future: 'boolean',
 }
 
+const VCalendarEvent = {
+  input: 'any',
+  start: VTimestamp,
+  startIdentifier: 'number',
+  startTimestampIdentifier: 'number',
+  end: VTimestamp,
+  endIdentifier: 'number',
+  endTimestampIdentifier: 'number',
+  allDay: 'boolean',
+  index: 'number',
+  category: 'string',
+}
+
 const VCalendarEventSlot = {
   event: 'any',
+  eventParsed: VCalendarEvent,
   day: VCalendarDay,
   outside: 'boolean',
   start: 'boolean',
   end: 'boolean',
   timed: 'boolean',
+  singleline: 'boolean',
+  overlapsNoon: 'boolean',
+  formatTime: '(time: VTimestamp, ampm: boolean): string',
+  timeSummary: '(): string',
+  eventSummary: '(): string',
 }
 
 const VTimestampWithTime = {
@@ -310,14 +329,55 @@ const VTimestampWithTime = {
   past: 'boolean',
   present: 'boolean',
   future: 'boolean',
-  timeToY: '(time: string | number | {hour: number, minute: number}, clamp: boolean = false): number',
+  timeToY: '(time: string | number | {hour: number, minute: number}, clamp: boolean = false): number | false',
+  timeDelta: '(time: string | number | {hour: number, minute: number}): number | false',
   minutesToPixels: '(minutes: number): number',
   week: [VTimestamp],
+}
+
+const VTimestampWithCategory = {
+  date: 'string',
+  time: 'string',
+  year: 'number',
+  month: 'number',
+  day: 'number',
+  hour: 'number',
+  minute: 'number',
+  weekday: 'number',
+  hasDay: 'boolean',
+  hasTime: 'boolean',
+  past: 'boolean',
+  present: 'boolean',
+  future: 'boolean',
+  week: [VTimestamp],
+  category: 'string | null',
+}
+
+const VTimestampWithTimeCategory = {
+  date: 'string',
+  time: 'string',
+  year: 'number',
+  month: 'number',
+  day: 'number',
+  hour: 'number',
+  minute: 'number',
+  weekday: 'number',
+  hasDay: 'boolean',
+  hasTime: 'boolean',
+  past: 'boolean',
+  present: 'boolean',
+  future: 'boolean',
+  timeToY: '(time: string | number | {hour: number, minute: number}, clamp: boolean = false): number | false',
+  timeDelta: '(time: string | number | {hour: number, minute: number}): number | false',
+  minutesToPixels: '(minutes: number): number',
+  week: [VTimestamp],
+  category: 'string | null',
 }
 
 module.exports = {
   createItems,
   VCalendarDay,
+  VCalendarEvent,
   VCalendarEventSlot,
   VGridProps,
   VInput,
@@ -325,6 +385,8 @@ module.exports = {
   VSlider,
   VTextField,
   VTimestamp,
+  VTimestampWithCategory,
   VTimestampWithTime,
+  VTimestampWithTimeCategory,
   VTreeviewScopedProps,
 }

--- a/packages/api-generator/src/maps/v-calendar.js
+++ b/packages/api-generator/src/maps/v-calendar.js
@@ -1,8 +1,12 @@
-const { VTimestamp, VTimestampWithTime, VCalendarDay, VCalendarEventSlot } = require('../helpers/variables')
+const { VTimestamp, VTimestampWithTime, VTimestampWithTimeCategory, VTimestampWithCategory, VCalendarDay, VCalendarEventSlot } = require('../helpers/variables')
 
 module.exports = {
   'v-calendar': {
     slots: [
+      {
+        name: 'category',
+        props: VTimestampWithCategory,
+      },
       {
         name: 'event',
         props: VCalendarEventSlot,
@@ -38,6 +42,10 @@ module.exports = {
     ],
     functions: [
       {
+        name: 'title',
+        signature: 'string',
+      },
+      {
         name: 'checkChange',
         signature: '(): void',
       },
@@ -62,6 +70,10 @@ module.exports = {
         signature: '(time: number | string | { hour: number, minute: number }, clamp: boolean = true): number | false',
       },
       {
+        name: 'timeDelta',
+        signature: '(time: number | string | { hour: number, minute: number }): number | false',
+      },
+      {
         name: 'minutesToPixels',
         signature: '(minutes: number): number',
       },
@@ -72,6 +84,18 @@ module.exports = {
       {
         name: 'getVisibleEvents',
         signature: '(): CalendarEventParsed[]',
+      },
+      {
+        name: 'parseEvent',
+        signature: '(input: CalendarEvent, index: number = 0): CalendarEventParsed',
+      },
+      {
+        name: 'parseTimestamp',
+        signature: '(input: VTimestampInput, required?: false): CalendarTimestamp | null',
+      },
+      {
+        name: 'timestampToDate',
+        signature: '(timestamp: CalendarTimestamp): Date',
       },
     ],
     events: [
@@ -140,6 +164,46 @@ module.exports = {
         value: VTimestampWithTime,
       },
       {
+        name: 'click:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'contextmenu:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'mousedown:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'mousemove:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'mouseup:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'mouseenter:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'mouseleave:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'touchstart:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'touchmove:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
+        name: 'touchend:day-category',
+        value: VTimestampWithCategory,
+      },
+      {
         name: 'click:time',
         value: VTimestampWithTime,
       },
@@ -178,6 +242,46 @@ module.exports = {
       {
         name: 'touchend:time',
         value: VTimestampWithTime,
+      },
+      {
+        name: 'click:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'contextmenu:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'mousedown:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'mousemove:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'mouseup:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'mouseenter:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'mouseleave:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'touchstart:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'touchmove:time-category',
+        value: VTimestampWithTimeCategory,
+      },
+      {
+        name: 'touchend:time-category',
+        value: VTimestampWithTimeCategory,
       },
       {
         name: 'click:interval',

--- a/packages/docs/src/data/pages/components/Calendars.pug
+++ b/packages/docs/src/data/pages/components/Calendars.pug
@@ -10,7 +10,10 @@ examples(:value=`[
   'simple/weekly',
   'simple/daily',
   'intermediate/slots',
-  'complex/events'
+  'complex/events',
+  'complex/category',
+  'intermediate/nowline',
+  'complex/dragndrop'
 ]`)
 
 up-next(:value=`[

--- a/packages/docs/src/examples/calendars/complex/category.vue
+++ b/packages/docs/src/examples/calendars/complex/category.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-row class="fill-height">
+    <v-col>
+      <v-sheet height="64">
+        <v-toolbar flat color="white">
+          <v-btn outlined class="mr-4" color="grey darken-2" @click="setToday">
+            Today
+          </v-btn>
+          <v-btn fab text small color="grey darken-2" @click="prev">
+            <v-icon small>mdi-chevron-left</v-icon>
+          </v-btn>
+          <v-btn fab text small color="grey darken-2" @click="next">
+            <v-icon small>mdi-chevron-right</v-icon>
+          </v-btn>
+          <v-toolbar-title v-if="$refs.calendar">
+            {{ $refs.calendar.title }}
+          </v-toolbar-title>
+          <v-spacer></v-spacer>
+        </v-toolbar>
+      </v-sheet>
+      <v-sheet height="600">
+        <v-calendar
+          ref="calendar"
+          v-model="focus"
+          color="primary"
+          type="category"
+          category-show-all
+          :categories="categories"
+          :events="events"
+          :event-color="getEventColor"
+          @change="fetchEvents"
+        ></v-calendar>
+      </v-sheet>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      focus: '',
+      events: [],
+      colors: ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey darken-1'],
+      names: ['Meeting', 'Holiday', 'PTO', 'Travel', 'Event', 'Birthday', 'Conference', 'Party'],
+      categories: ['John Smith', 'Tori Walker'],
+    }),
+    mounted () {
+      this.$refs.calendar.checkChange()
+    },
+    methods: {
+      getEventColor (event) {
+        return event.color
+      },
+      setToday () {
+        this.focus = ''
+      },
+      prev () {
+        this.$refs.calendar.prev()
+      },
+      next () {
+        this.$refs.calendar.next()
+      },
+      fetchEvents ({ start, end }) {
+        const events = []
+
+        const min = new Date(`${start.date}T00:00:00`)
+        const max = new Date(`${end.date}T23:59:59`)
+        const days = (max.getTime() - min.getTime()) / 86400000
+        const eventCount = this.rnd(days, days + 20)
+
+        for (let i = 0; i < eventCount; i++) {
+          const allDay = this.rnd(0, 3) === 0
+          const firstTimestamp = this.rnd(min.getTime(), max.getTime())
+          const first = new Date(firstTimestamp - (firstTimestamp % 900000))
+          const secondTimestamp = this.rnd(2, allDay ? 288 : 8) * 900000
+          const second = new Date(first.getTime() + secondTimestamp)
+
+          events.push({
+            name: this.names[this.rnd(0, this.names.length - 1)],
+            start: first,
+            end: second,
+            color: this.colors[this.rnd(0, this.colors.length - 1)],
+            timed: !allDay,
+            category: this.categories[this.rnd(0, this.categories.length - 1)],
+          })
+        }
+
+        this.events = events
+      },
+      rnd (a, b) {
+        return Math.floor((b - a + 1) * Math.random()) + a
+      },
+    },
+  }
+</script>

--- a/packages/docs/src/examples/calendars/complex/dragndrop.vue
+++ b/packages/docs/src/examples/calendars/complex/dragndrop.vue
@@ -1,0 +1,220 @@
+<template>
+  <v-row class="fill-height">
+    <v-col>
+      <v-sheet height="600">
+        <v-calendar
+          ref="calendar"
+          v-model="value"
+          color="primary"
+          type="4day"
+          :events="events"
+          :event-color="getEventColor"
+          :event-ripple="false"
+          @change="getEvents"
+          @mousedown:event="startDrag"
+          @mousedown:time="startTime"
+          @mousemove:time="mouseMove"
+          @mouseup:time="endDrag"
+          @mouseleave.native="cancelDrag"
+        >
+          <template #event="{ event, timed, eventSummary }">
+            <div
+              class="v-event-draggable"
+              v-html="eventSummary()"
+            ></div>
+            <div
+              v-if="timed"
+              class="v-event-drag-bottom"
+              @mousedown.stop="extendBottom(event)"
+            ></div>
+          </template>
+        </v-calendar>
+      </v-sheet>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      value: '',
+      events: [],
+      colors: ['#2196F3', '#3F51B5', '#673AB7', '#00BCD4', '#4CAF50', '#FF9800', '#757575'],
+      names: ['Meeting', 'Holiday', 'PTO', 'Travel', 'Event', 'Birthday', 'Conference', 'Party'],
+      dragEvent: null,
+      dragStart: null,
+      createEvent: null,
+      createStart: null,
+      extendOriginal: null,
+    }),
+    methods: {
+      startDrag ({ event, timed }) {
+        if (event && timed) {
+          this.dragEvent = event
+          this.dragTime = null
+          this.extendOriginal = null
+        }
+      },
+      startTime (tms) {
+        const mouse = this.toTime(tms)
+
+        if (this.dragEvent && this.dragTime === null) {
+          const start = this.dragEvent.start
+
+          this.dragTime = mouse - start
+        } else {
+          this.createStart = this.roundTime(mouse)
+          this.createEvent = {
+            name: `Event #${this.events.length}`,
+            color: this.rndElement(this.colors),
+            start: this.createStart,
+            end: this.createStart,
+            timed: true,
+          }
+
+          this.events.push(this.createEvent)
+        }
+      },
+      extendBottom (event) {
+        this.createEvent = event
+        this.createStart = event.start
+        this.extendOriginal = event.end
+      },
+      mouseMove (tms) {
+        const mouse = this.toTime(tms)
+
+        if (this.dragEvent && this.dragTime !== null) {
+          const start = this.dragEvent.start
+          const end = this.dragEvent.end
+          const duration = end - start
+          const newStartTime = mouse - this.dragTime
+          const newStart = this.roundTime(newStartTime)
+          const newEnd = newStart + duration
+
+          this.dragEvent.start = newStart
+          this.dragEvent.end = newEnd
+        } else if (this.createEvent && this.createStart !== null) {
+          const mouseRounded = this.roundTime(mouse, false)
+          const min = Math.min(mouseRounded, this.createStart)
+          const max = Math.max(mouseRounded, this.createStart)
+
+          this.createEvent.start = min
+          this.createEvent.end = max
+        }
+      },
+      endDrag () {
+        this.dragTime = null
+        this.dragEvent = null
+        this.createEvent = null
+        this.createStart = null
+        this.extendOriginal = null
+      },
+      cancelDrag () {
+        if (this.createEvent) {
+          if (this.extendOriginal) {
+            this.createEvent.end = this.extendOriginal
+          } else {
+            const i = this.events.indexOf(this.createEvent)
+            if (i !== -1) {
+              this.events.splice(i, 1)
+            }
+          }
+        }
+
+        this.createEvent = null
+        this.createStart = null
+        this.dragTime = null
+        this.dragEvent = null
+      },
+      roundTime (time, down = true) {
+        const roundTo = 15 // minutes
+        const roundDownTime = roundTo * 60 * 1000
+
+        return down
+          ? time - time % roundDownTime
+          : time + (roundDownTime - (time % roundDownTime))
+      },
+      toTime (tms) {
+        return new Date(tms.year, tms.month - 1, tms.day, tms.hour, tms.minute).getTime()
+      },
+      getEventColor (event) {
+        const rgb = parseInt(event.color.substring(1), 16)
+        const r = (rgb >> 16) & 0xFF
+        const g = (rgb >> 8) & 0xFF
+        const b = (rgb >> 0) & 0xFF
+
+        return event === this.dragEvent
+          ? `rgba(${r}, ${g}, ${b}, 0.7)`
+          : event === this.createEvent
+            ? `rgba(${r}, ${g}, ${b}, 0.7)`
+            : event.color
+      },
+      getEvents ({ start, end }) {
+        const events = []
+
+        const min = new Date(`${start.date}T00:00:00`).getTime()
+        const max = new Date(`${end.date}T23:59:59`).getTime()
+        const days = (max - min) / 86400000
+        const eventCount = this.rnd(days, days + 20)
+
+        for (let i = 0; i < eventCount; i++) {
+          const timed = this.rnd(0, 3) !== 0
+          const firstTimestamp = this.rnd(min, max)
+          const secondTimestamp = this.rnd(2, timed ? 8 : 288) * 900000
+          const start = firstTimestamp - (firstTimestamp % 900000)
+          const end = start + secondTimestamp
+
+          events.push({
+            name: this.rndElement(this.names),
+            color: this.rndElement(this.colors),
+            start,
+            end,
+            timed,
+          })
+        }
+
+        this.events = events
+      },
+      rnd (a, b) {
+        return Math.floor((b - a + 1) * Math.random()) + a
+      },
+      rndElement (arr) {
+        return arr[this.rnd(0, arr.length - 1)]
+      },
+    },
+  }
+</script>
+
+<style scoped lang="scss">
+.v-event-draggable {
+  user-select: none;
+  -webkit-user-select: none;
+  padding-left: 6px;
+}
+
+.v-event-drag-bottom {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 4px;
+  height: 4px;
+  cursor: ns-resize;
+
+  &::after {
+    display: none;
+    position: absolute;
+    left: 50%;
+    height: 4px;
+    border-top: 1px solid white;
+    border-bottom: 1px solid white;
+    width: 16px;
+    margin-left: -8px;
+    opacity: 0.8;
+    content: '';
+  }
+
+  &:hover::after {
+    display: block;
+  }
+}
+</style>

--- a/packages/docs/src/examples/calendars/complex/events.vue
+++ b/packages/docs/src/examples/calendars/complex/events.vue
@@ -12,7 +12,9 @@
           <v-btn fab text small color="grey darken-2" @click="next">
             <v-icon small>mdi-chevron-right</v-icon>
           </v-btn>
-          <v-toolbar-title>{{ title }}</v-toolbar-title>
+          <v-toolbar-title v-if="$refs.calendar">
+            {{ $refs.calendar.title }}
+          </v-toolbar-title>
           <v-spacer></v-spacer>
           <v-menu bottom right>
             <template v-slot:activator="{ on }">
@@ -49,7 +51,6 @@
           color="primary"
           :events="events"
           :event-color="getEventColor"
-          :now="today"
           :type="type"
           @click:event="showEvent"
           @click:more="viewDay"
@@ -113,8 +114,6 @@
         day: 'Day',
         '4day': '4 Days',
       },
-      start: null,
-      end: null,
       selectedEvent: {},
       selectedElement: null,
       selectedOpen: false,
@@ -122,41 +121,6 @@
       colors: ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey darken-1'],
       names: ['Meeting', 'Holiday', 'PTO', 'Travel', 'Event', 'Birthday', 'Conference', 'Party'],
     }),
-    computed: {
-      title () {
-        const { start, end } = this
-        if (!start || !end) {
-          return ''
-        }
-
-        const startMonth = this.monthFormatter(start)
-        const endMonth = this.monthFormatter(end)
-        const suffixMonth = startMonth === endMonth ? '' : endMonth
-
-        const startYear = start.year
-        const endYear = end.year
-        const suffixYear = startYear === endYear ? '' : endYear
-
-        const startDay = start.day + this.nth(start.day)
-        const endDay = end.day + this.nth(end.day)
-
-        switch (this.type) {
-          case 'month':
-            return `${startMonth} ${startYear}`
-          case 'week':
-          case '4day':
-            return `${startMonth} ${startDay} ${startYear} - ${suffixMonth} ${endDay} ${suffixYear}`
-          case 'day':
-            return `${startMonth} ${startDay} ${startYear}`
-        }
-        return ''
-      },
-      monthFormatter () {
-        return this.$refs.calendar.getFormatter({
-          timeZone: 'UTC', month: 'long',
-        })
-      },
-    },
     mounted () {
       this.$refs.calendar.checkChange()
     },
@@ -169,7 +133,7 @@
         return event.color
       },
       setToday () {
-        this.focus = this.today
+        this.focus = ''
       },
       prev () {
         this.$refs.calendar.prev()
@@ -210,28 +174,17 @@
 
           events.push({
             name: this.names[this.rnd(0, this.names.length - 1)],
-            start: this.formatDate(first, !allDay),
-            end: this.formatDate(second, !allDay),
+            start: first,
+            end: second,
             color: this.colors[this.rnd(0, this.colors.length - 1)],
+            timed: !allDay,
           })
         }
 
-        this.start = start
-        this.end = end
         this.events = events
-      },
-      nth (d) {
-        return d > 3 && d < 21
-          ? 'th'
-          : ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'][d % 10]
       },
       rnd (a, b) {
         return Math.floor((b - a + 1) * Math.random()) + a
-      },
-      formatDate (a, withTime) {
-        return withTime
-          ? `${a.getFullYear()}-${a.getMonth() + 1}-${a.getDate()} ${a.getHours()}:${a.getMinutes()}`
-          : `${a.getFullYear()}-${a.getMonth() + 1}-${a.getDate()}`
       },
     },
   }

--- a/packages/docs/src/examples/calendars/intermediate/nowline.vue
+++ b/packages/docs/src/examples/calendars/intermediate/nowline.vue
@@ -1,0 +1,79 @@
+<template>
+  <v-row>
+    <v-col>
+      <v-sheet height="500">
+        <v-calendar
+          ref="calendar"
+          v-model="value"
+          type="week"
+        >
+          <template #day-body="{ date, week }">
+            <div
+              class="v-current-time"
+              :class="{ first: date === week[0].date }"
+              :style="{ top: nowY }"
+            ></div>
+          </template>
+        </v-calendar>
+      </v-sheet>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      value: '',
+      ready: false,
+    }),
+    computed: {
+      cal () {
+        return this.ready ? this.$refs.calendar : null
+      },
+      nowY () {
+        return this.cal ? this.cal.timeToY(this.cal.times.now) + 'px' : '-10px'
+      },
+    },
+    mounted () {
+      this.ready = true
+      this.scrollToTime()
+      this.updateTime()
+    },
+    methods: {
+      getCurrentTime () {
+        return this.cal ? this.cal.times.now.hour * 60 + this.cal.times.now.minute : 0
+      },
+      scrollToTime () {
+        const time = this.getCurrentTime()
+        const first = Math.max(0, time - (time % 30) - 30)
+
+        this.cal.scrollToTime(first)
+      },
+      updateTime () {
+        setInterval(() => this.cal.updateTimes(), 60 * 1000)
+      },
+    },
+  }
+</script>
+
+<style lang="scss">
+.v-current-time {
+  height: 2px;
+  background-color: #ea4335;
+  position: absolute;
+  left: -1px;
+  right: 0;
+  pointer-events: none;
+
+  &.first::before {
+    content: '';
+    position: absolute;
+    background-color: #ea4335;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    margin-top: -5px;
+    margin-left: -6.5px;
+  }
+}
+</style>

--- a/packages/docs/src/examples/calendars/playground.vue
+++ b/packages/docs/src/examples/calendars/playground.vue
@@ -456,8 +456,9 @@
 
           events.push({
             name: this.names[this.rnd(0, this.names.length - 1)],
-            start: this.formatDate(first, !allDay),
-            end: this.formatDate(second, !allDay),
+            start: first,
+            end: second,
+            timed: !allDay,
             color: this.colors[this.rnd(0, this.colors.length - 1)],
           })
         }
@@ -466,11 +467,6 @@
       },
       rnd (a, b) {
         return Math.floor((b - a + 1) * Math.random()) + a
-      },
-      formatDate (a, withTime) {
-        return withTime
-          ? `${a.getFullYear()}-${a.getMonth() + 1}-${a.getDate()} ${a.getHours()}:${a.getMinutes()}`
-          : `${a.getFullYear()}-${a.getMonth() + 1}-${a.getDate()}`
       },
     },
   }

--- a/packages/docs/src/examples/calendars/usage.vue
+++ b/packages/docs/src/examples/calendars/usage.vue
@@ -102,9 +102,10 @@
 
           events.push({
             name: this.names[this.rnd(0, this.names.length - 1)],
-            start: this.formatDate(first, !allDay),
-            end: this.formatDate(second, !allDay),
+            start: first,
+            end: second,
             color: this.colors[this.rnd(0, this.colors.length - 1)],
+            timed: !allDay,
           })
         }
 
@@ -115,11 +116,6 @@
       },
       rnd (a, b) {
         return Math.floor((b - a + 1) * Math.random()) + a
-      },
-      formatDate (a, withTime) {
-        return withTime
-          ? `${a.getFullYear()}-${a.getMonth() + 1}-${a.getDate()} ${a.getHours()}:${a.getMinutes()}`
-          : `${a.getFullYear()}-${a.getMonth() + 1}-${a.getDate()}`
       },
     },
   }

--- a/packages/docs/src/lang/en/components/Calendars.json
+++ b/packages/docs/src/lang/en/components/Calendars.json
@@ -1,6 +1,6 @@
 {
   "heading": "# Calendars",
-  "headingText": "The `v-calendar` component is used to display information in a daily, weekly, or monthly view. The daily view has slots for all day or timed elements, and the weekly and monthly view has a slot for each day. Optionally you can pass in an array of events and they will be rendered over the appropriate days and times.",
+  "headingText": "The `v-calendar` component is used to display information in a daily, weekly, monthly, or category view. The daily view has slots for all day or timed elements, and the weekly and monthly view has a slot for each day. The category view has a slot for each category in the day and timed sections based on the categories given or the categories in the given events. Optionally you can pass in an array of events and they will be rendered over the appropriate days and times.",
   "examples": {
     "usage": {
       "desc": "A calendar has a type and a value which determines what type of calendar is shown over what span of time. This shows the bare minimum configuration, an array of events with `name`, `start` and `end` properties. `end` is optional, it defaults to the `start`. If the `start` has a time it's considered a timed event and will be shown accordingly in the day views. An event can span multiple days and will be rendered accordingly."
@@ -13,6 +13,18 @@
       "heading": "### Events",
       "desc": "This is an example of a planner with additional event handlers and external components controlling the display of the calendar."
     },
+    "category": {
+      "heading": "### Category",
+      "desc": "This is an example of an event calendar with a type of `category` that allows you to compare two schedules side-by-side."
+    },
+    "dragndrop": {
+      "heading": "### Drag and Drop",
+      "desc": "This is an example of an event calendar where you can drag events, extend their length, and create events."
+    },
+    "nowline": {
+      "heading": "### Now Line",
+      "desc": "This is an example of an calendar with a line for the current time."
+    },
     "weekly": {
       "heading": "### Weekly",
       "desc": "This is an example of an event calendar with all-day and timed events with a type of `week`."
@@ -23,8 +35,14 @@
     }
   },
   "props": {
+    "categories": "Specifies what categories to display in the `category` view. This controls the order of the categories as well. If the calendar uses events any categories specified in those events not specified in this value are dynamically rendered in the view unless `category-hide-dynamic` is true.",
+    "categoryHideDynamic": "Sets whether categories specified in an event should be hidden if it's not defined in `categories`.",
+    "categoryShowAll": "Set whether the `category` view should show all defined `categories` even if there are no events for a category.",
+    "categoryForInvalid": "The category to place events in that have invalid categories. A category is invalid when it is not a string. By default events without a category are not displayed until this value is specified.",
+    "categoryDays": "The number of days to render in the `category` view.",
     "dayFormat": "Formats day of the month string that appears in a day to a specified locale",
     "end": "The ending date on the calendar (inclusive) in the format of `YYYY-MM-DD`. This may be ignored depending on the `type` of the calendar.",
+    "eventCategory": "Set property of *event*'s category. Instead of a property a function can be given which takes an event and returns the category.",
     "eventColor": "A background color for all events or a function which accepts an event object passed to the calendar to return a color.",
     "eventEnd": "Set property of *event*'s end timestamp.",
     "eventHeight": "The height of an event in pixels in the `month` view and at the top of the `day` views.",
@@ -38,7 +56,9 @@
     "events": "An array of event objects with a property for a start timestamp and optionally a name and end timestamp. If an end timestamp is not given, the value of start will be used. If no name is given, you must provide an implementation for the `event` slot.",
     "eventStart": "Set property of *event*'s start timestamp.",
     "eventTextColor": "A text color for all events or a function which accepts an event object passed to the calendar to return a color.",
+    "eventTimed": "If Dates or milliseconds are used as the start or end timestamp of an event, this prop can be a string to a property on the event that is truthy if the event is a timed event or a function which takes the event and returns a truthy value if the event is a timed event.",
     "firstInterval": "The first interval to display in the `day` view. If `intervalMinutes` is set to 60 and this is set to 9 the first time in the view is 9am.",
+    "firstTime": "The first time to display in the `day` view. If specified, this overwrites any `firstInterval` value specified. This can be the number of minutes since midnight, a string in the format of `HH:mm`, or an object with number properties hour and minute.",
     "hideHeader": "If the header at the top of the `day` view should be visible.",
     "intervalCount": "The number of intervals to display in the `day` view.",
     "intervalFormat": "Formats time of day string that appears in the interval gutter of the `day` and `week` view to specified locale",
@@ -57,11 +77,11 @@
     "showIntervalLabel": "Checks if a given day and time should be displayed in the interval gutter of the `day` view.",
     "showMonthOnFirst": "Whether the name of the month should be displayed on the first day of the month.",
     "start": "The starting date on the calendar (inclusive) in the format of `YYYY-MM-DD`. This may be ignored depending on the `type` of the calendar.",
-    "type": "A string which is one of `month`, `week`, `day`, `4day`, `custom-weekly`, and `custom-daily`. The custom types look at the `start` and `end` dates passed to the component as opposed to the `value`.",
+    "type": "A string which is one of `month`, `week`, `day`, `4day`, `custom-weekly`, `custom-daily`, and `category`. The custom types look at the `start` and `end` dates passed to the component as opposed to the `value`.",
     "v-model": "Sets the `value` property but also updates it when the link of a day is clicked.",
     "value": "A date in the format of `YYYY-MM-DD` which determines what span of time for the calendar.",
     "weekdayFormat": "Formats day of the week string that appears in the header to specified locale",
-    "weekdays": "Specifies which days of the week to display. To display Monday through Friday only, a value of `[1, 2, 3, 4, 5]` can be used. To display a week starting on Monday a value of `[1, 2, 3, 4, 5, 6, 0]` can be used."
+    "weekdays": "Specifies which days of the week to display. To display Monday through Friday only, a value of `[1, 2, 3, 4, 5]` can be used. To display a week starting on Monday a value of `[1, 2, 3, 4, 5, 6, 0]` can be used."    
   },
   "functions": {
     "checkChange": "Checks for change in start and end dates. Updates and emits a change event if they have changed.",
@@ -73,11 +93,16 @@
     "prev": "Triggers the input event with a date that would progress the calendar to the previous timespan. If the type is `month` it will return a day in the previous month, if the type is `4day` it will return a date 4 days before `value`/`v-model`, etc.",
     "scrollToTime": "Scrolls the scrollable area in the `day` view to the given time. If the time is not in a valid format or if the calendar is not in the `day` view then false is returned.",
     "timeToY": "Converts a time to a pixel value on the y-axis for the `day` view. If the time is not in a valid format or if the calendar is not in the `day` view then false is returned.",
+    "timeDelta": "Converts a time to a delta value for the `day` view. If the time is not in a valid format or if the calendar is not in the `day` view then false is returned. A delta value is typically between 0 and 1. If the time given is before the first interval then a negative number will be returned. If the timee given is after the last interval than a number greater than 1 will be returned.",
     "updateEventVisibility": "If the calendar has events and `event-more` is truthy the days with too many events contain a 'button' to represent how many events had to be hidden.",
     "updateTimes": "Updates now & today in the calendar, possibly updating the styles in the calendar.",
-    "getVisibleEvents": "Returns the list of events seen on the current calendar where each element returned has the following properties:<br>- `input`: the event passed in the `events` prop.<br>- `start`: a CalendarTimestamp of the start timestamp parsed.<br>- `startIdentifier`: a number which represents the day the event starts on.<br>- `startTimestampIdentifier`: a number which represents the day and time the event starts on.<br>- `end`: a CalendarTimestamp of the end timestamp parsed.<br>- `endIdentifier`: a number which represents the day the event ends on.<br>- `endTimestampIdentifier`: a number which represents the day & time the event ends on.<br>- `allDay`: if this is an all-day event (has no time specified in the `start`/`end` on the event).<br>- `index`: the index of the event in the given array."
+    "getVisibleEvents": "Returns the list of events seen on the current calendar where each element returned has the following properties:<br>- `input`: the event passed in the `events` prop.<br>- `start`: a CalendarTimestamp of the start timestamp parsed.<br>- `startIdentifier`: a number which represents the day the event starts on.<br>- `startTimestampIdentifier`: a number which represents the day and time the event starts on.<br>- `end`: a CalendarTimestamp of the end timestamp parsed.<br>- `endIdentifier`: a number which represents the day the event ends on.<br>- `endTimestampIdentifier`: a number which represents the day & time the event ends on.<br>- `allDay`: if this is an all-day event (has no time specified in the `start`/`end` on the event).<br>- `index`: the index of the event in the given array.<br>- `category`: the category of the event if the calendar type is category, otherwise false.",
+    "parseTimestamp": "A utility function which takes timestamp input and returns a timestamp object.",
+    "timestampToDate": "A utility function which takes timestamp and returns a Date.",
+    "parseEvent": "A utility function which takes an event and returns the parsed version of that event."
   },
   "slots": {
+    "category": "The content placed in a category header for the `category` type. The category variable is null for events with invalid (non-string) categories.",
     "day-body": "The content that is placed in a `day` view in the scrollable interval container. The day & time object is passed through this slots scope.",
     "day-header": "The content that is placed in a `day` view in the top container. The day & time object is passed through this slots scope.",
     "day-label": "The content that is placed in the day of the month space in the `custom-weekly` or `month` view. The day & time object is passed through this slots scope.",
@@ -92,48 +117,68 @@
     "change": "The range of days displayed on the calendar changed. This is triggered on initialization. The event passed is an object with start and end date objects.",
     "click:date": "The click event on the day of the month link. The event passed is the day & time object.",
     "click:day": "The click event on a day. The event passed is the day object.",
+    "click:day-category": "The click event on a day in the `category` view. The event passed is the day object.",
     "click:event": "The click event on a specific event. The event passed is the day & time object.",
     "click:interval": "The click event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "click:more": "The click event on the `X more` button on views with too many events in a day.",
     "click:time": "The click event at a specific time in the `day` view. The event passed is the day & time object.",
+    "click:time-category": "The click event at a specific time in the `category` view. The event passed is the day & time object.",
     "contextmenu:date": "The right-click event on the day of the month link. The event passed is the day & time object.",
     "contextmenu:day": "The right-click event on a day. The event passed is the day object.",
+    "contextmenu:day-category": "The right-click event on a day in the `category` view. The event passed is the day object.",
     "contextmenu:event": "The right-click event on an event. The event passed is the day & time object.",
     "contextmenu:interval": "The right-click event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "contextmenu:time": "The right-click event at a specific time in the `day` view. The event passed is the day & time object.",
+    "contextmenu:time-category": "The right-click event at a specific time in the `category` view. The event passed is the day & time object.",
     "input": "An alias to the `click:date` event used to support v-model.",
     "mousedown:day": "The mousedown event on a day. The event passed is the day object.",
+    "mousedown:day-category": "The mousedown event on a day in the `category` view. The event passed is the day object.",
     "mousedown:event": "The mousedown event on an event. The event passed is the day & time object.",
     "mousedown:interval": "The mousedown event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "mousedown:time": "The mousedown event at a specific time in the `day` view. The event passed is the day & time object.",
+    "mousedown:time-category": "The mousedown event at a specific time in the `category` view. The event passed is the day & time object.",
     "mouseenter:day": "The mouseenter event on a day. The event passed is the day object.",
+    "mouseenter:day-category": "The mouseenter event on a day in the `category` view. The event passed is the day object.",
     "mouseenter:event": "The mouseenter event on an event. The event passed is the day & time object.",
     "mouseenter:interval": "The mouseenter event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "mouseenter:time": "The mouseenter event at a specific time in the `day` view. The event passed is the day & time object.",
+    "mouseenter:time-category": "The mouseenter event at a specific time in the `category` view. The event passed is the day & time object.",
     "mouseleave:day": "The mouseleave event on a day. The event passed is the day object.",
+    "mouseleave:day-category": "The mouseleave event on a day in the `category` view. The event passed is the day object.",
     "mouseleave:event": "The mouseleave event on an event. The event passed is the day & time object.",
     "mouseleave:interval": "The mouseleave event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "mouseleave:time": "The mouseleave event at a specific time in the `day` view. The event passed is the day & time object.",
+    "mouseleave:time-category": "The mouseleave event at a specific time in the `category` view. The event passed is the day & time object.",
     "mousemove:day": "The mousemove event on a day. The event passed is the day object.",
+    "mousemove:day-category": "The mousemove event on a day in the `category` view. The event passed is the day object.",
     "mousemove:event": "The mousemove event on an event. The event passed is the day & time object.",
     "mousemove:interval": "The mousemove event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "mousemove:time": "The mousemove event at a specific time in the `day` view. The event passed is the day & time object.",
+    "mousemove:time-category": "The mousemove event at a specific time in the `category` view. The event passed is the day & time object.",
     "mouseup:day": "The mouseup event on a day. The event passed is the day object.",
+    "mouseup:day-category": "The mouseup event on a day in the `category` view. The event passed is the day object.",
     "mouseup:event": "The mouseup event on an event. The event passed is the day & time object.",
     "mouseup:interval": "The mouseup event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "mouseup:time": "The mouseup event at a specific time in the `day` view. The event passed is the day & time object.",
+    "mouseup:time-category": "The mouseup event at a specific time in the `category` view. The event passed is the day & time object.",
     "moved": "One of the functions `next`, `prev`, and `move` was called. The event passed is the day object calculated for the movement.",
     "touchend:day": "The touchend event on a day. The event passed is the day object.",
+    "touchend:day-category": "The touchend event on a day in the `category` view. The event passed is the day object.",
     "touchend:event": "The touchend event on am view. The event passed is the day & time object.",
     "touchend:interval": "The touchend event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "touchend:time": "The touchend event at a specific time in the `day` view. The event passed is the day & time object.",
+    "touchend:time-category": "The touchend event at a specific time in the `category` view. The event passed is the day & time object.",
     "touchmove:day": "The touchmove event on a day. The event passed is the day object.",
+    "touchmove:day-category": "The touchmove event on a day in the `category` view. The event passed is the day object.",
     "touchmove:event": "The touchmove event on an `event` view. The event passed is the day & time object.",
     "touchmove:interval": "The touchmove event at a specific interval label in the `day` view. The event passed is the day & time object.",
     "touchmove:time": "The touchmove event at a specific time in the `day` view. The event passed is the day & time object.",
+    "touchmove:time-category": "The touchmove event at a specific time in the `category` view. The event passed is the day & time object.",
     "touchstart:day": "The touchstart event on a day. The event passed is the day object.",
+    "touchstart:day-category": "The touchstart event on a day in the `category` view. The event passed is the day object.",
     "touchstart:event": "The touchstart event on an event` view. The event passed is the day & time object.",
     "touchstart:interval": "The touchstart event at a specific interval label in the `day` view. The event passed is the day & time object.",
-    "touchstart:time": "The touchstart event at a specific time in the `day` view. The event passed is the day & time object."
+    "touchstart:time": "The touchstart event at a specific time in the `day` view. The event passed is the day & time object.",
+    "touchstart:time-category": "The touchstart event at a specific time in the `category` view. The event passed is the day & time object."
   }
 }

--- a/packages/docs/src/lang/en/components/SlideGroups.json
+++ b/packages/docs/src/lang/en/components/SlideGroups.json
@@ -38,7 +38,9 @@
   },
   "events": {
     "change": "Emitted when the component value is changed by user interaction",
-    "click:location": "Emitted when a slide item is selected inside of the slide group"
+    "click:location": "Emitted when a slide item is selected inside of the slide group",
+    "near:start": "Emitted when the slide group is approaching within one scroll of the start",
+    "near:end": "Emitted when the slide group is approaching within one scroll of the end"
   },
   "slots": {
     "next": "The next slot",

--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.sass
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.sass
@@ -1,0 +1,27 @@
+@import './_variables.scss'
+
+// Theme
++theme(v-calendar-category) using ($material)
+  .v-calendar-category__column,
+  .v-calendar-category__column-header
+    border-right: map-deep-get($material, 'calendar', 'line-color') $calendar-line-width solid
+
+.v-calendar-category
+  .v-calendar-category__category
+    text-align: center
+    
+  .v-calendar-daily__day-container
+    .v-calendar-category__columns
+      position: absolute
+      height: 100%
+      width: 100%
+      top: 0
+
+  .v-calendar-category__columns
+    display: flex
+    
+    .v-calendar-category__column,
+    .v-calendar-category__column-header
+      flex: 1 1 auto
+      width: 0
+      position: relative

--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
@@ -1,0 +1,95 @@
+// Styles
+import './VCalendarCategory.sass'
+
+// Types
+import { VNode } from 'vue'
+
+// Mixins
+import VCalendarDaily from './VCalendarDaily'
+
+// Util
+import { getSlot } from '../../util/helpers'
+import { CalendarTimestamp } from 'types'
+import props from './util/props'
+
+/* @vue/component */
+export default VCalendarDaily.extend({
+  name: 'v-calendar-category',
+
+  props: props.category,
+
+  computed: {
+    classes (): object {
+      return {
+        'v-calendar-daily': true,
+        'v-calendar-category': true,
+        ...this.themeClasses,
+      }
+    },
+    parsedCategories (): string[] {
+      return typeof this.categories === 'string' && this.categories
+        ? this.categories.split(/\s*,\s*/)
+        : Array.isArray(this.categories)
+          ? this.categories as string[]
+          : []
+    },
+  },
+
+  methods: {
+    genDayHeader (day: CalendarTimestamp, index: number): VNode[] {
+      const data = {
+        staticClass: 'v-calendar-category__columns',
+      }
+      const scope = {
+        week: this.days, ...day, index,
+      }
+
+      const children = this.parsedCategories.map(category => this.genDayHeaderCategory(day, this.getCategoryScope(scope, category)))
+
+      return [this.$createElement('div', data, children)]
+    },
+    getCategoryScope (scope: any, category: string) {
+      return {
+        ...scope,
+        category: category === this.categoryForInvalid ? null : category,
+      }
+    },
+    genDayHeaderCategory (day: CalendarTimestamp, scope: any): VNode {
+      return this.$createElement('div', {
+        staticClass: 'v-calendar-category__column-header',
+        on: this.getDefaultMouseEventHandlers(':day-category', e => {
+          return this.getCategoryScope(this.getSlotScope(day), scope.category)
+        }),
+      }, [
+        getSlot(this, 'category', scope) || this.genDayHeaderCategoryTitle(scope.category),
+        getSlot(this, 'day-header', scope),
+      ])
+    },
+    genDayHeaderCategoryTitle (category: string) {
+      return this.$createElement('div', {
+        staticClass: 'v-calendar-category__category',
+      }, category === null ? this.categoryForInvalid : category)
+    },
+    genDayBody (day: CalendarTimestamp): VNode[] {
+      const data = {
+        staticClass: 'v-calendar-category__columns',
+      }
+
+      const children = this.parsedCategories.map(category => this.genDayBodyCategory(day, category))
+
+      return [this.$createElement('div', data, children)]
+    },
+    genDayBodyCategory (day: CalendarTimestamp, category: string): VNode {
+      const data = {
+        staticClass: 'v-calendar-category__column',
+        on: this.getDefaultMouseEventHandlers(':time-category', e => {
+          return this.getCategoryScope(this.getSlotScope(this.getTimestampAtEvent(e, day)), category)
+        }),
+      }
+
+      const children = getSlot(this, 'day-body', () => this.getCategoryScope(this.getSlotScope(day), category))
+
+      return this.$createElement('div', data, children)
+    },
+  },
+})

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -78,10 +78,6 @@ export default CalendarWithIntervals.extend({
       return this.days.map(this.genHeadDay)
     },
     genHeadDay (day: CalendarTimestamp, index: number): VNode {
-      const header = getSlot(this, 'day-header', () => ({
-        week: this.days, ...day, index,
-      }))
-
       return this.$createElement('div', {
         key: day.date,
         staticClass: 'v-calendar-daily_head-day',
@@ -92,8 +88,13 @@ export default CalendarWithIntervals.extend({
       }, [
         this.genHeadWeekday(day),
         this.genHeadDayLabel(day),
-        ...(header || []),
+        ...this.genDayHeader(day, index),
       ])
+    },
+    genDayHeader (day: CalendarTimestamp, index: number): VNode[] {
+      return getSlot(this, 'day-header', () => ({
+        week: this.days, ...day, index,
+      })) || []
     },
     genHeadWeekday (day: CalendarTimestamp): VNode {
       const color = day.present ? this.color : undefined
@@ -171,8 +172,11 @@ export default CalendarWithIntervals.extend({
         }),
       }, [
         ...this.genDayIntervals(index),
-        ...(getSlot(this, 'day-body', () => this.getSlotScope(day)) || []),
+        ...this.genDayBody(day),
       ])
+    },
+    genDayBody (day: CalendarTimestamp): VNode[] {
+      return getSlot(this, 'day-body', () => this.getSlotScope(day)) || []
     },
     genDayIntervals (index: number): VNode[] {
       return this.intervals[index].map(this.genDayInterval)

--- a/packages/vuetify/src/components/VCalendar/index.ts
+++ b/packages/vuetify/src/components/VCalendar/index.ts
@@ -2,12 +2,14 @@ import VCalendar from './VCalendar'
 import VCalendarDaily from './VCalendarDaily'
 import VCalendarWeekly from './VCalendarWeekly'
 import VCalendarMonthly from './VCalendarMonthly'
+import VCalendarCategory from './VCalendarCategory'
 
-export { VCalendar, VCalendarDaily, VCalendarWeekly, VCalendarMonthly }
+export { VCalendar, VCalendarCategory, VCalendarDaily, VCalendarWeekly, VCalendarMonthly }
 
 export default {
   $_vuetify_subcomponents: {
     VCalendar,
+    VCalendarCategory,
     VCalendarDaily,
     VCalendarWeekly,
     VCalendarMonthly,

--- a/packages/vuetify/src/components/VCalendar/mixins/__tests__/__snapshots__/calendar-with-intervals.spec.ts.snap
+++ b/packages/vuetify/src/components/VCalendar/mixins/__tests__/__snapshots__/calendar-with-intervals.spec.ts.snap
@@ -4558,6 +4558,7 @@ Object {
   "past": false,
   "present": false,
   "time": "",
+  "timeDelta": [Function],
   "timeToY": [Function],
   "weekday": 5,
   "year": 2019,

--- a/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-events.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-events.spec.ts
@@ -105,13 +105,13 @@ describe('calendar-with-events.ts', () => {
     expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12', hour: 8, minute: 30, hasTime: true }, input: { Meetup: 'Meetup' } })).toBe('Meetup')
 
     wrapper.setProps({
-      eventName: 'Conference',
+      eventName: 'x',
     })
 
     expect(wrapper.vm.eventNameFunction).toBeDefined()
     expect(typeof wrapper.vm.eventNameFunction).toBe('function')
-    expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12' }, input: { Conference: 'Conference' } })).toBe('Conference')
-    expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12', hour: 8, minute: 30, hasTime: true }, input: { Conference: 'Conference' } })).toMatch(/^<strong>0?8:30( AM)?<\/strong> Conference$/) // will match 8:30 AM|| 08:30 AM || 8:30 || 08:30
+    expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12' }, input: { x: 'Conference' } })).toBe('Conference')
+    expect(wrapper.vm.eventNameFunction({ start: { date: '2019-02-12', hour: 8, minute: 30, hasTime: true }, input: { x: 'Conference' } })).toMatch('Conference') // will match 8:30 AM|| 08:30 AM || 8:30 || 08:30
   })
 
   it('should format time', async () => {

--- a/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-intervals.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-intervals.spec.ts
@@ -184,6 +184,7 @@ describe('calendar-with-intervals.ts', () => {
 
     expect(scope).toMatchSnapshot()
     expect(typeof wrapper.vm.getSlotScope(parseTimestamp('2019-02-08')).timeToY).toBe('function')
+    expect(typeof wrapper.vm.getSlotScope(parseTimestamp('2019-02-08')).timeDelta).toBe('function')
     expect(typeof wrapper.vm.getSlotScope(parseTimestamp('2019-02-08')).minutesToPixels).toBe('function')
   })
 
@@ -214,6 +215,31 @@ describe('calendar-with-intervals.ts', () => {
     expect(wrapper.vm.timeToY('23:50', false)).toBe(6624)
 
     expect(wrapper.vm.timeToY('bad')).toBe(false)
+  })
+
+  it('should convert time delta', async () => {
+    const wrapper = mountFunction()
+
+    expect(typeof wrapper.vm.timeDelta).toBe('function')
+    expect(wrapper.vm.timeDelta('08:30')).toBeDefined()
+    expect(wrapper.vm.timeDelta('08:30')).toBe((8 * 60 + 30) / 1440)
+    expect(wrapper.vm.timeDelta('09:30')).toBe((9 * 60 + 30) / 1440)
+    expect(Math.round(wrapper.vm.timeDelta('23:50') || 0)).toBe(1)
+
+    wrapper.setProps({
+      firstInterval: 5,
+      intervalCount: 5,
+      intervalMinutes: 10,
+      bodyHeight: 400,
+    })
+
+    expect(wrapper.vm.timeDelta('08:30')).toBe((8 * 60 + 30 - 50) / 50)
+    expect(wrapper.vm.timeDelta('09:30')).toBe((9 * 60 + 30 - 50) / 50)
+    expect(wrapper.vm.timeDelta('23:50')).toBe((23 * 60 + 50 - 50) / 50)
+
+    expect(wrapper.vm.timeDelta('00:50')).toBe(0)
+
+    expect(wrapper.vm.timeDelta('bad')).toBe(false)
   })
 
   it('should convert minutes to pixels', async () => {

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
@@ -33,19 +33,22 @@ import {
   CalendarEventVisual,
   CalendarEventColorFunction,
   CalendarEventNameFunction,
+  CalendarEventTimedFunction,
   CalendarDaySlotScope,
   CalendarDayBodySlotScope,
   CalendarEventOverlapMode,
+  CalendarEvent,
+  CalendarEventCategoryFunction,
 } from 'vuetify/types'
 
 // Types
-type VEventGetter = (day: CalendarTimestamp) => CalendarEventParsed[]
+type VEventGetter<D> = (day: D) => CalendarEventParsed[]
 
-type VEventVisualToNode<D> = (visual: CalendarEventVisual, day: D) => VNode
+type VEventVisualToNode<D> = (visual: CalendarEventVisual, day: D) => VNode | false
 
 type VEventsToNodes = <D extends CalendarDaySlotScope>(
   day: D,
-  getter: VEventGetter,
+  getter: VEventGetter<D>,
   mapper: VEventVisualToNode<D>,
   timed: boolean) => VNode[] | undefined
 
@@ -55,6 +58,14 @@ type VDailyEventsMap = {
     more: HTMLElement | null
     events: HTMLElement[]
   }
+}
+
+interface VEventScopeInput {
+  eventParsed: CalendarEventParsed
+  day: CalendarDaySlotScope
+  start: boolean
+  end: boolean
+  timed: boolean
 }
 
 const WIDTH_FULL = 100
@@ -76,53 +87,60 @@ export default CalendarBase.extend({
       return this.events.length === 0
     },
     parsedEvents (): CalendarEventParsed[] {
-      return this.events.map((input, index) => parseEvent(input, index, this.eventStart, this.eventEnd))
+      return this.events.map(this.parseEvent)
     },
     parsedEventOverlapThreshold (): number {
       return parseInt(this.eventOverlapThreshold)
     },
     eventColorFunction (): CalendarEventColorFunction {
       return typeof this.eventColor === 'function'
-        ? this.eventColor as CalendarEventColorFunction
+        ? this.eventColor
         : () => (this.eventColor as string)
+    },
+    eventTimedFunction (): CalendarEventTimedFunction {
+      return typeof this.eventTimed === 'function'
+        ? this.eventTimed
+        : event => !!event[this.eventTimed as string]
+    },
+    eventCategoryFunction (): CalendarEventCategoryFunction {
+      return typeof this.eventCategory === 'function'
+        ? this.eventCategory
+        : event => event[this.eventCategory as string]
     },
     eventTextColorFunction (): CalendarEventColorFunction {
       return typeof this.eventTextColor === 'function'
-        ? this.eventTextColor as CalendarEventColorFunction
-        : () => (this.eventTextColor as string)
+        ? this.eventTextColor
+        : () => this.eventTextColor as string
     },
     eventNameFunction (): CalendarEventNameFunction {
       return typeof this.eventName === 'function'
-        ? this.eventName as CalendarEventNameFunction
-        : (event, timedEvent) => {
-          const name = escapeHTML(event.input[this.eventName as string] as string)
-          if (event.start.hasTime) {
-            if (timedEvent) {
-              const showStart = event.start.hour < 12 && event.end.hour >= 12
-              const start = this.formatTime(event.start, showStart)
-              const end = this.formatTime(event.end, true)
-              const singline = diffMinutes(event.start, event.end) <= this.parsedEventOverlapThreshold
-              const separator = singline ? ', ' : '<br>'
-              return `<strong>${name}</strong>${separator}${start} - ${end}`
-            } else {
-              const time = this.formatTime(event.start, true)
-              return `<strong>${time}</strong> ${name}`
-            }
-          }
-          return name
-        }
+        ? this.eventName
+        : (event, timedEvent) => escapeHTML(event.input[this.eventName as string] as string)
     },
     eventModeFunction (): CalendarEventOverlapMode {
       return typeof this.eventOverlapMode === 'function'
-        ? this.eventOverlapMode as CalendarEventOverlapMode
+        ? this.eventOverlapMode
         : CalendarEventOverlapModes[this.eventOverlapMode]
     },
     eventWeekdays (): number[] {
       return this.parsedWeekdays
     },
+    categoryMode (): boolean {
+      return false
+    },
   },
 
   methods: {
+    parseEvent (input: CalendarEvent, index = 0): CalendarEventParsed {
+      return parseEvent(
+        input,
+        index,
+        this.eventStart,
+        this.eventEnd,
+        this.eventTimedFunction(input),
+        this.categoryMode ? this.eventCategoryFunction(input) : false,
+      )
+    },
     formatTime (withTime: CalendarTimestamp, ampm: boolean): string {
       const formatter = this.getFormatter({
         timeZone: 'UTC',
@@ -209,19 +227,20 @@ export default CalendarBase.extend({
       const start = dayIdentifier === event.startIdentifier
       let end = dayIdentifier === event.endIdentifier
       let width = WIDTH_START
-      for (let i = day.index + 1; i < week.length; i++) {
-        const weekdayIdentifier = getDayIdentifier(week[i])
-        if (event.endIdentifier >= weekdayIdentifier) {
-          width += WIDTH_FULL
-          if (weekdayIdentifier === event.endIdentifier) {
+
+      if (!this.categoryMode) {
+        for (let i = day.index + 1; i < week.length; i++) {
+          const weekdayIdentifier = getDayIdentifier(week[i])
+          if (event.endIdentifier >= weekdayIdentifier) {
+            width += WIDTH_FULL
+            end = end || weekdayIdentifier === event.endIdentifier
+          } else {
             end = true
+            break
           }
-        } else {
-          end = true
-          break
         }
       }
-      const scope = { event: event.input, day, outside: day.outside, start, end, timed: false }
+      const scope = { eventParsed: event, day, start, end, timed: false }
 
       return this.genEvent(event, scope, false, {
         staticClass: 'v-event',
@@ -242,14 +261,18 @@ export default CalendarBase.extend({
         refInFor: true,
       })
     },
-    genTimedEvent ({ event, left, width }: CalendarEventVisual, day: CalendarDayBodySlotScope): VNode {
+    genTimedEvent ({ event, left, width }: CalendarEventVisual, day: CalendarDayBodySlotScope): VNode | false {
+      if (day.timeDelta(event.end) <= 0 || day.timeDelta(event.start) >= 1) {
+        return false
+      }
+
       const dayIdentifier = getDayIdentifier(day)
       const start = event.startIdentifier >= dayIdentifier
       const end = event.endIdentifier > dayIdentifier
       const top = start ? day.timeToY(event.start) : 0
       const bottom = end ? day.timeToY(MINUTES_IN_DAY) : day.timeToY(event.end)
       const height = Math.max(this.eventHeight, bottom - top)
-      const scope = { event: event.input, day, outside: day.outside, start, end, timed: true }
+      const scope = { eventParsed: event, day, start, end, timed: true }
 
       return this.genEvent(event, scope, true, {
         staticClass: 'v-event-timed',
@@ -261,10 +284,43 @@ export default CalendarBase.extend({
         },
       })
     },
-    genEvent (event: CalendarEventParsed, scope: object, timedEvent: boolean, data: VNodeData): VNode {
+    genEvent (event: CalendarEventParsed, scopeInput: VEventScopeInput, timedEvent: boolean, data: VNodeData): VNode {
       const slot = this.$scopedSlots.event
       const text = this.eventTextColorFunction(event.input)
       const background = this.eventColorFunction(event.input)
+      const overlapsNoon = event.start.hour < 12 && event.end.hour >= 12
+      const singline = diffMinutes(event.start, event.end) <= this.parsedEventOverlapThreshold
+      const formatTime = this.formatTime
+      const timeSummary = () => formatTime(event.start, overlapsNoon) + ' - ' + formatTime(event.end, true)
+      const eventSummary = () => {
+        const name = this.eventNameFunction(event, timedEvent)
+
+        if (event.start.hasTime) {
+          if (timedEvent) {
+            const time = timeSummary()
+            const delimiter = singline ? ', ' : '<br>'
+
+            return `<strong>${name}</strong>${delimiter}${time}`
+          } else {
+            const time = formatTime(event.start, true)
+
+            return `<strong>${time}</strong> ${name}`
+          }
+        }
+
+        return name
+      }
+
+      const scope = {
+        ...scopeInput,
+        event: event.input,
+        outside: scopeInput.day.outside,
+        singline,
+        overlapsNoon,
+        formatTime,
+        timeSummary,
+        eventSummary,
+      }
 
       return this.$createElement('div',
         this.setTextColor(text,
@@ -278,14 +334,14 @@ export default CalendarBase.extend({
           })
         ), slot
           ? slot(scope)
-          : [this.genName(event, timedEvent)]
+          : [this.genName(eventSummary)]
       )
     },
-    genName (event: CalendarEventParsed, timedEvent: boolean): VNode {
+    genName (eventSummary: () => string): VNode {
       return this.$createElement('div', {
         staticClass: 'pl-1',
         domProps: {
-          innerHTML: this.eventNameFunction(event, timedEvent),
+          innerHTML: eventSummary(),
         },
       })
     },
@@ -340,7 +396,12 @@ export default CalendarBase.extend({
         event => isEventOverlapping(event, start, end)
       )
     },
-    getEventsForDay (day: CalendarTimestamp): CalendarEventParsed[] {
+    isEventForCategory (event: CalendarEventParsed, category: string | undefined | null): boolean {
+      return !this.categoryMode ||
+        category === event.category ||
+        (typeof event.category !== 'string' && category === null)
+    },
+    getEventsForDay (day: CalendarDaySlotScope): CalendarEventParsed[] {
       const identifier = getDayIdentifier(day)
       const firstWeekday = this.eventWeekdays[0]
 
@@ -348,19 +409,23 @@ export default CalendarBase.extend({
         event => isEventStart(event, day, identifier, firstWeekday)
       )
     },
-    getEventsForDayAll (day: CalendarTimestamp): CalendarEventParsed[] {
+    getEventsForDayAll (day: CalendarDaySlotScope): CalendarEventParsed[] {
       const identifier = getDayIdentifier(day)
       const firstWeekday = this.eventWeekdays[0]
 
       return this.parsedEvents.filter(
-        event => event.allDay && isEventStart(event, day, identifier, firstWeekday)
+        event => event.allDay &&
+          (this.categoryMode ? isEventOn(event, identifier) : isEventStart(event, day, identifier, firstWeekday)) &&
+          this.isEventForCategory(event, day.category)
       )
     },
-    getEventsForDayTimed (day: CalendarTimestamp): CalendarEventParsed[] {
+    getEventsForDayTimed (day: CalendarDaySlotScope): CalendarEventParsed[] {
       const identifier = getDayIdentifier(day)
 
       return this.parsedEvents.filter(
-        event => !event.allDay && isEventOn(event, identifier)
+        event => !event.allDay &&
+          isEventOn(event, identifier) &&
+          this.isEventForCategory(event, day.category)
       )
     },
     getScopedSlots () {
@@ -374,17 +439,13 @@ export default CalendarBase.extend({
         this.parsedEventOverlapThreshold
       )
 
+      const isNode = (input: VNode | false): input is VNode => !!input
       const getSlotChildren: VEventsToNodes = (day, getter, mapper, timed) => {
         const events = getter(day)
-
-        if (events.length === 0) {
-          return
-        }
-
-        const visuals = mode(day, events, timed)
+        const visuals = mode(day, events, timed, this.categoryMode)
 
         if (timed) {
-          return visuals.map(visual => mapper(visual, day))
+          return visuals.map(visual => mapper(visual, day)).filter(isNode)
         }
 
         const children: VNode[] = []
@@ -393,7 +454,11 @@ export default CalendarBase.extend({
           while (children.length < visual.column) {
             children.push(this.genPlaceholder(day))
           }
-          children.push(mapper(visual, day))
+
+          const mapped = mapper(visual, day)
+          if (mapped) {
+            children.push(mapped)
+          }
         })
 
         return children

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-intervals.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-intervals.ts
@@ -12,8 +12,9 @@ import {
   createIntervalList,
   createNativeLocaleFormatter,
   VTime,
+  MINUTES_IN_DAY,
 } from '../util/timestamp'
-import { CalendarTimestamp, CalendarFormatter } from 'vuetify/types'
+import { CalendarTimestamp, CalendarFormatter, CalendarDayBodySlotScope } from 'vuetify/types'
 
 /* @vue/component */
 export default CalendarBase.extend({
@@ -34,8 +35,15 @@ export default CalendarBase.extend({
     parsedIntervalHeight (): number {
       return parseFloat(this.intervalHeight)
     },
+    parsedFirstTime (): number | false {
+      return parseTime(this.firstTime)
+    },
     firstMinute (): number {
-      return this.parsedFirstInterval * this.parsedIntervalMinutes
+      const time = this.parsedFirstTime
+
+      return time !== false && time >= 0 && time <= MINUTES_IN_DAY
+        ? time
+        : this.parsedFirstInterval * this.parsedIntervalMinutes
     },
     bodyHeight (): number {
       return this.parsedIntervalCount * this.parsedIntervalHeight
@@ -51,7 +59,7 @@ export default CalendarBase.extend({
     },
     intervals (): CalendarTimestamp[][] {
       const days: CalendarTimestamp[] = this.days
-      const first: number = this.parsedFirstInterval
+      const first: number = this.firstMinute
       const minutes: number = this.parsedIntervalMinutes
       const count: number = this.parsedIntervalCount
       const now: CalendarTimestamp = this.times.now
@@ -97,9 +105,10 @@ export default CalendarBase.extend({
 
       return updateMinutes(timestamp, minutes, this.times.now)
     },
-    getSlotScope (timestamp: CalendarTimestamp): any {
+    getSlotScope (timestamp: CalendarTimestamp): CalendarDayBodySlotScope {
       const scope = copyTimestamp(timestamp) as any
       scope.timeToY = this.timeToY
+      scope.timeDelta = this.timeDelta
       scope.minutesToPixels = this.minutesToPixels
       scope.week = this.days
       return scope
@@ -120,6 +129,24 @@ export default CalendarBase.extend({
       return minutes / this.parsedIntervalMinutes * this.parsedIntervalHeight
     },
     timeToY (time: VTime, clamp = true): number | false {
+      let y = this.timeDelta(time)
+
+      if (y !== false) {
+        y *= this.bodyHeight
+
+        if (clamp) {
+          if (y < 0) {
+            y = 0
+          }
+          if (y > this.bodyHeight) {
+            y = this.bodyHeight
+          }
+        }
+      }
+
+      return y
+    },
+    timeDelta (time: VTime): number | false {
       const minutes = parseTime(time)
 
       if (minutes === false) {
@@ -128,19 +155,8 @@ export default CalendarBase.extend({
 
       const min: number = this.firstMinute
       const gap: number = this.parsedIntervalCount * this.parsedIntervalMinutes
-      const delta: number = (minutes - min) / gap
-      let y: number = delta * this.bodyHeight
 
-      if (clamp) {
-        if (y < 0) {
-          y = 0
-        }
-        if (y > this.bodyHeight) {
-          y = this.bodyHeight
-        }
-      }
-
-      return y
+      return (minutes - min) / gap
     },
   },
 })

--- a/packages/vuetify/src/components/VCalendar/modes/__tests__/__snapshots__/common.spec.ts.snap
+++ b/packages/vuetify/src/components/VCalendar/modes/__tests__/__snapshots__/common.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`common.ts should get visuals 1 1`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -48,6 +49,7 @@ Object {
 exports[`common.ts should get visuals 1 2`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -93,6 +95,7 @@ Object {
 exports[`common.ts should get visuals 1 3`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -138,6 +141,7 @@ Object {
 exports[`common.ts should get visuals 1 4`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,

--- a/packages/vuetify/src/components/VCalendar/modes/column.ts
+++ b/packages/vuetify/src/components/VCalendar/modes/column.ts
@@ -6,8 +6,8 @@ const FULL_WIDTH = 100
 export const column: CalendarEventOverlapMode = (events, firstWeekday, overlapThreshold) => {
   const handler = getOverlapGroupHandler(firstWeekday)
 
-  return (day, dayEvents, timed) => {
-    const visuals = handler.getVisuals(day, dayEvents, timed)
+  return (day, dayEvents, timed, reset) => {
+    const visuals = handler.getVisuals(day, dayEvents, timed, reset)
 
     if (timed) {
       visuals.forEach(visual => {

--- a/packages/vuetify/src/components/VCalendar/modes/common.ts
+++ b/packages/vuetify/src/components/VCalendar/modes/common.ts
@@ -86,8 +86,8 @@ export function getOverlapGroupHandler (firstWeekday: number) {
       handler.groups = []
       handler.min = handler.max = -1
     },
-    getVisuals: (day: CalendarTimestamp, dayEvents: CalendarEventParsed[], timed: boolean) => {
-      if (day.weekday === firstWeekday || timed) {
+    getVisuals: (day: CalendarTimestamp, dayEvents: CalendarEventParsed[], timed: boolean, reset = false) => {
+      if (day.weekday === firstWeekday || reset) {
         handler.reset()
       }
 
@@ -127,6 +127,10 @@ export function getOverlapGroupHandler (firstWeekday: number) {
       })
 
       setColumnCount(handler.groups)
+
+      if (timed) {
+        handler.reset()
+      }
 
       return visuals
     },

--- a/packages/vuetify/src/components/VCalendar/modes/stack.ts
+++ b/packages/vuetify/src/components/VCalendar/modes/stack.ts
@@ -42,9 +42,9 @@ export const stack: CalendarEventOverlapMode = (events, firstWeekday, overlapThr
   const handler = getOverlapGroupHandler(firstWeekday)
 
   // eslint-disable-next-line max-statements
-  return (day, dayEvents, timed) => {
+  return (day, dayEvents, timed, reset) => {
     if (!timed) {
-      return handler.getVisuals(day, dayEvents, timed)
+      return handler.getVisuals(day, dayEvents, timed, reset)
     }
 
     const dayStart = getTimestampIdentifier(day)

--- a/packages/vuetify/src/components/VCalendar/util/__tests__/__snapshots__/events.spec.ts.snap
+++ b/packages/vuetify/src/components/VCalendar/util/__tests__/__snapshots__/events.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`events.ts should parse events 1`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -48,6 +49,7 @@ Object {
 exports[`events.ts should parse events 2`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -93,6 +95,7 @@ Object {
 exports[`events.ts should parse events 3`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -138,6 +141,7 @@ Object {
 exports[`events.ts should parse events 4`] = `
 Object {
   "allDay": true,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,
@@ -183,6 +187,7 @@ Object {
 exports[`events.ts should parse timed events 1`] = `
 Object {
   "allDay": false,
+  "category": false,
   "end": Object {
     "date": "2019-02-14",
     "day": 14,

--- a/packages/vuetify/src/components/VCalendar/util/__tests__/events.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/util/__tests__/events.spec.ts
@@ -57,6 +57,6 @@ describe('events.ts', () => {
       end: '2019-02-15',
     }, 0, 'start', 'end')
 
-    expect(fn).toThrow('undefined is not a valid timestamp. It must be in the format of YYYY-MM-DD or YYYY-MM-DD hh:mm. Zero-padding is optional and seconds are ignored.')
+    expect(fn).toThrow('undefined is not a valid timestamp. It must be a Date, number of seconds since Epoch, or a string in the format of YYYY-MM-DD or YYYY-MM-DD hh:mm. Zero-padding is optional and seconds are ignored.')
   })
 })

--- a/packages/vuetify/src/components/VCalendar/util/__tests__/timestamp.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/util/__tests__/timestamp.spec.ts
@@ -71,8 +71,8 @@ describe('VCalendar/util/timestamp.ts', () => { // eslint-disable-line max-state
     expect(validateTimestamp('not a timestamp')).toBe(false)
     expect(validateTimestamp([])).toBe(false)
     expect(validateTimestamp({})).toBe(false)
-    expect(validateTimestamp(new Date())).toBe(false)
-    expect(validateTimestamp(2345)).toBe(false)
+    expect(validateTimestamp(new Date())).toBe(true)
+    expect(validateTimestamp(2345)).toBe(true)
   })
 
   it('should parse timestamp', () => {
@@ -373,9 +373,9 @@ describe('VCalendar/util/timestamp.ts', () => { // eslint-disable-line max-state
   })
 
   it('should create interval list', () => {
-    expect(createIntervalList(parseTimestamp('2019-02-08'), 2, 15, 10)).toMatchSnapshot()
-    expect(createIntervalList(parseTimestamp('2019-02-08'), 1, 15, 10)).toMatchSnapshot()
-    expect(createIntervalList(parseTimestamp('2019-02-08'), 2, 5, 2)).toMatchSnapshot()
+    expect(createIntervalList(parseTimestamp('2019-02-08'), 30, 15, 10)).toMatchSnapshot()
+    expect(createIntervalList(parseTimestamp('2019-02-08'), 15, 15, 10)).toMatchSnapshot()
+    expect(createIntervalList(parseTimestamp('2019-02-08'), 10, 5, 2)).toMatchSnapshot()
   })
 
   // TODO Create a test that doesn't fail when

--- a/packages/vuetify/src/components/VCalendar/util/events.ts
+++ b/packages/vuetify/src/components/VCalendar/util/events.ts
@@ -3,12 +3,29 @@ import {
   getDayIdentifier,
   getTimestampIdentifier,
   OFFSET_TIME,
+  isTimedless,
+  updateHasTime,
 } from './timestamp'
 import { CalendarTimestamp, CalendarEvent, CalendarEventParsed } from 'vuetify/types'
 
-export function parseEvent (input: CalendarEvent, index: number, startProperty: string, endProperty: string): CalendarEventParsed {
-  const start: CalendarTimestamp = parseTimestamp(input[startProperty], true)
-  const end: CalendarTimestamp = (input[endProperty] ? parseTimestamp(input[endProperty], true) : start)
+export function parseEvent (
+  input: CalendarEvent,
+  index: number,
+  startProperty: string,
+  endProperty: string,
+  timed = false,
+  category: string | false = false,
+): CalendarEventParsed {
+  const startInput = input[startProperty]
+  const endInput = input[endProperty]
+  const startParsed: CalendarTimestamp = parseTimestamp(startInput, true)
+  const endParsed: CalendarTimestamp = (endInput ? parseTimestamp(endInput, true) : startParsed)
+  const start: CalendarTimestamp = isTimedless(startInput)
+    ? updateHasTime(startParsed, timed)
+    : startParsed
+  const end: CalendarTimestamp = isTimedless(endInput)
+    ? updateHasTime(endParsed, timed)
+    : endParsed
   const startIdentifier: number = getDayIdentifier(start)
   const startTimestampIdentifier: number = getTimestampIdentifier(start)
   const endIdentifier: number = getDayIdentifier(end)
@@ -16,7 +33,7 @@ export function parseEvent (input: CalendarEvent, index: number, startProperty: 
   const endTimestampIdentifier: number = getTimestampIdentifier(end) + endOffset
   const allDay: boolean = !start.hasTime
 
-  return { input, start, startIdentifier, startTimestampIdentifier, end, endIdentifier, endTimestampIdentifier, allDay, index }
+  return { input, start, startIdentifier, startTimestampIdentifier, end, endIdentifier, endTimestampIdentifier, allDay, index, category }
 }
 
 export function isEventOn (event: CalendarEventParsed, dayIdentifier: number): boolean {

--- a/packages/vuetify/src/components/VCalendar/util/props.ts
+++ b/packages/vuetify/src/components/VCalendar/util/props.ts
@@ -1,29 +1,28 @@
 
-import { validateTimestamp, parseDate, DAYS_IN_WEEK } from './timestamp'
+import { validateTimestamp, parseDate, DAYS_IN_WEEK, validateTime } from './timestamp'
 import { PropType } from 'vue'
-import { CalendarEvent, CalendarFormatter, CalendarTimestamp, CalendarEventOverlapMode } from 'vuetify/types'
+import { CalendarEvent, CalendarFormatter, CalendarTimestamp, CalendarEventOverlapMode, CalendarEventNameFunction, CalendarEventColorFunction, CalendarEventCategoryFunction, CalendarEventTimedFunction } from 'vuetify/types'
 import { CalendarEventOverlapModes } from '../modes'
 import { PropValidator } from 'vue/types/options'
 
 export default {
   base: {
     start: {
-      type: String,
+      type: [String, Number, Date],
       validate: validateTimestamp,
       default: () => parseDate(new Date()).date,
     },
     end: {
-      type: String,
+      type: [String, Number, Date],
       validate: validateTimestamp,
     },
     weekdays: {
-      type: [Array, String],
+      type: [Array, String] as PropType<number[] | string>,
       default: () => [0, 1, 2, 3, 4, 5, 6],
       validate: validateWeekdays,
-    } as PropValidator<number[] | string>,
+    },
     hideHeader: {
       type: Boolean,
-      default: false,
     },
     shortWeekdays: {
       type: Boolean,
@@ -67,6 +66,10 @@ export default {
       default: 0,
       validate: validateNumber,
     },
+    firstTime: {
+      type: [Number, String, Object],
+      validate: validateTime,
+    },
     intervalCount: {
       type: [Number, String],
       default: 24,
@@ -109,8 +112,29 @@ export default {
       default: 'month',
     },
     value: {
-      type: String,
+      type: [String, Number, Date] as PropType<string | number | Date>,
       validate: validateTimestamp,
+    },
+  },
+  category: {
+    categories: {
+      type: [Array, String],
+      default: '',
+    },
+    categoryHideDynamic: {
+      type: Boolean,
+    },
+    categoryShowAll: {
+      type: Boolean,
+    },
+    categoryForInvalid: {
+      type: String,
+      default: '',
+    },
+    categoryDays: {
+      type: [Number, String],
+      default: 1,
+      validate: (x: any) => isFinite(parseInt(x)) && parseInt(x) > 0,
     },
   },
   events: {
@@ -126,20 +150,28 @@ export default {
       type: String,
       default: 'end',
     },
+    eventTimed: {
+      type: [String, Function] as PropType<string | CalendarEventTimedFunction>,
+      default: 'timed',
+    },
+    eventCategory: {
+      type: [String, Function] as PropType<string | CalendarEventCategoryFunction>,
+      default: 'category',
+    },
     eventHeight: {
       type: Number,
       default: 20,
     },
     eventColor: {
-      type: [String, Function],
+      type: [String, Function] as PropType<string | CalendarEventColorFunction>,
       default: 'primary',
     },
     eventTextColor: {
-      type: [String, Function],
+      type: [String, Function] as PropType<string | CalendarEventColorFunction>,
       default: 'white',
     },
     eventName: {
-      type: [String, Function],
+      type: [String, Function] as PropType<string | CalendarEventNameFunction>,
       default: 'name',
     },
     eventOverlapThreshold: {

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
@@ -128,8 +128,29 @@ export const BaseSlideGroup = mixins<options &
     // the widths of the content and wrapper
     // and need to be recalculated
     isOverflowing: 'setWidths',
-    scrollOffset (val) {
+    scrollOffset (val, oldVal) {
       this.$refs.content.style.transform = `translateX(${-val}px)`
+
+      const offset = Math.abs(val)
+      const oldOffset = Math.abs(oldVal)
+      const { content, wrapper } = this.widths
+      const twoWrapperWidths = 2 * wrapper
+      if (content > twoWrapperWidths) {
+        if (offset >= content - twoWrapperWidths && offset < content - wrapper && oldOffset < content - twoWrapperWidths) {
+          // scrollOffset is 1 scroll away from right-most item, from > 1 scroll away
+          this.$emit('near:end')
+        } else if (offset > 0 && offset <= wrapper && oldOffset > wrapper) {
+          // scrollOffset has come to within 1 scroll away of left-most item, from > 1 scroll away
+          this.$emit('near:start')
+        }
+      } else if (content > wrapper) {
+        // if content spans 1-2 wrapper widths
+        if (!this.hasNext) {
+          this.$emit('near:end')
+        } else if (!this.hasPrev) {
+          this.$emit('near:start')
+        }
+      }
     },
   },
 

--- a/packages/vuetify/src/components/VSlideGroup/__tests__/VSlideGroup.spec.ts
+++ b/packages/vuetify/src/components/VSlideGroup/__tests__/VSlideGroup.spec.ts
@@ -311,4 +311,121 @@ describe('VSlideGroup.ts', () => {
     expect(html1).not.toEqual(html2)
     expect(html2).toMatchSnapshot()
   })
+
+  it('should emit events when near the start and end for content > 2 * wrapper', async () => {
+    const nearStart = jest.fn()
+    const nearEnd = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        showArrows: true,
+      },
+      data: () => ({
+        isOverflowing: true,
+        scrollOffset: 0,
+        widths: {
+          content: 1000,
+          wrapper: 400,
+        },
+      }),
+      listeners: {
+        'near:start': nearStart,
+        'near:end': nearEnd,
+      },
+      mocks: {
+        $vuetify: {
+          rtl: false,
+        },
+      },
+    })
+
+    const testNearEventsOnScroll = (isNearStart: boolean, isNearEnd: boolean) => {
+      if (isNearStart) {
+        expect(nearStart).toHaveBeenCalled()
+      } else {
+        expect(nearStart).not.toHaveBeenCalled()
+      }
+      if (isNearEnd) {
+        expect(nearEnd).toHaveBeenCalled()
+      } else {
+        expect(nearEnd).not.toHaveBeenCalled()
+      }
+      nearStart.mockReset()
+      nearEnd.mockReset()
+    }
+
+    wrapper.setData({ scrollOffset: 400 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(false, true)
+
+    wrapper.setData({ scrollOffset: 450 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(false, false)
+
+    wrapper.setData({ scrollOffset: 600 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(false, false)
+
+    wrapper.setData({ scrollOffset: 450 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(false, false)
+
+    wrapper.setData({ scrollOffset: 200 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(true, false)
+
+    wrapper.setData({ scrollOffset: 0 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(false, false)
+  })
+
+  it('should emit events when near the start and end for content < 2 * wrapper', async () => {
+    const nearStart = jest.fn()
+    const nearEnd = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        showArrows: true,
+      },
+      data: () => ({
+        isOverflowing: true,
+        scrollOffset: 0,
+        widths: {
+          content: 150,
+          wrapper: 100,
+        },
+      }),
+      listeners: {
+        'near:start': nearStart,
+        'near:end': nearEnd,
+      },
+      mocks: {
+        $vuetify: {
+          rtl: false,
+        },
+      },
+    })
+
+    const testNearEventsOnScroll = (isNearStart: boolean, isNearEnd: boolean) => {
+      if (isNearStart) {
+        expect(nearStart).toHaveBeenCalled()
+      } else {
+        expect(nearStart).not.toHaveBeenCalled()
+      }
+      if (isNearEnd) {
+        expect(nearEnd).toHaveBeenCalled()
+      } else {
+        expect(nearEnd).not.toHaveBeenCalled()
+      }
+      nearStart.mockReset()
+      nearEnd.mockReset()
+    }
+
+    // RTL false, content < 2 * wrapper
+    wrapper.setData({ scrollOffset: 50 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(false, true)
+
+    wrapper.setData({ scrollOffset: 0 })
+    await wrapper.vm.$nextTick()
+    testNearEventsOnScroll(true, false)
+  })
 })

--- a/packages/vuetify/types/index.d.ts
+++ b/packages/vuetify/types/index.d.ts
@@ -212,6 +212,7 @@ export interface CalendarEventParsed {
   endTimestampIdentifier: number
   allDay: boolean
   index: number
+  category: string | false
 }
 
 export interface CalendarEventVisual {
@@ -226,17 +227,25 @@ export interface CalendarDaySlotScope extends CalendarTimestamp {
   outside: boolean
   index: number
   week: CalendarTimestamp[]
+  category: string | undefined | null
 }
 
-export type CalendarTimeToY = (time: CalendarTimestamp | number | string) => number
+export type CalendarTimeToY = (time: CalendarTimestamp | number | string, clamp?: boolean) => number
+
+export type CalendarTimeDelta = (time: CalendarTimestamp | number | string) => number | false
 
 export interface CalendarDayBodySlotScope extends CalendarDaySlotScope {
   timeToY: CalendarTimeToY
+  timeDelta: CalendarTimeDelta
 }
 
-export type CalendarEventOverlapMode = (events: CalendarEventParsed[], firstWeekday: number, overlapThreshold: number) => (day: CalendarDaySlotScope, dayEvents: CalendarEventParsed[], timed: boolean) => CalendarEventVisual[]
+export type CalendarEventOverlapMode = (events: CalendarEventParsed[], firstWeekday: number, overlapThreshold: number) => (day: CalendarDaySlotScope, dayEvents: CalendarEventParsed[], timed: boolean, reset: boolean) => CalendarEventVisual[]
 
 export type CalendarEventColorFunction = (event: CalendarEvent) => string
+
+export type CalendarEventTimedFunction = (event: CalendarEvent) => boolean
+
+export type CalendarEventCategoryFunction = (event: CalendarEvent) => string
 
 export type CalendarEventNameFunction = (event: CalendarEventParsed, timedEvent: boolean) => string
 

--- a/packages/vuetify/types/lib.d.ts
+++ b/packages/vuetify/types/lib.d.ts
@@ -28,6 +28,7 @@ declare module 'vuetify/lib' {
   const VBtn: Component
   const VBtnToggle: Component
   const VCalendar: Component
+  const VCalendarCategory: Component
   const VCalendarDaily: Component
   const VCalendarWeekly: Component
   const VCalendarMonthly: Component
@@ -196,6 +197,7 @@ declare module 'vuetify/lib' {
     VBtn,
     VBtnToggle,
     VCalendar,
+    VCalendarCategory,
     VCalendarDaily,
     VCalendarWeekly,
     VCalendarMonthly,


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Implement two new VSlideGroup events - `near:start` and `near:end` -
using the following heuristic:

- When the content width is greater than twice the wrapper width,
  trigger an event if we are approaching to within one scroll of
  the start/end

- When the content width is equal to or less than the wrapper width,
  trigger an event if we are at the start/end

Fixes vuetifyjs/vuetify#11364

<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context

Some VSlideGroup users may want to listen for events indicating the
approaching towards the start or end of a slide group. These new events
and the heuristic that triggers them are so that users may be able to act _before_
the start/end has been reached, which would be useful when eg,
dynamically generating slide group items to simulate infinite scrolling

## How Has This Been Tested?

- Implement tests that exercise this for:
  - content width > 2 * wrapper widths
  - content width < 2 * wrapper widths

## Markup:
N/A - used GitPod

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
