### PR TITLE
fix(VSnackbar): set position of opposite direction values

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -7,11 +7,13 @@
 +sheet(v-snack__wrapper, $snackbar-elevation, $snackbar-border-radius, $snackbar-shaped-border-radius)
 
 .v-snack
+  bottom: $snackbar-bottom
   display: flex
   font-size: $snackbar-font-size
   justify-content: center
   left: $snackbar-left
   pointer-events: none
+  right: $snackbar-right
   top: $snackbar-top
   width: 100%
 
@@ -89,28 +91,20 @@
 
   &--left
     justify-content: flex-start
-    left: $snackbar-left
     right: auto
-
-  &--right
-    justify-content: flex-end
-    left: auto
-    right: $snackbar-right
-
-  &--bottom
-    bottom: $snackbar-bottom
-    top: auto
-
-  &--top
-    align-items: flex-start
-    bottom: auto
-    top: $snackbar-top
 
   &--multi-line &__wrapper
     min-height: $snackbar-multi-line-wrapper-min-height
 
+  &--right
+    justify-content: flex-end
+    left: auto
+
   &:not(.v-snack--has-background) &__wrapper
     box-shadow: none !important
+
+  &--bottom
+    top: auto
 
   &--text &__wrapper:before
     background-color: currentColor
@@ -123,6 +117,10 @@
     position: absolute
     right: 0
     top: 0
+
+  &--top
+    align-items: flex-start
+    bottom: auto
 
   &--vertical &__wrapper
     flex-direction: column

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -7,14 +7,12 @@
 +sheet(v-snack__wrapper, $snackbar-elevation, $snackbar-border-radius, $snackbar-shaped-border-radius)
 
 .v-snack
-  bottom: $snackbar-bottom
   display: flex
   font-size: $snackbar-font-size
   justify-content: center
+  top: $snackbar-top
   left: $snackbar-left
   pointer-events: none
-  right: $snackbar-right
-  top: $snackbar-top
   width: 100%
 
   &:not(.v-snack--absolute)
@@ -91,16 +89,28 @@
 
   &--left
     justify-content: flex-start
+    left: $snackbar-left
+    right: initial
+
+  &--right
+    justify-content: flex-end
+    left: initial
+    right: $snackbar-right
+
+  &--bottom
+    top: initial
+    bottom: $snackbar-bottom
+
+  &--top
+    align-items: flex-start
+    top: $snackbar-top
+    bottom: initial
 
   &--multi-line &__wrapper
     min-height: $snackbar-multi-line-wrapper-min-height
 
-  &--right
-    justify-content: flex-end
-
   &:not(.v-snack--has-background) &__wrapper
     box-shadow: none !important
-
 
   &--text &__wrapper:before
     background-color: currentColor
@@ -113,9 +123,6 @@
     position: absolute
     right: 0
     top: 0
-
-  &--top
-    align-items: flex-start
 
   &--vertical &__wrapper
     flex-direction: column

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -90,20 +90,20 @@
   &--left
     justify-content: flex-start
     left: $snackbar-left
-    right: initial
+    right: auto
 
   &--right
     justify-content: flex-end
-    left: initial
+    left: auto
     right: $snackbar-right
 
   &--bottom
     bottom: $snackbar-bottom
-    top: initial
+    top: auto
 
   &--top
     align-items: flex-start
-    bottom: initial
+    bottom: auto
     top: $snackbar-top
 
   &--multi-line &__wrapper

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -98,13 +98,13 @@
     right: $snackbar-right
 
   &--bottom
-    top: initial
     bottom: $snackbar-bottom
+    top: initial
 
   &--top
     align-items: flex-start
-    top: $snackbar-top
     bottom: initial
+    top: $snackbar-top
 
   &--multi-line &__wrapper
     min-height: $snackbar-multi-line-wrapper-min-height

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -10,9 +10,9 @@
   display: flex
   font-size: $snackbar-font-size
   justify-content: center
-  top: $snackbar-top
   left: $snackbar-left
   pointer-events: none
+  top: $snackbar-top
   width: 100%
 
   &:not(.v-snack--absolute)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Apply either `left` or `right`, and either `top` or `bottom` CSS properties to snackbar component, to avoid confusing some mobile browsers (Android Chrome, Firefox) causing unwanted positioning.

fixes #11781 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Scrolling up or down would make the snackbar up and down when positioned at the bottom. So if the browser address bar is visible, the snackbar is hidden when positioned at the bottom.

fixes #11781 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Tested with remote debugging on Android Chrome (version 87.0.4280.101) and Android Firefox (version 82.1.3).
With these changes, the snackbar is not hidden anymore behind the browser address bar, and remains fixed when scrolling (so long as the `absolute` prop is not provided).
### Discussion:
I don't see how the `absolute` prop is useful on mobile, since depending on `top` or `bottom` positioning the snackbar will be hidden behind the browser address bar on either Firefox or Chrome (Firefox address bar is located at the bottom and Chrome at the top).

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>
Playground.vue

```vue
<template>
  <v-container>
    <v-snackbar
      v-model="snackbar"
      :timeout="-1"
    >
      Snack!
    </v-snackbar>
    <p>Some very long lorem ipsum text to enable scroll...</p>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      snackbar: true
    })
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
