### PR TITLE
fix(VDataTable): add missing event as 3rd argument

### DIFF
--- a/packages/api-generator/src/locale/en/v-data-table.json
+++ b/packages/api-generator/src/locale/en/v-data-table.json
@@ -62,7 +62,7 @@
     "top": "Slot to add content above the table"
   },
   "events": {
-    "click:row": "Emits when a table row is clicked. This event provides 2 arguments: the first is the item data that was clicked and the second is the other related data provided by the `item` slot. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
+    "click:row": "Emits when a table row is clicked. This event provides 3 arguments: the first is the item data that was clicked, the second is the other related data provided by the `item` slot and the third is the events. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
     "contextmenu:row": "Emits when a table row is right-clicked. The item for the row is included. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
     "dblclick:row": "Emits when a table row is double-clicked. The item for the row is included. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
     "current-items": "Emits the items provided via the **items** prop, every time the internal **computedItems** is changed.",

--- a/packages/api-generator/src/maps/v-data-table.js
+++ b/packages/api-generator/src/maps/v-data-table.js
@@ -31,7 +31,7 @@ const DataTableEvents = [
   {
     name: 'click:row',
     source: 'v-data-table',
-    value: `any, ${dataString}`,
+    value: `any, ${dataString}, MouseEvent`,
   },
   {
     name: 'contextmenu:row',

--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -510,7 +510,7 @@ export default mixins(
         on: {
           // TODO: for click, the first argument should be the event, and the second argument should be data,
           // but this is a breaking change so it's for v3
-          click: () => this.$emit('click:row', item, data),
+          click: (event: MouseEvent) => this.$emit('click:row', item, data, event),
           contextmenu: (event: MouseEvent) => this.$emit('contextmenu:row', event, data),
           dblclick: (event: MouseEvent) => this.$emit('dblclick:row', event, data),
         },


### PR DESCRIPTION

## Description
Add event as 3rd argument to click:row
fixes #10302

## Motivation and Context
Since adding event as 1st argument would be an breaking change, we could at least add it as 3rd argument so we can at least make use of it in vuetify 2. The alternatives to make a click on each row have an huge impact on developing, since we need to add on all tables the item slot instead and add all the td's manually.

## How Has This Been Tested?
There is already tests for this, same as dblclick event.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
