### PR TITLE
fix(helpers): coerce name value to string in groupItems

### DIFF
--- a/packages/vuetify/src/components/VData/__tests__/VData.spec.ts
+++ b/packages/vuetify/src/components/VData/__tests__/VData.spec.ts
@@ -102,6 +102,38 @@ describe('VData.ts', () => {
     }))
   })
 
+  it('should group items with null key and missing key as a null group', async () => {
+    const render = jest.fn()
+    const items = [
+      { id: 1, text: 'foo', baz: null },
+      { id: 2, text: 'bar', baz: 'one' },
+      { id: 3, text: 'baz' },
+    ]
+
+    const wrapper = mountFunction({
+      propsData: {
+        items,
+        groupBy: ['baz'],
+      },
+      scopedSlots: {
+        default: render,
+      },
+    })
+
+    expect(render).toHaveBeenCalledWith(expect.objectContaining({
+      groupedItems: [
+        {
+          name: null,
+          items: [items[0], items[2]],
+        },
+        {
+          name: 'one',
+          items: [items[1]],
+        },
+      ],
+    }))
+  })
+
   it('should group items by deep keys', async () => {
     const render = jest.fn()
     const items = [

--- a/packages/vuetify/src/components/VData/__tests__/VData.spec.ts
+++ b/packages/vuetify/src/components/VData/__tests__/VData.spec.ts
@@ -123,7 +123,7 @@ describe('VData.ts', () => {
     expect(render).toHaveBeenCalledWith(expect.objectContaining({
       groupedItems: [
         {
-          name: null,
+          name: '',
           items: [items[0], items[2]],
         },
         {

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -268,10 +268,10 @@ export function groupItems<T extends any = any> (
 ): ItemGroup<T>[] {
   const key = groupBy[0]
   const groups: ItemGroup<T>[] = []
-  let current = null
+  let current = undefined
   for (var i = 0; i < items.length; i++) {
     const item = items[i]
-    const val = getObjectValueByPath(item, key)
+    const val = getObjectValueByPath(item, key, null)
     if (current !== val) {
       current = val
       groups.push({

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -268,7 +268,7 @@ export function groupItems<T extends any = any> (
 ): ItemGroup<T>[] {
   const key = groupBy[0]
   const groups: ItemGroup<T>[] = []
-  let current = undefined
+  let current
   for (var i = 0; i < items.length; i++) {
     const item = items[i]
     const val = getObjectValueByPath(item, key, null)

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -275,7 +275,7 @@ export function groupItems<T extends any = any> (
     if (current !== val) {
       current = val
       groups.push({
-        name: val || '',
+        name: val ?? '',
         items: [],
       })
     }

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -275,7 +275,7 @@ export function groupItems<T extends any = any> (
     if (current !== val) {
       current = val
       groups.push({
-        name: val,
+        name: val || '',
         items: [],
       })
     }

--- a/packages/vuetify/types/index.d.ts
+++ b/packages/vuetify/types/index.d.ts
@@ -81,7 +81,7 @@ export type TreeviewItemFunction = (item: object, search: string, textKey: strin
 export type SelectItemKey = string | (string | number)[] | ((item: object, fallback?: any) => any)
 
 export interface ItemGroup<T> {
-  name: string | null
+  name: string
   items: T[]
 }
 

--- a/packages/vuetify/types/index.d.ts
+++ b/packages/vuetify/types/index.d.ts
@@ -81,7 +81,7 @@ export type TreeviewItemFunction = (item: object, search: string, textKey: strin
 export type SelectItemKey = string | (string | number)[] | ((item: object, fallback?: any) => any)
 
 export interface ItemGroup<T> {
-  name: string
+  name: string | null
   items: T[]
 }
 


### PR DESCRIPTION
## Description
If the property which is used as groupBy contains null a TypeError is thrown (TypeError: Cannot read property 'items' of undefined) in https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/util/helpers.ts#L278 as the variable `current` is initialized with null.

Reproduction: https://codepen.io/WOL-Soft/pen/VweojBr

With this fix all items which are provided with null values or which completely miss the property used for grouping are grouped under a 'empty' group. The null group can be identified via the property `name` of the `ItemGroup` (name will be set to an empty string).

Fixes #12069
Fixes #12501 

## How Has This Been Tested?

* unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
