### PR TITLE
feat(VSlider): add $slider-track-active-size-offset variable

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.sass
+++ b/packages/vuetify/src/components/VSlider/VSlider.sass
@@ -57,4 +57,4 @@
   pointer-events: none
 
 .v-slider--has-labels .v-input__control
-  margin-bottom: $slider-tick-label-margin-bottom * .5
+  margin-bottom: $slider-tick-label-margin-top * .5

--- a/packages/vuetify/src/components/VSlider/VSliderTrack.sass
+++ b/packages/vuetify/src/components/VSlider/VSliderTrack.sass
@@ -74,7 +74,7 @@
     display: flex
     align-items: center
     width: 100%
-    height: calc(var(--v-slider-track-size) + 2px)
+    height: $slider-track-active-size
     touch-action: pan-y
 
     &__background
@@ -84,7 +84,7 @@
       height: inherit
 
   .v-slider-track__tick
-    margin-block-start: calc((var(--v-slider-track-size) / 2) + 1px)
+    margin-top: calc(#{$slider-track-active-size} / 2)
 
     @include tools.rtl()
       transform: translate(calc(var(--v-slider-tick-size) / 2), calc(var(--v-slider-tick-size) / -2))
@@ -110,7 +110,7 @@
           transform: translateX(100%)
 
     .v-slider-track__tick-label
-      bottom: calc((var(--v-slider-track-size) / -2) - #{$slider-tick-label-margin-bottom})
+      margin-top: calc(var(--v-slider-track-size) / 2 + #{$slider-tick-label-margin-top})
 
       @include tools.ltr()
         transform: translateX(-50%)
@@ -124,7 +124,7 @@
     height: 100%
     display: flex
     justify-content: center
-    width: calc(var(--v-slider-track-size, $slider-track-width) + 2px)
+    width: $slider-track-active-size
     touch-action: pan-x
 
     &__background
@@ -137,17 +137,17 @@
     height: 100%
 
   .v-slider-track__tick
-    margin-inline-start: calc((var(--v-slider-track-size) / 2) + 1px)
+    margin-inline-start: calc(#{$slider-track-active-size} / 2)
     transform: translate(calc(var(--v-slider-tick-size) / -2), calc(var(--v-slider-tick-size) / 2))
 
     @include tools.rtl()
       transform: translate(calc(var(--v-slider-tick-size) / 2), calc(var(--v-slider-tick-size) / 2))
 
     &:last-child
-      inset-block-end: calc(0% + var(--v-slider-tick-size) + 1px)
+      bottom: calc(0% + var(--v-slider-tick-size) + 1px)
 
     .v-slider-track__tick-label
-      margin-inline-start: calc(var(--v-slider-track-size) + 20px)
+      margin-inline-start: calc(var(--v-slider-track-size) / 2 + #{$slider-tick-label-margin-start})
       transform: translateY(-50%)
 
 // Modifiers

--- a/packages/vuetify/src/components/VSlider/VSliderTrack.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderTrack.tsx
@@ -81,7 +81,7 @@ export const VSliderTrack = defineComponent({
       const ticks = vertical.value ? parsedTicks.value.slice().reverse() : parsedTicks.value
 
       return ticks.map((tick, index) => {
-        const directionProperty = vertical.value ? 'inset-block-end' : 'margin-inline-start'
+        const directionProperty = vertical.value ? 'bottom' : 'margin-inline-start'
         return (
           <div
             key={ tick.value }

--- a/packages/vuetify/src/components/VSlider/_variables.scss
+++ b/packages/vuetify/src/components/VSlider/_variables.scss
@@ -22,10 +22,13 @@ $slider-thumb-label-transition: .2s settings.$accelerated-easing !default;
 $slider-thumb-label-padding: 6px !default;
 $slider-thumb-touch-size: 42px !default;
 $slider-tick-border-radius: 2px !default;
-$slider-tick-label-margin-bottom: 25px !default;
+$slider-tick-label-margin-top: 8px !default;
+$slider-tick-label-margin-start: 12px !default;
 $slider-track-border-radius: 6px !default;
-$slider-track-width: 2px !default;
+$slider-track-active-size-offset: 2px !default;
 $slider-transition: .3s cubic-bezier(0.25, 0.8, 0.5, 1) !default;
 $slider-vertical-margin-bottom: 12px !default;
 $slider-vertical-margin-top: 12px !default;
 $slider-vertical-min-height: 300px !default;
+
+$slider-track-active-size: calc(var(--v-slider-track-size) + #{$slider-track-active-size-offset}) !default;


### PR DESCRIPTION
Also fixed some weird positioning of tick labels

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-slider show-ticks="always" :ticks="[0, 1, 2, 3]" max="3" step="1" direction="horizontal" />
      <v-slider show-ticks="always" :ticks="[0, 1, 2, 3]" max="3" step="1" direction="vertical" />
    </v-container>
  </v-app>
</template>
```
</details>

