### PR TITLE
docs(VRadio): fix color prop example casing

### DIFF
--- a/packages/docs/src/examples/v-radio-group/prop-colors.vue
+++ b/packages/docs/src/examples/v-radio-group/prop-colors.vue
@@ -18,9 +18,9 @@
                 value="red"
               ></v-radio>
               <v-radio
-                label="red darken-3"
-                color="red darken-3"
-                value="red darken-3"
+                label="red-darken-3"
+                color="red-darken-3"
+                value="red-darken-3"
               ></v-radio>
               <v-radio
                 label="indigo"
@@ -28,9 +28,9 @@
                 value="indigo"
               ></v-radio>
               <v-radio
-                label="indigo darken-3"
-                color="indigo darken-3"
-                value="indigo darken-3"
+                label="indigo-darken-3"
+                color="indigo-darken-3"
+                value="indigo-darken-3"
               ></v-radio>
               <v-radio
                 label="orange"
@@ -38,9 +38,9 @@
                 value="orange"
               ></v-radio>
               <v-radio
-                label="orange darken-3"
-                color="orange darken-3"
-                value="orange darken-3"
+                label="orange-darken-3"
+                color="orange-darken-3"
+                value="orange-darken-3"
               ></v-radio>
             </v-radio-group>
           </v-col>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
Fix dark variants color props in VRadioButton docs
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
Check the [V3 docs on radio buttons](https://next.vuetifyjs.com/en/components/radio-buttons/#colors) color prop examples. The dark variant examples display as the base color because they are written as `"red darken-2"` instead of `"red-darken-2"`



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] The PR title is no longer than 64 characters.
- [ x ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ x ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
