### PR TITLE
fix(VDataTable): dense mode not working, missing header border

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -18,11 +18,13 @@
     > table
       > thead
         > tr
-          > &:last-child th
-            border-bottom: thin solid map-get($material, 'dividers')
-
           > th
             color: map-deep-get($material, 'text', 'secondary')
+
+          &:last-child
+            > th
+              border-bottom: thin solid map-get($material, 'dividers')
+
 
   > .v-data-table__wrapper
     > table
@@ -99,10 +101,11 @@
       > tbody,
       > thead,
       > tfoot
-        > td
-          height: $data-table-dense-row-height
-        > th
-          height: $data-table-dense-header-height
+        > tr
+          > td
+            height: $data-table-dense-row-height
+          > th
+            height: $data-table-dense-header-height
 
 .v-data-table--fixed-height
   .v-data-table__wrapper
@@ -114,11 +117,12 @@
 
     > table
       > thead
-        > th
-          border-bottom: 0px !important
-          position: sticky
-          top: 0
-          z-index: 2
+        > tr
+          > th
+            border-bottom: 0px !important
+            position: sticky
+            top: 0
+            z-index: 2
 
         > tr:nth-child(2)
           > th

--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.sass
@@ -25,7 +25,6 @@
             > th
               border-bottom: thin solid map-get($material, 'dividers')
 
-
   > .v-data-table__wrapper
     > table
       > tbody


### PR DESCRIPTION
## Motivation and Context
fixes #11567
fixes #11566

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
```vue
<template>
  <v-data-table dense :headers="[{text:'foo',value:'foo'}]" :items="[{foo: 'foo'}, {foo: 'bar'}]" />
</template>
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
