### PR TITLE
fix(VListItem): dont trigger kb events for disabled item

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.ts
+++ b/packages/vuetify/src/components/VList/VListItem.ts
@@ -168,10 +168,12 @@ export default baseMixins.extend<options>().extend({
     data[this.to ? 'nativeOn' : 'on'] = {
       ...data[this.to ? 'nativeOn' : 'on'],
       keydown: (e: KeyboardEvent) => {
-        /* istanbul ignore else */
-        if (e.keyCode === keyCodes.enter) this.click(e)
+        if (!this.disabled) {
+          /* istanbul ignore else */
+          if (e.keyCode === keyCodes.enter) this.click(e)
 
-        this.$emit('keydown', e)
+          this.$emit('keydown', e)
+        }
       },
     }
 

--- a/packages/vuetify/src/components/VList/__tests__/VListItem.spec.ts
+++ b/packages/vuetify/src/components/VList/__tests__/VListItem.spec.ts
@@ -234,4 +234,16 @@ describe('VListItem.ts', () => {
     wrapper2.vm.toggle()
     expect(wrapper2.vm.isActive).toBeTruthy()
   })
+
+  it('should not react to keydown.enter when disabled', () => {
+    const click = jest.fn()
+    const wrapper = mountFunction({
+      methods: { click },
+      propsData: { disabled: true },
+    })
+
+    wrapper.trigger('keydown.enter')
+
+    expect(click).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Description
Add check for disabled prop to keydown handler

## Motivation and Context
Fixes #15322

## How Has This Been Tested?
unit and visually

## Markup:
<details>

```vue
<template>
  <v-container>
    <p class="pa-6 text-center">The second item should not emit the click event when focussed using keyboard and pressing enter:</p>
    <v-card class="mx-auto" max-width="400" tile>
      <v-list-item tabindex="0" @click="ClickMe()">
        <v-list-item-content>
          <v-list-item-title>Single-line item</v-list-item-title>
        </v-list-item-content>
      </v-list-item>

      <v-list-item disabled tabindex="0" two-line @click="ClickMe()">
        <v-list-item-content>
          <v-list-item-title>Two-line item</v-list-item-title>
          <v-list-item-subtitle>Secondary text</v-list-item-subtitle>
        </v-list-item-content>
      </v-list-item>

      <v-list-item tabindex="0" three-line>
        <v-list-item-content>
          <v-list-item-title>Three-line item</v-list-item-title>
          <v-list-item-subtitle>
            Secondary line text Lorem ipsum dolor sit amet,
          </v-list-item-subtitle>
          <v-list-item-subtitle>
            consectetur adipiscing elit.
          </v-list-item-subtitle>
        </v-list-item-content>
      </v-list-item>
    </v-card>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    //
    }),
    methods: {
      ClickMe() {
        alert("Clicked");
      }
    }
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
