### PR TITLE
fix(VAutocomplete): fix selected item reset when input is clear

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -346,6 +346,8 @@ export default VSelect.extend({
       // If typing and menu is not currently active
       if (target.value) this.activateMenu()
 
+      if (!this.multiple && value === '') this.deleteCurrentItem()
+
       this.internalSearch = value
       this.badInput = target.validity && target.validity.badInput
     },

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -237,4 +237,20 @@ describe('VAutocomplete.ts', () => {
 
     expect(onSearch).toHaveBeenCalledTimes(2)
   })
+
+  it('should reset selected item when text-field is cleared if not multiple', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo', 'bar'],
+        value: 'foo',
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.element.value = ''
+    input.trigger('input')
+
+    expect(wrapper.vm.internalValue).toBeNull()
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
This applies to non-multiple v-autocomplete component:
If you select an item and then try to remove it, selected item still appears.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## How Has This Been Tested?
Visually and by adding unit test.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
