### PR TITLE
feat(theme): redesign public interface

### DIFF
--- a/packages/docs/src/App.vue
+++ b/packages/docs/src/App.vue
@@ -66,7 +66,7 @@
         }
 
         watchEffect(() => {
-          theme.current.value = (
+          theme.name.value = (
             user.theme === 'system' ? systemTheme.value : user.theme
           )
         })

--- a/packages/docs/src/components/app/Markup.vue
+++ b/packages/docs/src/components/app/Markup.vue
@@ -129,7 +129,7 @@
       }
 
       const isDark = computed(() => {
-        return user.mixedTheme || theme.getTheme(theme.current.value).dark
+        return user.mixedTheme || theme.current.value.dark
       })
 
       return {

--- a/packages/docs/src/components/app/Toc.vue
+++ b/packages/docs/src/components/app/Toc.vue
@@ -236,7 +236,7 @@
               return aTier === bTier ? 0 : aTier > bTier ? 1 : -1
             })
         )),
-        dark: computed(() => theme.getTheme(theme.current.value).dark),
+        dark: computed(() => theme.current.value.dark),
         route,
       }
     },

--- a/packages/docs/src/components/app/settings/Group.vue
+++ b/packages/docs/src/components/app/settings/Group.vue
@@ -63,7 +63,7 @@
       const { t } = useI18n()
       const theme = useTheme()
 
-      return { t, dark: computed(() => theme.getTheme(theme.current.value).dark) }
+      return { t, dark: computed(() => theme.current.value.dark) }
     },
   })
 </script>

--- a/packages/docs/src/components/examples/Example.vue
+++ b/packages/docs/src/components/examples/Example.vue
@@ -138,7 +138,7 @@
   const parentTheme = useTheme()
   const _theme = ref<null | string>(null)
   const theme = computed({
-    get: () => _theme.value ?? parentTheme.current.value,
+    get: () => _theme.value ?? parentTheme.name.value,
     set: val => _theme.value = val,
   })
   const toggleTheme = () => theme.value = theme.value === 'light' ? 'dark' : 'light'

--- a/packages/docs/src/components/promoted/Base.vue
+++ b/packages/docs/src/components/promoted/Base.vue
@@ -40,7 +40,7 @@
       dark () {
         const theme = useTheme()
 
-        return theme.getTheme(theme.current.value).dark
+        return theme.current.value.dark
       },
     },
   })

--- a/packages/docs/src/components/sponsor/Card.vue
+++ b/packages/docs/src/components/sponsor/Card.vue
@@ -52,7 +52,7 @@
           lightLogo = '',
         } = sponsor?.value?.metadata ?? {}
 
-        const current = theme.getTheme(theme.current.value)
+        const current = theme.current.value
         return !current.dark ? logolight.url || lightLogo : logodark.url || darkLogo
       })
 

--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -70,31 +70,32 @@ export default createVuetify({
 
 ## Changing theme
 
-To dynamically change theme during run-time, add the **theme** prop to the `<v-app>` component.
+To dynamically change theme during runtime.
 
 ```html
 <template>
-  <v-app :theme="theme">
+  <v-app>
     <v-btn @click="toggleTheme">toggle theme</v-btn>
     ...
   </v-app>
 </template>
 
 <script>
-import { ref } from 'vue'
+import { useTheme } from 'vuetify'
 
 export default {
   setup () {
-    const theme = ref('light')
+    const theme = useTheme()
 
     return {
       theme,
-      toggleTheme: () => theme.value = theme.value === 'light' ? 'dark' : 'light'
+      toggleTheme: () => theme.name.value = theme.current.value.dark ? 'light' : 'dark'
     }
   }
 }
 </script>
 ```
+
 
 Most components support the **theme** prop. When used, a new context is created for _that_ specific component and **all** of its children. In the following example, the [v-btn](/components/buttons/) uses the **dark** theme applied by its parent [v-card](/components/cards/).
 
@@ -215,8 +216,24 @@ export default createVuetify({
 })
 ```
 
+## Theme object structure
+
+```ts
+interface ThemeInstance {
+  /** Name of the current theme */
+  name: Ref<string>
+
+  /** Raw theme objects */
+  themes: Ref<{ [name: string]: ThemeDefinition }>
+
+  /** Processed theme object, includes automatically generated colors */
+  readonly current: ThemeDefinition
+  readonly computedThemes: { [name: string]: ThemeDefinition }
+}
+```
+
 ## Implementation
 
-Vuetify generates theme styles at run-time according to the given configuration. The generated styles are injected into the `<head>` section of the DOM in a `<style>` tag with an **id** of `vuetify-theme-stylesheet`.
+Vuetify generates theme styles at runtime according to the given configuration. The generated styles are injected into the `<head>` section of the DOM in a `<style>` tag with an **id** of `vuetify-theme-stylesheet`.
 
 <backmatter />

--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -96,7 +96,6 @@ export default {
 </script>
 ```
 
-
 Most components support the **theme** prop. When used, a new context is created for _that_ specific component and **all** of its children. In the following example, the [v-btn](/components/buttons/) uses the **dark** theme applied by its parent [v-card](/components/cards/).
 
 ```html

--- a/packages/vuetify/src/composables/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/theme.spec.ts
@@ -40,7 +40,7 @@ describe('createTheme', () => {
     ]
 
     for (const color of colors) {
-      expect(theme.themes.value.light.colors).toHaveProperty(color)
+      expect(theme.computedThemes.value.light.colors).toHaveProperty(color)
     }
   })
 
@@ -56,8 +56,8 @@ describe('createTheme', () => {
     for (const color of ['primary', 'secondary']) {
       for (const variant of ['lighten', 'darken']) {
         for (const amount of [1, 2]) {
-          expect(theme.themes.value.light.colors).toHaveProperty(`${color}-${variant}-${amount}`)
-          expect(theme.themes.value.light.colors).toHaveProperty(`on-${color}-${variant}-${amount}`)
+          expect(theme.computedThemes.value.light.colors).toHaveProperty(`${color}-${variant}-${amount}`)
+          expect(theme.computedThemes.value.light.colors).toHaveProperty(`on-${color}-${variant}-${amount}`)
         }
       }
     }
@@ -68,17 +68,17 @@ describe('createTheme', () => {
       variations: false,
     })
 
-    expect(theme.themes.value.light.colors.background).not.toBe('#FF0000')
+    expect(theme.computedThemes.value.light.colors.background).not.toBe('#FF0000')
 
-    theme.setTheme('light', {
+    theme.themes.value.light = {
       ...theme.themes.value.light,
       colors: {
         ...theme.themes.value.light.colors,
         background: '#FF0000',
       },
-    })
+    }
 
-    expect(theme.themes.value.light.colors.background).toBe('#FF0000')
+    expect(theme.computedThemes.value.light.colors.background).toBe('#FF0000')
   })
 
   // it('should use vue-meta@2.3 functionality', () => {


### PR DESCRIPTION
Closes #15169

Also threw in a big ol' refactor because why not. 

Before
```ts
interface ThemeInstance {
  /** Name of the current theme */
  current: Ref<string>

  /** Processed theme objects */
  themes: Ref<{ [name: string]: ThemeDefinition }>

  /** Processed theme object */
  getTheme: (key: string) => ThemeDefinition
  setTheme:(key: string, theme: ThemeDefinition) => void
}
```

After
```ts
interface ThemeInstance {
  /** Name of the current theme */
  name: Ref<string>

  /** Raw theme objects */
  themes: Ref<{ [name: string]: ThemeDefinition }>

  /** Processed theme object, includes automatically generated colors */
  readonly current: ThemeDefinition
  readonly computedThemes: { [name: string]: ThemeDefinition }
}
```