### PR TITLE
feat(VTextField): only show placeholder on focus if label is set

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -187,11 +187,10 @@ export default baseMixins.extend<options>().extend({
       }
     },
     showLabel (): boolean {
-      return this.hasLabel && (!this.isSingle || (!this.isLabelActive && !this.placeholder))
+      return this.hasLabel && !(this.isSingle && this.labelValue)
     },
     labelValue (): boolean {
-      return !this.isSingle &&
-        Boolean(this.isFocused || this.isLabelActive || this.placeholder)
+      return this.isFocused || this.isLabelActive
     },
   },
 
@@ -388,7 +387,7 @@ export default baseMixins.extend<options>().extend({
           autofocus: this.autofocus,
           disabled: this.isDisabled,
           id: this.computedId,
-          placeholder: this.placeholder,
+          placeholder: this.isFocused || !this.hasLabel ? this.placeholder : undefined,
           readonly: this.isReadonly,
           type: this.type,
         },


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves #12499

Having both label and placeholder displayed can be a usability problem as the placeholder looks very similar to typed text and could be confused with user input at a glance.

Potentially breaking change, you can't show both label and placeholder any more but this should be discouraged anyway. 

EDIT: This is actually MD2 spec now:
![image](https://user-images.githubusercontent.com/16421948/99406327-e0704800-2941-11eb-9117-046a63fd21a7.png)


## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field label="Label"></v-text-field>
    <v-text-field
      label="Label"
      placeholder="Placeholder"
    ></v-text-field>
    <v-text-field
      label="Label"
      placeholder="Placeholder"
      single-line
    ></v-text-field>
    <v-text-field
      label="Label"
      placeholder="Placeholder"
      value="Value"
    ></v-text-field>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

