### PR TITLE
fix(VSlideGroup): handle rounding issue if using browser zoom

### DIFF
--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.ts
@@ -402,7 +402,10 @@ export const BaseSlideGroup = mixins<options &
           wrapper: wrapper ? wrapper.clientWidth : 0,
         }
 
-        this.isOverflowing = this.widths.wrapper < this.widths.content
+        // https://github.com/vuetifyjs/vuetify/issues/13212
+        // We add +1 to the wrappers width to prevent an issue where the `clientWidth`
+        // gets calculated wrongly by the browser if using a different zoom-level.
+        this.isOverflowing = this.widths.wrapper + 1 < this.widths.content
 
         this.scrollIntoView()
       })


### PR DESCRIPTION
## Description
fixes #13212 

## Motivation and Context
fixes #13212 

## How Has This Been Tested?
visually

### Before
https://user-images.githubusercontent.com/557005/111451899-37303780-8712-11eb-9d19-1c8db9d27849.mov

### After
https://user-images.githubusercontent.com/557005/111451928-3f887280-8712-11eb-95f4-4d94064a7c27.mov

## Markup:
Visit with chrome and set the Zoom to 110%, then resize the screen:

<details>

```vue
<template>
  <v-container>
    <v-tabs>
      <v-tab>Item One</v-tab>
      <v-tab>Item Two</v-tab>
      <v-tab>Item Three</v-tab>
    </v-tabs>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
<style lang="scss">
.v-tabs {
  padding-left: 14px;
  .v-tabs-bar {
    padding-left: 16px;
  }
}
</style>

```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
