### PR TITLE
fix(groupBy): working with multiple keys and sorts

### DIFF
--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -287,25 +287,22 @@ export function upperFirst (str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-export function groupItems<T extends any = any> (
-  items: T[],
-  groupBy: string[],
-  groupDesc: boolean[]
-): ItemGroup<T>[] {
-  const key = groupBy[0]
+export function groupItems<T extends any = any> (items: T[], groupBy: string[], groupDesc: boolean[]): ItemGroup<T>[] {
   const groups: ItemGroup<T>[] = []
-  let current
+  //grouping
   for (let i = 0; i < items.length; i++) {
-    const item = items[i]
-    const val = getObjectValueByPath(item, key, null)
-    if (current !== val) {
-      current = val
-      groups.push({
-        name: val ?? '',
-        items: [],
-      })
-    }
-    groups[groups.length - 1].items.push(item)
+    let group_name = groupBy.reduce((previous, current) => getObjectValueByPath(items[i], previous) + ' ' + getObjectValueByPath(items[i], current)).toUpperCase().trim();
+    let index = groups.findIndex(g => g.name === group_name);
+    if (index !== -1) groups[index].items.push(items[i]);
+    else groups.push({name: group_name, items: [items[i]], keys: groupBy.map(n => getObjectValueByPath(items[i], n))});
+  }
+  //sorting
+  for (let i = groupDesc.length - 1; i >= 0; i--) {
+    groups.sort((a,b) => {
+      if (a.keys[i] < b.keys[i]) return groupDesc[i] ? 1 : -1;
+      if (a.keys[i] > b.keys[i]) return groupDesc[i] ? -1 : 1;
+      return 0;
+    });
   }
   return groups
 }


### PR DESCRIPTION
## Motivation and Context
Currently v-data-table component only supports a single 'group-by' and single 'group-desc' value.
When using an array only the first element is considered.
This Pull Request solve this problem.

## How Has This Been Tested?
Visually tested and approved by my project team [Governmental Online Service](https://atendimento.crecims.gov.br) used in 3 states of the federative unit of Brazil.
At the CRECI-MS, CRECI-DF and CRECI-SC agencies.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>
Currently v-data-table component only supports a single grouping and single group sort, when using an array only the first element is considered.
The problem is the function "groupItems" in src/util/helpers.ts.
This Pull Request solve this problem.

```typescript
export function groupItems<T extends any = any> (items: T[], groupBy: string[], groupDesc: boolean[]): ItemGroup<T>[] {
  const groups: ItemGroup<T>[] = []
  //grouping
  for (let i = 0; i < items.length; i++) {
    let group_name = groupBy.reduce((previous, current) => getObjectValueByPath(items[i], previous) + ' ' + getObjectValueByPath(items[i], current)).toUpperCase().trim();
    let index = groups.findIndex(g => g.name === group_name);
    if (index !== -1) groups[index].items.push(items[i]);
    else groups.push({name: group_name, items: [items[i]], keys: groupBy.map(n => getObjectValueByPath(items[i], n))});
  }
  //sorting
  for (let i = groupDesc.length - 1; i >= 0; i--) {
    groups.sort((a,b) => {
      if (a.keys[i] < b.keys[i]) return groupDesc[i] ? 1 : -1;
      if (a.keys[i] > b.keys[i]) return groupDesc[i] ? -1 : 1;
      return 0;
    });
  }
  return groups
}
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
