### PR TITLE
fix(VAutocomplete): compare current lazyValue before emiting update

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -99,7 +99,7 @@ export default VSelect.extend({
         return this.lazySearch
       },
       set (val: any) { // TODO: this should be `string | null` but it breaks lots of other types
-        // only emit update event when the new 
+        // emit update event only when the new
         // search value is different from previous
         if (this.lazySearch !== val) {
           this.lazySearch = val

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -99,9 +99,12 @@ export default VSelect.extend({
         return this.lazySearch
       },
       set (val: any) { // TODO: this should be `string | null` but it breaks lots of other types
-        this.lazySearch = val
-
-        this.$emit('update:search-input', val)
+        // only emit update event when the new 
+        // search value is different from previous
+        if (this.lazySearch !== val) {
+          this.lazySearch = val
+          this.$emit('update:search-input', val)
+        }
       },
     },
     isAnyValueAllowed (): boolean {

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -204,4 +204,37 @@ describe('VAutocomplete.ts', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isMenuActive).toBe(true)
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/9489
+  it('should emit search-input update only once', async () => {
+    const onSearch = jest.fn()
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo', 'bar'],
+        value: 'foo',
+      },
+    })
+
+    wrapper.vm.$on('update:search-input', onSearch)
+
+    expect(onSearch).toHaveBeenCalledTimes(0)
+
+    wrapper.setData({ internalValue: 'bar' })
+
+    await wrapper.vm.$nextTick()
+
+    expect(onSearch).toHaveBeenCalledTimes(1)
+
+    wrapper.setData({ internalValue: 'foo' })
+
+    await wrapper.vm.$nextTick()
+
+    expect(onSearch).toHaveBeenCalledTimes(2)
+
+    wrapper.setData({ internalValue: 'foo' })
+
+    await wrapper.vm.$nextTick()
+
+    expect(onSearch).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Fixed infinite loop with update:search-input event for VAutocomplete

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
FIxes #9489

Whenever the items list is updated for VAutocomplete, the setSearch() method is called. This sets the value of search and emits the  update:search-input event even if there is no change in the search value. This will cause an infinite loop with the test case mentioned in the issue. The fix is to only emit the event if the new search value is different from the previous one.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here

<template>
   <v-app>
    <v-container>
      <v-autocomplete 
        v-model="selected"
        :items="items" 
        @update:search-input="search">
      </v-autocomplete>
    </v-container>
  </v-app>
</template>

<script>
export default {
  data() {
    return {
      selected: '',
      items: []
    }
  },
  methods: {
    search(term) {
      // Open the console, select an item and lose focus on the field
      // You will see this log in a loop instead of once
      console.log('SEARCH STARTED')

      setTimeout(() => {
        // api call, ignore term for this example
        this.items = [
          {text: 'Item 1', value: 'a'},
          {text: 'Item 2', value: 'b'},
          {text: 'Item 3', value: 'c'}
        ]
      }, 1000)
    }
  }
}
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
