### PR TITLE
feat: make active and link props default value undefined

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -30,6 +30,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 
 // Utilities
 import { defineComponent, useRender } from '@/util'
+import { computed } from 'vue'
 
 export const VCard = defineComponent({
   name: 'VCard',
@@ -43,7 +44,10 @@ export const VCard = defineComponent({
     flat: Boolean,
     hover: Boolean,
     image: String,
-    link: Boolean,
+    link: {
+      type: Boolean,
+      default: undefined,
+    },
     prependAvatar: String,
     prependIcon: IconValue,
     ripple: Boolean,
@@ -78,8 +82,15 @@ export const VCard = defineComponent({
     const { roundedClasses } = useRounded(props)
     const link = useLink(props, attrs)
 
+    const isLink = computed(() => props.link !== false && link.isLink.value)
+    const isClickable = computed(() =>
+      !props.disabled &&
+      props.link !== false &&
+      (props.link || link.isClickable.value)
+    )
+
     useRender(() => {
-      const Tag = (link.isLink.value) ? 'a' : props.tag
+      const Tag = isLink.value ? 'a' : props.tag
       const hasTitle = !!(slots.title || props.title)
       const hasSubtitle = !!(slots.subtitle || props.subtitle)
       const hasHeader = hasTitle || hasSubtitle
@@ -88,7 +99,6 @@ export const VCard = defineComponent({
       const hasImage = !!(slots.image || props.image)
       const hasCardItem = hasHeader || hasPrepend || hasAppend
       const hasText = !!(slots.text || props.text)
-      const isClickable = !props.disabled && (link.isClickable.value || props.link)
 
       return (
         <Tag
@@ -98,7 +108,7 @@ export const VCard = defineComponent({
               'v-card--disabled': props.disabled,
               'v-card--flat': props.flat,
               'v-card--hover': props.hover && !(props.disabled || props.flat),
-              'v-card--link': isClickable,
+              'v-card--link': isClickable.value,
             },
             themeClasses.value,
             borderClasses.value,
@@ -116,8 +126,8 @@ export const VCard = defineComponent({
             locationStyles.value,
           ]}
           href={ link.href.value }
-          onClick={ isClickable && link.navigate }
-          v-ripple={ isClickable }
+          onClick={ isClickable.value && link.navigate }
+          v-ripple={ isClickable.value }
         >
           { hasImage && (
             <VDefaultsProvider
@@ -174,7 +184,7 @@ export const VCard = defineComponent({
             <VCardActions v-slots={{ default: slots.actions }} />
           ) }
 
-          { genOverlays(isClickable, 'v-card') }
+          { genOverlays(isClickable.value, 'v-card') }
         </Tag>
       )
     })

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -63,19 +63,20 @@ export const VListItem = genericComponent<new () => {
 
   props: {
     active: Boolean,
-    activeColor: String,
     activeClass: String,
+    activeColor: String,
     appendAvatar: String,
     appendIcon: IconValue,
     disabled: Boolean,
+    inactive: Boolean,
     lines: String as PropType<'one' | 'two' | 'three'>,
+    link: Boolean,
     nav: Boolean,
     prependAvatar: String,
     prependIcon: IconValue,
     subtitle: [String, Number, Boolean],
     title: [String, Number, Boolean],
     value: null,
-    link: Boolean,
 
     ...makeBorderProps(),
     ...makeDensityProps(),
@@ -94,7 +95,7 @@ export const VListItem = genericComponent<new () => {
     const { select, isSelected, isIndeterminate, isGroupActivator, root, parent } = useNestedItem(id, false)
     const list = useList()
     const isActive = computed(() => {
-      return props.active || link.isExactActive?.value || isSelected.value
+      return !props.inactive && (props.active || link.isExactActive?.value || isSelected.value)
     })
     const roundedProps = computed(() => props.rounded || props.nav)
     const variantProps = computed(() => ({

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -99,9 +99,10 @@ export const VListItem = genericComponent<new () => {
     const id = computed(() => props.value ?? link.href.value)
     const { select, isSelected, isIndeterminate, isGroupActivator, root, parent } = useNestedItem(id, false)
     const list = useList()
-    const isActive = computed(() => {
-      return props.active !== false && (props.active || link.isExactActive?.value || isSelected.value)
-    })
+    const isActive = computed(() =>
+      props.active !== false &&
+      (props.active || link.isExactActive?.value || isSelected.value)
+    )
     const isLink = computed(() => props.link !== false && link.isLink.value)
     const isClickable = computed(() =>
       !props.disabled &&

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -62,15 +62,20 @@ export const VListItem = genericComponent<new () => {
   directives: { Ripple },
 
   props: {
-    active: Boolean,
+    active: {
+      type: Boolean,
+      default: undefined,
+    },
     activeClass: String,
     activeColor: String,
     appendAvatar: String,
     appendIcon: IconValue,
     disabled: Boolean,
-    inactive: Boolean,
     lines: String as PropType<'one' | 'two' | 'three'>,
-    link: Boolean,
+    link: {
+      type: Boolean,
+      default: undefined,
+    },
     nav: Boolean,
     prependAvatar: String,
     prependIcon: IconValue,
@@ -95,8 +100,15 @@ export const VListItem = genericComponent<new () => {
     const { select, isSelected, isIndeterminate, isGroupActivator, root, parent } = useNestedItem(id, false)
     const list = useList()
     const isActive = computed(() => {
-      return !props.inactive && (props.active || link.isExactActive?.value || isSelected.value)
+      return props.active !== false && (props.active || link.isExactActive?.value || isSelected.value)
     })
+    const isLink = computed(() => props.link !== false && link.isLink.value)
+    const isClickable = computed(() =>
+      !props.disabled &&
+        props.link !== false &&
+        (props.link || link.isClickable.value || (props.value != null && !!list))
+    )
+
     const roundedProps = computed(() => props.rounded || props.nav)
     const variantProps = computed(() => ({
       color: isActive.value ? props.activeColor ?? props.color : props.color,
@@ -126,14 +138,13 @@ export const VListItem = genericComponent<new () => {
     }))
 
     useRender(() => {
-      const Tag = (link.isLink.value) ? 'a' : props.tag
+      const Tag = isLink.value ? 'a' : props.tag
       const hasColor = !list || isSelected.value || isActive.value
       const hasTitle = (slots.title || props.title)
       const hasSubtitle = (slots.subtitle || props.subtitle)
       const hasHeader = !!(hasTitle || hasSubtitle)
       const hasAppend = !!(slots.append || props.appendAvatar || props.appendIcon)
       const hasPrepend = !!(slots.prepend || props.prependAvatar || props.prependIcon)
-      const isClickable = !props.disabled && (props.link || link.isClickable.value || (props.value != null && !!list))
 
       list?.updateHasPrepend(hasPrepend)
 
@@ -144,7 +155,7 @@ export const VListItem = genericComponent<new () => {
             {
               'v-list-item--active': isActive.value,
               'v-list-item--disabled': props.disabled,
-              'v-list-item--link': isClickable,
+              'v-list-item--link': isClickable.value,
               'v-list-item--nav': props.nav,
               'v-list-item--prepend': !hasPrepend && list?.hasPrepend.value,
               [`${props.activeClass}`]: isActive.value,
@@ -163,16 +174,16 @@ export const VListItem = genericComponent<new () => {
             dimensionStyles.value,
           ]}
           href={ link.href.value }
-          tabindex={ isClickable ? 0 : undefined }
-          onClick={ isClickable && ((e: MouseEvent) => {
+          tabindex={ isClickable.value ? 0 : undefined }
+          onClick={ isClickable.value && ((e: MouseEvent) => {
             if (isGroupActivator) return
 
             link.navigate?.(e)
             props.value != null && select(!isSelected.value, e)
           })}
-          v-ripple={ isClickable }
+          v-ripple={ isClickable.value }
         >
-          { genOverlays(isClickable || isActive.value, 'v-list-item') }
+          { genOverlays(isClickable.value || isActive.value, 'v-list-item') }
 
           { hasPrepend && (
             <>

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -105,8 +105,8 @@ export const VListItem = genericComponent<new () => {
     const isLink = computed(() => props.link !== false && link.isLink.value)
     const isClickable = computed(() =>
       !props.disabled &&
-        props.link !== false &&
-        (props.link || link.isClickable.value || (props.value != null && !!list))
+      props.link !== false &&
+      (props.link || link.isClickable.value || (props.value != null && !!list))
     )
 
     const roundedProps = computed(() => props.rounded || props.nav)


### PR DESCRIPTION
resolves #11149
fixes #15042

This **only** removes the active styling from links or selected items. In v2 it would also suppress `to`/`href`/`@click` and just render a plain div, which seems pretty pointless aside from `@click` as you could just remove `to`/`href` for the same behaviour. 
Should we bring that back, leave it like this, or make `:active` and `:link` undefined by default and able to accept false like #15042 assumed?

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-list nav>
        <v-list-item title="Active" to="/" />
        <v-list-item title="Inactive" inactive to="/" />
        <v-list-item title="Click" @click="" />
      </v-list>
    </v-container>
  </v-app>
</template>
```
</details>
