### PR TITLE
fix(VProgressCircular): dark theme background color clash

### DIFF
--- a/packages/vuetify/src/components/VProgressCircular/VProgressCircular.sass
+++ b/packages/vuetify/src/components/VProgressCircular/VProgressCircular.sass
@@ -36,7 +36,8 @@
     justify-content: center
 
   &__underlay
-    stroke: $progress-circular-underlay-stroke
+    stroke: currentColor
+    filter: invert(80%)
     z-index: 1
 
   &__overlay

--- a/packages/vuetify/src/components/VProgressCircular/VProgressCircular.sass
+++ b/packages/vuetify/src/components/VProgressCircular/VProgressCircular.sass
@@ -36,8 +36,7 @@
     justify-content: center
 
   &__underlay
-    stroke: currentColor
-    filter: invert(80%)
+    stroke: $progress-circular-underlay-stroke
     z-index: 1
 
   &__overlay

--- a/packages/vuetify/src/components/VProgressCircular/_variables.scss
+++ b/packages/vuetify/src/components/VProgressCircular/_variables.scss
@@ -3,4 +3,5 @@
 $progress-circular-rotate-animation: progress-circular-rotate 1.4s linear infinite !default;
 $progress-circular-rotate-dash: progress-circular-dash 1.4s ease-in-out infinite !default;
 $process-circular-intermediate-svg-transition: all .2s ease-in-out !default;
+$progress-circular-underlay-stroke: rgba(map-get($grey, 'base'), 0.4) !default;
 $progress-circular-overlay-transition: all .6s ease-in-out !default;

--- a/packages/vuetify/src/components/VProgressCircular/_variables.scss
+++ b/packages/vuetify/src/components/VProgressCircular/_variables.scss
@@ -3,5 +3,4 @@
 $progress-circular-rotate-animation: progress-circular-rotate 1.4s linear infinite !default;
 $progress-circular-rotate-dash: progress-circular-dash 1.4s ease-in-out infinite !default;
 $process-circular-intermediate-svg-transition: all .2s ease-in-out !default;
-$progress-circular-underlay-stroke: rgba(map-get($shades, 'black'), 0.1) !default;
 $progress-circular-overlay-transition: all .6s ease-in-out !default;


### PR DESCRIPTION
## Description
Tweaked the background color of circular progress bar


## Motivation and Context
Background color of circular progress bar clashes with the default app background color on the dark theme. Tweaked the background color to make it more visible.
fixes #12149 

## How Has This Been Tested?
Manual visual inspection

## Markup:
<details>

```vue
<template>
  <v-container>
    <VProgressCircular
      :value="10"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
