### PR TITLE
fix(VCarousel): add keys to delimiter buttons

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -139,6 +139,7 @@ export default VWindow.extend({
       const children = []
 
       for (let i = 0; i < length; i++) {
+        const val = this.getValue(this.items[i], i)
         const child = this.$createElement(VBtn, {
           staticClass: 'v-carousel__controls__item',
           attrs: {
@@ -147,8 +148,9 @@ export default VWindow.extend({
           props: {
             icon: true,
             small: true,
-            value: this.getValue(this.items[i], i),
+            value: val,
           },
+          key: val,
         }, [
           this.$createElement(VIcon, {
             props: { size: 18 },

--- a/packages/vuetify/src/components/VCarousel/VCarousel.ts
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.ts
@@ -139,7 +139,6 @@ export default VWindow.extend({
       const children = []
 
       for (let i = 0; i < length; i++) {
-        const val = this.getValue(this.items[i], i)
         const child = this.$createElement(VBtn, {
           staticClass: 'v-carousel__controls__item',
           attrs: {
@@ -148,9 +147,9 @@ export default VWindow.extend({
           props: {
             icon: true,
             small: true,
-            value: val,
+            value: this.getValue(this.items[i], i),
           },
-          key: val,
+          key: i,
         }, [
           this.$createElement(VIcon, {
             props: { size: 18 },


### PR DESCRIPTION
## Motivation and Context
The missing key would create issues with SSR, the controls would in some rare random cases get duplicated
![image](https://user-images.githubusercontent.com/6115458/179515064-3fbd5f8b-9570-4144-8e28-1a61638d3916.png)

The vue doc does say it's required on templated v-for custom components, I don't know how much of that applies to render components but from some reading through vue's code and some debugging, I'm confident the same applies
https://vuejs.org/style-guide/rules-essential.html#use-keyed-v-for

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
