### PR TITLE
fix(vcalendar): object inheritance

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendar.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendar.ts
@@ -297,7 +297,7 @@ export default CalendarWithEvents.extend({
           if (typeof category === 'object' && category.categoryName) map[category.categoryName] = { index, count: 0 }
 
           return map
-        })
+        }, {})
 
         if (!this.categoryHideDynamic || !this.categoryShowAll) {
           let categoryLength = categories.length

--- a/packages/vuetify/src/components/VCalendar/VCalendar.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendar.ts
@@ -293,11 +293,11 @@ export default CalendarWithEvents.extend({
     },
     getCategoryList (categories: CalendarCategory[]): CalendarCategory[] {
       if (!this.noEvents) {
-        const categoryMap = categories.reduce((map, category, index) => {
+        const categoryMap: any = categories.reduce((map: any, category, index) => {
           if (typeof category === 'object' && category.categoryName) map[category.categoryName] = { index, count: 0 }
 
           return map
-        }, Object.create(null))
+        })
 
         if (!this.categoryHideDynamic || !this.categoryShowAll) {
           let categoryLength = categories.length

--- a/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
@@ -4,14 +4,14 @@ import {
   MountOptions,
 } from '@vue/test-utils'
 import { ExtractVue } from '../../../util/mixins'
-import VCalendarCategory from '../VCalendarCategory'
+import VCalendar from '../VCalendar'
 
 describe('VCalendarCategory', () => {
-  type Instance = ExtractVue<typeof VCalendarCategory>
+  type Instance = ExtractVue<typeof VCalendar>
   let mountFunction: (options?: MountOptions<Instance>) => Wrapper<Instance>
   beforeEach(() => {
     mountFunction = (options?: MountOptions<Instance>) => {
-      return mount(VCalendarCategory, {
+      return mount(VCalendar, {
         ...options,
         mocks: {
           $vuetify: {
@@ -27,6 +27,8 @@ describe('VCalendarCategory', () => {
   it('should test categoryText prop as a string', () => {
     const wrapper = mountFunction({
       propsData: {
+        type: 'category',
+        events: [{ start: new Date(), category: 'Nate' }],
         categories: [{ name: 'Nate' }],
         categoryText: 'name',
       },
@@ -38,7 +40,9 @@ describe('VCalendarCategory', () => {
   it('should test categoryText prop as a function', () => {
     const wrapper = mountFunction({
       propsData: {
-        categories: [{ name: 'Nate', age: 20 }],
+        type: 'category',
+        events: [{ start: new Date(), category: '20' }],
+        categories: [{ name: 'Nate', age: '20' }],
         categoryText (category) {
           return category.age
         },
@@ -50,11 +54,15 @@ describe('VCalendarCategory', () => {
 
   it('should pass entire cateogry to interval style method', () => {
     function intervalStyle (obj) {
-      expect(obj.category).toEqual({ name: 'Nate', age: 20, categoryName: 'Nate' })
+      expect(obj.category.name).toEqual('Nate')
+      expect(obj.category.age).toEqual(20)
+      expect(obj.category.categoryName).toEqual('Nate')
     }
 
     const wrapper = mountFunction({
       propsData: {
+        type: 'category',
+        events: [{ start: new Date(), category: 'Nate' }],
         categories: [{ name: 'Nate', age: 20 }],
         categoryText: 'name',
         intervalStyle,


### PR DESCRIPTION
Tried to call .hasOwnProperty on an object that didn't enherit from Object prototype

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

Fixed a bug with VCalendar


## Description
There was an object we were calling .hasOwnProperty on which didn't have this method because it didn't inherit from 

## Motivation and Context
Bug was throwing an error

## How Has This Been Tested?
Wrote new unit test to make sure

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
   <v-calendar
      type="category"
      :categories="[{name: 'Nate', age: 20}]"
      category-text="name"
      category-show-all
      :events="[{start: new Date(), category: 'Nate', name: 'Event'}]"
      ></v-calendar>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
