### PR TITLE
feat: add resize observer composable

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -73,6 +73,7 @@
     "@mdi/font": "^5.9.55",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.10",
+    "@types/resize-observer-browser": "^0.1.5",
     "@vue/babel-plugin-jsx": "^1.0.3",
     "@vue/test-utils": "2.0.0-beta.13",
     "autoprefixer": "^9.6.1",

--- a/packages/vuetify/src/composables/__tests__/resizeObserver.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/resizeObserver.spec.ts
@@ -3,10 +3,10 @@ import { useResizeObserver } from '../resizeObserver'
 
 // Utilities
 import { mount } from '@vue/test-utils'
-import { h } from '@vue/runtime-core'
+import { h, nextTick } from '@vue/runtime-core'
 
 describe('resizeObserver', () => {
-  it('should invoke callback with html element', () => {
+  it('should make sure mock exists', async () => {
     const callback = jest.fn()
     mount({
       setup () {
@@ -16,22 +16,7 @@ describe('resizeObserver', () => {
       },
     })
 
-    expect(callback).toHaveBeenCalled()
-  })
-
-  it('should invoke callback with component', () => {
-    const Comp = {
-      template: '<div/>',
-    }
-
-    const callback = jest.fn()
-    mount({
-      setup () {
-        const { resizeRef } = useResizeObserver(callback)
-
-        return () => h(Comp, { ref: resizeRef })
-      },
-    })
+    await nextTick()
 
     expect(callback).toHaveBeenCalled()
   })

--- a/packages/vuetify/src/composables/__tests__/resizeObserver.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/resizeObserver.spec.ts
@@ -1,0 +1,38 @@
+// Composables
+import { useResizeObserver } from '../resizeObserver'
+
+// Utilities
+import { mount } from '@vue/test-utils'
+import { h } from '@vue/runtime-core'
+
+describe('resizeObserver', () => {
+  it('should invoke callback with html element', () => {
+    const callback = jest.fn()
+    mount({
+      setup () {
+        const { resizeRef } = useResizeObserver(callback)
+
+        return () => h('div', { ref: resizeRef }, ['foo'])
+      },
+    })
+
+    expect(callback).toHaveBeenCalled()
+  })
+
+  it('should invoke callback with component', () => {
+    const Comp = {
+      template: '<div/>',
+    }
+
+    const callback = jest.fn()
+    mount({
+      setup () {
+        const { resizeRef } = useResizeObserver(callback)
+
+        return () => h(Comp, { ref: resizeRef })
+      },
+    })
+
+    expect(callback).toHaveBeenCalled()
+  })
+})

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -1,15 +1,18 @@
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 
 export function useResizeObserver (callback: ResizeObserverCallback) {
   const resizeRef = ref()
   const observer = new ResizeObserver(callback)
 
-  onMounted(() => {
-    observer.observe(resizeRef.value)
-  })
-
   onBeforeUnmount(() => {
     observer.disconnect()
+  })
+
+  watch(resizeRef, (newValue, oldValue) => {
+    if (oldValue) observer.unobserve(oldValue)
+    if (newValue) observer.observe(newValue)
+  }, {
+    flush: 'post',
   })
 
   return { resizeRef }

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -1,11 +1,11 @@
 // Utilities
-import { onBeforeUnmount, ref, watch } from 'vue'
+import { onBeforeUnmount, readonly, ref, watch } from 'vue'
 
 export function useResizeObserver (callback: ResizeObserverCallback) {
   const resizeRef = ref<Element>()
-  const contentRect = ref<DOMRectReadOnly>(new DOMRect(0, 0, 0, 0))
-  const contentBoxSize = ref<ResizeObserverSize>({ blockSize: 0, inlineSize: 0 })
-  const borderBoxSize = ref<ResizeObserverSize>({ blockSize: 0, inlineSize: 0 })
+  const contentRect = ref<DOMRectReadOnly | undefined>()
+  const contentBoxSize = ref<ResizeObserverSize | undefined>()
+  const borderBoxSize = ref<ResizeObserverSize | undefined>()
 
   const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
     callback?.(entries, observer)
@@ -22,11 +22,22 @@ export function useResizeObserver (callback: ResizeObserverCallback) {
   })
 
   watch(resizeRef, (newValue, oldValue) => {
-    if (oldValue) observer.unobserve(oldValue)
+    if (oldValue) {
+      observer.unobserve(oldValue)
+      contentRect.value = undefined
+      contentBoxSize.value = undefined
+      borderBoxSize.value = undefined
+    }
+
     if (newValue) observer.observe(newValue)
   }, {
     flush: 'post',
   })
 
-  return { resizeRef, contentRect, contentBoxSize, borderBoxSize }
+  return {
+    resizeRef,
+    contentRect: readonly(contentRect),
+    contentBoxSize: readonly(contentBoxSize),
+    borderBoxSize: readonly(borderBoxSize),
+  }
 }

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -1,3 +1,4 @@
+// Utilities
 import { onBeforeUnmount, ref, watch } from 'vue'
 
 export function useResizeObserver (callback: ResizeObserverCallback) {

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -1,0 +1,16 @@
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+export function useResizeObserver (callback: ResizeObserverCallback) {
+  const resizeRef = ref()
+  const observer = new ResizeObserver(callback)
+
+  onMounted(() => {
+    observer.observe(resizeRef.value)
+  })
+
+  onBeforeUnmount(() => {
+    observer.disconnect()
+  })
+
+  return { resizeRef }
+}

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -3,9 +3,9 @@ import { onBeforeUnmount, readonly, ref, watch } from 'vue'
 
 export function useResizeObserver (callback?: ResizeObserverCallback) {
   const resizeRef = ref<Element>()
-  const contentRect = ref<DOMRectReadOnly | undefined>()
-  const contentBoxSize = ref<ResizeObserverSize | undefined>()
-  const borderBoxSize = ref<ResizeObserverSize | undefined>()
+  const contentRect = ref<DOMRectReadOnly>()
+  const contentBoxSize = ref<ResizeObserverSize>()
+  const borderBoxSize = ref<ResizeObserverSize>()
 
   const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
     callback?.(entries, observer)

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -1,7 +1,7 @@
 // Utilities
 import { onBeforeUnmount, readonly, ref, watch } from 'vue'
 
-export function useResizeObserver (callback: ResizeObserverCallback) {
+export function useResizeObserver (callback?: ResizeObserverCallback) {
   const resizeRef = ref<Element>()
   const contentRect = ref<DOMRectReadOnly | undefined>()
   const contentBoxSize = ref<ResizeObserverSize | undefined>()

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -2,7 +2,7 @@
 import { onBeforeUnmount, ref, watch } from 'vue'
 
 export function useResizeObserver (callback: ResizeObserverCallback) {
-  const resizeRef = ref()
+  const resizeRef = ref<Element>()
   const observer = new ResizeObserver(callback)
 
   onBeforeUnmount(() => {

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -3,7 +3,19 @@ import { onBeforeUnmount, ref, watch } from 'vue'
 
 export function useResizeObserver (callback: ResizeObserverCallback) {
   const resizeRef = ref<Element>()
-  const observer = new ResizeObserver(callback)
+  const contentRect = ref<DOMRectReadOnly>(new DOMRect(0, 0, 0, 0))
+  const contentBoxSize = ref<ResizeObserverSize>({ blockSize: 0, inlineSize: 0 })
+  const borderBoxSize = ref<ResizeObserverSize>({ blockSize: 0, inlineSize: 0 })
+
+  const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+    callback?.(entries, observer)
+
+    if (!entries.length) return
+
+    contentRect.value = entries[0].contentRect
+    contentBoxSize.value = entries[0].contentBoxSize[0]
+    borderBoxSize.value = entries[0].borderBoxSize[0]
+  })
 
   onBeforeUnmount(() => {
     observer.disconnect()
@@ -16,5 +28,5 @@ export function useResizeObserver (callback: ResizeObserverCallback) {
     flush: 'post',
   })
 
-  return { resizeRef }
+  return { resizeRef, contentRect, contentBoxSize, borderBoxSize }
 }

--- a/packages/vuetify/test/index.ts
+++ b/packages/vuetify/test/index.ts
@@ -66,7 +66,7 @@ export const scrollElement = (element: Element, y: number) => {
 }
 
 // Add a global mockup for IntersectionObserver
-(global as any).IntersectionObserver = class IntersectionObserver {
+class IntersectionObserver {
   callback?: (entries: any, observer: any) => {}
 
   constructor (callback: any) {
@@ -83,5 +83,29 @@ export const scrollElement = (element: Element, y: number) => {
     return null
   }
 }
+
+(global as any).IntersectionObserver = IntersectionObserver
+
+class ResizeObserver {
+  callback?: ResizeObserverCallback
+
+  constructor (callback: ResizeObserverCallback) {
+    this.callback = callback
+  }
+
+  observe () {
+    this.callback?.([], this)
+  }
+
+  unobserve () {
+    this.callback = undefined
+  }
+
+  disconnect () {
+    this.callback = undefined
+  }
+}
+
+(global as any).ResizeObserver = ResizeObserver
 
 toHaveBeenWarnedInit()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,6 +4350,11 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/resize-observer-browser@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz#36d897708172ac2380cd486da7a3daf1161c1e23"
+  integrity sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
adds ResizeObserver composable. exposes a ref that can be attached to element/component you want to observe.

usage

```ts
const { resizeRef } = useResizeObserver(entries => {
  // do something with observed entries
})

..

ref={resizeRef}
```

if there is only need to get size of actual element that ref is attached to, usage can be

```ts
const { resizeRef, contentRect, contentBoxSize, borderBoxSize } = useResizeObserver()

...

ref={resizeRef}
```

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
playground and unit tests

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div v-if="val" ref="resizeRef">{{ width }}</div>
  <v-btn @click="val = !val">toggle</v-btn>
</template>

<script>
  import { ref } from 'vue'
  import { useResizeObserver } from '../src/composables/resizeObserver'

  export default {
    name: 'Playground',
    setup () {
      const val = ref(true)
      const width = ref(0)
      const { resizeRef } = useResizeObserver(entries => {
        if (!entries.length) return

        const { contentBoxSize } = entries[0]

        width.value = contentBoxSize[0].inlineSize
      })

      return { resizeRef, width, val }
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
