### PR TITLE
fix(click-outside): detect shadowRoot in click-outside handler

### DIFF
--- a/packages/vuetify/src/directives/click-outside/__tests__/click-outside-shadow-dom.spec.ts
+++ b/packages/vuetify/src/directives/click-outside/__tests__/click-outside-shadow-dom.spec.ts
@@ -1,0 +1,115 @@
+// Directives
+import ClickOutside from '../'
+import { wait } from '../../../../test'
+
+function bootstrap (args?: object) {
+  const outsideEl = document.createElement('div')
+  const shadowHost = document.createElement('div')
+  const shadowRoot = shadowHost.attachShadow({ mode: 'open' })
+  const shadowEl = document.createElement('div')
+
+  const binding = {
+    value: {
+      handler: jest.fn(),
+      ...args,
+    },
+  }
+
+  let shadowClickHandler
+  let outsideClickHandler
+
+  let shadowMousedownHandler
+  let outsideMousedownHandler
+
+  document.body.appendChild(shadowHost)
+  shadowRoot.appendChild(shadowEl)
+
+  jest.spyOn(window.document.body, 'addEventListener').mockImplementation((eventName, eventHandler, options) => {
+    if (eventName === 'click') outsideClickHandler = eventHandler
+    if (eventName === 'mousedown') outsideMousedownHandler = eventHandler
+  })
+
+  jest.spyOn(shadowRoot, 'addEventListener').mockImplementation((eventName, eventHandler, options) => {
+    if (eventName === 'click') shadowClickHandler = eventHandler
+    if (eventName === 'mousedown') shadowMousedownHandler = eventHandler
+  })
+
+  jest.spyOn(window.document.body, 'removeEventListener')
+  jest.spyOn(shadowRoot, 'removeEventListener')
+
+  ClickOutside.inserted(shadowEl as HTMLElement, binding as any)
+
+  return {
+    callback: binding.value.handler,
+    shadowEl: shadowEl as HTMLElement,
+    outsideEl: outsideEl as HTMLElement,
+    shadowRoot: shadowRoot as Node,
+    shadowClickHandler,
+    outsideClickHandler,
+    shadowMousedownHandler,
+    outsideMousedownHandler,
+  }
+}
+
+describe('click-outside.js within the Shadow DOM', () => {
+  it('should register and unregister handler outside of the shadow DOM', () => {
+    const { outsideClickHandler, shadowEl } = bootstrap()
+    expect(window.document.body.addEventListener).toHaveBeenCalledWith('click', outsideClickHandler, true)
+
+    ClickOutside.unbind(shadowEl)
+    expect(window.document.body.removeEventListener).toHaveBeenCalledWith('click', outsideClickHandler, true)
+  })
+
+  it('should register and unregister handler within the shadow DOM', () => {
+    const { shadowClickHandler, shadowRoot, shadowEl } = bootstrap()
+    expect(shadowRoot.addEventListener).toHaveBeenCalledWith('click', shadowClickHandler, true)
+
+    ClickOutside.unbind(shadowEl)
+    expect(shadowRoot.removeEventListener).toHaveBeenCalledWith('click', shadowClickHandler, true)
+  })
+
+  it('should call the callback when closeConditional returns true and event target is outside the shadow DOM', async () => {
+    const { outsideClickHandler, callback, outsideEl } = bootstrap({ closeConditional: () => true })
+    const event = { target: outsideEl }
+
+    outsideClickHandler(event)
+    await wait()
+    expect(callback).toHaveBeenCalledWith(event)
+  })
+
+  it('should call the callback when closeConditional returns true and event target is within the shadow DOM', async () => {
+    const { shadowClickHandler, callback, shadowRoot } = bootstrap({ closeConditional: () => true })
+    const event = { target: shadowRoot }
+
+    shadowClickHandler(event)
+    await wait()
+    expect(callback).toHaveBeenCalledWith(event)
+  })
+
+  it('should not call the callback when closeConditional is not provided', async () => {
+    const { shadowClickHandler, callback, shadowEl } = bootstrap()
+
+    shadowClickHandler({ target: shadowEl })
+    await wait()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('should not call the callback when clicked in element within the shadow DOM', async () => {
+    const { shadowClickHandler, callback, shadowEl } = bootstrap({ closeConditional: () => true })
+
+    shadowClickHandler({ target: shadowEl })
+    await wait()
+    expect(callback).not.toHaveBeenCalledWith()
+  })
+
+  it('should not call the callback when mousedown was on the element within the shadow DOM', async () => {
+    const { shadowClickHandler, shadowMousedownHandler, callback, shadowEl } = bootstrap({ closeConditional: () => true })
+    const mousedownEvent = { target: shadowEl }
+    const clickEvent = { target: document.createElement('div') }
+
+    shadowMousedownHandler(mousedownEvent)
+    shadowClickHandler(clickEvent)
+    await wait()
+    expect(callback).not.toHaveBeenCalledWith(clickEvent)
+  })
+})


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
When a `Select` or `Autocomplete` component is used within the shadow DOM the `click-outside` directive will not recognize the correct root.  The result is that the component is auto-blurred upon focus via a click event.

This  PR:
- Leverages the `attachedRoot` DOM utility method introduced in PR #13053 to inform the registration of click listeners.
- Adds/removes a click listener to the DOM via [data-app] and the ShadowRoot when a ShadowRoot is present.

fixes#13275

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This will address issues with the `Autocomplete` and `Select` components leveraging the `click-outside` directive. It fixes recognition of the current `root` when working within  a shadow DOM context.

fixes#13275


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit
## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
