### PR TITLE
fix(VListItem): deselect item on external route change

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -111,6 +111,10 @@ export const VListItem = genericComponent<new () => {
       if (val && parent.value != null) {
         root.open(parent.value, true)
       }
+
+      if (isSelected.value && !link.isExactActive?.value) {
+        select(false)
+      }
     })
 
     const { themeClasses } = provideTheme(props)

--- a/packages/vuetify/src/components/VList/__tests__/VList.spec.cy.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VList.spec.cy.tsx
@@ -163,11 +163,12 @@ describe('VList', () => {
       ],
     })
 
+    // eslint-disable-next-line sonarjs/no-identical-functions
     cy.mount(() => (
       <CenteredGrid width="400px">
         <VList>
           <VListItem to="/" title="Home" />
-          <VListItem to="/team" title="Team" />
+          <VListItem to="/about" title="About" />
         </VList>
       </CenteredGrid>
     ), {
@@ -176,12 +177,54 @@ describe('VList', () => {
       },
     })
 
+    cy.get('.v-list-item').eq(1).trigger('click')
+
     cy.get('.v-list').then(() => {
-      router.push('/team')
+      expect(router.currentRoute.value.path).to.equal('/about')
+    })
+  })
+
+  it('should deselect v-list-item if route changes externally', () => {
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [
+        {
+          path: '/',
+          component: { template: 'Home' },
+        },
+        {
+          path: '/about',
+          component: { template: 'About' },
+        },
+        {
+          path: '/other',
+          component: { template: 'Other' },
+        },
+      ],
     })
 
-    cy.get('.v-list-item').eq(1).trigger('click').then(() => {
-      expect(router.currentRoute.value.path).to.equal('/team')
+    // eslint-disable-next-line sonarjs/no-identical-functions
+    cy.mount(() => (
+      <CenteredGrid width="400px">
+        <VList>
+          <VListItem to="/" title="Home" />
+          <VListItem to="/about" title="About" />
+        </VList>
+      </CenteredGrid>
+    ), {
+      global: {
+        plugins: [router],
+      },
     })
+
+    cy.get('.v-list-item').eq(1).click().should('have.class', 'v-list-item--active')
+
+    cy.get('.v-list').then(() => {
+      expect(router.currentRoute.value.path).to.equal('/about')
+    })
+
+    cy.get('.v-list').then(() => router.push('/other'))
+
+    cy.get('.v-list-item').eq(1).should('not.have.class', 'v-list-item--active')
   })
 })

--- a/packages/vuetify/src/components/VOverlay/__tests__/VOverlay.spec.cy.tsx
+++ b/packages/vuetify/src/components/VOverlay/__tests__/VOverlay.spec.cy.tsx
@@ -49,25 +49,34 @@ describe('VOverlay', () => {
       .get('[data-test="content"]').should('not.exist')
   })
 
-  it.skip('should have correct z-index inside layout item', () => {
+  it('should have correct z-index', () => {
     cy.mount(() => (
       <Application>
-        <VLayoutItem position="left" size="300" modelValue data-test="layout-item">
-          <VOverlay data-test="overlay">
-            {{
-              activator: ({ props }) => <div { ...props } data-test="activator">Click me</div>,
-              default: () => <div data-test="content">Content</div>,
-            }}
-          </VOverlay>
-        </VLayoutItem>
+        <VOverlay data-test="overlay">
+          {{
+            activator: ({ props }) => <div { ...props } data-test="activator">Click me</div>,
+            default: () => (
+              <div data-test="content">
+                <VOverlay data-test="overlay-2">
+                  {{
+                    activator: ({ props }) => <div { ...props } data-test="activator-2">Click me</div>,
+                    default: () => <div data-test="content-2">Content</div>,
+                  }}
+                </VOverlay>
+              </div>
+            ),
+          }}
+        </VOverlay>
       </Application>
     ))
 
     cy.get('[data-test="activator"]').should('exist').click()
 
-    cy.get('[data-test="layout-item"').should('have.css', 'z-index').then(zIndex => {
-      cy.get('[data-test="overlay"]').should('have.css', 'z-index', String(Number(zIndex) + 1))
-    })
+    cy.get('[data-test="overlay"]').should('have.css', 'z-index', '2001')
+
+    cy.get('[data-test="activator-2"]').should('exist').click()
+
+    cy.get('[data-test="overlay-2"]').should('have.css', 'z-index', '2002')
   })
 
   it('should render overlay on top of layout', () => {

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -203,7 +203,7 @@ export const useNestedItem = (id: Ref<string | undefined>, isGroup: boolean) => 
     open: (open: boolean, e: Event) => parent.root.open(computedId.value, open, e),
     isOpen: computed(() => parent.root.opened.value.has(computedId.value)),
     parent: computed(() => parent.root.parents.value.get(computedId.value)),
-    select: (selected: boolean, e: Event) => parent.root.select(computedId.value, selected, e),
+    select: (selected: boolean, e?: Event) => parent.root.select(computedId.value, selected, e),
     isSelected: computed(() => parent.root.selected.value.get(computedId.value) === 'on'),
     isIndeterminate: computed(() => parent.root.selected.value.get(computedId.value) === 'indeterminate'),
     isLeaf: computed(() => !parent.root.children.value.get(computedId.value)),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

make sure v-list-item does not keep active state if route changes externally

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
