### PR TITLE
feat: create rounded composable

### DIFF
--- a/packages/vuetify/src/composables/__tests__/rounded.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/rounded.spec.ts
@@ -1,0 +1,45 @@
+// Effects
+import type { RoundedProps } from '../rounded'
+import {
+  makeRoundedProps,
+  useRoundedClasses,
+} from '../rounded'
+
+describe('rounded.ts', () => {
+  it('should have the correct class', () => {
+    const values = [
+      [undefined, { 'rounded-0': true }],
+      [false, { 'rounded-0': true }],
+      [true, { rounded: true }],
+      ['lg', { 'rounded-lg': true }],
+      ['tl-lg br-xl', { 'rounded-tl-lg': true, 'rounded-br-xl': true }],
+    ] as const
+
+    for (const [rounded, equal] of values) {
+      const props = { rounded }
+      const { roundedClasses } = useRoundedClasses(props)
+
+      expect(roundedClasses.value).toEqual(equal)
+    }
+  })
+
+  it('should have the correct class with tile', () => {
+    const { roundedClasses } = useRoundedClasses({ tile: true })
+
+    expect(roundedClasses.value).toEqual({ 'rounded-0': true })
+  })
+
+  it('should only allow boolean or sm/lg/xl values', () => {
+    const { rounded: { validator } } = makeRoundedProps()
+    const validValues = [true, false, 'tl-lg', 'tl-lg br-xl', 'sm', 'xl', 'lg']
+    const invalidValues = [-1, 'ab']
+
+    for (const value of validValues) {
+      expect(validator(value)).toBe(true)
+    }
+
+    for (const value of invalidValues) {
+      expect(validator(value)).toBe(false)
+    }
+  })
+})

--- a/packages/vuetify/src/composables/rounded.ts
+++ b/packages/vuetify/src/composables/rounded.ts
@@ -1,0 +1,54 @@
+import { computed } from 'vue'
+import propsFactory from '@/util/propsFactory'
+
+// Types
+export interface RoundedProps {
+  rounded?: boolean | string
+  tile?: boolean
+}
+
+export const makeRoundedProps = propsFactory({
+  rounded: {
+    type: [Boolean, String],
+    validator (v: any) {
+      if (typeof v === 'boolean') {
+        return true
+      } else if (typeof v !== 'string') {
+        return false
+      }
+
+      const classes = v.split(' ')
+      for (const item of classes) {
+        if (item.match(/^(tl|tr|br|bl)?-?(sm|lg|xl)$/g) === null) {
+          return false
+        }
+      }
+
+      return true
+    },
+  },
+  tile: Boolean,
+})
+
+// Effect
+export function useRoundedClasses (props: RoundedProps) {
+  const roundedClasses = computed(() => {
+    const { rounded = props.tile ? 0 : undefined } = props
+
+    if (rounded === true) {
+      return { rounded: true }
+    } else if (typeof rounded === 'string') {
+      const classes: Record<string, boolean> = {}
+      const values = rounded.split(' ')
+
+      for (const value of values) {
+        classes[`rounded-${value}`] = true
+      }
+      return classes
+    } else {
+      return { 'rounded-0': true }
+    }
+  })
+
+  return { roundedClasses }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Create `rounded` composable for rounded corners.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Task  #12789

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
