### PR TITLE
feat(VTabs): right prop renamed to end

### DIFF
--- a/packages/docs/src/examples/v-tabs/prop-end.vue
+++ b/packages/docs/src/examples/v-tabs/prop-end.vue
@@ -3,7 +3,7 @@
     <v-tabs
       v-model="tab"
       color="deep-purple-accent-4"
-      right
+      end
     >
       <v-tab :value="1">Landscape</v-tab>
       <v-tab :value="2">City</v-tab>

--- a/packages/docs/src/pages/en/components/tabs.md
+++ b/packages/docs/src/pages/en/components/tabs.md
@@ -76,9 +76,9 @@ If the tab items overflow their container, pagination controls will appear on de
 
 #### Right
 
-The **right** prop aligns the tabs to the right.
+The **end** prop aligns the tabs to the right.
 
-<example file="v-tabs/prop-right" />
+<example file="v-tabs/prop-end" />
 
 #### Vertical Tabs
 

--- a/packages/vuetify/src/components/VTabs/VTabs.sass
+++ b/packages/vuetify/src/components/VTabs/VTabs.sass
@@ -40,7 +40,7 @@
     flex: 1 0 auto
     max-width: none
 
-.v-tabs--right
+.v-tabs--end
   .v-tab:first-child
     margin-inline-start: auto
 

--- a/packages/vuetify/src/components/VTabs/VTabs.tsx
+++ b/packages/vuetify/src/components/VTabs/VTabs.tsx
@@ -56,7 +56,7 @@ export const VTabs = defineComponent({
     },
     hideSlider: Boolean,
     optional: Boolean,
-    right: Boolean,
+    end: Boolean,
     sliderColor: String,
     modelValue: null,
 
@@ -94,7 +94,7 @@ export const VTabs = defineComponent({
             'v-tabs--centered': props.centered,
             'v-tabs--fixed-tabs': props.fixedTabs,
             'v-tabs--grow': props.grow,
-            'v-tabs--right': props.right,
+            'v-tabs--end': props.end,
             'v-tabs--stacked': props.stacked,
           },
           densityClasses.value,


### PR DESCRIPTION
## Description
According to @KaelWD Vuetify 3 renamed all `left` or `right` props to `start` and `end`. I also added this in `vtabs` component.

## Motivation and Context
Align with existing props

## How Has This Been Tested?
I don't know how to write test

## Markup:
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
