### PR TITLE
fix(VTextField): properly detect activeElement from shadowRoot

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
@@ -17,6 +17,7 @@ describe('VAutocomplete.ts', () => {
 
     mountFunction = (options = {}) => {
       return mount(VAutocomplete, {
+        attachToDocument: true,
         ...options,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
@@ -225,7 +226,6 @@ describe('VAutocomplete.ts', () => {
   // eslint-disable-next-line max-statements
   it.skip('should change selected index', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar', 'fizz'],
         multiple: true,
@@ -326,7 +326,6 @@ describe('VAutocomplete.ts', () => {
 
   it('should conditionally show the menu', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar', 'fizz'],
       },

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
@@ -17,6 +17,7 @@ describe('VAutocomplete.ts', () => {
 
     mountFunction = (options = {}) => {
       return mount(VAutocomplete, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         mocks: {

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -17,6 +17,7 @@ describe('VAutocomplete.ts', () => {
 
     mountFunction = (options = {}) => {
       return mount(VAutocomplete, {
+        attachToDocument: true,
         ...options,
         mocks: {
           $vuetify: {

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
@@ -16,6 +16,7 @@ describe('VCombobox.ts', () => {
 
     mountFunction = (options = {}) => {
       return mount(VCombobox, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         mocks: {
@@ -52,7 +53,6 @@ describe('VCombobox.ts', () => {
 
   it('should not use search input when blurring', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         eager: true,
         items: [1, 12],
@@ -121,7 +121,6 @@ describe('VCombobox.ts', () => {
   // TODO: fails with TS 3.9
   it.skip('should clear value', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
     })
     await wrapper.vm.$nextTick()
 
@@ -156,7 +155,6 @@ describe('VCombobox.ts', () => {
   it('should call methods on blur', async () => {
     const updateCombobox = jest.fn()
     const wrapper = mountFunction({
-      attachToDocument: true,
       methods: {
         updateCombobox,
       },
@@ -203,7 +201,6 @@ describe('VCombobox.ts', () => {
 
   it('should conditionally show the menu', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar', 'fizz'],
         searchInput: 'foobar',

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
@@ -120,8 +120,7 @@ describe('VCombobox.ts', () => {
 
   // TODO: fails with TS 3.9
   it.skip('should clear value', async () => {
-    const wrapper = mountFunction({
-    })
+    const wrapper = mountFunction()
     await wrapper.vm.$nextTick()
 
     const change = jest.fn()

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.ts
@@ -24,6 +24,7 @@ describe('VFileInput.ts', () => {
   beforeEach(() => {
     mountFunction = (options?: MountOptions<Instance>) => {
       return mount(VFileInput, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         mocks: {

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
@@ -20,6 +20,7 @@ describe('VSelect.ts', () => {
     document.body.appendChild(el)
     mountFunction = (options = {}) => {
       return mount(VSelect, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         mocks: {
@@ -160,7 +161,6 @@ describe('VSelect.ts', () => {
 
   it('should emit a single change event', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         attach: true,
         items: ['foo', 'bar'],
@@ -206,7 +206,6 @@ describe('VSelect.ts', () => {
   // Inspired by https://github.com/vuetifyjs/vuetify/pull/1425 - Thanks @kevmo314
   it('should open the select when focused and enter, space are pressed', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar'],
       },
@@ -228,7 +227,6 @@ describe('VSelect.ts', () => {
 
   it('should not open the select when readonly and focused and enter, space, up or down are pressed', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: ['foo', 'bar'],
         readonly: true,
@@ -251,7 +249,6 @@ describe('VSelect.ts', () => {
 
   it('should clear input value', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         clearable: true,
         items: ['foo', 'bar'],
@@ -276,7 +273,6 @@ describe('VSelect.ts', () => {
 
   it('should be clearable with prop, dirty and single select', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         clearable: true,
         items: [1, 2],
@@ -298,7 +294,6 @@ describe('VSelect.ts', () => {
 
   it('should be clearable with prop, dirty and multi select', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         clearable: true,
         items: [1, 2],
@@ -354,7 +349,6 @@ describe('VSelect.ts', () => {
   // #1704
   it('should populate select when using value as an object', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: [
           { text: 'foo', value: { id: 1 } },
@@ -375,7 +369,6 @@ describe('VSelect.ts', () => {
   // Discovered when working on #1704
   it('should remove item when re-selecting it', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         eager: true,
         items: [

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect3.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect3.spec.ts
@@ -18,6 +18,7 @@ describe('VSelect.ts', () => {
     document.body.appendChild(el)
     mountFunction = (options = {}) => {
       return mount(VSelect, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         mocks: {
@@ -284,7 +285,6 @@ describe('VSelect.ts', () => {
 
   it('should populate select[multiple=false] when using value as an object', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         items: [
           { text: 'foo', value: { id: { subid: 1 } } },

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect4.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect4.spec.ts
@@ -23,6 +23,7 @@ describe('VSelect.ts', () => {
       document.body.appendChild(el)
 
       return mount(VSelect, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         ...options,

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -428,7 +428,10 @@ export default baseMixins.extend<options>().extend({
       }, this[type])
     },
     getActiveElement () {
-      return (this.$el.getRootNode() as ShadowRoot | HTMLDocument).activeElement
+      const rootNode = this.$el.getRootNode
+        ? this.$el.getRootNode() as ShadowRoot | HTMLDocument
+        : document // IE11
+      return rootNode.activeElement
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -431,9 +431,6 @@ export default baseMixins.extend<options>().extend({
       if (!this.$el.getRootNode) return document.activeElement // IE11
 
       const rootNode = this.$el.getRootNode()
-
-      if (rootNode === this.$el) return document.activeElement // jest
-
       return (rootNode as ShadowRoot | HTMLDocument).activeElement
     },
     onBlur (e?: Event) {

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -427,8 +427,8 @@ export default baseMixins.extend<options>().extend({
         ref: type,
       }, this[type])
     },
-    getActiveElement() {
-      return this.$el.getRootNode().activeElement
+    getActiveElement () {
+      return (this.$el.getRootNode() as ShadowRoot | HTMLDocument).activeElement
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -428,10 +428,13 @@ export default baseMixins.extend<options>().extend({
       }, this[type])
     },
     getActiveElement () {
-      const rootNode = this.$el.getRootNode
-        ? this.$el.getRootNode() as ShadowRoot | HTMLDocument
-        : document // IE11
-      return rootNode.activeElement
+      if (!this.$el.getRootNode) return document.activeElement // IE11
+
+      const rootNode = this.$el.getRootNode()
+
+      if (rootNode === this.$el) return document.activeElement // jest
+
+      return (rootNode as ShadowRoot | HTMLDocument).activeElement
     },
     onBlur (e?: Event) {
       this.isFocused = false

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -427,6 +427,9 @@ export default baseMixins.extend<options>().extend({
         ref: type,
       }, this[type])
     },
+    getActiveElement() {
+      return this.$el.getRootNode().activeElement
+    },
     onBlur (e?: Event) {
       this.isFocused = false
       e && this.$nextTick(() => this.$emit('blur', e))
@@ -439,7 +442,7 @@ export default baseMixins.extend<options>().extend({
     onFocus (e?: Event) {
       if (!this.$refs.input) return
 
-      if (document.activeElement !== this.$refs.input) {
+      if (this.getActiveElement() !== this.$refs.input) {
         return this.$refs.input.focus()
       }
 
@@ -494,7 +497,7 @@ export default baseMixins.extend<options>().extend({
         !this.autofocus ||
         typeof document === 'undefined' ||
         !this.$refs.input ||
-        document.activeElement === this.$refs.input
+        this.getActiveElement() === this.$refs.input
       ) return false
 
       this.$refs.input.focus()

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -14,6 +14,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   beforeEach(() => {
     mountFunction = (options?: MountOptions<Instance>) => {
       return mount(VTextField, {
+        attachToDocument: true,
         // https://github.com/vuejs/vue-test-utils/issues/1130
         sync: false,
         mocks: {
@@ -290,7 +291,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
         })
       },
     }
-    const wrapper = mount(component)
+    const wrapper = mount(component, { attachToDocument: true })
 
     const input = wrapper.findAll('input').at(0)
 
@@ -401,7 +402,6 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should autofocus', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         autofocus: true,
       },
@@ -774,7 +774,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
         })
       },
     }
-    const wrapper = mount(component)
+    const wrapper = mount(component, { attachToDocument: true })
 
     const inputElement = wrapper.findAll('input').at(0)
     const clearIcon = wrapper.find('.v-input__icon--clear .v-icon')

--- a/packages/vuetify/src/components/VTextarea/__tests__/VTextarea.spec.ts
+++ b/packages/vuetify/src/components/VTextarea/__tests__/VTextarea.spec.ts
@@ -12,13 +12,15 @@ describe('VTextarea.ts', () => {
   let mountFunction: (options?: MountOptions<Instance>) => Wrapper<Instance>
   beforeEach(() => {
     mountFunction = (options?: MountOptions<Instance>) => {
-      return mount(VTextarea, options)
+      return mount(VTextarea, {
+        attachToDocument: true,
+        ...options,
+      })
     }
   })
 
   it('should calculate element height when using auto-grow prop', async () => {
     const wrapper = mountFunction({
-      attachToDocument: true,
       propsData: {
         value: '',
         autoGrow: true,
@@ -64,7 +66,6 @@ describe('VTextarea.ts', () => {
     const calculateInputHeight = jest.fn()
 
     mountFunction({
-      attachToDocument: true,
       propsData: {
         autoGrow: true,
       },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
When an `input` element is inside a shadowDom, and is active (focused), the `document.activeElement` will not reference the input element but rather the shadowRoot. In order to properly detect what the `activeElement` is, we must use the proper root node for that element, as explained on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement).

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is part of the solution for:
- #7622

And an alternative implementation to:
- #12134
- #12141

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
