### PR TITLE
fix(VSelect): make CSS order-independent

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -58,10 +58,12 @@
   &.v-text-field
     input
       flex: 1 1 // Doesn't resize on IE11 with 3rd param
-      margin-top: 0
       min-width: 0
       pointer-events: none
       position: relative
+      
+    &:not(.v-text-field--single-line) input
+      margin-top: 0
 
   @if $select-active-icon-flip
     &.v-select--is-menu-active


### PR DESCRIPTION
## Description
Fix vuetifyjs/vuetify#13149

## Motivation and Context
vuetifyjs/vuetify#13149

## How Has This Been Tested?
visually

## Markup:
```vue
<v-app>
  <v-container>
    <v-row>
      <v-col>
        <v-text-field
            label="v-text-field"
            filled
        ></v-text-field>
      </v-col>  
      <v-col>
        <v-select
            label="v-select"
            filled
        ></v-select>
      </v-col>  
      <v-col>
        <v-autocomplete
            label="v-autocomplete"
            filled
        ></v-autocomplete>
      </v-col>  
    </v-row>
  </v-container>
</v-app>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
