### PR TITLE
fix(theme): allow a csp nonce to be specified

### DIFF
--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -248,6 +248,30 @@ interface ThemeInstance {
 }
 ```
 
+## CSP Nonce
+
+Pages with the `script-src` or `style-src` CSP rules enabled may require a **nonce** to be specified for embedded style tags.
+
+```html
+<!-- Use with script-src -->
+Content-Security-Policy: script-src 'self' 'nonce-dQw4w9WgXcQ'
+
+<!-- Use with style-src -->
+Content-Security-Policy: style-src 'self' 'nonce-dQw4w9WgXcQ'
+```
+
+```ts
+// src/plugins/vuetify.js
+
+import {createVuetify} from 'vuetify'
+
+export const vuetify = createVuetify({
+  theme: {
+    cspNonce: 'dQw4w9WgXcQ'
+  }
+})
+```
+
 ## Implementation
 
 Vuetify generates theme styles at runtime according to the given configuration. The generated styles are injected into the `<head>` section of the DOM in a `<style>` tag with an **id** of `vuetify-theme-stylesheet`.

--- a/packages/vuetify/src/composables/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/theme.spec.ts
@@ -81,6 +81,20 @@ describe('createTheme', () => {
     expect(theme.computedThemes.value.light.colors.background).toBe('#FF0000')
   })
 
+  it('should set a CSP nonce if configured', async () => {
+    createTheme(app, { cspNonce: 'my-csp-nonce' })
+
+    const styleElement = document.getElementById('vuetify-theme-stylesheet')
+    expect(styleElement?.getAttribute('nonce')).toBe('my-csp-nonce')
+  })
+
+  it('should not set a CSP nonce if option was left blank', async () => {
+    createTheme(app, {})
+
+    const styleElement = document.getElementById('vuetify-theme-stylesheet')
+    expect(styleElement?.getAttribute('nonce')).toBeNull()
+  })
+
   // it('should use vue-meta@2.3 functionality', () => {
   //   const theme = createTheme()
   //   const set = jest.fn()

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -30,6 +30,7 @@ import type { HeadClient } from '@vueuse/head'
 type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 
 export type ThemeOptions = false | {
+  cspNonce?: string
   defaultTheme?: string
   variations?: false | VariationsOptions
   themes?: Record<string, ThemeDefinition>
@@ -37,6 +38,7 @@ export type ThemeOptions = false | {
 export type ThemeDefinition = DeepPartial<InternalThemeDefinition>
 
 interface InternalThemeOptions {
+  cspNonce?: string
   isDisabled: boolean
   defaultTheme: string
   variations: false | VariationsOptions
@@ -318,6 +320,7 @@ export function createTheme (app: App, options?: ThemeOptions): ThemeInstance {
         const el = document.createElement('style')
         el.type = 'text/css'
         el.id = 'vuetify-theme-stylesheet'
+        if (parsedOptions.cspNonce) el.setAttribute('nonce', parsedOptions.cspNonce)
 
         styleEl = el
         document.head.appendChild(styleEl)

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -25,7 +25,7 @@ import { APCAcontrast } from '@/util/color/APCA'
 
 // Types
 import type { App, DeepReadonly, InjectionKey, Ref } from 'vue'
-import type { HeadClient } from '@vueuse/head'
+import type { HeadAttrs, HeadClient } from '@vueuse/head'
 
 type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 
@@ -296,13 +296,16 @@ export function createTheme (app: App, options?: ThemeOptions): ThemeInstance {
   })
 
   if (head) {
-    head.addHeadObjs(computed(() => ({
-      style: [{
+    head.addHeadObjs(computed(() => {
+      const style: HeadAttrs = {
         children: styles.value,
         type: 'text/css',
         id: 'vuetify-theme-stylesheet',
-      }],
-    })))
+      }
+      if (parsedOptions.cspNonce) style.nonce = parsedOptions.cspNonce
+
+      return { style: [style] }
+    }))
 
     if (IN_BROWSER) {
       watchEffect(() => head.updateDOM())


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Allows to set a CSP Nonce via options on Vuetify v3
resolves #15358

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A content-security-policy is an effective mechanism to improve the security of a web application. Vuetify's theming is added as an inline script, which is not allowed by most CSPs.  
In order to make it pass the policy, it is necessary to add a nonce to the script and style sources.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
The feature is covered by two new unit tests.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->
```ts
createVuetify({
  theme: {
    cspNonce: 'my-csp-nonce',
  },
})
```

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
