### PR TITLE
fix(VTextField): add padding-top custom variable to details

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -343,6 +343,7 @@
       padding: $text-field-enclosed-details-padding
 
     .v-text-field__details
+      padding-top: $text-field-details-padding-top
       margin-bottom: $text-field-details-margin-bottom
 
   &--reverse

--- a/packages/vuetify/src/components/VTextField/_variables.scss
+++ b/packages/vuetify/src/components/VTextField/_variables.scss
@@ -26,6 +26,7 @@ $text-field-dense-prepend-append-margin-top: 14px !default;
 $text-field-single-line-prepend-append-margin-top: 9px !default;
 $text-field-outlined-prepend-append-margin-top: 8px !default;
 $text-field-enclosed-details-padding: 0 12px !default;
+$text-field-details-padding-top: 0px !default;
 $text-field-details-margin-bottom: 8px !default;
 $text-field-outlined-margin-bottom: 16px !default;
 $text-field-outlined-label-position-x: 18px !default;


### PR DESCRIPTION
fixed #12660
fixes #12401

This is a small update to the bug I just recently submitted allowing for explicitly setting the padding-top of .v-text-field__details as error messages get cut off when using some fonts.  One line was added to _variables.scss and one line to VTextField.sass.

## Description
Resolves #12660 / #12401 by simply adding padding-top custom variable to VTextField

## Motivation and Context
Error message in VTextField is cut off on top if using certain fonts like Nunito

## How Has This Been Tested?
Has not been tested as this does not change anything because default padding-top on .v-text-field__details was already 0.  Now it is just explicitly being set.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
