### PR TITLE
docs(VDataTable): add item-key prop info to expandable section

### DIFF
--- a/packages/docs/src/pages/en/components/data-tables.md
+++ b/packages/docs/src/pages/en/components/data-tables.md
@@ -157,7 +157,7 @@ The `v-edit-dialog` component can be used for editing data directly within a `v-
 
 #### Expandable rows
 
-The **show-expand** prop will render an expand icon on each default row. You can customize this with the `item.data-table-expand` slot. The position of this slot can be customized by adding a column with `value: 'data-table-expand'` to the headers array. You can also switch between allowing multiple expanded rows at the same time or just one with the **single-expand** prop. The expanded rows are available on the synced prop `expanded.sync`
+The **show-expand** prop will render an expand icon on each default row. You can customize this with the `item.data-table-expand` slot. The position of this slot can be customized by adding a column with `value: 'data-table-expand'` to the headers array. You can also switch between allowing multiple expanded rows at the same time or just one with the **single-expand** prop. The expanded rows are available on the synced prop `expanded.sync`. Row items require a unique key property for expansion to work. The default is `id`, but you can use the **item-key** prop to specify a different item property.
 
 <example file="v-data-table/misc-expand" />
 


### PR DESCRIPTION
## Description
A small documentation addition added to tell users that a unique row item key is required for v-data-table's expandable rows feature to work. Tells the user the default of `id` and tells the user how to change it with `item-key` prop. This documentation would have prevented false bug #8807.

## Motivation and Context
Added two short sentences because not knowing about the item-key prop tripped me up and I saw I wasn't the first: https://github.com/vuetifyjs/vuetify/issues/8807

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ x My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
