### PR TITLE
docs(SassVariables): add additionalData for sass-loader v9.0.0 update

### DIFF
--- a/packages/docs/src/lang/en/customization/SassVariables.json
+++ b/packages/docs/src/lang/en/customization/SassVariables.json
@@ -20,7 +20,7 @@
   "componentSassImportText1c": "The second method is to import your project's _specific_ variables file. This is recommended if you are using your own variables file to import the global Vuetify styles.",
   "componentSassImportText1d": "Keep in mind, it _does not matter_ which syntax you use, SASS or SCSS, when importing and using variable files.",
   "webpackHeading": "## Webpack install",
-  "webpackText1": "This section assumes you have already followed our Webpack guide on the [Quick start](/getting-started/quick-start#webpack-install) page. The option can vary depending upon the version of [sass-loader](https://github.com/webpack-contrib/sass-loader) you are use using. Ensure that you use the proper syntax when setting up the SASS/SCSS data options as they have different line endings. You can find more information about [prependData](https://github.com/webpack-contrib/sass-loader#prependdata) on sass-loader's Github page.",
+  "webpackText1": "This section assumes you have already followed our Webpack guide on the [Quick start](/getting-started/quick-start#webpack-install) page. The option can vary depending upon the version of [sass-loader](https://github.com/webpack-contrib/sass-loader) you are use using. Ensure that you use the proper syntax when setting up the SASS/SCSS data options as they have different line endings. You can find more information about [additionalData](https://github.com/webpack-contrib/sass-loader#additionaldata) or [prependData](https://github.com/webpack-contrib/sass-loader/tree/v8.0.0#prependdata) on sass-loader's Github page.",
   "exampleHeading1": "## Example variable file",
   "exampleText1a": "Below is an example of what a variable file looks like:"
 }

--- a/packages/docs/src/snippets/js/webpack_sass_variables.txt
+++ b/packages/docs/src/snippets/js/webpack_sass_variables.txt
@@ -22,6 +22,11 @@ module.exports = {
               // This is the path to your variables
               prependData: "@import '@/styles/variables.scss'"
             },
+            // Requires sass-loader@^9.0.0
+            options: {
+              // This is the path to your variables
+              additionalData: "@import '@/styles/variables.scss'"
+            },
           },
         ],
       },
@@ -43,6 +48,11 @@ module.exports = {
             options: {
               // This is the path to your variables
               prependData: "@import '@/styles/variables.scss';"
+            },
+            // Requires sass-loader@^9.0.0
+            options: {
+              // This is the path to your variables
+              additionalData: "@import '@/styles/variables.scss';"
             },
           },
         ],


### PR DESCRIPTION
this was changed with v9.0.0
https://github.com/webpack-contrib/sass-loader/releases/tag/v9.0.0

## Description
Our setup is using [sass-variables with `prependData` like described in the docs](https://vuetifyjs.com/en/customization/sass-variables/#webpack-install).

After upgrading [sass-loader](https://github.com/webpack-contrib/sass-loader/releases/tag/v9.0.0) to `9.0.0/9.0.1` builds started to fail with this error:

```
ValidationError: Invalid options object. Sass Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'prependData'. These properties are valid:
   object { implementation?, sassOptions?, additionalData?, sourceMap?, webpackImporter? }
```

Checking the release-notes of sass-loader 9.0.0 it states:

> the prependData option was removed in favor the additionalData option, see [docs](https://github.com/webpack-contrib/sass-loader#additionaldata)

Updating `prependData` to `additionalData` made it work again.  
This should inform others reading the docs to use the latest options for sass-laoder.

## Motivation and Context
Update docs to latest usage of sass-loader.


## How Has This Been Tested?
Builds are working again. Seems to look ok. How can this be tested more?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
