### PR TITLE
fix(sass): ordering of container-max-widths media queries

### DIFF
--- a/packages/vuetify/src/styles/settings/_variables.scss
+++ b/packages/vuetify/src/styles/settings/_variables.scss
@@ -125,6 +125,8 @@ $grid-gutters: map-deep-merge(
 $container-max-widths: () !default;
 $container-max-widths: map-deep-merge(
   (
+    'xs': null,
+    'sm': null,
     'md': map.get($grid-breakpoints, 'md') * 0.9375,
     'lg': map.get($grid-breakpoints, 'lg') * 0.9375,
     'xl': map.get($grid-breakpoints, 'xl') * 0.9375,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

As discussed on Discord:

> There's an issue with:
>
> ```scss
> $container-max-widths: map-deep-merge(
>   (
>     'md': map.get($grid-breakpoints, 'md') * 0.9375,
>     'lg': map.get($grid-breakpoints, 'lg') * 0.9375,
>     'xl': map.get($grid-breakpoints, 'xl') * 0.9375,
>     'xxl': map.get($grid-breakpoints, 'xxl') * 0.9375,
>   ),
>   $container-max-widths
> );
> ```
>
> ... if you want to add, for example, an `sm` breakpoint. Deep merge will append new items, so `sm` ends up at the end of the map, and the media queries are then out of order.

This is Kael's suggested solution.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It allows developers to set container max widths for `xs` and `sm` breakpoints, and have them applied in the correct order.

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
