### PR TITLE
fix(VCalendar): implicitly narrow TouchEvent

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -167,18 +167,21 @@ export default CalendarWithIntervals.extend({
         key: day.date,
         staticClass: 'v-calendar-daily__day',
         class: this.getRelativeClasses(day),
+        on: this.getDefaultMouseEventHandlers(':time', e => {
+          return this.getSlotScope(this.getTimestampAtEvent(e, day))
+        }),
       }, [
-        ...this.genDayIntervals(index, day),
+        ...this.genDayIntervals(index),
         ...this.genDayBody(day),
       ])
     },
     genDayBody (day: CalendarTimestamp): VNode[] {
       return getSlot(this, 'day-body', () => this.getSlotScope(day)) || []
     },
-    genDayIntervals (index: number, day: CalendarTimestamp): VNode[] {
-      return this.intervals[index].map(i => this.genDayInterval(i, day))
+    genDayIntervals (index: number): VNode[] {
+      return this.intervals[index].map(this.genDayInterval)
     },
-    genDayInterval (interval: CalendarTimestamp, day: CalendarTimestamp): VNode {
+    genDayInterval (interval: CalendarTimestamp): VNode {
       const height: string | undefined = convertToUnit(this.intervalHeight)
       const styler = this.intervalStyle || this.intervalStyleDefault
 
@@ -189,9 +192,6 @@ export default CalendarWithIntervals.extend({
           height,
           ...styler(interval),
         },
-        on: this.getDefaultMouseEventHandlers(':time', e => {
-          return this.getSlotScope(this.getTimestampAtEvent(e, day))
-        }),
       }
 
       const children = getSlot(this, 'interval', () => this.getSlotScope(interval))

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -167,6 +167,9 @@ export default CalendarWithIntervals.extend({
         key: day.date,
         staticClass: 'v-calendar-daily__day',
         class: this.getRelativeClasses(day),
+        on: this.getDefaultMouseEventHandlers(':time', e => {
+          return this.getSlotScope(this.getTimestampAtEvent(e, day))
+        }),
       }, [
         ...this.genDayIntervals(index),
         ...this.genDayBody(day),
@@ -189,9 +192,6 @@ export default CalendarWithIntervals.extend({
           height,
           ...styler(interval),
         },
-        on: this.getDefaultMouseEventHandlers(':time', e => {
-          return this.getSlotScope(interval)
-        }),
       }
 
       const children = getSlot(this, 'interval', () => this.getSlotScope(interval))

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -185,13 +185,13 @@ export default CalendarWithIntervals.extend({
       const data = {
         key: interval.time,
         staticClass: 'v-calendar-daily__day-interval',
-        on: this.getDefaultMouseEventHandlers(':time', e => {
-          return this.getSlotScope(interval)
-        }),
         style: {
           height,
           ...styler(interval),
         },
+        on: this.getDefaultMouseEventHandlers(':time', e => {
+          return this.getSlotScope(interval)
+        }),
       }
 
       const children = getSlot(this, 'interval', () => this.getSlotScope(interval))

--- a/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
+++ b/packages/vuetify/src/components/VCalendar/VCalendarDaily.ts
@@ -167,9 +167,6 @@ export default CalendarWithIntervals.extend({
         key: day.date,
         staticClass: 'v-calendar-daily__day',
         class: this.getRelativeClasses(day),
-        on: this.getDefaultMouseEventHandlers(':time', e => {
-          return this.getSlotScope(this.getTimestampAtEvent(e, day))
-        }),
       }, [
         ...this.genDayIntervals(index),
         ...this.genDayBody(day),
@@ -188,6 +185,9 @@ export default CalendarWithIntervals.extend({
       const data = {
         key: interval.time,
         staticClass: 'v-calendar-daily__day-interval',
+        on: this.getDefaultMouseEventHandlers(':time', e => {
+          return this.getSlotScope(interval)
+        }),
         style: {
           height,
           ...styler(interval),

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.sass
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.sass
@@ -45,7 +45,6 @@
 
   .v-event-timed
     position: absolute
-    overflow: hidden
     white-space: nowrap
     text-overflow: ellipsis
     font-size: $calendar-event-font-size

--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.sass
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.sass
@@ -45,6 +45,7 @@
 
   .v-event-timed
     position: absolute
+    overflow: hidden
     white-space: nowrap
     text-overflow: ellipsis
     font-size: $calendar-event-font-size

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -69,10 +69,10 @@ export default Vue.extend({
               const currentTarget = document.elementFromPoint(touchEvent.changedTouches[0].clientX, touchEvent.changedTouches[0].clientY)
 
               if (currentTarget &&
-                !(e.target as HTMLElement)?.isSameNode(currentTarget) &&
-                (e.target as HTMLElement)?.className === currentTarget.className
+                !(touchEvent.target as HTMLElement)?.isSameNode(currentTarget) &&
+                (touchEvent.target as HTMLElement)?.className === currentTarget.className
               ) {
-                currentTarget.dispatchEvent(new TouchEvent(e.type, {
+                currentTarget.dispatchEvent(new TouchEvent(touchEvent.type, {
                   changedTouches: touchEvent.changedTouches as unknown as Touch[],
                   targetTouches: touchEvent.targetTouches as unknown as Touch[],
                   touches: touchEvent.touches as unknown as Touch[],

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -65,17 +65,16 @@ export default Vue.extend({
             // Ref: https://developer.mozilla.org/en-US/docs/Web/API/Touch/target
             // This block of code aims to make sure touchEvent is always dispatched from the element that is being pointed at
             if (e && 'touches' in e) {
-              const touchEvent: TouchEvent = e as TouchEvent
-              const currentTarget = document.elementFromPoint(touchEvent.changedTouches[0].clientX, touchEvent.changedTouches[0].clientY)
+              const currentTarget = document.elementFromPoint(e.changedTouches[0].clientX, e.changedTouches[0].clientY)
 
               if (currentTarget &&
-                !(touchEvent.target as HTMLElement)?.isSameNode(currentTarget) &&
-                (touchEvent.target as HTMLElement)?.className === currentTarget.className
+                !(e.target as HTMLElement)?.isSameNode(currentTarget) &&
+                (e.target as HTMLElement)?.className === currentTarget.className
               ) {
-                currentTarget.dispatchEvent(new TouchEvent(touchEvent.type, {
-                  changedTouches: touchEvent.changedTouches as unknown as Touch[],
-                  targetTouches: touchEvent.targetTouches as unknown as Touch[],
-                  touches: touchEvent.touches as unknown as Touch[],
+                currentTarget.dispatchEvent(new TouchEvent(e.type, {
+                  changedTouches: e.changedTouches as unknown as Touch[],
+                  targetTouches: e.targetTouches as unknown as Touch[],
+                  touches: e.touches as unknown as Touch[],
                 }))
                 return
               }

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -64,17 +64,18 @@ export default Vue.extend({
             // Even if touch point has since moved outside the interactive area of that element
             // Ref: https://developer.mozilla.org/en-US/docs/Web/API/Touch/target
             // This block of code aims to make sure touchEvent is always dispatched from the element that is being pointed at
-            if (e instanceof TouchEvent) {
-              const currentTarget = document.elementFromPoint(e.changedTouches[0].clientX, e.changedTouches[0].clientY)
+            if (e && e.constructor.name === 'TouchEvent') {
+              const touchEvent: TouchEvent = e as TouchEvent
+              const currentTarget = document.elementFromPoint(touchEvent.changedTouches[0].clientX, touchEvent.changedTouches[0].clientY)
 
               if (currentTarget &&
                 !(e.target as HTMLElement)?.isSameNode(currentTarget) &&
                 (e.target as HTMLElement)?.className === currentTarget.className
               ) {
                 currentTarget.dispatchEvent(new TouchEvent(e.type, {
-                  changedTouches: e.changedTouches as unknown as Touch[],
-                  targetTouches: e.targetTouches as unknown as Touch[],
-                  touches: e.touches as unknown as Touch[],
+                  changedTouches: touchEvent.changedTouches as unknown as Touch[],
+                  targetTouches: touchEvent.targetTouches as unknown as Touch[],
+                  touches: touchEvent.touches as unknown as Touch[],
                 }))
                 return
               }

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -64,7 +64,7 @@ export default Vue.extend({
             // Even if touch point has since moved outside the interactive area of that element
             // Ref: https://developer.mozilla.org/en-US/docs/Web/API/Touch/target
             // This block of code aims to make sure touchEvent is always dispatched from the element that is being pointed at
-            if (e && e.constructor.name === 'TouchEvent') {
+            if (e?.constructor.name === 'TouchEvent') {
               const touchEvent: TouchEvent = e as TouchEvent
               const currentTarget = document.elementFromPoint(touchEvent.changedTouches[0].clientX, touchEvent.changedTouches[0].clientY)
 

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -64,7 +64,7 @@ export default Vue.extend({
             // Even if touch point has since moved outside the interactive area of that element
             // Ref: https://developer.mozilla.org/en-US/docs/Web/API/Touch/target
             // This block of code aims to make sure touchEvent is always dispatched from the element that is being pointed at
-            if (e?.constructor.name === 'TouchEvent') {
+            if (e && 'touches' in e) {
               const touchEvent: TouchEvent = e as TouchEvent
               const currentTarget = document.elementFromPoint(touchEvent.changedTouches[0].clientX, touchEvent.changedTouches[0].clientY)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
According to [MDN doc (TouchEvent)](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent)

`TouchEvent` constructor is not available on Safari and might not be available in Firefox.

Therefore, `if (e instanceof TouchEvent) {...}` does not work on Safari & Firefox

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

1. ✅fixes #14276 
2. ✅keeps the fix for #12366
3. ⚠️revert fix for #13174 and make a separate proper dedicated pull request to tackle it in future because previous changes of fixing it breaks #14243
4. ⚠️chagnes in point 3 restores [drag & drop example](https://vuetifyjs.com/en/components/calendars/#drag-and-drop) back to its previous version . #14243 is caused by a Firefix behaviour regarding `overflow: hidden` which has been officially  confirmed by Firefox as an issue [detail](https://bugzilla.mozilla.org/show_bug.cgi?id=1736188), a fix in vuetify level will be made by a separate pull request

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually
## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-container>
    <h1><a href="https://github.com/vuetifyjs/vuetify/issues/12366" target="_blank">12366 (fixed)</a></h1>
    <v-calendar 
      type="category"
      category-show-all
      :categories="categories"          
      :events="events"
      @mousemove:time-category="move"
      @touchmove:time-category="move"
    />
    <br> 
    <br> 
    <br> 
    <v-divider></v-divider>
    <br> 
    <br> 
    <br>
    <h1><a href="https://github.com/vuetifyjs/vuetify/issues/13174" target="_blank">13174 (not fixed)</a></h1>
    <div>Data and time: {{moveCategoryWeek}}</div>
    <v-calendar 
      type="week"
      :events="eventsWeek"
      @mousemove:time="moveWeek"
      @touchmove:time="moveWeek"
    />

  </v-container>
</template>

<script>
export default {
  data: () => ({
    events: [],
    eventsWeek: [],
    categories: ['John Smith', 'Tori Walker'],
    moveCategory: null,
    moveCategoryWeek: null
  }),
  methods: {
    move({category}) {
      console.log(category)
      this.moveCategory = category
    },
    moveWeek({date, time}) {
      console.log(date, time)
      this.moveCategoryWeek = date + ', ' + time
    }
  },
};
</script>

<style>
.scrolling-div {
  width: 200px;
  height: 100px;
  overflow: auto;
  white-space: nowrap;
}
</style>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
