### PR TITLE
fix(VTimePickerClock): race condition between event and $refs

### DIFF
--- a/packages/vuetify/src/components/VTimePicker/VTimePickerClock.ts
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerClock.ts
@@ -189,7 +189,7 @@ export default mixins<options &
     },
     onDragMove (e: MouseEvent | TouchEvent) {
       e.preventDefault()
-      if (!this.isDragging && e.type !== 'click') return
+      if ((!this.isDragging && e.type !== 'click') || !this.$refs.clock) return
 
       const { width, top, left } = this.$refs.clock.getBoundingClientRect()
       const { width: innerWidth } = this.$refs.innerClock.getBoundingClientRect()


### PR DESCRIPTION
In some rare cases the error `Cannot read property 'getBoundingClientRect' of undefined` is thrown, I believe it's due to the fact that the event may fire only after the element has been destroyed in some slow devices, for now it only has happened on chrome desktop

## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Simply gracefully exit the function without throwing in this very edge case

## Motivation and Context
Some of my users (less than 0.1%) experience this issue in production
![image](https://user-images.githubusercontent.com/6115458/118136042-f730bc80-b403-11eb-8d2e-508ee7ea5a1f.png)

![image](https://user-images.githubusercontent.com/6115458/118139130-5a701e00-b407-11eb-8ec9-99e3d44a3035.png)
![image](https://user-images.githubusercontent.com/6115458/118140892-17af4580-b409-11eb-9f46-40d54eb0143a.png)


## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
This is an edge case that happens randomly with very low incidence and probably impossible to reproduce deterministically, so it hasn't


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
