### PR TITLE
fix(types): number should not be allowed as a current breakpoint name

### DIFF
--- a/packages/vuetify/src/mixins/mobile/index.ts
+++ b/packages/vuetify/src/mixins/mobile/index.ts
@@ -9,8 +9,8 @@ export default Vue.extend({
 
   props: {
     mobileBreakpoint: {
-      type: [Number, String] as PropType<BreakpointName>,
-      default (): BreakpointName | undefined {
+      type: [Number, String] as PropType<number | BreakpointName>,
+      default (): number | BreakpointName | undefined {
         // Avoid destroying unit
         // tests for users
         return this.$vuetify

--- a/packages/vuetify/types/services/breakpoint.d.ts
+++ b/packages/vuetify/types/services/breakpoint.d.ts
@@ -1,5 +1,5 @@
 // Types
-export type BreakpointName = number | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+export type BreakpointName = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 // Interfaces
 export interface Breakpoint {
@@ -23,13 +23,13 @@ export interface Breakpoint {
   xs: boolean
   xsOnly: boolean
   mobile: boolean
-  mobileBreakpoint: BreakpointName
+  mobileBreakpoint: number | BreakpointName
   thresholds: BreakpointThresholds
   scrollBarWidth: number
 }
 
 export interface BreakpointOptions {
-  mobileBreakpoint?: BreakpointName
+  mobileBreakpoint?: number | BreakpointName
   scrollBarWidth?: number
   thresholds?: Partial<BreakpointThresholds>
 }


### PR DESCRIPTION
## Description
`Breakpoint['name']` is now `number | 'xs' | 'xm' | ... `, should be only `'xs' | 'sm' | ...`

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
```vue
<script lang="ts">
  import Vue from 'vue'

  export default Vue.extend({
    mounted () {
      this.$vuetify.breakpoint.name.trim()
    },
  })
</script>
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
