### PR TITLE
Fix(VCalendarCategory): fix touchmove does not notice category change

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.ts
@@ -129,6 +129,17 @@ export default VCalendarDaily.extend({
       const data = {
         staticClass: 'v-calendar-category__column',
         on: this.getDefaultMouseEventHandlers(':time-category', e => {
+          if (e instanceof TouchEvent) {
+            const target = document.elementFromPoint(e.changedTouches[0].clientX, e.changedTouches[0].clientY)
+
+            if (target?.parentElement?.parentElement) {
+              const dayContainerDom: Element = this.$refs['day-container'] as Element
+              const dailyDayArr = dayContainerDom.getElementsByClassName('v-calendar-daily__day')
+              const categoryIndex = Array.from(dailyDayArr).indexOf(target?.parentElement?.parentElement)
+              category = this.parsedCategories[categoryIndex]
+            }
+          }
+
           return this.getCategoryScope(this.getSlotScope(this.getTimestampAtEvent(e, day)), category)
         }),
       }

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -154,6 +154,7 @@ export default CalendarWithIntervals.extend({
     genDayContainer (): VNode {
       return this.$createElement('div', {
         staticClass: 'v-calendar-daily__day-container',
+        ref: 'day-container',
       }, [
         this.genBodyIntervals(),
         ...this.genDays(),


### PR DESCRIPTION
fixes #12366

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #12366

According to [developer api for Touch.target](https://developer.mozilla.org/en-US/docs/Web/API/Touch/target):

> Returns the Element (EventTarget) on which the touch contact started when it was first placed on the surface, even if the touch point has since moved outside the interactive area of that element or even been removed from the document.

Therefore, this issue is caused by `target` in `touchmove` is always the first touch div and it does not automatically change to different current div that touch point is on.

**Solution**: Add a dedicated logic to extract category by getting current div that touch point is on for `touchmove` only in `VCalendarCategory`, 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-container>
    <v-calendar 
      type="category"
      category-show-all
      :categories="categories"          
      :events="events"
      @mousemove:time-category="move"
      @touchmove:time-category="move"
    />
  </v-container>
</template>

<script>
export default {
  data: () => ({
    events: [],
    categories: ['John Smith', 'Tori Walker'],
    moveCategory: null
  }),
  methods: {
    move({category}) {
      console.log(category)
      this.moveCategory = category
    }
  },
};
</script>

<style>
.scrolling-div {
  width: 200px;
  height: 100px;
  overflow: auto;
  white-space: nowrap;
}
</style>


```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
