### PR TITLE
docs/demos: fix icons

### DIFF
--- a/packages/docs/src/layouts/layouts/demos/baseline-flipped.vue
+++ b/packages/docs/src/layouts/layouts/demos/baseline-flipped.vue
@@ -18,7 +18,7 @@
 
         <v-list-item link>
           <v-list-item-action>
-            <v-icon>mdi-contact-mail</v-icon>
+            <v-icon>mdi-email</v-icon>
           </v-list-item-action>
 
           <v-list-item-content>

--- a/packages/docs/src/layouts/layouts/demos/baseline.vue
+++ b/packages/docs/src/layouts/layouts/demos/baseline.vue
@@ -15,7 +15,7 @@
         </v-list-item>
         <v-list-item link>
           <v-list-item-action>
-            <v-icon>mdi-contact-mail</v-icon>
+            <v-icon>mdi-email</v-icon>
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title>Contact</v-list-item-title>

--- a/packages/docs/src/layouts/layouts/demos/centered.vue
+++ b/packages/docs/src/layouts/layouts/demos/centered.vue
@@ -42,7 +42,7 @@
                   <v-text-field
                     label="Login"
                     name="login"
-                    prepend-icon="person"
+                    prepend-icon="mdi-account"
                     type="text"
                   ></v-text-field>
 
@@ -50,7 +50,7 @@
                     id="password"
                     label="Password"
                     name="password"
-                    prepend-icon="lock"
+                    prepend-icon="mdi-lock"
                     type="password"
                   ></v-text-field>
                 </v-form>

--- a/packages/docs/src/layouts/layouts/demos/dark.vue
+++ b/packages/docs/src/layouts/layouts/demos/dark.vue
@@ -16,7 +16,7 @@
         </v-list-item>
         <v-list-item link>
           <v-list-item-action>
-            <v-icon>mdi-settings</v-icon>
+            <v-icon>mdi-cog</v-icon>
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title>Settings</v-list-item-title>

--- a/packages/docs/src/layouts/layouts/demos/google-contacts.vue
+++ b/packages/docs/src/layouts/layouts/demos/google-contacts.vue
@@ -272,7 +272,7 @@
             { text: 'Other contacts' },
           ],
         },
-        { icon: 'mdi-settings', text: 'Settings' },
+        { icon: 'mdi-cog', text: 'Settings' },
         { icon: 'mdi-message', text: 'Send feedback' },
         { icon: 'mdi-help-circle', text: 'Help' },
         { icon: 'mdi-cellphone-link', text: 'App downloads' },

--- a/packages/docs/src/layouts/layouts/demos/google-youtube.vue
+++ b/packages/docs/src/layouts/layouts/demos/google-youtube.vue
@@ -47,7 +47,7 @@
         </v-list-item>
         <v-list-item link>
           <v-list-item-action>
-            <v-icon color="grey darken-1">mdi-settings</v-icon>
+            <v-icon color="grey darken-1">mdi-cog</v-icon>
           </v-list-item-action>
           <v-list-item-title class="grey--text text--darken-1">Manage Subscriptions</v-list-item-title>
         </v-list-item>


### PR DESCRIPTION
* mdi-settings -> mdi-cog according to https://materialdesignicons.com/icon/cog

Signed-off-by: Victor Lourme <victor.lourme@icloud.com>

## Description
Change the mdi icon to **cog** instead of **settings**. `mdi-settings` seems not working anymore and is not referenced in https://materialdesignicons.com/.

## Motivation and Context
As these demos are accessible from the vuetifyjs.com docs, now the demo does not have any bugs.
Edit: the Codepen has the bug also.

## How Has This Been Tested?
Tested visually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
