### PR TITLE
feat(VPagination): Use <a> tags on the pagination component.

### DIFF
--- a/packages/vuetify/src/components/VPagination/VPagination.sass
+++ b/packages/vuetify/src/components/VPagination/VPagination.sass
@@ -49,6 +49,9 @@
     text-decoration: none
     transition: .3s map-get($transition, 'linear-out-slow-in')
     width: auto
+    display: flex
+    align-items: center
+    justify-content: center
     +elevation(2)
 
     &--active

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.ts
@@ -293,4 +293,20 @@ describe('VPagination.ts', () => {
 
     expect(wrapper.vm.items).toEqual([1, 2, 3, 4])
   })
+
+  it('render the links as <a> tags', async () => {
+    const linkFn = jest.fn(i => i)
+    const wrapper = mountFunction({
+      propsData: {
+        linkFn,
+        length: 5,
+        value: 2,
+      },
+    })
+    jest.runAllTimers()
+
+    await wrapper.vm.$nextTick()
+    expect(linkFn).toHaveBeenCalled()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VPagination/__tests__/__snapshots__/VPagination.spec.ts.snap
+++ b/packages/vuetify/src/components/VPagination/__tests__/__snapshots__/VPagination.spec.ts.snap
@@ -72,6 +72,78 @@ exports[`VPagination.ts emits an event when next or previous is clicked 1`] = `
 </nav>
 `;
 
+exports[`VPagination.ts render the links as <a> tags 1`] = `
+<nav role="navigation"
+     aria-label="$vuetify.pagination.ariaLabel.wrapper"
+>
+  <ul class="v-pagination theme--light">
+    <li>
+      <a href="1"
+         aria-label="$vuetify.pagination.ariaLabel.previous"
+         class="v-pagination__navigation"
+      >
+        <i aria-hidden="true"
+           class="v-icon notranslate mdi mdi-chevron-left theme--light"
+        >
+        </i>
+      </a>
+    </li>
+    <li>
+      <a href="1"
+         aria-label="$vuetify.pagination.ariaLabel.page"
+         class="v-pagination__item"
+      >
+        1
+      </a>
+    </li>
+    <li>
+      <a href="2"
+         aria-current="true"
+         aria-label="$vuetify.pagination.ariaLabel.currentPage"
+         class="v-pagination__item v-pagination__item--active primary"
+      >
+        2
+      </a>
+    </li>
+    <li>
+      <a href="3"
+         aria-label="$vuetify.pagination.ariaLabel.page"
+         class="v-pagination__item"
+      >
+        3
+      </a>
+    </li>
+    <li>
+      <a href="4"
+         aria-label="$vuetify.pagination.ariaLabel.page"
+         class="v-pagination__item"
+      >
+        4
+      </a>
+    </li>
+    <li>
+      <a href="5"
+         aria-label="$vuetify.pagination.ariaLabel.page"
+         class="v-pagination__item"
+      >
+        5
+      </a>
+    </li>
+    <li>
+      <a href="3"
+         aria-label="$vuetify.pagination.ariaLabel.next"
+         class="v-pagination__navigation"
+      >
+        <i aria-hidden="true"
+           class="v-icon notranslate mdi mdi-chevron-right theme--light"
+        >
+        </i>
+      </a>
+    </li>
+  </ul>
+</nav>
+`;
+
 exports[`VPagination.ts should only render end of range if value is equals "right" 1`] = `
 <nav role="navigation"
      aria-label="$vuetify.pagination.ariaLabel.wrapper"


### PR DESCRIPTION
This implement the use of optional <a> tags in the pagination component.

This is mostly a work in progress PR to gather feedback before adding the documentation.

## Description
As described in #8759, it's useful for SEO purpose but also usability one (open in new tab for instance)

Fix #8759

## Motivation and Context
This add a new optional prop `linkFn` whose job it to create an url for the given page.

## How Has This Been Tested?
I added a new unit test.

## Markup:

<details>

```vue
<template>
  <v-container>
    <v-pagination
      :value="4"
      :length="10"
      :linkFn="linkFn"
    />
    <v-pagination
      :value="4"
      :length="10"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      linkFn(i) {
        return `#${i}`;
      }
    }),
  }
</script>
```
</details>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
