### PR TITLE
fix(VCarousel): incorrect transition direction when using touch

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -157,7 +157,7 @@ export default VWindow.extend({
           mandatory: this.mandatory,
         },
         on: {
-          change: (val: any) => {
+          change: (val: unknown) => {
             this.internalValue = val
           },
         },

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -46,7 +46,7 @@ export default BaseItemGroup.extend({
     },
     reverse: {
       type: Boolean,
-      default: undefined,
+      default: false,
     },
     showArrows: Boolean,
     showArrowsOnHover: Boolean,
@@ -60,7 +60,6 @@ export default BaseItemGroup.extend({
 
   data () {
     return {
-      changedByDelimiters: false,
       internalHeight: undefined as undefined | string, // This can be fixed by child class.
       transitionHeight: undefined as undefined | string, // Intermediate height during transition.
       transitionCount: 0, // Number of windows in transition state.
@@ -83,7 +82,7 @@ export default BaseItemGroup.extend({
       if (!this.isBooted) return ''
 
       const axis = this.vertical ? 'y' : 'x'
-      const reverse = this.$vuetify.rtl && axis === 'x' ? !this.internalReverse : this.internalReverse
+      const reverse = this.internalReverse ? !this.isReverse : this.isReverse
       const direction = reverse ? '-reverse' : ''
 
       return `v-window-${axis}${direction}-transition`
@@ -105,12 +104,14 @@ export default BaseItemGroup.extend({
       })
     },
     internalReverse (): boolean {
-      return this.reverse ? !this.isReverse : this.isReverse
+      return this.$vuetify.rtl ? !this.reverse : this.reverse
     },
   },
 
   watch: {
-    internalIndex: 'updateReverse',
+    internalIndex (val, oldVal) {
+      this.isReverse = this.updateReverse(val, oldVal)
+    },
   },
 
   mounted () {
@@ -138,7 +139,7 @@ export default BaseItemGroup.extend({
     genIcon (
       direction: 'prev' | 'next',
       icon: string,
-      fn: () => void
+      click: () => void
     ) {
       return this.$createElement('div', {
         staticClass: `v-window__${direction}`,
@@ -149,10 +150,7 @@ export default BaseItemGroup.extend({
             'aria-label': this.$vuetify.lang.t(`$vuetify.carousel.${direction}`),
           },
           on: {
-            click: () => {
-              this.changedByDelimiters = true
-              fn()
-            },
+            click,
           },
         }, [
           this.$createElement(VIcon, {
@@ -211,8 +209,6 @@ export default BaseItemGroup.extend({
       return prevIndex
     },
     next () {
-      this.isReverse = this.$vuetify.rtl
-
       /* istanbul ignore if */
       if (!this.hasActiveItems || !this.hasNext) return
 
@@ -222,8 +218,6 @@ export default BaseItemGroup.extend({
       this.internalValue = this.getValue(item, nextIndex)
     },
     prev () {
-      this.isReverse = !this.$vuetify.rtl
-
       /* istanbul ignore if */
       if (!this.hasActiveItems || !this.hasPrev) return
 
@@ -233,12 +227,15 @@ export default BaseItemGroup.extend({
       this.internalValue = this.getValue(item, lastIndex)
     },
     updateReverse (val: number, oldVal: number) {
-      if (this.changedByDelimiters) {
-        this.changedByDelimiters = false
-        return
-      }
+      const lastIndex = this.items.length - 1
 
-      this.isReverse = val < oldVal
+      if (val === lastIndex && oldVal === 0) {
+        return true
+      } else if (val === 0 && oldVal === lastIndex) {
+        return false
+      } else {
+        return val < oldVal
+      }
     },
   },
 

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -44,10 +44,7 @@ export default BaseItemGroup.extend({
       type: [Boolean, String],
       default: '$prev',
     },
-    reverse: {
-      type: Boolean,
-      default: false,
-    },
+    reverse: Boolean,
     showArrows: Boolean,
     showArrowsOnHover: Boolean,
     touch: Object as PropType<TouchHandlers>,
@@ -149,9 +146,7 @@ export default BaseItemGroup.extend({
           attrs: {
             'aria-label': this.$vuetify.lang.t(`$vuetify.carousel.${direction}`),
           },
-          on: {
-            click,
-          },
+          on: { click },
         }, [
           this.$createElement(VIcon, {
             props: { large: true },

--- a/packages/vuetify/src/components/VWindow/__tests__/VWindow.spec.ts
+++ b/packages/vuetify/src/components/VWindow/__tests__/VWindow.spec.ts
@@ -56,31 +56,34 @@ describe('VWindow.ts', () => {
         default: [
           VWindowItem,
           VWindowItem,
+          VWindowItem,
         ],
       },
     })
 
+    wrapper.setData({ isBooted: true })
+
     // Reverse implicitly set by changed index
     wrapper.setProps({ value: 1 })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.internalReverse).toBeFalsy()
+    expect(wrapper.vm.isReverse).toBeFalsy()
 
     // Reverse implicitly set by changed index
     wrapper.setProps({ value: 0 })
     await wrapper.vm.$nextTick()
-    expect(wrapper.vm.internalReverse).toBeTruthy()
+    expect(wrapper.vm.isReverse).toBeTruthy()
 
     // Reverse explicit prop override
     wrapper.setProps({ reverse: false })
-    expect(wrapper.vm.internalReverse).toBeTruthy()
+    expect(wrapper.vm.computedTransition.includes('reverse')).toBeTruthy()
 
     // Reverse explicit prop override
     wrapper.setProps({ reverse: true })
-    expect(wrapper.vm.internalReverse).toBeFalsy()
+    expect(wrapper.vm.computedTransition.includes('reverse')).toBeFalsy()
 
     // Reverts back to local isReverse
     wrapper.setProps({ reverse: undefined })
-    expect(wrapper.vm.internalReverse).toBeTruthy()
+    expect(wrapper.vm.computedTransition.includes('reverse')).toBeTruthy()
   })
 
   it('should increment and decrement current value', async () => {

--- a/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
+++ b/packages/vuetify/src/components/VWindow/__tests__/VWindowItem.spec.ts
@@ -153,6 +153,11 @@ describe('VWindowItem.ts', () => {
       slots: {
         default: [VWindowItem, VWindowItem, VWindowItem],
       },
+      mocks: {
+        $vuetify: {
+          rtl: false,
+        },
+      },
     })
 
     const items = wrapper.vm.items


### PR DESCRIPTION
## Description
using touch would result in incorrect transition when looping around

## Motivation and Context
closes #11280

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-switch
      v-model="$vuetify.rtl"
      label="RTL"
    />
    <v-btn @click="foo = foo - 1 < 0 ? slides.length - 1 : foo - 1">prev</v-btn>
    <v-btn @click="foo = foo + 1 >= slides.length ? 0 : foo + 1">next</v-btn>
    <v-carousel
      v-model="foo"
      height="400"
      hide-delimiter-background
      show-arrows-on-hover
    >
      <v-carousel-item
        v-for="(slide, i) in slides"
        :key="i"
      >
        <v-sheet
          :color="colors[i]"
          height="100%"
        >
          <v-row
            class="fill-height"
            align="center"
            justify="center"
          >
            <div class="display-3">{{ slide }} Slide</div>
          </v-row>
        </v-sheet>
      </v-carousel-item>
    </v-carousel>

    <v-carousel
      height="400"
      hide-delimiter-background
      show-arrows-on-hover
      reverse
    >
      <v-carousel-item
        v-for="(slide, i) in slides"
        :key="i"
        :value="`value_${i}`"
      >
        <v-sheet
          :color="colors[i]"
          height="100%"
        >
          <v-row
            class="fill-height"
            align="center"
            justify="center"
          >
            <div class="display-3">{{ slide }} Slide</div>
          </v-row>
        </v-sheet>
      </v-carousel-item>
    </v-carousel>

    <v-carousel
      height="400"
      hide-delimiter-background
      show-arrows-on-hover
      vertical
    >
      <v-carousel-item
        v-for="(slide, i) in slides"
        :key="i"
        :value="`value_${i}`"
      >
        <v-sheet
          :color="colors[i]"
          height="100%"
        >
          <v-row
            class="fill-height"
            align="center"
            justify="center"
          >
            <div class="display-3">{{ slide }} Slide</div>
          </v-row>
        </v-sheet>
      </v-carousel-item>
    </v-carousel>
  </div>
</template>

<script>
  export default {
    data: () => ({
      foo: 0,
      colors: [
        'indigo',
        'warning',
        'pink darken-2',
        'red lighten-1',
        'deep-purple accent-4',
      ],
      slides: [
        'First',
        'Second',
        'Third',
        'Fourth',
        'Fifth',
      ],
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
