### PR TITLE
fix(VSlider): only emit a single change event

### DIFF
--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.ts
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.ts
@@ -144,11 +144,6 @@ export default VSlider.extend({
         this.genSteps(),
         createRange(2).map(index => {
           const value = this.internalValue[index]
-          const onDrag = (e: MouseEvent) => {
-            this.isActive = true
-            this.activeThumb = index
-            this.onSliderMouseDown(e)
-          }
           const onFocus = (e: Event) => {
             this.isFocused = true
             this.activeThumb = index
@@ -167,7 +162,7 @@ export default VSlider.extend({
           const isActive = this.isActive && this.activeThumb === index
           const isFocused = this.isFocused && this.activeThumb === index
 
-          return this.genThumbContainer(value, valueWidth, isActive, isFocused, onDrag, onFocus, onBlur, `thumb_${index}`)
+          return this.genThumbContainer(value, valueWidth, isActive, isFocused, onFocus, onBlur, `thumb_${index}`)
         }),
       ]
     },
@@ -178,7 +173,7 @@ export default VSlider.extend({
       thumbRef.focus()
     },
     onSliderMouseDown (e: MouseEvent) {
-      const { value } = this.parseMouseMove(e)
+      const value = this.parseMouseMove(e)
 
       this.reevaluateSelected(value)
 
@@ -215,11 +210,9 @@ export default VSlider.extend({
           return
         }
 
-        const { value, isInsideTrack } = this.parseMouseMove(e)
+        const value = this.parseMouseMove(e)
 
-        if (isInsideTrack) {
-          this.reevaluateSelected(value)
-        }
+        this.reevaluateSelected(value)
 
         this.setInternalValue(value)
 
@@ -227,15 +220,13 @@ export default VSlider.extend({
       }
     },
     onMouseMove (e: MouseEvent) {
-      const { value, isInsideTrack } = this.parseMouseMove(e)
+      const value = this.parseMouseMove(e)
 
       if (e.type === 'mousemove') {
         this.thumbPressed = true
       }
 
-      if (isInsideTrack && this.activeThumb === null) {
-        this.activeThumb = this.getIndexOfClosestValue(this.internalValue, value)
-      }
+      this.activeThumb = this.getIndexOfClosestValue(this.internalValue, value)
 
       this.setInternalValue(value)
     },

--- a/packages/vuetify/src/components/VSlider/VSlider.ts
+++ b/packages/vuetify/src/components/VSlider/VSlider.ts
@@ -477,7 +477,6 @@ export default mixins<options &
       this.$emit('start', this.internalValue)
     },
     onSliderMouseUp (e: Event) {
-      console.log(e)
       e.stopPropagation()
       window.clearTimeout(this.mouseTimeout)
       this.thumbPressed = false

--- a/packages/vuetify/src/components/VSlider/VSlider.ts
+++ b/packages/vuetify/src/components/VSlider/VSlider.ts
@@ -278,7 +278,6 @@ export default mixins<options &
           this.inputWidth,
           this.isActive,
           this.isFocused,
-          this.onSliderMouseDown,
           this.onFocus,
           this.onBlur,
         ),
@@ -363,7 +362,6 @@ export default mixins<options &
       valueWidth: number,
       isActive: boolean,
       isFocused: boolean,
-      onDrag: Function,
       onFocus: Function,
       onBlur: Function,
       ref = 'thumb'
@@ -398,8 +396,6 @@ export default mixins<options &
           focus: onFocus,
           blur: onBlur,
           keydown: this.onKeyDown,
-          touchstart: onDrag,
-          mousedown: onDrag,
         },
       }), children)
     },
@@ -481,6 +477,7 @@ export default mixins<options &
       this.$emit('start', this.internalValue)
     },
     onSliderMouseUp (e: Event) {
+      console.log(e)
       e.stopPropagation()
       window.clearTimeout(this.mouseTimeout)
       this.thumbPressed = false
@@ -498,11 +495,10 @@ export default mixins<options &
       this.isActive = false
     },
     onMouseMove (e: MouseEvent) {
-      const { value } = this.parseMouseMove(e)
       if (e.type === 'mousemove') {
         this.thumbPressed = true
       }
-      this.internalValue = value
+      this.internalValue = this.parseMouseMove(e)
     },
     onKeyDown (e: KeyboardEvent) {
       if (!this.isInteractive) return
@@ -556,10 +552,7 @@ export default mixins<options &
       if (this.vertical) clickPos = 1 - clickPos
       if (this.$vuetify.rtl) clickPos = 1 - clickPos
 
-      const isInsideTrack = clickOffset >= trackStart && clickOffset <= trackStart + trackLength
-      const value = parseFloat(this.min) + clickPos * (this.maxValue - this.minValue)
-
-      return { value, isInsideTrack }
+      return parseFloat(this.min) + clickPos * (this.maxValue - this.minValue)
     },
     parseKeyDown (e: KeyboardEvent, value: number) {
       if (!this.isInteractive) return


### PR DESCRIPTION
fixes #13151 (regression from #12640)

`onSliderMouseDown` was being bound to two elements so the event listeners would be triggered twice

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-slider @change="onChange"></v-slider>
      <v-range-slider @change="onChange"></v-range-slider>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    methods: {
      onChange (e) {
        console.log(e)
      },
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)
