### PR TITLE
fix(VField): don't show gap when missing label

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -213,6 +213,7 @@ export const VField = genericComponent<new <T>() => {
         })
         : props.label
       const [inputProps, _] = filterInputProps(props)
+
       return (
         <VInput
           class={[

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -140,7 +140,7 @@ export const VField = genericComponent<new <T>() => {
     }))
 
     watch(isActive, val => {
-      if (!props.singleLine) {
+      if (!props.singleLine && props.label) {
         const el: HTMLElement = labelRef.value!.$el
         const targetEl: HTMLElement = floatingLabelRef.value!.$el
         const rect = nullifyTransforms(el)
@@ -212,7 +212,6 @@ export const VField = genericComponent<new <T>() => {
         })
         : props.label
       const [inputProps, _] = filterInputProps(props)
-
       return (
         <VInput
           class={[
@@ -275,7 +274,7 @@ export const VField = genericComponent<new <T>() => {
                 ) }
 
                 <div class="v-field__field">
-                  { ['contained', 'filled'].includes(props.variant) && !props.singleLine && (
+                  { ['contained', 'filled'].includes(props.variant) && !props.singleLine && label && (
                     <VFieldLabel ref={ floatingLabelRef } floating>
                       { label }
                     </VFieldLabel>
@@ -332,19 +331,19 @@ export const VField = genericComponent<new <T>() => {
                     <>
                       <div class="v-field__outline__start" />
 
-                      <div class="v-field__outline__notch">
-                        { !props.singleLine && (
-                          <VFieldLabel ref={ floatingLabelRef } floating>
-                            { label }
-                          </VFieldLabel>
-                        ) }
-                      </div>
+                      { !props.singleLine && label && (
+                          <div class="v-field__outline__notch">
+                            <VFieldLabel ref={ floatingLabelRef } floating>
+                              { label }
+                            </VFieldLabel>
+                          </div>
+                      ) }
 
                       <div class="v-field__outline__end" />
                     </>
                   ) }
 
-                  { ['plain', 'underlined'].includes(props.variant) && !props.singleLine && (
+                  { ['plain', 'underlined'].includes(props.variant) && !props.singleLine && label && (
                     <VFieldLabel ref={ floatingLabelRef } floating>
                       { label }
                     </VFieldLabel>

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -334,11 +334,11 @@ export const VField = genericComponent<new <T>() => {
                       <div class="v-field__outline__start" />
 
                       { hasLabel.value && (
-                          <div class="v-field__outline__notch">
-                            <VFieldLabel ref={ floatingLabelRef } floating>
-                              { label }
-                            </VFieldLabel>
-                          </div>
+                        <div class="v-field__outline__notch">
+                          <VFieldLabel ref={ floatingLabelRef } floating>
+                            { label }
+                          </VFieldLabel>
+                        </div>
                       ) }
 
                       <div class="v-field__outline__end" />

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -126,7 +126,7 @@ export const VField = genericComponent<new <T>() => {
     const inputRef = ref<HTMLInputElement>()
     const isFocused = ref(false)
     const id = computed(() => props.id || `input-${uid}`)
-    const hasLabel = computed(() => !props.singleLine && !!props.label)
+    const hasLabel = computed(() => !props.singleLine && !!(props.label || slots.label))
 
     watchEffect(() => isActive.value = isFocused.value || props.dirty)
 

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -126,6 +126,7 @@ export const VField = genericComponent<new <T>() => {
     const inputRef = ref<HTMLInputElement>()
     const isFocused = ref(false)
     const id = computed(() => props.id || `input-${uid}`)
+    const hasLabel = computed(() => !props.singleLine && !!props.label)
 
     watchEffect(() => isActive.value = isFocused.value || props.dirty)
 
@@ -140,7 +141,7 @@ export const VField = genericComponent<new <T>() => {
     }))
 
     watch(isActive, val => {
-      if (!props.singleLine && props.label) {
+      if (hasLabel.value) {
         const el: HTMLElement = labelRef.value!.$el
         const targetEl: HTMLElement = floatingLabelRef.value!.$el
         const rect = nullifyTransforms(el)
@@ -274,7 +275,7 @@ export const VField = genericComponent<new <T>() => {
                 ) }
 
                 <div class="v-field__field">
-                  { ['contained', 'filled'].includes(props.variant) && !props.singleLine && label && (
+                  { ['contained', 'filled'].includes(props.variant) && hasLabel.value && (
                     <VFieldLabel ref={ floatingLabelRef } floating>
                       { label }
                     </VFieldLabel>
@@ -331,7 +332,7 @@ export const VField = genericComponent<new <T>() => {
                     <>
                       <div class="v-field__outline__start" />
 
-                      { !props.singleLine && label && (
+                      { hasLabel.value && (
                           <div class="v-field__outline__notch">
                             <VFieldLabel ref={ floatingLabelRef } floating>
                               { label }
@@ -343,7 +344,7 @@ export const VField = genericComponent<new <T>() => {
                     </>
                   ) }
 
-                  { ['plain', 'underlined'].includes(props.variant) && !props.singleLine && label && (
+                  { ['plain', 'underlined'].includes(props.variant) && hasLabel.value && (
                     <VFieldLabel ref={ floatingLabelRef } floating>
                       { label }
                     </VFieldLabel>


### PR DESCRIPTION

## Description
Handling the case when label is missing or it has falsy value
I am not aware of any open issue that this PR resolves. It resolves an issue that we discussed on the discord chat. 

## Motivation and Context
The layout is broken when using outlined variant. The notch is present and the border is interrupted with white space.

```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        v-model="something"
        variant="outlined"
        label="Something"
      />
      <v-text-field
        v-model="something"
        variant="outlined"
        label=""
      />
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
  setup() {
    return {
      something: "",
    };
  },
};
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
