### PR TITLE
fix: validate selected items instead of search

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -104,7 +104,7 @@ export const VAutocomplete = genericComponent<new <
       v => transformIn(wrapInArray(v)),
       v => {
         const transformed = transformOut(v)
-        return props.multiple ? transformed : transformed[0]
+        return props.multiple ? transformed : (transformed[0] ?? null)
       }
     )
     const { filteredItems } = useFilter(props, items, computed(() => isPristine.value ? undefined : search.value))
@@ -206,6 +206,8 @@ export const VAutocomplete = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           modelValue={ search.value }
+          onUpdate:modelValue={ v => { if (v == null) model.value = [] } }
+          validationValue={ props.modelValue }
           onInput={ onInput }
           class={[
             'v-autocomplete',
@@ -216,7 +218,6 @@ export const VAutocomplete = genericComponent<new <
             },
           ]}
           appendInnerIcon={ props.menuIcon }
-          dirty={ selected.value.length > 0 }
           onClick:clear={ onClear }
           onClick:control={ onClickControl }
           onClick:input={ onClickControl }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -108,7 +108,7 @@ export const VCombobox = genericComponent<new <
       v => transformIn(wrapInArray(v || [])),
       v => {
         const transformed = transformOut(v)
-        return props.multiple ? transformed : transformed[0]
+        return props.multiple ? transformed : (transformed[0] ?? null)
       }
     )
     const _search = ref('')
@@ -116,9 +116,9 @@ export const VCombobox = genericComponent<new <
       get: () => {
         if (props.multiple) return _search.value
 
-        const item = items.value.find(({ props }) => props.value === model.value[0])
+        const item = items.value.find(item => item.value === model.value[0]?.value)
 
-        return item?.props.value
+        return item?.value
       },
       set: val => {
         if (props.multiple) {
@@ -237,9 +237,6 @@ export const VCombobox = genericComponent<new <
         search.value = ''
       }
     }
-    function onInput (e: InputEvent) {
-      search.value = (e.target as HTMLInputElement).value
-    }
     function onAfterLeave () {
       if (isFocused.value) isPristine.value = true
     }
@@ -290,8 +287,9 @@ export const VCombobox = genericComponent<new <
       return (
         <VTextField
           ref={ vTextFieldRef }
-          modelValue={ search.value }
-          onInput={ onInput }
+          v-model={ search.value }
+          onUpdate:modelValue={ v => { if (v == null) model.value = [] } }
+          validationValue={ props.modelValue }
           class={[
             'v-combobox',
             {
@@ -302,7 +300,6 @@ export const VCombobox = genericComponent<new <
             },
           ]}
           appendInnerIcon={ props.items.length ? props.menuIcon : undefined }
-          dirty={ selected.value.length > 0 }
           onClick:clear={ onClear }
           onClick:control={ onClickControl }
           onClick:input={ onClickControl }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -108,7 +108,7 @@ export const VSelect = genericComponent<new <
       v => transformIn(wrapInArray(v)),
       v => {
         const transformed = transformOut(v)
-        return props.multiple ? transformed : transformed[0]
+        return props.multiple ? transformed : (transformed[0] ?? null)
       }
     )
     const selections = computed(() => {
@@ -162,6 +162,9 @@ export const VSelect = genericComponent<new <
       return (
         <VTextField
           ref={ vTextFieldRef }
+          modelValue={ model.value.map(v => v.props.value).join(', ') }
+          onUpdate:modelValue={ v => { if (v == null) model.value = [] } }
+          validationValue={ props.modelValue }
           class={[
             'v-select',
             {
@@ -176,7 +179,6 @@ export const VSelect = genericComponent<new <
           onClick:input={ onClickControl }
           onClick:control={ onClickControl }
           onBlur={ () => menu.value = false }
-          modelValue={ model.value.map(v => v.props.value).join(', ') }
           onKeydown={ onKeydown }
         >
           {{


### PR DESCRIPTION
fixes #15142

```html
<template>
  <v-app>
    <v-container>
      <v-form ref="form" @submit.prevent>
        <v-text-field v-model="text" label="text field" :rules="rules" />
        <v-select v-model="select" label="select" :items="items" multiple :rules="rules" />
        <v-autocomplete v-model="autocomplete" label="autocomplete" :items="items" multiple :rules="rules" />
        <v-combobox v-model="combobox" label="combobox" :items="items" multiple :rules="rules" />

        <v-btn type="submit">Validate</v-btn>
        <v-btn type="reset">Reset</v-btn>
        <v-btn @click="resetValidation">Reset validation</v-btn>
      </v-form>

      <pre>{{ {
        text,
        select,
        autocomplete,
        combobox,
      } }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { computed, ref, watch } from 'vue'

  const form = ref()
  const items = Array.from({ length: 5 }, (_, i) => `Item ${i + 1}`)
  const rules = [
    v => {
      console.log(v)
      return true
    },
  ]

  const text = ref()
  const select = ref()
  const autocomplete = ref()
  const combobox = ref()

  function resetValidation () {
    form.value?.resetValidation()
  }
</script>
```