### PR TITLE
docs: fix broken link in documentation of v-card img

### DIFF
--- a/packages/api-generator/src/locale/en/v-card.json
+++ b/packages/api-generator/src/locale/en/v-card.json
@@ -3,7 +3,7 @@
     "contain": "Applies **background-size: contain** to the background image (when using the **img** prop).",
     "flat": "Removes the card's elevation.",
     "hover": "Will apply an elevation of 4dp when hovered (default 2dp). You can find more information on the [elevation page](/styles/elevation).",
-    "img": "Specifies an image background for the card. For more advanced implementations, it is recommended that you use the [v-img](/components/images) component. You can find a [v-img example here](#media-with-text).",
+    "img": "Specifies an image background for the card. For more advanced implementations, it is recommended that you use the [v-img](/components/images) component. You can find a [v-img example here](/components/cards/#media-with-text).",
     "raised": "Specifies a higher default elevation (8dp). You can find more information on the [elevation page](/styles/elevation)."
   },
   "events": {


### PR DESCRIPTION
## Description
Fixes a broken link at https://vuetifyjs.com/en/api/v-card/#props at "v-img example here"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
