### PR TITLE
fix(theme): do not apply background colors in theme class

### DIFF
--- a/packages/vuetify/src/components/VApp/VApp.sass
+++ b/packages/vuetify/src/components/VApp/VApp.sass
@@ -2,6 +2,8 @@
 
 .v-application
   display: flex
+  background: rgb(var(--v-theme-background))
+  color: rgb(var(--v-theme-on-background))
 
   a
     cursor: pointer

--- a/packages/vuetify/src/components/VThemeProvider/VThemeProvider.sass
+++ b/packages/vuetify/src/components/VThemeProvider/VThemeProvider.sass
@@ -1,0 +1,3 @@
+.v-theme-provider
+  background: rgb(var(--v-theme-background))
+  color: rgb(var(--v-theme-on-background))

--- a/packages/vuetify/src/components/VThemeProvider/VThemeProvider.tsx
+++ b/packages/vuetify/src/components/VThemeProvider/VThemeProvider.tsx
@@ -1,3 +1,6 @@
+// Styles
+import './VThemeProvider.sass'
+
 // Utilities
 import { defineComponent } from 'vue'
 import { provideTheme } from '@/composables/theme'

--- a/packages/vuetify/src/composables/__tests__/__snapshots__/theme.spec.ts.snap
+++ b/packages/vuetify/src/composables/__tests__/__snapshots__/theme.spec.ts.snap
@@ -30,10 +30,6 @@ exports[`createTheme should create style element 1`] = `
       --v-border-color: 0, 0, 0;
       --v-border-opacity: 0.12;
     }
-    .v-theme--light {
-      background: rgb(var(--v-theme-background));
-      color: rgb(var(--v-theme-on-background));
-    }
     .v-theme--dark {
       --v-theme-background: 18,18,18;
       --v-theme-surface: 18,18,18;
@@ -57,10 +53,6 @@ exports[`createTheme should create style element 1`] = `
       --v-theme-on-warning: 0,0,0;
       --v-border-color: 255, 255, 255;
       --v-border-opacity: 0.12;
-    }
-    .v-theme--dark {
-      background: rgb(var(--v-theme-background));
-      color: rgb(var(--v-theme-on-background));
     }
     .bg-background {
       background: rgb(var(--v-theme-background));

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -215,6 +215,7 @@ export function createTheme (options?: ThemeOptions): ThemeInstance {
     genStyleElement()
 
     const lines = []
+
     for (const themeName of Object.keys(computedThemes.value)) {
       const variables = computedThemes.value[themeName].variables
 
@@ -223,11 +224,6 @@ export function createTheme (options?: ThemeOptions): ThemeInstance {
         ...Object.keys(variables).map(key => {
           return `--v-${key}: ${variables[key]}`
         }),
-      ]))
-
-      lines.push(...createCssClass(`.v-theme--${themeName}`, [
-        `background: rgb(var(--v-theme-background))`,
-        `color: rgb(var(--v-theme-on-background))`,
       ]))
     }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
`.theme--x` classes should not apply background colors since they are applied on component level

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
manually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
