### PR TITLE
fix(VExpansionPanels): change aria-expanded to use isActive

### DIFF
--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelHeader.ts
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelHeader.ts
@@ -105,7 +105,7 @@ export default baseMixins.extend<options>().extend({
       attrs: {
         tabindex: this.isDisabled ? -1 : null,
         type: 'button',
-        'aria-expanded': this.hasMousedown,
+        'aria-expanded': this.isActive,
       },
       directives: [{
         name: 'ripple',


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
updated aria-expanded on the v-expansion-panel-header button to use isActive instead of hasMousedown since that seemed much more appropriate. 
Fixes #13354

## Motivation and Context
I realized when reviewing the PR I put in yesterday that I should have used isActive instead of hasMousedown. I wanted to fix my mistake. 

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
