### PR TITLE
feat(hydration): create new composable

### DIFF
--- a/packages/vuetify/src/components/VNoSsr/VNoSsr.tsx
+++ b/packages/vuetify/src/components/VNoSsr/VNoSsr.tsx
@@ -1,12 +1,9 @@
 // Utilities
-import { defineComponent, IN_BROWSER } from '@/util'
-import { onMounted, ref } from 'vue'
+import { defineComponent } from '@/util'
+import { ref } from 'vue'
 
-function doesHydrate (fn: () => void) {
-  if (!IN_BROWSER) return
-  // @ts-expect-error
-  return document.querySelector('#app')?.__vue_app__ ? fn() : onMounted(fn)
-}
+// Composables
+import { useHydration } from '@/composables/hydration'
 
 export default defineComponent({
   name: 'VNoSsr',
@@ -14,7 +11,7 @@ export default defineComponent({
   setup (_, { slots }) {
     const show = ref(false)
 
-    doesHydrate(() => {
+    useHydration(() => {
       show.value = true
     })
 

--- a/packages/vuetify/src/components/VNoSsr/VNoSsr.tsx
+++ b/packages/vuetify/src/components/VNoSsr/VNoSsr.tsx
@@ -1,9 +1,9 @@
+// Composables
+import { useHydration } from '@/composables/hydration'
+
 // Utilities
 import { defineComponent } from '@/util'
 import { ref } from 'vue'
-
-// Composables
-import { useHydration } from '@/composables/hydration'
 
 export default defineComponent({
   name: 'VNoSsr',
@@ -11,9 +11,7 @@ export default defineComponent({
   setup (_, { slots }) {
     const show = ref(false)
 
-    useHydration(() => {
-      show.value = true
-    })
+    useHydration(() => (show.value = true))
 
     return () => show.value && slots.default?.()
   },

--- a/packages/vuetify/src/composables/hydration.ts
+++ b/packages/vuetify/src/composables/hydration.ts
@@ -1,0 +1,10 @@
+import { IN_BROWSER } from '@/util'
+import { getCurrentInstance, onMounted } from 'vue'
+
+export function useHydration (callback: () => void) {
+  if (!IN_BROWSER) return
+  const vm = getCurrentInstance()
+  const elId = vm?.root?.appContext?.app?._container?.id
+  // @ts-expect-error
+  return document.querySelector(`#${elId}`)?.__vue_app__ ? callback() : onMounted(callback)
+}

--- a/packages/vuetify/src/composables/hydration.ts
+++ b/packages/vuetify/src/composables/hydration.ts
@@ -4,7 +4,7 @@ import { getCurrentInstance, onMounted } from 'vue'
 export function useHydration (callback: () => void) {
   if (!IN_BROWSER) return
   const vm = getCurrentInstance()
-  const elId = vm?.root?.appContext?.app?._container?.id
-  // @ts-expect-error
-  return document.querySelector(`#${elId}`)?.__vue_app__ ? callback() : onMounted(callback)
+  const rootEl = vm?.root?.appContext?.app?._container
+
+  return rootEl?.__vue_app__ ? callback() : onMounted(callback)
 }

--- a/packages/vuetify/src/composables/hydration.ts
+++ b/packages/vuetify/src/composables/hydration.ts
@@ -1,9 +1,11 @@
-import { IN_BROWSER } from '@/util'
-import { getCurrentInstance, onMounted } from 'vue'
+// Utilities
+import { getCurrentInstance, IN_BROWSER } from '@/util'
+import { onMounted } from 'vue'
 
 export function useHydration (callback: () => void) {
   if (!IN_BROWSER) return
-  const vm = getCurrentInstance()
+
+  const vm = getCurrentInstance('useHydration')
   const rootEl = vm?.root?.appContext?.app?._container
 
   return rootEl?.__vue_app__ ? callback() : onMounted(callback)


### PR DESCRIPTION
## Description
Hydration composable checks if app/component is being generated/rendered on the server and waits to execute until on the client, else it executes right away.

## Motivation and Context
This composable supports the VNoSsr component and other components that need to only execute functions on the client.

## How Has This Been Tested?
Playground and dev:ssr

## Markup:
<details>

```vue
<template>
  <div>Server-side; This should display</div>
  <v-no-ssr> This is only supposed to be on the client</v-no-ssr>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
