### PR TITLE
Calendar category bug fix

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendar.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendar.ts
@@ -293,11 +293,11 @@ export default CalendarWithEvents.extend({
     },
     getCategoryList (categories: CalendarCategory[]): CalendarCategory[] {
       if (!this.noEvents) {
-        const categoryMap = categories.reduce((map, category, index) => {
+        const categoryMap: any = categories.reduce((map: any, category, index) => {
           if (typeof category === 'object' && category.categoryName) map[category.categoryName] = { index, count: 0 }
 
           return map
-        }, Object.create(null))
+        })
 
         if (!this.categoryHideDynamic || !this.categoryShowAll) {
           let categoryLength = categories.length

--- a/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
@@ -4,14 +4,14 @@ import {
   MountOptions,
 } from '@vue/test-utils'
 import { ExtractVue } from '../../../util/mixins'
-import VCalendarCategory from '../VCalendarCategory'
+import VCalendar from '../VCalendar'
 
 describe('VCalendarCategory', () => {
-  type Instance = ExtractVue<typeof VCalendarCategory>
+  type Instance = ExtractVue<typeof VCalendar>
   let mountFunction: (options?: MountOptions<Instance>) => Wrapper<Instance>
   beforeEach(() => {
     mountFunction = (options?: MountOptions<Instance>) => {
-      return mount(VCalendarCategory, {
+      return mount(VCalendar, {
         ...options,
         mocks: {
           $vuetify: {
@@ -27,6 +27,13 @@ describe('VCalendarCategory', () => {
   it('should test categoryText prop as a string', () => {
     const wrapper = mountFunction({
       propsData: {
+        type: 'category',
+        events: [{
+          name: 'TestEvent',
+          start: new Date(),
+          end: new Date(),
+          category: 'Nate',
+        }],
         categories: [{ name: 'Nate' }],
         categoryText: 'name',
       },
@@ -38,7 +45,14 @@ describe('VCalendarCategory', () => {
   it('should test categoryText prop as a function', () => {
     const wrapper = mountFunction({
       propsData: {
-        categories: [{ name: 'Nate', age: 20 }],
+        type: 'category',
+        events: [{
+          name: 'TestEvent',
+          start: new Date(),
+          end: new Date(),
+          category: '20',
+        }],
+        categories: [{ name: 'Nate', age: '20' }],
         categoryText (category) {
           return category.age
         },
@@ -55,8 +69,15 @@ describe('VCalendarCategory', () => {
 
     const wrapper = mountFunction({
       propsData: {
+        type: 'category',
         categories: [{ name: 'Nate', age: 20 }],
         categoryText: 'name',
+        events: [{
+          name: 'TestEvent',
+          start: new Date(),
+          end: new Date(),
+          category: '20',
+        }],
         intervalStyle,
       },
     })

--- a/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
@@ -48,7 +48,7 @@ describe('VCalendarCategory', () => {
     expect(wrapper.find('.v-calendar-category__column-header').text()).toEqual('20')
   })
 
-  it('should pass entire cateogry to interal', () => {
+  it('should pass entire cateogry to interval style method', () => {
     function intervalStyle (obj) {
       expect(obj.category).toEqual({ name: 'Nate', age: 20, categoryName: 'Nate' })
     }

--- a/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
@@ -24,7 +24,7 @@ describe('VCalendarCategory', () => {
     }
   })
 
-  it('should test categoryText prop as a string', async () => {
+  it('should test categoryText prop as a string', () => {
     const wrapper = mountFunction({
       propsData: {
         categories: [{ name: 'Nate' }],
@@ -35,7 +35,7 @@ describe('VCalendarCategory', () => {
     expect(wrapper.find('.v-calendar-category__column-header').text()).toEqual('Nate')
   })
 
-  it('should test categoryText prop as a function', async () => {
+  it('should test categoryText prop as a function', () => {
     const wrapper = mountFunction({
       propsData: {
         categories: [{ name: 'Nate', age: 20 }],
@@ -46,5 +46,19 @@ describe('VCalendarCategory', () => {
     })
 
     expect(wrapper.find('.v-calendar-category__column-header').text()).toEqual('20')
+  })
+
+  it('should pass entire cateogry to interal', () => {
+    function intervalStyle (obj) {
+      expect(obj.category).toEqual({ name: 'Nate', age: 20, categoryName: 'Nate' })
+    }
+
+    const wrapper = mountFunction({
+      propsData: {
+        categories: [{ name: 'Nate', age: 20 }],
+        categoryText: 'name',
+        intervalStyle,
+      },
+    })
   })
 })

--- a/packages/vuetify/src/components/VCalendar/util/parser.ts
+++ b/packages/vuetify/src/components/VCalendar/util/parser.ts
@@ -21,7 +21,7 @@ export function getParsedCategories (
       const categoryName = typeof v === 'string' ? v
         : typeof v === 'object' && v && typeof v.categoryName === 'string' ? v.categoryName
           : parsedCategoryText(v, categoryText)
-      return { categoryName }
+      return Object.assign({ categoryName }, v)
     })
   }
   return []

--- a/packages/vuetify/src/components/VCalendar/util/parser.ts
+++ b/packages/vuetify/src/components/VCalendar/util/parser.ts
@@ -18,11 +18,11 @@ export function getParsedCategories (
   if (typeof categories === 'string') return categories.split(/\s*,\s/)
   if (Array.isArray(categories)) {
     return categories.map((category: CalendarCategory) => {
-      const categoryName = typeof category === 'string' ? category
-        : typeof category === 'object' && category && typeof category.categoryName === 'string' ? category.categoryName
-          : parsedCategoryText(category, categoryText)
-      if (typeof category === 'string') return { categoryName }
-      return Object.assign({ categoryName }, category)
+      if (typeof category === 'string') return { categoryName: category }
+
+      const categoryName = typeof category.categoryName === 'string' ? category.categoryName
+        : parsedCategoryText(category, categoryText)
+      return { ...category, categoryName }
     })
   }
   return []

--- a/packages/vuetify/src/components/VCalendar/util/parser.ts
+++ b/packages/vuetify/src/components/VCalendar/util/parser.ts
@@ -17,11 +17,12 @@ export function getParsedCategories (
 ): CalendarCategory[] {
   if (typeof categories === 'string') return categories.split(/\s*,\s/)
   if (Array.isArray(categories)) {
-    return categories.map((v: CalendarCategory) => {
-      const categoryName = typeof v === 'string' ? v
-        : typeof v === 'object' && v && typeof v.categoryName === 'string' ? v.categoryName
-          : parsedCategoryText(v, categoryText)
-      return Object.assign({ categoryName }, v)
+    return categories.map((category: CalendarCategory) => {
+      const categoryName = typeof category === 'string' ? category
+        : typeof category === 'object' && category && typeof category.categoryName === 'string' ? category.categoryName
+          : parsedCategoryText(category, categoryText)
+      if (typeof category === 'string') return { categoryName }
+      return Object.assign({ categoryName }, category)
     })
   }
   return []


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

There was a changed advised to me at last pr that was supposed to be an easy code change but turned out to create a bug



## Description
Bug fix where we were calling .hasOwnProperty on an object that didn't inherit from Object so this method didn't exist

## Motivation and Context
Bugfix

## How Has This Been Tested?
Updated unit tests to properly test this code

## Markup:

<details>

```vue
<template>
  <v-container>
    <v-calendar
      color="primary"
      type="category"
      :categories="['Jeff', 'Nate']"
      category-show-all
      :events="events"
      :interval-style="intervalStyle"
    />
  </v-container>
</template>

<script>
export default {
  data: () => ({
    events: [
      {
        name: "Nate",
        category: "Nate",
        start: new Date(),
        end: new Date()
      }
    ]
  }),
  methods: {
    intervalStyle(obj){
      console.log(obj.category)
    }
  }
};
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
