### PR TITLE
fix(VDataTable): union column filter with search results

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -51,17 +51,16 @@ function searchTableItems (
 ) {
   search = typeof search === 'string' ? search.trim() : null
 
-  // If the `search` property is empty and there are no custom filters in use, there is nothing to do.
-  if (!(search && headersWithoutCustomFilters.length) && !headersWithCustomFilters.length) return items
-
   return items.filter(item => {
     // Headers with custom filters are evaluated whether or not a search term has been provided.
-    if (headersWithCustomFilters.length && headersWithCustomFilters.every(filterFn(item, search, defaultFilter))) {
-      return true
-    }
+    // We need to match every filter to be included in the results.
+    const matchesColumnFilters = headersWithCustomFilters.every(filterFn(item, search, defaultFilter))
 
-    // Otherwise, the `search` property is used to filter columns without a custom filter.
-    return (search && headersWithoutCustomFilters.some(filterFn(item, search, customFilter)))
+    // Headers without custom filters are only filtered by the `search` property if it is defined.
+    // We only need a single column to match the search term to be included in the results.
+    const matchesSearchTerm = !search || headersWithoutCustomFilters.some(filterFn(item, search, customFilter))
+
+    return matchesColumnFilters && matchesSearchTerm
   })
 }
 

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -926,22 +926,22 @@ describe('VDataTable.ts', () => {
     expect(wrapper.vm.internalCurrentItems).toHaveLength(1)
   })
 
-  it("should return results which match both search term and column filters if both specified", async () => {
+  it('should return results which match both search term and column filters if both specified', async () => {
     const wrapper = mountFunction({
       propsData: {
         items: testItems,
         headers: [
-          { text: "Dessert (100g serving)", align: "left", value: "name" },
-          { text: "Calories", value: "calories", filter: value => value < 300 },
-          { text: "Fat (g)", value: "fat" },
-          { text: "Carbs (g)", value: "carbs" },
-          { text: "Protein (g)", value: "protein" },
-          { text: "Iron (%)", value: "iron" }
+          { text: 'Dessert (100g serving)', align: 'left', value: 'name' },
+          { text: 'Calories', value: 'calories', filter: value => value < 300 },
+          { text: 'Fat (g)', value: 'fat' },
+          { text: 'Carbs (g)', value: 'carbs' },
+          { text: 'Protein (g)', value: 'protein' },
+          { text: 'Iron (%)', value: 'iron' }
         ]
       }
     });
 
-    wrapper.setProps({ search: "EA" });
+    wrapper.setProps({ search: 'EA' });
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.internalCurrentItems).toHaveLength(1);
   })

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -936,13 +936,13 @@ describe('VDataTable.ts', () => {
           { text: 'Fat (g)', value: 'fat' },
           { text: 'Carbs (g)', value: 'carbs' },
           { text: 'Protein (g)', value: 'protein' },
-          { text: 'Iron (%)', value: 'iron' }
-        ]
-      }
-    });
+          { text: 'Iron (%)', value: 'iron' },
+        ],
+      },
+    })
 
-    wrapper.setProps({ search: 'EA' });
-    await wrapper.vm.$nextTick();
-    expect(wrapper.vm.internalCurrentItems).toHaveLength(1);
+    wrapper.setProps({ search: 'EA' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(1)
   })
 })

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -857,22 +857,13 @@ describe('VDataTable.ts', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  // https://github.com/vuetifyjs/vuetify/issues/11179
-  it('should return rows from columns that exclusively match custom filters', async () => {
+  it('should return rows matching custom filters', async () => {
     const wrapper = mountFunction({
       propsData: {
         items: testItems,
         headers: [
-          {
-            text: 'Dessert (100g serving)',
-            align: 'left',
-            filter: (value, search) => {
-              if (!search) return true
-              return value === search
-            },
-            value: 'name',
-          },
-          { text: 'Calories', value: 'calories' },
+          { text: 'Dessert (100g serving)', align: 'left', value: 'name' },
+          { text: 'Calories', value: 'calories', filter: value => value === 159 },
           { text: 'Fat (g)', value: 'fat' },
           { text: 'Carbs (g)', value: 'carbs' },
           { text: 'Protein (g)', value: 'protein' },
@@ -881,11 +872,6 @@ describe('VDataTable.ts', () => {
       },
     })
 
-    wrapper.setProps({ search: 'eclair' })
-    await wrapper.vm.$nextTick()
-    expect(wrapper.vm.internalCurrentItems).toHaveLength(0)
-
-    wrapper.setProps({ search: 'Eclair' })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.internalCurrentItems).toHaveLength(1)
   })
@@ -914,5 +900,49 @@ describe('VDataTable.ts', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('should return rows matching search term if specified', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: testItems,
+        headers: [
+          { text: 'Dessert (100g serving)', align: 'left', value: 'name' },
+          { text: 'Calories', value: 'calories' },
+          { text: 'Fat (g)', value: 'fat' },
+          { text: 'Carbs (g)', value: 'carbs' },
+          { text: 'Protein (g)', value: 'protein' },
+          { text: 'Iron (%)', value: 'iron' },
+        ],
+      },
+    })
+
+    wrapper.setProps({ search: 'unknown-term' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(0)
+
+    wrapper.setProps({ search: 'Eclair' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(1)
+  })
+
+  it("should return results which match both search term and column filters if both specified", async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: testItems,
+        headers: [
+          { text: "Dessert (100g serving)", align: "left", value: "name" },
+          { text: "Calories", value: "calories", filter: value => value < 300 },
+          { text: "Fat (g)", value: "fat" },
+          { text: "Carbs (g)", value: "carbs" },
+          { text: "Protein (g)", value: "protein" },
+          { text: "Iron (%)", value: "iron" }
+        ]
+      }
+    });
+
+    wrapper.setProps({ search: "EA" });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(1);
   })
 })


### PR DESCRIPTION
## Description
Ensure that filters and search terms are combined to display the intersection of results, rather than the union - so each filter applied makes the set of matches smaller for refined searching.

fixes #11402 

## Motivation and Context
There is some discussion on issue #11402 , but the current behaviour is very surprising and unlikely to be what a majority of users would want.
Note that I have not marked this as a breaking change, though it changes behaviour - as in the wording below "would cause existing functionality to not work as expected", I don't believe the current behaviour is what would be expected..

## How Has This Been Tested?
Unit tests included for the case where we have column filtering only, search term only and both. I replaced a previous test which would no longer pass, since it would include items which matched EITHER search term OR column filter.
Note that I added two of the tests at the end as the snapshot IDs changed otherwise and I thought it best not to require regenerating that as part of this.
<!-- Please describe how you tested your changes. -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
(See unit tests)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library) (no changes, since they are already inline with the change)
