### PR TITLE
fix: change curser:default selector to [aria-disabled="true"]

### DIFF
--- a/packages/vuetify/src/styles/generic/_reset.scss
+++ b/packages/vuetify/src/styles/generic/_reset.scss
@@ -308,7 +308,7 @@
   }
 
   /* Specify the unstyled cursor of disabled, not-editable, or otherwise inoperable elements */
-  [aria-disabled] {
+  [aria-disabled="true"] {
     cursor: default;
   }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Changed the selector for "cursor: default" to `[aria-disabled="true"]` so that the behavior does not apply to `[aria-disabled="false"]`
<!-- Note any issues that are resolved by this PR -->
Resolves #11003 
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in the playground.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-container>
    <!--  -->
    <v-btn>
      button1 (cursor default)
    </v-btn>
    <v-btn aria-disabled="true">
      button2 (cursor pointer)
    </v-btn>
    <v-btn aria-disabled="false">
      button3 (cursor default)
    </v-btn>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
