### PR TITLE
fix(VChip): add aria-label to chip close button

### DIFF
--- a/packages/api-generator/.gitignore
+++ b/packages/api-generator/.gitignore
@@ -1,3 +1,3 @@
 /dist/
 /src/locale/*
-!/src/en
+!/src/locale/en

--- a/packages/api-generator/src/locale/en/v-chip.json
+++ b/packages/api-generator/src/locale/en/v-chip.json
@@ -3,6 +3,7 @@
     "active": "Determines whether the chip is visible or not.",
     "close": "Adds remove button",
     "closeIcon": "Change the default icon used for **close** chips",
+    "closeLabel": "Text used for *aria-label* on the close button in **close** chips. Can also be customized globally in [Internationalization](/customization/internationalization).",
     "disabled": "Disables the chip, making it un-selectable",
     "draggable": "Makes the chip draggable",
     "filter": "Displays a selection icon when selected",

--- a/packages/vuetify/src/components/VChip/VChip.ts
+++ b/packages/vuetify/src/components/VChip/VChip.ts
@@ -52,6 +52,10 @@ export default mixins(
       type: String,
       default: '$delete',
     },
+    closeLabel: {
+      type: String,
+      default: '$vuetify.close',
+    },
     disabled: Boolean,
     draggable: Boolean,
     filter: Boolean,
@@ -145,6 +149,9 @@ export default mixins(
         props: {
           right: true,
           size: 18,
+        },
+        attrs: {
+          'aria-label': this.$vuetify.lang.t(this.closeLabel),
         },
         on: {
           click: (e: Event) => {

--- a/packages/vuetify/src/components/VChip/__tests__/VChip.spec.ts
+++ b/packages/vuetify/src/components/VChip/__tests__/VChip.spec.ts
@@ -30,6 +30,13 @@ describe('VChip.ts', () => {
         sync: false,
         localVue,
         router,
+        mocks: {
+          $vuetify: {
+            lang: {
+              t: (val: string) => val,
+            },
+          },
+        },
         ...options,
       })
     }

--- a/packages/vuetify/src/components/VChip/__tests__/__snapshots__/VChip.spec.ts.snap
+++ b/packages/vuetify/src/components/VChip/__tests__/__snapshots__/VChip.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`VChip.ts should be removable 1`] = `
 <span class="v-chip v-chip--no-color v-chip--removable theme--light v-size--default">
   <span class="v-chip__content">
     <button type="button"
+            aria-label="$vuetify.close"
             class="v-icon notranslate v-chip__close v-icon--link v-icon--right material-icons theme--light"
             style="font-size: 18px;"
     >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #11165 by adding a default aria-label of `'$vuetify.close'` to the close `<button>` tag on VChip. This change also created a new prop of `close-label` on VChip.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#11165

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Tested in playground and with unit tests. Added a unit test to check for new aria-label when expected.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

```vue
<template>
  <v-container>
    <v-chip
      close
      close-icon="mdi-close-outline"
      color="green"
    >Hello Vuetify (default aria label)</v-chip>
    <v-chip
      close
      close-icon="mdi-close-outline"
      color="purple"
      close-label="custom aria label"
    >Hello Vuetify (custom aria label)</v-chip>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      //
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
