### PR TITLE
fix(VCombobox): re-compute menu items before setting index

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -658,12 +658,6 @@ export default baseMixins.extend<options>().extend({
       const keyCode = e.keyCode
       const menu = this.$refs.menu
 
-      // If enter, space, open menu
-      if ([
-        keyCodes.enter,
-        keyCodes.space,
-      ].includes(keyCode)) this.activateMenu()
-
       this.$emit('keydown', e)
 
       if (!menu) return
@@ -676,6 +670,12 @@ export default baseMixins.extend<options>().extend({
           this.$emit('update:list-index', menu.listIndex)
         })
       }
+
+      // If enter, space, open menu
+      if ([
+        keyCodes.enter,
+        keyCodes.space,
+      ].includes(keyCode)) this.activateMenu()
 
       // If menu is not active, up/down/home/end can do
       // one of 2 things. If multiple, opens the
@@ -696,11 +696,13 @@ export default baseMixins.extend<options>().extend({
       if (keyCode === keyCodes.space) return this.onSpaceDown(e)
     },
     onMenuActiveChange (val: boolean) {
-      if (!val) {
-        this.setMenuIndex(-1)
-        return
-      }
-      if (this.getMenuIndex() > -1) return
+      // If menu is closing and mulitple
+      // or menuIndex is already set
+      // skip menu index recalculation
+      if (
+        (this.multiple && !val) ||
+        this.getMenuIndex() > -1
+      ) return
 
       const menu = this.$refs.menu
 

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -696,19 +696,18 @@ export default baseMixins.extend<options>().extend({
       if (keyCode === keyCodes.space) return this.onSpaceDown(e)
     },
     onMenuActiveChange (val: boolean) {
-      // If menu is closing and mulitple
-      // or menuIndex is already set
-      // skip menu index recalculation
-      if (
-        (this.multiple && !val) ||
-        this.getMenuIndex() > -1
-      ) return
+      if (!val) {
+        this.setMenuIndex(-1)
+        return
+      }
+      if (this.getMenuIndex() > -1) return
 
       const menu = this.$refs.menu
 
       if (!menu || !this.isDirty) return
 
       // When menu opens, set index of first active item
+      this.$refs.menu.getTiles()
       for (let i = 0; i < menu.tiles.length; i++) {
         if (menu.tiles[i].getAttribute('aria-selected') === 'true') {
           this.setMenuIndex(i)
@@ -838,11 +837,6 @@ export default baseMixins.extend<options>().extend({
           this.$refs.menu &&
             (this.$refs.menu as { [key: string]: any }).updateDimensions()
         })
-
-        // We only need to reset list index for multiple
-        // to keep highlight when an item is toggled
-        // on and off
-        if (!this.multiple) return
 
         const listIndex = this.getMenuIndex()
 


### PR DESCRIPTION
fixes #12567

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-combobox :items="items"></v-combobox>
      <v-autocomplete :items="items"></v-autocomplete>
      <v-select :items="items"></v-select>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      items: ['a', 'b', 'c', 'd', 'e', 'f'],
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)
