### PR TITLE
fix(VBtn): restore original density values

### DIFF
--- a/packages/vuetify/src/components/VBtn/_variables.scss
+++ b/packages/vuetify/src/components/VBtn/_variables.scss
@@ -28,7 +28,6 @@ $button-height: 36px !default;
 $button-stacked-height: 72px !default;
 $button-icon-border-radius: map.get(settings.$rounded, 'circle') !default;
 $button-icon-font-size: 1rem !default;
-$button-icon-size: 40px !default;
 $button-line-height: normal !default;
 $button-stacked-line-height: 1.25 !default;
 $button-plain-opacity: .62 !default;
@@ -50,9 +49,9 @@ $button-stacked-width-ratio: 1 !default;
 $button-rounded-border-radius: map.get(settings.$rounded, 'xl') !default;
 $button-white-space: nowrap !default;
 
-$button-density: ('default': 1, 'comfortable': -2, 'compact': -3) !default;
+$button-density: ('default': 0, 'comfortable': -2, 'compact': -3) !default;
 $button-stacked-density: ('default': 0, 'comfortable': -4, 'compact': -6) !default;
-$button-icon-density: ('default': 1, 'comfortable': -2, 'compact': -2) !default;
+$button-icon-density: ('default': 3, 'comfortable': 0, 'compact': -2) !default;
 
 $button-border: (
   $button-border-color,

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.cy.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.cy.tsx
@@ -89,7 +89,7 @@ describe('VPagination', () => {
       <VPagination length="100" />
     ))
 
-    cy.get('.v-pagination__item').should('have.length', 8)
+    cy.get('.v-pagination__item').should('have.length', 7)
   })
 
   it('should render in RTL mode', () => {


### PR DESCRIPTION
Before: 
![Screenshot_20220706_012909](https://user-images.githubusercontent.com/16421948/177373871-d58bbe99-3941-471b-aff4-f68cbe5a7cb2.png)

After:
![Screenshot_20220706_013105](https://user-images.githubusercontent.com/16421948/177374030-4a5859b1-9412-442b-b7d3-138059d720f1.png)

Partially reverts #15213

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-btn density="default" prepend-icon="mdi-vuetify">vuetify</v-btn>
      <v-btn density="comfortable" prepend-icon="mdi-vuetify">vuetify</v-btn>
      <v-btn density="compact" prepend-icon="mdi-vuetify">vuetify</v-btn>

      <br>
      <br>

      <v-btn icon="mdi-vuetify" density="default" />
      <v-btn icon="mdi-vuetify" density="comfortable" />
      <v-btn icon="mdi-vuetify" density="compact" />

      <br>
      <br>

      <v-btn density="default" prepend-icon="mdi-vuetify">vuetify</v-btn>
      <v-btn icon="mdi-vuetify" density="default" />
      <br>
      <v-btn density="comfortable" prepend-icon="mdi-vuetify">vuetify</v-btn>
      <v-btn icon="mdi-vuetify" density="comfortable" />
      <br>
      <v-btn density="compact" prepend-icon="mdi-vuetify">vuetify</v-btn>
      <v-btn icon="mdi-vuetify" density="compact" />
    </v-container>
  </v-app>
</template>
```
</details>

