### PR TITLE
fix(VTextField): placeholder does not appear until focus the input

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -74,7 +74,8 @@
     .v-input__details
       padding: 0
 
-  &--persistent-placeholder
+  &--persistent-placeholder,
+  &--placeholder
     input
       opacity: 1
 /* endregion */

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -135,6 +135,7 @@ export const VTextField = genericComponent<new <T>() => {
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const [{ modelValue: _, ...inputProps }] = filterInputProps(props)
       const [fieldProps] = filterFieldProps(props)
+      const hasLabel = !!(props.label || slots.label?.())
 
       return (
         <VInput
@@ -147,6 +148,7 @@ export const VTextField = genericComponent<new <T>() => {
               'v-text-field--prefixed': props.prefix,
               'v-text-field--suffixed': props.suffix,
               'v-text-field--flush-details': ['plain', 'underlined'].includes(props.variant),
+              'v-text-field--placeholder': props.placeholder && !hasLabel,
             },
           ]}
           onClick:prepend={ (e: MouseEvent) => emit('click:prepend', e) }


### PR DESCRIPTION
## Description
I'm not sure if it's a good solution to create a new `css class` to fix it. As a possible solution I can use `persistent-placeholder` class.
fixes #15075

## How Has This Been Tested?
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-card>
      <v-row>
        <v-col
            cols="12"
            md="4"
        >
          <v-text-field
              v-model="firstname"
              :rules="nameRules"
              :counter="10"
              :persistent-placeholder="true"
              placeholder="First name"
              required
          ></v-text-field>
        </v-col>

        <v-col
            cols="12"
            md="4"
        >
          <v-text-field
              v-model="lastname"
              :rules="nameRules"
              :counter="10"
              label="test"
              placeholder="Last name"
              required
          ></v-text-field>
        </v-col>

        <v-col
            cols="12"
            md="4"
        >
          <v-text-field
              v-model="email"
              :rules="emailRules"
              placeholder="E-mail"
              required
          ></v-text-field>
        </v-col>
      </v-row>
    </v-card>

    <v-text-field
        v-model="lastname"
        :rules="nameRules"
        :counter="10"
        label="test"
        placeholder="Last name"
        required
    >
      <template v-slot:label>
        Test label example
      </template>
      
    </v-text-field>

    123
    <v-text-field
        v-model="lastname"
        :rules="nameRules"
        :counter="10"
        label="test"
        placeholder="Last name"
        persistent-placeholder
        required
    >
      <template v-slot:label>
        Test label example
      </template>

    </v-text-field>

    <v-text-field
        v-model="lastname"
        :rules="nameRules"
        :counter="10"
        persistent-placeholder
        placeholder="Last name"
        required
    >
    </v-text-field>

    <v-text-field
        v-model="lastname"
        :rules="nameRules"
        :counter="10"
        required
    >
    </v-text-field>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      valid: false,
      firstname: '',
      lastname: '',
      nameRules: [
        v => !!v || 'Name is required',
        v => v.length <= 10 || 'Name must be less than 10 characters',
      ],
      email: '',
      emailRules: [
        v => !!v || 'E-mail is required',
        v => /.+@.+/.test(v) || 'E-mail must be valid',
      ]
    })
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
