### PR TITLE
docs: add alert reg component variables in the global theme

### DIFF
--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -125,6 +125,13 @@ module.exports = {
 
 There are many SASS/SCSS variables that can be customized across the entire Vuetify framework. You can browse all the variables using the tool below:
 
+<alert type="info">
+
+  Some color related variables for components are defined in the global material-theme variables: `$material-light` / `$material-dark`
+
+</alert>
+
+
 <sass-api />
 
 ## Example variable file

--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -127,10 +127,9 @@ There are many SASS/SCSS variables that can be customized across the entire Vuet
 
 <alert type="info">
 
-  Some color related variables for components are defined in the global material-theme variables: `$material-light` / `$material-dark`
+  Some color-related variables for components are defined in the global material-theme variables: `$material-light` / `$material-dark`
 
 </alert>
-
 
 <sass-api />
 


### PR DESCRIPTION
## Description
Adding an alert to inform people that some variables that affect components can be found the the main theme variables.

## Motivation and Context
Wanted to change the default `VChip` color and expected the variable in the `chip-api`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
