### PR TITLE
fix(VDatePicker): prevent scroll beyond max date with touchpad

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -264,7 +264,7 @@ describe('VDatePicker.ts', () => { // eslint-disable-line max-statements
       },
     })
 
-    wrapper.findAll('.v-date-picker-table--date').at(0).trigger('wheel')
+    wrapper.findAll('.v-date-picker-table--date').at(0).trigger('wheel', { deltaY: 1 })
     expect(wrapper.vm.tableDate).toBe('2013-06')
   })
 

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
@@ -127,7 +127,7 @@ describe('VDatePicker.ts', () => {
       },
     })
 
-    wrapper.findAll('.v-date-picker-table--month').at(0).trigger('wheel')
+    wrapper.findAll('.v-date-picker-table--month').at(0).trigger('wheel', { deltaY: 1 })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.tableDate).toBe('2014')
   })

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerDateTable.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerDateTable.spec.ts
@@ -234,7 +234,7 @@ describe('VDatePickerDateTable.ts', () => {
     const tableDate = jest.fn()
     wrapper.vm.$on('update:table-date', tableDate)
 
-    wrapper.trigger('wheel')
+    wrapper.trigger('wheel', { deltaY: 1 })
     expect(tableDate).toHaveBeenCalledWith('2005-06')
   })
 
@@ -248,7 +248,7 @@ describe('VDatePickerDateTable.ts', () => {
     const tableDate = jest.fn()
     wrapper.vm.$on('update:table-date', tableDate)
 
-    wrapper.trigger('wheel')
+    wrapper.trigger('wheel', { deltaY: 1 })
     expect(tableDate).not.toHaveBeenCalled()
   })
 

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerMonthTable.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePickerMonthTable.spec.ts
@@ -124,7 +124,7 @@ describe('VDatePickerMonthTable.ts', () => {
     const tableDate = jest.fn()
     wrapper.vm.$on('update:table-date', tableDate)
 
-    wrapper.trigger('wheel')
+    wrapper.trigger('wheel', { deltaY: 1 })
     expect(tableDate).toHaveBeenCalledWith('2006')
   })
 
@@ -138,7 +138,7 @@ describe('VDatePickerMonthTable.ts', () => {
     const tableDate = jest.fn()
     wrapper.vm.$on('update:table-date', tableDate)
 
-    wrapper.trigger('wheel')
+    wrapper.trigger('wheel', { deltaY: 1 })
     expect(tableDate).not.toHaveBeenCalled()
   })
 

--- a/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
+++ b/packages/vuetify/src/components/VDatePicker/mixins/date-picker-table.ts
@@ -181,8 +181,7 @@ export default mixins(
       const tableDate = calculateTableDate(value)
       // tableDate is 'YYYY-MM' for DateTable and 'YYYY' for MonthTable
       const sanitizeType = tableDate.split('-').length === 1 ? 'year' : 'month'
-      return (value === 0) ||
-        (value < 0 && (this.min ? tableDate >= sanitizeDateString(this.min, sanitizeType) : true)) ||
+      return (value < 0 && (this.min ? tableDate >= sanitizeDateString(this.min, sanitizeType) : true)) ||
         (value > 0 && (this.max ? tableDate <= sanitizeDateString(this.max, sanitizeType) : true))
     },
     wheel (e: WheelEvent, calculateTableDate: CalculateTableDateFunction) {


### PR DESCRIPTION
## Motivation and Context
a bug
scroll using touchpad (2 fingers), it's possible to scroll beyond the max date


## How Has This Been Tested?
visually, updated unit tests

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-date-picker
      v-model="date"
      class="mt-4"
      min="2020-06-15"
      max="2021-05-20"
      scrollable
    ></v-date-picker>
  </v-container>
</template>

<script>
  export default {
    data: () => {
      return {}
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
