### PR TITLE
fix(VTreeView)Type independent selection drops on async children

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -228,7 +228,7 @@ export default mixins(
 
         this.nodes[key] = node
 
-        if (children.length) {
+        if (children.length && this.selectionType !== 'independent') {
           const { isSelected, isIndeterminate } = this.calculateState(key, this.nodes)
 
           node.isSelected = isSelected


### PR DESCRIPTION
From https://github.com/vuetifyjs/vuetify/issues/11015

When using selection-type="independant" and loading async children the current value of the v-model is resset.

## Description
Adding a check if current selection type is independant.
Resolves & inspired by https://github.com/vuetifyjs/vuetify/issues/11015


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
No tests added, I have tested this on my local dev, don't know if I should do more ?

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
