### PR TITLE
fix(VTreeview): independent selection inheriting parent state

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -217,7 +217,7 @@ export default mixins(
         this.buildTree(children, key)
 
         // This fixed bug with dynamic children resetting selected parent state
-        if (!this.nodes.hasOwnProperty(key) && parent !== null && this.nodes.hasOwnProperty(parent)) {
+        if (!this.nodes.hasOwnProperty(key) && parent !== null && this.nodes.hasOwnProperty(parent) && this.selectionType !== 'independent') {
           node.isSelected = this.nodes[parent].isSelected
         } else {
           node.isSelected = oldNode.isSelected

--- a/packages/vuetify/src/components/VTreeview/VTreeview.ts
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.ts
@@ -217,7 +217,12 @@ export default mixins(
         this.buildTree(children, key)
 
         // This fixed bug with dynamic children resetting selected parent state
-        if (!this.nodes.hasOwnProperty(key) && parent !== null && this.nodes.hasOwnProperty(parent) && this.selectionType !== 'independent') {
+        if (
+          this.selectionType !== 'independent' &&
+          parent !== null &&
+          !this.nodes.hasOwnProperty(key) &&
+          this.nodes.hasOwnProperty(parent)
+        ) {
           node.isSelected = this.nodes[parent].isSelected
         } else {
           node.isSelected = oldNode.isSelected


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

fixes https://github.com/vuetifyjs/vuetify/issues/14955

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app id="inspire">
    <v-main>
      <v-btn
        color="info"
        @click="setSelected"
      >select last added</v-btn>
      <!-- selection-type="independent" -->
      <v-treeview
        v-model="selectedItems"
        dense
        selectable
        :items="items"
        :load-children="loadChildren"
      ></v-treeview> </v-main></v-app>
</template>

<script>
  export default {
    data: () => ({
      selectedItems: [],
      ctr: 0,
      items: [
        {
          id: 1,
          name: '1',
          children: [
            { id: 2, name: '2', children: [] },
            { id: 3, name: '3', children: [] },
            { id: 4, name: '4', children: [] },
          ],
        },
      ],
    }),
    methods: {
      setSelected () {
        this.selectedItems.push('new_' + (this.ctr - 1))
      },
      loadChildren (node) {
        const id = 'new_' + this.ctr++
        node.children.push({ id, name: id, children: [] })
      },
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
