### PR TITLE
Icon missing the mdi- part

### DIFF
--- a/packages/docs/src/examples/v-btn/prop-loaders.vue
+++ b/packages/docs/src/examples/v-btn/prop-loaders.vue
@@ -49,7 +49,7 @@
       Icon Loader
       <template v-slot:loader>
         <span class="custom-loader">
-          <v-icon light>cached</v-icon>
+          <v-icon light>mdi-cached</v-icon>
         </span>
       </template>
     </v-btn>


### PR DESCRIPTION
## Description
The loading button icon is missing the 'mdi-' part. This causes the text 'cached' to rotate inside the button as instead to the icon. 

## Motivation and Context
Does not look good son. 

## How Has This Been Tested?
None at all, doing this is from my phone at the moment. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
