### PR TITLE
fix(VIcon): set svg dimensions in style instead of attributes

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -153,17 +153,23 @@ const VIcon = mixins(
       return h(this.hasClickListener ? 'button' : this.tag, data, newChildren)
     },
     renderSvgIcon (icon: string, h: CreateElement): VNode {
-      const fontSize = this.getSize()
       const svgData: VNodeData = {
         class: 'v-icon__svg',
         attrs: {
           xmlns: 'http://www.w3.org/2000/svg',
           viewBox: '0 0 24 24',
-          height: fontSize || '24',
-          width: fontSize || '24',
           role: 'img',
           'aria-hidden': true,
         },
+      }
+
+      const size = this.getSize()
+      if (size) {
+        svgData.style = {
+          fontSize: size,
+          height: size,
+          width: size,
+        }
       }
 
       return h(this.hasClickListener ? 'button' : 'span', this.getSvgWrapperData(), [

--- a/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
+++ b/packages/vuetify/src/components/VIcon/__tests__/__snapshots__/VIcon.spec.ts.snap
@@ -6,8 +6,6 @@ exports[`VIcon for component icon should render an svg icon 1`] = `
 >
   <svg xmlns="http://www.w3.org/2000/svg"
        viewbox="0 0 24 24"
-       height="24"
-       width="24"
        role="img"
        aria-hidden="true"
        class="v-icon__svg"
@@ -25,11 +23,10 @@ exports[`VIcon for component icon should render an svg icon 2`] = `
 >
   <svg xmlns="http://www.w3.org/2000/svg"
        viewbox="0 0 24 24"
-       height="36px"
-       width="36px"
        role="img"
        aria-hidden="true"
        class="v-icon__svg"
+       style="font-size: 36px; height: 36px; width: 36px;"
   >
     <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z">
     </path>


### PR DESCRIPTION
Fixes regression from #12148 preventing size props from working

fixes #12372

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-btn color="primary" icon>
      <v-icon large>{{ mdiAccountCircle }}</v-icon>
    </v-btn>

    <v-btn color="primary" icon>
      <v-icon>{{ mdiAccountCircle }}</v-icon>
    </v-btn>
  </v-container>
</template>

<script>
  import { mdiAccountCircle } from '@mdi/js'

  export default {
    data: () => ({
      mdiAccountCircle,
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

