### PR TITLE
fix(VIcon): allow colons to be used in icon names

### DIFF
--- a/packages/vuetify/src/composables/__tests__/icons.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/icons.spec.ts
@@ -1,0 +1,53 @@
+// Composables
+import { useIcon } from '../icons'
+
+// Utilities
+import { defineComponent } from 'vue'
+import { createVuetify } from '@/framework'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from '@jest/globals'
+
+describe('icons.tsx', () => {
+  const Component = defineComponent({
+    props: {
+      icon: String,
+    },
+    setup (props) {
+      const { iconData } = useIcon(props)
+
+      return () => iconData.value.icon
+    },
+  })
+
+  const vuetify = createVuetify({
+    icons: {
+      defaultSet: 'mdi',
+      sets: {
+        custom: {
+          component: () => null,
+        },
+      },
+    },
+  })
+
+  it.each([
+    // Default icon set.
+    ['success', 'success'],
+    ['https://example.com/icon.svg', 'https://example.com/icon.svg'],
+    // MDI icon set.
+    ['mdi:success', 'success'],
+    // Custom icon set.
+    ['custom:https://example.com/icon.png', 'https://example.com/icon.png'],
+  ])('should return the correct icon name', (icon, expected) => {
+    const wrapper = mount(Component, {
+      props: {
+        icon,
+      },
+      global: {
+        plugins: [vuetify],
+      },
+    })
+
+    expect(wrapper.text()).toEqual(expected)
+  })
+})

--- a/packages/vuetify/src/composables/icons.tsx
+++ b/packages/vuetify/src/composables/icons.tsx
@@ -182,23 +182,16 @@ export const useIcon = (props: Ref<string | undefined> | { icon?: IconValue }) =
       }
     }
 
-    let iconSet: IconSet | undefined
-    let iconName: string | undefined
+    const iconSetName = Object.keys(icons.sets).find(
+      setName => typeof icon === 'string' && icon.startsWith(`${setName}:`)
+    )
 
-    for (const iconSetName of Object.keys(icons.sets)) {
-      const iconSetPrefix = `${iconSetName}:`
-
-      if (icon.startsWith(iconSetPrefix)) {
-        iconSet = icons.sets[iconSetName]
-        iconName = icon.slice(iconSetPrefix.length)
-
-        break
-      }
-    }
+    const iconName = iconSetName ? icon.slice(iconSetName.length + 1) : icon
+    const iconSet = icons.sets[iconSetName ?? icons.defaultSet]
 
     return {
-      component: (iconSet ?? icons.sets[icons.defaultSet]).component,
-      icon: iconName ?? icon,
+      component: iconSet.component,
+      icon: iconName,
     }
   })
 

--- a/packages/vuetify/src/composables/icons.tsx
+++ b/packages/vuetify/src/composables/icons.tsx
@@ -182,18 +182,23 @@ export const useIcon = (props: Ref<string | undefined> | { icon?: IconValue }) =
       }
     }
 
-    const hasSet = icon.includes(':')
-    const setName = hasSet ? icon.split(':')[0] : icons.defaultSet
-    const iconName = hasSet ? icon.split(':')[1] : icon
-    const set = icons.sets[setName ?? icons.defaultSet]
+    let iconSet: IconSet | undefined
+    let iconName: string | undefined
 
-    if (!set) {
-      throw new Error(`Could not find icon set "${setName}"`)
+    for (const iconSetName of Object.keys(icons.sets)) {
+      const iconSetPrefix = `${iconSetName}:`
+
+      if (icon.startsWith(iconSetPrefix)) {
+        iconSet = icons.sets[iconSetName]
+        iconName = icon.slice(iconSetPrefix.length)
+
+        break
+      }
     }
 
     return {
-      component: set.component,
-      icon: iconName,
+      component: (iconSet ?? icons.sets[icons.defaultSet]).component,
+      icon: iconName ?? icon,
     }
   })
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

Implements the [suggestion](https://github.com/vuetifyjs/vuetify/issues/13975#issuecomment-893723888) by @nekosaur in #13975 – match the start of an icon string with the registered icon sets, instead of assuming that any string containing a colon includes an icon set name.

Fixes #13975. (_hopefully_ – not yet tested [see below])

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

See #13975. It allows icons to be URLs.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

There is no test file for the icon composable. I tried to add one, but I got a bit stuck:

```ts
// Composables
import { useIcon } from '../icons'

describe('icons.ts', () => {
  it.each([
    // Default icon set.
    ["success", {component: ???, icon: "success"}],
    ["https://example.com/icon.svg", {component: ???, icon: "https://example.com/icon.svg"}],
    // MDI icon set.
    ["mdi:success", {component: ???, icon: "success"}],
    // Custom icon set.
    ["custom:https://example.com/icon.png", {component: ???, icon: "https://example.com/icon.png"}],
  ])('should return the correct icon set and name', (props, expected) => {
    const { iconData } = useIcon(props)

    expect(iconData.value.component).toEqual(expected.component)
    expect(iconData.value.icon).toEqual(expected.icon)
  })
})
```

I'm not sure how to configure/reference the icon set components.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
