### PR TITLE
fix(VAutoComplete): fix cursor behavior

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -1,7 +1,7 @@
 @import './_variables.scss'
 
 .v-autocomplete
-  &.v-input > .v-input__control > .v-input__slot
+  &.v-input > .v-input__control > .v-input__slot > .v-select__slot > .v-select__selections
     cursor: text
 
   input


### PR DESCRIPTION
## Description
Set cursor style as `pointer` when a menu down icon is hoverd.

![cursor](https://user-images.githubusercontent.com/23548312/154837869-f0a8d2e3-da14-41b5-ba80-1779ffaea3f5.gif)




## Motivation and Context
resolve  #14641

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<template>
  <v-container>
    <div style="width: 500px">
      <v-autocomplete
        v-model="values"
        :items="items"
        multiple
      />
    </div>
  </v-container>
</template>

<script lang="ts">

  export default {
    data: () => ({
      items: ['foo', 'bar', 'fizz', 'buzz'],
      values: ['foo', 'bar'],
      value: null,
    }),
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
