### PR TITLE
fix(VCard): Incorrect positioning for v-card-actions in v-dialog

### DIFF
--- a/packages/vuetify/src/components/VCard/_variables.scss
+++ b/packages/vuetify/src/components/VCard/_variables.scss
@@ -1,6 +1,6 @@
 @import '../../styles/styles.sass';
 
-$card-actions-padding: 8px !default;
+$card-actions-padding: 8px 24px !default;
 $card-adjacent-sibling-text-padding-top: 0 !default;
 $card-border-radius: $border-radius-root !default;
 $card-btn-margin-x: 8px !default;

--- a/packages/vuetify/src/components/VCard/_variables.scss
+++ b/packages/vuetify/src/components/VCard/_variables.scss
@@ -1,6 +1,6 @@
 @import '../../styles/styles.sass';
 
-$card-actions-padding: 8px 24px !default;
+$card-actions-padding: 8px 16px  !default;
 $card-adjacent-sibling-text-padding-top: 0 !default;
 $card-border-radius: $border-radius-root !default;
 $card-btn-margin-x: 8px !default;

--- a/packages/vuetify/src/components/VCard/_variables.scss
+++ b/packages/vuetify/src/components/VCard/_variables.scss
@@ -1,6 +1,6 @@
 @import '../../styles/styles.sass';
 
-$card-actions-padding: 8px 16px  !default;
+$card-actions-padding: 8px !default;
 $card-adjacent-sibling-text-padding-top: 0 !default;
 $card-border-radius: $border-radius-root !default;
 $card-btn-margin-x: 8px !default;

--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -30,6 +30,9 @@
     > .v-card__subtitle
       padding: $dialog-card-subtitle-padding
 
+    > .v-card__actions
+      padding: $dialog-card-actions-padding
+
 // Element
 .v-dialog__content
   align-items: center

--- a/packages/vuetify/src/components/VDialog/_variables.scss
+++ b/packages/vuetify/src/components/VDialog/_variables.scss
@@ -2,7 +2,7 @@
 
 $dialog-border-radius: $border-radius-root !default;
 $dialog-card-subtitle-padding: 0 24px 20px !default;
-$dialog-card-actions-padding: 8px 24px !default;
+$dialog-card-actions-padding: 8px 16px !default;
 $dialog-card-text-padding: 0 24px 20px !default;
 $dialog-card-title-font-size: map-deep-get($headings, 'h6', 'size') !default;
 $dialog-card-title-font-weight: map-deep-get($headings, 'h6', 'weight') !default;

--- a/packages/vuetify/src/components/VDialog/_variables.scss
+++ b/packages/vuetify/src/components/VDialog/_variables.scss
@@ -2,6 +2,7 @@
 
 $dialog-border-radius: $border-radius-root !default;
 $dialog-card-subtitle-padding: 0 24px 20px !default;
+$dialog-card-actions-padding: 8px 24px !default;
 $dialog-card-text-padding: 0 24px 20px !default;
 $dialog-card-title-font-size: map-deep-get($headings, 'h6', 'size') !default;
 $dialog-card-title-font-weight: map-deep-get($headings, 'h6', 'weight') !default;


### PR DESCRIPTION
fixes #10605

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
Incorrect positioning for v-card-actions when v-card is used in v-dialog is fixed by changing the default padding for v-card-actions to get it into correct position.
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
Changed default padding for v-card-actions in variables file in order to make it correctly positioned .
fixes #10605
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
In order to start phase # 1 of Vuetify Titan all bugs with vcard had to be resolved.
Resolves Following Issue.
#10605
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has been tested visually.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```
<template>
  <v-container>
    <v-dialog v-model="showDialog">
      <v-card>
        <v-card-title>This is positioned correctly</v-card-title>
        <v-card-subtitle>This is positioned too far to the left</v-card-subtitle>
        <v-card-text>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in ipsum purus. Vestibulum non diam ultricies, scelerisque ex vel, commodo sem. Phasellus blandit vehicula arcu, in dignissim magna. Nullam et augue sit amet eros dictum feugiat. Nam mi lorem, interdum non elementum vitae, sollicitudin nec mi. Phasellus facilisis enim sit amet porttitor dictum. Sed molestie ex vitae augue convallis blandit. Nulla a dapibus tortor, eu accumsan urna. Fusce varius turpis sed justo pellentesque pulvinar. Morbi eu leo nec ipsum elementum ullamcorper. Pellentesque at urna risus. Aliquam consequat id velit et elementum.
        </v-card-text>
        <v-card-actions>
          <v-btn>Click Me</v-btn>
        </v-card-actions>
      </v-card>
    </v-dialog>
    <v-card>
      <v-card-title>This is positioned correctly</v-card-title>
      <v-card-subtitle>This is positioned too far to the left</v-card-subtitle>
      <v-card-text>
        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in ipsum purus. Vestibulum non diam ultricies, scelerisque ex vel, commodo sem. Phasellus blandit vehicula arcu, in dignissim magna. Nullam et augue sit amet eros dictum feugiat. Nam mi lorem, interdum non elementum vitae, sollicitudin nec mi. Phasellus facilisis enim sit amet porttitor dictum. Sed molestie ex vitae augue convallis blandit. Nulla a dapibus tortor, eu accumsan urna. Fusce varius turpis sed justo pellentesque pulvinar. Morbi eu leo nec ipsum elementum ullamcorper. Pellentesque at urna risus. Aliquam consequat id velit et elementum.
      </v-card-text>
      <v-card-actions>
        <v-btn>Click Me</v-btn>
      </v-card-actions>
    </v-card>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      showDialog: () => true,
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
