### PR TITLE
docs(api): update v-navigation-drawer clipped description

### DIFF
--- a/packages/api-generator/src/locale/en/v-navigation-drawer.json
+++ b/packages/api-generator/src/locale/en/v-navigation-drawer.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "bottom": "Expands from the bottom of the screen on mobile devices",
-    "clipped": "A clipped drawer rests under the application toolbar. Requires `clipped-left` or `clipped-right` prop for `v-app-bar` to work as intended.",
+    "clipped": "A clipped drawer rests under the application toolbar. **Note:** requires the **clipped-left** or **clipped-right** prop on `v-app-bar` to work as intended",
     "disableResizeWatcher": "Will automatically open/close drawer when resized depending if mobile or desktop.",
     "disableRouteWatcher": "Disables opening of navigation drawer when route changes",
     "expandOnHover": "Collapses the drawer to a **mini-variant** until hovering with the mouse",

--- a/packages/api-generator/src/locale/en/v-navigation-drawer.json
+++ b/packages/api-generator/src/locale/en/v-navigation-drawer.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "bottom": "Expands from the bottom of the screen on mobile devices",
-    "clipped": "A clipped drawer rests under the application toolbar",
+    "clipped": "A clipped drawer rests under the application toolbar. Requires `clipped-left` or `clipped-right` prop for `v-app-bar` to work as intended.",
     "disableResizeWatcher": "Will automatically open/close drawer when resized depending if mobile or desktop.",
     "disableRouteWatcher": "Disables opening of navigation drawer when route changes",
     "expandOnHover": "Collapses the drawer to a **mini-variant** until hovering with the mouse",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Added 'clipped-left' and 'clipped-right' prop reference for v-app-bar to get 'clipped' prop functionality to work as intended.

## Motivation and Context
I could not figure out why the clipped prop wasn't working until I went into the api for the v-app-bar to see that an additional prop was required.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Visually

## Markup:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [X] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
