### PR TITLE
revert(VTextField): partial revert of #12554

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -239,7 +239,7 @@ export default baseMixins.extend<options>().extend({
       }, this.$slots.label || this.label)
     },
     genMessages () {
-      if (this.hideDetails === true) return null
+      if (!this.showDetails) return null
 
       return this.$createElement(VMessages, {
         props: {

--- a/packages/vuetify/src/components/VInput/__tests__/VInput.spec.ts
+++ b/packages/vuetify/src/components/VInput/__tests__/VInput.spec.ts
@@ -196,10 +196,10 @@ describe('VInput.ts', () => {
       },
     })
 
-    expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapper.vm.genMessages()).toBeNull()
 
     wrapper.setProps({ error: true })
-    expect(wrapper.vm.genMessages()).not.toBeNull()
+    expect(wrapper.vm.genMessages()).toBeNull()
 
     wrapper.setProps({ errorMessages: 'required' })
     expect(wrapper.vm.genMessages()).not.toBeNull()

--- a/packages/vuetify/src/components/VInput/__tests__/__snapshots__/VInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VInput/__tests__/__snapshots__/VInput.spec.ts.snap
@@ -172,22 +172,6 @@ exports[`VInput.ts should generate append and prepend slots 2`] = `
 </div>
 `;
 
-exports[`VInput.ts should hide messages if no messages and hide-details is auto 1`] = `
-<div class="v-input v-input--hide-details theme--light">
-  <div class="v-input__control">
-    <div class="v-input__slot">
-    </div>
-    <div class="v-messages theme--light">
-      <span name="message-transition"
-            tag="div"
-            class="v-messages__wrapper"
-      >
-      </span>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`VInput.ts should not apply attrs to element 1`] = `
 <div class="v-input theme--light">
   <div class="v-input__control">

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -407,7 +407,7 @@ export default baseMixins.extend<options>().extend({
       })
     },
     genMessages () {
-      if (this.hideDetails === true) return null
+      if (!this.showDetails) return null
 
       const messagesNode = VInput.options.methods.genMessages.call(this)
       const counterNode = this.genCounter()

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -108,15 +108,6 @@ exports[`VTextField.ts should hide messages if no messages and hide-details is a
         >
       </div>
     </div>
-    <div class="v-text-field__details">
-      <div class="v-messages theme--light">
-        <span name="message-transition"
-              tag="div"
-              class="v-messages__wrapper"
-        >
-        </span>
-      </div>
-    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Description
Partial revert of #12554.

## Motivation and Context
#12554 introduced unintended regression of the functionality of `hide-details="auto"`
resolves #12755

## How Has This Been Tested?
visual | jest

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-checkbox
      v-model="hasMessage"
      label="Show Message"
    />
    <v-checkbox
      v-model="hideDetails"
      label="hideDetails"
    />
    <v-row>
      <v-col>
        <v-text-field
          label="Test Message Animation"
          :hide-details="d"
          :error="hasMessage"
          :messages="hasMessage ? 'Message to see' : undefined"
        />
      </v-col>
      <v-col>
        <v-radio-group
          :error="hasMessage"
          :messages="hasMessage ? 'Message to see' : undefined"
          hide-details="auto"
        >
          <v-radio label="Test" />
        </v-radio-group>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      hasMessage: false,
      hideDetails: false,
    }),
    computed: {
      d () {
        return this.hideDetails ? this.hideDetails : 'auto'
      },
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
