### PR TITLE
fix: inbox.vue: placement of :key

### DIFF
--- a/packages/docs/src/examples/wireframes/inbox.vue
+++ b/packages/docs/src/examples/wireframes/inbox.vue
@@ -61,11 +61,8 @@
               <v-subheader>{{ card }}</v-subheader>
 
               <v-list two-line>
-                <template v-for="n in 6">
-                  <v-list-item
-
-                    :key="n"
-                  >
+                <template v-for="n in 6" :key="n">
+                  <v-list-item>
                     <v-list-item-avatar color="grey darken-1">
                     </v-list-item-avatar>
 


### PR DESCRIPTION
## Description
Key should be placed on the `<template>` tag which using v-for.

## Motivation and Context

## How Has This Been Tested?

## Markup:

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
