### PR TITLE
docs: update title on link to vuetify next

### DIFF
--- a/packages/docs/src/components/menus/ReleasesMenu.vue
+++ b/packages/docs/src/components/menus/ReleasesMenu.vue
@@ -26,7 +26,7 @@
         return [
           { heading: this.$t('documentation') },
           {
-            title: '3.0.0 Alpha',
+            title: '3.0.0 Beta',
             href: 'https://next.vuetifyjs.com',
           },
           {


### PR DESCRIPTION
## Description
Changed the title of the link to the vuetify next, from Alpha to Beta

## Motivation and Context
The vuetify next is currently in version Beta, not version Alpha

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
