### PR TITLE
style: stop resizing headers on accordions

### DIFF
--- a/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-events.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/__tests__/calendar-with-events.spec.ts
@@ -124,10 +124,14 @@ describe('calendar-with-events.ts', () => {
     // Depending on the time format of the underlying system
     // (12-hour with `h` || 12-hour with `hh` || 24-hour with `h` || 24-hour with `hh`),
     // we expect the value passed to be-
-    expect(wrapper.vm.formatTime(testData1, true)).toMatch(/^0?8:30( AM)?$/i) // 8:30 AM || 08:30 AM || 8:30 || 08:30
-    expect(wrapper.vm.formatTime(testData2, true)).toMatch(/^(0?5:45 PM|17:45)$/i) // 5:45 PM || 05:45 PM || 17:45
-    expect(wrapper.vm.formatTime(testData3, true)).toMatch(/^0?9:05( AM)?$/i) // 9:05 AM || 09:05 AM || 9:05 || 09:45
-    expect(wrapper.vm.formatTime(testData4, true)).toMatch(/^(0?3 PM|15)$/i) // 3 AM || 03 AM || 15
+    // 8:30 AM || 08:30 AM || 8:30 || 08:30 || 8.30 AM || 08.30 AM || 8.30 || 08.30
+    expect(wrapper.vm.formatTime(testData1, true)).toMatch(/^0?8:|\.30( AM)?$/i)
+    // 5:45 PM || 05:45 PM || 17:45 || 5.45 PM || 05.45 PM || 17.45
+    expect(wrapper.vm.formatTime(testData2, true)).toMatch(/^(0?5(:|\.)45 PM|17(:|\.)45)$/i)
+    // 9:05 AM || 09:05 AM || 9:05 || 09:45 || 9.05 AM || 09.05 AM || 9.05 || 09.45
+    expect(wrapper.vm.formatTime(testData3, true)).toMatch(/^0?9:|\.05( AM)?$/i)
+    // 3 AM || 03 AM || 15
+    expect(wrapper.vm.formatTime(testData4, true)).toMatch(/^(0?3 PM|15)$/i)
   })
 
   it('should get events map', async () => {

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass
@@ -108,7 +108,7 @@
         opacity: 0
 
     > .v-expansion-panel-header
-         min-height: $expansion-panel-active-header-min-height
+      min-height: $expansion-panel-active-header-min-height
 
     > .v-expansion-panel-header--active .v-expansion-panel-header__icon
       &:not(.v-expansion-panel-header__icon--disable-rotate) .v-icon
@@ -180,6 +180,9 @@
 
     &::after
       opacity: 1
+
+  .v-expansion-panel-header
+    min-height: inherit
 
 .v-expansion-panels--popout
   > .v-expansion-panel


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
The changing of header sizes makes sense when the it's regular
expansion-panels component, however when it's an accordion style panel
it makes more sense to not move the header at all, the expansion will
already be a good indication that something is open

Please note that I had to fix some test because I'm on a computer configured to be Finnish, and in Finland time and dates are split by a `.` instead of a `:`. Without the regex changes I was unable to push.

**Before:**

https://user-images.githubusercontent.com/5371454/117673539-8c894200-b1b3-11eb-8799-5e428583d238.mp4

**After:**

https://user-images.githubusercontent.com/5371454/117673590-97dc6d80-b1b3-11eb-92ba-3ee9fd34b821.mp4

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I think it's weird to have moving headers when the styling doesn't ask for it.
On the default v-expansion-panels the header resize might be nice to have,
however on the accordion style panels it's more of a distraction.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
none

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-row justify="center">
      <v-expansion-panels accordion>
        <v-expansion-panel v-for="(item, i) in 5" :key="i">
          <v-expansion-panel-header>Item</v-expansion-panel-header>
          <v-expansion-panel-content>
            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
            aliquip ex ea commodo consequat.
          </v-expansion-panel-content>
        </v-expansion-panel>
      </v-expansion-panels>
    </v-row>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    //
  }),
};
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
