### PR TITLE
docs(navigation-drawers): fix typo

### DIFF
--- a/packages/docs/src/pages/en/components/navigation-drawers.md
+++ b/packages/docs/src/pages/en/components/navigation-drawers.md
@@ -77,7 +77,7 @@ By default, a navigation drawer has a 1px right border that separates it from co
 
 #### Right
 
-Navigation drawers can also be positioned on the right side of your application (or an element). This is also useful for creating a side-sheet with auxilliary information that may not have any navigation links. When using **RTL** you must explicitly define **right** for your drawer.
+Navigation drawers can also be positioned on the right side of your application (or an element). This is also useful for creating a side-sheet with auxiliary information that may not have any navigation links. When using **RTL** you must explicitly define **right** for your drawer.
 
 <example file="v-navigation-drawer/prop-right" />
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Description
Fix a typo in [Navigation drawers docs (v2.5.6)](https://vuetifyjs.com/en/components/navigation-drawers/#right).

## Types of changes
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
