### PR TITLE
fix(inputs): display title attribute on root element

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.ts
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.ts
@@ -81,6 +81,9 @@ export default Selectable.extend({
 
   methods: {
     genCheckbox () {
+      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
+      const checkboxAttrs = { ...this.attrs$ }
+      delete checkboxAttrs.title
       return this.$createElement('div', {
         staticClass: 'v-input--selection-controls__input',
       }, [
@@ -92,7 +95,7 @@ export default Selectable.extend({
           },
         }), this.computedIcon),
         this.genInput('checkbox', {
-          ...this.attrs$,
+          ...checkboxAttrs,
           'aria-checked': this.inputIndeterminate
             ? 'mixed'
             : this.isActive.toString(),

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.ts
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.ts
@@ -81,9 +81,7 @@ export default Selectable.extend({
 
   methods: {
     genCheckbox () {
-      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
-      const checkboxAttrs = { ...this.attrs$ }
-      delete checkboxAttrs.title
+      const { title, ...checkboxAttrs } = this.attrs$
       return this.$createElement('div', {
         staticClass: 'v-input--selection-controls__input',
       }, [

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -154,6 +154,9 @@ export default baseMixins.extend<options>().extend({
     genControl () {
       return this.$createElement('div', {
         staticClass: 'v-input__control',
+        attrs: {
+          title: this.attrs$.title,
+        },
       }, [
         this.genInputSlot(),
         this.genMessages(),

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -154,9 +154,7 @@ export default baseMixins.extend<options>().extend({
     genControl () {
       return this.$createElement('div', {
         staticClass: 'v-input__control',
-        attrs: {
-          title: this.attrs$.title,
-        },
+        attrs: { title: this.attrs$.title },
       }, [
         this.genInputSlot(),
         this.genMessages(),

--- a/packages/vuetify/src/components/VRadioGroup/VRadio.ts
+++ b/packages/vuetify/src/components/VRadioGroup/VRadio.ts
@@ -140,6 +140,9 @@ export default baseMixins.extend<options>().extend({
       }, getSlot(this, 'label') || this.label)
     },
     genRadio () {
+      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
+      const radioAttrs = { ...this.attrs$ }
+      delete radioAttrs.title
       return this.$createElement('div', {
         staticClass: 'v-input--selection-controls__input',
       }, [
@@ -151,7 +154,7 @@ export default baseMixins.extend<options>().extend({
         this.genInput({
           name: this.computedName,
           value: this.value,
-          ...this.attrs$,
+          ...radioAttrs,
         }),
         this.genRipple(this.setTextColor(this.rippleState)),
       ])
@@ -179,6 +182,9 @@ export default baseMixins.extend<options>().extend({
       on: mergeListeners({
         click: this.onChange,
       }, this.listeners$),
+      attrs: {
+        title: this.attrs$.title,
+      },
     }
 
     return h('div', data, [

--- a/packages/vuetify/src/components/VRadioGroup/VRadio.ts
+++ b/packages/vuetify/src/components/VRadioGroup/VRadio.ts
@@ -140,9 +140,8 @@ export default baseMixins.extend<options>().extend({
       }, getSlot(this, 'label') || this.label)
     },
     genRadio () {
-      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
-      const radioAttrs = { ...this.attrs$ }
-      delete radioAttrs.title
+      const { title, ...radioAttrs } = this.attrs$
+
       return this.$createElement('div', {
         staticClass: 'v-input--selection-controls__input',
       }, [
@@ -182,9 +181,7 @@ export default baseMixins.extend<options>().extend({
       on: mergeListeners({
         click: this.onChange,
       }, this.listeners$),
-      attrs: {
-        title: this.attrs$.title,
-      },
+      attrs: { title: this.attrs$.title },
     }
 
     return h('div', data, [

--- a/packages/vuetify/src/components/VSwitch/VSwitch.ts
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.ts
@@ -77,9 +77,8 @@ export default Selectable.extend({
       ]
     },
     genSwitch (): VNode {
-      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
-      const switchAttrs = { ...this.attrs$ }
-      delete switchAttrs.title
+      const { title, ...switchAttrs } = this.attrs$
+
       return this.$createElement('div', {
         staticClass: 'v-input--selection-controls__input',
       }, [

--- a/packages/vuetify/src/components/VSwitch/VSwitch.ts
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.ts
@@ -77,12 +77,15 @@ export default Selectable.extend({
       ]
     },
     genSwitch (): VNode {
+      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
+      const switchAttrs = { ...this.attrs$ }
+      delete switchAttrs.title
       return this.$createElement('div', {
         staticClass: 'v-input--selection-controls__input',
       }, [
         this.genInput('checkbox', {
           ...this.attrs,
-          ...this.attrs$,
+          ...switchAttrs,
         }),
         this.genRipple(this.setTextColor(this.validationState, {
           directives: [{

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -156,6 +156,7 @@
     &--active
       max-width: 133%
       transform: $text-field-label-active-transform
+      pointer-events: auto // Show title attr on label hover
 
   & > .v-input__control > .v-input__slot
     cursor: text

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -376,9 +376,7 @@ export default baseMixins.extend<options>().extend({
     genInput () {
       const listeners = Object.assign({}, this.listeners$)
       delete listeners.change // Change should not be bound externally
-      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
-      const inputAttrs = { ...this.attrs$ }
-      delete inputAttrs.title
+      const { title, ...inputAttrs } = this.attrs$
 
       return this.$createElement('input', {
         style: {},

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -376,6 +376,9 @@ export default baseMixins.extend<options>().extend({
     genInput () {
       const listeners = Object.assign({}, this.listeners$)
       delete listeners.change // Change should not be bound externally
+      // title attr is used on parent directly, so that its hover effect includes VLabel; this avoids a duplicate
+      const inputAttrs = { ...this.attrs$ }
+      delete inputAttrs.title
 
       return this.$createElement('input', {
         style: {},
@@ -383,7 +386,7 @@ export default baseMixins.extend<options>().extend({
           value: (this.type === 'number' && Object.is(this.lazyValue, -0)) ? '-0' : this.lazyValue,
         },
         attrs: {
-          ...this.attrs$,
+          ...inputAttrs,
           autofocus: this.autofocus,
           disabled: this.isDisabled,
           id: this.computedId,

--- a/packages/vuetify/src/styles/components/_selection-controls.sass
+++ b/packages/vuetify/src/styles/components/_selection-controls.sass
@@ -76,6 +76,7 @@
     left: -12px
     top: calc(50% - 24px)
     margin: 7px
+    pointer-events: none // Enable title attr hover effect, as ripple blocks the input
 
     &:before
       border-radius: inherit

--- a/packages/vuetify/src/styles/components/_selection-controls.sass
+++ b/packages/vuetify/src/styles/components/_selection-controls.sass
@@ -76,7 +76,6 @@
     left: -12px
     top: calc(50% - 24px)
     margin: 7px
-    pointer-events: none // Enable title attr hover effect, as ripple blocks the input
 
     &:before
       border-radius: inherit


### PR DESCRIPTION
Display hover effect of title attr even on label of v-text-field, which may have moved outside (above) the input when not outlined, by enabling pointer-events only when it's active (not otherwise).

Fix another v-switch bug of ripple effect's event blocking hover.

Fix displaying title at all in v-radio. (Also fixed ripple here.)

Move title attr to a parent object, making it trigger even on the threshold of input boundaries, increasing its accessibility scope to avoid blind zones. Remove the duplicate title in v-text-field, v-radio, v-switch, and v-checkbox after moving to parent element; specifically VInput, or in the v-radio's case via its own parent. Modified VInput's genInputSlot(): it's being called by components VAutocomplete, VRadioGroup, VSelect, and VTextField (maybe more).

This also fixed v-select's issue of title not appearing.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

Fixes #12775, #11253

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Title issues, details are in the issue #12775.

## Implementation details

There's a related issue for v-select: #11253 where the `pointer-events: none` implementation was described as a workaround to achieve expected behavior. In my implementation I enabled `pointer-events: auto` on active label, but there may be a better solution; I was unsuccessful in trying to use something like `& :not(&--active)` or `& :not(.v-label--active)` with `pointer-events: none` instead, intending to avoid setting `auto` as an override in case the developer explicitly changes it in a parent component, so you may also reconsider this.

The title attribute was moved to the parent, and then removed from child elements by copying the `{ ...this.attrs$ }` and `delete`-ing `title` field. This shouldn't be necessary, as the duplicate doesn't cause any harm, but will produce cleaner output.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

visually, but without exhaustive testing, so I'd appreciate any help.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
template>
  <v-container>
    <v-text-field title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-text-field>
    <v-text-field outlined title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-text-field>
    <v-textarea title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-textarea>
    <v-switch title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-switch>
    <v-checkbox title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-checkbox>
    <v-radio title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-radio>
    <v-select title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-select>
    <v-combobox title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-combobox>
    <v-autocomplete title="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details" label="A very long label that doesn't fit on the screen, so the user may have to hover on the label to read more details"></v-autocomplete>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
* This may introduce potential issues and isn't a fix for a critical functionality, so I'd conservatively classify it as a new feature (of label tooltips) and submit to dev first
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
