### PR TITLE
revert(VDivider): vertical v-divider not displayed when inside div

### DIFF
--- a/packages/vuetify/src/components/VDivider/VDivider.sass
+++ b/packages/vuetify/src/components/VDivider/VDivider.sass
@@ -25,7 +25,7 @@
     align-self: stretch
     border: solid
     border-width: 0 thin 0 0
-    display: inline
+    display: inline-flex
     height: inherit
     min-height: 100%
     max-height: 100%


### PR DESCRIPTION


## Description
Reverts vuetifyjs/vuetify#12735

## Motivation and Context
regression caused by #12755
resolves #12752

## How Has This Been Tested?
visual

## Markup:
<details>

```vue

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
