### PR TITLE
fix(VDataTable): on mobile, expand rows to fit text

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -21,20 +21,21 @@
 .v-data-table
   border-radius: $data-table-border-radius
 
-  tbody
-    tr
-      &.v-data-table__expanded
-        border-bottom: 0
+  > .v-data-table__wrapper
+    tbody
+      tr
+        &.v-data-table__expanded
+          border-bottom: 0
 
-      &.v-data-table__expanded__content
-        box-shadow: $data-table-expanded-content-box-shadow
+        &.v-data-table__expanded__content
+          box-shadow: $data-table-expanded-content-box-shadow
 
-  .v-data-table__mobile-table-row
-    display: initial
+    .v-data-table__mobile-table-row
+      display: initial
 
-  .v-data-table__mobile-row
-    height: initial
-    min-height: $data-table-mobile-row-min-height
+    .v-data-table__mobile-row
+      height: initial
+      min-height: $data-table-mobile-row-min-height
 
 .v-data-table__empty-wrapper
   text-align: center
@@ -46,6 +47,12 @@
 
   &__header
     font-weight: $data-table-mobile-row-header-font-weight
+    
+    +ltr()
+      padding-right: 16px
+
+    +rtl()
+      padding-left: 16px
 
   &__cell
     +ltr()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

There was already a rule resetting the row height for mobile row, but looks like after #11325 it no longer had enough CSS specificity to apply.
I increased the specificity of the rule, and also added padding for the mobile column header, which was brought up in a comment to #8411.
Fixes #8411

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #8411

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-data-table
    :headers="headers"
    :items="desserts"
    :items-per-page="5"
    class="elevation-1"
  ></v-data-table>
</template>

<script>
export default {
  data: () => ({
    headers: [
      {
        text: "Dessert (100g serving)",
        align: "left",
        sortable: false,
        value: "name",
      },
      { text: "Calories", value: "calories" },
      { text: "Fat (g)", value: "fat" },
      { text: "Carbs (g)", value: "carbs" },
      { text: "Protein (g)", value: "protein" },
      { text: "Test", value: "iron" },
    ],
    desserts: [
      {
        name: "Frozen Yogurt",
        calories: 159,
        fat: 6.0,
        carbs: 24,
        protein: 4.0,
        iron:
          "text to demonstrate the inability for text to wrap without overlapping the row below it while in the mobile viewing mode if it surpasses two rows of text. Three rows is close, but four entirely spills over.",
      },
      {
        name: "Ice cream sandwich",
        calories: 237,
        fat: 9.0,
        carbs: 37,
        protein: 4.3,
        iron: "1%",
      },
    ],
  }),
};
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
