### PR TITLE
fix(VCalendar): missing events under certain circumstances

### DIFF
--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
@@ -172,23 +172,25 @@ export default CalendarBase.extend({
 
         const parentBounds = parent.getBoundingClientRect()
         const last = events.length - 1
-        let hide = false
+        const eventsSorted = events.map(event => ({
+          event,
+          bottom: event.getBoundingClientRect().bottom,
+        })).sort((a, b) => a.bottom - b.bottom)
         let hidden = 0
 
         for (let i = 0; i <= last; i++) {
-          if (!hide) {
-            const eventBounds = events[i].getBoundingClientRect()
-            hide = i === last
-              ? (eventBounds.bottom > parentBounds.bottom)
-              : (eventBounds.bottom + eventHeight > parentBounds.bottom)
-          }
+          const bottom = eventsSorted[i].bottom
+          const hide = i === last
+            ? (bottom > parentBounds.bottom)
+            : (bottom + eventHeight > parentBounds.bottom)
+
           if (hide) {
-            events[i].style.display = 'none'
+            eventsSorted[i].event.style.display = 'none'
             hidden++
           }
         }
 
-        if (hide) {
+        if (hidden) {
           more.style.display = ''
           more.innerHTML = this.$vuetify.lang.t(this.eventMoreText, hidden)
         } else {


### PR DESCRIPTION
`events` in https://github.com/vuetifyjs/vuetify/blob/d9668ce058c4cccad5456d47194b42857e50226a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts#L168 were not sorted by the position (bounding rect), so if the first event was outside of the calendar cell then `hide` was set to `true` and all next events were treated as hidden. This PR sorts event by the `bottom` position, not sure if there's a way to get events properly sorted in `getEventsMap`

fixes #13720


## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
https://gist.githubusercontent.com/jacekkarczmarczyk/cd30d957a7d2a629e2bdd738d2fc6d61/raw/eaaf8d89c770c66fc27015bbeb382a27e5ba5ef1/vuetify-13720-playground.vue

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
