### PR TITLE
fix(VCard): set correct radius for direct VAvatar children

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -29,7 +29,7 @@
     border-top-left-radius: inherit
     border-top-right-radius: inherit
 
-  > *:last-child:not(.v-btn):not(.v-chip)
+  > *:last-child:not(.v-btn):not(.v-chip):not(.v-avatar)
     border-bottom-left-radius: inherit
     border-bottom-right-radius: inherit
 

--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -24,8 +24,8 @@
   position: relative
   white-space: $card-white-space
 
-  > *:first-child:not(.v-btn):not(.v-chip),
-  > .v-card__progress + *:not(.v-btn):not(.v-chip)
+  > *:first-child:not(.v-btn):not(.v-chip):not(.v-avatar),
+  > .v-card__progress + *:not(.v-btn):not(.v-chip):not(.v-avatar)
     border-top-left-radius: inherit
     border-top-right-radius: inherit
 


### PR DESCRIPTION
## Description

A sass rule makes a `VAvatar` that is the first child of a `VCard` look weird :

![image](https://user-images.githubusercontent.com/32643653/121726803-50ffd180-caeb-11eb-84e3-cd4d18f1bd62.png)

My change makes it back to normal :

![image](https://user-images.githubusercontent.com/32643653/121726834-5d842a00-caeb-11eb-91d9-bde131b17ee3.png)

It doesn't change modifiers, like `tile` :

![image](https://user-images.githubusercontent.com/32643653/121726882-6ecd3680-caeb-11eb-8e2f-2341489da87b.png)

## How Has This Been Tested?

I tested it visually. I am not comfortable with unit testing with a Vue framework but am willing to implement unit tests if they are required here, with some direction pointing

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-row>
      <v-card>
        <v-avatar size="40" color="primary">
          <span class="white--text text-h5">A</span>
        </v-avatar>
      </v-card>
    </v-row>
    <v-row>
      <v-card>
        <v-avatar tile size="40" color="primary">
          <span class="white--text text-h5">B</span>
        </v-avatar>
      </v-card>
    </v-row>
    <v-row>
      <v-card>
        <v-avatar rounded size="40" color="primary">
          <span class="white--text text-h5">C</span>
        </v-avatar>
      </v-card>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
