### PR TITLE
fix(VBtn): use flex: 1 instead of 100% width in bottom nav

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -131,7 +131,7 @@
     @include tools.rounded($button-bottom-navigation-border-radius)
 
   .v-bottom-navigation--grow &
-    width: 100%
+    flex: 1;
 
   .v-bottom-navigation--horizontal &
     flex-direction: row


### PR DESCRIPTION
Using `width: 100%` to grow the buttons in a bottom navigation makes them too wide:

![grafik](https://user-images.githubusercontent.com/8600029/131973166-8b4cb01a-b7e6-4ea8-b08f-09ffa3096624.png)

Since the surrounding container is a `flex` container, `flex: 1` should be used:

![grafik](https://user-images.githubusercontent.com/8600029/131973259-7d1c5729-93c5-4071-9552-8c4b33542a2d.png)
