### PR TITLE
Fix(VImg): support gradient prop

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.sass
+++ b/packages/vuetify/src/components/VImg/VImg.sass
@@ -15,6 +15,9 @@
   width: 100%
   height: 100%
 
+.v-img__wrapper
+  width: 100%
+
 .v-img__img
   &--preload
     filter: $img-preload-filter

--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -47,6 +47,7 @@ export default defineComponent({
     alt: String,
     cover: Boolean,
     eager: Boolean,
+    gradient: String,
     lazySrc: String,
     options: {
       type: Object as PropType<IntersectionObserverInit>,
@@ -192,15 +193,29 @@ export default defineComponent({
         onError,
       })
 
+      const imagWrapperStyle: any = {}
+
+      if (props.gradient) {
+        imagWrapperStyle.backgroundImage = `linear-gradient(${props.gradient})`
+        imagWrapperStyle.backgroundPosition = props.position
+      }
+
       const sources = slots.sources?.()
+
+      const imgContent = sources
+        ? <picture class="v-img__picture">{ sources }{ img }</picture>
+        : img
+
+      const imgWrapper = h('div', {
+        class: ['v-img__wrapper'],
+        style: imagWrapperStyle,
+      }, [imgContent])
 
       return (
         <MaybeTransition transition={ props.transition } appear>
           {
             withDirectives(
-              sources
-                ? <picture class="v-img__picture">{ sources }{ img }</picture>
-                : img,
+              imgWrapper,
               [[vShow, state.value === 'loaded']]
             )
           }

--- a/packages/vuetify/src/components/VImg/__tests__/__snapshots__/VImg.spec.ts.snap
+++ b/packages/vuetify/src/components/VImg/__tests__/__snapshots__/VImg.spec.ts.snap
@@ -5,9 +5,11 @@ exports[`VImg should display error slot 1`] = `
   <div class="v-responsive__sizer">
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain"
+    <div class="v-img__wrapper"
          style="display: none;"
     >
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -26,9 +28,11 @@ exports[`VImg should display placeholders 1`] = `
   <div class="v-responsive__sizer">
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain"
+    <div class="v-img__wrapper"
          style="display: none;"
     >
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
     <img class="v-img__img v-img__img--preload v-img__img--contain"
@@ -52,7 +56,9 @@ exports[`VImg should display placeholders 2`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain">
+    <div class="v-img__wrapper">
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -71,7 +77,9 @@ exports[`VImg should have aria attributes 1`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain">
+    <div class="v-img__wrapper">
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -83,9 +91,11 @@ exports[`VImg should load 1`] = `
   <div class="v-responsive__sizer">
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain"
+    <div class="v-img__wrapper"
          style="display: none;"
     >
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -99,7 +109,9 @@ exports[`VImg should load 2`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain">
+    <div class="v-img__wrapper">
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -113,9 +125,11 @@ exports[`VImg should override vuetify-loader values 1`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain"
+    <div class="v-img__wrapper"
          style="display: none;"
     >
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
     <img class="v-img__img v-img__img--preload v-img__img--contain"
@@ -132,10 +146,12 @@ exports[`VImg should render a <picture> 1`] = `
   >
   </div>
   <transition-stub>
-    <picture class="v-img__picture">
-      <source srcset="LOAD_SUCCESS_SRC.webp">
-      <img class="v-img__img v-img__img--contain">
-    </picture>
+    <div class="v-img__wrapper">
+      <picture class="v-img__picture">
+        <source srcset="LOAD_SUCCESS_SRC.webp">
+        <img class="v-img__img v-img__img--contain">
+      </picture>
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -149,7 +165,9 @@ exports[`VImg should update src 1`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain">
+    <div class="v-img__wrapper">
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -163,7 +181,9 @@ exports[`VImg should update src 2`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain">
+    <div class="v-img__wrapper">
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -175,9 +195,11 @@ exports[`VImg should update src while still loading 1`] = `
   <div class="v-responsive__sizer">
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain"
+    <div class="v-img__wrapper"
          style="display: none;"
     >
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -191,7 +213,9 @@ exports[`VImg should update src while still loading 2`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain">
+    <div class="v-img__wrapper">
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
   </transition-stub>
@@ -205,9 +229,11 @@ exports[`VImg should use vuetify-loader data 1`] = `
   >
   </div>
   <transition-stub>
-    <img class="v-img__img v-img__img--contain"
+    <div class="v-img__wrapper"
          style="display: none;"
     >
+      <img class="v-img__img v-img__img--contain">
+    </div>
   </transition-stub>
   <transition-stub>
     <img class="v-img__img v-img__img--preload v-img__img--contain"


### PR DESCRIPTION
fixes #13964

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
resolves #13964

1. I assume the issue is talking about `gradient` prop that is supposed to be consistent with Vuetify 2 (https://vuetifyjs.com/en/api/v-img/#api-props). If my assumption is wrong, feel free to close this pull request
2. My solution is adding a wrapper `div` around the eventual `img` tag and apply  gradient effect into this wrapper `div`, because the div with `v-responsive__sizer` should not be responsible for gradient effect

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves #13964

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit & visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-container>
    <v-img src="https://images.unsplash.com/photo-1621192488040-c91d793fb659?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=750&q=80" cover max-height="300" gradient="to bottom, rgba(0,0,0,.87), rgba(0,0,0.87)"></v-img>
    <v-img class="v-workaround-img" src="https://images.unsplash.com/photo-1621192488040-c91d793fb659?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=750&q=80" cover max-height="300"></v-img>
  </v-container>
</template>

<script>
export default {
  data: () => ({
  }),
  mounted () {
  },
};
</script>

<style>
.v-workaround-img .v-responsive__sizer {
  
  background: linear-gradient(to bottom, rgba(0,0,0,.87), rgba(0,0,0.87))
}
</style>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
