### PR TITLE
fix(VSelect): do not highlight search text without an item match

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelectList.ts
+++ b/packages/vuetify/src/components/VSelect/VSelectList.ts
@@ -132,7 +132,7 @@ export default mixins(Colorable, Themeable).extend({
       const searchInput = (this.searchInput || '').toString().toLocaleLowerCase()
       const index = text.toLocaleLowerCase().indexOf(searchInput)
 
-      if (index < 0) return { start: '', middle: text, end: '' }
+      if (index < 0) return { start: text, middle: '', end: '' }
 
       const start = text.slice(0, index)
       const middle = text.slice(index, index + searchInput.length)


### PR DESCRIPTION

## Description
when genFilteredText could not find the supplied text, it would always highlight the entire string. This behavior was unwanted, especially when using genFilteredText multiple times within an item slot, where it would highlight all other strings that did not match. With this change, it will instead not highlight the string when it can't find a match. fixes #10843

## Motivation and Context
fixes #10843

## How Has This Been Tested?
I visually tested the change locally.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
