### PR TITLE
feat(VAppBar): don't truncate title with shrink-on-scroll

### DIFF
--- a/packages/api-generator/src/maps/v-app-bar-title.js
+++ b/packages/api-generator/src/maps/v-app-bar-title.js
@@ -1,0 +1,10 @@
+module.exports = {
+  'v-app-bar-title': {
+    slots: [
+      {
+        name: 'default',
+        props: undefined,
+      },
+    ],
+  },
+}

--- a/packages/docs/src/examples/v-app-bar/prop-img-fade.vue
+++ b/packages/docs/src/examples/v-app-bar/prop-img-fade.vue
@@ -19,7 +19,7 @@
 
       <v-app-bar-nav-icon></v-app-bar-nav-icon>
 
-      <v-toolbar-title>Title</v-toolbar-title>
+      <v-app-bar-title>Title</v-app-bar-title>
 
       <v-spacer></v-spacer>
 

--- a/packages/docs/src/examples/v-app-bar/prop-img.vue
+++ b/packages/docs/src/examples/v-app-bar/prop-img.vue
@@ -17,7 +17,7 @@
 
       <v-app-bar-nav-icon></v-app-bar-nav-icon>
 
-      <v-toolbar-title>Title</v-toolbar-title>
+      <v-app-bar-title>Title</v-app-bar-title>
 
       <v-spacer></v-spacer>
 

--- a/packages/docs/src/examples/v-app-bar/prop-prominent.vue
+++ b/packages/docs/src/examples/v-app-bar/prop-prominent.vue
@@ -10,7 +10,7 @@
     >
       <v-app-bar-nav-icon></v-app-bar-nav-icon>
 
-      <v-toolbar-title>Title</v-toolbar-title>
+      <v-app-bar-title>Title</v-app-bar-title>
 
       <v-spacer></v-spacer>
 

--- a/packages/docs/src/examples/v-app-bar/prop-scroll-threshold.vue
+++ b/packages/docs/src/examples/v-app-bar/prop-scroll-threshold.vue
@@ -20,7 +20,7 @@
 
       <v-app-bar-nav-icon></v-app-bar-nav-icon>
 
-      <v-toolbar-title>Title</v-toolbar-title>
+      <v-app-bar-title>Title</v-app-bar-title>
 
       <v-spacer></v-spacer>
 

--- a/packages/docs/src/pages/en/components/app-bars.md
+++ b/packages/docs/src/pages/en/components/app-bars.md
@@ -35,7 +35,7 @@ A styled icon button component created specifically for use with [v-toolbar](/co
 
 ### v-app-bar-title
 
-A modified [v-toolbar-title](/components/toolbars) specifically for use with the `shrink-on-scroll` prop. `v-toolbar-title` will be truncated on small screens (see [issue #12514](https://github.com/vuetifyjs/vuetify/issues/12514)) but this component uses absolute positioning to be fully visible when expanded. Don't use `v-app-bar-title` without `shrink-on-scroll` as it does add a resize watcher and some extra calculations.
+A modified [v-toolbar-title](/components/toolbars/) specifically for use with the `shrink-on-scroll` prop. `v-toolbar-title` will be truncated on small screens (see [issue #12514](https://github.com/vuetifyjs/vuetify/issues/12514)) but this component uses absolute positioning to be fully visible when expanded. Don't use `v-app-bar-title` without `shrink-on-scroll` as it does add a resize watcher and some extra calculations.
 
 ## Caveats
 

--- a/packages/docs/src/pages/en/components/app-bars.md
+++ b/packages/docs/src/pages/en/components/app-bars.md
@@ -25,12 +25,17 @@ The `v-app-bar` component is used for application-wide actions and information.
 
 - [v-app-bar](/api/v-app-bar)
 - [v-app-bar-nav-icon](/api/v-app-bar-nav-icon)
+- [v-app-bar-title](/api/v-app-bar-title)
 
 ## Sub-components
 
 ### v-app-bar-nav-icon
 
 A styled icon button component created specifically for use with [v-toolbar](/components/toolbars) and `v-app-bar`. Typically seen on the left side of a toolbar as a hamburger menu, it is often used to control the state of a navigation drawer. The `default` slot can be used to customize the icon and function of this component. This is a **functional** component.
+
+### v-app-bar-title
+
+A modified [v-toolbar-title](/components/toolbars) specifically for use with the `shrink-on-scroll` prop. `v-toolbar-title` will be truncated on small screens (see [issue #12514](https://github.com/vuetifyjs/vuetify/issues/12514)) but this component uses absolute positioning to be fully visible when expanded. Don't use `v-app-bar-title` without `shrink-on-scroll` as it does add a resize watcher and some extra calculations.
 
 ## Caveats
 

--- a/packages/docs/src/pages/en/components/app-bars.md
+++ b/packages/docs/src/pages/en/components/app-bars.md
@@ -35,7 +35,7 @@ A styled icon button component created specifically for use with [v-toolbar](/co
 
 ### v-app-bar-title
 
-A modified [v-toolbar-title](/components/toolbars/) specifically for use with the `shrink-on-scroll` prop. `v-toolbar-title` will be truncated on small screens (see [issue #12514](https://github.com/vuetifyjs/vuetify/issues/12514)) but this component uses absolute positioning to be fully visible when expanded. Don't use `v-app-bar-title` without `shrink-on-scroll` as it does add a resize watcher and some extra calculations.
+A modified [v-toolbar-title](/components/toolbars/) specifically for use with the `shrink-on-scroll` prop. `v-toolbar-title` will be truncated on small screens (see [issue #12514](https://github.com/vuetifyjs/vuetify/issues/12514)) but this component uses absolute positioning to be fully visible when expanded. We don't recommend using `v-app-bar-title` without `shrink-on-scroll` as it does add a resize watcher and some extra calculations.
 
 ## Caveats
 

--- a/packages/vuetify/src/components/VAppBar/VAppBar.sass
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.sass
@@ -46,3 +46,13 @@
 .v-app-bar.v-app-bar--shrink-on-scroll
   .v-toolbar__title
     font-size: inherit
+
+.v-app-bar-title
+  &__placeholder,
+  &__content
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
+
+  &__content
+    position: absolute

--- a/packages/vuetify/src/components/VAppBar/VAppBar.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.ts
@@ -42,6 +42,10 @@ export default baseMixins.extend({
 
   directives: { Scroll },
 
+  provide (): object {
+    return { VAppBar: this }
+  },
+
   props: {
     clippedLeft: Boolean,
     clippedRight: Boolean,
@@ -77,7 +81,7 @@ export default baseMixins.extend({
           this.hideOnScroll ||
           this.collapseOnScroll ||
           this.isBooted ||
-          // If falsey, user has provided an
+          // If falsy, user has provided an
           // explicit value which should
           // overwrite anything we do
           !this.value
@@ -98,28 +102,25 @@ export default baseMixins.extend({
         'v-app-bar--shrink-on-scroll': this.shrinkOnScroll,
       }
     },
+    scrollRatio (): number {
+      const threshold = this.computedScrollThreshold
+      return Math.max((threshold - this.currentScroll) / threshold, 0)
+    },
     computedContentHeight (): number {
       if (!this.shrinkOnScroll) return VToolbar.options.computed.computedContentHeight.call(this)
 
-      const height = this.computedOriginalHeight
-
       const min = this.dense ? 48 : 56
-      const max = height
-      const difference = max - min
-      const iteration = difference / this.computedScrollThreshold
-      const offset = this.currentScroll * iteration
+      const max = this.computedOriginalHeight
 
-      return Math.max(min, max - offset)
+      return min + (max - min) * this.scrollRatio
     },
     computedFontSize (): number | undefined {
       if (!this.isProminent) return undefined
 
-      const max = this.dense ? 96 : 128
-      const difference = max - this.computedContentHeight
-      const increment = 0.00347
+      const min = 1.25
+      const max = 1.5
 
-      // 1.5rem to a minimum of 1.25rem
-      return Number((1.50 - difference * increment).toFixed(2))
+      return min + (max - min) * this.scrollRatio
     },
     computedLeft (): number {
       if (!this.app || this.clippedLeft) return 0
@@ -134,12 +135,7 @@ export default baseMixins.extend({
     computedOpacity (): number | undefined {
       if (!this.fadeImgOnScroll) return undefined
 
-      const opacity = Math.max(
-        (this.computedScrollThreshold - this.currentScroll) / this.computedScrollThreshold,
-        0
-      )
-
-      return Number(parseFloat(opacity).toFixed(2))
+      return this.scrollRatio
     },
     computedOriginalHeight (): number {
       let height = VToolbar.options.computed.computedContentHeight.call(this)

--- a/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
@@ -6,7 +6,7 @@ import { VNode } from 'vue'
 import { ExtractVue } from '../../util/mixins'
 import VAppBar from './VAppBar'
 
-// Helpers
+// Utilities
 import { convertToUnit } from '../../util/helpers'
 import { easeInOutCubic } from '../../services/goto/easing-patterns'
 

--- a/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
@@ -1,0 +1,76 @@
+// Mixins
+import { inject } from '../../mixins/registrable'
+
+// Types
+import { VNode } from 'vue'
+import { ExtractVue } from '../../util/mixins'
+import VAppBar from './VAppBar'
+
+// Helpers
+import { convertToUnit } from '../../util/helpers'
+
+const base = inject<'VAppBar', typeof VAppBar>('VAppBar', 'v-app-bar-title', 'v-app-bar')
+
+interface options extends ExtractVue<typeof base> {
+  $refs: {
+    content: Element
+  }
+}
+
+export default base.extend<options>().extend({
+  name: 'v-app-bar-title',
+
+  data: () => ({
+    width: 0,
+    contentWidth: 0,
+    left: 0,
+  }),
+
+  watch: {
+    '$vuetify.breakpoint.width': 'updateDimensions',
+  },
+
+  computed: {
+    styles (): object {
+      if (!this.contentWidth) return {}
+
+      const min = this.width
+      const max = this.contentWidth
+      return {
+        width: convertToUnit(min + (max - min) * this.VAppBar.scrollRatio),
+        visibility: this.VAppBar.scrollRatio ? 'visible' : 'hidden',
+      }
+    },
+  },
+
+  mounted () {
+    this.updateDimensions()
+    this.contentWidth = this.$refs.content.getBoundingClientRect().width
+  },
+
+  methods: {
+    updateDimensions (): void {
+      const dimensions = this.$el.getBoundingClientRect()
+      this.width = dimensions.width
+      this.left = dimensions.left
+    },
+  },
+
+  render (h): VNode {
+    return h('div', {
+      class: 'v-toolbar__title v-app-bar-title',
+    }, [
+      h('div', {
+        class: 'v-app-bar-title__content',
+        style: this.styles,
+        ref: 'content',
+      }, [this.$slots.default]),
+      h('div', {
+        class: 'v-app-bar-title__placeholder',
+        style: {
+          visibility: this.VAppBar.scrollRatio ? 'hidden' : 'visible',
+        },
+      }, [this.$slots.default]),
+    ])
+  },
+})

--- a/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
@@ -23,9 +23,9 @@ export default base.extend<options>().extend({
   name: 'v-app-bar-title',
 
   data: () => ({
-    width: 0,
     contentWidth: 0,
     left: 0,
+    width: 0,
   }),
 
   watch: {

--- a/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
+++ b/packages/vuetify/src/components/VAppBar/VAppBarTitle.ts
@@ -8,12 +8,14 @@ import VAppBar from './VAppBar'
 
 // Helpers
 import { convertToUnit } from '../../util/helpers'
+import { easeInOutCubic } from '../../services/goto/easing-patterns'
 
 const base = inject<'VAppBar', typeof VAppBar>('VAppBar', 'v-app-bar-title', 'v-app-bar')
 
 interface options extends ExtractVue<typeof base> {
   $refs: {
     content: Element
+    placeholder: Element
   }
 }
 
@@ -36,8 +38,9 @@ export default base.extend<options>().extend({
 
       const min = this.width
       const max = this.contentWidth
+      const ratio = easeInOutCubic(Math.min(1, this.VAppBar.scrollRatio * 1.5))
       return {
-        width: convertToUnit(min + (max - min) * this.VAppBar.scrollRatio),
+        width: convertToUnit(min + (max - min) * ratio),
         visibility: this.VAppBar.scrollRatio ? 'visible' : 'hidden',
       }
     },
@@ -45,14 +48,14 @@ export default base.extend<options>().extend({
 
   mounted () {
     this.updateDimensions()
-    this.contentWidth = this.$refs.content.getBoundingClientRect().width
   },
 
   methods: {
     updateDimensions (): void {
-      const dimensions = this.$el.getBoundingClientRect()
+      const dimensions = this.$refs.placeholder.getBoundingClientRect()
       this.width = dimensions.width
       this.left = dimensions.left
+      this.contentWidth = this.$refs.content.scrollWidth
     },
   },
 
@@ -70,6 +73,7 @@ export default base.extend<options>().extend({
         style: {
           visibility: this.VAppBar.scrollRatio ? 'hidden' : 'visible',
         },
+        ref: 'placeholder',
       }, [this.$slots.default]),
     ])
   },

--- a/packages/vuetify/src/components/VAppBar/__tests__/VAppBar.spec.ts
+++ b/packages/vuetify/src/components/VAppBar/__tests__/VAppBar.spec.ts
@@ -221,7 +221,7 @@ describe('AppBar.ts', () => {
     expect(wrapper.vm.computedOpacity).toBe(1)
 
     wrapper.setData({ currentScroll: 5 })
-    expect(wrapper.vm.computedOpacity).toBe(0.38)
+    expect(wrapper.vm.computedOpacity).toBe(0.375)
 
     wrapper.setData({ currentScroll: 100 })
     expect(wrapper.vm.computedOpacity).toBe(0)

--- a/packages/vuetify/src/components/VAppBar/index.ts
+++ b/packages/vuetify/src/components/VAppBar/index.ts
@@ -1,11 +1,13 @@
 import VAppBar from './VAppBar'
 import VAppBarNavIcon from './VAppBarNavIcon'
+import VAppBarTitle from './VAppBarTitle'
 
-export { VAppBar, VAppBarNavIcon }
+export { VAppBar, VAppBarNavIcon, VAppBarTitle }
 
 export default {
   $_vuetify_subcomponents: {
     VAppBar,
     VAppBarNavIcon,
+    VAppBarTitle,
   },
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Adds a new v-app-bar-title component which uses absolute positioning to avoid
being truncated when there isn't enough space in the main part of the toolbar

closes #12514


## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container style="height: 1200px">
    <v-app-bar
      fixed
      shrink-on-scroll
    >
      <v-app-bar-nav-icon />
      <v-app-bar-title>Vuetify.js</v-app-bar-title>
      <v-spacer />
      <v-btn icon>
        <v-icon>mdi-chart-box-outline</v-icon>
      </v-btn>
      <v-btn icon>
        <v-icon>mdi-cog-outline</v-icon>
      </v-btn>
      <v-responsive max-width="260">
        <v-text-field
          class="ml-1"
          dense
          flat
          placeholder="Search Anywhere"
          hide-details
          rounded
          solo-inverted
          prepend-inner-icon="mdi-magnify"
        />
      </v-responsive>
      <v-btn icon>
        <v-icon>mdi-menu</v-icon>
      </v-btn>
    </v-app-bar>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
