### PR TITLE
fix(VCombobox): don't reset value to null if search is empty

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -134,8 +134,7 @@ export default VSelect.extend({
       }
     },
     searchIsDirty (): boolean {
-      return this.internalSearch != null &&
-        this.internalSearch !== ''
+      return this.internalSearch != null
     },
     selectedItem (): any {
       if (this.multiple) return null

--- a/packages/vuetify/src/components/VCombobox/VCombobox.ts
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.ts
@@ -177,18 +177,15 @@ export default VAutocomplete.extend({
       this.editingIndex = -1
     },
     updateCombobox () {
-      const isUsingSlot = Boolean(this.$scopedSlots.selection) || this.hasChips
-
-      // If search is not dirty and is
-      // using slot, do nothing
-      if (isUsingSlot && !this.searchIsDirty) return
+      // If search is not dirty, do nothing
+      if (!this.searchIsDirty) return
 
       // The internal search is not matching
       // the internal value, update the input
       if (this.internalSearch !== this.getText(this.internalValue)) this.setValue()
 
-      // Reset search if using slot
-      // to avoid a double input
+      // Reset search if using slot to avoid a double input
+      const isUsingSlot = Boolean(this.$scopedSlots.selection) || this.hasChips
       if (isUsingSlot) this.internalSearch = undefined
     },
     updateSelf () {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #12322

I can't think of a good reason to count `''` as clean, search is reset to null on blur anyway so it can only mean:
 - value is `''` and nothing was changed, or
 - value is set and search was deleted by the user

Only checked with combobox, probably doesn't break autocomplete though. 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <pre>{{ JSON.stringify(String(select)) }}</pre>
    <pre>{{ JSON.stringify(String(search)) }}</pre>
    <v-combobox v-model="select" :search-input.sync="search"></v-combobox>
    <v-btn @click="select = ''">reset</v-btn>
    <v-btn @click="search = ''">reset search</v-btn>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      select: '',
      search: '',
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

