### PR TITLE
fix(VDataTable): respect hide-default-header prop on mobile

### DIFF
--- a/packages/vuetify/src/components/VDataTable/MobileRow.ts
+++ b/packages/vuetify/src/components/VDataTable/MobileRow.ts
@@ -11,6 +11,7 @@ export default Vue.extend({
     headers: Array as PropType<DataTableHeader[]>,
     item: Object,
     rtl: Boolean,
+    hideDefaultHeader: Boolean,
   },
 
   render (h, { props, slots, data }): VNode {
@@ -42,7 +43,7 @@ export default Vue.extend({
         }, children),
       ]
 
-      if (header.value !== 'dataTableSelect') {
+      if (header.value !== 'dataTableSelect' && !props.hideDefaultHeader) {
         mobileRowChildren.unshift(
           h('div', {
             staticClass: 'v-data-table__mobile-row__header',

--- a/packages/vuetify/src/components/VDataTable/MobileRow.ts
+++ b/packages/vuetify/src/components/VDataTable/MobileRow.ts
@@ -9,9 +9,9 @@ export default Vue.extend({
 
   props: {
     headers: Array as PropType<DataTableHeader[]>,
+    hideDefaultHeader: Boolean,
     item: Object,
     rtl: Boolean,
-    hideDefaultHeader: Boolean,
   },
 
   render (h, { props, slots, data }): VNode {

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -464,9 +464,9 @@ export default mixins(
         ),
         props: {
           headers: this.computedHeaders,
+          hideDefaultHeader: this.hideDefaultHeader,
           item,
           rtl: this.$vuetify.rtl,
-          hideDefaultHeader: this.hideDefaultHeader,
         },
         scopedSlots,
         on: {

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -466,6 +466,7 @@ export default mixins(
           headers: this.computedHeaders,
           item,
           rtl: this.$vuetify.rtl,
+          hideDefaultHeader: this.hideDefaultHeader,
         },
         scopedSlots,
         on: {

--- a/packages/vuetify/src/components/VDataTable/__tests__/MobileRow.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/MobileRow.spec.ts
@@ -121,11 +121,11 @@ describe('MobileRow', () => {
             { text: 'Petrol', value: 'petrol' },
             { text: 'Diesel', value: 'diesel' },
           ],
+          hideDefaultHeader: true,
           item: {
             petrol: 0.68,
             diesel: 0.65,
           },
-          hideDefaultHeader: true,
         },
       },
     })

--- a/packages/vuetify/src/components/VDataTable/__tests__/MobileRow.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/MobileRow.spec.ts
@@ -112,4 +112,27 @@ describe('MobileRow', () => {
     expect(wrapper.findAll('p.test')).toHaveLength(2)
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('should render without header when hideDefaultHeader: true', () => {
+    const wrapper = mountFunction({
+      context: {
+        props: {
+          headers: [
+            { text: 'Petrol', value: 'petrol' },
+            { text: 'Diesel', value: 'diesel' },
+          ],
+          item: {
+            petrol: 0.68,
+            diesel: 0.65,
+          },
+          hideDefaultHeader: true,
+        },
+      },
+    })
+
+    expect(wrapper.findAll('tr')).toHaveLength(1)
+    expect(wrapper.findAll('td')).toHaveLength(2)
+    expect(wrapper.findAll('.v-data-table__mobile-row__header')).toHaveLength(0)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/MobileRow.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/MobileRow.spec.ts.snap
@@ -102,6 +102,21 @@ exports[`MobileRow should render with scoped slots 1`] = `
 </tr>
 `;
 
+exports[`MobileRow should render without header when hideDefaultHeader: true 1`] = `
+<tr class="v-data-table__mobile-table-row">
+  <td class="v-data-table__mobile-row">
+    <div class="v-data-table__mobile-row__cell">
+      0.68
+    </div>
+  </td>
+  <td class="v-data-table__mobile-row">
+    <div class="v-data-table__mobile-row__cell">
+      0.65
+    </div>
+  </td>
+</tr>
+`;
+
 exports[`MobileRow should render without slots 1`] = `
 <tr class="v-data-table__mobile-table-row">
   <td class="v-data-table__mobile-row">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Don't render the inline column headers on mobile when hide-default-header is specified on the VDataTable. Fixes #8774
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Fixes #8774
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
unit, visually
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <h1>Table below</h1>
    <v-data-table
      :headers="headers"
      :items="names"
      :items-per-page="5"
      class="elevation-1"
    ></v-data-table>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    headers: [
      {
        text: "Name",
        value: "name",
      },
    ],
    names: [
      {
        name: "Oscar",
      },
      {
        name: "Orlando",
      },
      {
        name: "Osvaldo",
      },
    ],
  }),
};
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
