### PR TITLE
fix: filter both VInput and VSelectionControl props

### DIFF
--- a/packages/api-generator/src/locale/en/v-checkbox.json
+++ b/packages/api-generator/src/locale/en/v-checkbox.json
@@ -10,8 +10,8 @@
     "mandatory": "Forces a selection on a `v-radio` child",
     "multiple": "Changes expected model to an array",
     "name": "Sets the component's name attribute",
-    "offIcon": "The icon used when inactive",
-    "onIcon": "The icon used when active",
+    "falseIcon": "The icon used when inactive",
+    "trueIcon": "The icon used when active",
     "row": "Displays radio buttons in row"
   },
   "events": {

--- a/packages/api-generator/src/locale/en/v-radio.json
+++ b/packages/api-generator/src/locale/en/v-radio.json
@@ -1,8 +1,8 @@
 {
   "props": {
     "name": "Sets the component's name attribute",
-    "offIcon": "The icon used when inactive",
-    "onIcon": "The icon used when active"
+    "falseIcon": "The icon used when inactive",
+    "trueIcon": "The icon used when active"
   },
   "events": {
     "change": "Emitted when the input is changed by user interaction",

--- a/packages/api-generator/src/locale/en/v-simple-checkbox.json
+++ b/packages/api-generator/src/locale/en/v-simple-checkbox.json
@@ -6,8 +6,8 @@
     "indeterminate": "Sets an indeterminate state for the simple checkbox.",
     "indeterminateIcon": "The icon used when in an indeterminate state.",
     "light": "Applies the light theme variant to the component.",
-    "offIcon": "The icon used when inactive.",
-    "onIcon": "The icon used when active.",
+    "falseIcon": "The icon used when inactive.",
+    "trueIcon": "The icon used when active.",
     "ripple": "Applies the [v-ripple](/directives/ripple) directive.",
     "value": "A boolean value that represents whether the simple checkbox is checked."
   },

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -2,16 +2,15 @@
 import './VCheckbox.sass'
 
 // Components
-import { filterInputAttrs, filterInputProps } from '@/components/VInput/VInput'
-import { VInput } from '@/components/VInput'
-import { VSelectionControl } from '@/components/VSelectionControl'
+import { filterInputProps, makeVInputProps, VInput } from '@/components/VInput/VInput'
+import { filterControlProps, makeSelectionControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
 
 // Composables
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
 import { computed, defineComponent } from 'vue'
-import { useRender } from '@/util'
+import { filterInputAttrs, useRender } from '@/util'
 
 export const VCheckbox = defineComponent({
   name: 'VCheckbox',
@@ -24,6 +23,10 @@ export const VCheckbox = defineComponent({
       type: String,
       default: '$checkboxIndeterminate',
     },
+
+    ...makeVInputProps(),
+    ...makeSelectionControlProps(),
+
     offIcon: {
       type: String,
       default: '$checkboxOff',
@@ -32,7 +35,6 @@ export const VCheckbox = defineComponent({
       type: String,
       default: '$checkboxOn',
     },
-    modelValue: null,
   },
 
   emits: {
@@ -61,14 +63,15 @@ export const VCheckbox = defineComponent({
     }
 
     useRender(() => {
-      const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
-      const [rootProps, inputProps] = filterInputProps(inputAttrs)
+      const [inputAttrs, controlAttrs] = filterInputAttrs(attrs)
+      const [inputProps, _1] = filterInputProps(props)
+      const [controlProps, _2] = filterControlProps(props)
 
       return (
         <VInput
           class="v-checkbox"
-          { ...rootAttrs }
-          { ...rootProps }
+          { ...inputAttrs }
+          { ...inputProps }
           v-slots={{
             ...slots,
             default: ({
@@ -78,13 +81,14 @@ export const VCheckbox = defineComponent({
               <VSelectionControl
                 type="checkbox"
                 v-model={ model.value }
-                disabled={ isDisabled.value }
-                readonly={ isReadonly.value }
                 onUpdate:modelValue={ onChange }
                 offIcon={ offIcon.value }
                 onIcon={ onIcon.value }
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }
-                { ...inputProps }
+                { ...controlAttrs }
+                { ...controlProps }
+                disabled={ isDisabled.value }
+                readonly={ isReadonly.value }
               />
             ),
           }}

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -39,11 +39,9 @@ export const VCheckbox = defineComponent({
 
   emits: {
     'update:indeterminate': (val: boolean) => true,
-    'update:modelValue': (val: any) => true,
   },
 
   setup (props, { attrs, slots }) {
-    const model = useProxiedModel(props, 'modelValue')
     const indeterminate = useProxiedModel(props, 'indeterminate')
     const falseIcon = computed(() => {
       return indeterminate.value
@@ -79,16 +77,15 @@ export const VCheckbox = defineComponent({
               isReadonly,
             }) => (
               <VSelectionControl
+                { ...controlProps }
                 type="checkbox"
-                v-model={ model.value }
                 onUpdate:modelValue={ onChange }
                 falseIcon={ falseIcon.value }
                 trueIcon={ trueIcon.value }
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }
-                { ...controlAttrs }
-                { ...controlProps }
                 disabled={ isDisabled.value }
                 readonly={ isReadonly.value }
+                { ...controlAttrs }
               />
             ),
           }}

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -27,11 +27,11 @@ export const VCheckbox = defineComponent({
     ...makeVInputProps(),
     ...makeSelectionControlProps(),
 
-    offIcon: {
+    falseIcon: {
       type: String,
       default: '$checkboxOff',
     },
-    onIcon: {
+    trueIcon: {
       type: String,
       default: '$checkboxOn',
     },
@@ -45,15 +45,15 @@ export const VCheckbox = defineComponent({
   setup (props, { attrs, slots }) {
     const model = useProxiedModel(props, 'modelValue')
     const indeterminate = useProxiedModel(props, 'indeterminate')
-    const offIcon = computed(() => {
+    const falseIcon = computed(() => {
       return indeterminate.value
         ? props.indeterminateIcon
-        : props.offIcon
+        : props.falseIcon
     })
-    const onIcon = computed(() => {
+    const trueIcon = computed(() => {
       return indeterminate.value
         ? props.indeterminateIcon
-        : props.onIcon
+        : props.trueIcon
     })
 
     function onChange () {
@@ -82,8 +82,8 @@ export const VCheckbox = defineComponent({
                 type="checkbox"
                 v-model={ model.value }
                 onUpdate:modelValue={ onChange }
-                offIcon={ offIcon.value }
-                onIcon={ onIcon.value }
+                falseIcon={ falseIcon.value }
+                trueIcon={ trueIcon.value }
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }
                 { ...controlAttrs }
                 { ...controlProps }

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -13,11 +13,10 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref } from 'vue'
-import { defineComponent, humanReadableFileSize, useRender, wrapInArray } from '@/util'
+import { defineComponent, filterInputAttrs, humanReadableFileSize, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
-import { filterInputAttrs } from '@/components/VInput/VInput'
 
 export const VFileInput = defineComponent({
   name: 'VFileInput',

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -11,10 +11,10 @@ import { makeValidationProps, useValidation } from '@/composables/validation'
 
 // Utilities
 import { computed } from 'vue'
-import { genericComponent, pick, propsFactory, toKebabCase } from '@/util'
+import { genericComponent, pick, propsFactory } from '@/util'
 
 // Types
-import type { ComputedRef, PropType, Ref } from 'vue'
+import type { ComputedRef, ExtractPropTypes, PropType, Ref } from 'vue'
 import type { MakeSlots } from '@/util'
 
 export type VInputSlot = {
@@ -31,7 +31,6 @@ export type VInputSlot = {
 export const makeVInputProps = propsFactory({
   appendIcon: String,
   prependIcon: String,
-  focused: Boolean,
   hideDetails: [Boolean, String] as PropType<boolean | 'auto'>,
   hint: String,
   messages: {
@@ -54,7 +53,11 @@ export const VInput = genericComponent<new <T>() => {
 }>()({
   name: 'VInput',
 
-  props: makeVInputProps(),
+  props: {
+    focused: Boolean,
+
+    ...makeVInputProps(),
+  },
 
   emits: {
     'click:prepend': (e: MouseEvent) => true,
@@ -159,10 +162,6 @@ export const VInput = genericComponent<new <T>() => {
 
 export type VInput = InstanceType<typeof VInput>
 
-export function filterInputAttrs (attrs: Record<string, unknown>) {
-  return pick(attrs, ['class', 'style', 'id', /^data-/])
-}
-
-export function filterInputProps (attrs: Record<string, unknown>) {
-  return pick(attrs, Object.keys(VInput.props).map(toKebabCase))
+export function filterInputProps (props: ExtractPropTypes<ReturnType<typeof makeVInputProps>>) {
+  return pick(props, Object.keys(VInput.props) as any)
 }

--- a/packages/vuetify/src/components/VRadio/VRadio.tsx
+++ b/packages/vuetify/src/components/VRadio/VRadio.tsx
@@ -9,11 +9,11 @@ export const VRadio = defineComponent({
   name: 'VRadio',
 
   props: {
-    offIcon: {
+    falseIcon: {
       type: String,
       default: '$radioOff',
     },
-    onIcon: {
+    trueIcon: {
       type: String,
       default: '$radioOn',
     },
@@ -23,8 +23,8 @@ export const VRadio = defineComponent({
     useRender(() => (
       <VSelectionControl
         class="v-radio"
-        onIcon={ props.onIcon }
-        offIcon={ props.offIcon }
+        trueIcon={ props.trueIcon }
+        falseIcon={ props.falseIcon }
         type="radio"
         v-slots={ slots }
       />

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -78,15 +78,15 @@ export const VRadioGroup = defineComponent({
                 ) }
 
                 <VSelectionControlGroup
+                  { ...controlProps }
                   id={ id.value }
                   trueIcon={ props.trueIcon }
                   falseIcon={ props.falseIcon }
                   type={ props.type }
-                  v-slots={ slots }
-                  { ...controlAttrs }
-                  { ...controlProps }
                   disabled={ isDisabled.value }
                   readonly={ isReadonly.value }
+                  { ...controlAttrs }
+                  v-slots={ slots }
                 />
               </>
             ),

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -25,11 +25,11 @@ export const VRadioGroup = defineComponent({
     ...makeVInputProps(),
     ...makeSelectionControlProps(),
 
-    onIcon: {
+    trueIcon: {
       type: String,
       default: '$radioOn',
     },
-    offIcon: {
+    falseIcon: {
       type: String,
       default: '$radioOff',
     },
@@ -79,8 +79,8 @@ export const VRadioGroup = defineComponent({
 
                 <VSelectionControlGroup
                   id={ id.value }
-                  onIcon={ props.onIcon }
-                  offIcon={ props.offIcon }
+                  trueIcon={ props.trueIcon }
+                  falseIcon={ props.falseIcon }
                   type={ props.type }
                   v-slots={ slots }
                   { ...controlAttrs }

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -2,13 +2,14 @@
 import './VRadioGroup.sass'
 
 // Components
-import { filterInputAttrs, filterInputProps, VInput } from '@/components/VInput/VInput'
+import { filterInputProps, makeVInputProps, VInput } from '@/components/VInput/VInput'
 import { VLabel } from '@/components/VLabel'
 import { VSelectionControlGroup } from '@/components/VSelectionControlGroup'
+import { filterControlProps, makeSelectionControlProps } from '@/components/VSelectionControl/VSelectionControl'
 
 // Utility
 import { computed, defineComponent } from 'vue'
-import { getUid, useRender } from '@/util'
+import { filterInputAttrs, getUid, useRender } from '@/util'
 
 export const VRadioGroup = defineComponent({
   name: 'VRadioGroup',
@@ -20,9 +21,10 @@ export const VRadioGroup = defineComponent({
       type: [Number, String],
       default: 'auto',
     },
-    label: String,
-    id: String,
-    inline: Boolean,
+
+    ...makeVInputProps(),
+    ...makeSelectionControlProps(),
+
     onIcon: {
       type: String,
       default: '$radioOn',
@@ -42,8 +44,9 @@ export const VRadioGroup = defineComponent({
     const id = computed(() => props.id || `radio-group-${uid}`)
 
     useRender(() => {
-      const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
-      const [rootProps, inputProps] = filterInputProps(inputAttrs)
+      const [inputAttrs, controlAttrs] = filterInputAttrs(attrs)
+      const [inputProps, _1] = filterInputProps(props)
+      const [controlProps, _2] = filterControlProps(props)
       const label = slots.label
         ? slots.label({
           label: props.label,
@@ -54,8 +57,8 @@ export const VRadioGroup = defineComponent({
       return (
         <VInput
           class="v-radio-group"
-          { ...rootAttrs }
-          { ...rootProps }
+          { ...inputAttrs }
+          { ...inputProps }
           v-slots={{
             ...slots,
             default: ({
@@ -76,14 +79,14 @@ export const VRadioGroup = defineComponent({
 
                 <VSelectionControlGroup
                   id={ id.value }
-                  disabled={ isDisabled.value }
                   onIcon={ props.onIcon }
                   offIcon={ props.offIcon }
                   type={ props.type }
-                  readonly={ isReadonly.value }
-                  inline={ props.inline }
                   v-slots={ slots }
-                  { ...inputProps }
+                  { ...controlAttrs }
+                  { ...controlProps }
+                  disabled={ isDisabled.value }
+                  readonly={ isReadonly.value }
                 />
               </>
             ),

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -51,8 +51,8 @@ export const makeSelectionControlProps = propsFactory({
   id: String,
   inline: Boolean,
   label: String,
-  offIcon: String,
-  onIcon: String,
+  falseIcon: String,
+  trueIcon: String,
   ripple: {
     type: Boolean,
     default: true,
@@ -131,8 +131,8 @@ export function useSelectionControl (
   }))
   const icon = computed(() => {
     return model.value
-      ? group?.onIcon.value ?? props.onIcon
-      : group?.offIcon.value ?? props.offIcon
+      ? group?.trueIcon.value ?? props.trueIcon
+      : group?.falseIcon.value ?? props.falseIcon
   })
 
   return {

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -17,7 +17,16 @@ import { Ripple } from '@/directives/ripple'
 
 // Utilities
 import { computed, inject, ref } from 'vue'
-import { deepEqual, genericComponent, getUid, SUPPORTS_FOCUS_VISIBLE, useRender, wrapInArray } from '@/util'
+import {
+  deepEqual,
+  genericComponent,
+  getUid,
+  pick,
+  propsFactory,
+  SUPPORTS_FOCUS_VISIBLE,
+  useRender,
+  wrapInArray,
+} from '@/util'
 
 // Types
 import type { ComputedRef, ExtractPropTypes, PropType, Ref, WritableComputedRef } from 'vue'
@@ -35,7 +44,7 @@ export type SelectionControlSlot = {
   }
 }
 
-const selectionControlProps = {
+export const makeSelectionControlProps = propsFactory({
   color: String,
   disabled: Boolean,
   error: Boolean,
@@ -66,10 +75,10 @@ const selectionControlProps = {
 
   ...makeThemeProps(),
   ...makeDensityProps(),
-} as const
+})
 
 export function useSelectionControl (
-  props: ExtractPropTypes<typeof selectionControlProps> & {
+  props: ExtractPropTypes<ReturnType<typeof makeSelectionControlProps>> & {
     'onUpdate:modelValue': ((val: any) => void) | undefined
   }
 ) {
@@ -154,7 +163,7 @@ export const VSelectionControl = genericComponent<new <T>() => {
 
   inheritAttrs: false,
 
-  props: selectionControlProps,
+  props: makeSelectionControlProps(),
 
   emits: {
     'update:modelValue': (val: any) => true,
@@ -278,3 +287,7 @@ export const VSelectionControl = genericComponent<new <T>() => {
 })
 
 export type VSelectionControl = InstanceType<typeof VSelectionControl>
+
+export function filterControlProps (props: ExtractPropTypes<ReturnType<typeof makeSelectionControlProps>>) {
+  return pick(props, Object.keys(VSelectionControl.props) as any)
+}

--- a/packages/vuetify/src/components/VSelectionControl/__tests__/VSelectionControl.spec.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/__tests__/VSelectionControl.spec.tsx
@@ -1,5 +1,5 @@
 // Components
-import { useSelectionControl, VSelectionControl } from '../VSelectionControl'
+import { makeSelectionControlProps, useSelectionControl } from '../VSelectionControl'
 
 // Utilities
 import { createVuetify } from '@/framework'
@@ -12,7 +12,7 @@ describe('VSelectionControl', () => {
 
   function mountFunction (options = {}) {
     return mount({
-      props: VSelectionControl.props,
+      props: makeSelectionControlProps(),
       setup (props) {
         return useSelectionControl(props as any)
       },

--- a/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
+++ b/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
@@ -17,8 +17,8 @@ export interface VSelectionGroupContext {
   name: Ref<string | undefined>
   modelValue: Ref<any>
   multiple: Ref<boolean>
-  onIcon: Ref<string | undefined>
-  offIcon: Ref<string | undefined>
+  trueIcon: Ref<string | undefined>
+  falseIcon: Ref<string | undefined>
   readonly: Ref<boolean>
   type: Ref<string | undefined>
 }
@@ -33,8 +33,8 @@ export const VSelectionControlGroup = defineComponent({
     id: String,
     inline: Boolean,
     name: String,
-    offIcon: String,
-    onIcon: String,
+    falseIcon: String,
+    trueIcon: String,
     multiple: {
       type: Boolean as PropType<boolean | null>,
       default: null,
@@ -60,8 +60,8 @@ export const VSelectionControlGroup = defineComponent({
       modelValue,
       multiple: computed(() => !!props.multiple || (props.multiple == null && Array.isArray(modelValue.value))),
       name,
-      offIcon: toRef(props, 'offIcon'),
-      onIcon: toRef(props, 'onIcon'),
+      falseIcon: toRef(props, 'falseIcon'),
+      trueIcon: toRef(props, 'trueIcon'),
       readonly: toRef(props, 'readonly'),
       type: toRef(props, 'type'),
     })

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -62,14 +62,14 @@ export const VSwitch = defineComponent({
               isReadonly,
             }) => (
               <VSelectionControl
+                ref={ control }
+                { ...controlProps }
                 type="checkbox"
                 onUpdate:modelValue={ onChange }
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }
-                ref={ control }
-                { ...controlAttrs }
-                { ...controlProps }
                 disabled={ isDisabled.value }
                 readonly={ isReadonly.value }
+                { ...controlAttrs }
                 v-slots={{
                   default: () => (<div class="v-switch__track" onClick={ onClick }></div>),
                   input: ({ textColorClasses }) => (

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -2,13 +2,12 @@
 import './VSwitch.sass'
 
 // Components
-import { VSelectionControl } from '@/components/VSelectionControl'
-import { VInput } from '@/components/VInput'
-import { filterInputAttrs, filterInputProps } from '@/components/VInput/VInput'
+import { filterInputProps, makeVInputProps, VInput } from '@/components/VInput/VInput'
+import { filterControlProps, makeSelectionControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
 
 // Utility
 import { defineComponent, ref } from 'vue'
-import { useRender } from '@/util'
+import { filterInputAttrs, useRender } from '@/util'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 export const VSwitch = defineComponent({
@@ -21,7 +20,11 @@ export const VSwitch = defineComponent({
     inset: Boolean,
     loading: [Boolean, String],
     flat: Boolean,
+
+    ...makeVInputProps(),
+    ...makeSelectionControlProps(),
   },
+
   emits: {
     'update:indeterminate': (val: boolean) => true,
   },
@@ -35,8 +38,9 @@ export const VSwitch = defineComponent({
     }
 
     useRender(() => {
-      const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
-      const [rootProps, inputProps] = filterInputProps(inputAttrs)
+      const [inputAttrs, controlAttrs] = filterInputAttrs(attrs)
+      const [inputProps, _1] = filterInputProps(props)
+      const [controlProps, _2] = filterControlProps(props)
       const control = ref<VSelectionControl>()
 
       function onClick () {
@@ -49,8 +53,8 @@ export const VSwitch = defineComponent({
             'v-switch',
             { 'v-switch--indeterminate': indeterminate.value },
           ]}
-          { ...rootAttrs }
-          { ...rootProps }
+          { ...inputAttrs }
+          { ...inputProps }
           v-slots={{
             ...slots,
             default: ({
@@ -59,12 +63,13 @@ export const VSwitch = defineComponent({
             }) => (
               <VSelectionControl
                 type="checkbox"
-                disabled={ isDisabled.value }
-                readonly={ isReadonly.value }
                 onUpdate:modelValue={ onChange }
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }
                 ref={ control }
-                { ...inputProps }
+                { ...controlAttrs }
+                { ...controlProps }
+                disabled={ isDisabled.value }
+                readonly={ isReadonly.value }
                 v-slots={{
                   default: () => (<div class="v-switch__track" onClick={ onClick }></div>),
                   input: ({ textColorClasses }) => (

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -5,7 +5,6 @@ import './VTextField.sass'
 import { filterFieldProps, makeVFieldProps } from '@/components/VField/VField'
 import { VCounter } from '@/components/VCounter'
 import { VField } from '@/components/VField'
-import { filterInputAttrs } from '@/components/VInput/VInput'
 
 // Composables
 import { useProxiedModel } from '@/composables/proxiedModel'
@@ -15,7 +14,7 @@ import Intersect from '@/directives/intersect'
 
 // Utilities
 import { computed, ref } from 'vue'
-import { defineComponent, useRender } from '@/util'
+import { defineComponent, filterInputAttrs, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -14,11 +14,10 @@ import Intersect from '@/directives/intersect'
 
 // Utilities
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { convertToUnit, defineComponent, useRender } from '@/util'
+import { convertToUnit, defineComponent, filterInputAttrs, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
-import { filterInputAttrs } from '@/components/VInput/VInput'
 
 export const VTextarea = defineComponent({
   name: 'VTextarea',

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -43,10 +43,7 @@ export const makeValidationProps = propsFactory({
     type: Array as PropType<ValidationRule[]>,
     default: () => ([]),
   },
-  modelValue: {
-    type: null,
-    default: undefined as any,
-  },
+  modelValue: null,
 })
 
 export function useValidation (

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -190,15 +190,15 @@ type MaybePick<
 export function pick<
   T extends object,
   U extends Extract<keyof T, string>
-> (obj: T, paths: U[]): [MaybePick<T, U>, Omit<T, U>]
+> (obj: T, paths: U[]): [yes: MaybePick<T, U>, no: Omit<T, U>]
 export function pick<
   T extends object,
   U extends Extract<keyof T, string>
-> (obj: T, paths: (U | RegExp)[]): [Partial<T>, Partial<T>]
+> (obj: T, paths: (U | RegExp)[]): [yes: Partial<T>, no: Partial<T>]
 export function pick<
   T extends object,
   U extends Extract<keyof T, string>
-> (obj: T, paths: (U | RegExp)[]): [Partial<T>, Partial<T>] {
+> (obj: T, paths: (U | RegExp)[]): [yes: Partial<T>, no: Partial<T>] {
   const found = Object.create(null)
   const rest = Object.create(null)
 
@@ -216,6 +216,15 @@ export function pick<
   }
 
   return [found, rest]
+}
+
+/**
+ * Filter attributes that should be applied to
+ * the root element of a an input component. Remaining
+ * attributes should be passed to the <input> element inside.
+ */
+export function filterInputAttrs (attrs: Record<string, unknown>) {
+  return pick(attrs, ['class', 'style', 'id', /^data-/])
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: renamed `onIcon`/`offIcon` to `trueIcon`/`falseIcon`

Vue 3 interprets props starting with `/on[A-Z]/` as events, so mergeProps
will combine them into an array instead of overwriting with the latest
value.

Related: 776881372767d10aeacf6408ac10362fa9a79e35