### PR TITLE
docs(misc-wysiwyg): update example padding

### DIFF
--- a/packages/docs/src/examples/v-btn-toggle/misc-wysiwyg.vue
+++ b/packages/docs/src/examples/v-btn-toggle/misc-wysiwyg.vue
@@ -1,9 +1,23 @@
 <template>
-  <v-card max-width="400" class="mx-auto px-4">
-    <v-textarea v-model="value" auto-grow full-width rows="2"></v-textarea>
+  <v-card
+    max-width="400"
+    class="mx-auto px-4"
+  >
+    <v-textarea
+      v-model="value"
+      auto-grow
+      full-width
+      rows="2"
+    ></v-textarea>
 
-    <v-row class="pb-2 ma-0" justify="space-between">
-      <v-btn-toggle v-model="formatting" multiple>
+    <v-row
+      class="pb-2 ma-0"
+      justify="space-between"
+    >
+      <v-btn-toggle
+        v-model="formatting"
+        multiple
+      >
         <v-btn>
           <v-icon>mdi-format-italic</v-icon>
         </v-btn>
@@ -17,12 +31,18 @@
         </v-btn>
 
         <v-btn>
-          <v-row align="center" class="flex-column" justify="center">
-            <v-icon class="cols 12"> mdi-format-color-text </v-icon>
+          <v-row
+            align="center"
+            class="flex-column"
+            justify="center"
+          >
+            <v-icon class="cols 12">
+              mdi-format-color-text
+            </v-icon>
 
             <v-sheet
               tile
-              style="margin-top: -4px"
+              style="margin-top: -4px;"
               height="4"
               width="26"
               color="purple"
@@ -46,8 +66,14 @@
       </v-btn-toggle>
     </v-row>
 
-    <v-sheet class="py-4 text-center" tile>
-      <v-row class="mb-2" dense>
+    <v-sheet
+      class="py-4 text-center"
+      tile
+    >
+      <v-row
+        class="mb-2"
+        dense
+      >
         <v-col
           v-for="n in numbers"
           :key="n"

--- a/packages/docs/src/examples/v-btn-toggle/misc-wysiwyg.vue
+++ b/packages/docs/src/examples/v-btn-toggle/misc-wysiwyg.vue
@@ -95,14 +95,13 @@
 </template>
 
 <script>
-export default {
-  data: () => ({
-    alignment: 1,
-    formatting: [],
-    numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
-    letters: "qwertyuiop".split(""),
-    value:
-      "Toggle button requirements.\r\rHave at least three toggle buttons in a group\rLabel buttons with text, an icon, or",
-  }),
-};
+  export default {
+    data: () => ({
+      alignment: 1,
+      formatting: [],
+      numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+      letters: 'qwertyuiop'.split(''),
+      value: 'Toggle button requirements.\r\rHave at least three toggle buttons in a group\rLabel buttons with text, an icon, or',
+    }),
+  }
 </script>

--- a/packages/docs/src/examples/v-btn-toggle/misc-wysiwyg.vue
+++ b/packages/docs/src/examples/v-btn-toggle/misc-wysiwyg.vue
@@ -1,23 +1,9 @@
 <template>
-  <v-card
-    max-width="400"
-    class="mx-auto"
-  >
-    <v-textarea
-      v-model="value"
-      auto-grow
-      full-width
-      rows="2"
-    ></v-textarea>
+  <v-card max-width="400" class="mx-auto px-4">
+    <v-textarea v-model="value" auto-grow full-width rows="2"></v-textarea>
 
-    <v-row
-      class="px-2 pb-2 ma-0"
-      justify="space-between"
-    >
-      <v-btn-toggle
-        v-model="formatting"
-        multiple
-      >
+    <v-row class="pb-2 ma-0" justify="space-between">
+      <v-btn-toggle v-model="formatting" multiple>
         <v-btn>
           <v-icon>mdi-format-italic</v-icon>
         </v-btn>
@@ -31,18 +17,12 @@
         </v-btn>
 
         <v-btn>
-          <v-row
-            align="center"
-            class="flex-column"
-            justify="center"
-          >
-            <v-icon class="cols 12">
-              mdi-format-color-text
-            </v-icon>
+          <v-row align="center" class="flex-column" justify="center">
+            <v-icon class="cols 12"> mdi-format-color-text </v-icon>
 
             <v-sheet
               tile
-              style="margin-top: -4px;"
+              style="margin-top: -4px"
               height="4"
               width="26"
               color="purple"
@@ -66,14 +46,8 @@
       </v-btn-toggle>
     </v-row>
 
-    <v-sheet
-      class="pa-4 text-center"
-      tile
-    >
-      <v-row
-        class="mb-2"
-        dense
-      >
+    <v-sheet class="py-4 text-center" tile>
+      <v-row class="mb-2" dense>
         <v-col
           v-for="n in numbers"
           :key="n"
@@ -95,13 +69,14 @@
 </template>
 
 <script>
-  export default {
-    data: () => ({
-      alignment: 1,
-      formatting: [],
-      numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
-      letters: 'qwertyuiop'.split(''),
-      value: 'Toggle button requirements.\r\rHave at least three toggle buttons in a group\rLabel buttons with text, an icon, or',
-    }),
-  }
+export default {
+  data: () => ({
+    alignment: 1,
+    formatting: [],
+    numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+    letters: "qwertyuiop".split(""),
+    value:
+      "Toggle button requirements.\r\rHave at least three toggle buttons in a group\rLabel buttons with text, an icon, or",
+  }),
+};
 </script>


### PR DESCRIPTION
Padding in v-btn-toggle example in vuetify doc

## Description
I have changed the padding of an example which is in vuetify documentation

## Motivation and Context
Just to make documentation more readable

## How Has This Been Tested?
I added padding only nothing more

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
