### PR TITLE
fix(VBtn): use correct base opacity for disabled buttons

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -80,23 +80,19 @@
 
   &--disabled
     pointer-events: none
-
-    // This is multiplied by the text opacity,
-    // so we need to divide it to get the desired value
-    $button-overlay-opacity: math.div($button-disabled-overlay, $button-disabled-opacity)
-
-    &.v-btn--disabled
-      color: rgba(var(--v-theme-on-surface), $button-disabled-opacity)
-      opacity: $button-overlay-opacity
+    opacity: $button-disabled-opacity
 
     &.v-btn--variant-elevated,
     &.v-btn--variant-flat
+      color: rgba(var(--v-theme-on-surface), $button-disabled-opacity)
       background: rgb(var(--v-theme-surface))
       box-shadow: none
       opacity: 1
 
       .v-btn__overlay
-        opacity: $button-overlay-opacity
+        // __overlay uses currentColor, so we need to divide
+        // by the text opacity to get the correct value
+        opacity: math.div($button-disabled-overlay, $button-disabled-opacity)
 
   &--loading
     pointer-events: none


### PR DESCRIPTION
fixes #15566
replaces #15573

Before:
![Screenshot_20220805_204006](https://user-images.githubusercontent.com/16421948/183060779-a23d9941-29c7-496f-b406-62ea990e4110.png)

After:
![Screenshot_20220805_203427](https://user-images.githubusercontent.com/16421948/183059818-44aa06f6-7b28-4611-87a0-283684752919.png)

