### PR TITLE
fix(VCalendar): add support for string[] of categories

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendar.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendar.ts
@@ -295,7 +295,7 @@ export default CalendarWithEvents.extend({
       if (!this.noEvents) {
         const categoryMap: any = categories.reduce((map: any, category, index) => {
           if (typeof category === 'object' && category.categoryName) map[category.categoryName] = { index, count: 0 }
-
+          else if (typeof category === 'string') map[category] = { index, count: 0 }
           return map
         }, {})
 
@@ -335,6 +335,8 @@ export default CalendarWithEvents.extend({
         categories = categories.filter((category: CalendarCategory) => {
           if (typeof category === 'object' && category.categoryName) {
             return categoryMap.hasOwnProperty(category.categoryName)
+          } else if (typeof category === 'string') {
+            return categoryMap.hasOwnProperty(category)
           }
           return false
         })

--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
@@ -55,13 +55,14 @@ export default VCalendarDaily.extend({
       }
     },
     genDayHeaderCategory (day: CalendarTimestamp, scope: any): VNode {
+      const headerTitle = typeof scope.category === 'object' ? scope.category.categoryName : scope.category
       return this.$createElement('div', {
         staticClass: 'v-calendar-category__column-header',
         on: this.getDefaultMouseEventHandlers(':day-category', e => {
           return this.getCategoryScope(this.getSlotScope(day), scope.category)
         }),
       }, [
-        getSlot(this, 'category', scope) || this.genDayHeaderCategoryTitle(scope.category && scope.category.categoryName),
+        getSlot(this, 'category', scope) || this.genDayHeaderCategoryTitle(headerTitle),
         getSlot(this, 'day-header', scope),
       ])
     },

--- a/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
@@ -63,8 +63,46 @@ describe('VCalendarCategory', () => {
       propsData: {
         type: 'category',
         events: [{ start: new Date(), category: 'Nate' }],
-        categories: [{ name: 'Nate', age: 20 }],
+        categories: [{ name: 'Nate', age: 20 }, { name: 'Bob', age: 30 }],
         categoryText: 'name',
+        intervalStyle,
+      },
+    })
+  })
+
+  it('should show all categories when events arent tied to each catogry', () => {
+    let intervals = 0
+    function intervalStyle (obj) {
+      if (intervals < 24) expect(obj.category.name).toEqual('Nate')
+      else expect(obj.category.name).toEqual('Bob')
+      intervals++
+    }
+
+    const wrapper = mountFunction({
+      propsData: {
+        type: 'category',
+        categoryShowAll: true,
+        events: [{ start: new Date(), category: 'Nate' }],
+        categories: [{ name: 'Nate', age: 20 }, { name: 'Bob', age: 30 }],
+        categoryText: 'name',
+        intervalStyle,
+      },
+    })
+  })
+
+  it('should pass strings from an array', () => {
+    let intervals = 0
+    function intervalStyle (obj) {
+      if (intervals < 24) expect(obj.category).toEqual('Nate')
+      else expect(obj.category).toEqual('Bob')
+      intervals++
+    }
+
+    const wrapper = mountFunction({
+      propsData: {
+        type: 'category',
+        events: [{ start: new Date(), category: 'Nate' }, { start: new Date(), category: 'Bob' }],
+        categories: ['Nate', 'Bob'],
         intervalStyle,
       },
     })

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
@@ -405,6 +405,7 @@ export default CalendarBase.extend({
       return !this.categoryMode ||
         (typeof category === 'object' && category.categoryName &&
         category.categoryName === event.category) ||
+        (typeof event.category === 'string' && category === event.category) ||
         (typeof event.category !== 'string' && category === null)
     },
     getEventsForDay (day: CalendarDaySlotScope): CalendarEventParsed[] {

--- a/packages/vuetify/src/components/VCalendar/util/parser.ts
+++ b/packages/vuetify/src/components/VCalendar/util/parser.ts
@@ -18,7 +18,7 @@ export function getParsedCategories (
   if (typeof categories === 'string') return categories.split(/\s*,\s/)
   if (Array.isArray(categories)) {
     return categories.map((category: CalendarCategory) => {
-      if (typeof category === 'string') return { categoryName: category }
+      if (typeof category === 'string') return category
 
       const categoryName = typeof category.categoryName === 'string'
         ? category.categoryName


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

Support for array of strings for categories was removed during last release. 
This adds that functionality back in

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
resolves #12922

## Motivation and Context
https://github.com/vuetifyjs/vuetify/issues/12922

## How Has This Been Tested?
added unit tests

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-calendar
      type="category"
      :categories="['Nate', 'Bob', 'Jeff']"
      :events="[{start: new Date(), category: 'Nate', name: 'Cool story'}]"
      categoryText="name"
      category-show-all
    />
  </v-container>
</template>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] The PR title is no longer than 64 characters.
- [x ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x ] My code follows the code style of this project.
- [ x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
