### PR TITLE
fix(VSelect): Fixes missing selectedIndex initialization #13747

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -217,7 +217,7 @@ export default VSelect.extend({
       // for duplicate items? no idea
       if (val === oldVal) return
 
-      this.setMenuIndex(-1)
+      this.initializeSelectItemIndex()
 
       this.$nextTick(() => {
         if (

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
@@ -35,7 +35,7 @@ describe('VAutocomplete.ts', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/3793
-  it('should reset menu index after selection', async () => {
+  it('should reset menu index to selected item after selection', async () => {
     const wrapper = mountFunction({
       propsData: {
         items: ['foo', 'bar'],

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete2.spec.ts
@@ -39,7 +39,7 @@ describe('VAutocomplete.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         items: ['foo', 'bar'],
-        value: 'foo',
+        value: 'bar',
       },
     })
 
@@ -49,7 +49,7 @@ describe('VAutocomplete.ts', () => {
 
     expect(wrapper.vm.isMenuActive).toBe(true)
 
-    expect(wrapper.vm.getMenuIndex()).toBe(-1)
+    expect(wrapper.vm.getMenuIndex()).toBe(1)
   })
 
   it('should not remove a disabled item', () => {

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -129,6 +129,7 @@ export default baseMixins.extend<options>().extend({
       selectedItems: [] as any[],
       keyboardLookupPrefix: '',
       keyboardLookupLastTime: 0,
+      customIndex: -1,
     }
   },
 
@@ -279,11 +280,7 @@ export default baseMixins.extend<options>().extend({
   },
 
   mounted () {
-    // no need for initialization for multiple select
-    // as no single item can be selected
-    if (this.multiple) return
-    const index = this.allItems.findIndex(item => item === this.selectedItems[0])
-    this.setMenuIndex(index)
+    this.initializeSelectItemIndex()
   },
 
   methods: {
@@ -897,6 +894,14 @@ export default baseMixins.extend<options>().extend({
       const appendInner = this.$refs['append-inner']
 
       return appendInner && (appendInner === target || appendInner.contains(target))
+    },
+    initializeSelectItemIndex () {
+      if (this.multiple) return
+      if (this.customIndex === -1) {
+        const index = this.allItems.findIndex(item => item === this.selectedItems[0])
+        this.setMenuIndex(index)
+        this.customIndex = index
+      }
     },
   },
 })

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -284,7 +284,6 @@ export default baseMixins.extend<options>().extend({
     if (this.multiple) return
     const index = this.allItems.findIndex(item => item === this.selectedItems[0])
     this.setMenuIndex(index)
-    // this.selectedIndex = index
   },
 
   methods: {

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -278,6 +278,15 @@ export default baseMixins.extend<options>().extend({
     },
   },
 
+  mounted () {
+    // no need for initialization for multiple select
+    // as no single item can be selected
+    if (this.multiple) return
+    const index = this.allItems.findIndex(item => item === this.selectedItems[0])
+    this.setMenuIndex(index)
+    // this.selectedIndex = index
+  },
+
   methods: {
     /** @public */
     blur (e?: Event) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Add initialization of selectedIndex for VSelect so that when starting to use it with the keyboard, the selection movement starts from the currently selected item, instead of from the top.

## Motivation and Context
This resolves the issue #13747 

## How Has This Been Tested?
The testing has been done visually using the playground below.
Click the select and use the keyboard to dchange the selected item. 
Before the change it would start from the top, after the change it should start from the selected item.
Also one test has been updated to take this into account.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
 <v-container>
   <v-autocomplete
     v-model="value"
     :items="items"
     dense
     filled
     label="Filled"
   ></v-autocomplete>
 </v-container>
</template>
 
<script>
 export default {
   data: () => ({
     items: ['foo', 'bar', 'fizz', 'buzz'],
     value: 'bar',
   }),
 }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
