### PR TITLE
fix(locales): hu-Hungarian 1i8n translation

### DIFF
--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -1,21 +1,21 @@
 export default {
   badge: 'Jelvény',
-  close: 'Close',
+  close: 'Bezárás',
   dataIterator: {
     noResultsText: 'Nincs egyező találat',
-    loadingText: 'Loading item...',
+    loadingText: 'Betöltés...',
   },
   dataTable: {
     itemsPerPageText: 'Elem oldalanként:',
     ariaLabel: {
-      sortDescending: 'Sorted descending. Activate to remove sorting.',
-      sortAscending: 'Sorted ascending. Activate to sort descending.',
-      sortNone: 'Not sorted. Activate to sort ascending.',
-      activateNone: 'Activate to remove sorting.',
-      activateDescending: 'Activate to sort descending.',
-      activateAscending: 'Activate to sort ascending.',
+      sortDescending: 'Csökkenő sorrendbe rendezve.',
+      sortAscending: 'Növekvő sorrendbe rendezve.',
+      sortNone: 'Rendezetlen.',
+      activateNone: 'Rendezés törlése.',
+      activateDescending: 'Aktiváld a csökkenő rendezésért.',
+      activateAscending: 'Aktiváld a növekvő rendezésért.',
     },
-    sortBy: 'Sort by',
+    sortBy: 'Rendezés',
   },
   dataFooter: {
     itemsPerPageText: 'Elem oldalanként:',
@@ -27,7 +27,7 @@ export default {
     pageText: '{0}-{1} / {2}',
   },
   datePicker: {
-    itemsSelected: '{0} kiválaszta/-ott',
+    itemsSelected: '{0} kiválasztva',
     nextMonthAriaLabel: 'Következő hónap',
     nextYearAriaLabel: 'Következő év',
     prevMonthAriaLabel: 'Előző hónap',
@@ -35,30 +35,30 @@ export default {
   },
   noDataText: 'Nincs elérhető adat',
   carousel: {
-    prev: 'Korábbi vizuális',
-    next: 'Következő vizuális',
+    prev: 'Előző',
+    next: 'Következő',
     ariaLabel: {
-      delimiter: 'Carousel slide {0} of {1}',
+      delimiter: 'Dia {0}/{1}',
     },
   },
   calendar: {
     moreEvents: '{0} további',
   },
   fileInput: {
-    counter: '{0} files',
-    counterSize: '{0} files ({1} in total)',
+    counter: '{0} fájl',
+    counterSize: '{0} fájl ({1} összesen)',
   },
   timePicker: {
-    am: 'AM',
-    pm: 'PM',
+    am: 'de',
+    pm: 'du',
   },
   pagination: {
     ariaLabel: {
-      wrapper: 'Lapszámozásának navigáció',
+      wrapper: 'Oldal navigáció',
       next: 'Következő oldal',
       previous: 'Előző oldal',
-      page: 'Menj az oldalra {0}',
-      currentPage: 'Aktuális oldal, oldal {0}',
+      page: 'Menj a(z) {0}. oldalra',
+      currentPage: 'Aktuális oldal: {0}',
     },
   },
 }


### PR DESCRIPTION
Fixed hu-Hungarian i18n

## Description
Following keys were changed:
### Fixed
- datePicker.itemsSelected
- carousel.prev
- carousel.next
- pagination.ariaLabel.wrapper
- pagination.ariaLabel.page
- pagination.ariaLabel.currentPage


### Translated
- close
- dataIterator.loadingText
- dataTable.ariaLabel.sortDescending
- dataTable.ariaLabel.sortAscending
- dataTable.ariaLabel.sortNone
- dataTable.ariaLabel.activateNone
- dataTable.ariaLabel.activateDescending
- dataTable.ariaLabel.activateAscending
- dataTable.sortBy
- carousel.ariaLabel.delimiter
- fileInput.counter
- fileInput.counterSize
- timePicker.am
- timePicker.pm

## Motivation and Context
The hungarian translation was incomplete and incorrect.

## How Has This Been Tested?
As far as the changes are only visual, every occurrence in components are tested by implementing them in a project.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
