### PR TITLE
fix(VListItem): allow default color to change when inactive

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -6,7 +6,7 @@
     color: map-deep-get($material, 'text', 'disabled')
 
   &:not(.v-list-item--active):not(.v-list-item--disabled)
-    color: map-deep-get($material, 'text', 'primary') !important
+    color: map-deep-get($material, 'text', 'primary')
 
   .v-list-item__mask
     color: map-deep-get($material, 'text', 'disabled')
@@ -265,3 +265,4 @@
     -webkit-line-clamp: 2
     -webkit-box-orient: vertical
     display: -webkit-box
+

--- a/packages/vuetify/src/components/VList/VListItem.ts
+++ b/packages/vuetify/src/components/VList/VListItem.ts
@@ -150,6 +150,10 @@ export default baseMixins.extend<options>().extend({
 
       return attrs
     },
+    toggle () {
+      this.isActive = !this.isActive
+      this.$emit('change')
+    },
   },
 
   render (h): VNode {
@@ -182,6 +186,6 @@ export default baseMixins.extend<options>().extend({
       })
       : this.$slots.default
 
-    return h(tag, this.setTextColor(this.color, data), children)
+    return h(tag, this.isActive ? this.setTextColor(this.color, data) : data, children)
   },
 })

--- a/packages/vuetify/src/components/VList/VListItem.ts
+++ b/packages/vuetify/src/components/VList/VListItem.ts
@@ -151,8 +151,10 @@ export default baseMixins.extend<options>().extend({
       return attrs
     },
     toggle () {
-      this.isActive = !this.isActive
-      this.$emit('change')
+      if (this.inputValue === undefined) {
+        this.isActive = !this.isActive
+        this.$emit('change')
+      }
     },
   },
 

--- a/packages/vuetify/src/components/VList/VListItem.ts
+++ b/packages/vuetify/src/components/VList/VListItem.ts
@@ -151,10 +151,10 @@ export default baseMixins.extend<options>().extend({
       return attrs
     },
     toggle () {
-      if (this.inputValue === undefined) {
+      if (this.to && this.inputValue === undefined) {
         this.isActive = !this.isActive
-        this.$emit('change')
       }
+      this.$emit('change')
     },
   },
 

--- a/packages/vuetify/src/components/VList/__tests__/VListItem.spec.ts
+++ b/packages/vuetify/src/components/VList/__tests__/VListItem.spec.ts
@@ -218,4 +218,20 @@ describe('VListItem.ts', () => {
     })
     expect(wrapper5.element.getAttribute('role')).toBe('listitem')
   })
+
+  it('should not have an internal state unless its a router-link', async () => {
+    const wrapper = mountFunction({})
+
+    expect(wrapper.vm.isActive).toBeFalsy()
+    wrapper.vm.toggle()
+    expect(wrapper.vm.isActive).toBeFalsy()
+    wrapper.vm.toggle()
+    expect(wrapper.vm.isActive).toBeFalsy()
+
+    const wrapper2 = mountFunction({ propsData: { to: { name: 'test' } }, stubs: ['router-link'] })
+
+    expect(wrapper2.vm.isActive).toBeFalsy()
+    wrapper2.vm.toggle()
+    expect(wrapper2.vm.isActive).toBeTruthy()
+  })
 })

--- a/packages/vuetify/src/mixins/routable/__tests__/routable.spec.ts
+++ b/packages/vuetify/src/mixins/routable/__tests__/routable.spec.ts
@@ -1,17 +1,94 @@
 import Routable from '../'
-import { mount } from '@vue/test-utils'
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils'
+import Router from 'vue-router'
+import Vue, { VNode } from 'vue'
 
 describe('routable.ts', () => {
+  let mountFunction: (options?: object) => Wrapper<Vue>
+  let router: Router
+  let localVue: typeof Vue
+
+  beforeEach(() => {
+    router = new Router()
+    localVue = createLocalVue()
+    localVue.use(Router)
+
+    mountFunction = (options = {}) => {
+      return mount({
+        mixins: [Routable],
+        props: {
+          activeClass: {
+            default: 'active',
+          },
+          exactActiveClass: {
+            default: 'exact-active',
+          },
+        },
+        render (h): VNode {
+          const { tag, data } = this.generateRouteLink()
+
+          data.attrs = {
+            ...data.attrs,
+          }
+          data.on = {
+            ...data.on,
+          }
+
+          return h(tag, data, this.$slots.default)
+        },
+      }, {
+        localVue,
+        router,
+        ...options,
+      })
+    }
+  })
   it('should generate exact route link with to="/" and undefined exact', async () => {
-    const wrapper = mount({
-      mixins: [Routable],
-      render: h => h('div'),
-    }, {
+    const wrapper = mountFunction({
       propsData: {
         to: '/',
       },
     })
 
     expect(wrapper.vm.generateRouteLink().data.props.exact).toBe(true)
+  })
+
+  it('should reflect the link state to isActive', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        to: '/',
+      },
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
+
+    // Simulate route changing
+    wrapper.vm.$router.push('/foo')
+
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+
+    wrapper.vm.$router.push('/')
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
+  })
+
+  it('should reflect the link state to isActive if not exact', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        to: '/foo',
+      },
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+
+    // Simulate route changing
+    wrapper.vm.$router.push('/foo')
+
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(true)
   })
 })

--- a/packages/vuetify/src/mixins/routable/index.ts
+++ b/packages/vuetify/src/mixins/routable/index.ts
@@ -75,6 +75,10 @@ export default Vue.extend({
     $route: 'onRouteChange',
   },
 
+  mounted () {
+    this.onRouteChange()
+  },
+
   methods: {
     click (e: MouseEvent): void {
       this.$emit('click', e)
@@ -145,11 +149,13 @@ export default Vue.extend({
 
       this.$nextTick(() => {
         /* istanbul ignore else */
-        if (getObjectValueByPath(this.$refs.link, path)) {
+        if (!getObjectValueByPath(this.$refs.link, path) === this.isActive) {
           this.toggle()
         }
       })
     },
-    toggle: () => { /* noop */ },
+    toggle () {
+      this.isActive = !this.isActive
+    },
   },
 })

--- a/packages/vuetify/src/mixins/routable/index.ts
+++ b/packages/vuetify/src/mixins/routable/index.ts
@@ -144,8 +144,9 @@ export default Vue.extend({
     onRouteChange () {
       if (!this.to || !this.$refs.link || !this.$route) return
       const activeClass = `${this.activeClass} ${this.proxyClass || ''}`.trim()
+      const exactActiveClass = `${this.exactActiveClass} ${this.proxyClass || ''}`.trim() || activeClass
 
-      const path = `_vnode.data.class.${activeClass}`
+      const path = '_vnode.data.class.' + (this.exact ? exactActiveClass : activeClass)
 
       this.$nextTick(() => {
         /* istanbul ignore else */


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Restores #13719
Fixes #14186
Fixes #9285

## Motivation and Context
The isActive variable was not changing when using a router element, with this PR this makes sure that it reflects the current state of the router link, taking into account if it's exact

## How Has This Been Tested?
With the playground, the doc and new test units
![image](https://user-images.githubusercontent.com/6115458/135163708-fd62ffa9-e751-44fa-8ec8-534e23d34464.png)


## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue<template>
 <template>
  <v-container>
    <v-list-group group="/page2">
      <template #activator>
        <v-list-item-title>Pages</v-list-item-title>
      </template>
      <v-list>
        <v-list-item
          v-for="i in 2"
          :key="i"
          :to="{path: '/page' + i}"
          color="primary"
        >
          <v-list-item-content>
            <v-list-item-title>Page {{ i }}</v-list-item-title>
          </v-list-item-content>
        </v-list-item>
      </v-list>
    </v-list-group>
    <v-list-group group="/page1">
      <template #activator>
        <v-list-item-title>Pages</v-list-item-title>
      </template>
      <v-list>
        <v-list-item
          v-for="i in 2"
          :key="i"
          :to="{path: '/page' + i}"
          color="primary"
        >
          <v-list-item-content>
            <v-list-item-title>Page {{ i }}</v-list-item-title>
          </v-list-item-content>
        </v-list-item>
      </v-list>
    </v-list-group>
    <v-list>
      <v-list-item>
        <v-list-item-icon>
          <v-icon>mdi-home</v-icon>
        </v-list-item-icon>

        <v-list-item-title>Home</v-list-item-title>
      </v-list-item>

      <v-list-group
        :value="true"
        prepend-icon="mdi-account-circle"
      >
        <template v-slot:activator>
          <v-list-item-title>Users</v-list-item-title>
        </template>

        <v-list-group
          :value="true"
          no-action
          sub-group
        >
          <template v-slot:activator>
            <v-list-item-content>
              <v-list-item-title>Admin</v-list-item-title>
            </v-list-item-content>
          </template>

          <v-list-item
            v-for="([title, icon], i) in admins"
            :key="i"
            link
          >
            <v-list-item-title v-text="title"></v-list-item-title>

            <v-list-item-icon>
              <v-icon v-text="icon"></v-icon>
            </v-list-item-icon>
          </v-list-item>
        </v-list-group>

        <v-list-group
          no-action
          sub-group
        >
          <template v-slot:activator>
            <v-list-item-content>
              <v-list-item-title>Actions</v-list-item-title>
            </v-list-item-content>
          </template>

          <v-list-item
            v-for="([title, icon], i) in cruds"
            :key="i"
            link
          >
            <v-list-item-title v-text="title"></v-list-item-title>

            <v-list-item-icon>
              <v-icon v-text="icon"></v-icon>
            </v-list-item-icon>
          </v-list-item>
        </v-list-group>
      </v-list-group>
    </v-list>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      admins: [
        ['Management', 'mdi-account-multiple-outline'],
        ['Settings', 'mdi-cog-outline'],
      ],
      cruds: [
        ['Create', 'mdi-plus-outline'],
        ['Read', 'mdi-file-outline'],
        ['Update', 'mdi-update'],
        ['Delete', 'mdi-delete'],
      ],
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
