### PR TITLE
fix(VTextField): properly detect activeElement from shadowRoot

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
@@ -206,6 +206,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should not display menu when tab focused', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: [1, 2],
         value: 1,
@@ -405,7 +406,9 @@ describe('VAutocomplete.ts', () => {
   })
 
   it('should select input text on focus', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
     const select = jest.fn()
     wrapper.vm.$refs.input.select = select
 

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
@@ -37,6 +37,7 @@ describe('VAutocomplete.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/3793
   it('should reset menu index after selection', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar'],
         value: 'foo',
@@ -54,6 +55,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should not remove a disabled item', () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         chips: true,
         multiple: true,
@@ -156,6 +158,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should not hide menu when no data but has no-data slot', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         combobox: true,
       },
@@ -172,7 +175,9 @@ describe('VAutocomplete.ts', () => {
 
   // https://github.com/vuetifyjs/vuetify/issues/2834
   it('should not update search if selectedIndex is > -1', () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
 
     const input = wrapper.find('input')
     const element = input.element as HTMLInputElement
@@ -198,6 +203,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should clear search input on clear callback', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         items: ['foo'],
@@ -278,6 +284,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should not show menu when items are updated and hide-no-data is enabled ', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         hideNoData: true,
         items: ['Something first'],
@@ -345,6 +352,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should auto select first', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         autoSelectFirst: true,
         items: [
@@ -373,6 +381,7 @@ describe('VAutocomplete.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/4580
   it('should display menu when hide-no-date and hide-selected are enabled and selected item does not match search', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: [1, 2],
         value: 1,
@@ -396,6 +405,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should retain search value when item selected and multiple is enabled', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['Sandra Adams', 'Ali Connors', 'Trevor Hansen', 'Tucker Smith'],
         multiple: true,
@@ -451,6 +461,7 @@ describe('VAutocomplete.ts', () => {
   it('should not replicate html select hotkeys in v-autocomplete', async () => {
     const onKeyPress = jest.fn()
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['aaa', 'foo', 'faa'],
       },

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -17,6 +17,7 @@ describe('VAutocomplete.ts', () => {
 
     mountFunction = (options = {}) => {
       return mount(VAutocomplete, {
+        attachToDocument: true,
         ...options,
         mocks: {
           $vuetify: {

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
@@ -173,7 +173,9 @@ describe('VCombobox.ts', () => {
   })
 
   it('should emit custom value on blur', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
 
     const input = wrapper.find('input')
     const element = input.element as HTMLInputElement
@@ -234,6 +236,7 @@ describe('VCombobox.ts', () => {
       { text: 'Vuetify', value: 3 },
     ]
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items,
       },

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
@@ -120,7 +120,9 @@ describe('VFileInput.ts', () => {
 
   it('should proxy icon and text click to input', () => {
     const fn = jest.fn()
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
 
     const input = wrapper.find('input').element
     input.click = fn
@@ -202,6 +204,7 @@ describe('VFileInput.ts', () => {
   it('should not emit change event when blurred', async () => {
     const change = jest.fn()
     const wrapper = mountFunction({
+      attachToDocument: true,
       listeners: {
         change,
       },

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
@@ -97,6 +97,7 @@ describe('VSelect.ts', () => {
 
   it('should toggle menu on icon click', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar'],
         'menu-props': {
@@ -397,6 +398,7 @@ describe('VSelect.ts', () => {
 
   it('should open menu when cleared with open-on-clear', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         openOnClear: true,
@@ -417,6 +419,7 @@ describe('VSelect.ts', () => {
   /* eslint-disable-next-line max-statements */
   it('should react to different key down', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: [1, 2, 3, 4],
       },

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect3.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect3.spec.ts
@@ -269,6 +269,7 @@ describe('VSelect.ts', () => {
   it('should use custom clear icon cb', async () => {
     const clearIconCb = jest.fn()
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         items: ['foo'],
@@ -350,7 +351,7 @@ describe('VSelect.ts', () => {
 
   // Inspired by https://github.com/vuetifyjs/vuetify/pull/1425 - Thanks @kevmo314
   it('should open the select when focused and enter, space, up or down are pressed', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({ attachToDocument: true })
 
     wrapper.vm.hasMouseDown = true
     wrapper.trigger('mouseup')

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect4.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect4.spec.ts
@@ -62,6 +62,7 @@ describe('VSelect.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/4431
   it('should accept null and "" as values', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         items: [
@@ -88,6 +89,7 @@ describe('VSelect.ts', () => {
 
   it('should only calls change once when clearing', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         items: ['foo'],
@@ -171,6 +173,7 @@ describe('VSelect.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/4853
   it('should select item after typing its first few letters', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['aaa', 'foo', 'faa'],
       },
@@ -192,6 +195,7 @@ describe('VSelect.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/10406
   it('should load more items when typing', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: Array.from({ length: 24 }, (_, i) => 'Item ' + i).concat('foo'),
       },
@@ -341,6 +345,7 @@ describe('VSelect.ts', () => {
 
   it('should close menu when append icon is clicked', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar'],
       },
@@ -359,6 +364,7 @@ describe('VSelect.ts', () => {
 
   it('should open menu when append icon is clicked', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar'],
       },
@@ -376,6 +382,7 @@ describe('VSelect.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/9960
   it('should not manipulate menu state if is readonly or disabled', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       data: () => ({ hasMouseDown: true }),
       propsData: { readonly: true },
     })

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -428,7 +428,10 @@ export default baseMixins.extend<options>().extend({
       }, this[type])
     },
     getActiveElement () {
-      return (this.$el.getRootNode() as ShadowRoot | HTMLDocument).activeElement
+      const rootNode = this.$el.getRootNode
+        ? this.$el.getRootNode() as ShadowRoot | HTMLDocument
+        : document // IE11
+      return rootNode.activeElement
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -431,9 +431,6 @@ export default baseMixins.extend<options>().extend({
       if (!this.$el.getRootNode) return document.activeElement // IE11
 
       const rootNode = this.$el.getRootNode()
-
-      if (rootNode === this.$el) return document.activeElement // jest
-
       return (rootNode as ShadowRoot | HTMLDocument).activeElement
     },
     onBlur (e?: Event) {

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -427,8 +427,8 @@ export default baseMixins.extend<options>().extend({
         ref: type,
       }, this[type])
     },
-    getActiveElement() {
-      return this.$el.getRootNode().activeElement
+    getActiveElement () {
+      return (this.$el.getRootNode() as ShadowRoot | HTMLDocument).activeElement
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -428,10 +428,13 @@ export default baseMixins.extend<options>().extend({
       }, this[type])
     },
     getActiveElement () {
-      const rootNode = this.$el.getRootNode
-        ? this.$el.getRootNode() as ShadowRoot | HTMLDocument
-        : document // IE11
-      return rootNode.activeElement
+      if (!this.$el.getRootNode) return document.activeElement // IE11
+
+      const rootNode = this.$el.getRootNode()
+
+      if (rootNode === this.$el) return document.activeElement // jest
+
+      return (rootNode as ShadowRoot | HTMLDocument).activeElement
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -427,6 +427,9 @@ export default baseMixins.extend<options>().extend({
         ref: type,
       }, this[type])
     },
+    getActiveElement() {
+      return this.$el.getRootNode().activeElement
+    },
     onBlur (e?: Event) {
       this.isFocused = false
       e && this.$nextTick(() => this.$emit('blur', e))
@@ -439,7 +442,7 @@ export default baseMixins.extend<options>().extend({
     onFocus (e?: Event) {
       if (!this.$refs.input) return
 
-      if (document.activeElement !== this.$refs.input) {
+      if (this.getActiveElement() !== this.$refs.input) {
         return this.$refs.input.focus()
       }
 
@@ -494,7 +497,7 @@ export default baseMixins.extend<options>().extend({
         !this.autofocus ||
         typeof document === 'undefined' ||
         !this.$refs.input ||
-        document.activeElement === this.$refs.input
+        this.getActiveElement() === this.$refs.input
       ) return false
 
       this.$refs.input.focus()

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -162,6 +162,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should clear input value', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         value: 'foo',
@@ -202,6 +203,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should not clear input if not clearable and has appended icon (without callback)', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         value: 'foo',
         appendIcon: 'block',
@@ -217,6 +219,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   it('should start validating on blur', async () => {
     const rule = jest.fn().mockReturnValue(true)
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         rules: [rule],
         validateOnBlur: true,
@@ -290,7 +293,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
         })
       },
     }
-    const wrapper = mount(component)
+    const wrapper = mount(component, { attachToDocument: true })
 
     const input = wrapper.findAll('input').at(0)
 
@@ -454,6 +457,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   it('should use a custom clear callback', async () => {
     const clear = jest.fn()
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         clearable: true,
         value: 'foo',
@@ -621,7 +625,9 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   })
 
   it('should fire change event when pressing enter', () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
     const input = wrapper.find('input')
     const change = jest.fn()
 
@@ -637,7 +643,9 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   })
 
   it('should have focus and blur methods', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
     const onBlur = jest.spyOn(wrapper.vm.$refs.input, 'blur')
     const onFocus = jest.spyOn(wrapper.vm.$refs.input, 'focus')
 
@@ -774,7 +782,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
         })
       },
     }
-    const wrapper = mount(component)
+    const wrapper = mount(component, { attachToDocument: true })
 
     const inputElement = wrapper.findAll('input').at(0)
     const clearIcon = wrapper.find('.v-input__icon--clear .v-icon')
@@ -809,6 +817,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should autofocus text-field when intersected', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: { autofocus: true },
     })
     const input = wrapper.find('input')
@@ -841,6 +850,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should use the correct icon color when using the solo inverted prop', () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: { soloInverted: true },
       mocks: {
         $vuetify: {

--- a/packages/vuetify/src/components/VTextarea/__tests__/VTextarea.spec.ts
+++ b/packages/vuetify/src/components/VTextarea/__tests__/VTextarea.spec.ts
@@ -114,7 +114,7 @@ describe('VTextarea.ts', () => {
   })
 
   it('should emit keydown event', () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({ attachToDocument: true })
     const keydown = jest.fn()
     const textarea = wrapper.find('textarea')
     wrapper.vm.$on('keydown', keydown)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
When an `input` element is inside a shadowDom, and is active (focused), the `document.activeElement` will not reference the input element but rather the shadowRoot. In order to properly detect what the `activeElement` is, we must use the proper root node for that element, as explained on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is part of the solution for:
- #7622

And an alternative implementation to:
- #12134
- #12142

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
none

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
