### PR TITLE
fix(VTreeView): Null check when building tree from children

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -201,14 +201,10 @@ export default mixins(
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
         const key = getObjectValueByPath(item, this.itemKey)
-        const children = getObjectValueByPath(item, this.itemChildren, [])
+        const children = getObjectValueByPath(item, this.itemChildren, []) ?? []
         const oldNode = this.nodes.hasOwnProperty(key) ? this.nodes[key] : {
           isSelected: false, isIndeterminate: false, isActive: false, isOpen: false, vnode: null,
         } as NodeState
-
-        if(!children){
-          children = []
-        }
 
         const node: any = {
           vnode: oldNode.vnode,

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -201,7 +201,7 @@ export default mixins(
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
         const key = getObjectValueByPath(item, this.itemKey)
-        const children = getObjectValueByPath(item, this.itemChildren, [])
+        const children = getObjectValueByPath(item, this.itemChildren, []) ?? []
         const oldNode = this.nodes.hasOwnProperty(key) ? this.nodes[key] : {
           isSelected: false, isIndeterminate: false, isActive: false, isOpen: false, vnode: null,
         } as NodeState

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -201,7 +201,7 @@ export default mixins(
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
         const key = getObjectValueByPath(item, this.itemKey)
-        const children = getObjectValueByPath(item, this.itemChildren, []) ?? []
+        const children = getObjectValueByPath(item, this.itemChildren) ?? []
         const oldNode = this.nodes.hasOwnProperty(key) ? this.nodes[key] : {
           isSelected: false, isIndeterminate: false, isActive: false, isOpen: false, vnode: null,
         } as NodeState

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -201,10 +201,14 @@ export default mixins(
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
         const key = getObjectValueByPath(item, this.itemKey)
-        const children = getObjectValueByPath(item, this.itemChildren, []) ?? []
+        const children = getObjectValueByPath(item, this.itemChildren, [])
         const oldNode = this.nodes.hasOwnProperty(key) ? this.nodes[key] : {
           isSelected: false, isIndeterminate: false, isActive: false, isOpen: false, vnode: null,
         } as NodeState
+
+        if(!children){
+          children = []
+        }
 
         const node: any = {
           vnode: oldNode.vnode,


### PR DESCRIPTION
## Description

When using VTreeView and the [item-children](https://vuetifyjs.com/en/api/v-treeview/#props-item-children) is null or undefined, then a `children.map` in `VTreeview.ts` will cause an error. 

![image](https://user-images.githubusercontent.com/15127381/125161923-7123be80-e185-11eb-9f72-15ac75812352.png)

## Motivation and Context
Adding a simple null/undefined check and then setting it to `[]` fixes this problem. 
[[Bug Report] VTreeNode: Null or Undefined children causing trouble with event bubbling #9376 (comment)](https://github.com/vuetifyjs/vuetify/issues/9376#issuecomment-572765655) 

## How Has This Been Tested?
Tested in my current project by adding the same code and this fixes the problem. Children which are undefined are not expandable. 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-treeview :items="items" />
</template>

<script>
  export default {
    data: () => ({
      items: [
        {
          id: 'a',
          name: 'This one is  active with no exception',
        },
        {
          id: 'b',
          name: 'So it this one, you can see it as active',
          children: [
            {
              id: 'a',
              name: 'This one is  active with no exception',
            },
            {
              id: 'b',
              name: 'So it this one, you can see it as active',
              children: [],
            },
            {
              id: 'c',
              name: 'But this one is crashing during the build tree so its messing up',
              children: null,
            },
            {
              id: 'd',
              name: 'and so is tzhis one',
              children: undefined,
            },
          ],
        },
        {
          id: 'c',
          name: 'But this one is crashing during the build tree so its messing up',
          children: null,
        },
        {
          id: 'd',
          name: 'and so is tzhis one',
          children: undefined,
        },
      ],
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [X] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
