### PR TITLE
Allow removal of all Sass side effects from components

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.ts
+++ b/packages/vuetify/src/components/VAlert/VAlert.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VAlert.sass'
-
 // Extensions
 import VSheet from '../VSheet'
 

--- a/packages/vuetify/src/components/VAlert/index.ts
+++ b/packages/vuetify/src/components/VAlert/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VAlert.sass'
+
 import VAlert from './VAlert'
 
 export { VAlert }

--- a/packages/vuetify/src/components/VApp/VApp.sass
+++ b/packages/vuetify/src/components/VApp/VApp.sass
@@ -1,4 +1,4 @@
-@import '../../styles/styles.sass'
+@import '../../styles/main.sass'
 
 // Theme
 +theme(v-application) using ($material)

--- a/packages/vuetify/src/components/VApp/VApp.ts
+++ b/packages/vuetify/src/components/VApp/VApp.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VApp.sass'
-
 // Mixins
 import Themeable from '../../mixins/themeable'
 

--- a/packages/vuetify/src/components/VApp/index.ts
+++ b/packages/vuetify/src/components/VApp/index.ts
@@ -1,3 +1,5 @@
+// Styles
+import './VApp.sass'
 import VApp from './VApp'
 
 export { VApp }

--- a/packages/vuetify/src/components/VAppBar/VAppBar.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VAppBar.sass'
-
 // Extensions
 import VToolbar from '../VToolbar/VToolbar'
 

--- a/packages/vuetify/src/components/VAppBar/index.ts
+++ b/packages/vuetify/src/components/VAppBar/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VAppBar.sass'
+
 import VAppBar from './VAppBar'
 import VAppBarNavIcon from './VAppBarNavIcon'
 

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VAutocomplete.sass'
-
 // Extensions
 import VSelect, { defaultMenuProps as VSelectMenuProps } from '../VSelect/VSelect'
 import VTextField from '../VTextField/VTextField'

--- a/packages/vuetify/src/components/VAutocomplete/index.ts
+++ b/packages/vuetify/src/components/VAutocomplete/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VAutocomplete.sass'
+
 import VAutocomplete from './VAutocomplete'
 
 export { VAutocomplete }

--- a/packages/vuetify/src/components/VAvatar/VAvatar.ts
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.ts
@@ -1,5 +1,3 @@
-import './VAvatar.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Measurable from '../../mixins/measurable'

--- a/packages/vuetify/src/components/VAvatar/index.ts
+++ b/packages/vuetify/src/components/VAvatar/index.ts
@@ -1,3 +1,5 @@
+import './VAvatar.sass'
+
 import VAvatar from './VAvatar'
 
 export { VAvatar }

--- a/packages/vuetify/src/components/VBadge/VBadge.ts
+++ b/packages/vuetify/src/components/VBadge/VBadge.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VBadge.sass'
-
 // Components
 import VIcon from '../VIcon/VIcon'
 

--- a/packages/vuetify/src/components/VBadge/index.ts
+++ b/packages/vuetify/src/components/VBadge/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VBadge.sass'
+
 import VBadge from './VBadge'
 
 export { VBadge }

--- a/packages/vuetify/src/components/VBanner/VBanner.ts
+++ b/packages/vuetify/src/components/VBanner/VBanner.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VBanner.sass'
-
 // Extensions
 import VSheet from '../VSheet'
 

--- a/packages/vuetify/src/components/VBanner/index.ts
+++ b/packages/vuetify/src/components/VBanner/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VBanner.sass'
+
 import VBanner from './VBanner'
 
 export { VBanner }

--- a/packages/vuetify/src/components/VBottomNavigation/VBottomNavigation.ts
+++ b/packages/vuetify/src/components/VBottomNavigation/VBottomNavigation.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VBottomNavigation.sass'
-
 // Mixins
 import Applicationable from '../../mixins/applicationable'
 import ButtonGroup from '../../mixins/button-group'

--- a/packages/vuetify/src/components/VBottomNavigation/index.ts
+++ b/packages/vuetify/src/components/VBottomNavigation/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VBottomNavigation.sass'
+
 import VBottomNavigation from './VBottomNavigation'
 
 export { VBottomNavigation }

--- a/packages/vuetify/src/components/VBottomSheet/VBottomSheet.ts
+++ b/packages/vuetify/src/components/VBottomSheet/VBottomSheet.ts
@@ -1,5 +1,3 @@
-import './VBottomSheet.sass'
-
 // Extensions
 import VDialog from '../VDialog/VDialog'
 

--- a/packages/vuetify/src/components/VBottomSheet/index.ts
+++ b/packages/vuetify/src/components/VBottomSheet/index.ts
@@ -1,3 +1,5 @@
+import './VBottomSheet.sass'
+
 import VBottomSheet from './VBottomSheet'
 
 export { VBottomSheet }

--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.ts
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VBreadcrumbs.sass'
-
 // Types
 import { VNode } from 'vue'
 import { PropValidator } from 'vue/types/options'

--- a/packages/vuetify/src/components/VBreadcrumbs/index.ts
+++ b/packages/vuetify/src/components/VBreadcrumbs/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VBreadcrumbs.sass'
+
 import VBreadcrumbs from './VBreadcrumbs'
 import VBreadcrumbsItem from './VBreadcrumbsItem'
 import VBreadcrumbsDivider from './VBreadcrumbsDivider'

--- a/packages/vuetify/src/components/VBtn/VBtn.ts
+++ b/packages/vuetify/src/components/VBtn/VBtn.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VBtn.sass'
-
 // Extensions
 import VSheet from '../VSheet'
 

--- a/packages/vuetify/src/components/VBtn/index.ts
+++ b/packages/vuetify/src/components/VBtn/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VBtn.sass'
+
 import VBtn from './VBtn'
 
 export { VBtn }

--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.ts
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VBtnToggle.sass'
-
 // Mixins
 import ButtonGroup from '../../mixins/button-group'
 import Colorable from '../../mixins/colorable'

--- a/packages/vuetify/src/components/VBtnToggle/index.ts
+++ b/packages/vuetify/src/components/VBtnToggle/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VBtnToggle.sass'
+
 import VBtnToggle from './VBtnToggle'
 
 export { VBtnToggle }

--- a/packages/vuetify/src/components/VCalendar/VCalendar.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendar.ts
@@ -1,6 +1,3 @@
-// Styles
-// import '../../stylus/components/_calendar-daily.styl'
-
 // Types
 import { VNode, Component } from 'vue'
 

--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCalendarCategory.sass'
-
 // Types
 import { VNode } from 'vue'
 

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCalendarDaily.sass'
-
 // Types
 import { VNode } from 'vue'
 

--- a/packages/vuetify/src/components/VCalendar/VCalendarMonthly.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarMonthly.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCalendarWeekly.sass'
-
 // Mixins
 import VCalendarWeekly from './VCalendarWeekly'
 

--- a/packages/vuetify/src/components/VCalendar/VCalendarWeekly.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarWeekly.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCalendarWeekly.sass'
-
 // Types
 import { VNode } from 'vue'
 

--- a/packages/vuetify/src/components/VCalendar/index.ts
+++ b/packages/vuetify/src/components/VCalendar/index.ts
@@ -1,3 +1,8 @@
+// Styles
+import './VCalendarCategory.sass'
+import './VCalendarDaily.sass'
+import './VCalendarWeekly.sass'
+
 import VCalendar from './VCalendar'
 import VCalendarDaily from './VCalendarDaily'
 import VCalendarWeekly from './VCalendarWeekly'

--- a/packages/vuetify/src/components/VCard/VCard.ts
+++ b/packages/vuetify/src/components/VCard/VCard.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCard.sass'
-
 // Extensions
 import VSheet from '../VSheet'
 

--- a/packages/vuetify/src/components/VCard/index.ts
+++ b/packages/vuetify/src/components/VCard/index.ts
@@ -1,3 +1,5 @@
+import './VCard.sass'
+
 import VCard from './VCard'
 import { createSimpleFunctional } from '../../util/helpers'
 

--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCarousel.sass'
-
 // Extensions
 import VWindow from '../VWindow/VWindow'
 

--- a/packages/vuetify/src/components/VCarousel/index.ts
+++ b/packages/vuetify/src/components/VCarousel/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VCarousel.sass'
+
 import VCarousel from './VCarousel'
 import VCarouselItem from './VCarouselItem'
 

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.ts
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.ts
@@ -1,7 +1,3 @@
-// Styles
-import './VCheckbox.sass'
-import '../../styles/components/_selection-controls.sass'
-
 // Components
 import VIcon from '../VIcon'
 import VInput from '../VInput'

--- a/packages/vuetify/src/components/VCheckbox/VSimpleCheckbox.ts
+++ b/packages/vuetify/src/components/VCheckbox/VSimpleCheckbox.ts
@@ -1,5 +1,3 @@
-import './VSimpleCheckbox.sass'
-
 import ripple from '../../directives/ripple'
 
 import Vue, { VNode, VNodeDirective } from 'vue'

--- a/packages/vuetify/src/components/VCheckbox/index.ts
+++ b/packages/vuetify/src/components/VCheckbox/index.ts
@@ -1,3 +1,8 @@
+// Styles
+import './VCheckbox.sass'
+import '../../styles/components/_selection-controls.sass'
+import './VSimpleCheckbox.sass'
+
 import VCheckbox from './VCheckbox'
 import VSimpleCheckbox from './VSimpleCheckbox'
 

--- a/packages/vuetify/src/components/VChip/VChip.ts
+++ b/packages/vuetify/src/components/VChip/VChip.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VChip.sass'
-
 // Types
 import { VNode } from 'vue'
 import mixins from '../../util/mixins'

--- a/packages/vuetify/src/components/VChip/index.ts
+++ b/packages/vuetify/src/components/VChip/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VChip.sass'
+
 import VChip from './VChip'
 
 export { VChip }

--- a/packages/vuetify/src/components/VChipGroup/VChipGroup.ts
+++ b/packages/vuetify/src/components/VChipGroup/VChipGroup.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VChipGroup.sass'
-
 // Extensions
 import { BaseSlideGroup } from '../VSlideGroup/VSlideGroup'
 

--- a/packages/vuetify/src/components/VChipGroup/index.ts
+++ b/packages/vuetify/src/components/VChipGroup/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VChipGroup.sass'
+
 import VChipGroup from './VChipGroup'
 
 export { VChipGroup }

--- a/packages/vuetify/src/components/VColorPicker/VColorPicker.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPicker.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VColorPicker.sass'
-
 // Components
 import VSheet from '../VSheet/VSheet'
 import VColorPickerPreview from './VColorPickerPreview'

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VColorPickerCanvas.sass'
-
 // Helpers
 import { clamp, convertToUnit } from '../../util/helpers'
 import { fromHSVA, VColorPickerColor, fromRGBA } from './util'

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VColorPickerEdit.sass'
-
 // Components
 import VBtn from '../VBtn'
 import VIcon from '../VIcon'

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VColorPickerPreview.sass'
-
 // Components
 import VSlider from '../VSlider/VSlider'
 

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerSwatches.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerSwatches.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VColorPickerSwatches.sass'
-
 // Components
 import VIcon from '../VIcon'
 

--- a/packages/vuetify/src/components/VColorPicker/index.ts
+++ b/packages/vuetify/src/components/VColorPicker/index.ts
@@ -1,3 +1,10 @@
+// Styles
+import './VColorPicker.sass'
+import './VColorPickerCanvas.sass'
+import './VColorPickerEdit.sass'
+import './VColorPickerPreview.sass'
+import './VColorPickerSwatches.sass'
+
 import VColorPicker from './VColorPicker'
 import VColorPickerSwatches from './VColorPickerSwatches'
 import VColorPickerCanvas from './VColorPickerCanvas'

--- a/packages/vuetify/src/components/VCombobox/VCombobox.ts
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.ts
@@ -1,6 +1,3 @@
-// Styles
-import '../VAutocomplete/VAutocomplete.sass'
-
 // Extensions
 import VSelect from '../VSelect/VSelect'
 import VAutocomplete from '../VAutocomplete/VAutocomplete'

--- a/packages/vuetify/src/components/VCombobox/index.ts
+++ b/packages/vuetify/src/components/VCombobox/index.ts
@@ -1,3 +1,5 @@
+import '../VAutocomplete/VAutocomplete.sass'
+
 import VCombobox from './VCombobox'
 
 export { VCombobox }

--- a/packages/vuetify/src/components/VCounter/VCounter.ts
+++ b/packages/vuetify/src/components/VCounter/VCounter.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VCounter.sass'
-
 // Mixins
 import Themeable, { functionalThemeClasses } from '../../mixins/themeable'
 

--- a/packages/vuetify/src/components/VCounter/index.ts
+++ b/packages/vuetify/src/components/VCounter/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VCounter.sass'
+
 import VCounter from './VCounter'
 
 export { VCounter }

--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -1,5 +1,3 @@
-import './VDataFooter.sass'
-
 // Components
 import VSelect from '../VSelect/VSelect'
 import VIcon from '../VIcon'

--- a/packages/vuetify/src/components/VDataIterator/index.ts
+++ b/packages/vuetify/src/components/VDataIterator/index.ts
@@ -1,3 +1,5 @@
+import './VDataFooter.sass'
+
 import VDataIterator from './VDataIterator'
 import VDataFooter from './VDataFooter'
 

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -1,5 +1,3 @@
-import './VDataTable.sass'
-
 // Types
 import { VNode, VNodeChildrenArrayContents, VNodeChildren } from 'vue'
 import { PropValidator } from 'vue/types/options'

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeader.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeader.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VDataTableHeader.sass'
-
 // Components
 import VDataTableHeaderMobile from './VDataTableHeaderMobile'
 import VDataTableHeaderDesktop from './VDataTableHeaderDesktop'

--- a/packages/vuetify/src/components/VDataTable/VEditDialog.ts
+++ b/packages/vuetify/src/components/VDataTable/VEditDialog.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VEditDialog.sass'
-
 // Mixins
 import Returnable from '../../mixins/returnable'
 import Themeable from '../../mixins/themeable'

--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.ts
@@ -1,5 +1,3 @@
-import './VSimpleTable.sass'
-
 import { convertToUnit } from '../../util/helpers'
 import Themeable from '../../mixins/themeable'
 import mixins from '../../util/mixins'

--- a/packages/vuetify/src/components/VDataTable/VVirtualTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VVirtualTable.ts
@@ -1,5 +1,3 @@
-import './VVirtualTable.sass'
-
 // Components
 import VSimpleTable from './VSimpleTable'
 

--- a/packages/vuetify/src/components/VDataTable/index.ts
+++ b/packages/vuetify/src/components/VDataTable/index.ts
@@ -1,3 +1,10 @@
+// Styles
+import './VDataTable.sass'
+import './VDataTableHeader.sass'
+import './VEditDialog.sass'
+import './VSimpleTable.sass'
+import './VVirtualTable.sass'
+
 import { createSimpleFunctional } from '../../util/helpers'
 
 import VDataTable from './VDataTable'

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.ts
@@ -1,5 +1,3 @@
-import './VDatePickerHeader.sass'
-
 // Components
 import VBtn from '../VBtn'
 import VIcon from '../VIcon'

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerTitle.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerTitle.ts
@@ -1,5 +1,3 @@
-import './VDatePickerTitle.sass'
-
 // Components
 import VIcon from '../VIcon'
 

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerYears.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerYears.ts
@@ -1,5 +1,3 @@
-import './VDatePickerYears.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Localable from '../../mixins/localable'

--- a/packages/vuetify/src/components/VDatePicker/index.ts
+++ b/packages/vuetify/src/components/VDatePicker/index.ts
@@ -1,3 +1,8 @@
+import './VDatePickerHeader.sass'
+import './VDatePickerTitle.sass'
+import './VDatePickerTable.sass'
+import './VDatePickerYears.sass'
+
 import VDatePicker from './VDatePicker'
 import VDatePickerTitle from './VDatePickerTitle'
 import VDatePickerHeader from './VDatePickerHeader'

--- a/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
+++ b/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
@@ -1,5 +1,3 @@
-import '../VDatePickerTable.sass'
-
 // Directives
 import Touch from '../../../directives/touch'
 

--- a/packages/vuetify/src/components/VDialog/VDialog.ts
+++ b/packages/vuetify/src/components/VDialog/VDialog.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VDialog.sass'
-
 // Components
 import { VThemeProvider } from '../VThemeProvider'
 

--- a/packages/vuetify/src/components/VDialog/index.ts
+++ b/packages/vuetify/src/components/VDialog/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VDialog.sass'
+
 import VDialog from './VDialog'
 
 export { VDialog }

--- a/packages/vuetify/src/components/VDivider/VDivider.ts
+++ b/packages/vuetify/src/components/VDivider/VDivider.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VDivider.sass'
-
 // Types
 import { VNode } from 'vue'
 

--- a/packages/vuetify/src/components/VDivider/index.ts
+++ b/packages/vuetify/src/components/VDivider/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VDivider.sass'
+
 import VDivider from './VDivider'
 
 export { VDivider }

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanels.ts
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanels.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VExpansionPanel.sass'
-
 // Components
 import { BaseItemGroup, GroupableInstance } from '../VItemGroup/VItemGroup'
 import VExpansionPanel from './VExpansionPanel'

--- a/packages/vuetify/src/components/VExpansionPanel/index.ts
+++ b/packages/vuetify/src/components/VExpansionPanel/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VExpansionPanel.sass'
+
 import VExpansionPanels from './VExpansionPanels'
 import VExpansionPanel from './VExpansionPanel'
 import VExpansionPanelContent from './VExpansionPanelContent'

--- a/packages/vuetify/src/components/VFileInput/VFileInput.ts
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VFileInput.sass'
-
 // Extensions
 import VTextField from '../VTextField'
 

--- a/packages/vuetify/src/components/VFileInput/index.ts
+++ b/packages/vuetify/src/components/VFileInput/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VFileInput.sass'
+
 import VFileInput from './VFileInput'
 
 export { VFileInput }

--- a/packages/vuetify/src/components/VFooter/VFooter.ts
+++ b/packages/vuetify/src/components/VFooter/VFooter.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VFooter.sass'
-
 // Components
 import VSheet from '../VSheet/VSheet'
 

--- a/packages/vuetify/src/components/VFooter/index.ts
+++ b/packages/vuetify/src/components/VFooter/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VFooter.sass'
+
 import VFooter from './VFooter'
 
 export { VFooter }

--- a/packages/vuetify/src/components/VGrid/VCol.ts
+++ b/packages/vuetify/src/components/VGrid/VCol.ts
@@ -1,5 +1,3 @@
-import './VGrid.sass'
-
 import Vue, { VNode, PropOptions } from 'vue'
 import mergeData from '../../util/mergeData'
 import { upperFirst } from '../../util/helpers'

--- a/packages/vuetify/src/components/VGrid/VContainer.ts
+++ b/packages/vuetify/src/components/VGrid/VContainer.ts
@@ -1,6 +1,3 @@
-import './_grid.sass'
-import './VGrid.sass'
-
 import Grid from './grid'
 
 import mergeData from '../../util/mergeData'

--- a/packages/vuetify/src/components/VGrid/VFlex.ts
+++ b/packages/vuetify/src/components/VGrid/VFlex.ts
@@ -1,5 +1,3 @@
-import './_grid.sass'
-
 import Grid from './grid'
 
 export default Grid('flex')

--- a/packages/vuetify/src/components/VGrid/VGrid.sass
+++ b/packages/vuetify/src/components/VGrid/VGrid.sass
@@ -1,5 +1,6 @@
 @import '../../styles/styles.sass'
 @import './_mixins'
+@import './_grid'
 
 .container
   +make-container

--- a/packages/vuetify/src/components/VGrid/VLayout.ts
+++ b/packages/vuetify/src/components/VGrid/VLayout.ts
@@ -1,5 +1,3 @@
-import './_grid.sass'
-
 import Grid from './grid'
 
 export default Grid('layout')

--- a/packages/vuetify/src/components/VGrid/VRow.ts
+++ b/packages/vuetify/src/components/VGrid/VRow.ts
@@ -1,5 +1,3 @@
-import './VGrid.sass'
-
 import Vue, { PropOptions } from 'vue'
 import mergeData from '../../util/mergeData'
 import { upperFirst } from '../../util/helpers'

--- a/packages/vuetify/src/components/VGrid/VSpacer.ts
+++ b/packages/vuetify/src/components/VGrid/VSpacer.ts
@@ -1,4 +1,3 @@
-import './_grid.sass'
 import { createSimpleFunctional } from '../../util/helpers'
 
 export default createSimpleFunctional('spacer', 'div', 'v-spacer')

--- a/packages/vuetify/src/components/VGrid/_grid.sass
+++ b/packages/vuetify/src/components/VGrid/_grid.sass
@@ -1,5 +1,3 @@
-@import '../../styles/styles.sass'
-
 .container
   &.grow-shrink-0
     flex-grow: 0

--- a/packages/vuetify/src/components/VGrid/index.ts
+++ b/packages/vuetify/src/components/VGrid/index.ts
@@ -1,3 +1,5 @@
+import './VGrid.sass'
+
 import VContainer from './VContainer'
 import VCol from './VCol'
 import VRow from './VRow'

--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -1,5 +1,3 @@
-import './VIcon.sass'
-
 // Mixins
 import BindsAttrs from '../../mixins/binds-attrs'
 import Colorable from '../../mixins/colorable'

--- a/packages/vuetify/src/components/VIcon/index.ts
+++ b/packages/vuetify/src/components/VIcon/index.ts
@@ -1,3 +1,5 @@
+import './VIcon.sass'
+
 import VIcon from './VIcon'
 
 export { VIcon }

--- a/packages/vuetify/src/components/VImg/VImg.ts
+++ b/packages/vuetify/src/components/VImg/VImg.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VImg.sass'
-
 // Directives
 import intersect from '../../directives/intersect'
 

--- a/packages/vuetify/src/components/VImg/index.ts
+++ b/packages/vuetify/src/components/VImg/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VImg.sass'
+
 import VImg from './VImg'
 
 export { VImg }

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VInput.sass'
-
 // Components
 import VIcon from '../VIcon'
 import VLabel from '../VLabel'

--- a/packages/vuetify/src/components/VInput/index.ts
+++ b/packages/vuetify/src/components/VInput/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VInput.sass'
+
 import VInput from './VInput'
 
 export { VInput }

--- a/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
+++ b/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VItemGroup.sass'
-
 // Mixins
 import Groupable from '../../mixins/groupable'
 import Proxyable from '../../mixins/proxyable'

--- a/packages/vuetify/src/components/VItemGroup/index.ts
+++ b/packages/vuetify/src/components/VItemGroup/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VItemGroup.sass'
+
 import VItem from './VItem'
 import VItemGroup from './VItemGroup'
 

--- a/packages/vuetify/src/components/VLabel/VLabel.ts
+++ b/packages/vuetify/src/components/VLabel/VLabel.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VLabel.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Themeable, { functionalThemeClasses } from '../../mixins/themeable'

--- a/packages/vuetify/src/components/VLabel/index.ts
+++ b/packages/vuetify/src/components/VLabel/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VLabel.sass'
+
 import VLabel from './VLabel'
 
 export { VLabel }

--- a/packages/vuetify/src/components/VList/VList.ts
+++ b/packages/vuetify/src/components/VList/VList.ts
@@ -1,5 +1,3 @@
-// Styles
-import './VList.sass'
 import VListGroup from './VListGroup'
 
 // Components

--- a/packages/vuetify/src/components/VList/VListGroup.ts
+++ b/packages/vuetify/src/components/VList/VListGroup.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VListGroup.sass'
-
 // Components
 import VIcon from '../VIcon'
 import VList from './VList'

--- a/packages/vuetify/src/components/VList/VListItem.ts
+++ b/packages/vuetify/src/components/VList/VListItem.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VListItem.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Routable from '../../mixins/routable'

--- a/packages/vuetify/src/components/VList/VListItemGroup.ts
+++ b/packages/vuetify/src/components/VList/VListItemGroup.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VListItemGroup.sass'
-
 // Extensions
 import { BaseItemGroup } from '../VItemGroup/VItemGroup'
 

--- a/packages/vuetify/src/components/VList/index.ts
+++ b/packages/vuetify/src/components/VList/index.ts
@@ -1,3 +1,9 @@
+// Styles
+import './VList.sass'
+import './VListGroup.sass'
+import './VListItem.sass'
+import './VListItemGroup.sass'
+
 import { createSimpleFunctional } from '../../util/helpers'
 
 import VList from './VList'

--- a/packages/vuetify/src/components/VMain/VMain.ts
+++ b/packages/vuetify/src/components/VMain/VMain.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VMain.sass'
-
 // Mixins
 import SSRBootable from '../../mixins/ssr-bootable'
 

--- a/packages/vuetify/src/components/VMain/index.ts
+++ b/packages/vuetify/src/components/VMain/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VMain.sass'
+
 import VMain from './VMain'
 
 export { VMain }

--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VMenu.sass'
-
 // Components
 import { VThemeProvider } from '../VThemeProvider'
 

--- a/packages/vuetify/src/components/VMenu/index.ts
+++ b/packages/vuetify/src/components/VMenu/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VMenu.sass'
+
 import VMenu from './VMenu'
 
 export { VMenu }

--- a/packages/vuetify/src/components/VMessages/VMessages.ts
+++ b/packages/vuetify/src/components/VMessages/VMessages.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VMessages.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Themeable from '../../mixins/themeable'

--- a/packages/vuetify/src/components/VMessages/index.ts
+++ b/packages/vuetify/src/components/VMessages/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VMessages.sass'
+
 import VMessages from './VMessages'
 
 export { VMessages }

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VNavigationDrawer.sass'
-
 // Components
 import VImg, { srcObject } from '../VImg/VImg'
 

--- a/packages/vuetify/src/components/VNavigationDrawer/index.ts
+++ b/packages/vuetify/src/components/VNavigationDrawer/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VNavigationDrawer.sass'
+
 import VNavigationDrawer from './VNavigationDrawer'
 
 export { VNavigationDrawer }

--- a/packages/vuetify/src/components/VOverflowBtn/VOverflowBtn.ts
+++ b/packages/vuetify/src/components/VOverflowBtn/VOverflowBtn.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VOverflowBtn.sass'
-
 // Extensions
 import VSelect from '../VSelect/VSelect'
 import VAutocomplete from '../VAutocomplete'

--- a/packages/vuetify/src/components/VOverflowBtn/index.ts
+++ b/packages/vuetify/src/components/VOverflowBtn/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VOverflowBtn.sass'
+
 import VOverflowBtn from './VOverflowBtn'
 
 export { VOverflowBtn }

--- a/packages/vuetify/src/components/VOverlay/VOverlay.ts
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VOverlay.sass'
-
 // Mixins
 import Colorable from './../../mixins/colorable'
 import Themeable from '../../mixins/themeable'

--- a/packages/vuetify/src/components/VOverlay/index.ts
+++ b/packages/vuetify/src/components/VOverlay/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VOverlay.sass'
+
 import VOverlay from './VOverlay'
 
 export { VOverlay }

--- a/packages/vuetify/src/components/VPagination/VPagination.ts
+++ b/packages/vuetify/src/components/VPagination/VPagination.ts
@@ -1,5 +1,3 @@
-import './VPagination.sass'
-
 import VIcon from '../VIcon'
 
 // Directives

--- a/packages/vuetify/src/components/VPagination/index.ts
+++ b/packages/vuetify/src/components/VPagination/index.ts
@@ -1,3 +1,5 @@
+import './VPagination.sass'
+
 import VPagination from './VPagination'
 
 export { VPagination }

--- a/packages/vuetify/src/components/VParallax/VParallax.ts
+++ b/packages/vuetify/src/components/VParallax/VParallax.ts
@@ -1,6 +1,3 @@
-// Style
-import './VParallax.sass'
-
 // Mixins
 import Translatable from '../../mixins/translatable'
 

--- a/packages/vuetify/src/components/VParallax/index.ts
+++ b/packages/vuetify/src/components/VParallax/index.ts
@@ -1,3 +1,6 @@
+// Style
+import './VParallax.sass'
+
 import VParallax from './VParallax'
 
 export { VParallax }

--- a/packages/vuetify/src/components/VPicker/VPicker.ts
+++ b/packages/vuetify/src/components/VPicker/VPicker.ts
@@ -1,6 +1,3 @@
-import './VPicker.sass'
-import '../VCard/VCard.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Elevatable from '../../mixins/elevatable'

--- a/packages/vuetify/src/components/VPicker/index.ts
+++ b/packages/vuetify/src/components/VPicker/index.ts
@@ -1,3 +1,6 @@
+import './VPicker.sass'
+import '../VCard/VCard.sass'
+
 import VPicker from './VPicker'
 
 export { VPicker }

--- a/packages/vuetify/src/components/VProgressCircular/VProgressCircular.ts
+++ b/packages/vuetify/src/components/VProgressCircular/VProgressCircular.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VProgressCircular.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 

--- a/packages/vuetify/src/components/VProgressCircular/index.ts
+++ b/packages/vuetify/src/components/VProgressCircular/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VProgressCircular.sass'
+
 import VProgressCircular from './VProgressCircular'
 
 export { VProgressCircular }

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.ts
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.ts
@@ -1,5 +1,3 @@
-import './VProgressLinear.sass'
-
 // Components
 import {
   VFadeTransition,

--- a/packages/vuetify/src/components/VProgressLinear/index.ts
+++ b/packages/vuetify/src/components/VProgressLinear/index.ts
@@ -1,3 +1,5 @@
+import './VProgressLinear.sass'
+
 import VProgressLinear from './VProgressLinear'
 
 export { VProgressLinear }

--- a/packages/vuetify/src/components/VRadioGroup/VRadio.ts
+++ b/packages/vuetify/src/components/VRadioGroup/VRadio.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VRadio.sass'
-
 // Components
 import VRadioGroup from './VRadioGroup'
 import VLabel from '../VLabel'

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.ts
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.ts
@@ -1,7 +1,3 @@
-// Styles
-import '../../styles/components/_selection-controls.sass'
-import './VRadioGroup.sass'
-
 // Extensions
 import VInput from '../VInput'
 import { BaseItemGroup } from '../VItemGroup/VItemGroup'

--- a/packages/vuetify/src/components/VRadioGroup/index.ts
+++ b/packages/vuetify/src/components/VRadioGroup/index.ts
@@ -1,3 +1,8 @@
+// Styles
+import './VRadio.sass'
+import '../../styles/components/_selection-controls.sass'
+import './VRadioGroup.sass'
+
 import VRadioGroup from './VRadioGroup'
 import VRadio from './VRadio'
 

--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.ts
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VRangeSlider.sass'
-
 // Components
 import VSlider from '../VSlider'
 

--- a/packages/vuetify/src/components/VRangeSlider/index.ts
+++ b/packages/vuetify/src/components/VRangeSlider/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VRangeSlider.sass'
+
 import VRangeSlider from './VRangeSlider'
 
 export { VRangeSlider }

--- a/packages/vuetify/src/components/VRating/VRating.ts
+++ b/packages/vuetify/src/components/VRating/VRating.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VRating.sass'
-
 // Components
 import VIcon from '../VIcon'
 

--- a/packages/vuetify/src/components/VRating/index.ts
+++ b/packages/vuetify/src/components/VRating/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VRating.sass'
+
 import VRating from './VRating'
 
 export { VRating }

--- a/packages/vuetify/src/components/VResponsive/VResponsive.ts
+++ b/packages/vuetify/src/components/VResponsive/VResponsive.ts
@@ -1,5 +1,3 @@
-import './VResponsive.sass'
-
 // Mixins
 import Measurable, { NumberOrNumberString } from '../../mixins/measurable'
 

--- a/packages/vuetify/src/components/VResponsive/index.ts
+++ b/packages/vuetify/src/components/VResponsive/index.ts
@@ -1,3 +1,5 @@
+import './VResponsive.sass'
+
 import VResponsive from './VResponsive'
 
 export { VResponsive }

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -1,7 +1,3 @@
-// Styles
-import '../VTextField/VTextField.sass'
-import './VSelect.sass'
-
 // Components
 import VChip from '../VChip'
 import VMenu from '../VMenu'

--- a/packages/vuetify/src/components/VSelect/index.ts
+++ b/packages/vuetify/src/components/VSelect/index.ts
@@ -1,3 +1,7 @@
+// Styles
+import '../VTextField/VTextField.sass'
+import './VSelect.sass'
+
 import VSelect from './VSelect'
 
 export { VSelect }

--- a/packages/vuetify/src/components/VSheet/VSheet.ts
+++ b/packages/vuetify/src/components/VSheet/VSheet.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSheet.sass'
-
 // Mixins
 import BindsAttrs from '../../mixins/binds-attrs'
 import Colorable from '../../mixins/colorable'

--- a/packages/vuetify/src/components/VSheet/index.ts
+++ b/packages/vuetify/src/components/VSheet/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSheet.sass'
+
 import VSheet from './VSheet'
 
 export { VSheet }

--- a/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.ts
+++ b/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSkeletonLoader.sass'
-
 // Mixins
 import Elevatable from '../../mixins/elevatable'
 import Measurable from '../../mixins/measurable'

--- a/packages/vuetify/src/components/VSkeletonLoader/index.ts
+++ b/packages/vuetify/src/components/VSkeletonLoader/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSkeletonLoader.sass'
+
 import VSkeletonLoader from './VSkeletonLoader'
 
 export { VSkeletonLoader }

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSlideGroup.sass'
-
 // Components
 import VIcon from '../VIcon'
 import { VFadeTransition } from '../transitions'

--- a/packages/vuetify/src/components/VSlideGroup/index.ts
+++ b/packages/vuetify/src/components/VSlideGroup/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSlideGroup.sass'
+
 import VSlideGroup from './VSlideGroup'
 import VSlideItem from './VSlideItem'
 

--- a/packages/vuetify/src/components/VSlider/VSlider.ts
+++ b/packages/vuetify/src/components/VSlider/VSlider.ts
@@ -1,5 +1,3 @@
-import './VSlider.sass'
-
 // Components
 import VInput from '../VInput'
 import { VScaleTransition } from '../transitions'

--- a/packages/vuetify/src/components/VSlider/index.ts
+++ b/packages/vuetify/src/components/VSlider/index.ts
@@ -1,3 +1,5 @@
+import './VSlider.sass'
+
 import VSlider from './VSlider'
 
 export { VSlider }

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.ts
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSnackbar.sass'
-
 // Components
 import VSheet from '../VSheet/VSheet'
 

--- a/packages/vuetify/src/components/VSnackbar/index.ts
+++ b/packages/vuetify/src/components/VSnackbar/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSnackbar.sass'
+
 import VSnackbar from './VSnackbar'
 
 export { VSnackbar }

--- a/packages/vuetify/src/components/VSpeedDial/VSpeedDial.ts
+++ b/packages/vuetify/src/components/VSpeedDial/VSpeedDial.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSpeedDial.sass'
-
 // Mixins
 import Toggleable from '../../mixins/toggleable'
 import Positionable from '../../mixins/positionable'

--- a/packages/vuetify/src/components/VSpeedDial/index.ts
+++ b/packages/vuetify/src/components/VSpeedDial/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSpeedDial.sass'
+
 import VSpeedDial from './VSpeedDial'
 
 export { VSpeedDial }

--- a/packages/vuetify/src/components/VStepper/VStepper.ts
+++ b/packages/vuetify/src/components/VStepper/VStepper.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VStepper.sass'
-
 // Components
 import VStepperStep from './VStepperStep'
 import VStepperContent from './VStepperContent'

--- a/packages/vuetify/src/components/VStepper/index.ts
+++ b/packages/vuetify/src/components/VStepper/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VStepper.sass'
+
 import { createSimpleFunctional } from '../../util/helpers'
 import VStepper from './VStepper'
 import VStepperStep from './VStepperStep'

--- a/packages/vuetify/src/components/VSubheader/VSubheader.ts
+++ b/packages/vuetify/src/components/VSubheader/VSubheader.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSubheader.sass'
-
 // Mixins
 import Themeable from '../../mixins/themeable'
 import mixins from '../../util/mixins'

--- a/packages/vuetify/src/components/VSubheader/index.ts
+++ b/packages/vuetify/src/components/VSubheader/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSubheader.sass'
+
 import VSubheader from './VSubheader'
 
 export { VSubheader }

--- a/packages/vuetify/src/components/VSwitch/VSwitch.ts
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.ts
@@ -1,7 +1,3 @@
-// Styles
-import '../../styles/components/_selection-controls.sass'
-import './VSwitch.sass'
-
 // Mixins
 import Selectable from '../../mixins/selectable'
 import VInput from '../VInput'

--- a/packages/vuetify/src/components/VSwitch/index.ts
+++ b/packages/vuetify/src/components/VSwitch/index.ts
@@ -1,3 +1,7 @@
+// Styles
+import '../../styles/components/_selection-controls.sass'
+import './VSwitch.sass'
+
 import VSwitch from './VSwitch'
 
 export { VSwitch }

--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.ts
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VSystemBar.sass'
-
 // Mixins
 import Applicationable from '../../mixins/applicationable'
 import Colorable from '../../mixins/colorable'

--- a/packages/vuetify/src/components/VSystemBar/index.ts
+++ b/packages/vuetify/src/components/VSystemBar/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VSystemBar.sass'
+
 import VSystemBar from './VSystemBar'
 
 export { VSystemBar }

--- a/packages/vuetify/src/components/VTabs/VTabs.ts
+++ b/packages/vuetify/src/components/VTabs/VTabs.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VTabs.sass'
-
 // Components
 import VTabsBar from './VTabsBar'
 import VTabsItems from './VTabsItems'

--- a/packages/vuetify/src/components/VTabs/index.ts
+++ b/packages/vuetify/src/components/VTabs/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VTabs.sass'
+
 import VTabs from './VTabs'
 import VTab from './VTab'
 import VTabsItems from './VTabsItems'

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VTextField.sass'
-
 // Extensions
 import VInput from '../VInput'
 

--- a/packages/vuetify/src/components/VTextField/index.ts
+++ b/packages/vuetify/src/components/VTextField/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VTextField.sass'
+
 import VTextField from './VTextField'
 
 export { VTextField }

--- a/packages/vuetify/src/components/VTextarea/VTextarea.ts
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VTextarea.sass'
-
 // Extensions
 import VTextField from '../VTextField/VTextField'
 

--- a/packages/vuetify/src/components/VTextarea/index.ts
+++ b/packages/vuetify/src/components/VTextarea/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VTextarea.sass'
+
 import VTextarea from './VTextarea'
 
 export { VTextarea }

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerClock.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerClock.ts
@@ -1,5 +1,3 @@
-import './VTimePickerClock.sass'
-
 // Mixins
 import Colorable from '../../mixins/colorable'
 import Themeable from '../../mixins/themeable'

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerTitle.ts
@@ -1,5 +1,3 @@
-import './VTimePickerTitle.sass'
-
 // Mixins
 import PickerButton from '../../mixins/picker-button'
 

--- a/packages/vuetify/src/components/VTimePicker/index.ts
+++ b/packages/vuetify/src/components/VTimePicker/index.ts
@@ -1,3 +1,6 @@
+import './VTimePickerClock.sass'
+import './VTimePickerTitle.sass'
+
 import VTimePicker from './VTimePicker'
 import VTimePickerClock from './VTimePickerClock'
 import VTimePickerTitle from './VTimePickerTitle'

--- a/packages/vuetify/src/components/VTimeline/VTimeline.ts
+++ b/packages/vuetify/src/components/VTimeline/VTimeline.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VTimeline.sass'
-
 // Types
 import { VNode } from 'vue'
 import mixins from '../../util/mixins'

--- a/packages/vuetify/src/components/VTimeline/index.ts
+++ b/packages/vuetify/src/components/VTimeline/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VTimeline.sass'
+
 import VTimeline from './VTimeline'
 import VTimelineItem from './VTimelineItem'
 

--- a/packages/vuetify/src/components/VToolbar/VToolbar.ts
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VToolbar.sass'
-
 // Extensions
 import VSheet from '../VSheet/VSheet'
 

--- a/packages/vuetify/src/components/VToolbar/index.ts
+++ b/packages/vuetify/src/components/VToolbar/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VToolbar.sass'
+
 // Components
 import VToolbar from './VToolbar'
 

--- a/packages/vuetify/src/components/VTooltip/VTooltip.ts
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.ts
@@ -1,5 +1,3 @@
-import './VTooltip.sass'
-
 // Mixins
 import Activatable from '../../mixins/activatable'
 import Colorable from '../../mixins/colorable'

--- a/packages/vuetify/src/components/VTooltip/index.ts
+++ b/packages/vuetify/src/components/VTooltip/index.ts
@@ -1,3 +1,5 @@
+import './VTooltip.sass'
+
 import VTooltip from './VTooltip'
 
 export { VTooltip }

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VTreeview.sass'
-
 // Types
 import { VNode, VNodeChildrenArrayContents, PropType } from 'vue'
 import { PropValidator } from 'vue/types/options'

--- a/packages/vuetify/src/components/VTreeview/index.ts
+++ b/packages/vuetify/src/components/VTreeview/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VTreeview.sass'
+
 import VTreeview from './VTreeview'
 import VTreeviewNode from './VTreeviewNode'
 

--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.ts
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VVirtualScroll.sass'
-
 // Mixins
 import Measurable from '../../mixins/measurable'
 

--- a/packages/vuetify/src/components/VVirtualScroll/index.ts
+++ b/packages/vuetify/src/components/VVirtualScroll/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VVirtualScroll.sass'
+
 import VVirtualScroll from './VVirtualScroll'
 
 export { VVirtualScroll }

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -1,6 +1,3 @@
-// Styles
-import './VWindow.sass'
-
 // Types
 import { VNode, VNodeDirective } from 'vue/types/vnode'
 import { PropType } from 'vue'

--- a/packages/vuetify/src/components/VWindow/index.ts
+++ b/packages/vuetify/src/components/VWindow/index.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VWindow.sass'
+
 import VWindow from './VWindow'
 import VWindowItem from './VWindowItem'
 

--- a/packages/vuetify/src/presets/default/index.ts
+++ b/packages/vuetify/src/presets/default/index.ts
@@ -1,6 +1,3 @@
-// Styles
-import '../../styles/main.sass'
-
 // Locale
 import { en } from '../../locale'
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Fixes #12282 - I moved all Sass imports from components (and presets) to the `index.ts` of components. In a normal use case, this should result in no changes. However, it allows you to separately import the Sass file of a component from the component itself, which does the following:
1. This makes modifying sass-loader unnecessary if using a custom `variables.scss` file. (This can be placed in your `.vue` file before the component's styles.)
2. This makes it possible to export a Vuetify-based component library without downstream repos needing to add vuetify-loader and make changes to their `sass-loader` setup.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See: #12282

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Unit tests for the `vuetify` package all pass. I was unable, however, at any time, to build the entire project, despite the contributing guide. It generated endless Unhandled promise rejection errors. So I couldn't visually confirm there were no breaking changes; however, when importing this as a local package (instead of the NPM `vuetify`, it works exactly as described above).

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
