### PR TITLE
fix(VVirtualscroll): calculate child on mounted instead of created

### DIFF
--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.ts
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.ts
@@ -62,7 +62,7 @@ export default Measurable.extend({
     itemHeight: 'onScroll',
   },
 
-  created () {
+  mounted () {
     this.last = this.getLast(0)
   },
 

--- a/packages/vuetify/src/components/VVirtualScroll/__tests__/VVirtualScroll.spec.ts
+++ b/packages/vuetify/src/components/VVirtualScroll/__tests__/VVirtualScroll.spec.ts
@@ -39,11 +39,12 @@ describe('VVirtualScroll.ts', () => {
     mock.mockRestore()
   })
 
-  it('should render component with scopedSlot and match snapshot', () => {
+  it('should render component with scopedSlot and match snapshot', async () => {
     const wrapper = mountFunction({
       propsData,
     })
 
+    await wrapper.vm.$nextTick()
     expect(wrapper.html()).toMatchSnapshot()
   })
 


### PR DESCRIPTION
fix #11707

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
resolves #11707 
Calculate children to render on mounted instead of created.
This is because if the user instantiate a vvirtualscroller without providing a value for the `height` prop in the created we were falling back to $el.clientHeight value, but in created there is no DOM
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/vuetifyjs/vuetify/issues/11707

## How Has This Been Tested?
Playground and update a unit test that were affected by this change
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-app id="inspire">
      <v-card
        class="mx-auto"
        max-width="400"
          height="300"
      >
        <v-card-title class="white--text orange darken-4">
          User Directory
    
          <v-spacer></v-spacer>
    
          <v-btn
            color="white"
            class="text--primary"
            fab
            small
          >
            <v-icon>mdi-plus</v-icon>
          </v-btn>
        </v-card-title>
    
        <v-card-text class="pt-4">
          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Quasi nobis a at voluptates culpa optio amet! Inventore deserunt voluptatem maxime a veniam placeat, eos impedit nulla quos? Officiis, aperiam ducimus.
        </v-card-text>
    
        <v-divider></v-divider>
    
        <v-virtual-scroll
          :items="items"
          :item-height="50"
        >
          <template v-slot="{ index, item }">
            <v-list-item>
              <v-list-item-avatar>
                <v-avatar
                  :color="item.color"
                  size="56"
                  class="white--text"
                >
                  {{ item.initials }}
                </v-avatar>
              </v-list-item-avatar>
    
              <v-list-item-content>
                <v-list-item-title>{{ index + ': ' + item.fullName }}</v-list-item-title>
              </v-list-item-content>
    
              <v-list-item-action>
                <v-btn
                  depressed
                  small
                >
                  View User
    
                  <v-icon
                    color="orange darken-4"
                    right
                  >
                    mdi-open-in-new
                  </v-icon>
                </v-btn>
              </v-list-item-action>
            </v-list-item>
          </template>
        </v-virtual-scroll>
      </v-card>
    </v-app>
  </v-container>
</template>

<script>
import VDataTable from '../src/components'
import VSelect from '../src/components'

export default {
  data: () => ({
    colors: ['#2196F3', '#90CAF9', '#64B5F6', '#42A5F5', '#1E88E5', '#1976D2', '#1565C0', '#0D47A1', '#82B1FF', '#448AFF', '#2979FF', '#2962FF'],
    names: ['Oliver', 'Jake', 'Noah', 'James', 'Jack', 'Connor', 'Liam', 'John', 'Harry', 'Callum', 'Mason', 'Robert', 'Jacob', 'Jacob', 'Jacob', 'Michael', 'Charlie', 'Kyle', 'William', 'William', 'Thomas', 'Joe', 'Ethan', 'David', 'George', 'Reece', 'Michael', 'Richard', 'Oscar', 'Rhys', 'Alexander', 'Joseph', 'James', 'Charlie', 'James', 'Charles', 'William', 'Damian', 'Daniel', 'Thomas', 'Amelia', 'Margaret', 'Emma', 'Mary', 'Olivia', 'Samantha', 'Olivia', 'Patricia', 'Isla', 'Bethany'],
    surnames: ['Smith', 'Anderson', 'Clark', 'Wright', 'Mitchell', 'Johnson', 'Thomas', 'Rodriguez', 'Lopez', 'Perez', 'Williams', 'Jackson', 'Lewis', 'Hill', 'Roberts', 'Jones', 'White', 'Lee', 'Scott', 'Turner', 'Brown', 'Harris', 'Walker', 'Green', 'Phillips', 'Davis', 'Martin', 'Hall', 'Adams', 'Campbell', 'Miller', 'Thompson', 'Allen', 'Baker', 'Parker', 'Wilson', 'Garcia', 'Young', 'Gonzalez', 'Evans', 'Moore', 'Martinez', 'Hernandez', 'Nelson', 'Edwards', 'Taylor', 'Robinson', 'King', 'Carter', 'Collins'],
  }),

  computed: {
    items () {
      const namesLength = this.names.length
      const surnamesLength = this.surnames.length
      const colorsLength = this.colors.length

      return Array.from({ length: 10000 }, (k, v) => {
        const name = this.names[this.genRandomIndex(namesLength)]
        const surname = this.surnames[this.genRandomIndex(surnamesLength)]

        return {
          color: this.colors[this.genRandomIndex(colorsLength)],
          fullName: `${name} ${surname}`,
          initials: `${name[0]} ${surname[0]}`,
        }
      })
    },
  },

  methods: {
    genRandomIndex (length) {
      return Math.ceil(Math.random() * (length - 1))
    },
  },
}
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
