### PR TITLE
fix(VMenu): disabled activatorFixed when attach is enabled

### DIFF
--- a/packages/vuetify/src/mixins/menuable/index.ts
+++ b/packages/vuetify/src/mixins/menuable/index.ts
@@ -281,7 +281,10 @@ export default baseMixins.extend<options>().extend({
       }
     },
     checkActivatorFixed () {
-      if (this.attach !== false) return
+      if (this.attach !== false) {
+        this.activatorFixed = false
+        return
+      }
       let el = this.getActivator()
       while (el) {
         if (window.getComputedStyle(el).position === 'fixed') {


### PR DESCRIPTION
## Description
- https://github.com/vuetifyjs/vuetify/issues/14922

## Markup:

▼`packages/vuetify/dev/Playground.vue`

```vue
<template>
  <div id="app">
    <v-app id="inspire">
      <div
        :style="{
          display: 'flex',
          flexDirection: 'column',
          alignItems: 'center'
        }"
      >
        <v-btn @click="attachInPlace = !attachInPlace">
          Toggle Attach
        </v-btn>
        <div :style="{ position: 'fixed', top: '50px' }">
          <v-menu :attach="attachInPlace ? $refs.container : false" offset-y>
            <template #activator="{ on }">
              <v-btn v-on="on">
                Menu
              </v-btn>
            </template>
            <v-list>
              <v-list-item v-for="item in items" :key="item">
                <v-list-item-title>
                  {{ item }}
                </v-list-item-title>
              </v-list-item>
            </v-list>
          </v-menu>
          <div ref="container"></div>
        </div>
      </div>
    </v-app>
  </div>
</template>

<script>
export default {
  data: () => ({
    attachInPlace: true,
    items: ["First", "Second"]
  })
};
</script>

```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
