### PR TITLE
fix(VSlideGroup): vertical scroll lock for touch

### DIFF
--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.sass
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.sass
@@ -43,6 +43,7 @@
   display: flex
   flex: 1 1 auto
   overflow: hidden
+  touch-action: none
 
 // Modifiers
 .v-slide-group__next,


### PR DESCRIPTION
partially implements #10673

## Description
Fixes slide group issue on mobile where browser scrolls vertically when you are trying to only scroll horizontally.

## Motivation and Context
When using touch to scroll in a slide group the browser also scrolls vertically which is undesired.

## How Has This Been Tested?
Visually in the docs

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
