### PR TITLE
fix(VCalendar): forward all bound events to internal elements

### DIFF
--- a/packages/vuetify/src/components/VCalendar/mixins/__tests__/mouse.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/__tests__/mouse.spec.ts
@@ -35,11 +35,11 @@ describe('mouse.ts', () => {
     const noop = e => e
     const wrapper = mount(Mock, {
       listeners: {
-        click: noop,
+        'click:foo': noop,
       },
     })
 
-    expect(typeof wrapper.vm.getDefaultMouseEventHandlers('', noop).click).toBe('function')
+    expect(typeof wrapper.vm.getDefaultMouseEventHandlers(':foo', noop).click).toBe('function')
     expect(Object.keys(typeof wrapper.vm.getDefaultMouseEventHandlers('', noop))).toHaveLength(6)
   })
 

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -24,17 +24,15 @@ export default Vue.extend({
 
   methods: {
     getDefaultMouseEventHandlers (suffix: string, getEvent: MouseHandler): MouseEventsMap {
+      const listeners = Object.fromEntries(
+        Object.keys(this.$listeners)
+          .filter(key => key.endsWith(suffix))
+          .map(key => [key, { event: key.slice(0, -suffix.length) }])
+      )
+
       return this.getMouseEventHandlers({
-        ['click' + suffix]: { event: 'click' },
+        ...listeners,
         ['contextmenu' + suffix]: { event: 'contextmenu', prevent: true, result: false },
-        ['mousedown' + suffix]: { event: 'mousedown' },
-        ['mousemove' + suffix]: { event: 'mousemove' },
-        ['mouseup' + suffix]: { event: 'mouseup' },
-        ['mouseenter' + suffix]: { event: 'mouseenter' },
-        ['mouseleave' + suffix]: { event: 'mouseleave' },
-        ['touchstart' + suffix]: { event: 'touchstart' },
-        ['touchmove' + suffix]: { event: 'touchmove' },
-        ['touchend' + suffix]: { event: 'touchend' },
       }, getEvent)
     },
     getMouseEventHandlers (events: MouseEvents, getEvent: MouseHandler): MouseEventsMap {

--- a/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/mouse.ts
@@ -24,11 +24,12 @@ export default Vue.extend({
 
   methods: {
     getDefaultMouseEventHandlers (suffix: string, getEvent: MouseHandler): MouseEventsMap {
-      const listeners = Object.fromEntries(
-        Object.keys(this.$listeners)
-          .filter(key => key.endsWith(suffix))
-          .map(key => [key, { event: key.slice(0, -suffix.length) }])
-      )
+      const listeners = Object.keys(this.$listeners)
+        .filter(key => key.endsWith(suffix))
+        .reduce((acc, key) => {
+          acc[key] = { event: key.slice(0, -suffix.length) }
+          return acc
+        }, {} as MouseEvents)
 
       return this.getMouseEventHandlers({
         ...listeners,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
       "es2016",
       "es2017",
       "es2018",
-      "es2019",
       "dom",
       "dom.iterable"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "es2016",
       "es2017",
       "es2018",
+      "es2019",
       "dom",
       "dom.iterable"
     ],


### PR DESCRIPTION
## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-sheet height="300">
      <v-chip
        draggable
        color="blue"
      >drag me over the calendar</v-chip> mouseUp and mouseEnter functions no longer work with the dragged element
      <v-calendar
        ref="calendar"
        type="month"
        start="2021-01-17"
        :weekdays="[1, 2, 3, 4, 5, 6, 0]"
        @dragover:day="dragoverDay"
        @mouseenter:day="mouseenterDay"
        @mouseup:day="mouseupDay"
      ></v-calendar>
    </v-sheet>
  </div>
</template>

<script>
  export default {
    data: () => ({
    }),
    methods: {
      dragoverDay (event) {
        console.log('dragover', event.day)
      },
      mouseenterDay (event) {
        console.log('enter', event.day)
      },
      mouseupDay (event) {
        console.log('up', event.day)
      },
    },
  }
</script>
```
</details>

