### PR TITLE
docs(bottom-navigation): update usage description

### DIFF
--- a/packages/docs/src/pages/en/components/bottom-navigation.md
+++ b/packages/docs/src/pages/en/components/bottom-navigation.md
@@ -17,7 +17,7 @@ The `v-bottom-navigation` component is an alternative to the sidebar. It is prim
 
 ## Usage
 
-While the bottom nav is meant to be used with the [vue-router](https://router.vuejs.org/), you can also programmatically control the active state of the buttons by using the **active** prop with the _sync_ modifier—e.g. `active.sync`. Modify the **value** property to designate the synced value. A button is given a default value of its _index_ with `v-bottom-navigation`.
+Modify the **value** property to designate the synced value. A button is given a default value of its _index_ with `v-bottom-navigation`.
 
 <example file="v-bottom-navigation/usage" />
 

--- a/packages/docs/src/pages/en/components/bottom-navigation.md
+++ b/packages/docs/src/pages/en/components/bottom-navigation.md
@@ -17,7 +17,7 @@ The `v-bottom-navigation` component is an alternative to the sidebar. It is prim
 
 ## Usage
 
-Modify the **value** property to designate the synced value. A button is given a default value of its _index_ with `v-bottom-navigation`.
+While `v-bottom navigation` is meant to be used with [vue-router](https://router.vuejs.org/), you can also programmatically control the active state of the buttons by using the **value** property. A button is given a default value of its _index_ with `v-bottom-navigation`.
 
 <example file="v-bottom-navigation/usage" />
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
The `active` property of the `v-bottom-navigation` component and the event 'update:active' are not implemented but they are desccribed in documentation of the `2.3.*` and `2.4.*` branches.
I tried to achieve that it worked, but it seems that it does not work at all. Perhaps this piece of text from the old documentation.

And i didn't find any `active` property or the `update:active` event in API docs of 2.3.* &amp; 2.4.* versions for the `v-bottom-navigation` component.

## Motivation and Context
It's the misleading text

## How Has This Been Tested?
https://codepen.io/Perlover/pen/zYoVbMM?editors=101

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
