### PR TITLE
fix(VSelect): compare object values before emitting change

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -878,9 +878,13 @@ export default baseMixins.extend<options>().extend({
       this.selectedItems = selectedItems
     },
     setValue (value: any) {
-      const oldValue = this.internalValue
-      this.internalValue = value
-      value !== oldValue && this.$emit('change', value)
+      const newValue = this.returnObject ? value : this.getValue(value)
+      const oldValue = this.returnObject ? this.internalValue : this.getValue(this.internalValue)
+
+      if (!this.valueComparator(newValue, oldValue)) {
+        this.internalValue = value
+        this.$emit('change', value)
+      }
     },
     isAppendInner (target: any) {
       // return true if append inner is present

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect2.spec.ts
@@ -233,6 +233,28 @@ describe('VSelect.ts', () => {
     expect(change.mock.calls).toHaveLength(1)
   })
 
+  // https://github.com/vuetifyjs/vuetify/issues/13658
+  it('should not emit when clicked on the selected item - object values', async () => {
+    const onInput = jest.fn()
+    const itemA = { text: 'A', value: { foo: null } }
+    const itemB = { text: 'B', value: { foo: '' } }
+    const wrapper = mountFunction({
+      propsData: {
+        items: [itemA, itemB],
+        value: { foo: null },
+      },
+    })
+    wrapper.vm.$on('input', onInput)
+
+    wrapper.vm.selectItem(itemA)
+    await wrapper.vm.$nextTick()
+    expect(onInput).toHaveBeenCalledTimes(0)
+
+    wrapper.vm.selectItem(itemB)
+    await wrapper.vm.$nextTick()
+    expect(onInput).toHaveBeenCalledTimes(1)
+  })
+
   // Inspired by https://github.com/vuetifyjs/vuetify/pull/1425 - Thanks @kevmo314
   it('should open the select when focused and enter, space are pressed', async () => {
     const wrapper = mountFunction({

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`VSelect.ts should be clearable with prop, dirty and multi select 1`] = 
     <div role="button"
          aria-haspopup="listbox"
          aria-expanded="false"
-         aria-owns="list-106"
+         aria-owns="list-112"
          class="v-input__slot"
     >
       <div class="v-select__slot">
@@ -14,7 +14,7 @@ exports[`VSelect.ts should be clearable with prop, dirty and multi select 1`] = 
           <div class="v-select__selection v-select__selection--comma">
             1
           </div>
-          <input id="input-106"
+          <input id="input-112"
                  readonly="readonly"
                  type="text"
                  aria-readonly="false"
@@ -66,7 +66,7 @@ exports[`VSelect.ts should be clearable with prop, dirty and single select 1`] =
     <div role="button"
          aria-haspopup="listbox"
          aria-expanded="false"
-         aria-owns="list-99"
+         aria-owns="list-105"
          class="v-input__slot"
     >
       <div class="v-select__slot">
@@ -74,7 +74,7 @@ exports[`VSelect.ts should be clearable with prop, dirty and single select 1`] =
           <div class="v-select__selection v-select__selection--comma">
             1
           </div>
-          <input id="input-99"
+          <input id="input-105"
                  readonly="readonly"
                  type="text"
                  aria-readonly="false"


### PR DESCRIPTION
fixes #13658

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-select
      v-model="selected"
      :items="options"
    ></v-select>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      selected: { foo: null },
      options: [
        { text: 'A', value: { foo: null } },
        { text: 'B', value: { foo: '' } },
      ],
    }),
    watch: {
      selected (oldValue, newValue) {
        console.log(newValue.foo)
        console.log(oldValue.foo)
      },
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

