### PR TITLE
fix(VAutocomplete): fix unable to set default searchInput

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -50,7 +50,7 @@ export default VSelect.extend({
     },
     noFilter: Boolean,
     searchInput: {
-      type: String as PropType<string | null>,
+      type: String as PropType<String | null>,
     },
   },
 
@@ -95,7 +95,7 @@ export default VSelect.extend({
       })
     },
     internalSearch: {
-      get (): string | null {
+      get (): String | null {
         return this.lazySearch
       },
       set (val: any) { // TODO: this should be `string | null` but it breaks lots of other types
@@ -204,6 +204,9 @@ export default VSelect.extend({
   },
 
   created () {
+    if (this.searchInput) {
+      this.selectItem(this.searchInput)
+    }
     this.setSearch()
   },
 


### PR DESCRIPTION
resolves #9757

## Description
When using a default value in search-input it was reset because VSelect wasn't aware that it was selected. Now when a default value is used, it will be selected when VAutocomplete is created.

## Motivation and Context
This change fixes issue #9757.

## How Has This Been Tested?
I've tested this manually.

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-autocomplete
      :search-input.sync="search"
      :items="items"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      search: 'three',
      items: [
        'one',
        'two',
        'three'
      ],
    }),
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
