### PR TITLE
fix(VTextField): align dense mode text field prefix and content

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -58,6 +58,8 @@
   padding-top: $text-field-active-label-height
   margin-top: $input-top-spacing - $text-field-active-label-height
 
+  &__prefix
+    line-height: $text-field-line-height
   input
     flex: 1 1 auto
     line-height: $text-field-line-height
@@ -88,6 +90,7 @@
     padding-top: 0
 
     &:not(.v-text-field--outlined)
+      .v-text-field__prefix,
       input
         padding: $text-field-dense-padding
 

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -98,6 +98,10 @@
       .v-text-field__suffix,
       input
         padding: $text-field-dense-padding
+      .v-text-field__prefix
+        padding-right: $text-field-append-prepend-margin
+      .v-text-field__suffix
+        padding-left: $text-field-append-prepend-margin
 
     &[type=text]::-ms-clear
       display: none

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -89,6 +89,9 @@
   &.v-input--dense
     padding-top: 0
 
+    .v-label
+      top: 4px
+
     &:not(.v-text-field--outlined)
       .v-text-field__prefix,
       input

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -104,12 +104,6 @@
     .v-input__append-inner
       margin-top: $text-field-dense-append-prepend-margin
 
-    &:not(.v-text-field--enclosed):not(.v-text-field--full-width)
-      .v-input__prepend-inner,
-      .v-input__append-inner
-        .v-input__icon > .v-icon
-          margin-top: $text-field-dense-icon-append-prepend-margin-top
-
   .v-input__prepend-inner,
   .v-input__append-inner
     align-self: flex-start

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -58,7 +58,8 @@
   padding-top: $text-field-active-label-height
   margin-top: $input-top-spacing - $text-field-active-label-height
 
-  &__prefix
+  &__prefix,
+  &__suffix
     line-height: $text-field-line-height
   input
     flex: 1 1 auto
@@ -94,6 +95,7 @@
 
     &:not(.v-text-field--outlined)
       .v-text-field__prefix,
+      .v-text-field__suffix,
       input
         padding: $text-field-dense-padding
 


### PR DESCRIPTION
fixes #12743

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #12743

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
(https://github.com/vuetifyjs/vuetify/issues/12743)
## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
Since this change was strictly a matter of specific sass rules, I tested using Chrome inspector to confirm style application and visually confirming that elements are aligned precisely in the proper context
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row>
      <v-text-field
        label="Amount"
        value="10.00"
        prefix="0x"
        suffix="2x"
      ></v-text-field>
      <v-select
        label="Amount"
        value="10.00"
        suffix="2x"
        prefix="0x"
        :items="['10.00']"
      ></v-select>
      <v-combobox
        label="Amount"
        value="10.00"
        prefix="0x"
        suffix="2x"
        :items="['10.00']"
      ></v-combobox>
      <v-autocomplete
        label="Amount"
        value="10.00"
        prefix="0x"
        suffix="2x"
        :items="['10.00']"
      ></v-autocomplete>
    </v-row>
    <v-row>
      <v-text-field
        dense
        label="Amount"
        value="10.00"
        suffix="2x"
        prefix="0x"
      ></v-text-field>
      <v-select
        dense
        label="Amount"
        value="10.00"
        suffix="2x"
        prefix="0x"
        :items="['10.00']"
      ></v-select>
      <v-combobox
        dense
        label="Amount"
        value="10.00"
        suffix="2x"
        prefix="0x"
        :items="['10.00']"
      ></v-combobox>
      <v-autocomplete
        dense
        label="Amount"
        value="10.00"
        suffix="2x"
        prefix="0x"
        :items="['10.00']"
      ></v-autocomplete>
    </v-row>
    <v-row>
      <v-text-field
        label="Amount"
        prefix="0x"
        suffix="2x"
      ></v-text-field>
      <v-select
        label="Amount"
        prefix="0x"
        suffix="2x"
      ></v-select>
      <v-combobox
        label="Amount"
        prefix="0x"
        suffix="2x"
      ></v-combobox>
      <v-autocomplete
        label="Amount"
        suffix="2x"
        prefix="0x"
      ></v-autocomplete>
    </v-row>
    <v-row>
      <v-text-field
        dense
        suffix="2x"
        label="Amount"
        prefix="0x"
      ></v-text-field>
      <v-select
        dense
        label="Amount"
        suffix="2x"
        prefix="0x"
      ></v-select>
      <v-combobox
        dense
        label="Amount"
        suffix="2x"
        prefix="0x"
      ></v-combobox>
      <v-autocomplete
        dense
        label="Amount"
        prefix="0x"
        suffix="2x"
      ></v-autocomplete>
    </v-row>

    <v-row>
      <p class="text-h6">Below I have included the contents of the Codepen for previously resolved issue <a href="https://github.com/vuetifyjs/vuetify/issues/11011" target="_blank">11011</a>. The current fix removes code originally added to resolve #11011.</p>
    </v-row>

    <v-row>
      <v-col cols="12" sm="6">
        <v-text-field
          outlined
          label="Prepend inner"
          prepend-inner-icon="place"
          clearable
          value="Test"
        ></v-text-field>
      </v-col>
      <v-col cols="12" sm="3">
        <v-text-field
          outlined
          label="Prepend inner"
          prepend-inner-icon="place"
          clearable
          value="Test"
          dense
        ></v-text-field>
      </v-col>
      <v-col cols="12" sm="3">
        <v-text-field
          outlined
          label="Prepend inner"
          prepend-inner-icon="place"
          clearable
          value="Test"
          dense
          class="oldStyle"
        ></v-text-field>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>

  export default {
    data: () => ({
    //
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
