### PR TITLE
feat(VOtpInput): Add support for style props

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.ts
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.ts
@@ -37,15 +37,21 @@ export default baseMixins.extend<options>().extend({
   inheritAttrs: false,
 
   props: {
+    filled: Boolean,
+    flat: Boolean,
     length: {
       type: [Number, String],
       default: 6,
     },
+    plain: Boolean,
+    rounded: Boolean,
+    shaped: Boolean,
+    solo: Boolean,
+    soloInverted: Boolean,
     type: {
       type: String,
       default: 'text',
     },
-    plain: Boolean,
   },
 
   data: () => ({
@@ -63,11 +69,29 @@ export default baseMixins.extend<options>().extend({
       return {
         ...VInput.options.computed.classes.call(this),
         ...VTextField.options.computed.classes.call(this),
+        'v-otp-input--enclosed': this.isEnclosed,
+        'v-otp-input--filled': this.filled,
+        'v-otp-input--outlined': this.outlined,
         'v-otp-input--plain': this.plain,
+        'v-otp-input--rounded': this.rounded,
+        'v-otp-input--shaped': this.shaped,
+        'v-otp-input--solo': this.isSolo,
+        'v-text-field--solo-flat': this.flat,
+        'v-otp-input--solo-inverted': this.soloInverted,
       }
     },
     isDirty (): boolean {
       return VInput.options.computed.isDirty.call(this) || this.badInput
+    },
+    isEnclosed (): boolean {
+      return (
+        this.filled ||
+        this.isSolo ||
+        this.outlined
+      ) as boolean
+    },
+    isSolo (): boolean {
+      return this.solo || this.soloInverted
     },
   },
 


### PR DESCRIPTION
Add support for style props like `filled`, `solo`, and `rounded`.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
I used VTextField code as reference to add support for style props. This my first time contributing to the codebase, but testing the props in Playground showed that they work as expected (almost!)

The current implementation of VOtpInput uses outlined style by default, which is not consistent with the other input fields. This becomes an issue when using any styled props like `solo`, because the border of the outlined style persists and doesn't go away.

I found that making the component consistent with the rest of the input components will introduce breaking changes, so I decided to do that in another PR.

Upon merging this PR, style props like `solo` will work on VOtpInput, however the visually it will not be identical of `solo` effect in other input components because of the current implementation of VOtpInput.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #15299

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
I am not familiar with unit tests, and though I added none. I just changed the code and saw the wanted behavior reflected in the Playground.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<v-container>
  <v-otp-input length="4" solo />
</v-container>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
