### PR TITLE
fix(VImg): add an empty alt to VImg generated img element

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -188,6 +188,7 @@ export const VImg = defineComponent({
         class: ['v-img__img', containClasses.value],
         src: normalisedSrc.value.src,
         srcset: normalisedSrc.value.srcset,
+        alt: '',
         sizes: props.sizes,
         ref: image,
         onLoad,


### PR DESCRIPTION
## Description

This PR fixes the VImg component for screen readers by adding an empty `alt` attribute to the generated `img` element.

Since this is a fix on Vuetify 3, I'm submitting the PR to the `next` branch.

## Motivation and Context

When generating a decorative image, the generated `img` was not having an `alt` attribute, making the `img` processed as a non-decorative image by screen readers. 

My proposed change is to always generate an empty `alt` attribute since the image textual alternative is managed on an higher level (`VResponsive`) when necessary.

## How Has This Been Tested?

None since it is just an empty attribute addition.

## Markup:

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
