### PR TITLE
fix(VOverflowBtn): make persistentPlaceholder label visible

### DIFF
--- a/packages/api-generator/src/locale/en/v-overflow-btn.json
+++ b/packages/api-generator/src/locale/en/v-overflow-btn.json
@@ -2,6 +2,7 @@
   "props": {
     "editable": "Creates an editable button",
     "overflow": "Creates an overflow button",
-    "segmented": "Creates a segmented button"
+    "segmented": "Creates a segmented button",
+    "persistentPlaceholder": "Forces label to always be visible"
   }
 }

--- a/packages/vuetify/src/components/VOverflowBtn/VOverflowBtn.ts
+++ b/packages/vuetify/src/components/VOverflowBtn/VOverflowBtn.ts
@@ -40,6 +40,9 @@ export default VAutocomplete.extend({
     computedItems (): object[] {
       return this.segmented ? this.allItems : this.filteredItems
     },
+    labelValue (): boolean {
+      return (this.isFocused || this.isLabelActive) && !this.persistentPlaceholder
+    },
   },
 
   methods: {

--- a/packages/vuetify/src/components/VOverflowBtn/VOverflowBtn.ts
+++ b/packages/vuetify/src/components/VOverflowBtn/VOverflowBtn.ts
@@ -41,7 +41,7 @@ export default VAutocomplete.extend({
       return this.segmented ? this.allItems : this.filteredItems
     },
     labelValue (): boolean {
-      return (this.isFocused || this.isLabelActive) && !this.persistentPlaceholder
+      return (this.isFocused && !this.persistentPlaceholder) || this.isLabelActive
     },
   },
 

--- a/packages/vuetify/src/components/VOverflowBtn/__tests__/VOverflowBtn.spec.ts
+++ b/packages/vuetify/src/components/VOverflowBtn/__tests__/VOverflowBtn.spec.ts
@@ -108,4 +108,22 @@ describe('VOverflowBtn.js', () => {
 
     expect(callback).toHaveBeenCalled()
   })
+
+  it('should show label with persistentPlaceholder property set to true', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo'],
+        label: 'Some label',
+        persistentPlaceholder: true,
+      },
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+
+    wrapper.find('input').trigger('click')
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/vuetify/src/components/VOverflowBtn/__tests__/__snapshots__/VOverflowBtn.spec.ts.snap
+++ b/packages/vuetify/src/components/VOverflowBtn/__tests__/__snapshots__/VOverflowBtn.spec.ts.snap
@@ -1,5 +1,101 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VOverflowBtn.js should show label with persistentPlaceholder property set to true 1`] = `
+<div class="v-input theme--light v-text-field v-text-field--single-line v-select v-autocomplete v-overflow-btn">
+  <div class="v-input__control">
+    <div role="combobox"
+         aria-haspopup="listbox"
+         aria-expanded="false"
+         aria-owns="list-14"
+         class="v-input__slot"
+    >
+      <div class="v-select__slot">
+        <label for="input-14"
+               class="v-label theme--light"
+        >
+          Some label
+        </label>
+        <div class="v-select__selections">
+          <input id="input-14"
+                 readonly="readonly"
+                 type="text"
+          >
+        </div>
+        <div class="v-input__append-inner">
+          <div class="v-input__icon v-input__icon--append">
+            <i aria-hidden="true"
+               class="v-icon notranslate material-icons theme--light"
+            >
+              $dropdown
+            </i>
+          </div>
+        </div>
+        <input type="hidden">
+      </div>
+      <div class="v-menu">
+      </div>
+    </div>
+    <div class="v-text-field__details">
+      <div class="v-messages theme--light">
+        <span name="message-transition"
+              tag="div"
+              class="v-messages__wrapper"
+        >
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VOverflowBtn.js should show label with persistentPlaceholder property set to true 2`] = `
+<div class="v-input theme--light v-text-field v-text-field--single-line v-select v-select--is-menu-active v-autocomplete v-overflow-btn">
+  <div class="v-input__control">
+    <div role="combobox"
+         aria-haspopup="listbox"
+         aria-expanded="true"
+         aria-owns="list-14"
+         class="v-input__slot"
+    >
+      <div class="v-select__slot">
+        <label for="input-14"
+               class="v-label theme--light"
+        >
+          Some label
+        </label>
+        <div class="v-select__selections">
+          <input id="input-14"
+                 readonly="readonly"
+                 type="text"
+          >
+        </div>
+        <div class="v-input__append-inner">
+          <div class="v-input__icon v-input__icon--append">
+            <i aria-hidden="true"
+               class="v-icon notranslate material-icons theme--light"
+            >
+              $dropdown
+            </i>
+          </div>
+        </div>
+        <input type="hidden">
+      </div>
+      <div class="v-menu">
+      </div>
+    </div>
+    <div class="v-text-field__details">
+      <div class="v-messages theme--light">
+        <span name="message-transition"
+              tag="div"
+              class="v-messages__wrapper"
+        >
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`VOverflowBtn.js should use default autocomplete selections 1`] = `
 <div class="v-input v-input--is-label-active v-input--is-dirty theme--light v-text-field v-text-field--single-line v-select v-select--is-multi v-autocomplete v-overflow-btn">
   <div class="v-input__control">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Fixes #15052

v-overflow-btn fixed so that with 'persistent-placeholder' property set to 'true' v-overflow-btn label will be visible in both focused and blurred states

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #15052

Prior to Vuetify version 2.4.0 v-overflow-btn label was visible when being focused
Since version 2.4.0 v-overflow-btn label disappears when being focused, v-overflow-btn is empty
v-overflow-btn "persistent-placeholder" property does not address this issue - with "persistent-placeholder" property set to "true" v-overflow-btn label is absent both in focused and blurred states
This fix aims to make v-overflow-btn label visible with "persistent-placeholder" set to "true" for both focused and blurred states

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
unit, visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>
<template>
  <v-container>
    <div></div>

    <v-overflow-btn
      :items="items"
      label="Label One"
    />

    <v-overflow-btn
      :items="items"
      :persistent-placeholder="true"
      label="Label Two"
    />

    <v-overflow-btn
      :items="items"
    >
      <template #label>
        <span>Label Three</span>
      </template>
    </v-overflow-btn>

    <v-overflow-btn
      :items="items"
      :persistent-placeholder="true"
    >
      <template #label>
        <span>Label Four</span>
      </template>
    </v-overflow-btn>
  </v-container>
</template>

```vue
<script>
  export default {
    data: () => ({
      items: ['Item 1', 'Item 2', 'Item 3'],
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
