### PR TITLE
fix(VTabs): correctly set active state with exact prop

### DIFF
--- a/packages/vuetify/src/mixins/routable/index.ts
+++ b/packages/vuetify/src/mixins/routable/index.ts
@@ -140,8 +140,8 @@ export default Vue.extend({
     },
     onRouteChange () {
       if (!this.to || !this.$refs.link || !this.$route) return
-      const activeClass = `${this.activeClass} ${this.proxyClass || ''}`.trim()
-      const exactActiveClass = `${this.exactActiveClass} ${this.proxyClass || ''}`.trim() || activeClass
+      const activeClass = `${this.activeClass || ''} ${this.proxyClass || ''}`.trim()
+      const exactActiveClass = `${this.exactActiveClass || ''} ${this.proxyClass || ''}`.trim() || activeClass
 
       const path = '_vnode.data.class.' + (this.exact ? exactActiveClass : activeClass)
 


### PR DESCRIPTION
The v-tabs component didn't move the slider if the v-tab had the property "exact"


## Description
After investigating, it came from the mixin routable,
The value of "exactActiveClass" was not checked before assigning to the path, resulting in

`'_vnode.data.class.undefined` 
I change the code to fall back on `proxyClass ` if  `exactActiveClass` is undefined
As a precaution I did the same for `activeClass` even if it's not needed for resolving this issue

the bug was introduced by PR https://github.com/vuetifyjs/vuetify/pull/14207

## Motivation and Context
Resolves #14431 
Resolves #14459 

## How Has This Been Tested?
didn't add unit tests

## Markup:
Playground.vue

```vue
<template>
  <v-container>
    <v-tabs>
      <v-tab
        to="/page1"
      >page1</v-tab>
      <v-tab
        to="/page2"
      >page2</v-tab>
    </v-tabs>
    <v-btn to="/page2">Go to page 2</v-btn>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] The PR title is no longer than 64 characters.
- [ x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ x] My code follows the code style of this project.
- [ x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
