### PR TITLE
docs(contributing): fix broken link "Core Team"

### DIFF
--- a/packages/docs/src/pages/en/getting-started/contributing.md
+++ b/packages/docs/src/pages/en/getting-started/contributing.md
@@ -326,6 +326,6 @@ Once complete, instead of using <kbd>git commit</kbd> you will run the command <
 
 [commitizen]: https://github.com/commitizen/cz-cli
 [community]: https://community.vuetifyjs.com/
-[Core Team]: /about/team/
+[Core Team]: /about/meet-the-team/
 [pull request]: https://github.com/vuetifyjs/vuetify/pulls
 [Issues]: https://github.com/vuetifyjs/vuetify/issues


### PR DESCRIPTION
## Description
Fixed broken link on page "Contributing"

## Motivation and Context
Dead link

## How Has This Been Tested?
on the deployed Preview

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
