### PR TITLE
fix(VAlert): use v-btn for closable functionality

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.sass
+++ b/packages/vuetify/src/components/VAlert/VAlert.sass
@@ -67,11 +67,8 @@
     border-bottom-width: $alert-border-thin-width
 
 .v-alert__close
-  cursor: pointer
-  display: flex
   flex: 0 1 auto
   grid-area: close
-  user-select: none
 
 .v-alert__content
   align-self: center

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -218,7 +218,7 @@ export const VAlert = defineComponent({
               }}
             >
               <div class="v-alert__close">
-                { slots.close?.(closeProps.value) ?? <VBtn { ...closeProps.value } /> }
+                { slots.close?.({ props: closeProps.value }) ?? <VBtn { ...closeProps.value } /> }
               </div>
             </VDefaultsProvider>
           ) }

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -210,7 +210,6 @@ export const VAlert = defineComponent({
               key="close"
               defaults={{
                 VBtn: {
-                  density: 'compact',
                   icon: props.closeIcon,
                   size: 'x-small',
                   variant: 'text',

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -3,6 +3,7 @@ import './VAlert.sass'
 
 // Components
 import { VAlertTitle } from './VAlertTitle'
+import { VBtn } from '@/components/VBtn'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VIcon } from '@/components/VIcon'
 
@@ -16,6 +17,7 @@ import { makePositionProps, usePosition } from '@/composables/position'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
+import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { useTextColor } from '@/composables/color'
 import { IconValue } from '@/composables/icons'
@@ -109,10 +111,14 @@ export const VAlert = defineComponent({
     const { positionClasses } = usePosition(props)
     const { roundedClasses } = useRounded(props)
     const { textColorClasses, textColorStyles } = useTextColor(toRef(props, 'borderColor'))
+    const { t } = useLocale()
 
-    function onCloseClick (e: MouseEvent) {
-      isActive.value = false
-    }
+    const closeProps = computed(() => ({
+      'aria-label': t(props.closeLabel),
+      onClick (e: MouseEvent) {
+        isActive.value = false
+      },
+    }))
 
     return () => {
       const hasPrepend = !!(slots.prepend || icon.value)
@@ -203,20 +209,16 @@ export const VAlert = defineComponent({
             <VDefaultsProvider
               key="close"
               defaults={{
-                VIcon: {
+                VBtn: {
+                  density: 'compact',
                   icon: props.closeIcon,
-                  size: 'small',
+                  size: 'x-small',
+                  variant: 'text',
                 },
               }}
             >
-              <div
-                class="v-alert__close"
-                onClick={ onCloseClick }
-              >
-                { slots.close
-                  ? slots.close()
-                  : (<VIcon />)
-                }
+              <div class="v-alert__close">
+                { slots.close?.(closeProps.value) ?? <VBtn { ...closeProps.value } /> }
               </div>
             </VDefaultsProvider>
           ) }


### PR DESCRIPTION
## Motivation and Context
fixes #15589

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-4 pa-4">
    <v-alert closable>
      Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!

      <template #close="props">
        <v-btn size="large" v-bind="props" />
      </template>
    </v-alert>
  </div>
</template>

<script>
  export default {

  }
</script>

```
</details>