### PR TITLE
docs(v-slide-group): update the click receive params description 

### DIFF
--- a/packages/api-generator/src/locale/en/v-slide-group.json
+++ b/packages/api-generator/src/locale/en/v-slide-group.json
@@ -12,6 +12,7 @@
   },
   "events": {
     "change": "Emitted when the component value is changed by user interaction",
-    "click:${location}": "Emitted when a slide item is selected inside of the slide group, ${location} recivce **prev** or **next**, example **click:prev**"
+    "click:prev": "Emitted when the prev is clicked",
+    "click:next": "Emitted when the next is clicked"
   }
 }

--- a/packages/api-generator/src/locale/en/v-slide-group.json
+++ b/packages/api-generator/src/locale/en/v-slide-group.json
@@ -12,6 +12,6 @@
   },
   "events": {
     "change": "Emitted when the component value is changed by user interaction",
-    "click:location": "Emitted when a slide item is selected inside of the slide group"
+    "click:${location}": "Emitted when a slide item is selected inside of the slide group, ${location} recivce **prev** or **next**, example **click:prev**"
   }
 }

--- a/packages/api-generator/src/maps/v-slide-group.js
+++ b/packages/api-generator/src/maps/v-slide-group.js
@@ -6,7 +6,11 @@ module.exports = {
         value: 'any[] | any',
       },
       {
-        name: 'click:location',
+        name: 'click:prev',
+        value: 'void',
+      },
+      {
+        name: 'click:next',
         value: 'void',
       },
     ],


### PR DESCRIPTION
## Description

https://vuetifyjs.com/en/api/v-slide-group/#events 

`click:location` only support receive two param: ‘prev' | 'next' form the source code.  

`src/components/VSlideGroup/VSlideGroup.ts`:
```
onAffixClick (location: 'prev' | 'next') {
  this.$emit(`click:${location}`)
  this.scrollTo(location)
},
```

## Motivation and Context

The current version of the documentation does not allow the user to use it correctly.

## How Has This Been Tested?

Visual

## Markup:
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
