### PR TITLE
fix(VBtn): Inconsistency with v-icon in rtl and ltr mode

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -116,8 +116,8 @@
       margin-right: 8px
 
     +rtl()
-      margin-left: 8px
-      margin-right: -4px
+      margin-left: -4px
+      margin-right: 8px
 
   .v-icon--right
     +ltr()
@@ -125,8 +125,8 @@
       margin-right: -4px
 
     +rtl()
-      margin-left: -4px
-      margin-right: 8px
+      margin-left: 8px
+      margin-right: -4px
 
 .v-btn__loader
   align-items: center


### PR DESCRIPTION
fixes #10960

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

Inconsistency with v-icon in rtl and ltr mode when using it with button and without button was fixed by changing the sass file code to match position in both mode.
<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
Changed margin on v-icon in v-btn to make the icon in v-btn consistent with ltr and rtl mode.
resolves #10960
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
In order to start phase # 1 of Vuetify Titan all bugs with vicon had to be resolved.
Resolves Following Issue.
https://github.com/vuetifyjs/vuetify/issues/10960
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has been tested visually.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-simple-table>
      <tr class="text-center">
        <td colspan="3">
          Currently it is {{ $vuetify.rtl ? "Right to Left" : "Left to Right" }}
        </td>
      </tr>
      <tr>
        <td>
          <v-btn
            class="text-none"
            @click="toggleRTL"
          >Switch to {{ $vuetify.rtl ? "LTR" : "RTL" }}</v-btn>
        </td>
        <td>Icon within a button</td>
        <td>Icon without a button</td>
      </tr>
      <tr>
        <td>Left</td>
        <td><v-btn><v-icon left>mdi-face</v-icon></v-btn></td>
        <td><v-icon left>mdi-face</v-icon></td>
      </tr>
      <tr>
        <td>Right</td>
        <td><v-btn><v-icon right>mdi-face</v-icon></v-btn></td>
        <td><v-icon right>mdi-face</v-icon></td>
      </tr>
    </v-simple-table>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
    methods: {
      toggleRTL () {
        this.$vuetify.rtl = !this.$vuetify.rtl
      },
    },
  }
</script>

<style>
td {
  border: 1px solid black
}
</style>
```

</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
