### PR TITLE
feat: consolidate all position and location props

### DIFF
--- a/packages/docs/src/components/about/TeamMember.vue
+++ b/packages/docs/src/components/about/TeamMember.vue
@@ -16,7 +16,7 @@
             <v-tooltip
               v-if="link.href || link.copyText"
               :key="link.href || link.copyText"
-              anchor="bottom"
+              location="bottom"
             >
               <template #activator="{ props }">
                 <a

--- a/packages/docs/src/components/app/Markup.vue
+++ b/packages/docs/src/components/app/Markup.vue
@@ -27,7 +27,7 @@
 
       <v-spacer />
 
-      <v-tooltip anchor="bottom">
+      <v-tooltip location="bottom">
         <template #activator="{ props }">
           <v-btn
             :icon="clicked ? 'mdi-check' : 'mdi-clipboard-text'"

--- a/packages/docs/src/components/app/Toc.vue
+++ b/packages/docs/src/components/app/Toc.vue
@@ -5,7 +5,7 @@
     class="py-4 pr-3"
     floating
     width="256"
-    position="right"
+    location="right"
   >
     <template
       v-if="toc.length"

--- a/packages/docs/src/components/app/TooltipBtn.vue
+++ b/packages/docs/src/components/app/TooltipBtn.vue
@@ -17,7 +17,7 @@
       />
 
       <v-tooltip
-        anchor="bottom"
+        location="bottom"
         class="v-app-tooltip-btn__content"
         open-delay="200"
         activator="parent"

--- a/packages/docs/src/components/app/menu/Menu.vue
+++ b/packages/docs/src/components/app/menu/Menu.vue
@@ -5,7 +5,7 @@
     open-delay="60"
     :open-on-hover="false"
     transition="slide-y-transition"
-    anchor="bottom"
+    location="bottom"
   >
     <template #activator="{ props }">
       <slot name="activator" v-bind="{ props }" />

--- a/packages/docs/src/components/app/settings/Drawer.vue
+++ b/packages/docs/src/components/app/settings/Drawer.vue
@@ -2,9 +2,9 @@
   <v-navigation-drawer
     id="settings-drawer"
     v-model="app.settings"
-    :position="isRtl ? 'left' : 'right'"
+    :location="isRtl ? 'left' : 'right'"
     disable-route-watcher
-    fixed
+    position="fixed"
     hide-overlay
     temporary
     width="300"

--- a/packages/docs/src/components/examples/Example.vue
+++ b/packages/docs/src/components/examples/Example.vue
@@ -20,7 +20,7 @@
         <v-tooltip
           v-for="{ path, ...action } in actions"
           :key="path"
-          anchor="top"
+          location="top"
         >
           <template #activator="{ props: tooltip }">
             <v-btn

--- a/packages/docs/src/components/examples/UsageExample.vue
+++ b/packages/docs/src/components/examples/UsageExample.vue
@@ -25,7 +25,7 @@
 
       <v-spacer />
 
-      <v-tooltip anchor="bottom">
+      <v-tooltip location="bottom">
         <template #activator="{ props }">
           <v-btn
             icon="mdi-code-tags"
@@ -39,7 +39,7 @@
         <span>Show code</span>
       </v-tooltip>
 
-      <v-tooltip anchor="bottom">
+      <v-tooltip location="bottom">
         <template #activator="{ props }">
           <v-btn
             icon="mdi-tune"

--- a/packages/docs/src/components/examples/UsageExample.vue
+++ b/packages/docs/src/components/examples/UsageExample.vue
@@ -71,7 +71,7 @@
         :model-value="tune"
         permanent
         name="tune"
-        position="right"
+        location="right"
         width="200"
       >
         <v-list>

--- a/packages/docs/src/examples/application-layout/discord.vue
+++ b/packages/docs/src/examples/application-layout/discord.vue
@@ -4,8 +4,8 @@
     <v-navigation-drawer width="72" color="grey-darken-2" permanent></v-navigation-drawer>
     <v-navigation-drawer width="150" color="grey-darken-1" permanent></v-navigation-drawer>
     <v-app-bar height="48" color="grey" elevation="0"></v-app-bar>
-    <v-navigation-drawer position="right" width="150" color="grey-lighten-1" permanent></v-navigation-drawer>
-    <v-app-bar position="bottom" height="48" color="grey-lighten-2" elevation="0"></v-app-bar>
+    <v-navigation-drawer location="right" width="150" color="grey-lighten-1" permanent></v-navigation-drawer>
+    <v-app-bar location="bottom" height="48" color="grey-lighten-2" elevation="0"></v-app-bar>
     <v-main>
       <v-card elevation="0" height="400px"></v-card>
     </v-main>

--- a/packages/docs/src/examples/application-layout/position.vue
+++ b/packages/docs/src/examples/application-layout/position.vue
@@ -2,7 +2,7 @@
   <v-app style="z-index: 0">
     <v-app-bar color="grey-lighten-2"></v-app-bar>
     <v-navigation-drawer color="grey-darken-2" permanent></v-navigation-drawer>
-    <v-navigation-drawer color="grey-darken-2" permanent position="right"></v-navigation-drawer>
+    <v-navigation-drawer color="grey-darken-2" permanent location="right"></v-navigation-drawer>
     <v-main>
       <v-card height="200px"></v-card>
     </v-main>

--- a/packages/docs/src/examples/v-menu/misc-popover.vue
+++ b/packages/docs/src/examples/v-menu/misc-popover.vue
@@ -3,7 +3,7 @@
     <v-menu
       v-model="menu"
       :close-on-content-click="false"
-      anchor="end"
+      location="end"
     >
       <template v-slot:activator="{ props }">
         <v-btn

--- a/packages/docs/src/examples/v-menu/prop-location.vue
+++ b/packages/docs/src/examples/v-menu/prop-location.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="text-center">
     <v-select
-      v-model="anchor"
-      :items="anchors"
-      label="Anchor"
+      v-model="location"
+      :items="locations"
+      label="Location"
     ></v-select>
-    <v-menu :anchor="anchor">
+    <v-menu :location="location">
       <template v-slot:activator="{ props }">
         <v-btn
           color="primary"
@@ -37,14 +37,14 @@
         { title: 'Click Me' },
         { title: 'Click Me 2' },
       ],
-      anchors: [
+      locations: [
         'top',
         'bottom',
         'start',
         'end',
         'center',
       ],
-      anchor: 'end',
+      location: 'end',
     }),
   }
 </script>

--- a/packages/docs/src/examples/v-menu/slot-activator-and-tooltip.vue
+++ b/packages/docs/src/examples/v-menu/slot-activator-and-tooltip.vue
@@ -2,7 +2,7 @@
   <div class="text-center">
     <v-menu>
       <template v-slot:activator="{ props: menu }">
-        <v-tooltip anchor="top">
+        <v-tooltip location="top">
           <template v-slot:activator="{ props: tooltip }">
             <v-btn
               color="primary"

--- a/packages/docs/src/examples/v-navigation-drawer/prop-right.vue
+++ b/packages/docs/src/examples/v-navigation-drawer/prop-right.vue
@@ -3,7 +3,7 @@
     <v-layout>
       <v-navigation-drawer
         permanent
-        position="right"
+        location="right"
       >
         <template v-slot:prepend>
           <v-list-item

--- a/packages/docs/src/examples/v-overlay/connected-playground.vue
+++ b/packages/docs/src/examples/v-overlay/connected-playground.vue
@@ -6,7 +6,7 @@
 
         <v-tooltip
           :model-value="true"
-          :anchor="anchor"
+          :location="location"
           :origin="origin"
           no-click-animation
         >
@@ -18,7 +18,7 @@
       </v-col>
 
       <v-col>
-        <v-radio-group v-model="anchorSide" label="Anchor side">
+        <v-radio-group v-model="locationSide" label="Location side">
           <v-radio value="top" label="top"></v-radio>
           <v-radio value="end" label="end"></v-radio>
           <v-radio value="bottom" label="bottom"></v-radio>
@@ -27,12 +27,12 @@
       </v-col>
 
       <v-col>
-        <v-radio-group v-model="anchorAlign" label="Anchor alignment">
-          <v-radio value="top" label="top" :disabled="anchorSide === 'top' || anchorSide === 'bottom'"></v-radio>
-          <v-radio value="start" label="start" :disabled="!(anchorSide === 'top' || anchorSide === 'bottom')"></v-radio>
+        <v-radio-group v-model="locationAlign" label="Location alignment">
+          <v-radio value="top" label="top" :disabled="locationSide === 'top' || locationSide === 'bottom'"></v-radio>
+          <v-radio value="start" label="start" :disabled="!(locationSide === 'top' || locationSide === 'bottom')"></v-radio>
           <v-radio value="center" label="center"></v-radio>
-          <v-radio value="end" label="end" :disabled="!(anchorSide === 'top' || anchorSide === 'bottom')"></v-radio>
-          <v-radio value="bottom" label="bottom" :disabled="anchorSide === 'top' || anchorSide === 'bottom'"></v-radio>
+          <v-radio value="end" label="end" :disabled="!(locationSide === 'top' || locationSide === 'bottom')"></v-radio>
+          <v-radio value="bottom" label="bottom" :disabled="locationSide === 'top' || locationSide === 'bottom'"></v-radio>
         </v-radio-group>
       </v-col>
 
@@ -63,37 +63,37 @@
 <script>
   export default {
     data: () => ({
-      anchorSide: 'top',
-      anchorAlign: 'center',
+      locationSide: 'top',
+      locationAlign: 'center',
       originSide: 'auto',
       originAlign: '',
     }),
     computed: {
-      anchor () {
-        return `${this.anchorSide} ${this.anchorAlign}`
+      location () {
+        return `${this.locationSide} ${this.anchorAlign}`
       },
       origin () {
         return this.originDisabled ? this.originSide : `${this.originSide} ${this.originAlign}`
       },
       code () {
-        return `<v-tooltip anchor="${this.anchor}" origin="${this.origin}" />`
+        return `<v-tooltip location="${this.location}" origin="${this.origin}" />`
       },
       originDisabled () {
         return ['auto', 'overlap'].includes(this.originSide)
       },
     },
     watch: {
-      anchorSide (val) {
+      locationSide (val) {
         if (['top', 'bottom'].includes(val)) {
-          this.anchorAlign = {
+          this.locationAlign = {
             top: 'start',
             bottom: 'end',
-          }[this.anchorAlign] || this.anchorAlign
+          }[this.locationAlign] || this.locationAlign
         } else {
-          this.anchorAlign = {
+          this.locationAlign = {
             start: 'top',
             end: 'bottom',
-          }[this.anchorAlign] || this.anchorAlign
+          }[this.locationAlign] || this.locationAlign
         }
       },
       originDisabled (val) {

--- a/packages/docs/src/examples/v-tooltip/prop-location.vue
+++ b/packages/docs/src/examples/v-tooltip/prop-location.vue
@@ -4,7 +4,7 @@
       Start
       <v-tooltip
         activator="parent"
-        anchor="start"
+        location="start"
       >Tooltip</v-tooltip>
     </v-btn>
 
@@ -12,7 +12,7 @@
       End
       <v-tooltip
         activator="parent"
-        anchor="end"
+        location="end"
       >Tooltip</v-tooltip>
     </v-btn>
 
@@ -20,7 +20,7 @@
       Top
       <v-tooltip
         activator="parent"
-        anchor="top"
+        location="top"
       >Tooltip</v-tooltip>
     </v-btn>
 
@@ -28,7 +28,7 @@
       Bottom
       <v-tooltip
         activator="parent"
-        anchor="bottom"
+        location="bottom"
       >Tooltip</v-tooltip>
     </v-btn>
   </div>

--- a/packages/docs/src/pages/en/components/menus.md
+++ b/packages/docs/src/pages/en/components/menus.md
@@ -66,11 +66,11 @@ You can disable the menu. Disabled menus can't be opened.
 
 <example file="v-menu/prop-disabled" /> -->
 
-#### Anchor
+#### Location
 
-Menu can be offset relative to the activator by using the **anchor** prop. Read more about **anchor** [here](/components/overlays).
+Menu can be offset relative to the activator by using the **location** prop. Read more about **location** [here](/components/overlays/#location).
 
-<example file="v-menu/prop-anchor" />
+<example file="v-menu/prop-location" />
 
 #### Open on hover
 

--- a/packages/docs/src/pages/en/components/navigation-drawers.md
+++ b/packages/docs/src/pages/en/components/navigation-drawers.md
@@ -68,9 +68,9 @@ By default, a navigation drawer has a 1px right border that separates it from co
 
 <example file="v-navigation-drawer/prop-permanent-and-floating" />
 
-#### Position
+#### Location
 
-Navigation drawers can also be positioned on the right side of your application (or an element) using the **position** prop. This is useful for creating a side-sheet with auxiliary information that may not have any navigation links.
+Navigation drawers can also be positioned on the right side of your application (or an element) using the **location** prop. This is useful for creating a side-sheet with auxiliary information that may not have any navigation links.
 
 <example file="v-navigation-drawer/prop-right" />
 

--- a/packages/docs/src/pages/en/components/overlays.md
+++ b/packages/docs/src/pages/en/components/overlays.md
@@ -28,7 +28,7 @@ In its simplest form, the `v-overlay` component will add a dimmed layer over you
 
 ## Activator
 
-Overlays can be opened with v-model, or by clicking or hovering on an activator element. An activator is mandatory for the connected position strategy. The activator element (if present) will also be used by some transitions to slide or scale from the activator's position instead of the middle of the screen.
+Overlays can be opened with v-model, or by clicking or hovering on an activator element. An activator is mandatory for the connected locationLocation strategy. The activator element (if present) will also be used by some transitions to slide or scale from the activator's location instead of the middle of the screen.
 
 Related props:
 
@@ -65,21 +65,21 @@ For more manual control, the slot can be used instead. `props` is an object cont
 </v-overlay>
 ```
 
-## Position Strategies
+## Location Strategies
 
 ### Static (default)
 
-`position-strategy="static"`
+`location-strategy="static"`
 
 Overlay content is absolutely positioned to the center of its container by default.
 
 ### Connected
 
-`position-strategy="connected"`
+`location-strategy="connected"`
 
 The connected strategy is used by [v-menu](/components/menus) and [v-tooltip](/components/tooltips) to attach the overlay content to an activator element.
 
-`anchor` selects a point on the activator, and `origin` a point on the overlay content. The content element will be positioned so the two points overlap.
+`location` selects a point on the activator, and `origin` a point on the overlay content. The content element will be positioned so the two points overlap.
 
 <example file="v-overlay/connected-playground" />
 

--- a/packages/docs/src/pages/en/components/tooltips.md
+++ b/packages/docs/src/pages/en/components/tooltips.md
@@ -30,11 +30,11 @@ Tooltips can wrap any element.
 
 ### Props
 
-#### Anchor
+#### Location
 
-Use the **anchor** prop to specify on which side of the element the tooltip should show. Read more about **anchor** [here](/components/overlays).
+Use the **location** prop to specify on which side of the element the tooltip should show. Read more about **location** [here](/components/overlays/#location).
 
-<example file="v-tooltip/prop-anchor" />
+<example file="v-tooltip/prop-location" />
 
 #### Visibility
 

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -11,6 +11,7 @@ import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant
 import { makeDensityProps, useDensity } from '@/composables/density'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { makeLocationProps, useLocation } from '@/composables/location'
 import { makePositionProps, usePosition } from '@/composables/position'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
@@ -73,6 +74,7 @@ export const VAlert = defineComponent({
     ...makeDensityProps(),
     ...makeDimensionProps(),
     ...makeElevationProps(),
+    ...makeLocationProps(),
     ...makePositionProps(),
     ...makeRoundedProps(),
     ...makeTagProps(),
@@ -102,7 +104,8 @@ export const VAlert = defineComponent({
     const { densityClasses } = useDensity(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
-    const { positionClasses, positionStyles } = usePosition(props)
+    const { locationStyles } = useLocation(props)
+    const { positionClasses } = usePosition(props)
     const { roundedClasses } = useRounded(props)
     const { textColorClasses, textColorStyles } = useTextColor(toRef(props, 'borderColor'))
 
@@ -138,7 +141,7 @@ export const VAlert = defineComponent({
           style={[
             colorStyles.value,
             dimensionStyles.value,
-            positionStyles.value,
+            locationStyles.value,
           ]}
           role="alert"
         >

--- a/packages/vuetify/src/components/VAppBar/VAppBar.tsx
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.tsx
@@ -30,7 +30,7 @@ export const VAppBar = defineComponent({
       type: Boolean,
       default: true,
     },
-    position: {
+    location: {
       type: String as PropType<'top' | 'bottom'>,
       default: 'top',
       validator: (value: any) => ['top', 'bottom'].includes(value),
@@ -61,7 +61,7 @@ export const VAppBar = defineComponent({
     const { layoutItemStyles } = useLayoutItem({
       id: props.name,
       priority: computed(() => parseInt(props.priority, 10)),
-      position: toRef(props, 'position'),
+      position: toRef(props, 'location'),
       layoutSize: height,
       elementSize: height,
       active: isActive,
@@ -77,7 +77,7 @@ export const VAppBar = defineComponent({
           class={[
             'v-app-bar',
             {
-              'v-app-bar--bottom': props.position === 'bottom',
+              'v-app-bar--bottom': props.location === 'bottom',
             },
           ]}
           style={{

--- a/packages/vuetify/src/components/VBadge/VBadge.tsx
+++ b/packages/vuetify/src/components/VBadge/VBadge.tsx
@@ -11,11 +11,11 @@ import { makeThemeProps, useTheme } from '@/composables/theme'
 import { makeTransitionProps, MaybeTransition } from '@/composables/transition'
 import { useBackgroundColor, useTextColor } from '@/composables/color'
 import { useLocale } from '@/composables/locale'
-import { useRtl } from '@/composables/rtl'
+import { makeLocationProps, useLocation } from '@/composables/location'
 
 // Utilities
 import { computed, toRef } from 'vue'
-import { convertToUnit, defineComponent, pick } from '@/util'
+import { defineComponent, pick } from '@/util'
 
 export const VBadge = defineComponent({
   name: 'VBadge',
@@ -34,26 +34,14 @@ export const VBadge = defineComponent({
       type: String,
       default: '$vuetify.badge',
     },
-    location: {
-      type: String,
-      default: 'top-end',
-      validator: (value: string) => {
-        const [vertical, horizontal] = (value ?? '').split('-')
-
-        return (
-          ['top', 'bottom'].includes(vertical) &&
-          ['start', 'end'].includes(horizontal)
-        )
-      },
-    },
     max: [Number, String],
     modelValue: {
       type: Boolean,
       default: true,
     },
-    offsetX: [Number, String],
-    offsetY: [Number, String],
     textColor: String,
+
+    ...makeLocationProps({ location: 'top end' } as const),
     ...makeRoundedProps(),
     ...makeTagProps(),
     ...makeThemeProps(),
@@ -62,41 +50,16 @@ export const VBadge = defineComponent({
 
   setup (props, ctx) {
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
-    const { isRtl } = useRtl()
     const { roundedClasses } = useRounded(props)
     const { t } = useLocale()
     const { textColorClasses, textColorStyles } = useTextColor(toRef(props, 'textColor'))
     const { themeClasses } = useTheme()
 
-    const position = computed(() => {
+    const { locationStyles } = useLocation(props, true, computed(() => {
       return props.floating
         ? (props.dot ? 2 : 4)
         : (props.dot ? 8 : 12)
-    })
-
-    function calculatePosition (offset?: number | string) {
-      return `calc(100% - ${convertToUnit(position.value + parseInt(offset ?? 0, 10))})`
-    }
-
-    const locationStyles = computed(() => {
-      const [vertical, horizontal] = (props.location ?? '').split('-')
-
-      const styles = {
-        bottom: 'auto',
-        left: 'auto',
-        right: 'auto',
-        top: 'auto',
-      }
-
-      if (!props.inline) {
-        const isRight = (isRtl.value && horizontal === 'end') || (!isRtl.value && horizontal === 'start')
-
-        styles[isRight ? 'right' : 'left'] = calculatePosition(props.offsetX)
-        styles[vertical === 'top' ? 'bottom' : 'top'] = calculatePosition(props.offsetY)
-      }
-
-      return styles
-    })
+    }))
 
     return () => {
       const value = Number(props.content)
@@ -140,8 +103,8 @@ export const VBadge = defineComponent({
                 ]}
                 style={[
                   backgroundColorStyles.value,
-                  locationStyles.value,
                   textColorStyles.value,
+                  props.inline ? {} : locationStyles.value,
                 ]}
                 aria-atomic="true"
                 aria-label={ t(props.label, value) }

--- a/packages/vuetify/src/components/VBanner/VBanner.tsx
+++ b/packages/vuetify/src/components/VBanner/VBanner.tsx
@@ -12,6 +12,7 @@ import { makeBorderProps, useBorder } from '@/composables/border'
 import { makeDensityProps, useDensity } from '@/composables/density'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { makeLocationProps, useLocation } from '@/composables/location'
 import { makePositionProps, usePosition } from '@/composables/position'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
@@ -42,6 +43,7 @@ export const VBanner = defineComponent({
     ...makeDensityProps(),
     ...makeDimensionProps(),
     ...makeElevationProps(),
+    ...makeLocationProps(),
     ...makePositionProps(),
     ...makeRoundedProps(),
     ...makeTagProps(),
@@ -54,7 +56,8 @@ export const VBanner = defineComponent({
     const { mobile } = useDisplay()
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
-    const { positionClasses, positionStyles } = usePosition(props)
+    const { locationStyles } = useLocation(props)
+    const { positionClasses } = usePosition(props)
     const { roundedClasses } = useRounded(props)
 
     const { themeClasses } = provideTheme(props)
@@ -90,7 +93,7 @@ export const VBanner = defineComponent({
           ]}
           style={[
             dimensionStyles.value,
-            positionStyles.value,
+            locationStyles.value,
           ]}
           role="banner"
         >

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -32,6 +32,7 @@
     @include button-density('height', $button-density)
 
   @include tools.border($button-border...)
+  @include tools.position($button-positions)
   @include tools.states('.v-btn__overlay')
   @include tools.variant($button-variants...)
 

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -11,6 +11,7 @@ import { makeDensityProps, useDensity } from '@/composables/density'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { makeGroupItemProps, useGroupItem } from '@/composables/group'
+import { makeLocationProps, useLocation } from '@/composables/location'
 import { makePositionProps, usePosition } from '@/composables/position'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeRouterProps, useLink } from '@/composables/router'
@@ -57,6 +58,7 @@ export const VBtn = defineComponent({
     ...makeDimensionProps(),
     ...makeElevationProps(),
     ...makeGroupItemProps(),
+    ...makeLocationProps(),
     ...makePositionProps(),
     ...makeRouterProps(),
     ...makeSizeProps(),
@@ -72,7 +74,8 @@ export const VBtn = defineComponent({
     const { densityClasses } = useDensity(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
-    const { positionClasses, positionStyles } = usePosition(props)
+    const { locationStyles } = useLocation(props)
+    const { positionClasses } = usePosition(props)
     const { roundedClasses } = useRounded(props)
     const { sizeClasses } = useSize(props)
     const group = useGroupItem(props, props.symbol, false)
@@ -116,7 +119,7 @@ export const VBtn = defineComponent({
           style={[
             hasColor ? colorStyles.value : undefined,
             dimensionStyles.value,
-            positionStyles.value,
+            locationStyles.value,
           ]}
           disabled={ isDisabled.value || undefined }
           href={ link.href.value }

--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -21,6 +21,7 @@ import { makeBorderProps, useBorder } from '@/composables/border'
 import { makeDensityProps, useDensity } from '@/composables/density'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { makeLocationProps, useLocation } from '@/composables/location'
 import { makePositionProps, usePosition } from '@/composables/position'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeRouterProps, useLink } from '@/composables/router'
@@ -60,6 +61,7 @@ export const VCard = defineComponent({
     ...makeDensityProps(),
     ...makeDimensionProps(),
     ...makeElevationProps(),
+    ...makeLocationProps(),
     ...makePositionProps(),
     ...makeRoundedProps(),
     ...makeRouterProps(),
@@ -74,7 +76,8 @@ export const VCard = defineComponent({
     const { densityClasses } = useDensity(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
-    const { positionClasses, positionStyles } = usePosition(props)
+    const { locationStyles } = useLocation(props)
+    const { positionClasses } = usePosition(props)
     const { roundedClasses } = useRounded(props)
     const link = useLink(props, attrs)
 
@@ -112,7 +115,7 @@ export const VCard = defineComponent({
           style={[
             colorStyles.value,
             dimensionStyles.value,
-            positionStyles.value,
+            locationStyles.value,
           ]}
           href={ link.href.value }
           onClick={ isClickable && link.navigate }

--- a/packages/vuetify/src/components/VList/VList.sass
+++ b/packages/vuetify/src/components/VList/VList.sass
@@ -10,7 +10,6 @@
 
   @include tools.border($list-border...)
   @include tools.elevation($list-elevation)
-  @include tools.position($list-positions)
   @include tools.rounded($list-border-radius)
   @include tools.theme($list-theme...)
 

--- a/packages/vuetify/src/components/VList/_variables.scss
+++ b/packages/vuetify/src/components/VList/_variables.scss
@@ -13,7 +13,6 @@ $list-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !de
 $list-disabled-opacity: 0.6 !default;
 $list-elevation: 0 !default;
 $list-padding: 8px 0 !default;
-$list-positions: absolute fixed !default;
 $list-rounded-border-radius: map.get(settings.$rounded, null) !default;
 $list-indent-size: 16px !default;
 

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -85,7 +85,7 @@ export const VMenu = genericComponent<new () => {
         transition={ props.transition }
         absolute
         closeOnContentClick
-        positionStrategy="connected"
+        locationStrategy="connected"
         scrollStrategy="reposition"
         scrim={ false }
         openDelay="300"

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -47,7 +47,7 @@ export const VNavigationDrawer = defineComponent({
       type: [Number, String],
       default: 256,
     },
-    position: {
+    location: {
       type: String as PropType<'left' | 'right' | 'bottom'>,
       default: 'left',
       validator: (value: any) => ['left', 'right', 'bottom'].includes(value),
@@ -107,7 +107,7 @@ export const VNavigationDrawer = defineComponent({
       isTemporary,
       width,
       touchless: toRef(props, 'touchless'),
-      position: toRef(props, 'position'),
+      position: toRef(props, 'location'),
     })
 
     const layoutSize = computed(() => {
@@ -120,7 +120,7 @@ export const VNavigationDrawer = defineComponent({
     const { layoutItemStyles, layoutRect, layoutItemScrimStyles } = useLayoutItem({
       id: props.name,
       priority: computed(() => parseInt(props.priority, 10)),
-      position: toRef(props, 'position'),
+      position: toRef(props, 'location'),
       layoutSize,
       elementSize: width,
       active: computed(() => isActive.value || isDragging.value),
@@ -154,13 +154,13 @@ export const VNavigationDrawer = defineComponent({
             class={[
               'v-navigation-drawer',
               {
-                'v-navigation-drawer--bottom': props.position === 'bottom',
-                'v-navigation-drawer--end': props.position === 'right',
+                'v-navigation-drawer--bottom': props.location === 'bottom',
+                'v-navigation-drawer--end': props.location === 'right',
                 'v-navigation-drawer--expand-on-hover': props.expandOnHover,
                 'v-navigation-drawer--floating': props.floating,
                 'v-navigation-drawer--is-hovering': isHovering.value,
                 'v-navigation-drawer--rail': props.rail,
-                'v-navigation-drawer--start': props.position === 'left',
+                'v-navigation-drawer--start': props.location === 'left',
                 'v-navigation-drawer--temporary': isTemporary.value,
                 'v-navigation-drawer--active': isActive.value,
               },

--- a/packages/vuetify/src/components/VNavigationDrawer/__tests__/VNavigationDrawer.spec.cy.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/__tests__/VNavigationDrawer.spec.cy.tsx
@@ -120,7 +120,7 @@ describe('VNavigationDrawer', () => {
   it('should position drawer to the right', () => {
     cy.mount(() => (
       <VLayout>
-        <VNavigationDrawer position="right" permanent />
+        <VNavigationDrawer location="right" permanent />
       </VLayout>
     ))
 
@@ -130,7 +130,7 @@ describe('VNavigationDrawer', () => {
   it('should position drawer on the bottom', () => {
     cy.mount(() => (
       <VLayout>
-        <VNavigationDrawer position="bottom" permanent />
+        <VNavigationDrawer location="bottom" permanent />
       </VLayout>
     ))
 

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -3,7 +3,7 @@ import './VOverlay.sass'
 
 // Composables
 import { makeActivatorProps, useActivator } from './useActivator'
-import { makePositionStrategyProps, usePositionStrategies } from './positionStrategies'
+import { makeLocationStrategyProps, useLocationStrategies } from './locationStrategies'
 import { makeScrollStrategyProps, useScrollStrategies } from './scrollStrategies'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { makeTransitionProps, MaybeTransition } from '@/composables/transition'
@@ -91,6 +91,7 @@ export const VOverlay = genericComponent<new () => {
     },
     contained: Boolean,
     contentClass: null,
+    contentProps: null,
     noClickAnimation: Boolean,
     modelValue: Boolean,
     persistent: Boolean,
@@ -105,7 +106,7 @@ export const VOverlay = genericComponent<new () => {
 
     ...makeActivatorProps(),
     ...makeDimensionProps(),
-    ...makePositionStrategyProps(),
+    ...makeLocationStrategyProps(),
     ...makeScrollStrategyProps(),
     ...makeThemeProps(),
     ...makeTransitionProps(),
@@ -133,7 +134,7 @@ export const VOverlay = genericComponent<new () => {
 
     const root = ref<HTMLElement>()
     const contentEl = ref<HTMLElement>()
-    const { contentStyles, updatePosition } = usePositionStrategies(props, {
+    const { contentStyles, updateLocation } = useLocationStrategies(props, {
       contentEl,
       activatorEl,
       isActive,
@@ -143,7 +144,7 @@ export const VOverlay = genericComponent<new () => {
       contentEl,
       activatorEl,
       isActive,
-      updatePosition,
+      updateLocation,
     })
 
     function onClickOutside (e: MouseEvent) {
@@ -264,6 +265,7 @@ export const VOverlay = genericComponent<new () => {
                       contentStyles.value,
                     ]}
                     { ...toHandlers(contentEvents.value) }
+                    { ...props.contentProps }
                   >
                     { slots.default?.({ isActive }) }
                   </div>
@@ -280,7 +282,7 @@ export const VOverlay = genericComponent<new () => {
       contentEl,
       activatorEl,
       isTop,
-      updatePosition,
+      updateLocation,
     }
   },
 })

--- a/packages/vuetify/src/components/VOverlay/scrollStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/scrollStrategies.ts
@@ -11,7 +11,7 @@ export interface ScrollStrategyData {
   contentEl: Ref<HTMLElement | undefined>
   activatorEl: Ref<HTMLElement | undefined>
   isActive: Ref<boolean>
-  updatePosition: Ref<((e: Event) => void) | undefined>
+  updateLocation: Ref<((e: Event) => void) | undefined>
 }
 
 const scrollStrategies = {
@@ -110,7 +110,7 @@ function repositionScrollStrategy (data: ScrollStrategyData) {
   function update (e: Event) {
     requestNewFrame(() => {
       const start = performance.now()
-      data.updatePosition.value?.(e)
+      data.updateLocation.value?.(e)
       const time = performance.now() - start
       slow = time / (1000 / 60) > 2
     })

--- a/packages/vuetify/src/components/VSheet/VSheet.tsx
+++ b/packages/vuetify/src/components/VSheet/VSheet.tsx
@@ -5,6 +5,7 @@ import './VSheet.sass'
 import { makeBorderProps, useBorder } from '@/composables/border'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { makeLocationProps, useLocation } from '@/composables/location'
 import { makePositionProps, usePosition } from '@/composables/position'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
@@ -24,6 +25,7 @@ export const VSheet = defineComponent({
     ...makeBorderProps(),
     ...makeDimensionProps(),
     ...makeElevationProps(),
+    ...makeLocationProps(),
     ...makePositionProps(),
     ...makeRoundedProps(),
     ...makeTagProps(),
@@ -36,7 +38,8 @@ export const VSheet = defineComponent({
     const { borderClasses } = useBorder(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
-    const { positionClasses, positionStyles } = usePosition(props)
+    const { locationStyles } = useLocation(props)
+    const { positionClasses } = usePosition(props)
     const { roundedClasses } = useRounded(props)
 
     return () => (
@@ -53,7 +56,7 @@ export const VSheet = defineComponent({
         style={[
           backgroundColorStyles.value,
           dimensionStyles.value,
-          positionStyles.value,
+          locationStyles.value,
         ]}
         v-slots={ slots }
       />

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -59,24 +59,6 @@
   &--multi-line &__wrapper
     min-height: $snackbar-multi-line-wrapper-min-height
 
-  &--centered
-    align-items: center
-
-  &--start
-    justify-content: flex-start
-    right: auto
-
-  &--end
-    justify-content: flex-end
-    left: auto
-
-  &--bottom
-    top: auto
-
-  &--top
-    align-items: flex-start
-    bottom: auto
-
   &--vertical &__wrapper
     flex-direction: column
 

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -15,13 +15,13 @@ import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant
 import { onMounted, watch } from 'vue'
 import { defineComponent, useRender } from '@/util'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
+import { makeLocationProps, useLocation } from '@/composables/location'
 
 export const VSnackbar = defineComponent({
   name: 'VSnackbar',
 
   props: {
     app: Boolean,
-    centered: Boolean,
     contentClass: {
       type: String,
       default: '',
@@ -35,6 +35,7 @@ export const VSnackbar = defineComponent({
 
     modelValue: Boolean,
 
+    ...makeLocationProps({ location: 'bottom' } as const),
     ...makePositionProps(),
     ...makeRoundedProps(),
     ...makeVariantProps(),
@@ -47,7 +48,8 @@ export const VSnackbar = defineComponent({
 
   setup (props, { slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
-    const { positionClasses, positionStyles } = usePosition(props)
+    const { locationStyles } = useLocation(props)
+    const { positionClasses } = usePosition(props)
 
     const { colorClasses, colorStyles, variantClasses } = useVariant(props)
     const { roundedClasses } = useRounded(props)
@@ -82,20 +84,15 @@ export const VSnackbar = defineComponent({
           'v-snackbar',
           {
             'v-snackbar--active': isActive.value,
-            'v-snackbar--bottom': props.bottom || !props.top,
-            'v-snackbar--centered': props.centered,
-            'v-snackbar--end': props.right,
             'v-snackbar--multi-line': props.multiLine && !props.vertical,
-            'v-snackbar--start': props.left,
-            'v-snackbar--top': props.top,
             'v-snackbar--vertical': props.vertical,
           },
           positionClasses.value,
         ]}
-        style={[
-          colorStyles.value,
-          positionStyles.value,
-        ]}
+        style={[colorStyles.value]}
+        contentProps={{
+          style: locationStyles.value,
+        }}
         persistent
         noClickAnimation
         scrim={ false }

--- a/packages/vuetify/src/components/VTooltip/VTooltip.tsx
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.tsx
@@ -15,7 +15,7 @@ import { genericComponent, getUid } from '@/util'
 // Types
 import type { PropType } from 'vue'
 import type { OverlaySlots } from '@/components/VOverlay/VOverlay'
-import type { StrategyProps } from '@/components/VOverlay/positionStrategies'
+import type { StrategyProps } from '@/components/VOverlay/locationStrategies'
 
 export const VTooltip = genericComponent<new () => {
   $slots: OverlaySlots
@@ -29,8 +29,8 @@ export const VTooltip = genericComponent<new () => {
     modelValue: Boolean,
     text: String,
 
-    anchor: {
-      type: String as PropType<StrategyProps['anchor']>,
+    location: {
+      type: String as PropType<StrategyProps['location']>,
       default: 'end',
     },
     origin: {
@@ -53,10 +53,10 @@ export const VTooltip = genericComponent<new () => {
     const uid = getUid()
     const id = computed(() => props.id || `v-tooltip-${uid}`)
 
-    const anchor = computed(() => {
-      return props.anchor.split(' ').length > 1
-        ? props.anchor
-        : props.anchor + ' center' as StrategyProps['anchor']
+    const location = computed(() => {
+      return props.location.split(' ').length > 1
+        ? props.location
+        : props.location + ' center' as StrategyProps['location']
     })
 
     const origin = computed(() => {
@@ -64,7 +64,7 @@ export const VTooltip = genericComponent<new () => {
         props.origin === 'auto' ||
         props.origin === 'overlap' ||
         props.origin.split(' ').length > 1 ||
-        props.anchor.split(' ').length > 1
+        props.location.split(' ').length > 1
       ) ? props.origin
         : props.origin + ' center' as StrategyProps['origin']
     })
@@ -84,9 +84,9 @@ export const VTooltip = genericComponent<new () => {
           id={ id.value }
           transition={ transition.value }
           absolute
-          positionStrategy="connected"
+          locationStrategy="connected"
           scrollStrategy="reposition"
-          anchor={ anchor.value }
+          location={ location.value }
           origin={ origin.value }
           min-width={ 0 }
           offset={ 10 }

--- a/packages/vuetify/src/composables/__tests__/location.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/location.spec.ts
@@ -1,0 +1,34 @@
+// Composables
+import { useLocation } from '../location'
+
+// Utilities
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from '@jest/globals'
+
+// Types
+import { createVuetify } from '@/framework'
+
+describe('location', () => {
+  it.each([
+    ['top', { top: 0, left: '50%', transform: 'translateX(-50%)' }],
+    ['bottom', { bottom: 0, left: '50%', transform: 'translateX(-50%)' }],
+    ['start', { left: 0, top: '50%', transform: 'translateY(-50%)' }],
+    ['end', { right: 0, top: '50%', transform: 'translateY(-50%)' }],
+    ['center', { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }],
+    ['top start', { top: 0, left: 0 }],
+  ])('placement=%s', (location, styles) => {
+    mount({
+      setup () {
+        const { locationStyles } = useLocation({ location })
+
+        expect(locationStyles.value).toEqual(styles)
+
+        return () => {}
+      },
+    }, {
+      global: {
+        plugins: [createVuetify()],
+      },
+    })
+  })
+})

--- a/packages/vuetify/src/composables/__tests__/position.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/position.spec.ts
@@ -1,32 +1,19 @@
 // Utilities
 import { usePosition } from '../position'
+import { describe, expect, it } from '@jest/globals'
 
 // Types
 import type { PositionProps } from '../position'
 
-describe('position.ts', () => {
+describe('position', () => {
   it.each([
     [{ position: undefined }, undefined],
     [{ position: false }, undefined],
-    [{ position: 'absolute' }, 'position-absolute'],
-    [{ position: 'fixed' }, 'position-fixed'],
-    [{ absolute: true }, 'foo--absolute'],
-    [{ fixed: true }, 'foo--fixed'],
-  ])('should have proper classes', (props, expected) => {
+    [{ position: 'absolute' }, 'foo--absolute'],
+    [{ position: 'fixed' }, 'foo--fixed'],
+  ])('position=%s', (props, expected) => {
     const { positionClasses } = usePosition(props as PositionProps, 'foo')
 
     expect(positionClasses.value).toEqual(expected)
-  })
-
-  it.each([
-    [{ top: true }, { top: '0px' }],
-    [{ right: 20 }, { right: '20px' }],
-    [{ bottom: '20' }, { bottom: '20px' }],
-    [{ left: undefined }, {}],
-    [{ right: false, left: '50' }, { left: '50px' }],
-  ])('should have proper styles', (props, expected) => {
-    const { positionStyles } = usePosition(props, 'bar')
-
-    expect(positionStyles.value).toEqual(expected)
   })
 })

--- a/packages/vuetify/src/composables/location.ts
+++ b/packages/vuetify/src/composables/location.ts
@@ -1,0 +1,80 @@
+import type { MaybeRef } from '@/util'
+import { propsFactory } from '@/util'
+import { computed, unref } from 'vue'
+import type { CSSProperties, PropType } from 'vue'
+import type { Anchor } from '@/components/VOverlay/util/anchor'
+import { parseAnchor } from '@/components/VOverlay/util/anchor'
+import { useRtl } from '@/composables/rtl'
+
+const oppositeMap = {
+  center: 'center',
+  top: 'bottom',
+  bottom: 'top',
+  left: 'right',
+  right: 'left',
+} as const
+
+export interface LocationProps {
+  location: Anchor | undefined
+}
+
+export const makeLocationProps = propsFactory({
+  location: String as PropType<Anchor>,
+}, 'location')
+
+export function useLocation (props: LocationProps, opposite = false, offset: MaybeRef<number> = 0) {
+  const { isRtl } = useRtl()
+
+  function toPhysical (side: string) {
+    return (
+      side === 'start' ? (isRtl.value ? 'right' : 'left')
+      : side === 'end' ? (isRtl.value ? 'left' : 'right')
+      : side
+    ) as 'right' | 'left' | 'top' | 'bottom' | 'center'
+  }
+
+  const locationStyles = computed(() => {
+    if (!props.location) return {}
+
+    const anchor = parseAnchor(
+      props.location.split(' ').length > 1
+        ? props.location
+        : `${props.location} center` as Anchor
+    )
+
+    const side = toPhysical(anchor.side)
+    const align = toPhysical(anchor.align)
+
+    const styles = {} as CSSProperties
+
+    if (side !== 'center') {
+      if (opposite) styles[oppositeMap[side]] = `calc(100% - ${unref(offset)}px)`
+      else styles[side] = 0
+    }
+    if (align !== 'center') {
+      if (opposite) styles[oppositeMap[align]] = `calc(100% - ${unref(offset)}px)`
+      else styles[align] = 0
+    } else {
+      if (side === 'center') styles.top = styles.left = '50%'
+      else {
+        styles[({
+          top: 'left',
+          bottom: 'left',
+          left: 'top',
+          right: 'top',
+        } as const)[side]] = '50%'
+      }
+      styles.transform = {
+        top: 'translateX(-50%)',
+        bottom: 'translateX(-50%)',
+        left: 'translateY(-50%)',
+        right: 'translateY(-50%)',
+        center: 'translate(-50%, -50%)',
+      }[side]
+    }
+
+    return styles
+  })
+
+  return { locationStyles }
+}

--- a/packages/vuetify/src/composables/position.ts
+++ b/packages/vuetify/src/composables/position.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { computed } from 'vue'
-import { convertToUnit, getCurrentInstanceName, propsFactory } from '@/util'
+import { getCurrentInstanceName, propsFactory } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -10,55 +10,24 @@ const positionValues = ['static', 'relative', 'fixed', 'absolute', 'sticky'] as 
 type Position = typeof positionValues[number]
 
 export interface PositionProps {
-  absolute?: boolean
-  bottom?: boolean | number | string
-  fixed?: boolean
-  left?: boolean | number | string
-  position?: Position
-  right?: boolean | number | string
-  top?: boolean | number | string
+  position: Position | undefined
 }
 
 // Composables
 export const makePositionProps = propsFactory({
-  absolute: Boolean,
-  bottom: [Boolean, Number, String],
-  fixed: Boolean,
-  left: [Boolean, Number, String],
   position: {
     type: String as PropType<Position>,
     validator: /* istanbul ignore next */ (v: any) => positionValues.includes(v),
   },
-  right: [Boolean, Number, String],
-  top: [Boolean, Number, String],
 }, 'position')
 
 export function usePosition (
   props: PositionProps,
   name = getCurrentInstanceName(),
 ) {
-  const targets = ['top', 'right', 'bottom', 'left'] as const
-
   const positionClasses = computed(() => {
-    if (props.fixed) return `${name}--fixed`
-    if (props.absolute) return `${name}--absolute`
-
-    return props.position ? `position-${props.position}` : undefined
+    return props.position ? `${name}--${props.position}` : undefined
   })
 
-  const positionStyles = computed(() => {
-    const styles: Partial<Record<typeof targets[number], string>> = {}
-
-    for (const target of targets) {
-      const prop = props[target]
-
-      if (prop == null || prop === false) continue
-
-      styles[target] = convertToUnit(prop === true ? '0' : String(prop))
-    }
-
-    return styles
-  })
-
-  return { positionClasses, positionStyles }
+  return { positionClasses }
 }


### PR DESCRIPTION
resolves #14952

- `anchor`/`position`/`location`/`top`/`bottom`/`left`/`right` combined into a single `location` prop
- `position`/`absolute`/`fixed` combined into `position`, now uses per-component classes instead of utility classes
- layout components still use `absolute` because they're fixed by default and I'm lazy
  - They also still use left/right instead of start/end
  - I didn't fix this but I noticed navigation drawers are inconsistent with rtl. `location="left"` opens on the left side, but applies a `--start` class which is rtl-aware for the border