### PR TITLE
fix(VField/VInput): append/prepend click not being emitted

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -243,10 +243,12 @@ export const VField = genericComponent<new <T>() => {
           { hasPrepend && (
             <div
               class="v-field__prepend-inner"
-              onClick={ e => emit('click:prepend-inner', e) }
             >
               { props.prependInnerIcon && (
-                <VIcon icon={ props.prependInnerIcon } />
+                <VIcon
+                  onClick={ (e: MouseEvent) => emit('click:prepend-inner', e) }
+                  icon={ props.prependInnerIcon }
+                />
               ) }
 
               { slots?.prependInner?.(slotProps.value) }
@@ -297,12 +299,14 @@ export const VField = genericComponent<new <T>() => {
           { hasAppend && (
             <div
               class="v-field__append-inner"
-              onClick={ e => emit('click:append-inner', e) }
             >
               { slots?.appendInner?.(slotProps.value) }
 
               { props.appendInnerIcon && (
-                <VIcon icon={ props.appendInnerIcon } />
+                <VIcon
+                  onClick={ (e: MouseEvent) => emit('click:append-inner', e) }
+                  icon={ props.appendInnerIcon }
+                />
               ) }
             </div>
           ) }

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -127,12 +127,14 @@ export const VInput = genericComponent<new <T>() => {
           { hasPrepend && (
             <div
               class="v-input__prepend"
-              onClick={ e => emit('click:prepend', e) }
             >
               { slots?.prepend?.(slotProps.value) }
 
               { props.prependIcon && (
-                <VIcon icon={ props.prependIcon } />
+                <VIcon
+                  onClick={ (e: MouseEvent) => emit('click:prepend', e) }
+                  icon={ props.prependIcon }
+                />
               ) }
             </div>
           ) }
@@ -146,12 +148,14 @@ export const VInput = genericComponent<new <T>() => {
           { hasAppend && (
             <div
               class="v-input__append"
-              onClick={ e => emit('click:append', e) }
             >
               { slots?.append?.(slotProps.value) }
 
               { props.appendIcon && (
-                <VIcon icon={ props.appendIcon } />
+                <VIcon
+                  onClick={ (e: MouseEvent) => emit('click:append', e) }
+                  icon={ props.appendIcon }
+                />
               ) }
             </div>
           ) }


### PR DESCRIPTION
## Description
resolves #14685

## Motivation and Context
(#14685 )

## How Has This Been Tested?
testing the playground just check the console:
![imagen](https://user-images.githubusercontent.com/6311119/152409076-32f09f7b-aac8-4af8-aeae-7d45ddecc95e.png)

## Markup:
Forked vuetify repo, checkout next branch and create a new one: I fix `VField` and `VInput` components, then `yarn build` from root.

<details>
<summary><strong>Playground</strong></summary>

```vue
<template>
  <v-container>
    <v-text-field
      label="What's your name?"
      append-icon="mdi:account"
      prepend-icon="mdi:account"
      prepend-inner-icon="mdi:account"
      append-inner-icon="mdi:account"
      @click:append="handleClick('append')"
      @click:prepend="handleClick('prepend')"
      @click:append-inner="handleClick('append-inner')"
      @click:prepend-inner="handleClick('prepend-inner')"
    />
  </v-container>
</template>

<script>
  export default {
    methods: {
      handleClick (from) {
        // eslint-disable-next-line no-console
        console.log(`click ${from}`)
      },
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
