### PR TITLE
fix(VSelectionControl): set internal model from input.checked

### DIFF
--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -252,12 +252,15 @@ export const VSelectionControl = genericComponent<new <T>() => {
               { icon.value && <VIcon key="icon" icon={ icon.value } /> }
 
               <input
-                v-model={ model.value }
                 ref={ input }
+                checked={ model.value }
                 disabled={ props.disabled }
                 id={ id.value }
                 onBlur={ onBlur }
                 onFocus={ onFocus }
+                onInput={ (e: Event) => {
+                  model.value = (e.target as HTMLInputElement).checked
+                } }
                 aria-readonly={ props.readonly }
                 type={ type }
                 value={ trueValue.value }

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -204,6 +204,10 @@ export const VSelectionControl = genericComponent<new <T>() => {
       isFocusVisible.value = false
     }
 
+    function onInput (e: Event) {
+      model.value = (e.target as HTMLInputElement).checked
+    }
+
     useRender(() => {
       const label = slots.label
         ? slots.label({
@@ -258,9 +262,7 @@ export const VSelectionControl = genericComponent<new <T>() => {
                 id={ id.value }
                 onBlur={ onBlur }
                 onFocus={ onFocus }
-                onInput={ (e: Event) => {
-                  model.value = (e.target as HTMLInputElement).checked
-                } }
+                onInput={ onInput }
                 aria-readonly={ props.readonly }
                 type={ type }
                 value={ trueValue.value }


### PR DESCRIPTION
use internal input checked for determining model

fixes #15601

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-4 pa-4">

    <v-container
      class="px-0"
      fluid
    >
      <v-radio-group v-model="radioGroup">
        <v-radio
          v-for="item in list"
          :key="item.value"
          :label="`Radio ${item.text}`"
          :value="item.value"
        />

        {{ typeof radioGroup }}
        {{ radioGroup }}
      </v-radio-group>

      <v-checkbox v-model="radioGroup2" />
    </v-container>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        radioGroup: null,
        radioGroup2: null,
        list: [
          { text: 'Number 0', value: 0 },
          { text: 'Empty string', value: '' },
          { text: 'Number 1', value: 1 },
          { text: 'Number 2', value: 2 },
          { text: 'Boolean false', value: false },
          { text: 'Boolean true', value: true },
        ],
      }
    },
  }
</script>

```
</details>
