### PR TITLE
feat(ripple): add .stop modifier

### DIFF
--- a/packages/docs/src/examples/v-ripple/stop.vue
+++ b/packages/docs/src/examples/v-ripple/stop.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-row>
+    <v-col cols="12">
+      <v-card v-ripple>
+        <v-card-text>Card with ripple</v-card-text>
+        <v-card-actions>
+          <v-btn>Button with ripple</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-col>
+    <v-col cols="12">
+      <v-card v-ripple>
+        <v-card-text>
+          Outer card with ripple
+          <v-card-actions>
+            <v-card v-ripple.stop>
+              <v-card-text>
+                Inner card with <code>ripple.stop</code>
+              </v-card-text>
+            </v-card>
+          </v-card-actions>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>

--- a/packages/docs/src/pages/en/directives/ripple.md
+++ b/packages/docs/src/pages/en/directives/ripple.md
@@ -28,6 +28,12 @@ Basic ripple functionality can be enabled just by using `v-ripple` directive on 
 
 ## Examples
 
+### Propagation
+
+If multiple elements have the ripple directive applied, only the inner one will show the effect. This can also be done without having a visible ripple by using `v-ripple.stop` to prevent ripples in the outer element if the inner element is clicked on. `v-ripple.stop` will not actually stop propagation of the mousedown/touchstart events unlike other workarounds.
+
+<example file="v-ripple/stop" />
+
 ### Options
 
 #### Center

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -10,9 +10,9 @@ import type {
   ObjectDirective,
 } from 'vue'
 
-const rippleStop = Symbol('rippleStop')
+const stopSymbol = Symbol('rippleStop')
 
-type VuetifyRippleEvent = (MouseEvent | TouchEvent | KeyboardEvent) & { [rippleStop]?: boolean }
+type VuetifyRippleEvent = (MouseEvent | TouchEvent | KeyboardEvent) & { [stopSymbol]?: boolean }
 
 const DELAY_RIPPLE = 80
 
@@ -36,6 +36,7 @@ export interface RippleDirectiveBinding extends Omit<DirectiveBinding, 'modifier
   modifiers: {
     center?: boolean
     circle?: boolean
+    stop?: boolean
   }
 }
 
@@ -172,10 +173,10 @@ function rippleShow (e: VuetifyRippleEvent) {
   const value: RippleOptions = {}
   const element = e.currentTarget as HTMLElement | undefined
 
-  if (!element?._ripple || element._ripple.touched || e[rippleStop]) return
+  if (!element?._ripple || element._ripple.touched || e[stopSymbol]) return
 
   // Don't allow the event to trigger ripples on any other elements
-  e[rippleStop] = true
+  e[stopSymbol] = true
 
   if (isTouchEvent(e)) {
     element._ripple.touched = true
@@ -209,6 +210,10 @@ function rippleShow (e: VuetifyRippleEvent) {
   } else {
     ripples.show(e, element, value)
   }
+}
+
+function rippleStop (e: VuetifyRippleEvent) {
+  e[stopSymbol] = true
 }
 
 function rippleHide (e: Event) {
@@ -287,6 +292,12 @@ function updateRipple (el: HTMLElement, binding: RippleDirectiveBinding, wasEnab
   }
 
   if (enabled && !wasEnabled) {
+    if (modifiers.stop) {
+      el.addEventListener('touchstart', rippleStop, { passive: true })
+      el.addEventListener('mousedown', rippleStop)
+      return
+    }
+
     el.addEventListener('touchstart', rippleShow, { passive: true })
     el.addEventListener('touchend', rippleHide, { passive: true })
     el.addEventListener('touchmove', rippleCancelShow, { passive: true })


### PR DESCRIPTION
Simpler alternative for the workaround described in #5999. Ripples are already prevented on multiple elements since 364fb8e5c2ae24cb3533e5f29b4f72e4a01c4a05, but if you want to prevent a ripple without the inner element having one you have to use `@mousedown.stop @touchstart.stop` on the inner element. 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-card v-ripple>
        <v-card-text>
          Card content
          <v-text-field v-ripple.stop />
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>
```
</details>
