### PR TITLE
feat(defaults): add support to scope defaults

### DIFF
--- a/packages/vuetify/src/components/VDefaultsProvider/VDefaultsProvider.tsx
+++ b/packages/vuetify/src/components/VDefaultsProvider/VDefaultsProvider.tsx
@@ -1,14 +1,20 @@
+// Composables
 import { provideDefaults } from '@/composables/defaults'
+
+// Utilities
 import { defineComponent } from 'vue'
 
-import type { PropType } from 'vue'
+// Types
 import type { DefaultsOptions } from '@/composables/defaults'
+import type { PropType } from 'vue'
 
 export const VDefaultsProvider = defineComponent({
   name: 'VDefaultsProvider',
 
   props: {
     defaults: Object as PropType<DefaultsOptions>,
+    reset: [Number, String],
+    root: Boolean,
     scoped: Boolean,
   },
 

--- a/packages/vuetify/src/components/VDefaultsProvider/VDefaultsProvider.tsx
+++ b/packages/vuetify/src/components/VDefaultsProvider/VDefaultsProvider.tsx
@@ -9,6 +9,7 @@ export const VDefaultsProvider = defineComponent({
 
   props: {
     defaults: Object as PropType<DefaultsOptions>,
+    scoped: Boolean,
   },
 
   setup (props, { slots }) {

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -1,6 +1,8 @@
+// Utilities
 import { computed, inject, provide, ref } from 'vue'
 import { mergeDeep } from '@/util/helpers'
 
+// Types
 import type { InjectionKey, Ref } from 'vue'
 
 export interface DefaultsInstance {
@@ -24,10 +26,17 @@ export function useDefaults () {
   return defaults
 }
 
-export function provideDefaults (props?: { defaults?: DefaultsInstance }) {
+export function provideDefaults (props?: {
+  defaults?: DefaultsInstance
+  scoped?: boolean
+}) {
   const defaults = useDefaults()
 
-  const newDefaults = computed(() => mergeDeep(defaults.value, props?.defaults) as any as DefaultsInstance)
+  const newDefaults = computed(() => (
+    !props?.scoped
+      ? mergeDeep(defaults.value, props?.defaults)
+      : props?.defaults
+  ) as any as DefaultsInstance)
 
   provide(DefaultsSymbol, newDefaults)
 

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -33,9 +33,9 @@ export function provideDefaults (props?: {
   const defaults = useDefaults()
 
   const newDefaults = computed(() => (
-    !props?.scoped
-      ? mergeDeep(defaults.value, props?.defaults)
-      : props?.defaults
+    props?.scoped
+      ? props.defaults
+      : mergeDeep(defaults.value, props?.defaults)
   ) as any as DefaultsInstance)
 
   provide(DefaultsSymbol, newDefaults)


### PR DESCRIPTION
## Description
Default providers can now scope their settings to avoid inheriting from their parents or globally.

* the **scoped** prop only provides its specifically defined props. Nothing from parents or root is inherited.
  * some components modify the styling of slotted components. this avoids potentially unintended chained defaults; e.g. `v-bottom-navigation` targets `v-btn` with specific defaults but does not want to use parent / global properties
* the **reset** prop traverses its parents based upon the provided number
  * for use with components like `v-menu` that may not be interested in passing scoped defaults from a parent such as `v-bottom-navigation`
* the **root** property does not merge specifically defined or parent defaults, only global defaults

<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Many components within Material have specific styling that they add to existing Vuetify components such as `v-bottom-navigation`. This change is designed to utilize properties in place of SASS in cases where it makes sense.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <v-btn>Global Default: Contained</v-btn>

      <br>
      <br>

      <v-defaults-provider
        :defaults="{
          VBtn: {
            variant: 'contained-text',
          }
        }"
      >
        <v-btn>Provided Default: Contained Text</v-btn>

        <br>
        <br>

        <v-btn variant="outlined">Local Default: Outlined</v-btn>
      </v-defaults-provider>

      <br>
      <br>

      <v-defaults-provider :defaults="defaults">
        <v-btn>Provided Default: Text</v-btn>

        <br>
        <br>

        <v-defaults-provider root>
          <v-btn>Root: Contained</v-btn>
        </v-defaults-provider>

        <br>
        <br>

        <v-defaults-provider
          :defaults="{
            VBtn: {
              color: 'primary',
            }
          }"
        >
          <v-btn>Nested Provided Default: Text / Primary Color</v-btn>

          <br>
          <br>

          <v-defaults-provider reset="1">
            <v-btn>Reset: Text / Height / No Color</v-btn>
          </v-defaults-provider>
        </v-defaults-provider>
      </v-defaults-provider>
    </div>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      defaults: {
        VBtn: {
          height: 56,
          variant: 'text',
        },
      },
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
