### PR TITLE
fix(icons): use correct mdi icon for rating-half

### DIFF
--- a/packages/vuetify/src/services/icons/__tests__/__snapshots__/icons.spec.ts.snap
+++ b/packages/vuetify/src/services/icons/__tests__/__snapshots__/icons.spec.ts.snap
@@ -29,7 +29,7 @@ Object {
   "radioOn": "mdi-radiobox-marked",
   "ratingEmpty": "mdi-star-outline",
   "ratingFull": "mdi-star",
-  "ratingHalf": "mdi-star-half",
+  "ratingHalf": "mdi-star-half-full",
   "sort": "mdi-arrow-up",
   "subgroup": "mdi-menu-down",
   "success": "mdi-check-circle",

--- a/packages/vuetify/src/services/icons/presets/mdi.ts
+++ b/packages/vuetify/src/services/icons/presets/mdi.ts
@@ -26,7 +26,7 @@ const icons: VuetifyIcons = {
   edit: 'mdi-pencil',
   ratingEmpty: 'mdi-star-outline',
   ratingFull: 'mdi-star',
-  ratingHalf: 'mdi-star-half',
+  ratingHalf: 'mdi-star-half-full',
   loading: 'mdi-cached',
   first: 'mdi-page-first',
   last: 'mdi-page-last',


### PR DESCRIPTION
## Description
fixes the `mdi-` rating-half icon to match mdi-svg and docs

## Motivation and Context
resolves #12336

## How Has This Been Tested?
visually

## Markup:

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
