### PR TITLE
fix(VAutocomplete): don't count search as dirty if it is empty

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -133,7 +133,8 @@ export default VSelect.extend({
       }
     },
     searchIsDirty (): boolean {
-      return this.internalSearch != null
+      return this.internalSearch != null &&
+        this.internalSearch !== ''
     },
     selectedItem (): any {
       if (this.multiple) return null

--- a/packages/vuetify/src/components/VCombobox/VCombobox.ts
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.ts
@@ -48,6 +48,9 @@ export default VAutocomplete.extend({
       return this.hasDisplayedItems ||
         (!!this.$slots['no-data'] && !this.hideNoData)
     },
+    searchIsDirty (): boolean {
+      return this.internalSearch != null
+    },
   },
 
   methods: {


### PR DESCRIPTION
## Description
fixes #12958

## Motivation and Context
The issue is regression after #12415
Search should not be counted as dirty when empty string in VCombobox, but not in VAutocomplete

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
Visually on the markup from #12958 (https://codepen.io/djaler/pen/ZEpmazq) and from #12322 (https://codepen.io/MatthewAry/pen/BaKgBNq)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
