### PR TITLE
fix: Replace deprecated String.prototype.substr()

### DIFF
--- a/packages/docs/src/components/doc/ColorPalette.vue
+++ b/packages/docs/src/components/doc/ColorPalette.vue
@@ -106,7 +106,7 @@
       },
       convertToClass (str) {
         const end = this.endStr(str)
-        const sub = str.substr(0, str.length - 1)
+        const sub = str.slice(0, -1)
 
         if (isNaN(parseInt(end))) return str
 

--- a/packages/docs/src/examples/v-date-picker-month/misc-dialog-and-menu.vue
+++ b/packages/docs/src/examples/v-date-picker-month/misc-dialog-and-menu.vue
@@ -99,7 +99,7 @@
 <script>
   export default {
     data: () => ({
-      date: new Date().toISOString().substr(0, 7),
+      date: new Date().toISOString().slice(0, 7),
       menu: false,
       modal: false,
     }),

--- a/packages/docs/src/examples/v-date-picker-month/misc-internationalization.vue
+++ b/packages/docs/src/examples/v-date-picker-month/misc-internationalization.vue
@@ -17,7 +17,7 @@
   export default {
     data () {
       return {
-        picker: new Date().toISOString().substr(0, 7),
+        picker: new Date().toISOString().slice(0, 7),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker-month/misc-orientation.vue
+++ b/packages/docs/src/examples/v-date-picker-month/misc-orientation.vue
@@ -16,7 +16,7 @@
   export default {
     data () {
       return {
-        picker: new Date().toISOString().substr(0, 7),
+        picker: new Date().toISOString().slice(0, 7),
         landscape: false,
       }
     },

--- a/packages/docs/src/examples/v-date-picker-month/prop-colors.vue
+++ b/packages/docs/src/examples/v-date-picker-month/prop-colors.vue
@@ -18,8 +18,8 @@
   export default {
     data () {
       return {
-        picker: new Date().toISOString().substr(0, 7),
-        picker2: new Date().toISOString().substr(0, 7),
+        picker: new Date().toISOString().slice(0, 7),
+        picker2: new Date().toISOString().slice(0, 7),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker-month/prop-icons.vue
+++ b/packages/docs/src/examples/v-date-picker-month/prop-icons.vue
@@ -14,7 +14,7 @@
   export default {
     data () {
       return {
-        picker: new Date().toISOString().substr(0, 7),
+        picker: new Date().toISOString().slice(0, 7),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker-month/prop-readonly.vue
+++ b/packages/docs/src/examples/v-date-picker-month/prop-readonly.vue
@@ -12,7 +12,7 @@
   export default {
     data () {
       return {
-        date: new Date().toISOString().substr(0, 7),
+        date: new Date().toISOString().slice(0, 7),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker-month/prop-show-current.vue
+++ b/packages/docs/src/examples/v-date-picker-month/prop-show-current.vue
@@ -17,7 +17,7 @@
   export default {
     data () {
       return {
-        month1: new Date().toISOString().substr(0, 7),
+        month1: new Date().toISOString().slice(0, 7),
         month2: '2013-09',
       }
     },

--- a/packages/docs/src/examples/v-date-picker-month/prop-width.vue
+++ b/packages/docs/src/examples/v-date-picker-month/prop-width.vue
@@ -18,7 +18,7 @@
 <script>
   export default {
     data: () => ({
-      date: new Date().toISOString().substr(0, 7),
+      date: new Date().toISOString().slice(0, 7),
     }),
   }
 </script>

--- a/packages/docs/src/examples/v-date-picker-month/usage.vue
+++ b/packages/docs/src/examples/v-date-picker-month/usage.vue
@@ -11,7 +11,7 @@
   export default {
     data () {
       return {
-        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker/event-button-events.vue
+++ b/packages/docs/src/examples/v-date-picker/event-button-events.vue
@@ -50,7 +50,7 @@
 <script>
   export default {
     data: () => ({
-      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       done: [false, false, false],
       mouseMonth: null,
     }),

--- a/packages/docs/src/examples/v-date-picker/event-events.vue
+++ b/packages/docs/src/examples/v-date-picker/event-events.vue
@@ -27,8 +27,8 @@
   export default {
     data: () => ({
       arrayEvents: null,
-      date1: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
-      date2: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+      date1: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
+      date2: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
     }),
 
     mounted () {
@@ -36,7 +36,7 @@
         const day = Math.floor(Math.random() * 30)
         const d = new Date()
         d.setDate(day)
-        return d.toISOString().substr(0, 10)
+        return d.toISOString().slice(0, 10)
       })
     },
 

--- a/packages/docs/src/examples/v-date-picker/misc-birthday.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-birthday.vue
@@ -22,7 +22,7 @@
       <v-date-picker
         v-model="date"
         :active-picker.sync="activePicker"
-        :max="(new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10)"
+        :max="(new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10)"
         min="1950-01-01"
         @change="save"
       ></v-date-picker>

--- a/packages/docs/src/examples/v-date-picker/misc-dialog-and-menu.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-dialog-and-menu.vue
@@ -128,7 +128,7 @@
 <script>
   export default {
     data: () => ({
-      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       menu: false,
       modal: false,
       menu2: false,

--- a/packages/docs/src/examples/v-date-picker/misc-formatting.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-formatting.vue
@@ -74,8 +74,8 @@
 <script>
   export default {
     data: vm => ({
-      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
-      dateFormatted: vm.formatDate((new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10)),
+      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
+      dateFormatted: vm.formatDate((new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10)),
       menu1: false,
       menu2: false,
     }),

--- a/packages/docs/src/examples/v-date-picker/misc-internationalization.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-internationalization.vue
@@ -17,7 +17,7 @@
   export default {
     data () {
       return {
-        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker/misc-orientation.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-orientation.vue
@@ -15,7 +15,7 @@
   export default {
     data () {
       return {
-        picker: new Date().toISOString().substr(0, 7),
+        picker: new Date().toISOString().slice(0, 7),
         landscape: false,
       }
     },

--- a/packages/docs/src/examples/v-date-picker/prop-colors.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-colors.vue
@@ -16,8 +16,8 @@
   export default {
     data () {
       return {
-        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
-        picker2: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
+        picker2: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker/prop-icons.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-icons.vue
@@ -13,7 +13,7 @@
   export default {
     data () {
       return {
-        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker/prop-picker-date.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-picker-date.vue
@@ -38,7 +38,7 @@
 <script>
   export default {
     data: () => ({
-      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       pickerDate: null,
       notes: [],
       allNotes: [

--- a/packages/docs/src/examples/v-date-picker/prop-readonly.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-readonly.vue
@@ -11,7 +11,7 @@
   export default {
     data () {
       return {
-        date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       }
     },
   }

--- a/packages/docs/src/examples/v-date-picker/prop-show-current.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-show-current.vue
@@ -15,7 +15,7 @@
   export default {
     data () {
       return {
-        date1: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        date1: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
         date2: '2013-07-29',
       }
     },

--- a/packages/docs/src/examples/v-date-picker/prop-width.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-width.vue
@@ -16,7 +16,7 @@
 <script>
   export default {
     data: () => ({
-      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+      date: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
     }),
   }
 </script>

--- a/packages/docs/src/examples/v-date-picker/usage.vue
+++ b/packages/docs/src/examples/v-date-picker/usage.vue
@@ -8,7 +8,7 @@
   export default {
     data () {
       return {
-        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10),
+        picker: (new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 10),
       }
     },
   }

--- a/packages/docs/src/util/date.js
+++ b/packages/docs/src/util/date.js
@@ -1,5 +1,5 @@
 import { format, parseISO } from 'date-fns'
 
 export function formatDate (date) {
-  return format(parseISO(date.toISOString().substr(0, 10)), 'MMMM d')
+  return format(parseISO(date.toISOString().slice(0, 10)), 'MMMM d')
 }

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.ts
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.ts
@@ -117,7 +117,7 @@ export default Vue.extend({
     genInputs (): VNode[] | VNode {
       if (this.internalMode === 'hexa') {
         const hex = this.color.hexa
-        const value = this.hideAlpha && hex.endsWith('FF') ? hex.substr(0, 7) : hex
+        const value = this.hideAlpha && hex.endsWith('FF') ? hex.slice(0, 7) : hex
         return this.genInput(
           'hex',
           {

--- a/packages/vuetify/src/components/VColorPicker/util/index.ts
+++ b/packages/vuetify/src/components/VColorPicker/util/index.ts
@@ -32,7 +32,7 @@ export function fromHSVA (hsva: HSVA): VColorPickerColor {
   const rgba = HSVAtoRGBA(hsva)
   return {
     alpha: hsva.a,
-    hex: hexa.substr(0, 7),
+    hex: hexa.slice(0, 7),
     hexa,
     hsla,
     hsva,
@@ -47,7 +47,7 @@ export function fromHSLA (hsla: HSLA): VColorPickerColor {
   const rgba = HSVAtoRGBA(hsva)
   return {
     alpha: hsva.a,
-    hex: hexa.substr(0, 7),
+    hex: hexa.slice(0, 7),
     hexa,
     hsla,
     hsva,
@@ -62,7 +62,7 @@ export function fromRGBA (rgba: RGBA): VColorPickerColor {
   const hsla = HSVAtoHSLA(hsva)
   return {
     alpha: hsva.a,
-    hex: hexa.substr(0, 7),
+    hex: hexa.slice(0, 7),
     hexa,
     hsla,
     hsva,
@@ -77,7 +77,7 @@ export function fromHexa (hexa: Hexa): VColorPickerColor {
   const rgba = HSVAtoRGBA(hsva)
   return {
     alpha: hsva.a,
-    hex: hexa.substr(0, 7),
+    hex: hexa.slice(0, 7),
     hexa,
     hsla,
     hsva,

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.ts
@@ -171,9 +171,9 @@ export default mixins(
       if (!this.value || this.type === 'month') {
         return this.value
       } else if (this.isMultiple) {
-        return this.multipleValue.map(val => val.substr(0, 7))
+        return this.multipleValue.map(val => val.slice(0, 7))
       } else {
-        return (this.value as string).substr(0, 7)
+        return (this.value as string).slice(0, 7)
       }
     },
     current (): string | null {

--- a/packages/vuetify/src/components/VDatePicker/util/createNativeLocaleFormatter.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/createNativeLocaleFormatter.ts
@@ -32,7 +32,7 @@ function createNativeLocaleFormatter (
     return (dateString: string) => intlFormatter.format(new Date(`${makeIsoString(dateString)}T00:00:00+00:00`))
   } catch (e) {
     return (substrOptions.start || substrOptions.length)
-      ? (dateString: string) => makeIsoString(dateString).substr(substrOptions.start || 0, substrOptions.length)
+      ? (dateString: string) => makeIsoString(dateString).slice(substrOptions.start || 0, (substrOptions.start || 0) + substrOptions.length)
       : undefined
   }
 }

--- a/packages/vuetify/src/components/VDatePicker/util/isDateAllowed.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/isDateAllowed.ts
@@ -2,6 +2,6 @@ import { DatePickerAllowedDatesFunction } from 'vuetify/types'
 
 export default function isDateAllowed (date: string, min: string, max: string, allowedFn: DatePickerAllowedDatesFunction | undefined) {
   return (!allowedFn || allowedFn(date)) &&
-    (!min || date >= min.substr(0, 10)) &&
+    (!min || date >= min.slice(0, 10)) &&
     (!max || date <= max)
 }

--- a/packages/vuetify/src/components/VDatePicker/util/sanitizeDateString.ts
+++ b/packages/vuetify/src/components/VDatePicker/util/sanitizeDateString.ts
@@ -4,5 +4,5 @@ import pad from './pad'
 
 export default (dateString: string, type: 'date' | 'month' | 'year'): string => {
   const [year, month = 1, date = 1] = dateString.split('-')
-  return `${year}-${pad(month)}-${pad(date)}`.substr(0, { date: 10, month: 7, year: 4 }[type])
+  return `${year}-${pad(month)}-${pad(date)}`.slice(0, { date: 10, month: 7, year: 4 }[type])
 }

--- a/packages/vuetify/src/util/colorUtils.ts
+++ b/packages/vuetify/src/util/colorUtils.ts
@@ -168,7 +168,7 @@ export function RGBtoCSS (rgba: RGBA): string {
 export function RGBAtoHex (rgba: RGBA): Hex {
   const toHex = (v: number) => {
     const h = Math.round(v).toString(16)
-    return ('00'.substr(0, 2 - h.length) + h).toUpperCase()
+    return ('00'.substring(0, 2 - h.length) + h).toUpperCase()
   }
 
   return `#${[
@@ -216,7 +216,7 @@ export function parseHex (hex: string): Hex {
     hex = padEnd(padEnd(hex, 6), 8, 'F')
   }
 
-  return `#${hex}`.toUpperCase().substr(0, 9)
+  return `#${hex}`.toUpperCase().slice(0, 9)
 }
 
 export function parseGradient (

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -439,7 +439,7 @@ export function chunk (str: string, size = 1) {
   const chunked: string[] = []
   let index = 0
   while (index < str.length) {
-    chunked.push(str.substr(index, size))
+    chunked.push(str.slice(index, index + size))
     index += size
   }
   return chunked


### PR DESCRIPTION
## Description
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## How Has This Been Tested?
I have tested all functions individually to make sure they return the same results as before

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
