### PR TITLE
docs(icons): add simple svg example import

### DIFF
--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -273,7 +273,6 @@ Let's say your application calls for a custom icon in a Vuetify component. Inste
 
 import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
-import myIconSvg from 'myIcon.svg' // only paths without <svg> wrapper, like in the example below
 
 Vue.use(Vuetify)
 
@@ -283,9 +282,28 @@ export default new Vuetify({
     values: {
       cancel: 'fas fa-ban',
       menu: 'fas fa-ellipsis-v',
+    },
+  },
+})
+```
+
+You can import and assign an svg to an icon value. The imported svg should contain only the path without the `<svg>` wrapper. For importing a more elaborate svg, use a [component icon](#component-icons).
+
+```js
+// src/plugins/vuetify.js
+
+import Vue from 'vue'
+import Vuetify from 'vuetify/lib'
+import myIconSvg from 'myIcon.svg'
+
+Vue.use(Vuetify)
+
+export default new Vuetify({
+  icons: {
+    iconfont: 'fa',
+    values: {
       customIconSvg: myIconSvg,
-      customIconSvgPath:
-        'M10,1.375c-3.17,0-5.75,2.548-5.75,5.682c0,6.685,5.259,11.276,5.483,11.469c0.152,0.132,0.382,0.132,0.534,0c0.224-0.193,5.481-4.784,5.483-11.469C15.75,3.923,13.171,1.375,10,1.375 M10,17.653c-1.064-1.024-4.929-5.127-4.929-10.596c0-2.68,2.212-4.861,4.929-4.861s4.929,2.181,4.929,4.861C14.927,12.518,11.063,16.627,10,17.653 M10,3.839c-1.815,0-3.286,1.47-3.286,3.286s1.47,3.286,3.286,3.286s3.286-1.47,3.286-3.286S11.815,3.839,10,3.839 M10,9.589c-1.359,0-2.464-1.105-2.464-2.464S8.641,4.661,10,4.661s2.464,1.105,2.464,2.464S11.359,9.589,10,9.589'
+      customIconSvgPath: 'M14.989,9.491L6.071,0.537C5.78,0.246,5.308,0.244,5.017,0.535c-0.294,0.29-0.294,0.763-0.003,1.054l8.394,8.428L5.014,18.41c-0.291,0.291-0.291,0.763,0,1.054c0.146,0.146,0.335,0.218,0.527,0.218c0.19,0,0.382-0.073,0.527-0.218l8.918-8.919C15.277,10.254,15.277,9.784,14.989,9.491z',
     },
   },
 })

--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -273,6 +273,7 @@ Let's say your application calls for a custom icon in a Vuetify component. Inste
 
 import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
+import myIconSvg from 'myIcon.svg' // only paths without <svg> wrapper, like in the example below
 
 Vue.use(Vuetify)
 
@@ -282,6 +283,9 @@ export default new Vuetify({
     values: {
       cancel: 'fas fa-ban',
       menu: 'fas fa-ellipsis-v',
+      customIconSvg: myIconSvg,
+      customIconSvgPath:
+        'M10,1.375c-3.17,0-5.75,2.548-5.75,5.682c0,6.685,5.259,11.276,5.483,11.469c0.152,0.132,0.382,0.132,0.534,0c0.224-0.193,5.481-4.784,5.483-11.469C15.75,3.923,13.171,1.375,10,1.375 M10,17.653c-1.064-1.024-4.929-5.127-4.929-10.596c0-2.68,2.212-4.861,4.929-4.861s4.929,2.181,4.929,4.861C14.927,12.518,11.063,16.627,10,17.653 M10,3.839c-1.815,0-3.286,1.47-3.286,3.286s1.47,3.286,3.286,3.286s3.286-1.47,3.286-3.286S11.815,3.839,10,3.839 M10,9.589c-1.359,0-2.464-1.105-2.464-2.464S8.641,4.661,10,4.661s2.464,1.105,2.464,2.464S11.359,9.589,10,9.589'
     },
   },
 })


### PR DESCRIPTION
## Description
Adding an example of how to use SVGs with the workflow.

## Motivation and Context
I struggled figuring out on how to exactly import and use an SVG-file for a custom icon.  
After several tries and asking in discord @MajesticPotatoe created this example:  
https://codesandbox.io/s/icon-example-gfelz?file=/src/main.js  
With this I finally understood it.

Maybe this should be added to https://vuetifyjs.com/en/features/icon-fonts/#component-icons instead.  
Could also explain that the SVG-files or direct imports only work with very simple path. For more complex SVGs the "Component Icon" should be used.

## How Has This Been Tested?

## Markup:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
