### PR TITLE
feat(vdatafooter): add itemsPerPageMenuProps to VDataFooter

### DIFF
--- a/packages/docs/src/lang/en/components/DataIterators.json
+++ b/packages/docs/src/lang/en/components/DataIterators.json
@@ -38,7 +38,7 @@
       "itemsPerPageAllText": "Text for 'All' option in items-per-page dropdown",
       "itemsPerPageOptions": "Array of options to show in the items-per-page dropdown",
       "itemsPerPageText": "Text for items-per-page dropdown",
-      "itemsPerPageMenuProps": "Pass props through to the `v-menu` items per page component. Accepts either a string for boolean props `menu-props=\"auto, overflowY\"`, or an object `:menu-props=\"{ auto: true, overflowY: true }\"`",
+      "itemsPerPageMenuProps": "Pass props to the \"Items per page\" `v-menu` component. Accepts either a string for boolean props `items-per-page-menu-props=\"auto, overflowY\"`, or an object `:items-per-page-menu-props=\"{ auto: true, overflowY: true }\"`",
       "lastIcon": "Last icon",
       "nextIcon": "Next icon",
       "options": "DataOptions",

--- a/packages/docs/src/lang/en/components/DataIterators.json
+++ b/packages/docs/src/lang/en/components/DataIterators.json
@@ -38,6 +38,7 @@
       "itemsPerPageAllText": "Text for 'All' option in items-per-page dropdown",
       "itemsPerPageOptions": "Array of options to show in the items-per-page dropdown",
       "itemsPerPageText": "Text for items-per-page dropdown",
+      "itemsPerPageMenuProps": "Pass props through to the `v-menu` items per page component. Accepts either a string for boolean props `menu-props=\"auto, overflowY\"`, or an object `:menu-props=\"{ auto: true, overflowY: true }\"`",
       "lastIcon": "Last icon",
       "nextIcon": "Next icon",
       "options": "DataOptions",

--- a/packages/docs/src/lang/en/components/DataTables.json
+++ b/packages/docs/src/lang/en/components/DataTables.json
@@ -146,6 +146,22 @@
       "singleSelect": "Toggles rendering of select-all checkbox",
       "someItems": "Indicates if one or more items in table are selected",
       "sortIcon": "Icon used for sort button"
+    },
+    "v-data-footer": {
+      "disableItemsPerPage": "Disables items-per-page dropdown",
+      "disablePagination": "Disables pagination buttons",
+      "firstIcon": "First icon",
+      "itemsPerPageAllText": "Text for 'All' option in items-per-page dropdown",
+      "itemsPerPageOptions": "Array of options to show in the items-per-page dropdown",
+      "itemsPerPageText": "Text for items-per-page dropdown",
+      "itemsPerPageMenuProps": "Pass props through to the `v-menu` items per page component. Accepts either a string for boolean props `menu-props=\"auto, overflowY\"`, or an object `:menu-props=\"{ auto: true, overflowY: true }\"`",
+      "lastIcon": "Last icon",
+      "nextIcon": "Next icon",
+      "options": "DataOptions",
+      "pagination": "DataPagination",
+      "prevIcon": "Previous icon",
+      "showCurrentPage": "Show current page number between prev/next icons",
+      "showFirstLastPage": "Show first/last icons"
     }
   },
   "slots": {

--- a/packages/docs/src/lang/en/components/DataTables.json
+++ b/packages/docs/src/lang/en/components/DataTables.json
@@ -154,7 +154,7 @@
       "itemsPerPageAllText": "Text for 'All' option in items-per-page dropdown",
       "itemsPerPageOptions": "Array of options to show in the items-per-page dropdown",
       "itemsPerPageText": "Text for items-per-page dropdown",
-      "itemsPerPageMenuProps": "Pass props through to the `v-menu` items per page component. Accepts either a string for boolean props `menu-props=\"auto, overflowY\"`, or an object `:menu-props=\"{ auto: true, overflowY: true }\"`",
+      "itemsPerPageMenuProps": "Pass props to the \"Rows per page\" `v-menu` component. Accepts either a string for boolean props `items-per-page-menu-props=\"auto, overflowY\"`, or an object `:items-per-page-menu-props=\"{ auto: true, overflowY: true }\"`",
       "lastIcon": "Last icon",
       "nextIcon": "Next icon",
       "options": "DataOptions",

--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -50,6 +50,10 @@ export default Vue.extend({
       type: String,
       default: '$vuetify.dataFooter.itemsPerPageAll',
     },
+    itemsPerPageMenuProps: {
+      type: [String, Array, Object],
+      default: null,
+    },
     showFirstLastPage: Boolean,
     showCurrentPage: Boolean,
     disablePagination: Boolean,
@@ -107,6 +111,19 @@ export default Vue.extend({
 
       if (!computedIPPO.find(ippo => ippo.value === value)) value = computedIPPO[0]
 
+      const itemsPerPageSelectProps = {
+        disabled: this.disableItemsPerPage,
+        items: computedIPPO,
+        value,
+        hideDetails: true,
+        auto: true,
+        minWidth: '75px',
+      } as any
+
+      if (this.itemsPerPageMenuProps) {
+        itemsPerPageSelectProps.menuProps = this.itemsPerPageMenuProps
+      }
+
       return this.$createElement('div', {
         staticClass: 'v-data-footer__select',
       }, [
@@ -115,14 +132,7 @@ export default Vue.extend({
           attrs: {
             'aria-label': this.itemsPerPageText,
           },
-          props: {
-            disabled: this.disableItemsPerPage,
-            items: computedIPPO,
-            value,
-            hideDetails: true,
-            auto: true,
-            minWidth: '75px',
-          },
+          props: itemsPerPageSelectProps,
           on: {
             input: this.onChangeItemsPerPage,
           },

--- a/packages/vuetify/src/components/VDataIterator/__tests__/VDataFooter.spec.ts
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/VDataFooter.spec.ts
@@ -59,6 +59,9 @@ describe('VDataFooter.ts', () => {
           pageCount: 10,
           itemsLength: 100,
         },
+        itemsPerPageMenuProps: {
+          contentClass: 'some-css-class',
+        },
       },
     })
 


### PR DESCRIPTION
Added possibility to specify `menuProps` on "items per page" select in VDataFooter component.

fix #10535

## Description
When using VDataTable with default footer, there is no possibility to customize the "items per page" list. It is described in detail in #10535.

This PR adds the possibility to specify custom **menuProps** on VDataFooter. So, i.e. now on VDataTable I can specify:
```
:footer-props="{
    itemsPerPageMenuProps: { contentClass: 'my-fancy-class' }
}"
```

## Motivation and Context
The inability to just simply target the "Items per page" list in `v-data-table` default footer was a little bit annoying for me. That's why I made this PR.

## How Has This Been Tested?
visually

## Markup:
<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table
      :headers="headers"
      :items="desserts"
      :items-per-page="5"
      class="elevation-1"
      :footer-props="{
        itemsPerPageMenuProps: { contentClass: 'my-fancy-class' }
      }"
    ></v-data-table>
  </v-container>
</template>

<script>
  export default {
    data() {
      return {
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'left',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
