### PR TITLE
refactor(grid): update components to use tag composable

### DIFF
--- a/packages/vuetify/src/components/VGrid/VCol.ts
+++ b/packages/vuetify/src/components/VGrid/VCol.ts
@@ -1,5 +1,10 @@
+// Styles
 import './VGrid.sass'
 
+// Composables
+import { makeTagProps } from '@/composables/tag'
+
+// Utilities
 import { defineComponent, computed, h, capitalize } from 'vue'
 import makeProps from '@/util/makeProps'
 
@@ -92,10 +97,7 @@ export default defineComponent({
       default: null,
       validator: (str: any) => ['auto', 'start', 'end', 'center', 'baseline', 'stretch'].includes(str),
     },
-    tag: {
-      type: String,
-      default: 'div',
-    },
+    ...makeTagProps(),
   }),
 
   setup (props, { slots }) {

--- a/packages/vuetify/src/components/VGrid/VContainer.tsx
+++ b/packages/vuetify/src/components/VGrid/VContainer.tsx
@@ -1,5 +1,10 @@
+// Styles
 import './VGrid.sass'
 
+// Composables
+import { makeTagProps } from '@/composables/tag'
+
+// Utilities
 import { defineComponent } from 'vue'
 import makeProps from '@/util/makeProps'
 
@@ -7,14 +12,11 @@ export default defineComponent({
   name: 'VContainer',
 
   props: makeProps({
-    tag: {
-      type: String,
-      default: 'div',
-    },
     fluid: {
       type: Boolean,
       default: false,
     },
+    ...makeTagProps(),
   }),
 
   setup (props, { slots }) {

--- a/packages/vuetify/src/components/VGrid/VRow.ts
+++ b/packages/vuetify/src/components/VGrid/VRow.ts
@@ -1,5 +1,10 @@
+// Styles
 import './VGrid.sass'
 
+// Composables
+import { makeTagProps } from '@/composables/tag'
+
+// Utilities
 import { capitalize, computed, defineComponent, h } from 'vue'
 import makeProps from '@/util/makeProps'
 
@@ -69,10 +74,6 @@ export default defineComponent({
   name: 'VRow',
 
   props: makeProps({
-    tag: {
-      type: String,
-      default: 'div',
-    },
     dense: Boolean,
     noGutters: Boolean,
     align: {
@@ -93,6 +94,7 @@ export default defineComponent({
       validator: alignContentValidator,
     },
     ...alignContentProps,
+    ...makeTagProps(),
   }),
 
   setup (props, { slots }) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
updates components to use the tag composable

## Motivation and Context
Consistency with other components

## How Has This Been Tested?
unit | visually 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container tag="ul">
      <v-row tag="strong">
        <v-col tag="li">Hello</v-col>
      </v-row>
    </v-container>
  </v-app>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
