### PR TITLE
fix(grid): don't halve gutters between v-rows

### DIFF
--- a/packages/vuetify/src/components/VGrid/VGrid.sass
+++ b/packages/vuetify/src/components/VGrid/VGrid.sass
@@ -14,6 +14,12 @@
 .row
   +make-row
 
+  & + .row
+    margin-top: $grid-gutter / 2
+
+    &--dense
+      margin-top: $form-grid-gutter / 2
+
   &--dense
     margin: -$form-grid-gutter / 2
 


### PR DESCRIPTION
fixes #12915

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row dense>
      <v-col cols="8">
        <v-card height="100%"></v-card>
      </v-col>
      <v-col cols="4">
        <v-row dense>
          <v-col cols="12">
            <v-card>
              <v-skeleton-loader type="article" />
            </v-card>
          </v-col>
          <v-col cols="12">
            <v-card>
              <v-skeleton-loader type="article" />
            </v-card>
          </v-col>
        </v-row>
      </v-col>
    </v-row>
    <v-row dense>
      <v-col
        v-for="i in 6"
        :key="i"
        cols="6"
      >
        <v-card>
          <v-skeleton-loader type="article" />
        </v-card>
      </v-col>
    </v-row>
  </v-container>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
