### PR TITLE
fix(VTextField): detect activeElement from shadowRoot

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
@@ -405,7 +405,9 @@ describe('VAutocomplete.ts', () => {
   })
 
   it('should select input text on focus', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
     const select = jest.fn()
     wrapper.vm.$refs.input.select = select
 

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
@@ -156,6 +156,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should not hide menu when no data but has no-data slot', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         combobox: true,
       },
@@ -278,6 +279,7 @@ describe('VAutocomplete.ts', () => {
 
   it('should not show menu when items are updated and hide-no-data is enabled', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         hideNoData: true,
         items: ['Something first'],
@@ -373,6 +375,7 @@ describe('VAutocomplete.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/4580
   it('should display menu when hide-no-date and hide-selected are enabled and selected item does not match search', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: [1, 2],
         value: 1,

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -43,6 +43,7 @@ describe('VAutocomplete.ts', () => {
   // https://github.com/vuetifyjs/vuetify/issues/7259
   it('should update search when same item is selected', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items: ['foo'],
         value: 'foo',

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.ts
@@ -234,6 +234,7 @@ describe('VCombobox.ts', () => {
       { text: 'Vuetify', value: 3 },
     ]
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         items,
       },

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -18,6 +18,7 @@ import resize from '../../directives/resize'
 import ripple from '../../directives/ripple'
 
 // Utilities
+import { attachedRoot } from '../../util/dom'
 import { convertToUnit, keyCodes } from '../../util/helpers'
 import { breaking, consoleWarn } from '../../util/console'
 
@@ -446,7 +447,10 @@ export default baseMixins.extend<options>().extend({
     onFocus (e?: Event) {
       if (!this.$refs.input) return
 
-      if (document.activeElement !== this.$refs.input) {
+      const root = attachedRoot(this.$el)
+      if (!root) return
+
+      if (root.activeElement !== this.$refs.input) {
         return this.$refs.input.focus()
       }
 
@@ -500,9 +504,10 @@ export default baseMixins.extend<options>().extend({
       if (
         !this.autofocus ||
         typeof document === 'undefined' ||
-        !this.$refs.input ||
-        document.activeElement === this.$refs.input
-      ) return false
+        !this.$refs.input) return false
+
+      const root = attachedRoot(this.$el)
+      if (!root || root.activeElement === this.$refs.input) return false
 
       this.$refs.input.focus()
 

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.ts
@@ -96,7 +96,9 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   })
 
   it('should start validating on input', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
 
     expect(wrapper.vm.shouldValidate).toEqual(false)
     wrapper.setProps({ value: 'asd' })
@@ -218,6 +220,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   it('should start validating on blur', async () => {
     const rule = jest.fn().mockReturnValue(true)
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: {
         rules: [rule],
         validateOnBlur: true,
@@ -291,7 +294,9 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
         })
       },
     }
-    const wrapper = mount(component)
+    const wrapper = mount(component, {
+      attachToDocument: true,
+    })
 
     const input = wrapper.findAll('input').at(0)
 
@@ -640,7 +645,9 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
   })
 
   it('should have focus and blur methods', async () => {
-    const wrapper = mountFunction()
+    const wrapper = mountFunction({
+      attachToDocument: true,
+    })
     const onBlur = jest.spyOn(wrapper.vm.$refs.input, 'blur')
     const onFocus = jest.spyOn(wrapper.vm.$refs.input, 'focus')
 
@@ -777,7 +784,9 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
         })
       },
     }
-    const wrapper = mount(component)
+    const wrapper = mount(component, {
+      attachToDocument: true,
+    })
 
     const inputElement = wrapper.findAll('input').at(0)
     const clearIcon = wrapper.find('.v-input__icon--clear .v-icon')
@@ -812,6 +821,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should autofocus text-field when intersected', async () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: { autofocus: true },
     })
     const input = wrapper.find('input')
@@ -844,6 +854,7 @@ describe('VTextField.ts', () => { // eslint-disable-line max-statements
 
   it('should use the correct icon color when using the solo inverted prop', () => {
     const wrapper = mountFunction({
+      attachToDocument: true,
       propsData: { soloInverted: true },
       mocks: {
         $vuetify: {

--- a/packages/vuetify/src/util/__tests__/dom.spec.ts
+++ b/packages/vuetify/src/util/__tests__/dom.spec.ts
@@ -1,0 +1,42 @@
+import Vue from 'vue'
+import {
+  mount,
+} from '@vue/test-utils'
+import {
+  attachedRoot,
+} from '../dom'
+
+const FooComponent = Vue.extend({
+  render (h) {
+    return h('div', ['foo'])
+  },
+})
+
+describe('dom', () => {
+  it('should properly detect an element\'s root', () => {
+    const shadowHost = document.createElement('div')
+    expect(attachedRoot(shadowHost)).toBeNull()
+
+    const shadowRoot = shadowHost.attachShadow({ mode: 'closed' })
+    expect(attachedRoot(shadowRoot)).toBeNull()
+
+    document.body.appendChild(shadowHost)
+    expect(attachedRoot(shadowHost)).toBe(document)
+
+    expect(attachedRoot(shadowRoot)).toBe(shadowRoot)
+
+    const insideDiv = document.createElement('div')
+    expect(attachedRoot(insideDiv)).toBeNull()
+
+    shadowRoot.appendChild(insideDiv)
+    expect(attachedRoot(insideDiv)).toBe(shadowRoot)
+  })
+
+  it('should detect the root of mounted components', () => {
+    const attachedWrapper = mount(FooComponent, { attachToDocument: true })
+    expect(attachedRoot(attachedWrapper.element)).toBe(document)
+
+    const detachedWrapper = mount(FooComponent, { attachToDocument: false })
+    expect(attachedRoot(detachedWrapper.element)).toBeNull()
+  })
+})

--- a/packages/vuetify/src/util/dom.ts
+++ b/packages/vuetify/src/util/dom.ts
@@ -1,0 +1,24 @@
+/**
+ * Returns:
+ *  - 'null' if the node is not attached to the DOM
+ *  - the root node (HTMLDocument | ShadowRoot) otherwise
+ */
+export function attachedRoot (node: Node): null | HTMLDocument | ShadowRoot {
+  /* istanbul ignore next */
+  if (typeof node.getRootNode !== 'function') {
+    // Shadow DOM not supported (IE11), lets find the root of this node
+    while (node.parentNode) node = node.parentNode
+
+    // The root parent is the document if the node is attached to the DOM
+    if (node !== document) return null
+
+    return document
+  }
+
+  const root = node.getRootNode()
+
+  // The composed root node is the document if the node is attached to the DOM
+  if (root !== document && root.getRootNode({ composed: true }) !== document) return null
+
+  return root as HTMLDocument | ShadowRoot
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

When an input element is inside a shadowDom, and is active (focused), the `document.activeElement` will not reference the input element but rather its shadowRoot. In order to properly detect what the `activeElement` is, we must use the proper root node for that element, as explained on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement).

This PR:

- Considers whether an element is attached to the DOM when computing `tryAutofocus`, and during the processing of `onFocus` event.
- Correctly detects the focused element event if the component is inside a Shadow DOM (solving part of #7622)
- Improves the quality of tests by enforcing `focus`/`activeElement` dependent tests to attach the mounted components to the DOM (read below for motivation)
- Uses a shim to support IE11 (which does not have Shadow DOM)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is part of the solution for #7622 ("Weird behaviour inside shadow DOM"). If fixes focus related issues when using Vuetify inside a shadow DOM.

It also improves the code base by attaching the element to the DOM for tests related to focus. This is important because Browsers (as well as `jsdom` used in tests) have a different behavior when trying to focus an element that is attached, and not (namely, when you focus an element that is not attached, is will not become the `documet.activeElement`).

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

unit

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
