### PR TITLE
fix(VCarousel): VCarousel is changing context to dark mode

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -77,7 +77,7 @@ export default VWindow.extend({
       }
     },
     isDark (): boolean {
-      return this.dark || !this.light
+      return this.dark === true || this.light === false
     },
     isVertical (): boolean {
       return this.verticalDelimiters != null

--- a/packages/vuetify/src/components/VCarousel/__tests__/VCarousel.spec.ts
+++ b/packages/vuetify/src/components/VCarousel/__tests__/VCarousel.spec.ts
@@ -125,4 +125,29 @@ describe('VCarousel.ts', () => {
 
     expect(wrapper.vm.internalHeight).toBe(300)
   })
+
+  it.only('should not change context to dark mode automatically', async () => {
+    const wrapper = mountFunction()
+
+    expect(wrapper.vm.isDark).toBe(false)
+
+    wrapper.setProps({ dark: true })
+
+    expect(wrapper.vm.isDark).toBe(true)
+
+    wrapper.setProps({ dark: false })
+
+    expect(wrapper.vm.isDark).toBe(false)
+
+    // reset previous dark
+    wrapper.setProps({ dark: null })
+
+    wrapper.setProps({ light: true })
+
+    expect(wrapper.vm.isDark).toBe(false)
+
+    wrapper.setProps({ light: false })
+
+    expect(wrapper.vm.isDark).toBe(true)
+  })
 })

--- a/packages/vuetify/src/components/VCarousel/__tests__/VCarousel.spec.ts
+++ b/packages/vuetify/src/components/VCarousel/__tests__/VCarousel.spec.ts
@@ -126,7 +126,7 @@ describe('VCarousel.ts', () => {
     expect(wrapper.vm.internalHeight).toBe(300)
   })
 
-  it.only('should not change context to dark mode automatically', async () => {
+  it('should not change context to dark mode automatically', async () => {
     const wrapper = mountFunction()
 
     expect(wrapper.vm.isDark).toBe(false)


### PR DESCRIPTION
## Description
When using `VCarousel` is an app in light mode it was changing context to dark mode

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #8392

Reason for this is this sequence:
- with current implementation of `isDark` (1)
- since `VCarousel` extends `VWindow` which is turn extends `VItemGroup`which mixes in `Themable` (2)
- and `Themable` is watching `isDark` property to set the context (3)
- and on the other hand `Themable` has defaults for `dark` and `light` with `null` (4)


<details>
  <summary>code snippets for the above</summary> 

(1):
https://github.com/vuetifyjs/vuetify/blob/9bec589dcd6ba4630e1ce5473753165cf238b622/packages/vuetify/src/components/VCarousel/VCarousel.ts#L79-L81
(2):
https://github.com/vuetifyjs/vuetify/blob/9bec589dcd6ba4630e1ce5473753165cf238b622/packages/vuetify/src/components/VCarousel/VCarousel.ts#L23
 
 https://github.com/vuetifyjs/vuetify/blob/9bec589dcd6ba4630e1ce5473753165cf238b622/packages/vuetify/src/components/VWindow/VWindow.ts#L18
 
 https://github.com/vuetifyjs/vuetify/blob/9bec589dcd6ba4630e1ce5473753165cf238b622/packages/vuetify/src/components/VItemGroup/VItemGroup.ts#L22-L25
(3):
https://github.com/vuetifyjs/vuetify/blob/9bec589dcd6ba4630e1ce5473753165cf238b622/packages/vuetify/src/mixins/themeable/index.ts#L90-L98
(4):
https://github.com/vuetifyjs/vuetify/blob/9bec589dcd6ba4630e1ce5473753165cf238b622/packages/vuetify/src/mixins/themeable/index.ts#L28-L36
</details>

So not setting any value to `dark` or `light` on `VCarousel` leaves those 2 props as `null` and the `isDark` computed property in `VCarousel` is checking literally `null || !null`. So it becomes true in both scenarios:
- `dark=true`
- nothing specified (both `dark` and `light` are `null`s)

what indicates a bug

## How Has This Been Tested?
- added a unit-test
- run the unit test, note the https://github.com/vuetifyjs/vuetify/issues/10537 makes it harder
<details>
  <summary>Tests output</summary>
<pre>
Test Suites: 188 passed, 188 total
Tests:       64 skipped, 1581 passed, 1645 total
Snapshots:   637 passed, 637 total
Time:        15.301 s
Ran all test suites.
</pre>
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)

## Workaround
If similar issue is faced it can be workaround by
```jsx
    <v-carousel
      ...
      :light="!$vuetify.theme.isDark"
    >
```