### PR TITLE
fix(types): add declaration for vuetify/lib/components

### DIFF
--- a/packages/vuetify/types/lib.d.ts
+++ b/packages/vuetify/types/lib.d.ts
@@ -1,19 +1,21 @@
 declare module 'vuetify/lib' {
-  // eslint-disable-next-line import/no-duplicates
-  import { VueConstructor, DirectiveOptions } from 'vue'
   import Vuetify from 'vuetify'
   import { Colors } from 'vuetify/lib/util/colors'
 
   export default Vuetify
 
   const colors: Colors
-  const ClickOutside: DirectiveOptions
-  const Intersect: DirectiveOptions
-  const Mutate: DirectiveOptions
-  const Resize: DirectiveOptions
-  const Ripple: DirectiveOptions
-  const Scroll: DirectiveOptions
-  const Touch: DirectiveOptions
+
+  export {
+    colors,
+  }
+  export * from 'vuetify/lib/components'
+  export * from 'vuetify/lib/directives'
+}
+
+declare module 'vuetify/lib/components' {
+  import { VueConstructor } from 'vue'
+
   const VApp: VueConstructor
   const VAppBar: VueConstructor
   const VAppBarNavIcon: VueConstructor
@@ -179,14 +181,6 @@ declare module 'vuetify/lib' {
   const VExpandXTransition: VueConstructor
 
   export {
-    colors,
-    ClickOutside,
-    Intersect,
-    Mutate,
-    Ripple,
-    Resize,
-    Scroll,
-    Touch,
     VApp,
     VAppBar,
     VAppBarNavIcon,
@@ -354,7 +348,6 @@ declare module 'vuetify/lib' {
 }
 
 declare module 'vuetify/lib/directives' {
-  // eslint-disable-next-line import/no-duplicates
   import { DirectiveOptions } from 'vue'
 
   const ClickOutside: DirectiveOptions


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Vuetify has separated `declare module` for `vuetify/lib/directives`. This add `vuetify/lib/components` too.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Now we can do something like `import * as VuetifyComponents from 'vuetify/lib/components';` without typescript errors.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
