### PR TITLE
feat(card): Improved card structure style

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -141,6 +141,9 @@
   transition: inherit
   transition-property: color, opacity
 
+  & + &
+    padding-top: 0
+
   @include card-line-height-densities($card-text-densities)
 
 .v-card-content


### PR DESCRIPTION
## Description
Addes `padding-top: 0` to `v-card-text` which is placed after `v-card-text` itself.

## Motivation and Context
If we use two `v-card-text` next to each other like below:
```vue
<v-card>
  <v-card-text />
  <v-card-text />
</v-card>
```

![image](https://user-images.githubusercontent.com/47495003/166880244-a27be8d6-de4e-4210-9469-8ac53c1be737.png)


With this styles:
![image](https://user-images.githubusercontent.com/47495003/166880357-23dd6943-0fad-4d63-91c1-1f2870f4bcf6.png)


## How Has This Been Tested?
Not tested

## Markup:
```vue
<v-card>
  <v-card-text>
    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ad cumque ea voluptate magni, exercitationem mollitia eum sunt? Nulla, numquam eaque.
  </v-card-text>
  <v-card-text>
    Lorem ipsum dolor sit amet consectetur, adipisicing elit. Harum, ducimus. Possimus eligendi asperiores accusamus rerum!
  </v-card-text>
</v-card>
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
