### PR TITLE
fix(VItemGroup): allow null values

### DIFF
--- a/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
+++ b/packages/vuetify/src/components/VItemGroup/VItemGroup.ts
@@ -114,7 +114,7 @@ export const BaseItemGroup = mixins(
       }
     },
     getValue (item: GroupableInstance, i: number): unknown {
-      return item.value == null || item.value === ''
+      return item.value === undefined
         ? i
         : item.value
     },

--- a/packages/vuetify/src/components/VItemGroup/__tests__/VItemGroup.spec.ts
+++ b/packages/vuetify/src/components/VItemGroup/__tests__/VItemGroup.spec.ts
@@ -58,9 +58,9 @@ describe('VItemGroup', () => {
 
     const getValue = wrapper.vm.getValue
 
-    expect(getValue({ value: null }, 0)).toBe(0)
+    expect(getValue({ value: null }, 0)).toBeNull()
     expect(getValue({ value: undefined }, 1)).toBe(1)
-    expect(getValue({ value: '' }, 2)).toBe(2)
+    expect(getValue({ value: '' }, 2)).toBe('')
     expect(getValue({ value: 'foo' }, 'foo')).toBe('foo')
   })
 

--- a/packages/vuetify/src/components/VTabs/VTab.ts
+++ b/packages/vuetify/src/components/VTabs/VTab.ts
@@ -55,7 +55,9 @@ export default baseMixins.extend<options>().extend(
       }
     },
     value (): any {
-      let to = this.to || this.href || ''
+      let to = this.to || this.href
+
+      if (to == null) return to
 
       if (this.$router &&
         this.to === Object(this.to)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
fixes #9073
I couldn't find any justification for this in #5009. There is a chance this change could break anything relying on that behaviour but it seems pretty obtuse. 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-radio-group v-model="selected">
        <v-radio
          label="Yes"
          :value="true"
        ></v-radio>
        <v-radio
          label="No"
          :value="false"
        ></v-radio>
        <v-radio
          label="N/A"
          :value="null"
        ></v-radio>
      </v-radio-group>

      <v-tabs>
        <v-tab>Tab</v-tab>
        <v-tab>Tab</v-tab>
        <v-tab>Tab</v-tab>
      </v-tabs>

      <pre>{{ String(selected) }}</pre>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      selected: undefined,
    }),
  }
</script>
```
</details>
