### PR TITLE
fix(VIcon): render a button element around clickable component icons

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.sass
+++ b/packages/vuetify/src/components/VIcon/VIcon.sass
@@ -58,15 +58,11 @@
   &--disabled
     pointer-events: none
 
-  &--is-component
-    height: $icon-size
-    width: $icon-size
-
-  &--svg
-    height: $icon-size
-    width: $icon-size
-    fill: currentColor
-
   &--dense
     &--is-component
       height: $icon-size-dense
+
+  &__svg
+    height: $icon-size
+    width: $icon-size
+    fill: currentColor

--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -86,9 +86,9 @@ const VIcon = mixins(
         (explicitSize && SIZE_MAP[explicitSize]) || convertToUnit(this.size)
       )
     },
-    // Component data for both font and svg icon.
+    // Component data for both font icon and SVG wrapper span
     getDefaultData (): VNodeData {
-      const data: VNodeData = {
+      return {
         staticClass: 'v-icon notranslate',
         class: {
           'v-icon--disabled': this.disabled,
@@ -105,8 +105,20 @@ const VIcon = mixins(
         },
         on: this.listeners$,
       }
+    },
+    getSvgWrapperData () {
+      const fontSize = this.getSize()
+      const wrapperData = {
+        ...this.getDefaultData(),
+        style: fontSize ? {
+          fontSize,
+          height: fontSize,
+          width: fontSize,
+        } : undefined,
+      }
+      this.applyColors(wrapperData)
 
-      return data
+      return wrapperData
     },
     applyColors (data: VNodeData): void {
       data.class = { ...data.class, ...this.themeClasses }
@@ -142,18 +154,8 @@ const VIcon = mixins(
     },
     renderSvgIcon (icon: string, h: CreateElement): VNode {
       const fontSize = this.getSize()
-      const wrapperData = {
-        ...this.getDefaultData(),
-        style: fontSize ? {
-          fontSize,
-          height: fontSize,
-          width: fontSize,
-        } : undefined,
-      }
-      wrapperData.class['v-icon--svg'] = true
-      this.applyColors(wrapperData)
-
       const svgData: VNodeData = {
+        class: 'v-icon__svg',
         attrs: {
           xmlns: 'http://www.w3.org/2000/svg',
           viewBox: '0 0 24 24',
@@ -164,7 +166,7 @@ const VIcon = mixins(
         },
       }
 
-      return h(this.hasClickListener ? 'button' : 'span', wrapperData, [
+      return h(this.hasClickListener ? 'button' : 'span', this.getSvgWrapperData(), [
         h('svg', svgData, [
           h('path', {
             attrs: {
@@ -178,8 +180,11 @@ const VIcon = mixins(
       icon: VuetifyIconComponent,
       h: CreateElement
     ): VNode {
-      const data = this.getDefaultData()
-      data.class['v-icon--is-component'] = true
+      const data: VNodeData = {
+        class: {
+          'v-icon__svg': true,
+        },
+      }
 
       const size = this.getSize()
       if (size) {
@@ -196,7 +201,9 @@ const VIcon = mixins(
       data.props = icon.props
       data.nativeOn = data.on
 
-      return h(component, data)
+      return h(this.hasClickListener ? 'button' : 'span', this.getSvgWrapperData(), [
+        h(component, data),
+      ])
     },
   },
 

--- a/packages/vuetify/src/components/VIcon/__tests__/VIcon.spec.ts
+++ b/packages/vuetify/src/components/VIcon/__tests__/VIcon.spec.ts
@@ -234,7 +234,6 @@ describe('VIcon', () => {
       const wrapper = mountFunction({}, '$testIcon')
 
       expect(wrapper.text()).toBe('test icon')
-      expect(wrapper.element.className).toBe('v-icon notranslate test-component v-icon--is-component theme--light')
       expect(wrapper.html()).toMatchSnapshot()
     })
 

--- a/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
+++ b/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`VIcon for component icon should render an svg icon 1`] = `
 <span aria-hidden="true"
-      class="v-icon notranslate v-icon--svg theme--light"
+      class="v-icon notranslate theme--light"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
        viewbox="0 0 24 24"
@@ -10,6 +10,7 @@ exports[`VIcon for component icon should render an svg icon 1`] = `
        width="24"
        role="img"
        aria-hidden="true"
+       class="v-icon__svg"
   >
     <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
     </path>
@@ -19,7 +20,7 @@ exports[`VIcon for component icon should render an svg icon 1`] = `
 
 exports[`VIcon for component icon should render an svg icon 2`] = `
 <span aria-hidden="true"
-      class="v-icon notranslate v-icon--svg theme--light"
+      class="v-icon notranslate theme--light"
       style="font-size: 36px; height: 36px; width: 36px;"
 >
   <svg xmlns="http://www.w3.org/2000/svg"
@@ -28,6 +29,7 @@ exports[`VIcon for component icon should render an svg icon 2`] = `
        width="36px"
        role="img"
        aria-hidden="true"
+       class="v-icon__svg"
   >
     <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
     </path>
@@ -36,46 +38,62 @@ exports[`VIcon for component icon should render an svg icon 2`] = `
 `;
 
 exports[`VIcon for component icon should render component 1`] = `
-<div class="v-icon notranslate test-component v-icon--is-component theme--light"
-     aria-hidden="true"
+<span aria-hidden="true"
+      class="v-icon notranslate theme--light"
 >
-  test icon
-</div>
+  <div class="test-component v-icon__svg theme--light">
+    test icon
+  </div>
+</span>
 `;
 
 exports[`VIcon for component icon should set font size from helper prop 1`] = `
-<div class="v-icon notranslate test-component v-icon--is-component theme--light"
-     aria-hidden="true"
-     style="font-size: 16px; height: 16px; width: 16px;"
+<span aria-hidden="true"
+      class="v-icon notranslate theme--light"
+      style="font-size: 16px; height: 16px; width: 16px;"
 >
-  test icon
-</div>
+  <div class="test-component v-icon__svg theme--light"
+       style="font-size: 16px; height: 16px; width: 16px;"
+  >
+    test icon
+  </div>
+</span>
 `;
 
 exports[`VIcon for component icon should set font size from helper prop 2`] = `
-<div class="v-icon notranslate test-component v-icon--is-component theme--light"
-     aria-hidden="true"
+<span aria-hidden="true"
+      class="v-icon notranslate theme--light"
 >
-  test icon
-</div>
+  <div class="test-component v-icon__svg theme--light">
+    test icon
+  </div>
+</span>
 `;
 
 exports[`VIcon for component icon should set font size from helper prop 3`] = `
-<div class="v-icon notranslate test-component v-icon--is-component theme--light"
-     aria-hidden="true"
-     style="font-size: 36px; height: 36px; width: 36px;"
+<span aria-hidden="true"
+      class="v-icon notranslate theme--light"
+      style="font-size: 36px; height: 36px; width: 36px;"
 >
-  test icon
-</div>
+  <div class="test-component v-icon__svg theme--light"
+       style="font-size: 36px; height: 36px; width: 36px;"
+  >
+    test icon
+  </div>
+</span>
 `;
 
 exports[`VIcon for component icon should set font size from helper prop 4`] = `
-<div class="v-icon notranslate test-component v-icon--is-component theme--light"
-     aria-hidden="true"
-     style="font-size: 40px; height: 40px; width: 40px;"
+<span aria-hidden="true"
+      class="v-icon notranslate theme--light"
+      style="font-size: 40px; height: 40px; width: 40px;"
 >
-  test icon
-</div>
+  <div class="test-component v-icon__svg theme--light"
+       style="font-size: 40px; height: 40px; width: 40px;"
+  >
+    test icon
+  </div>
+</span>
 `;
 
 exports[`VIcon set font size from helper prop 1`] = `


### PR DESCRIPTION
fixes #10623

Font icons and SVG strings had a `<span>` or `<button>` put around them, but icon components were just rendered directly. This PR normalises the rendering behaviour between different types of icons. This probably fixes #9999 properly too as the click listener is now on the wrapping button instead of the provided component. 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
Switch to `iconfont: 'faSvg'` in `dev/vuetify.js` first

```vue
<template>
  <v-container>
    <v-text-field clearable value="value" label="clearable"></v-text-field>
  </v-container>
</template>
```

IDK if anyone has a complete icon playground, mostly just relying on snapshot tests for this. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

