### PR TITLE
fix(VTabs): allow set VTab inactive if optional property is set

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTab.ts
+++ b/packages/vuetify/src/components/VTabs/VTab.ts
@@ -11,6 +11,9 @@ import { ExtractVue } from './../../util/mixins'
 // Types
 import { VNode } from 'vue/types'
 
+// Components
+import VTabsBar from '../VTabs/VTabsBar'
+
 const baseMixins = mixins(
   Routable,
   // Must be after routable
@@ -19,8 +22,11 @@ const baseMixins = mixins(
   Themeable
 )
 
+type VTabBarInstance = InstanceType<typeof VTabsBar>
+
 interface options extends ExtractVue<typeof baseMixins> {
   $el: HTMLElement
+  tabsBar: VTabBarInstance
 }
 
 export default baseMixins.extend<options>().extend(
@@ -92,7 +98,7 @@ export default baseMixins.extend<options>().extend(
     },
     toggle () {
       // VItemGroup treats a change event as a click
-      if (!this.isActive) {
+      if (!this.isActive || !this.tabsBar.mandatory) {
         this.$emit('change')
       }
     },

--- a/packages/vuetify/src/components/VTabs/VTab.ts
+++ b/packages/vuetify/src/components/VTabs/VTab.ts
@@ -98,7 +98,7 @@ export default baseMixins.extend<options>().extend(
     },
     toggle () {
       // VItemGroup treats a change event as a click
-      if (!this.isActive || !this.tabsBar.mandatory) {
+      if (!this.isActive || (!this.tabsBar.mandatory && !this.to)) {
         this.$emit('change')
       }
     },


### PR DESCRIPTION
## Description
Fixes problem with active item in VTabs component could not be set to inactive when [optional](https://vuetifyjs.com/en/api/v-tabs/#props-optional) property was set.

resolves #14397 

## Motivation and Context
This PR solves a problem with [optional](https://vuetifyjs.com/en/api/v-tabs/#props-optional) property not working as declared in docs.

## How Has This Been Tested?
I visualy tested on local project by building package locally.

## Markup:

<details>

```vue
<template>
  <div id="app">
    <v-app dark>
        <v-tabs v-model="selectedTab" optional>
          <v-tab v-for="tabData in allTabData" :key="tabData.id">
            {{ tabData.name }}
          </v-tab>
        </v-tabs>
        <v-tabs-items v-model="selectedTab">
          <v-tab-item v-for="tabData in allTabData" :key="tabData.id">
            {{ tabData.text }}
          </v-tab-item>
        </v-tabs-items>
        Selected tab is {{ selectedTab }}
    </v-app>
  </div>
</template>

<script>
  new Vue({
    el: "#app",
    vuetify: new Vuetify(),
    data: {
      selectedTab: 0,
      renderKey: 0,
      allTabData: [{
        id: 0,
        name: "First",
        text: "First text"
      },{
        id: 1,
        name: "Second",
        text: "Second text"
      },{
        id: 2,
        name: "Third",
        text: "Third text"
      }]
    }
  })
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)