### PR TITLE
feat(border-radius) add test refactor with type guards

### DIFF
--- a/packages/vuetify/src/composables/__tests__/border-radius.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/border-radius.spec.ts
@@ -1,0 +1,49 @@
+import {
+  useBorderRadius,
+  borderRadiusClassNames,
+} from '../border-radius'
+import type {
+  BorderRadiusProps,
+} from '../border-radius'
+
+describe('border-radius', () => {
+  const assertions = [
+    // Rounded with 0
+    [{ rounded: false }, ['rounded-0']],
+    [{ rounded: '0' }, ['rounded-0']],
+    [{ rounded: 0 }, ['rounded-0']],
+    [{ rounded: 'tile' }, ['rounded-0']],
+    // Rounded with a word
+    [{ rounded: 'circle' }, ['rounded-circle']],
+    [{ rounded: 'shaped' }, ['rounded-shaped']],
+    [{ rounded: 'pill' }, ['rounded-pill']],
+    // Rounded only
+    [{ rounded: true }, ['rounded']],
+    [{ rounded: '' }, ['rounded']],
+    // When should return nothing
+    [{ rounded: 1 }, []],
+    [{ rounded: { toString: () => 'pill' } }, []],
+    [undefined, []],
+    [{ rounded: null }, []],
+    // Rounded with more than one words, ensure sorting
+    [
+      { rounded: 'tr-xl br-lg' },
+      ['rounded-br-lg', 'rounded-tr-xl'],
+    ],
+    [{ rounded: 'sm-3 4' }, ['rounded-4', 'rounded-sm-3']],
+    // All strings are accepted?
+    [{ rounded: 'foo-bar-bazz-buzz' }, ['rounded-foo-bar-bazz-buzz']],
+    [{ rounded: '!' }, ['rounded-!']],
+  ] as [BorderRadiusProps, string[]][]
+
+  it.each(assertions)(
+    'should return correct rounded classes',
+    (propsData, expected) => {
+      const vm = useBorderRadius(propsData)
+      const subject = borderRadiusClassNames(propsData)
+
+      expect(vm.borderRadiusClasses.value).toMatchObject(expected)
+      expect(subject).toMatchObject(expected)
+    },
+  )
+})

--- a/packages/vuetify/src/composables/__tests__/rounded.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/rounded.spec.ts
@@ -1,12 +1,11 @@
-import {
-  useBorderRadius,
-  borderRadiusClassNames,
-} from '../border-radius'
 import type {
-  BorderRadiusProps,
-} from '../border-radius'
+  IMaybeRoundedProps,
+} from '../rounded'
+import {
+  roundedClassNames,
+} from '../rounded'
 
-describe('border-radius', () => {
+describe('rounded', () => {
   const assertions = [
     // Rounded with 0
     [{ rounded: false }, ['rounded-0']],
@@ -34,15 +33,13 @@ describe('border-radius', () => {
     // All strings are accepted?
     [{ rounded: 'foo-bar-bazz-buzz' }, ['rounded-foo-bar-bazz-buzz']],
     [{ rounded: '!' }, ['rounded-!']],
-  ] as [BorderRadiusProps, string[]][]
+  ] as [IMaybeRoundedProps, string[]][]
 
   it.each(assertions)(
     'should return correct rounded classes',
     (propsData, expected) => {
-      const vm = useBorderRadius(propsData)
-      const subject = borderRadiusClassNames(propsData)
+      const subject = roundedClassNames(propsData)
 
-      expect(vm.borderRadiusClasses.value).toMatchObject(expected)
       expect(subject).toMatchObject(expected)
     },
   )

--- a/packages/vuetify/src/composables/border-radius.ts
+++ b/packages/vuetify/src/composables/border-radius.ts
@@ -1,63 +1,23 @@
-// Utilities
 import { computed } from 'vue'
-import type { Prop } from 'vue'
-
-import propsFactory from '@/util/propsFactory'
 
 // Types
-export type IRounded = typeof radius[number]
+import type { Prop } from 'vue'
+import type { IRounded } from './rounded'
+
+// Utils
+import { roundedClassNames, isRounded } from './rounded'
+import propsFactory from '@/util/propsFactory'
+
 export interface BorderRadiusProps {
   rounded?: IRounded
 }
 
-const radius = [
-  true,
-  false,
-  '',
-  0,
-  '0',
-  'xs',
-  'sm',
-  'lg',
-  'xl',
-  'circle',
-  'pill',
-  'shaped',
-  'tile',
-] as const
-
 export const makeBorderRadiusProps = propsFactory({
   rounded: {
     type: [Boolean, Number, String],
-    validator: (v: any) => radius.includes(v),
+    validator: isRounded,
   } as Prop<IRounded>,
 })
-
-export const roundedClassNames = (
-  props: BorderRadiusProps,
-): string[] => {
-  const classes = []
-
-  if (props && 'rounded' in props) {
-    const rounded = props.rounded
-
-    if (rounded == null) {
-      // noop
-    } else if (rounded === true || rounded === '') {
-      classes.push('rounded')
-    } else if ([false, 0, '0', 'tile'].includes(rounded)) {
-      classes.push('rounded-0')
-    } else if (typeof rounded === 'string') {
-      const values = rounded.split(' ')
-
-      for (const value of values) {
-        classes.push(`rounded-${value}`)
-      }
-    }
-  }
-
-  return classes.sort()
-}
 
 // Effect
 export function useBorderRadius (props: BorderRadiusProps) {

--- a/packages/vuetify/src/composables/border-radius.ts
+++ b/packages/vuetify/src/composables/border-radius.ts
@@ -1,15 +1,19 @@
 // Utilities
 import { computed } from 'vue'
+import type { Prop } from 'vue'
+
 import propsFactory from '@/util/propsFactory'
 
 // Types
+export type IRounded = typeof radius[number]
 export interface BorderRadiusProps {
-  rounded?: boolean | number | string
+  rounded?: IRounded
 }
 
 const radius = [
   true,
   false,
+  '',
   0,
   '0',
   'xs',
@@ -26,14 +30,16 @@ export const makeBorderRadiusProps = propsFactory({
   rounded: {
     type: [Boolean, Number, String],
     validator: (v: any) => radius.includes(v),
-  },
+  } as Prop<IRounded>,
 })
 
-// Effect
-export function useBorderRadiusClasses (props: BorderRadiusProps) {
-  const borderRadiusClasses = computed(() => {
+export const roundedClassNames = (
+  props: BorderRadiusProps,
+): string[] => {
+  const classes = []
+
+  if (props && 'rounded' in props) {
     const rounded = props.rounded
-    const classes = []
 
     if (rounded == null) {
       // noop
@@ -48,8 +54,15 @@ export function useBorderRadiusClasses (props: BorderRadiusProps) {
         classes.push(`rounded-${value}`)
       }
     }
+  }
 
-    return classes
+  return classes.sort()
+}
+
+// Effect
+export function useBorderRadius (props: BorderRadiusProps) {
+  const borderRadiusClasses = computed(() => {
+    return roundedClassNames(props)
   })
 
   return { borderRadiusClasses }

--- a/packages/vuetify/src/composables/border-radius.ts
+++ b/packages/vuetify/src/composables/border-radius.ts
@@ -1,0 +1,56 @@
+// Utilities
+import { computed } from 'vue'
+import propsFactory from '@/util/propsFactory'
+
+// Types
+export interface BorderRadiusProps {
+  rounded?: boolean | number | string
+}
+
+const radius = [
+  true,
+  false,
+  0,
+  '0',
+  'xs',
+  'sm',
+  'lg',
+  'xl',
+  'circle',
+  'pill',
+  'shaped',
+  'tile',
+] as const
+
+export const makeBorderRadiusProps = propsFactory({
+  rounded: {
+    type: [Boolean, Number, String],
+    validator: (v: any) => radius.includes(v),
+  },
+})
+
+// Effect
+export function useBorderRadiusClasses (props: BorderRadiusProps) {
+  const borderRadiusClasses = computed(() => {
+    const rounded = props.rounded
+    const classes = []
+
+    if (rounded == null) {
+      // noop
+    } else if (rounded === true || rounded === '') {
+      classes.push('rounded')
+    } else if ([false, 0, '0', 'tile'].includes(rounded)) {
+      classes.push('rounded-0')
+    } else if (typeof rounded === 'string') {
+      const values = rounded.split(' ')
+
+      for (const value of values) {
+        classes.push(`rounded-${value}`)
+      }
+    }
+
+    return classes
+  })
+
+  return { borderRadiusClasses }
+}

--- a/packages/vuetify/src/composables/rounded.ts
+++ b/packages/vuetify/src/composables/rounded.ts
@@ -1,0 +1,50 @@
+
+const ROUNDED = [
+  true,
+  false,
+  '',
+  0,
+  '0',
+  'xs',
+  'sm',
+  'lg',
+  'xl',
+  'circle',
+  'pill',
+  'shaped',
+  'tile',
+] as const
+
+export type IRounded = typeof ROUNDED[number]
+
+export type IMaybeRoundedProps = Partial<Record<'rounded', IRounded>>
+
+export const roundedClassNames = (
+  props: IMaybeRoundedProps,
+): string[] => {
+  const classes = []
+
+  if (props && 'rounded' in props) {
+    const rounded = props.rounded
+
+    if (rounded == null) {
+      // noop
+    } else if (rounded === true || rounded === '') {
+      classes.push('rounded')
+    } else if ([false, 0, '0', 'tile'].includes(rounded)) {
+      classes.push('rounded-0')
+    } else if (typeof rounded === 'string') {
+      const values = rounded.split(' ')
+
+      for (const value of values) {
+        classes.push(`rounded-${value}`)
+      }
+    }
+  }
+
+  return classes.sort()
+}
+
+export const isRounded = (input: any): input is IRounded => {
+  return ROUNDED.includes(input)
+}

--- a/packages/vuetify/src/composables/tag.ts
+++ b/packages/vuetify/src/composables/tag.ts
@@ -1,0 +1,10 @@
+// Setup
+import propsFactory from '@/util/propsFactory'
+
+// Props
+export const makeTagProps = propsFactory({
+  tag: {
+    type: String,
+    default: 'div',
+  },
+})


### PR DESCRIPTION
Related to vuetifyjs/vuetify#12692 vuetifyjs/vuetify#12789

## Description

Moved tests, extracted logic into stateless functions, an attempt at making things explicit. (Maybe be too verbose now though).

* Added border-radius test case copy-pasta from rounded mixin


## Motivation and Context

* Introducing a way to be more specific with what's acceptable as input w.r.t. typing
* Separate computation from Vue, test without Vue, then mount into appropriate effect
 
## How Has This Been Tested?

* Separated computation tested without runtime (Vue), then in integration

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
