### PR TITLE
docs(examples): fix v-date-picker date-fns in formatting-external-libraries 

### DIFF
--- a/packages/docs/src/examples/v-date-picker/misc-formatting-external-libraries.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-formatting-external-libraries.vue
@@ -75,7 +75,7 @@
         return this.date ? moment(this.date).format('dddd, MMMM Do YYYY') : ''
       },
       computedDateFormattedDatefns () {
-        return this.date ? format(this.date, 'EEEE, MMMM do yyyy') : ''
+        return this.date ? format(parseISO(this.date), 'EEEE, MMMM do yyyy') : ''
       },
     },
   }


### PR DESCRIPTION
…in date-fns library

See: https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#string-arguments

## Description
Simple fix, this example is throwing an error on the live site. You can see (or not see, rather) the issue here:

https://vuetifyjs.com/en/components/date-pickers/#formatting-with-external-libraries

## Motivation and Context
Fix documentation

## How Has This Been Tested?
visually

