### PR TITLE
feat(_utilities.scss): custom width and height to elements (+grid)

### DIFF
--- a/packages/vuetify/src/styles/settings/_utilities.scss
+++ b/packages/vuetify/src/styles/settings/_utilities.scss
@@ -21,7 +21,7 @@ $utilities: map-deep-merge(
       print: true,
       property: display,
       class: d,
-      values: none inline inline-block block table table-row table-cell flex inline-flex
+      values: none inline inline-block block table table-row table-cell flex inline-flex grid
     ),
     "float": (
       responsive: true,
@@ -135,6 +135,29 @@ $utilities: map-deep-merge(
         12: 12,
         last: 13,
       ),
+    ),
+
+    // Spacing  
+    "width": (
+      property: width,
+      class: w,
+      values: (
+        25: 25%,
+        50: 50%,
+        75: 75%,
+        100: 100%
+      )
+    ),
+
+    "height": (
+      property: height,
+      class: h,
+      values: (
+        25: 25%,
+        50: 50%,
+        75: 75%,
+        100: 100%
+      )
     ),
 
     // Margin utilities


### PR DESCRIPTION
## Description
Custom classes that you can add to elements to give a certain width or height (e.g. w-50 to give 50%
width, h-75 to give 75% height etc). There is also another class added which is d-grid to display a grid

## Motivation and Context
Expanding useful classes which are used often

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
 <div class="d-grid">
      <div class="w-100 h-100 red">100%</div>
      <div class="w-75 h-75 orange">75%</div>
      <div class="w-50 h-50 yellow">50%</div>
      <div class="w-25 h-25 lime">25%</div>
</div>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
