### PR TITLE
docs(prerender): do not prerender wireframes

### DIFF
--- a/packages/docs/build/generate-routes.js
+++ b/packages/docs/build/generate-routes.js
@@ -48,12 +48,15 @@ function genDemos () {
   return paths
 }
 
-function generateRoutes () {
+function generateRoutes (options = {}) {
+  const { excludeDemos } = options
   const paths = [
     ...genRoutes(DATA_PATH_DOC_FILES, ''),
     ...genRoutes(DATA_PATH_API_FILES, 'api/'),
-    ...genDemos(),
   ]
+  if (!excludeDemos) {
+    paths.push(...genDemos())
+  }
 
   const routes = [{ locale: '', path: '', fullPath: '/' }]
 

--- a/packages/docs/build/prerender.js
+++ b/packages/docs/build/prerender.js
@@ -123,7 +123,7 @@ function render ({ routes, template, bundle, clientManifest }) {
 }
 
 if (isMainThread) {
-  const routes = generateRoutes()
+  const routes = generateRoutes({ excludeDemos: true })
   const template = readFile('../src/ssr.template.html')
   const bundle = JSON.parse(readFile('../dist/vue-ssr-server-bundle.json'))
   const clientManifest = JSON.parse(readFile('../dist/vue-ssr-client-manifest.json'))


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
resolves #12854

## Motivation and Context
#12854

## How Has This Been Tested?
 visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
