### PR TITLE
fix(VBtn): disabled state background-color

### DIFF
--- a/packages/vuetify/src/components/VBottomNavigation/__tests__/__snapshots__/VBottomNavigation.spec.ts.snap
+++ b/packages/vuetify/src/components/VBottomNavigation/__tests__/__snapshots__/VBottomNavigation.spec.ts.snap
@@ -12,13 +12,13 @@ exports[`VBottomNavigation.ts should be visible with a true value 2`] = `
      style="height: 56px; transform: none;"
 >
   <button type="button"
-          class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
+          class="v-btn v-btn--flat theme--light v-size--default"
   >
     <span class="v-btn__content">
     </span>
   </button>
   <button type="button"
-          class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
+          class="v-btn v-btn--flat theme--light v-size--default"
   >
     <span class="v-btn__content">
     </span>
@@ -38,13 +38,13 @@ exports[`VBottomNavigation.ts should be visible with a true value 4`] = `
      style="height: 56px; transform: translateY(100%);"
 >
   <button type="button"
-          class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
+          class="v-btn v-btn--flat theme--light v-size--default"
   >
     <span class="v-btn__content">
     </span>
   </button>
   <button type="button"
-          class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
+          class="v-btn v-btn--flat theme--light v-size--default"
   >
     <span class="v-btn__content">
     </span>

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -22,6 +22,9 @@
     .v-btn__loading
       color: map-deep-get($material, 'buttons', 'disabled') !important
 
+    &:not(.v-btn--outlined):not(.v-btn--plain):not(.v-btn--text)
+      background-color: map-deep-get($material, 'buttons', 'focused') !important
+
     &.v-btn--has-bg
       background-color: map-deep-get($material, 'buttons', 'focused') !important
 

--- a/packages/vuetify/src/components/VBtn/VBtn.ts
+++ b/packages/vuetify/src/components/VBtn/VBtn.ts
@@ -10,6 +10,7 @@ import VProgressCircular from '../VProgressCircular'
 // Mixins
 import { factory as GroupableFactory } from '../../mixins/groupable'
 import { factory as ToggleableFactory } from '../../mixins/toggleable'
+import Elevatable from '../../mixins/elevatable'
 import Positionable from '../../mixins/positionable'
 import Routable from '../../mixins/routable'
 import Sizeable from '../../mixins/sizeable'
@@ -108,6 +109,11 @@ export default baseMixins.extend<options>().extend({
         ...this.sizeableClasses,
       }
     },
+    computedElevation (): string | number | undefined {
+      if (this.disabled) return undefined
+
+      return Elevatable.options.computed.computedElevation.call(this)
+    },
     computedRipple (): RippleOptions | boolean {
       const defaultRipple = this.icon || this.fab ? { circle: true } : true
       if (this.disabled) return false
@@ -123,8 +129,9 @@ export default baseMixins.extend<options>().extend({
         !this.outlined &&
         !this.depressed &&
         !this.disabled &&
-        !this.plain
-      ) || Number(this.elevation) > 0
+        !this.plain &&
+        (this.elevation != null || Number(this.elevation) < 1)
+      )
     },
     isRound (): boolean {
       return Boolean(

--- a/packages/vuetify/src/components/VBtn/__tests__/__snapshots__/VBtn.spec.ts.snap
+++ b/packages/vuetify/src/components/VBtn/__tests__/__snapshots__/VBtn.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`VBtn.ts should not add color classes if disabled 1`] = `
 <button type="button"
-        class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary--text text--darken-2"
+        class="v-btn v-btn--flat theme--light v-size--default primary--text--text text--text--darken-2"
 >
   <span class="v-btn__content">
   </span>
@@ -21,7 +21,7 @@ exports[`VBtn.ts should not add color classes if disabled 2`] = `
 
 exports[`VBtn.ts should render an <a> tag when using href prop 1`] = `
 <a href="http://www.google.com"
-   class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
+   class="v-btn v-btn--flat theme--light v-size--default"
 >
   <span class="v-btn__content">
   </span>
@@ -30,7 +30,7 @@ exports[`VBtn.ts should render an <a> tag when using href prop 1`] = `
 
 exports[`VBtn.ts should render component and match snapshot 1`] = `
 <button type="button"
-        class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default"
+        class="v-btn v-btn--flat theme--light v-size--default"
 >
   <span class="v-btn__content">
   </span>
@@ -39,7 +39,7 @@ exports[`VBtn.ts should render component and match snapshot 1`] = `
 
 exports[`VBtn.ts should render component with color prop and match snapshot 1`] = `
 <button type="button"
-        class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default green darken-1"
+        class="v-btn v-btn--flat theme--light v-size--default green--text text--darken-1"
 >
   <span class="v-btn__content">
   </span>
@@ -57,7 +57,7 @@ exports[`VBtn.ts should render component with color prop and match snapshot 2`] 
 
 exports[`VBtn.ts should render component with loader and match snapshot 1`] = `
 <button type="button"
-        class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg v-btn--loading theme--light v-size--default"
+        class="v-btn v-btn--flat v-btn--loading theme--light v-size--default"
 >
   <span class="v-btn__content">
   </span>
@@ -92,7 +92,7 @@ exports[`VBtn.ts should render component with loader and match snapshot 1`] = `
 
 exports[`VBtn.ts should render component with loader slot and match snapshot 1`] = `
 <button type="button"
-        class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg v-btn--loading theme--light v-size--default"
+        class="v-btn v-btn--flat v-btn--loading theme--light v-size--default"
 >
   <span class="v-btn__content">
   </span>
@@ -105,7 +105,7 @@ exports[`VBtn.ts should render component with loader slot and match snapshot 1`]
 `;
 
 exports[`VBtn.ts should render specified tag when using tag prop 1`] = `
-<a class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg theme--light v-size--default">
+<a class="v-btn v-btn--flat theme--light v-size--default">
   <span class="v-btn__content">
   </span>
 </a>
@@ -113,7 +113,7 @@ exports[`VBtn.ts should render specified tag when using tag prop 1`] = `
 
 exports[`VBtn.ts should render tile button and match snapshot 1`] = `
 <button type="button"
-        class="v-btn v-btn--contained v-btn--is-elevated v-btn--has-bg v-btn--tile theme--light v-size--default"
+        class="v-btn v-btn--flat v-btn--tile theme--light v-size--default"
 >
   <span class="v-btn__content">
   </span>


### PR DESCRIPTION
add check to isElevated to ensure elevation prop is not null.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #12845

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-12 pa-12">
    <v-card>
      <v-card-text>
        <v-container>
          <v-row
            align="center"
            justify="space-around"
            class="my-10"
          >
            <v-btn disabled>Disabled</v-btn>

            <v-btn color="red" :disabled="disabled"  outlined>outlined</v-btn>

            <v-btn color="primary"  :disabled="disabled" icon>
              <v-icon dark>
                mdi-vuetify
              </v-icon>
            </v-btn>

            <v-btn color="blue" :disabled="disabled" text>text</v-btn>

            <v-btn color="green" :disabled="disabled" elevation="5">elevated</v-btn>
          </v-row>

          <v-row
            align="center"
            justify="space-around"
            class="my-10"
          >
            <v-btn color="green"  :disabled="disabled"  plain>plain</v-btn>

            <v-btn color="red" depressed :disabled="disabled">depressed</v-btn>

            <v-btn color="blue" :disabled="disabled" rounded>rounded</v-btn>

            <v-btn color="primary" :disabled="disabled" tile>tile</v-btn>
          </v-row>
        </v-container>
      </v-card-text>
    </v-card>

    <v-row
      aligh="center"
      justify="center"
      class="my-10"
    >
      <v-btn color="black" @click="toggleDisabled">toggle</v-btn>
    </v-row>
  </div>
</template>
<script>
  export default {
    data () {
      return {
        disabled: false,
      }
    },
    methods: {
      toggleDisabled() {
        this.disabled = !this.disabled
      }
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
