### PR TITLE
fix(VAlert): adjust default prepended icon size

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -166,7 +166,7 @@ export const VAlert = defineComponent({
                 VIcon: {
                   density: props.density,
                   icon: icon.value,
-                  size: props.prominent ? 44 : 'default',
+                  size: props.prominent ? 44 : 28,
                 },
               }}
             >


### PR DESCRIPTION
## Motivation and Context
fixes #15557

## Markup:
<details>

```vue
<template>
  <div class="ma-4 pa-4">
    <v-alert type="success" title="Alert title" prominent>
      {{ lorem }}
    </v-alert>
    <br>
    <v-alert density="comfortable" type="success" title="Alert title" prominent>
      {{ lorem }}
    </v-alert>
    <br>
    <v-alert density="compact" type="success" title="Alert title" prominent>
      {{ lorem }}
    </v-alert>
    <br>
    <v-alert type="success" title="Alert title">
      {{ lorem }}
    </v-alert>
    <br>
    <v-alert density="comfortable" type="success" title="Alert title">
      {{ lorem }}
    </v-alert>
    <br>
    <v-alert density="compact" type="success" title="Alert title">
      {{ lorem }}
    </v-alert>
  </div>
</template>

<script>
  export default {
    data: () => ({
      lorem: 'Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!',
    }),
  }
</script>

```
</details>