### PR TITLE
feat(VForm): emit custom SubmitEventPromise event on submit

### DIFF
--- a/packages/api-generator/src/maps/components/v-form.js
+++ b/packages/api-generator/src/maps/components/v-form.js
@@ -22,12 +22,12 @@ module.exports = {
     ],
     events: [
       {
-        name: 'input',
+        name: 'update:modelValue',
         value: 'boolean',
       },
       {
         name: 'submit',
-        value: 'event',
+        value: 'SubmitEventPromise',
       },
     ],
   },

--- a/packages/vuetify/src/components/VForm/VForm.tsx
+++ b/packages/vuetify/src/components/VForm/VForm.tsx
@@ -39,14 +39,16 @@ export const VForm = defineComponent({
       e.finally = ready.finally.bind(ready)
 
       emit('submit', e)
-      const { defaultPrevented } = e
-      e.preventDefault()
 
-      ready.then(({ valid }) => {
-        if (valid && !defaultPrevented) {
-          formRef.value?.submit()
-        }
-      })
+      if (!e.defaultPrevented) {
+        ready.then(({ valid }) => {
+          if (valid) {
+            formRef.value?.submit()
+          }
+        })
+      }
+
+      e.preventDefault()
     }
 
     useRender(() => ((

--- a/packages/vuetify/src/components/VForm/__tests__/VForm.spec.cy.tsx
+++ b/packages/vuetify/src/components/VForm/__tests__/VForm.spec.cy.tsx
@@ -5,6 +5,7 @@ import { ref } from 'vue'
 import { Application } from '../../../../cypress/templates'
 import { VForm } from '../'
 import { VBtn, VTextField } from '@/components'
+import type { SubmitEventPromise } from '@/composables'
 
 describe('VForm', () => {
   it('should emit when inputs are updated', () => {
@@ -157,6 +158,28 @@ describe('VForm', () => {
 
     cy.get('.v-btn').click().url().should('not.contain', '/action')
     cy.get('.v-text-field').should('have.class', 'v-input--error').find('.v-messages').should('have.text', 'Field required')
+  })
+
+  it('should emit a SubmitEventPromise', () => {
+    cy.mount(() => (
+      <Application>
+        <VForm action="/action" onSubmit={ onSubmit }>
+          <VTextField modelValue="foo" rules={ [v => !!v || 'Field required'] } />
+          <VBtn type="submit">Submit</VBtn>
+        </VForm>
+      </Application>
+    ))
+
+    function onSubmit (e: SubmitEventPromise) {
+      e.preventDefault()
+    }
+
+    cy.get('.v-btn').click().url().should('not.contain', '/action')
+    cy.vue().then(async wrapper => {
+      const emits = wrapper.findComponent('.v-form').emitted('submit')
+
+      expect(await emits[0][0]).to.deep.equal({ valid: true, errorMessages: [] })
+    })
   })
 
   // TODO: This test has to be the last one,

--- a/packages/vuetify/src/composables/form.ts
+++ b/packages/vuetify/src/composables/form.ts
@@ -34,6 +34,8 @@ interface FormValidationResult {
   errorMessages: string[]
 }
 
+export interface SubmitEventPromise extends SubmitEvent, Promise<{ valid: boolean, errorMessages: FormValidationResult[] }> {}
+
 export const FormKey: InjectionKey<FormProvide> = Symbol.for('vuetify:form')
 
 export interface FormProps {

--- a/packages/vuetify/src/composables/index.ts
+++ b/packages/vuetify/src/composables/index.ts
@@ -10,6 +10,7 @@ export { useLayout } from './layout'
 
 export type { DefaultsInstance } from './defaults'
 export type { DisplayBreakpoint, DisplayInstance, DisplayThresholds } from './display'
+export type { SubmitEventPromise } from './form'
 export type { IconAliases, IconProps, IconSet, IconOptions } from './icons'
 export type { LocaleAdapter } from './locale'
 export type { RtlInstance } from './rtl'


### PR DESCRIPTION
## Description
Related: #14945

If `preventDefault` is not called on the submit event then the form will be submitted normally when validation succeeds. Otherwise, consumers can await the submit event to take their own action after validation. 


## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-form ref="form" @submit.prevent="onSubmit">
        <v-text-field />
        <v-btn type="submit">submit</v-btn>
      </v-form>

      <v-btn type="submit" @click="submit">external submit</v-btn>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { computed, ref, watch } from 'vue'
  import type { SubmitEventPromise } from 'vuetify'
  import type { VForm } from 'vuetify/components'

  const form = ref<VForm>()

  function onSubmit (e: SubmitEventPromise) {
    // or const { valid } = await e
    e.then(({ valid }) => {
      console.log(valid)
    })
  }

  function submit () {
    form.value?.validate().then(({ valid }) => {
      console.log(valid)
      // form.value.submit() or axios.post()
    })
  }
</script>
```
</details>

