### PR TITLE
Changing 'vuetify' to 'lib/vuetify'

### DIFF
--- a/packages/docs/src/pages/en/getting-started/unit-testing.md
+++ b/packages/docs/src/pages/en/getting-started/unit-testing.md
@@ -39,7 +39,7 @@ This can vary between test runners. Make sure to reference the appropriate docum
 // tests/setup.js
 
 import Vue from 'vue'
-import Vuetify from 'lib/vuetify'
+import Vuetify from 'vuetify/lib'
 
 Vue.use(Vuetify)
 ```
@@ -57,7 +57,7 @@ Creating unit tests in Vuetify are similar to **vuex** and **vue-router** in tha
 ```js
 // Imports
 import AppBtn from '../AppBtn.vue'
-import Vuetify from 'vuetify'
+import Vuetify from 'vuetify/lib'
 
 // Utilities
 import { createLocalVue, mount } from '@vue/test-utils'
@@ -133,7 +133,7 @@ In the example above we have created a custom component with a **title** prop an
 
 // Libraries
 import Vue from 'vue'
-import Vuetify from 'vuetify'
+import Vuetify from 'vuetify/lib'
 
 // Components
 import CustomCard from '@/components/CustomCard'
@@ -242,7 +242,7 @@ Many of Vuetify's components utilize the global `$vuetify` object to derive sett
 
 // Libraries
 import Vue from 'vue'
-import Vuetify from 'vuetify'
+import Vuetify from 'vuetify/lib'
 
 // Components
 import CustomAlert from '@/components/CustomAlert'
@@ -285,7 +285,7 @@ Keep in mind, you **only need to stub** the services that are being used. such a
 
 // Libraries
 import Vue from 'vue'
-import Vuetify from 'vuetify'
+import Vuetify from 'vuetify/lib'
 
 // Components
 import CustomNavigationDrawer from '@/components/CustomNavigationDrawer'

--- a/packages/docs/src/pages/en/getting-started/unit-testing.md
+++ b/packages/docs/src/pages/en/getting-started/unit-testing.md
@@ -39,7 +39,7 @@ This can vary between test runners. Make sure to reference the appropriate docum
 // tests/setup.js
 
 import Vue from 'vue'
-import Vuetify from 'vuetify'
+import Vuetify from 'lib/vuetify'
 
 Vue.use(Vuetify)
 ```


### PR DESCRIPTION
## Description
Fix for #12420 

## Motivation and Context
I could be wrong, but the documentation seems to have a typo here.
If true, then it should exhaustively be checked for similar typos.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
