### PR TITLE
fix(VDataFooter): Show set footer.page-text on empty data table

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
+++ b/packages/vuetify/src/components/VDataIterator/VDataFooter.ts
@@ -131,17 +131,21 @@ export default Vue.extend({
     },
     genPaginationInfo () {
       let children: VNodeChildrenArrayContents = ['–']
+      const itemsLength: number = this.pagination.itemsLength
+      let pageStart: number = this.pagination.pageStart
+      let pageStop: number = this.pagination.pageStop
 
       if (this.pagination.itemsLength && this.pagination.itemsPerPage) {
-        const itemsLength = this.pagination.itemsLength
-        const pageStart = this.pagination.pageStart + 1
-        const pageStop = itemsLength < this.pagination.pageStop || this.pagination.pageStop < 0
+        pageStart = this.pagination.pageStart + 1
+        pageStop = itemsLength < this.pagination.pageStop || this.pagination.pageStop < 0
           ? itemsLength
           : this.pagination.pageStop
 
         children = this.$scopedSlots['page-text']
           ? [this.$scopedSlots['page-text']!({ pageStart, pageStop, itemsLength })]
           : [this.$vuetify.lang.t(this.pageText, pageStart, pageStop, itemsLength)]
+      } else if (this.$scopedSlots['page-text']) {
+        children = [this.$scopedSlots['page-text']!({ pageStart, pageStop, itemsLength })]
       }
 
       return this.$createElement('div', {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
This resolves #11829.
`footer.page-text` template will always be applied even if there are no items in the table.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Solves the issue where one always wants to show the set custom `footer.page-text` even if table is empty.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Only tested visually, with the given example from issue #11829

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-data-table :items="tableItems">
      <template v-slot:footer.page-text="props">
        Custom page-text
      </template>
    </v-data-table>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      tableItems: []
      // tableItems: [{}]
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
