### PR TITLE
Draft: fix(VAutocomplete): update search value for mobile

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -138,6 +138,9 @@ export const VAutocomplete = genericComponent<new <T>() => {
         isPristine.value = true
       }
     }
+    function onInput (e: InputEvent) {
+      search.value = (e.target as HTMLInputElement).value
+    }
     function onAfterLeave () {
       if (isFocused.value) isPristine.value = true
     }
@@ -195,7 +198,8 @@ export const VAutocomplete = genericComponent<new <T>() => {
       return (
         <VTextField
           ref={ vTextFieldRef }
-          v-model={ search.value }
+          value={ search.value }
+          onInput={ onInput }
           class={[
             'v-autocomplete',
             {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
VAutoComplete only filters complete waits for words to be completed on Android. The input of the inner VTextField of VAutoComplete is binded with a v-model. When using an android phone with autocomplete keyboard (GBoard) the value is first emitted when a word is completed. For instance if you write "House" v-model will first be updated when the word is completed and not on "H" -> "Ho" -> "Hou"... This means that VAutoComplete only filters on completed words. 

## Description
This pull request changes the databinding of VTextField in VAutoComplete from v-model into `@input` and `:value`. `@input` is emitted on every key, while v-model waits for a word to be completed when using autocomplete on android keyboards. 
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->



## How Has This Been Tested?
The code has been tested visually.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-autocomplete :items="items" />
</template>

<script>
  export default {
    name: 'Playground',
    data: () => ({
      items: [
        {
          value: 'foo',
          title: 'Foo',
        },
        {
          value: 'bar2',
          title: 'Foo',
        },
        {
          value: 'baz',
          title: 'Baz',
        },
      ],
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] The PR title is no longer than 64 characters.
- [ x ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ x ] My code follows the code style of this project.
- [ x ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
