### PR TITLE
docs(icons): fix mdi webfont dependency name

### DIFF
--- a/packages/docs/src/pages/en/features/icons.md
+++ b/packages/docs/src/pages/en/features/icons.md
@@ -61,9 +61,9 @@ This is the default icon font for Vuetify. You can include it through a CDN:
 Or as a local dependency:
 
 ```bash
-$ yarn add @mdi/js -D
+$ yarn add @mdi/font -D
 // OR
-$ npm install @mdi/js -D
+$ npm install @mdi/font -D
 ```
 
 ```js


### PR DESCRIPTION
## Description
When using Material Design Icons webfont, the dependency is `@mdi/font` (not `@mdi/js`) as described in [this repository](https://github.com/Templarian/MaterialDesign-Webfont#webfont---material-design-icons).

Closes #12359

## Motivation and Context
Unknown import when following the current ["Installing iconfonts / Material Design Icons"](https://vuetifyjs.com/en/features/icons/#material-design-icons) documentation:
```
import '@mdi/font/css/materialdesignicons.css'
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
