### PR TITLE
fix(VCheckbox) label slot rendering

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -65,8 +65,7 @@ export const VCheckbox = defineComponent({
       const [inputProps, _1] = filterInputProps(props)
       const [controlProps, _2] = filterControlProps(props)
       
-      const inputSlots = pick(slots, ['prepend', 'append', 'details']);
-      const selectionControlSlots = pick(slots, ['default', 'input']);
+      const [inputSlots, selectionControlSlots] = pick(slots, ['prepend', 'append', 'details']);
 
       return (
         <VInput

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -10,7 +10,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
 import { computed } from 'vue'
-import { defineComponent, filterInputAttrs, useRender } from '@/util'
+import { pick, defineComponent, filterInputAttrs, useRender } from '@/util'
 
 export const VCheckbox = defineComponent({
   name: 'VCheckbox',
@@ -64,6 +64,9 @@ export const VCheckbox = defineComponent({
       const [inputAttrs, controlAttrs] = filterInputAttrs(attrs)
       const [inputProps, _1] = filterInputProps(props)
       const [controlProps, _2] = filterControlProps(props)
+      
+      const inputSlots = pick(slots, ['prepend', 'append', 'details']);
+      const selectionControlSlots = pick(slots, ['default', 'input']);
 
       return (
         <VInput
@@ -72,7 +75,7 @@ export const VCheckbox = defineComponent({
           { ...inputProps }
         >
           {{
-            ...slots,
+            ...inputSlots,
             default: ({
               isDisabled,
               isReadonly,
@@ -86,6 +89,7 @@ export const VCheckbox = defineComponent({
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }
                 disabled={ isDisabled.value }
                 readonly={ isReadonly.value }
+                v-slots={ selectionControlSlots }
                 { ...controlAttrs }
               />
             ),


### PR DESCRIPTION
## Description
Pass `default` and `label` slots to `VSelectionControl` component.

## Motivation and Context
Currently, `label` slot is not being rendered on `VCheckbox` component.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
