### PR TITLE
fix(VExpandTransition): Properly trigger transition listeners

### DIFF
--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -24,10 +24,10 @@ function verifyFactory (mergeMethod: (target: any, source: any) => any) {
     }
 
     if (targetSnapshot) {
-      expect(targetSnapshot).toStrictEqual(target)
+      expect(target).toStrictEqual(targetSnapshot)
     }
     if (sourceSnapshot) {
-      expect(sourceSnapshot).toStrictEqual(source)
+      expect(source).toStrictEqual(sourceSnapshot)
     }
   }
 }

--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -1,11 +1,33 @@
 import { mergeClasses, mergeListeners, mergeStyles } from '../mergeData'
 
+function copy(value) {
+  if (Array.isArray(value)) {
+    return value.map(copy)
+  }
+  if (typeof value === 'object' && value !== null) {
+    const dest = {}
+    for (const key in value) dest[key] = copy(value[key])
+    return dest
+  }
+  return value
+}
+
 function verifyFactory (mergeMethod: (target: any, source: any) => any) {
   return function verify (target: any, source: any, expected: any) {
+    const targetSnapshot = typeof target === 'object' ? copy(target) : null
+    const sourceSnapshot = typeof source === 'object' ? copy(source) : null
+
     if (expected === target) {
       expect(mergeMethod(target, source)).toBe(expected)
     } else {
       expect(mergeMethod(target, source)).toStrictEqual(expected)
+    }
+
+    if (targetSnapshot) {
+      expect(targetSnapshot).toStrictEqual(target)
+    }
+    if (sourceSnapshot) {
+      expect(sourceSnapshot).toStrictEqual(source)
     }
   }
 }

--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -1,6 +1,6 @@
 import { mergeClasses, mergeListeners, mergeStyles } from '../mergeData'
 
-function copy(value) {
+function copy (value) {
   if (Array.isArray(value)) {
     return value.map(copy)
   }

--- a/packages/vuetify/src/util/__tests__/mergeData.spec.ts
+++ b/packages/vuetify/src/util/__tests__/mergeData.spec.ts
@@ -1,12 +1,13 @@
+import { isObject } from '../helpers'
 import { mergeClasses, mergeListeners, mergeStyles } from '../mergeData'
 
-function copy (value) {
+function simpleClone (value) {
   if (Array.isArray(value)) {
-    return value.map(copy)
+    return value.map(simpleClone)
   }
-  if (typeof value === 'object' && value !== null) {
+  if (isObject(value)) {
     const dest = {}
-    for (const key in value) dest[key] = copy(value[key])
+    for (const key in value) dest[key] = simpleClone(value[key])
     return dest
   }
   return value
@@ -14,8 +15,8 @@ function copy (value) {
 
 function verifyFactory (mergeMethod: (target: any, source: any) => any) {
   return function verify (target: any, source: any, expected: any) {
-    const targetSnapshot = typeof target === 'object' ? copy(target) : null
-    const sourceSnapshot = typeof source === 'object' ? copy(source) : null
+    const targetClone = simpleClone(target)
+    const sourceClone = simpleClone(source)
 
     if (expected === target) {
       expect(mergeMethod(target, source)).toBe(expected)
@@ -23,11 +24,12 @@ function verifyFactory (mergeMethod: (target: any, source: any) => any) {
       expect(mergeMethod(target, source)).toStrictEqual(expected)
     }
 
-    if (targetSnapshot) {
-      expect(target).toStrictEqual(targetSnapshot)
+    // Ensure that mergeMethod does not mutate anything
+    if (isObject(target)) {
+      expect(target).toStrictEqual(targetClone)
     }
-    if (sourceSnapshot) {
-      expect(source).toStrictEqual(sourceSnapshot)
+    if (isObject(source)) {
+      expect(source).toStrictEqual(sourceClone)
     }
   }
 }

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -148,7 +148,7 @@ export function mergeListeners (
 
       if (dest[event]) {
         // Merge previous and new listeners. Note that dest[event] must not be
-        // altered, event if it was already an array. This is due to the fact
+        // altered, even if it was already an array. This is due to the fact
         // that neither "target" or "source" must be altered.
         dest[event] = [...wrapInArray(dest[event]), ...wrapInArray(listeners[event])]
       } else {

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -150,7 +150,7 @@ export function mergeListeners (
         // Merge previous and new listeners. Note that dest[event] must not be
         // altered, even if it was already an array. This is due to the fact
         // that neither "target" or "source" must be altered.
-        dest[event] = [...wrapInArray(dest[event]), ...wrapInArray(listeners[event])]
+        dest[event] = ([] as Function[]).concat(dest[event], listeners[event])
       } else {
         // Straight assign.
         dest[event] = listeners[event]

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -139,19 +139,24 @@ export function mergeListeners (
   if (!target) return source
   if (!source) return target
 
-  let event: string
+  const dest: { [key: string]: Function | Function[] } = {}
 
-  for (event of Object.keys(source)) {
-    // Concat function to array of functions if callback present.
-    if (target[event]) {
-      // Insert current iteration data in beginning of merged array.
-      target[event] = wrapInArray(target[event])
-      ;(target[event] as Function[]).push(...wrapInArray(source[event]))
-    } else {
-      // Straight assign.
-      target[event] = source[event]
+  for (const listeners of [target, source]) {
+    for (const event in listeners) {
+      if (!listeners[event]) continue
+      if (Array.isArray(listeners[event]) && listeners[event].length === 0) continue
+
+      if (dest[event]) {
+        // Merge previousa and new listeners. Note that dest[event] must not be
+        // altered, event if it was already an array. This is due to the fact
+        // that neither "target" or "source" must be altered.
+        dest[event] = [...wrapInArray(dest[event]), ...wrapInArray(listeners[event])]
+      } else {
+        // Straight assign.
+        dest[event] = listeners[event]
+      }
     }
   }
 
-  return target
+  return dest
 }

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -141,19 +141,19 @@ export function mergeListeners (
 
   const dest: { [key: string]: Function | Function[] } = {}
 
-  for (const listeners of [target, source]) {
-    for (const event in listeners) {
-      if (!listeners[event]) continue
-      if (Array.isArray(listeners[event]) && listeners[event].length === 0) continue
+  let i = 2
+
+  while (i--) {
+    for (const event in arguments[i]) {
+      if (!arguments[i][event]) continue
 
       if (dest[event]) {
-        // Merge previous and new listeners. Note that dest[event] must not be
-        // altered, even if it was already an array. This is due to the fact
-        // that neither "target" or "source" must be altered.
-        dest[event] = ([] as Function[]).concat(dest[event], listeners[event])
+        // Merge current listeners before (because we are iterating backwards).
+        // Note that neither "target" or "source" must be altered.
+        dest[event] = ([] as Function[]).concat(arguments[i][event], dest[event])
       } else {
         // Straight assign.
-        dest[event] = listeners[event]
+        dest[event] = arguments[i][event]
       }
     }
   }

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -132,28 +132,27 @@ export function mergeClasses (target: any, source: any) {
   return target ? wrapInArray(target).concat(source) : source
 }
 
-export function mergeListeners (
-  target: { [key: string]: Function | Function[] } | undefined,
-  source: { [key: string]: Function | Function[] } | undefined
-) {
-  if (!target) return source
-  if (!source) return target
+export function mergeListeners (...args: [
+  { [key: string]: Function | Function[] } | undefined,
+  { [key: string]: Function | Function[] } | undefined
+]) {
+  if (!args[0]) return args[1]
+  if (!args[1]) return args[0]
 
   const dest: { [key: string]: Function | Function[] } = {}
 
-  let i = 2
-
-  while (i--) {
-    for (const event in arguments[i]) {
-      if (!arguments[i][event]) continue
+  for (let i = 2; i--;) {
+    const arg = args[i]
+    for (const event in arg) {
+      if (!arg[event]) continue
 
       if (dest[event]) {
         // Merge current listeners before (because we are iterating backwards).
         // Note that neither "target" or "source" must be altered.
-        dest[event] = ([] as Function[]).concat(arguments[i][event], dest[event])
+        dest[event] = ([] as Function[]).concat(arg[event], dest[event])
       } else {
         // Straight assign.
-        dest[event] = arguments[i][event]
+        dest[event] = arg[event]
       }
     }
   }

--- a/packages/vuetify/src/util/mergeData.ts
+++ b/packages/vuetify/src/util/mergeData.ts
@@ -147,7 +147,7 @@ export function mergeListeners (
       if (Array.isArray(listeners[event]) && listeners[event].length === 0) continue
 
       if (dest[event]) {
-        // Merge previousa and new listeners. Note that dest[event] must not be
+        // Merge previous and new listeners. Note that dest[event] must not be
         // altered, event if it was already an array. This is due to the fact
         // that neither "target" or "source" must be altered.
         dest[event] = [...wrapInArray(dest[event]), ...wrapInArray(listeners[event])]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes https://github.com/vuetifyjs/vuetify/issues/12018

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/vuetifyjs/vuetify/issues/12018

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-btn @click="visible = !visible">toggle</v-btn>
    <v-expand-transition @afterEnter="afterEnter">
      <div v-if="visible" style="height: 100px; background: red">
        {{text}}
      </div>
    </v-expand-transition>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      visible: false,
      text: 'afterEnter was NOT triggered'
    }),
    methods: {
      afterEnter(el) {
        this.text = 'afterEnter WAS triggered'
      }
    }
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
