### PR TITLE
fix(VTextField): re-focus when :autofocus changes

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -231,7 +231,8 @@ export default baseMixins.extend<options>().extend({
   mounted () {
     // #11533
     this.$watch(() => this.labelValue, this.setLabelWidth)
-    this.autofocus && this.tryAutofocus()
+    this.$watch(() => this.autofocus, this.tryAutofocus, { immediate: true })
+
     requestAnimationFrame(() => {
       this.isBooted = true
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Description
Re-focus whenever the `autofocus` binding becomes true.

## Motivation and Context
If can be useful to allow re-triggering a textfield's focus using `:autofocus`.

Consider for example the case when a text field can dynamically become editable, after it was mounted:

```html
<VTextField :readonly="readonly" :autofocus="!readonly" />
```

## How Has This Been Tested?
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
