### PR TITLE
fix(types): add missing icons to VuetifyIcons interface

### DIFF
--- a/packages/vuetify/types/services/icons.d.ts
+++ b/packages/vuetify/types/services/icons.d.ts
@@ -60,5 +60,8 @@ export interface VuetifyIcons {
   first: VuetifyIcon
   last: VuetifyIcon
   unfold: VuetifyIcon
+  file: VuetifyIcon
+  plus: VuetifyIcon
+  minus: VuetifyIcon
   [name: string]: VuetifyIcon
 }


### PR DESCRIPTION
Add missing icons (file|plus|minus) to VuetifyIcons interface

## Description
Added file, plus, minus to icons.d.ts to bring it into line with the icons listed in the preset [files](https://github.com/vuetifyjs/vuetify/tree/master/packages/vuetify/src/services/icons/presets)

## Motivation and Context
Consistency

## How Has This Been Tested?
Untested

## Markup:
N/A

<!-- Paste markup for testing your change --->
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
