### PR TITLE
fix: allow $material-dark-elevation-colors to be overridden

### DIFF
--- a/packages/vuetify/src/styles/settings/_dark.scss
+++ b/packages/vuetify/src/styles/settings/_dark.scss
@@ -3,17 +3,20 @@
 $material-dark-elevation-colors: () !default;
 // https://material.io/design/color/dark-theme.html#properties
 // https://material.io/design/environment/elevation.html#default-elevations
-$material-dark-elevation-colors: (
-  '0': #000000,
-  '1': #1E1E1E,
-  '2': #222222,
-  '3': #252525,
-  '4': #272727,
-  '6': #2C2C2C,
-  '8': #2E2E2E,
-  '12': #333333,
-  '16': #363636,
-  '24': #373737
+$material-dark-elevation-colors: map-deep-merge(
+  (
+    '0': #000000,
+    '1': #1E1E1E,
+    '2': #222222,
+    '3': #252525,
+    '4': #272727,
+    '6': #2C2C2C,
+    '8': #2E2E2E,
+    '12': #333333,
+    '16': #363636,
+    '24': #373737
+  ),
+  $material-dark-elevation-colors
 );
 
 $material-dark: () !default;


### PR DESCRIPTION
## Description
https://vuetifyjs.com/en/features/sass-variables/#variable-api lists `$material-dark-elevation-colors` as a variable which can be overridden, however that is not currently possible since the value was always being overridden since it was not merged with any other values provided.

## Motivation and Context
The dark theme is very dark, I would like to be able to customize it without having to individually override the `$material-dark` individual elements.

## How Has This Been Tested?
I made this change locally and was able to override the `$material-dark-elevation-colors` variable as described on https://vuetifyjs.com/en/features/sass-variables/#variable-api

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
