### PR TITLE
docs: Fixed icon reference

### DIFF
--- a/packages/docs/src/examples/text-fields/simple/icon.vue
+++ b/packages/docs/src/examples/text-fields/simple/icon.vue
@@ -7,22 +7,22 @@
 
           <v-text-field
             label="Prepend"
-            prepend-icon="place"
+            prepend-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             label="Prepend inner"
-            prepend-inner-icon="place"
+            prepend-inner-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             label="Append"
-            append-icon="place"
+            append-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             label="Append outer"
-            append-outer-icon="place"
+            append-outer-icon="mdi-map-marker"
           ></v-text-field>
 
         </v-col>
@@ -32,25 +32,25 @@
           <v-text-field
             solo
             label="Prepend"
-            prepend-icon="place"
+            prepend-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             solo
             label="Prepend inner"
-            prepend-inner-icon="place"
+            prepend-inner-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             solo
             label="Append"
-            append-icon="place"
+            append-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             solo
             label="Append outer"
-            append-outer-icon="place"
+            append-outer-icon="mdi-map-marker"
           ></v-text-field>
 
         </v-col>
@@ -60,25 +60,25 @@
           <v-text-field
             filled
             label="Prepend"
-            prepend-icon="place"
+            prepend-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             filled
             label="Prepend inner"
-            prepend-inner-icon="place"
+            prepend-inner-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             filled
             label="Append"
-            append-icon="place"
+            append-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             filled
             label="Append outer"
-            append-outer-icon="place"
+            append-outer-icon="mdi-map-marker"
           ></v-text-field>
 
         </v-col>
@@ -88,25 +88,25 @@
           <v-text-field
             outlined
             label="Prepend"
-            prepend-icon="place"
+            prepend-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             outlined
             label="Prepend inner"
-            prepend-inner-icon="place"
+            prepend-inner-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             outlined
             label="Append"
-            append-icon="place"
+            append-icon="mdi-map-marker"
           ></v-text-field>
 
           <v-text-field
             outlined
             label="Append outer"
-            append-outer-icon="place"
+            append-outer-icon="mdi-map-marker"
           ></v-text-field>
 
         </v-col>


### PR DESCRIPTION
# Before
<img width="491" alt="before" src="https://user-images.githubusercontent.com/38455912/84569559-98615e00-adc2-11ea-8d8d-58f9c105eeab.png">

# After
<img width="486" alt="after" src="https://user-images.githubusercontent.com/38455912/84569565-a1522f80-adc2-11ea-9f2f-0311108fbdf8.png">

[Reference](https://vuetifyjs.com/en/components/text-fields/#text-fields)
Text field / icons