### PR TITLE
fix(vMenu): add touch event in click outside directive

### DIFF
--- a/packages/vuetify/src/directives/click-outside/index.ts
+++ b/packages/vuetify/src/directives/click-outside/index.ts
@@ -78,12 +78,17 @@ export const ClickOutside = {
   // clicks on body
   inserted (el: HTMLElement, binding: ClickOutsideDirective) {
     const onClick = (e: Event) => directive(e as PointerEvent, el, binding)
+    const onTouch = (e: Event) => {
+      el._clickOutside!.lastMousedownWasOutside = checkEvent(e as PointerEvent, el, binding)
+      directive(e as PointerEvent, el, binding)
+    }
     const onMousedown = (e: Event) => {
       el._clickOutside!.lastMousedownWasOutside = checkEvent(e as PointerEvent, el, binding)
     }
 
     handleShadow(el, (app: HTMLElement) => {
       app.addEventListener('click', onClick, true)
+      app.addEventListener('touchend', onTouch, true)
       app.addEventListener('mousedown', onMousedown, true)
     })
 


### PR DESCRIPTION
fix #14110

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Add `touchend` event in the `click-outside` directive which act the same way as `click` event
fixes #14110
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The change itself helps fixing an UI behavior (#14110)
## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually
## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

Used issue reporter's example.
Add  `<script src="https://unpkg.com/konva@7.0.3/konva.js"></script>` in `dev/index.html`

```vue
<template>
  <v-container>
    <v-menu
      :close-on-content-click="false"
      offset-y
      bottom
    >
      <template #activator="{ on, attrs }">
        <v-btn
          v-bind="attrs"
          class="mb-4"
          v-on="on"
        >
          Open List
        </v-btn>
      </template>

      <v-card
        width="200"
        height="300"
      >
        <v-card-text>Clicking the stage should close this menu. But it doesn't
          close when on touch devices.</v-card-text>
      </v-card>
    </v-menu>

    <div id="container"></div>
  </v-container>
</template>
<script>
  export default {
    data: () => ({
    }),
    mounted () {
      const width = window.innerWidth
      const height = window.innerHeight

      const stage = new Konva.Stage({
        container: 'container',
        width,
        height,
      })

      const layer = new Konva.Layer()

      const rect1 = new Konva.Rect({
        x: 20,
        y: 20,
        width: 100,
        height: 50,
        fill: 'green',
        stroke: 'black',
        strokeWidth: 4,
        preventDefault: false,
      })
      // add the shape to the layer
      layer.add(rect1)

      const rect2 = new Konva.Rect({
        x: 150,
        y: 40,
        width: 100,
        height: 50,
        fill: 'red',
        shadowBlur: 10,
        cornerRadius: 10,
        preventDefault: false,
      })
      layer.add(rect2)

      const rect3 = new Konva.Rect({
        x: 50,
        y: 120,
        width: 100,
        height: 100,
        fill: 'blue',
        cornerRadius: [0, 10, 20, 30],
        preventDefault: false,
      })
      layer.add(rect3)

      // add the layer to the stage
      stage.add(layer)
    },
  }
</script>

```

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
