### PR TITLE
fix(typescript): added missing VThemeProvider export in lib.d.ts

### DIFF
--- a/packages/vuetify/types/lib.d.ts
+++ b/packages/vuetify/types/lib.d.ts
@@ -142,6 +142,7 @@ declare module 'vuetify/lib' {
   const VTabsSlider: VueConstructor
   const VTextarea: VueConstructor
   const VTextField: VueConstructor
+  const VThemeProvider: VueConstructor
   const VTimeline: VueConstructor
   const VTimelineItem: VueConstructor
   const VTimePicker: VueConstructor
@@ -314,6 +315,7 @@ declare module 'vuetify/lib' {
     VTabsSlider,
     VTextarea,
     VTextField,
+    VThemeProvider,
     VTimeline,
     VTimelineItem,
     VTimePicker,


### PR DESCRIPTION
fixes #13578


## Description
added missing VThemeProvider export in lib.d.ts

## Motivation and Context
missing VThemeProvider export in lib.d.ts

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
