### PR TITLE
fix(VImg): default ratio to 1:1 for SVG images

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.ts
+++ b/packages/vuetify/src/components/VImg/VImg.ts
@@ -216,7 +216,12 @@ export default mixins(
       const poll = () => {
         let { naturalHeight, naturalWidth } = img
 
-        if (img.src.endsWith('.svg') && naturalHeight === 0 && naturalWidth === 0) {
+        if (
+          img.src &&
+          img.src.endsWith('.svg') &&
+          naturalHeight === 0 &&
+          naturalWidth === 0
+        ) {
           naturalHeight = 1
           naturalWidth = 1
         }

--- a/packages/vuetify/src/components/VImg/VImg.ts
+++ b/packages/vuetify/src/components/VImg/VImg.ts
@@ -214,7 +214,12 @@ export default mixins(
     },
     pollForSize (img: HTMLImageElement, timeout: number | null = 100) {
       const poll = () => {
-        const { naturalHeight, naturalWidth } = img
+        let { naturalHeight, naturalWidth } = img
+
+        if (img.src.endsWith('.svg') && naturalHeight === 0 && naturalWidth === 0) {
+          naturalHeight = 1
+          naturalWidth = 1
+        }
 
         if (naturalHeight || naturalWidth) {
           this.naturalWidth = naturalWidth

--- a/packages/vuetify/src/components/VImg/VImg.ts
+++ b/packages/vuetify/src/components/VImg/VImg.ts
@@ -218,7 +218,7 @@ export default mixins(
 
         if (
           img.src &&
-          img.src.endsWith('.svg') &&
+          (img.src.endsWith('.svg') || img.src.startsWith('data:image/svg+xml')) &&
           naturalHeight === 0 &&
           naturalWidth === 0
         ) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #11426 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=700533
In Firefox, the image.onload callback is not called (size 0 for SVG)

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

![image](https://user-images.githubusercontent.com/5492274/102708093-51a57100-42db-11eb-9011-22eecd661be8.png)


## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div id="app">
    <v-app>
      <v-container>
        <v-row>
          svg no given height/width
          <v-img src="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/410.svg"></v-img>
        </v-row>
        <v-row>
          svg with height/width
          <v-img src="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/AJ_Digital_Camera.svg"></v-img>
        </v-row>
        <v-row>
          data-url:
          <v-img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle r='50' cx='50' cy='50' fill='tomato'/%3E%3Ccircle r='41' cx='47' cy='50' fill='orange'/%3E%3Ccircle r='33' cx='48' cy='53' fill='gold'/%3E%3Ccircle r='25' cx='49' cy='51' fill='yellowgreen'/%3E%3Ccircle r='17' cx='52' cy='50' fill='lightseagreen'/%3E%3Ccircle r='9' cx='55' cy='48' fill='teal'/%3E%3C/svg%3E" />
        </v-row>
      </v-container>
    </v-app>
  </div>
</template>

<script>
  export default {

  }
</script>

```


</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
