### PR TITLE
fix(VSlideGroup): `window not defined` when using SSR

### DIFF
--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
@@ -17,6 +17,7 @@ import Touch from '../../directives/touch'
 
 // Utilities
 import mixins, { ExtractVue } from '../../util/mixins'
+import { passiveSupported } from '../../util/helpers'
 
 // Types
 import Vue, { VNode } from 'vue'
@@ -394,6 +395,8 @@ export const BaseSlideGroup = mixins<options &
       }, this.$vuetify.rtl, this.scrollOffset)
     },
     setWidths /* istanbul ignore next */  () {
+      if (!passiveSupported) return
+
       window.requestAnimationFrame(() => {
         const { content, wrapper } = this.$refs
 


### PR DESCRIPTION
## Description
This was mentioned in a few PRs that were then closed, specifically #12016,  #12017, and #12571. When using a static site generator or SSR with Nuxt, an error is output into the console due to the window object not being defined in `setWidths`.

[Output Example](https://app.netlify.com/sites/code-with-friends/deploys/5f98a25efe4fc800073d210b)

```
3:44:33 PM: [error] window is not defined
3:44:33 PM:   at a.setWidths (pages/events/_event/index.js:7128:7)
3:44:33 PM:   at un.run (node_modules/vue/dist/vue.runtime.common.prod.js:6:27543)
3:44:33 PM:   at sn (node_modules/vue/dist/vue.runtime.common.prod.js:6:25554)
3:44:33 PM:   at Array.<anonymous> (node_modules/vue/dist/vue.runtime.common.prod.js:6:12260)
3:44:33 PM:   at Wt (node_modules/vue/dist/vue.runtime.common.prod.js:6:11661)
3:44:33 PM:   at runNextTicks (internal/process/task_queues.js:62:5)
3:44:33 PM:   at listOnTimeout (internal/timers.js:518:9)
3:44:33 PM:   at processTimers (internal/timers.js:492:7)
```

This PR makes use of `passiveSupported`, which is a check already in place in the [utility helpers](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/util/helpers.ts#L48), a solution that was [similarly suggested](https://github.com/vuetifyjs/vuetify/pull/12571#issuecomment-748517180`) by @johnleider (I could not use the referenced `IN_BROWSER` global utility since it was in a different package).

## Motivation and Context
I would like to remove the error when running `nuxt generate` to create static sites.

## How Has This Been Tested?
Was tested in my Nuxt environment and it has removed the error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
