### PR TITLE
docs: Fix Combobox Docs Error

### DIFF
--- a/packages/docs/src/examples/v-combobox/usage.vue
+++ b/packages/docs/src/examples/v-combobox/usage.vue
@@ -55,7 +55,7 @@
           'multiple',
           'persistent-hint',
           'small-chips',
-        ]
+        ],
       },
       tabs: ['dense', 'filled', 'outlined', 'solo'],
     }),

--- a/packages/docs/src/examples/v-combobox/usage.vue
+++ b/packages/docs/src/examples/v-combobox/usage.vue
@@ -55,9 +55,9 @@
           'multiple',
           'persistent-hint',
           'small-chips',
-        ],
-        tabs: ['dense', 'filled', 'outlined', 'solo'],
+        ]
       },
+      tabs: ['dense', 'filled', 'outlined', 'solo'],
     }),
   }
 </script>


### PR DESCRIPTION
Fix length of null error for the settings for usage in docs

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->
Fixed data structure to fix error: `TypeError: Cannot read property 'length' of undefined` on combobox documents usage section

## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

Moved the tabs data from within the options object to the data root as should be.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix for error: `TypeError: Cannot read property 'length' of undefined` on combobox documents usage section

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
