### PR TITLE
feat(VInput): add hide-spin-buttons prop

### DIFF
--- a/packages/api-generator/src/locale/en/v-input.json
+++ b/packages/api-generator/src/locale/en/v-input.json
@@ -4,6 +4,7 @@
     "backgroundColor": "Changes the background-color of the input",
     "dark": "Applies the dark theme variant to the component. This will default the components color to _white_ unless you've configured your [application theme](/customization/theme) to **dark** or if you are using the **color** prop on the component. You can find more information on the Material Design documentation for [dark themes](https://material.io/design/color/dark-theme.html).",
     "hideDetails": "Hides hint and validation errors. When set to `auto` messages will be rendered only if there's a message (hint, error message, counter value etc) to display",
+    "hideSpinButtons": "Hides spin buttons on the input when type is set to `number`.",
     "dense": "Reduces the input height",
     "height": "Sets the height of the input",
     "hint": "Hint text",

--- a/packages/vuetify/src/components/VInput/VInput.sass
+++ b/packages/vuetify/src/components/VInput/VInput.sass
@@ -125,3 +125,11 @@
   &--has-state
     &.error--text .v-label
       animation: v-shake .6s map-get($transition, 'swing')
+
+  &--hide-spin-buttons
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button 
+      -webkit-appearance: none
+      margin: 0
+    input[type=number] 
+      -moz-appearance: textfield

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -48,6 +48,7 @@ export default baseMixins.extend<options>().extend({
     dense: Boolean,
     height: [Number, String],
     hideDetails: [Boolean, String] as PropType<boolean | 'auto'>,
+    hideSpinButtons: Boolean,
     hint: String,
     id: String,
     label: String,
@@ -77,6 +78,7 @@ export default baseMixins.extend<options>().extend({
         'v-input--is-loading': this.loading !== false && this.loading != null,
         'v-input--is-readonly': this.isReadonly,
         'v-input--dense': this.dense,
+        'v-input--hide-spin-buttons': this.hideSpinButtons,
         ...this.themeClasses,
       }
     },


### PR DESCRIPTION
Add prop to hide spin buttons on number type input

feat #6157

## Description

Resolves #6157

Adds the `hide-spin-buttons` to `VInput`. This hides the spin buttons added by the browser to `number` type inputs.

## Motivation and Context

Hiding the spin buttons for VInput is a commonly searched/requested feature. The current solution is a copy-paste css snippet (see #6157).

## How Has This Been Tested?

Visually tested on Chrome, Firefox, and Safari.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-text-field
      type="number"
      hide-spin-buttons
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
```
</details>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [X] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
