### PR TITLE
feat(SSRBooted): create new composable

### DIFF
--- a/packages/vuetify/src/composables/__tests__/ssr-booted.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/ssr-booted.spec.ts
@@ -1,0 +1,24 @@
+// Utilities
+import { useSSRBooted } from '../ssr-booted'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import { waitAnimationFrame } from '../../../test'
+
+describe('ssr-booted.ts', () => {
+  it('should set isBooted ref to true', async () => {
+    const wrapper = mount({
+      setup () {
+        const root = ref(null)
+
+        const { isBooted } = useSSRBooted({ el: root })
+
+        return { root, isBooted }
+      },
+      template: '<div ref="root">{{ isBooted }}</div>',
+    })
+
+    await waitAnimationFrame()
+
+    expect(wrapper.html()).toEqual('<div data-booted="true">true</div>')
+  })
+})

--- a/packages/vuetify/src/composables/ssr-booted.ts
+++ b/packages/vuetify/src/composables/ssr-booted.ts
@@ -1,0 +1,28 @@
+// Utilities
+import {
+  onMounted,
+  ref,
+} from 'vue'
+
+// Types
+import type { Ref } from 'vue'
+
+export interface SSRBootedProps {
+  el?: Ref<Element | null | undefined>
+}
+
+export function useSSRBooted (props: SSRBootedProps) {
+  const isBooted = ref(false)
+
+  onMounted(() => {
+    // Use setAttribute instead of dataset
+    // because dataset does not work well
+    // with unit tests
+    window.requestAnimationFrame(() => {
+      props.el?.value?.setAttribute('data-booted', 'true')
+      isBooted.value = true
+    })
+  })
+
+  return { isBooted }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Create `SSRBooted` composable in place of `SSRBootable` mixin.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Vuetify 3 prep

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
`jest`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
