### PR TITLE
fix(VCombobox): reset editingIndex after clear

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.ts
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.ts
@@ -251,5 +251,10 @@ export default VAutocomplete.extend({
         VSelect.options.methods.selectItem.call(this, pastedItemText as any)
       }
     },
+    clearableCallback () {
+      this.editingIndex = -1
+
+      VAutocomplete.options.methods.clearableCallback.call(this)
+    },
   },
 })

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox-multiple.spec.ts
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox-multiple.spec.ts
@@ -483,4 +483,41 @@ describe('VCombobox.ts', () => {
 
     expect(change).not.toHaveBeenCalled()
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/10827
+  it('should not add empty chips after clear', async () => {
+    const { wrapper, change } = createMultipleCombobox({
+      chips: true,
+      multiple: true,
+      clearable: true,
+      items: ['foo', 'bar'],
+      value: ['foo', 'bar'],
+    })
+
+    const input = wrapper.find('input')
+    const element = input.element as HTMLInputElement
+
+    // Dbl click chip at index 1
+    const chip = wrapper.findAll('.v-chip').at(1)
+    chip.trigger('dblclick')
+    expect(wrapper.vm.editingIndex).toBe(1)
+    expect(wrapper.vm.internalSearch).toBe('bar')
+
+    // Click clear button
+    const clear = wrapper.find('.v-input__icon--clear .v-icon')
+    clear.trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(change).toHaveBeenCalledWith([])
+    await wrapper.vm.$nextTick()
+
+    // Add 'foo'
+    input.trigger('focus')
+    element.value = 'foo'
+    input.trigger('input')
+    await wrapper.vm.$nextTick()
+    input.trigger('keydown.enter')
+    await wrapper.vm.$nextTick()
+
+    expect(change).toHaveBeenLastCalledWith(['foo'])
+  })
 })

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox-multiple.spec.ts
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox-multiple.spec.ts
@@ -485,7 +485,7 @@ describe('VCombobox.ts', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/10827
-  it('should not add empty chips after clear', async () => {
+  it('should not add empty chips after clear and re-select', async () => {
     const { wrapper, change } = createMultipleCombobox({
       chips: true,
       multiple: true,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Multiple Combobox adds empty chips when double click on chip and then re-select an item. Fixes #10827 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This issue was happening because of incorrect value of editingIndex in combobox. When we double click a chip, its text is displayed as editable text in the combobox and this sets the editingIndex to the index of the chip double clicked. This is done in VCombobox.ts where dbl click event for chip is handled

```
dblclick: () => {
            this.editingIndex = index
            this.internalSearch = this.getText(item)
            this.selectedIndex = -1
          }
``` 

Currently, after clicking clear button we don't reset editingIndex. And, if we try to add any value after clear, it will cause updateEditing() function to get called instead of adding that item. updateEditing() adds the null value to the combobox.

```
 selectItem (item: object) {
      // Currently only supports items:<string[]>
      if (this.editingIndex > -1) {
        this.updateEditing()
      } else {
        VAutocomplete.options.methods.selectItem.call(this, item)
         ...
     }
```

The fix is to reset editingIndex when clear button is clicked.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Visually and unit test.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <div id="app">
    <v-app id="inspire">
      <v-container fluid>
        <v-row>
          <v-col cols="12">
            <v-combobox
              v-model="select"
              :items="items"
              label="I use chips"
              multiple
              chips
              clearable
            ></v-combobox>
          </v-col>
        </v-row>
      </v-container>
    </v-app>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        select: ['Vuetify', 'Programming'],
        items: [
          'Programming',
          'Design',
          'Vue',
          'Vuetify',
        ],
      }
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
