### PR TITLE
fix(VSelect): toggle menu when clicking control

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -132,7 +132,7 @@ export const VSelect = genericComponent<new <
     function onClickControl () {
       if (props.hideNoData && !items.value.length) return
 
-      menu.value = true
+      menu.value = !menu.value
     }
     function onKeydown (e: KeyboardEvent) {
       if (['Enter', 'ArrowDown', ' '].includes(e.key)) {
@@ -180,7 +180,6 @@ export const VSelect = genericComponent<new <
           appendInnerIcon={ props.menuIcon }
           readonly
           onClick:clear={ onClear }
-          onClick:input={ onClickControl }
           onClick:control={ onClickControl }
           onBlur={ () => menu.value = false }
           onKeydown={ onKeydown }


### PR DESCRIPTION
## Motivation and Context
fixes #15522

## Markup:

<details>

```vue
<template>
  <div class="ma-4 pa-4">
    <v-select label="Test" :items="[0, 1, 2, 3]" />
    <v-autocomplete label="Test" :items="[0, 1, 2, 3]" />
    <v-combobox label="Test" :items="[0, 1, 2, 3]" />
  </div>
</template>
```
</details>

