### PR TITLE
fix(VToolbar): v-btn location in and outside of prepend/append elements

### DIFF
--- a/packages/vuetify/src/components/VToolbar/VToolbar.sass
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.sass
@@ -62,6 +62,15 @@
   width: 100%
 
 .v-toolbar__content
+  > .v-btn:first-child
+    margin-inline-start: $toolbar-prepend-btn-margin-start
+
+    + .v-toolbar-title
+      padding-inline-start: $toolbar-title-padding
+
+  > .v-btn:last-child
+    margin-inline-end: $toolbar-append-btn-margin-end
+
   .v-toolbar--density-prominent &
     align-items: flex-start
 
@@ -75,19 +84,15 @@
   display: flex
 
 .v-toolbar__prepend
+  margin-inline-start: $toolbar-prepend-btn-margin-start
   margin-inline-end: auto
-
-  > .v-btn:first-child
-    margin-inline-start: $toolbar-prepend-btn-margin-start
 
   + .v-toolbar-title
     padding-inline-start: $toolbar-title-padding
 
 .v-toolbar__append
   margin-inline-start: auto
-
-  > .v-btn:last-child
-    margin-inline-end: $toolbar-append-btn-margin-end
+  margin-inline-end: $toolbar-append-btn-margin-end
 
 .v-toolbar-title
   flex: 1 1

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -47,7 +47,7 @@ export const makeVToolbarProps = propsFactory({
   floating: Boolean,
   height: {
     type: [Number, String],
-    default: 56,
+    default: 64,
   },
   image: String,
   title: String,

--- a/packages/vuetify/src/components/VToolbar/_variables.scss
+++ b/packages/vuetify/src/components/VToolbar/_variables.scss
@@ -23,8 +23,8 @@ $toolbar-flex: 1 1 auto !default;
 $toolbar-padding-end: 16px !default;
 $toolbar-padding-start: 16px !default;
 $toolbar-padding: 16px !default;
-$toolbar-prepend-btn-margin-start: -12px !default;
-$toolbar-append-btn-margin-end: -12px !default;
+$toolbar-prepend-btn-margin-start: -6px !default;
+$toolbar-append-btn-margin-end: -6px !default;
 $toolbar-rounded-border-radius: variables.$border-radius-root !default;
 $toolbar-transition: .2s variables.$standard-easing !default;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Adjust v-btn location depending upon it's location in v-toolbar.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Visual consistency
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
visually
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-main>
      <div>
        <v-container>
          <v-toolbar>
            <template #prepend>
              <v-app-bar-nav-icon />
            </template>

            <v-toolbar-title class="text-h6">
              Messages
            </v-toolbar-title>

            <template #append>
              <v-btn icon="mdi-dots-vertical" />
            </template>
          </v-toolbar>
          <br>
          <br>
          <v-toolbar density="compact">
            <v-app-bar-nav-icon />

            <v-toolbar-title class="text-h6">
              Messages
            </v-toolbar-title>

            <template #append>
              <v-btn icon="mdi-dots-vertical" />
            </template>
          </v-toolbar>
        </v-container>
      </div>
    </v-main>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      messages: [
        {
          from: 'You',
          message: `Sure, I'll see you later.`,
          time: '10:42am',
          color: 'deep-purple lighten-1',
        },
        {
          from: 'John Doe',
          message: 'Yeah, sure. Does 1:00pm work?',
          time: '10:37am',
          color: 'green',
        },
        {
          from: 'You',
          message: 'Did you still want to grab lunch today?',
          time: '9:47am',
          color: 'deep-purple lighten-1',
        },
      ],
    }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
