### PR TITLE
fix(ripple): check parent before calling removeChild

### DIFF
--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -139,7 +139,7 @@ const ripples = {
           delete el.dataset.previousPosition
         }
 
-        animation.parentNode && el.removeChild(animation.parentNode)
+        animation.parentNode && el === animation.parentNode.parentNode && el.removeChild(animation.parentNode)
       }, 300)
     }, delay)
   },

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -139,7 +139,7 @@ const ripples = {
           delete el.dataset.previousPosition
         }
 
-        animation.parentNode && el === animation.parentNode.parentNode && el.removeChild(animation.parentNode)
+        if(animation?.parentNode?.parentNode === el) el.removeChild(animation.parentNode)
       }, 300)
     }, delay)
   },

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -139,7 +139,7 @@ const ripples = {
           delete el.dataset.previousPosition
         }
 
-        if (animation?.parentNode?.parentNode === el) el.removeChild(animation.parentNode)
+        if (animation.parentNode?.parentNode === el) el.removeChild(animation.parentNode)
       }, 300)
     }, delay)
   },

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -139,7 +139,7 @@ const ripples = {
           delete el.dataset.previousPosition
         }
 
-        if(animation?.parentNode?.parentNode === el) el.removeChild(animation.parentNode)
+        if (animation?.parentNode?.parentNode === el) el.removeChild(animation.parentNode)
       }, 300)
     }, delay)
   },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Check parent before calling removeChild in v-ripple ( #13457 )

fixes #13457

## Motivation and Context
User actions with ripple effect in iOS devices throw quite a few those errors.

## How Has This Been Tested?
Only 1 line non-breaking change, so no additional test created. 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
