### PR TITLE
align the component towards the left fixed

### DIFF
--- a/packages/docs/src/examples/menus/intermediate/popover.vue
+++ b/packages/docs/src/examples/menus/intermediate/popover.vue
@@ -5,6 +5,7 @@
       :close-on-content-click="false"
       :nudge-width="200"
       offset-x
+      :left="true"
     >
       <template v-slot:activator="{ on }">
         <v-btn

--- a/packages/docs/src/examples/menus/intermediate/popover.vue
+++ b/packages/docs/src/examples/menus/intermediate/popover.vue
@@ -5,7 +5,7 @@
       :close-on-content-click="false"
       :nudge-width="200"
       offset-x
-      :left="true"
+      left
     >
       <template v-slot:activator="{ on }">
         <v-btn

--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -201,6 +201,7 @@ export default baseMixins.extend({
       // Update coordinates and dimensions of menu
       // and its activator
       this.updateDimensions()
+      this.updateDimensions()
       // Start the transition
       requestAnimationFrame(() => {
         // Once transitioning, calculate scroll and top position


### PR DESCRIPTION
This is a hack/fix for #11548 .

It seems that dimensions are not properly calculated during the first call. 
I wasn't able to found a root cause of that weird behavior, but calling updateDimensions twice solves the problem.

I'm not sure if this can be merged. I hope this is useful and we will find the root cause soon.