### PR TITLE
fix(VFileInput): avoid input field event capturing in safari

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.sass
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.sass
@@ -20,6 +20,7 @@
   input[type="file"]
     left: 0
     opacity: 0
+    pointer-events: none
     position: absolute
     max-width: 0
     width: 0


### PR DESCRIPTION
## Description

This pull request avoids that the native `input[type="file"]` field receives events when clicking on the input part of v-file-input.

Fixes #10832.

## Motivation and Context

With this change, v-file-input works as expected in Safari, as described in #10832.

## How Has This Been Tested?

I tested the change locally with the code provided in https://codepen.io/anon/pen/RXaPOX?&editable=true&editors=101.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<div id="app">
  <v-app id="inspire">
    <v-file-input label="File input"></v-file-input>
  </v-app>
</div>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
