### PR TITLE
docs(text-fields): remove conflict msg about cant use append/prepend icon

### DIFF
--- a/packages/docs/src/pages/en/components/overflow-btns.md
+++ b/packages/docs/src/pages/en/components/overflow-btns.md
@@ -55,7 +55,7 @@ You can use `dense` prop to reduce overflow button height and lower max height o
 
 #### Filled
 
-Text fields can be used with an alternative box design. Append and prepend icon props are **not** supported in this mode.
+Text fields can be used with an alternative box design.
 
 <example file="v-overflow-btn/prop-filled" />
 

--- a/packages/docs/src/pages/en/components/text-fields.md
+++ b/packages/docs/src/pages/en/components/text-fields.md
@@ -61,7 +61,7 @@ Text fields can be **disabled** or **readonly**.
 
 #### Filled
 
-Text fields can be used with an alternative box design. **append-icon** and **prepend-icon** props are _**not**_ supported in this mode.
+Text fields can be used with an alternative box design.
 
 <example file="v-text-field/prop-filled" />
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

Remove conflicting message about v-text-field and v-overflow-btn using "filled" prop can't use append and prepend icons

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

fixes #13817

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

Visually / Docs

## Markup:

<!-- Paste markup for testing your change --->
<details>
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)