### PR TITLE
fix(vselect): fix autowidth

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataFooter.spec.ts.snap
@@ -23,6 +23,7 @@ exports[`VDataFooter.ts should disable last page button if no items 1`] = `
                      type="text"
                      aria-readonly="false"
                      autocomplete="off"
+                     style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
               >
             </div>
             <div class="v-input__append-inner">
@@ -124,6 +125,7 @@ exports[`VDataFooter.ts should render first & last icons with showFirstLastPage 
                      type="text"
                      aria-readonly="false"
                      autocomplete="off"
+                     style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
               >
             </div>
             <div class="v-input__append-inner">
@@ -221,6 +223,7 @@ exports[`VDataFooter.ts should render in RTL mode 1`] = `
                      type="text"
                      aria-readonly="false"
                      autocomplete="off"
+                     style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
               >
             </div>
             <div class="v-input__append-inner">
@@ -318,6 +321,7 @@ exports[`VDataFooter.ts should render with custom itemsPerPage 1`] = `
                      type="text"
                      aria-readonly="false"
                      autocomplete="off"
+                     style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
               >
             </div>
             <div class="v-input__append-inner">
@@ -394,6 +398,7 @@ exports[`VDataFooter.ts should show current page if has showCurrentPage 1`] = `
                      type="text"
                      aria-readonly="false"
                      autocomplete="off"
+                     style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
               >
             </div>
             <div class="v-input__append-inner">

--- a/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataIterator/__tests__/__snapshots__/VDataIterator.spec.ts.snap
@@ -35,6 +35,7 @@ exports[`VDataIterator.ts should render and match snapshot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -126,6 +127,7 @@ exports[`VDataIterator.ts should render and match snapshot with data 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -208,6 +210,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -290,6 +293,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -372,6 +376,7 @@ exports[`VDataIterator.ts should render valid no-data, loading and no-results st
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -335,6 +335,7 @@ exports[`VDataTable.ts should apply class from item to rows 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -727,6 +728,7 @@ exports[`VDataTable.ts should apply class function to rows 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -1119,6 +1121,7 @@ exports[`VDataTable.ts should apply class list to rows 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -1511,6 +1514,7 @@ exports[`VDataTable.ts should apply class unique to rows 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -2153,6 +2157,7 @@ exports[`VDataTable.ts should default to first option in itemsPerPageOptions if 
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -2795,6 +2800,7 @@ exports[`VDataTable.ts should handle object when checking if it should default t
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -3438,6 +3444,7 @@ exports[`VDataTable.ts should hide group button when column is not groupable 1`]
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -3831,6 +3838,7 @@ exports[`VDataTable.ts should limit page to current page count if not using serv
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -3978,6 +3986,7 @@ exports[`VDataTable.ts should not limit page to current item count when using se
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -4370,6 +4379,7 @@ exports[`VDataTable.ts should not limit page to current item count when using se
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -5011,6 +5021,7 @@ exports[`VDataTable.ts should not search column with filterable set to false 1`]
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -5159,6 +5170,7 @@ exports[`VDataTable.ts should not search column with filterable set to false 2`]
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -5452,6 +5464,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6095,6 +6108,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6386,6 +6400,7 @@ exports[`VDataTable.ts should not select item that is not selectable 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6485,6 +6500,7 @@ exports[`VDataTable.ts should pass kebab-case footer props correctly 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6584,6 +6600,7 @@ exports[`VDataTable.ts should render 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6680,6 +6697,7 @@ exports[`VDataTable.ts should render footer.page-text slot content 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6781,6 +6799,7 @@ exports[`VDataTable.ts should render footer.prepend slot content 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -6983,6 +7002,7 @@ exports[`VDataTable.ts should render item slot when using group-by function 1`] 
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -7107,6 +7127,7 @@ exports[`VDataTable.ts should render loading state 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -7264,6 +7285,7 @@ exports[`VDataTable.ts should render loading state 2`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -7408,6 +7430,7 @@ exports[`VDataTable.ts should render with body slot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -7800,6 +7823,7 @@ exports[`VDataTable.ts should render with data 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -8195,6 +8219,7 @@ exports[`VDataTable.ts should render with foot slot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -8348,6 +8373,7 @@ exports[`VDataTable.ts should render with group scoped slot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -8859,6 +8885,7 @@ exports[`VDataTable.ts should render with group.summary scoped slot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -9318,6 +9345,7 @@ exports[`VDataTable.ts should render with grouped rows 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -9475,6 +9503,7 @@ exports[`VDataTable.ts should render with item scoped slot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -9892,6 +9921,7 @@ exports[`VDataTable.ts should render with item.expanded scoped slot 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -10340,6 +10370,7 @@ exports[`VDataTable.ts should render with showExpand 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -10788,6 +10819,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -11281,6 +11313,7 @@ exports[`VDataTable.ts should render with showSelect 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -11518,6 +11551,7 @@ exports[`VDataTable.ts should respect mustSort property on options 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -11730,6 +11764,7 @@ exports[`VDataTable.ts should search group-by column 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -11905,6 +11940,7 @@ exports[`VDataTable.ts should search group-by column 2`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -12013,6 +12049,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 1`] = `
                                type="text"
                                aria-readonly="false"
                                autocomplete="off"
+                               style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                         >
                       </div>
                       <div class="v-input__append-inner">
@@ -12313,6 +12350,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 1`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">
@@ -12421,6 +12459,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 2`] = `
                                type="text"
                                aria-readonly="false"
                                autocomplete="off"
+                               style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                         >
                       </div>
                       <div class="v-input__append-inner">
@@ -12721,6 +12760,7 @@ exports[`VDataTable.ts should show correct aria-labels when sorting 2`] = `
                        type="text"
                        aria-readonly="false"
                        autocomplete="off"
+                       style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                 >
               </div>
               <div class="v-input__append-inner">

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTableHeader.spec.ts.snap
@@ -663,6 +663,7 @@ exports[`VDataTableHeader.ts mobile should work with multiSort 1`] = `
                          type="text"
                          aria-readonly="false"
                          autocomplete="off"
+                         style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                   >
                 </div>
                 <div class="v-input__append-inner">
@@ -778,6 +779,7 @@ exports[`VDataTableHeader.ts mobile should work with sortBy correctly 1`] = `
                          type="text"
                          aria-readonly="false"
                          autocomplete="off"
+                         style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                   >
                 </div>
                 <div class="v-input__append-inner">
@@ -843,6 +845,7 @@ exports[`VDataTableHeader.ts mobile should work with sortDesc correctly 1`] = `
                          type="text"
                          aria-readonly="false"
                          autocomplete="off"
+                         style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
                   >
                 </div>
                 <div class="v-input__append-inner">

--- a/packages/vuetify/src/components/VOverflowBtn/__tests__/__snapshots__/VOverflowBtn.spec.ts.snap
+++ b/packages/vuetify/src/components/VOverflowBtn/__tests__/__snapshots__/VOverflowBtn.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`VOverflowBtn.js should use default autocomplete selections 1`] = `
           <input id="input-1"
                  readonly="readonly"
                  type="text"
+                 style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
           >
         </div>
         <div class="v-input__append-inner">
@@ -65,6 +66,7 @@ exports[`VOverflowBtn.js should use default autocomplete selections 2`] = `
           <input id="input-1"
                  readonly="readonly"
                  type="text"
+                 style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
           >
         </div>
         <div class="v-input__append-inner">

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -129,7 +129,7 @@
     min-width: 0
 
   &__selection
-    max-width: 90%
+    max-width: none
 
     &--comma
       margin: $select-selections-margin

--- a/packages/vuetify/src/components/VSelect/VSelect.ts
+++ b/packages/vuetify/src/components/VSelect/VSelect.ts
@@ -20,7 +20,7 @@ import Filterable from '../../mixins/filterable'
 import ClickOutside from '../../directives/click-outside'
 
 // Utilities
-import mergeData from '../../util/mergeData'
+import mergeData, { mergeStyles } from '../../util/mergeData'
 import { getPropertyFromItem, getObjectValueByPath, keyCodes } from '../../util/helpers'
 import { consoleError } from '../../util/console'
 
@@ -405,6 +405,16 @@ export default baseMixins.extend<options>().extend({
       // Otherwise push it into children
       } else {
         selections.children = selections.children || []
+        if (selections.children.length > 0) {
+          input.data!.style = mergeStyles(input.data!.style, {
+            minWidth: '0 !important',
+            maxWidth: '0 !important',
+            width: '0 !important',
+            minHeight: '0 !important',
+            maxHeight: '0 !important',
+            height: '0 !important',
+          })
+        }
         selections.children.push(input)
       }
 

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect2.spec.ts.snap
@@ -19,6 +19,7 @@ exports[`VSelect.ts should be clearable with prop, dirty and multi select 1`] = 
                  type="text"
                  aria-readonly="false"
                  autocomplete="off"
+                 style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
           >
         </div>
         <div class="v-input__append-inner">
@@ -79,6 +80,7 @@ exports[`VSelect.ts should be clearable with prop, dirty and single select 1`] =
                  type="text"
                  aria-readonly="false"
                  autocomplete="off"
+                 style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
           >
         </div>
         <div class="v-input__append-inner">
@@ -139,6 +141,7 @@ exports[`VSelect.ts should use scoped slot for selection generation 1`] = `
                  type="text"
                  aria-readonly="false"
                  autocomplete="off"
+                 style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
           >
         </div>
         <div class="v-input__append-inner">

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect3.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect3.spec.ts.snap
@@ -19,6 +19,7 @@ exports[`VSelect.ts should add color to selected index 1`] = `
                  type="text"
                  aria-readonly="false"
                  autocomplete="off"
+                 style="min-width: 0 !important; max-width: 0 !important; width: 0px !important; min-height: 0 !important; max-height: 0 !important; height: 0px;"
           >
         </div>
         <div class="v-input__append-inner">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Remove an extraneous input when selections are present.

fix #6275

## Motivation and Context
Currently there are problems with the width of VSelect. Please see #6275 for more details.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested using the demo environment from Markup section below. Also, updated relevant previous snapshots.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

Live demo: https://codesandbox.io/s/vuetify-dynamic-width-vselect-public-6zr3h?file=/index.html
<!-- Paste markup for testing your change --->
<details>

```vue
<body>
    <div id="app">
      <v-app>
        <v-row>
          <v-col cols="1"
            ><v-autocomplete
              v-model="candidate.identifier"
              :items="items"
              dense
              filled
              label="Filled"
              item-text="name"
              item-value="id"
            >
              <template v-slot:selection="{ item }">
                {{ item.name }}
              </template>
            </v-autocomplete></v-col
          >
          <v-spacer> </v-spacer>
        </v-row>
        <v-row>
          <div
            class="d-flex flex-grow-0 flex-shrink-0"
            style="flex-basis: 22%;"
          >
            <v-select
              class="ml-3"
              v-model="value"
              :items="simpleItems"
              attach
              chips
              label="Chips"
              multiple
            ></v-select>
          </div>
          <div
            class="d-flex flex-grow-0 flex-shrink-0"
            style="flex-basis: 78%;"
          ></div>
        </v-row>
      </v-app>
    </div>
    <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
    <!-- 2.6.2-alpha.8 involves js-focused changes -->
    <!-- 2.6.2-beta.5 involves css-focused changes -->
    <script src="https://cdn.jsdelivr.net/gh/abdih/vuetify@2.6.2-alpha.8/packages/vuetify/dist/vuetify.min.js"></script>
    <!-- <script src="https://cdn.jsdelivr.net/gh/abdih/vuetify@2.6.2-beta.5/packages/vuetify/dist/vuetify.min.js"></script> -->
    <script>
      new Vue({
        el: "#app",
        vuetify: new Vuetify(),
        data() {
          return {
            items: [
              { name: "Foo", id: 1 },
              { name: "Bar", id: 2 },
              { name: "Fizz", id: 3 },
              { name: "Buzz", id: 4 }
            ],
            simpleItems: ["foo", "bar", "fizz", "buzz"],
            value: ["foo", "bar", "buzz"],
            candidate: { identifier: 2 }
          };
        }
      });
    </script>
  </body>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
