### PR TITLE
fix(VTextField): count non-string types

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -131,7 +131,7 @@ export default baseMixins.extend<options>().extend({
       if (typeof this.counterValue === 'function') {
         return this.counterValue(this.internalValue)
       }
-      return [...(this.internalValue || '')].length
+      return [...(this.internalValue || '').toString()].length
     },
     hasCounter (): boolean {
       return this.counter !== false && this.counter != null


### PR DESCRIPTION
## Description
fixed #12451 that is the issue with number and boolean types that could cause errors.

## How Has This Been Tested?
```html
<v-text-field
  v-model.number="age"
  counter="3"
/>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
