### PR TITLE
fix(VCalendar): support horizontal scroll

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.sass
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.sass
@@ -9,7 +9,7 @@
 .v-calendar-category
   .v-calendar-category__category
     text-align: center
-    
+
   .v-calendar-daily__day-container
     .v-calendar-category__columns
       position: absolute
@@ -19,9 +19,18 @@
 
   .v-calendar-category__columns
     display: flex
-    
+
     .v-calendar-category__column,
     .v-calendar-category__column-header
       flex: 1 1 auto
       width: 0
       position: relative
+
+    .v-calendar-category__column-header
+      min-width: $calendar-category-column-min-width
+
+  .v-calendar-category__horizontal-scrollable
+    width: 100%
+    overflow-x: scroll
+    .v-calendar-daily__day
+      min-width: $calendar-category-column-min-width

--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
@@ -19,6 +19,10 @@ export default VCalendarDaily.extend({
 
   props: props.category,
 
+  data: () => ({
+    horizontalScroll: null as any,
+  }),
+
   computed: {
     classes (): object {
       return {
@@ -30,6 +34,25 @@ export default VCalendarDaily.extend({
     parsedCategories (): CalendarCategory[] {
       return getParsedCategories(this.categories, this.categoryText)
     },
+  },
+  updated () {
+    const horizontalScrollables = Array.from(this.$el.getElementsByClassName('v-calendar-category__horizontal-scrollable'))
+
+    // reset all horizontalScrollables to left
+    horizontalScrollables.forEach(scrollableDiv => {
+      scrollableDiv.scrollLeft = 0
+    })
+
+    this.horizontalScroll = function (e: Event) {
+      const scrollingEle = e.target
+      horizontalScrollables.forEach(scrollableDiv => {
+        scrollableDiv.scrollLeft = (scrollingEle as any).scrollLeft
+      })
+    }
+
+    horizontalScrollables.forEach(ele => {
+      ele.addEventListener('scroll', this.horizontalScroll)
+    })
   },
   methods: {
     genDayHeader (day: CalendarTimestamp, index: number): VNode[] {
@@ -44,7 +67,11 @@ export default VCalendarDaily.extend({
         return this.genDayHeaderCategory(day, this.getCategoryScope(scope, category))
       })
 
-      return [this.$createElement('div', data, children)]
+      return [this.$createElement('div', {
+        staticClass: 'v-calendar-category__horizontal-scrollable',
+      }, [
+        this.$createElement('div', data, children),
+      ])]
     },
     getCategoryScope (scope: any, category: CalendarCategory) {
       const cat = typeof category === 'object' && category &&
@@ -69,6 +96,22 @@ export default VCalendarDaily.extend({
       return this.$createElement('div', {
         staticClass: 'v-calendar-category__category',
       }, categoryName === null ? this.categoryForInvalid : categoryName)
+    },
+    genDayContainer (): VNode {
+      return this.$createElement('div', {
+        staticClass: 'v-calendar-daily__day-container',
+      }, [
+        this.genBodyIntervals(),
+        this.$createElement('div', {
+          staticClass: 'v-calendar-category__horizontal-scrollable',
+        }, [
+          this.$createElement('div', {
+            staticClass: 'v-calendar-daily__day-container',
+          }, [
+            ...this.genDays(),
+          ]),
+        ]),
+      ])
     },
     genDays (): VNode[] {
       const d = this.days[0]

--- a/packages/vuetify/src/components/VCalendar/_variables.scss
+++ b/packages/vuetify/src/components/VCalendar/_variables.scss
@@ -12,6 +12,8 @@ $calendar-daily-interval-gutter-align: right !default;
 $calendar-daily-interval-gutter-line-width: 8px !default;
 $calendar-daily-interval-gutter-font-size: 10px !default;
 
+$calendar-category-column-min-width: 200px !default;
+
 $calendar-weekly-weekday-padding: 0px 4px 0px 4px !default;
 $calendar-weekly-weekday-font-size: 11px !default;
 $calendar-weekly-day-padding: 0px 0px 0px 0px !default;


### PR DESCRIPTION
fixes #13070

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
resolves #13070

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fixes #13070

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row class="fill-height">
      <v-col>
        <v-sheet height="64">
          <v-toolbar
            flat
          >
            <v-btn
              outlined
              class="mr-4"
              color="grey darken-2"
              @click="setToday"
            >
              Today
            </v-btn>
            <v-btn
              fab
              text
              small
              color="grey darken-2"
              @click="prev"
            >
              <v-icon small>
                mdi-chevron-left
              </v-icon>
            </v-btn>
            <v-btn
              fab
              text
              small
              color="grey darken-2"
              @click="next"
            >
              <v-icon small>
                mdi-chevron-right
              </v-icon>
            </v-btn>
            <v-toolbar-title v-if="$refs.calendar">
              {{ $refs.calendar.title }}
            </v-toolbar-title>
            <v-spacer></v-spacer>
          </v-toolbar>
        </v-sheet>
        <v-sheet height="600">
          <v-calendar
            ref="calendar"
            v-model="focus"
            color="primary"
            type="category"
            category-show-all
            :categories="categories"
            :events="events"
            :event-color="getEventColor"
            @change="fetchEvents"
          ></v-calendar>
        </v-sheet>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    focus: '',
    events: [],
    colors: ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey darken-1'],
    names: ['Meeting', 'Holiday', 'PTO', 'Travel', 'Event', 'Birthday', 'Conference', 'Party'],
    categories: ['John Smithhhhhh', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker', 'Tori Walker'],
  }),
  mounted () {
    this.$refs.calendar.checkChange()
  },
  methods: {
    getEventColor (event) {
      return event.color
    },
    setToday () {
      this.focus = ''
    },
    prev () {
      this.$refs.calendar.prev()
    },
    next () {
      this.$refs.calendar.next()
    },
    fetchEvents ({ start, end }) {
      const events = []

      const min = new Date(`${start.date}T00:00:00`)
      const max = new Date(`${end.date}T23:59:59`)
      const days = (max.getTime() - min.getTime()) / 86400000
      const eventCount = this.rnd(days, days + 20)

      for (let i = 0; i < eventCount; i++) {
        const allDay = this.rnd(0, 3) === 0
        const firstTimestamp = this.rnd(min.getTime(), max.getTime())
        const first = new Date(firstTimestamp - (firstTimestamp % 900000))
        const secondTimestamp = this.rnd(2, allDay ? 288 : 8) * 900000
        const second = new Date(first.getTime() + secondTimestamp)

        events.push({
          name: this.names[this.rnd(0, this.names.length - 1)],
          start: first,
          end: second,
          color: this.colors[this.rnd(0, this.colors.length - 1)],
          timed: !allDay,
          category: this.categories[this.rnd(0, this.categories.length - 1)],
        })
      }

      this.events = events
    },
    rnd (a, b) {
      return Math.floor((b - a + 1) * Math.random()) + a
    },
  }
};
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
