### PR TITLE
fix(VStepper): expand stepper label to full width

### DIFF
--- a/packages/vuetify/src/components/VStepper/VStepper.sass
+++ b/packages/vuetify/src/components/VStepper/VStepper.sass
@@ -137,9 +137,8 @@
           color: inherit
 
   &__label
-    align-items: flex-start
-    display: flex
-    flex-direction: column
+    display: block
+    flex-grow: 1
     line-height: $stepper-label-line-height
 
     +ltr()
@@ -149,6 +148,7 @@
       text-align: right
 
     small
+      display: block
       font-size: $stepper-label-small-font-size
       font-weight: $stepper-label-small-font-weight
       text-shadow: none
@@ -219,7 +219,7 @@
       flex-basis: $stepper-alt-labels-flex-basis
 
       small
-        align-self: center
+        text-align: center
 
     .v-stepper__step__step
       margin-bottom: $stepper-alt-labels-step-step-margin-bottom


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #12584

**changes on `v-stepper__label`**
- added `flex-grow: 1`, `display: block` to make it full the whole width
- removed flex as there is no need for it

**changes on `v-stepper__label small`**
- added `display: block` to `small` to make it appear in separate line
- changed `align-self: center` into `text-align: center` when `--alt-labels` is defined

## How Has This Been Tested?
I've checked all examples in VStepper document page. all of them works as expected

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
   <v-app>
    <v-container>
      <v-card width="600">
      <v-stepper
    v-model="e6"
    vertical
  >
    <v-stepper-step
      step="1"
    >
            <v-textarea                   
                  single-line
                  rows="1"
                  no-resize
                  hide-details
                  dense
                  outlined
                  label="why isn't this as wide as the stepper step?"
                ></v-textarea> 
      
    </v-stepper-step>
    <v-stepper-content step="1">
    </v-stepper-content>
    <v-stepper-step
      step="2"
    >
     Hello I am a lot of test that has no problem filling up the width of the card.
    </v-stepper-step>
    <v-stepper-content step="2">
    </v-stepper-content>        
     </v-stepper>
        </v-card>
      <v-card width="600">
                        <v-textarea

                  single-line
                  rows="1"
                  no-resize
                  hide-details
                  dense
                  outlined
                  label="normally I expand to fill the width."

                ></v-textarea> 
        </v-card>
    </v-container>
  </v-app>

</template>

<script>
export default {
  data: () => ({
    //
  }),
};
</script>
```

</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
