### PR TITLE
fix(VWindow): fix wrong reverse animation logic for only 2 items

### DIFF
--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -225,14 +225,12 @@ export default BaseItemGroup.extend({
       const itemsLength = this.items.length
       const lastIndex = itemsLength - 1
 
-      if (itemsLength > 2) {
-        if (val === lastIndex && oldVal === 0) {
-          return true
-        } else if (val === 0 && oldVal === lastIndex) {
-          return false
-        } else {
-          return val < oldVal
-        }
+      if (itemsLength <= 2) return val < oldVal
+
+      if (val === lastIndex && oldVal === 0) {
+        return true
+      } else if (val === 0 && oldVal === lastIndex) {
+        return false
       } else {
         return val < oldVal
       }

--- a/packages/vuetify/src/components/VWindow/VWindow.ts
+++ b/packages/vuetify/src/components/VWindow/VWindow.ts
@@ -222,12 +222,17 @@ export default BaseItemGroup.extend({
       this.internalValue = this.getValue(item, lastIndex)
     },
     updateReverse (val: number, oldVal: number) {
-      const lastIndex = this.items.length - 1
+      const itemsLength = this.items.length
+      const lastIndex = itemsLength - 1
 
-      if (val === lastIndex && oldVal === 0) {
-        return true
-      } else if (val === 0 && oldVal === lastIndex) {
-        return false
+      if (itemsLength > 2) {
+        if (val === lastIndex && oldVal === 0) {
+          return true
+        } else if (val === 0 && oldVal === lastIndex) {
+          return false
+        } else {
+          return val < oldVal
+        }
       } else {
         return val < oldVal
       }


### PR DESCRIPTION
fixes #12672

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Issue  #12672 is caused by a recent change from [PR 12357](https://github.com/vuetifyjs/vuetify/pull/12357). Its change results in wrong animation reverse logic when items length is less than 3. 

This pull request is making it fully support all items length in terms of animation reverse logic on top of the code from [PR 12357](https://github.com/vuetifyjs/vuetify/pull/12357). 

@nekosaur please help to check it out to see this change would raise any concerns from you and please also feel free to leave any feedback :). 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #12672

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-card>
      <v-toolbar flat>
        <template v-slot:extension>
          <v-tabs
            v-model="tabs"
            fixed-tabs
          >
            <v-tabs-slider></v-tabs-slider>
            <v-tab
              href="#mobile-tabs-5-1"
              class="primary--text"
            >
              <v-icon>mdi-phone</v-icon>
            </v-tab>

            <v-tab
              href="#mobile-tabs-5-2"
              class="primary--text"
            >
              <v-icon>mdi-heart</v-icon>
            </v-tab>
          </v-tabs>
        </template>
      </v-toolbar>

      <v-tabs-items v-model="tabs">
        <v-tab-item
          v-for="i in 2"
          :key="i"
          :value="'mobile-tabs-5-' + i"
        >
          <v-card flat>
            <v-card-text v-text="text"></v-card-text>
          </v-card>
        </v-tab-item>
      </v-tabs-items>
    </v-card>
  </v-container>
</template>

<script>
  export default {
    data () {
      return {
        tabs: null,
        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
      }
    },
    methods: {
    }
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
