### PR TITLE
fix(VMenu): open-on-hover does not close-on-content-click

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -380,7 +380,6 @@ export default baseMixins.extend({
         if (this.hasJustFocused) return
 
         this.hasJustFocused = true
-        this.isActive = true
       })
     },
     mouseLeaveHandler (e: MouseEvent) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #12412  

I fixed it so that VMenu closes the hover with a single click when open-on-hover is enabled in mobile.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fixes #12412  

Without this fix, VMenu would behave twice  with open-on-hover  enabled in mobile.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually
---
**before behavior**  
![Kapture 2020-11-06 at 22 26 29](https://user-images.githubusercontent.com/18192657/98376263-8ee4d500-2086-11eb-9497-698060eb3879.gif)

**after behavior**  
![Kapture 2020-11-06 at 23 09 03](https://user-images.githubusercontent.com/18192657/98376326-a754ef80-2086-11eb-8ec4-cfe286bfcff5.gif)


## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>


```vue
<template>
  <v-container>
    <!--  -->
    <div class="text-center">
      <v-menu open-on-hover top offset-y @change=temp()>
        <template v-slot:activator="{ on, attrs }">
          <v-btn color="primary" dark v-bind="attrs" v-on="on">
            Dropdown
          </v-btn>
        </template>
        <v-list>
          <v-list-item v-for="(item, index) in items" :key="index">
            <v-list-item-title>{{ item.title }}</v-list-item-title>
          </v-list-item>
        </v-list>
      </v-menu>
    </div>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    items: [
        { title: 'Click 1' },
        { title: 'Click 2' },
        { title: 'Click 3' },
        { title: 'Click 4' },
      ],
  })
};
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
