### PR TITLE
feat(VTextField): hide counter when input is not focused

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -66,6 +66,7 @@ export default baseMixins.extend<options>().extend({
     },
     counter: [Boolean, Number, String],
     counterValue: Function as PropType<(value: any) => number>,
+    counterShowOnFocus: Boolean,
     filled: Boolean,
     flat: Boolean,
     fullWidth: Boolean,
@@ -308,6 +309,10 @@ export default baseMixins.extend<options>().extend({
     },
     genCounter () {
       if (!this.hasCounter) return null
+
+      if (this.counterShowOnFocus && !this.isFocused) {
+        return null
+      }
 
       const max = this.counter === true ? this.attrs$.maxlength : this.counter
 

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -867,4 +867,21 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
     const input = wrapper.find('input')
     expect(input.element.value).toBe('-0')
   })
+
+  it('should hide counter if not focused when using the counter-show-on-focus prop', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        counter: true,
+        counterShowOnFocus: true,
+        value: 'text',
+      },
+    })
+    const input = wrapper.find('input')
+
+    await input.trigger('focus')
+    expect(wrapper.findAll('.v-counter').wrappers[0]).not.toBeUndefined()
+
+    await input.trigger('blur')
+    expect(wrapper.findAll('.v-counter').wrappers[0]).toBeUndefined()
+  })
 })


### PR DESCRIPTION

## Description
As per #7392 feature request, added a 'counter-show-on-focus' prop to v-text-field that, when set, modifies behaviour of counter display - counter becomes visible only when input has focus. Also added test for new feature.

## Motivation and Context
resolves https://github.com/vuetifyjs/vuetify/issues/7392

## How Has This Been Tested?
Updated existing unit tests for v-text-field and added new test for this feature.
Test imitates input focus and blur events and looks for el with class '.v-counter' to confirm it exists or not exists.

## Markup:

<details>

```vue
<template>
  <v-container>
    <v-text-field
      value="text"
      :counter="true"
      counter-show-on-focus
      :error="true"
      :error-messages="'error!'"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>

```
</details>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:

- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
