### PR TITLE
add selectable class to VDataTable

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.ts
@@ -573,6 +573,7 @@ export default mixins(
         height: this.height,
         fixedHeader: this.fixedHeader,
         dense: this.dense,
+        showSelect: this.showSelect,
       }
 
       // if (this.virtualRows) {

--- a/packages/vuetify/src/components/VDataTable/VSimpleTable.ts
+++ b/packages/vuetify/src/components/VDataTable/VSimpleTable.ts
@@ -12,6 +12,7 @@ export default mixins(Themeable).extend({
     dense: Boolean,
     fixedHeader: Boolean,
     height: [Number, String],
+    showSelect: Boolean,
   },
 
   computed: {
@@ -22,6 +23,7 @@ export default mixins(Themeable).extend({
         'v-data-table--fixed-header': this.fixedHeader,
         'v-data-table--has-top': !!this.$slots.top,
         'v-data-table--has-bottom': !!this.$slots.bottom,
+        'v-data-table--selectable': this.showSelect,
         ...this.themeClasses,
       }
     },

--- a/packages/vuetify/src/components/VDataTable/__tests__/VSimpleTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VSimpleTable.spec.ts
@@ -83,6 +83,12 @@ describe('VSimpleTable.ts', () => {
       'v-data-table--dense': true,
     })
     wrapper.setProps({
+      showSelect: true,
+    })
+    expect(wrapper.vm.classes).toMatchObject({
+      'v-data-table--selectable': true,
+    })
+    wrapper.setProps({
       dark: true,
     })
     expect(wrapper.vm.classes).toMatchObject({

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -6154,7 +6154,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
 `;
 
 exports[`VDataTable.ts should not select item that is not selectable 1`] = `
-<div class="v-data-table v-data-table--has-bottom theme--light v-data-table--mobile">
+<div class="v-data-table v-data-table--has-bottom v-data-table--selectable theme--light v-data-table--mobile">
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>
@@ -10846,7 +10846,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
 `;
 
 exports[`VDataTable.ts should render with showSelect 1`] = `
-<div class="v-data-table v-data-table--has-bottom theme--light v-data-table--mobile">
+<div class="v-data-table v-data-table--has-bottom v-data-table--selectable theme--light v-data-table--mobile">
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>


### PR DESCRIPTION
## Description
add v-data-table--selectable class to VDataTable when show-select props are true

## Motivation and Context
By adding this class, it is possible to create custom tables when there is a show-select prop

## How Has This Been Tested?
add v-data-table--selectable class to VDataTable when show-select props are true 
an updated existing test


<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-data-table
    v-model="selected"
    :headers="headers"
    :items="desserts"
    :single-select="singleSelect"
    item-key="name"
    show-select
    class="elevation-1"
  >
    <template v-slot:top>
      <v-switch
        v-model="singleSelect"
        label="Single select"
        class="pa-3"
      ></v-switch>
    </template>
  </v-data-table>
</template>

<script>
  export default {
    data () {
      return {
        singleSelect: false,
        selected: [],
        headers: [
          {
            text: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            value: 'name',
          },
          { text: 'Calories', value: 'calories' },
          { text: 'Fat (g)', value: 'fat' },
          { text: 'Carbs (g)', value: 'carbs' },
          { text: 'Protein (g)', value: 'protein' },
          { text: 'Iron (%)', value: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
