### PR TITLE
fix(defaults): merge scoped defaults with global config

### DIFF
--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -1,9 +1,9 @@
 // Utilities
-import { computed, inject, onScopeDispose, provide, ref, unref } from 'vue'
-import { getCurrentInstance, mergeDeep } from '@/util'
+import { computed, inject, provide, ref, unref } from 'vue'
+import { mergeDeep } from '@/util'
 
 // Types
-import type { ComponentInternalInstance, ComputedRef, InjectionKey, Ref } from 'vue'
+import type { ComputedRef, InjectionKey, Ref } from 'vue'
 import type { MaybeRef } from '@/util'
 
 export interface DefaultsInstance {
@@ -27,8 +27,6 @@ export function useDefaults () {
   return defaults
 }
 
-const provideMap = new WeakMap<ComponentInternalInstance, Record<symbol, any>>()
-
 export function provideDefaults (
   defaults?: MaybeRef<DefaultsInstance | undefined>,
   options?: {
@@ -37,11 +35,6 @@ export function provideDefaults (
     scoped?: MaybeRef<boolean | undefined>
   }
 ) {
-  const vm = getCurrentInstance('provideDefaults')
-  if (!provideMap.has(vm)) provideMap.set(vm, {})
-  const defaultsList = provideMap.get(vm)!
-  const key = Symbol('')
-
   const injectedDefaults = useDefaults()
   const providedDefaults = ref(defaults)
 
@@ -66,20 +59,8 @@ export function provideDefaults (
       return properties
     }
 
-    const symbols = Object.getOwnPropertySymbols(defaultsList)
-    const idx = symbols.indexOf(key)
-
-    return [
-      properties.prev,
-      ...symbols.slice(0, idx).map(v => defaultsList[v].value),
-      properties,
-    ].reduce((acc, val) => mergeDeep(acc, val), {})
+    return mergeDeep(properties.prev, properties)
   }) as ComputedRef<DefaultsInstance>
-
-  defaultsList[key] = newDefaults
-  onScopeDispose(() => {
-    delete defaultsList[key]
-  })
 
   provide(DefaultsSymbol, newDefaults)
 

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -10,8 +10,9 @@ import {
   watchEffect,
 } from 'vue'
 import { consoleWarn } from '@/util/console'
-import { toKebabCase } from '@/util/helpers'
-import { provideDefaults, useDefaults } from '@/composables/defaults'
+import { mergeDeep, toKebabCase } from '@/util/helpers'
+import { injectSelf } from '@/util/injectSelf'
+import { DefaultsSymbol, provideDefaults, useDefaults } from '@/composables/defaults'
 
 // Types
 import type {
@@ -81,7 +82,7 @@ export const defineComponent = (function defineComponent (options: ComponentOpti
         else if (val && !oldVal) {
           scope = effectScope()
           scope.run(() => {
-            provideDefaults(val)
+            provideDefaults(mergeDeep(injectSelf(DefaultsSymbol)?.value ?? {}, val))
           })
         }
       }, { immediate: true })

--- a/packages/vuetify/src/util/injectSelf.ts
+++ b/packages/vuetify/src/util/injectSelf.ts
@@ -1,0 +1,12 @@
+import { getCurrentInstance } from '@/util/getCurrentInstance'
+import type { InjectionKey } from 'vue'
+
+export function injectSelf<T>(key: InjectionKey<T> | string): T | undefined
+export function injectSelf (key: InjectionKey<any> | string) {
+  const { provides } = getCurrentInstance('injectSelf')
+
+  if (provides && (key as string | symbol) in provides) {
+    // TS doesn't allow symbol as index type
+    return provides[key as string]
+  }
+}


### PR DESCRIPTION
fixes #15595

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-card
        class="mx-auto"
        max-width="300"
      >
        <v-list :items="items" />
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { type: 'subheader', title: 'Group #1' },
    {
      title: 'Item #1',
      value: 1,
    },
    {
      title: 'Item #2',
      value: 2,
    },
    {
      title: 'Item #3',
      value: 3,
    },
    { type: 'divider' },
    { type: 'subheader', title: 'Group #2' },
    {
      title: 'Item #4',
      value: 4,
    },
    {
      title: 'Item #5',
      value: 5,
    },
    {
      title: 'Item #6',
      value: 6,
    },
  ]
</script>
```
</details>
