### PR TITLE
feat: rename variants

### DIFF
--- a/packages/api-generator/src/locale/en/variant.json
+++ b/packages/api-generator/src/locale/en/variant.json
@@ -1,5 +1,5 @@
 {
   "props": {
-    "variant": "Applies one of 6 styles, **contained** (default), **contained-flat**, **contained-text**, **outlined**, **plain**, and **text**."
+    "variant": "Applies one of 6 styles: **elevated**(default), **flat**, **tonal**, **outlined**, **text**, and **plain**."
   }
 }

--- a/packages/docs/src/components/Alert.vue
+++ b/packages/docs/src/components/Alert.vue
@@ -3,7 +3,7 @@
     :border-color="type"
     border="start"
     class="v-alert--doc mb-4 border-opacity-100"
-    variant="contained-text"
+    variant="tonal"
     :type="type"
   >
     <template #prepend>

--- a/packages/docs/src/components/app/PwaSnackbar.vue
+++ b/packages/docs/src/components/app/PwaSnackbar.vue
@@ -19,7 +19,7 @@
         />
       </v-btn>
       <app-btn
-        variant="contained"
+        variant="flat"
         color="primary"
         @click="pwa.update"
       >

--- a/packages/docs/src/components/app/Toc.vue
+++ b/packages/docs/src/components/app/Toc.vue
@@ -51,7 +51,7 @@
       <v-container>
         <v-card
           :color="dark ? undefined : 'grey-lighten-5'"
-          variant="contained-flat"
+          variant="flat"
         >
 
           <v-container class="pa-2">

--- a/packages/docs/src/examples/v-alert/prop-closable.vue
+++ b/packages/docs/src/examples/v-alert/prop-closable.vue
@@ -3,7 +3,7 @@
     <v-alert
       v-model="alert"
       border="start"
-      variant="contained-text"
+      variant="tonal"
       closable
       close-label="Close Alert"
       color="deep-purple accent-4"

--- a/packages/docs/src/examples/v-alert/prop-density.vue
+++ b/packages/docs/src/examples/v-alert/prop-density.vue
@@ -12,7 +12,7 @@
     <v-alert
       density="comfortable"
       type="success"
-      variant="contained-text"
+      variant="tonal"
     >
       I'm a comfortable alert with the <strong>text</strong> prop and a <strong>type</strong> of success
     </v-alert>

--- a/packages/docs/src/examples/v-alert/prop-variant.vue
+++ b/packages/docs/src/examples/v-alert/prop-variant.vue
@@ -3,8 +3,8 @@
     <v-alert
       color="yellow-darken-4"
       icon="mdi-flash"
-      title="Contained Flat (Default)"
-      variant="contained-flat"
+      title="Flat (Default)"
+      variant="flat"
     >
       Nullam tincidunt adipiscing enim. In consectetuer turpis ut velit. Maecenas egestas arcu quis ligula mattis placerat. Praesent metus tellus, elementum eu, semper a, adipiscing nec, purus.
     </v-alert>
@@ -13,8 +13,8 @@
 
     <v-alert
       color="info"
-      title="Contained Text"
-      variant="contained-text"
+      title="Tonal"
+      variant="tonal"
     >
       <div>
         Maecenas nec odio et ante tincidunt tempus. Sed mollis, eros et ultrices tempus, mauris ipsum aliquam libero, non adipiscing dolor urna a orci. Proin viverra, ligula sit amet ultrices semper, ligula arcu tristique sapien, a accumsan nisi mauris ac eros. Curabitur turpis.
@@ -54,8 +54,8 @@
       color="teal-darken-4"
       density="compact"
       icon="mdi-clock-fast"
-      title="Contained"
-      variant="contained"
+      title="Elevated"
+      variant="elevated"
     >
       Vestibulum ullamcorper mauris at ligula. Nulla porta dolor. Vestibulum facilisis, purus nec pulvinar iaculis, ligula mi congue nunc, vitae euismod ligula urna in dolor. Curabitur at lacus ac velit ornare lobortis.
     </v-alert>

--- a/packages/docs/src/examples/v-alert/usage.vue
+++ b/packages/docs/src/examples/v-alert/usage.vue
@@ -8,7 +8,7 @@
       :defaults="{
         VAlert: {
           border: model === 'border',
-          variant: model === 'contained' ? 'contained' : undefined,
+          variant: model === 'elevated' ? 'elevated' : undefined,
         }
       }"
     >
@@ -36,7 +36,7 @@
     data: () => ({
       alert: true,
       model: 'default',
-      options: ['contained', 'border'],
+      options: ['elevated', 'border'],
     }),
   }
 </script>

--- a/packages/docs/src/examples/v-badge/prop-dot.vue
+++ b/packages/docs/src/examples/v-badge/prop-dot.vue
@@ -24,7 +24,7 @@
 
     <v-btn
       stacked
-      variant="contained-text"
+      variant="tonal"
     >
       <v-icon icon="mdi-login"></v-icon>
 

--- a/packages/docs/src/examples/v-btn/prop-variant.vue
+++ b/packages/docs/src/examples/v-btn/prop-variant.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="d-flex justify-space-between">
-    <v-btn>contained (default)</v-btn>
-    <v-btn variant="contained-flat">contained-flat</v-btn>
-    <v-btn variant="contained-text">contained-text</v-btn>
+    <v-btn>elevates (default)</v-btn>
+    <v-btn variant="flat">flat</v-btn>
+    <v-btn variant="tonal">tonal</v-btn>
     <v-btn variant="outlined">outlined</v-btn>
-    <v-btn variant="plain">plain</v-btn>
     <v-btn variant="text">text</v-btn>
+    <v-btn variant="plain">plain</v-btn>
   </div>
 </template>

--- a/packages/docs/src/examples/v-card/usage.vue
+++ b/packages/docs/src/examples/v-card/usage.vue
@@ -46,7 +46,7 @@
 
     data: () => ({
       model: 'default',
-      options: ['contained-text', 'plain'],
+      options: ['tonal', 'plain'],
     }),
   }
 </script>

--- a/packages/docs/src/examples/v-carousel/slots-next-prev.vue
+++ b/packages/docs/src/examples/v-carousel/slots-next-prev.vue
@@ -6,14 +6,14 @@
   >
     <template v-slot:prev="{ props }">
       <v-btn
-        variant="contained"
+        variant="elevated"
         color="success"
         @click="props.onClick"
       >Previous slide</v-btn>
     </template>
     <template v-slot:next="{ props }">
       <v-btn
-        variant="contained"
+        variant="elevated"
         color="info"
         @click="props.onClick"
       >Next slide</v-btn>

--- a/packages/docs/src/examples/v-list/prop-variant.vue
+++ b/packages/docs/src/examples/v-list/prop-variant.vue
@@ -32,7 +32,7 @@
           :key="i"
           :value="item"
           active-color="primary"
-          variant="contained"
+          variant="elevated"
         >
           <v-list-item-avatar start>
             <v-icon :icon="item.icon"></v-icon>

--- a/packages/docs/src/examples/v-select/usage.vue
+++ b/packages/docs/src/examples/v-select/usage.vue
@@ -55,8 +55,8 @@
       >
         <v-select
           :items="items"
-          label="Contained variant"
-          variant="contained"
+          label="Solo variant"
+          variant="solo"
         ></v-select>
       </v-col>
     </v-row>

--- a/packages/docs/src/examples/v-snackbar/prop-variants.vue
+++ b/packages/docs/src/examples/v-snackbar/prop-variants.vue
@@ -44,7 +44,7 @@
       bottom
       color="primary"
       left
-      variant="contained-text"
+      variant="tonal"
     >
       Lorem ipsum dolor sit amet consectetur.
     </v-snackbar>

--- a/packages/docs/src/examples/v-text-field/prop-clearable.vue
+++ b/packages/docs/src/examples/v-text-field/prop-clearable.vue
@@ -19,8 +19,8 @@
         >
           <v-text-field
             v-model="message2"
-            label="Contained"
-            variant="contained"
+            label="Solo"
+            variant="solo"
             clearable
             clear-icon="mdi-delete"
           ></v-text-field>

--- a/packages/docs/src/examples/v-text-field/prop-contained.vue
+++ b/packages/docs/src/examples/v-text-field/prop-contained.vue
@@ -9,7 +9,7 @@
           <v-text-field
             v-model="first"
             label="First Name"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
         </v-col>
 
@@ -20,7 +20,7 @@
           <v-text-field
             v-model="last"
             label="Last Name"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
         </v-col>
       </v-row>

--- a/packages/docs/src/examples/v-text-field/prop-custom-colors.vue
+++ b/packages/docs/src/examples/v-text-field/prop-custom-colors.vue
@@ -22,7 +22,7 @@
           <v-text-field
             color="secondary"
             label="Contained"
-            variant="contained"
+            variant="solo"
             placeholder="Placeholder"
           ></v-text-field>
         </v-col>

--- a/packages/docs/src/examples/v-text-field/prop-custom-colors.vue
+++ b/packages/docs/src/examples/v-text-field/prop-custom-colors.vue
@@ -21,7 +21,7 @@
         >
           <v-text-field
             color="secondary"
-            label="Contained"
+            label="Solo"
             variant="solo"
             placeholder="Placeholder"
           ></v-text-field>

--- a/packages/docs/src/examples/v-text-field/prop-dense.vue
+++ b/packages/docs/src/examples/v-text-field/prop-dense.vue
@@ -37,7 +37,7 @@
             density="compact"
             label="Compact"
             placeholder="Compact"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
         </v-col>
 

--- a/packages/docs/src/examples/v-text-field/prop-disabled-and-readonly.vue
+++ b/packages/docs/src/examples/v-text-field/prop-disabled-and-readonly.vue
@@ -30,8 +30,8 @@
         >
           <v-text-field
             value="John Doe"
-            label="Contained"
-            variant="contained"
+            label="Solo"
+            variant="solo"
             disabled
           ></v-text-field>
         </v-col>
@@ -42,8 +42,8 @@
         >
           <v-text-field
             value="John Doe"
-            label="Contained"
-            variant="contained"
+            label="Solo"
+            variant="solo"
             readonly
           ></v-text-field>
         </v-col>

--- a/packages/docs/src/examples/v-text-field/prop-hint.vue
+++ b/packages/docs/src/examples/v-text-field/prop-hint.vue
@@ -32,7 +32,7 @@
             label="Your product or service"
             value="Grocery delivery"
             hint="For example, flowers or used cars"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
         </v-col>
 
@@ -44,7 +44,7 @@
             label="Your landing page"
             hint="www.example.com/page"
             persistent-hint
-            variant="contained"
+            variant="solo"
           ></v-text-field>
         </v-col>
 

--- a/packages/docs/src/examples/v-text-field/prop-icon.vue
+++ b/packages/docs/src/examples/v-text-field/prop-icon.vue
@@ -34,25 +34,25 @@
           <v-text-field
             label="Prepend"
             prepend-icon="mdi-map-marker"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
 
           <v-text-field
             label="Prepend inner"
             prepend-inner-icon="mdi-map-marker"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
 
           <v-text-field
             label="Append"
             append-icon="mdi-map-marker"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
 
           <v-text-field
             label="Append outer"
             append-outer-icon="mdi-map-marker"
-            variant="contained"
+            variant="solo"
           ></v-text-field>
         </v-col>
 

--- a/packages/docs/src/examples/v-text-field/prop-single-line.vue
+++ b/packages/docs/src/examples/v-text-field/prop-single-line.vue
@@ -17,8 +17,8 @@
           sm="6"
         >
           <v-text-field
-            label="Contained"
-            variant="contained"
+            label="Solo"
+            variant="solo"
             single-line
           ></v-text-field>
         </v-col>

--- a/packages/docs/src/examples/v-text-field/prop-variant.vue
+++ b/packages/docs/src/examples/v-text-field/prop-variant.vue
@@ -20,7 +20,7 @@
         >
           <v-text-field
             label="Contained"
-            variant="contained"
+            variant="solo"
             placeholder="Placeholder"
           ></v-text-field>
         </v-col>

--- a/packages/docs/src/examples/v-text-field/prop-variant.vue
+++ b/packages/docs/src/examples/v-text-field/prop-variant.vue
@@ -19,7 +19,7 @@
           md="4"
         >
           <v-text-field
-            label="Contained"
+            label="Solo"
             variant="solo"
             placeholder="Placeholder"
           ></v-text-field>

--- a/packages/docs/src/examples/v-text-field/usage.vue
+++ b/packages/docs/src/examples/v-text-field/usage.vue
@@ -29,8 +29,8 @@
           md="3"
         >
           <v-text-field
-            label="Contained"
-            variant="contained"
+            label="Solo"
+            variant="solo"
           ></v-text-field>
         </v-col>
 
@@ -40,8 +40,8 @@
           md="3"
         >
           <v-text-field
-            label="Contained"
-            variant="contained"
+            label="Solo"
+            variant="solo"
             placeholder="Placeholder"
           ></v-text-field>
         </v-col>

--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -82,7 +82,7 @@ The **density** prop supports 3 levels of component height; **default**, **comfo
 
 #### Variants
 
-`v-alert` has 6 style variants, **contained, contained-flat, contained-text, outlined, plain,** and **text**. By default, the `v-alert` component is **contained-flat**; which means that it has a solid background and does not have a box-shadow (elevation).
+`v-alert` has 6 style variants, **elevated**, **flat**, **tonal**, **outlined**, **text**, and **plain**. By default, the `v-alert` component is **flat**; which means that it has a solid background and does not have a box-shadow (elevation).
 
 <example file="v-alert/prop-variant" />
 

--- a/packages/docs/src/pages/en/components/buttons.md
+++ b/packages/docs/src/pages/en/components/buttons.md
@@ -53,11 +53,11 @@ The recommended placement of elements inside of `v-btn` is:
 
 #### Variant
 
-The **variant** prop gives you easy access to several different button styles. Available variants are: **contained**(default), **contained-flat**, **contained-text**, **outlined**, **plain**, and **text**.
+The **variant** prop gives you easy access to several different button styles. Available variants are: **elevated**(default), **flat**, **tonal**, **outlined**, **text**, and **plain**.
 
 <alert type="warning">
 
-  When a `v-btn` is used inside of `v-toolbar` and `v-app-bar` the default variant **text** is applied instead of **contained**.
+  When a `v-btn` is used inside of `v-toolbar` and `v-app-bar` the default variant **text** is applied instead of **elevated**.
 
 </alert>
 

--- a/packages/docs/src/pages/en/components/text-fields.md
+++ b/packages/docs/src/pages/en/components/text-fields.md
@@ -104,7 +104,7 @@ Vuetify includes simple validation through the **rules** prop. The prop accepts 
 
 #### Variant
 
-The **variant** prop provides an easy way to customize the style of your text field. The following values are valid options: **contained**, **filled**, **outlined**, **plain**, and **underlined**.
+The **variant** prop provides an easy way to customize the style of your text field. The following values are valid options: **solo**, **filled**, **outlined**, **plain**, and **underlined**.
 
 <example file="v-text-field/prop-variant" />
 

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -80,7 +80,7 @@ export const VAlert = defineComponent({
     ...makeRoundedProps(),
     ...makeTagProps(),
     ...makeThemeProps(),
-    ...makeVariantProps({ variant: 'contained-flat' } as const),
+    ...makeVariantProps({ variant: 'flat' } as const),
   },
 
   emits: {

--- a/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.cy.tsx
+++ b/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.cy.tsx
@@ -26,14 +26,14 @@ const stories = {
   'Icon badge': <VBadge icon="mdi-vuetify" />,
   'Offset badge': gridOn(['offsetX', 'offsetY'], offset, (xy, offset) => (
       <VBadge {...{ [xy]: offset }} content={ `${offset}` }>
-        <button class="v-btn v-btn--size-default v-btn--variant-contained">
+        <button class="v-btn v-btn--size-default v-btn--variant-elevated">
           { xy }
         </button>
       </VBadge>
   )),
   'Text color': gridOn(defaultColors, [null], color => (
     <VBadge textColor={ color } content={ color }>
-      <button class="v-btn v-btn--size-default v-btn--variant-contained">
+      <button class="v-btn v-btn--size-default v-btn--variant-elevated">
         { color }
       </button>
     </VBadge>

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -79,7 +79,7 @@
       color: rgba(var(--v-theme-on-surface), $button-disabled-opacity)
       opacity: 1
 
-    &.v-btn--variant-contained
+    &.v-btn--variant-elevated
       background: rgb(var(--v-theme-surface))
       box-shadow: none
 

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -71,7 +71,7 @@ export const VBtn = defineComponent({
     ...makeSizeProps(),
     ...makeTagProps({ tag: 'button' }),
     ...makeThemeProps(),
-    ...makeVariantProps({ variant: 'contained' } as const),
+    ...makeVariantProps({ variant: 'elevated' } as const),
   },
 
   setup (props, { attrs, slots }) {
@@ -89,7 +89,7 @@ export const VBtn = defineComponent({
     const link = useLink(props, attrs)
     const isDisabled = computed(() => group?.disabled.value || props.disabled)
     const isElevated = computed(() => {
-      return props.variant === 'contained' && !(props.disabled || props.flat || props.border)
+      return props.variant === 'elevated' && !(props.disabled || props.flat || props.border)
     })
 
     useSelectLink(link, group?.select)

--- a/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.cy.tsx
+++ b/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.cy.tsx
@@ -13,7 +13,7 @@ const anchor = {
 const colors = ['success', 'info', 'warning', 'error', 'invalid']
 const sizes = ['x-small', 'small', 'default', 'large', 'x-large'] as const
 const densities = ['default', 'comfortable', 'compact'] as const
-const variants = ['contained', 'outlined', 'plain', 'text', 'contained-text'] as const
+const variants = ['elevated', 'flat', 'tonal', 'outlined', 'text', 'plain'] as const
 const props = {
   color: colors,
   // variant: variants,

--- a/packages/vuetify/src/components/VBtnGroup/__tests__/VBtnGroup.spec.cy.tsx
+++ b/packages/vuetify/src/components/VBtnGroup/__tests__/VBtnGroup.spec.cy.tsx
@@ -6,8 +6,9 @@ import { VBtnGroup } from '..'
 
 const colors = ['success', 'info', 'warning', 'error', 'invalid'] as const
 const densities = ['default', 'comfortable', 'compact'] as const
-const variants = ['contained', 'outlined', 'plain', 'text', 'contained-text'] as const
+const variants = ['elevated', 'flat', 'tonal', 'outlined', 'text', 'plain'] as const
 
+// TODO: screenshot tests
 describe('VBtnGroup', () => {
   describe('color', () => {
     it('should render set length', () => {

--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -67,7 +67,7 @@ export const VCard = defineComponent({
     ...makeRoundedProps(),
     ...makeRouterProps(),
     ...makeTagProps(),
-    ...makeVariantProps({ variant: 'contained' } as const),
+    ...makeVariantProps({ variant: 'elevated' } as const),
   },
 
   setup (props, { attrs, slots }) {

--- a/packages/vuetify/src/components/VCard/__tests__/__snapshots__/VCard.spec.ts.snap
+++ b/packages/vuetify/src/components/VCard/__tests__/__snapshots__/VCard.spec.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VCard should match a snapshot 1`] = `
-<div class="v-card v-theme--light v-card--density-default v-card--variant-contained">
+<div class="v-card v-theme--light v-card--density-default v-card--variant-elevated">
   <div class="v-card__underlay">
   </div>
 </div>
 `;
 
 exports[`VCard should render slots and match a snapshot 1`] = `
-<div class="v-card v-theme--light v-card--density-default v-card--variant-contained">
+<div class="v-card v-theme--light v-card--density-default v-card--variant-elevated">
   <div class="v-card__underlay">
   </div>
   <div class="v-card-img">

--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -75,7 +75,7 @@ export const VChip = defineComponent({
     ...makeSizeProps(),
     ...makeTagProps({ tag: 'span' }),
     ...makeThemeProps(),
-    ...makeVariantProps({ variant: 'contained-text' } as const),
+    ...makeVariantProps({ variant: 'tonal' } as const),
   },
 
   emits: {

--- a/packages/vuetify/src/components/VChipGroup/VChipGroup.tsx
+++ b/packages/vuetify/src/components/VChipGroup/VChipGroup.tsx
@@ -31,7 +31,7 @@ export const VChipGroup = defineComponent({
     ...makeGroupProps({ selectedClass: 'v-chip--selected' }),
     ...makeTagProps(),
     ...makeThemeProps(),
-    ...makeVariantProps({ variant: 'contained-text' } as const),
+    ...makeVariantProps({ variant: 'tonal' } as const),
   },
 
   emits: {

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -41,14 +41,13 @@
   &--appended
     padding-inline-end: $field-control-affixed-padding
 
-  &--variant-contained
-    background: $field-control-contained-background
+  &--variant-solo
+    background: $field-control-solo-background
     border-color: transparent
-    color: $field-control-contained-color
+    color: $field-control-solo-color
 
-    @include tools.elevation($field-control-contained-elevation)
+    @include tools.elevation($field-control-solo-elevation)
 
-  &--variant-contained,
   &--variant-filled
     border-bottom-left-radius: 0
     border-bottom-right-radius: 0
@@ -68,7 +67,7 @@
   &--single-line
     --v-field-padding-top: 0
 
-  &--variant-contained,
+  &--variant-solo,
   &--variant-filled
     $root: &
 
@@ -209,7 +208,7 @@
     .v-field.v-field--active &
       visibility: visible
 
-    .v-field--variant-contained &,
+    .v-field--variant-solo &,
     .v-field--variant-filled &
       $root: &
 

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -32,7 +32,7 @@ import type { LoaderSlotProps } from '@/composables/loader'
 import type { PropType, Ref } from 'vue'
 import type { MakeSlots } from '@/util'
 
-const allowedVariants = ['underlined', 'outlined', 'filled', 'contained', 'plain'] as const
+const allowedVariants = ['underlined', 'outlined', 'filled', 'solo', 'plain'] as const
 type Variant = typeof allowedVariants[number]
 
 export interface DefaultInputSlot {

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -252,7 +252,7 @@ export const VField = genericComponent<new <T>() => {
           ) }
 
           <div class="v-field__field" data-no-activator="">
-            { ['contained', 'filled'].includes(props.variant) && hasLabel.value && (
+            { ['solo', 'filled'].includes(props.variant) && hasLabel.value && (
               <VFieldLabel
                 ref={ floatingLabelRef }
                 class={[textColorClasses.value]}

--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -15,9 +15,9 @@ $field-clearable-margin: 4px !default;
 $field-clearable-transition: .15s opacity, .15s width settings.$standard-easing !default;
 
 // CONTROL
-$field-control-contained-background: rgb(var(--v-theme-surface)) !default;
-$field-control-contained-color: rgba(var(--v-theme-on-background), var(--v-high-emphasis-opacity)) !default;
-$field-control-contained-elevation: 2 !default;
+$field-control-solo-background: rgb(var(--v-theme-surface)) !default;
+$field-control-solo-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !default;
+$field-control-solo-elevation: 2 !default;
 $field-control-filled-background: rgba(var(--v-theme-on-surface), var(--v-idle-opacity)) !default;
 $field-control-padding-start: 16px !default;
 $field-control-padding-end: 16px !default;

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -184,7 +184,7 @@
   top: 0
   transition: opacity 0.2s ease-in-out
 
-  .v-list-item--active.v-list-item--contained &
+  .v-list-item--active.v-list-item--variant-elevated &
     --v-theme-overlay-multiplier: 0
 
 $base-padding: list.nth($list-item-padding, 2)

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
@@ -4,7 +4,7 @@ import { VTextField } from '../VTextField'
 import { generate } from '../../../../cypress/templates'
 import { cloneVNode } from 'vue'
 
-const variants = ['underlined', 'outlined', 'filled', 'contained', 'plain']
+const variants = ['underlined', 'outlined', 'filled', 'solo', 'plain'] as const
 
 const stories = Object.fromEntries(Object.entries({
   'Default input': <VTextField label="label" />,

--- a/packages/vuetify/src/components/VToolbar/VToolbarItems.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbarItems.tsx
@@ -10,7 +10,7 @@ export const VToolbarItems = defineComponent({
   name: 'VToolbarItems',
 
   props: {
-    ...makeVariantProps({ variant: 'contained-text' }),
+    ...makeVariantProps({ variant: 'tonal' }),
   },
 
   setup (props, { slots }) {

--- a/packages/vuetify/src/composables/__tests__/variant.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/variant.spec.ts
@@ -1,6 +1,6 @@
 import { allowedVariants, makeVariantProps, useVariant } from '../variant'
 
-describe('size', () => {
+describe('variant', () => {
   it.each([
     [{ variant: 'default' }, 'test--variant-default'],
     [{ variant: 'contained' }, 'test--variant-contained'],
@@ -28,7 +28,7 @@ describe('size', () => {
   it.each([
     [{ color: 'primary' }, 'text-primary'],
     [{ variant: 'default', color: 'primary' }, 'text-primary'],
-    [{ variant: 'contained', color: 'primary' }, 'bg-primary'],
+    [{ variant: 'elevated', color: 'primary' }, 'bg-primary'],
     [{ variant: 'outlined', color: 'primary' }, 'text-primary'],
     [{ variant: 'text', color: 'primary' }, 'text-primary'],
   ] as const)('should return correct classes for %s props', (props, expected) => {

--- a/packages/vuetify/src/composables/variant.tsx
+++ b/packages/vuetify/src/composables/variant.tsx
@@ -10,12 +10,12 @@ import type { PropType } from 'vue'
 import type { MaybeRef } from '@/util'
 
 export const allowedVariants = [
+  'elevated',
+  'flat',
+  'tonal',
   'outlined',
-  'plain',
   'text',
-  'contained',
-  'contained-flat',
-  'contained-text',
+  'plain',
 ] as const
 
 export type Variant = typeof allowedVariants[number]
@@ -39,7 +39,7 @@ export const makeVariantProps = propsFactory({
   color: String,
   variant: {
     type: String as PropType<Variant>,
-    default: 'contained',
+    default: 'elevated',
     validator: (v: any) => allowedVariants.includes(v),
   },
 }, 'variant')
@@ -56,7 +56,7 @@ export function useVariant (
   const { colorClasses, colorStyles } = useColor(computed(() => {
     const { variant, color } = unref(props)
     return {
-      [['contained', 'contained-flat'].includes(variant) ? 'background' : 'text']: color,
+      [['elevated', 'flat'].includes(variant) ? 'background' : 'text']: color,
     }
   }))
 

--- a/packages/vuetify/src/styles/tools/_variant.sass
+++ b/packages/vuetify/src/styles/tools/_variant.sass
@@ -5,7 +5,7 @@
   &--variant-plain,
   &--variant-outlined,
   &--variant-text,
-  &--variant-contained-text
+  &--variant-tonal
     background: transparent
     color: inherit
 
@@ -20,16 +20,16 @@
     .#{$name}__overlay
       display: none
 
-  &--variant-contained,
-  &--variant-contained-flat
+  &--variant-elevated,
+  &--variant-flat
     background: $contained-background
     color: $contained-color
 
   @if ($contained-elevation > 0)
-    &--variant-contained
+    &--variant-elevated
       @include elevation($contained-elevation)
 
-  &--variant-contained-flat
+  &--variant-flat
     @include elevation(0)
 
   &--variant-outlined
@@ -39,7 +39,7 @@
     .#{$name}__overlay
       background: currentColor
 
-  &--variant-contained-text
+  &--variant-tonal
     .#{$name}__underlay
       background: currentColor
       opacity: var(--v-activated-opacity)


### PR DESCRIPTION
Match https://m3.material.io/components/all-buttons better, and remove hyphenated variant names. 

Sheets:
 - `contained` -> `elevated`
 - `contained-flat` -> `flat`
 - `contained-text` -> `tonal`

Fields:
 - `contained` -> `solo` (same as v2)

![Screenshot_20220617_032703](https://user-images.githubusercontent.com/16421948/174130827-b08e841a-f94c-4177-b9dd-168af2a5f1be.png)