### PR TITLE
feat(VAvatar): add variant support

### DIFF
--- a/packages/vuetify/src/components/VAvatar/VAvatar.sass
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.sass
@@ -18,8 +18,12 @@
 
   @include avatar-sizes($avatar-sizes)
   @include avatar-density(('height', 'width'), $avatar-density)
+  @include tools.elevation($avatar-elevation)
   @include tools.rounded($avatar-border-radius)
   @include tools.theme($avatar-theme...)
+
+  &--flat
+    box-shadow: none
 
   &--rounded
     @include tools.rounded($avatar-rounded-border-radius)

--- a/packages/vuetify/src/components/VAvatar/VAvatar.sass
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.sass
@@ -18,9 +18,8 @@
 
   @include avatar-sizes($avatar-sizes)
   @include avatar-density(('height', 'width'), $avatar-density)
-  @include tools.elevation($avatar-elevation)
   @include tools.rounded($avatar-border-radius)
-  @include tools.theme($avatar-theme...)
+  @include tools.variant($avatar-variants...)
 
   &--flat
     box-shadow: none

--- a/packages/vuetify/src/components/VAvatar/VAvatar.sass
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.sass
@@ -21,8 +21,5 @@
   @include tools.rounded($avatar-border-radius)
   @include tools.variant($avatar-variants...)
 
-  &--flat
-    box-shadow: none
-
   &--rounded
     @include tools.rounded($avatar-rounded-border-radius)

--- a/packages/vuetify/src/components/VAvatar/VAvatar.tsx
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.tsx
@@ -6,31 +6,27 @@ import { VIcon } from '@/components/VIcon'
 import { VImg } from '@/components/VImg'
 
 // Composables
+import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 import { IconValue } from '@/composables/icons'
 import { makeDensityProps, useDensity } from '@/composables/density'
-import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeSizeProps, useSize } from '@/composables/size'
 import { makeTagProps } from '@/composables/tag'
-import { useBackgroundColor } from '@/composables/color'
 
 // Utilities
 import { defineComponent, propsFactory, useRender } from '@/util'
-import { toRef } from 'vue'
 
 export const makeVAvatarProps = propsFactory({
-  color: String,
-  flat: Boolean,
   start: Boolean,
   end: Boolean,
   icon: IconValue,
   image: String,
 
   ...makeDensityProps(),
-  ...makeElevationProps(),
   ...makeRoundedProps(),
   ...makeSizeProps(),
   ...makeTagProps(),
+  ...makeVariantProps({ variant: 'text' } as const),
 })
 
 export const VAvatar = defineComponent({
@@ -39,9 +35,8 @@ export const VAvatar = defineComponent({
   props: makeVAvatarProps(),
 
   setup (props, { slots }) {
-    const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
+    const { colorClasses, colorStyles, variantClasses } = useVariant(props)
     const { densityClasses } = useDensity(props)
-    const { elevationClasses } = useElevation(props)
     const { roundedClasses } = useRounded(props)
     const { sizeClasses, sizeStyles } = useSize(props)
 
@@ -50,27 +45,30 @@ export const VAvatar = defineComponent({
         class={[
           'v-avatar',
           {
-            'v-avatar--flat': props.flat,
             'v-avatar--start': props.start,
             'v-avatar--end': props.end,
           },
-          backgroundColorClasses.value,
+          colorClasses.value,
           densityClasses.value,
-          elevationClasses.value,
           roundedClasses.value,
           sizeClasses.value,
+          variantClasses.value,
         ]}
         style={[
-          backgroundColorStyles.value,
+          colorStyles.value,
           sizeStyles.value,
         ]}
       >
-        { props.image
-          ? (<VImg src={ props.image } alt="" />)
-          : props.icon
-            ? (<VIcon icon={ props.icon } />)
-            : slots.default?.()
-        }
+        <>
+          { props.image
+            ? (<VImg src={ props.image } alt="" />)
+            : props.icon
+              ? (<VIcon icon={ props.icon } />)
+              : slots.default?.()
+          }
+
+          { genOverlays(false, 'v-avatar') }
+        </>
       </props.tag>
     ))
 

--- a/packages/vuetify/src/components/VAvatar/VAvatar.tsx
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.tsx
@@ -6,12 +6,13 @@ import { VIcon } from '@/components/VIcon'
 import { VImg } from '@/components/VImg'
 
 // Composables
+import { IconValue } from '@/composables/icons'
 import { makeDensityProps, useDensity } from '@/composables/density'
+import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeSizeProps, useSize } from '@/composables/size'
 import { makeTagProps } from '@/composables/tag'
 import { useBackgroundColor } from '@/composables/color'
-import { IconValue } from '@/composables/icons'
 
 // Utilities
 import { defineComponent, propsFactory, useRender } from '@/util'
@@ -19,12 +20,14 @@ import { toRef } from 'vue'
 
 export const makeVAvatarProps = propsFactory({
   color: String,
+  flat: Boolean,
   start: Boolean,
   end: Boolean,
   icon: IconValue,
   image: String,
 
   ...makeDensityProps(),
+  ...makeElevationProps(),
   ...makeRoundedProps(),
   ...makeSizeProps(),
   ...makeTagProps(),
@@ -38,6 +41,7 @@ export const VAvatar = defineComponent({
   setup (props, { slots }) {
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
     const { densityClasses } = useDensity(props)
+    const { elevationClasses } = useElevation(props)
     const { roundedClasses } = useRounded(props)
     const { sizeClasses, sizeStyles } = useSize(props)
 
@@ -46,11 +50,13 @@ export const VAvatar = defineComponent({
         class={[
           'v-avatar',
           {
+            'v-avatar--flat': props.flat,
             'v-avatar--start': props.start,
             'v-avatar--end': props.end,
           },
           backgroundColorClasses.value,
           densityClasses.value,
+          elevationClasses.value,
           roundedClasses.value,
           sizeClasses.value,
         ]}

--- a/packages/vuetify/src/components/VAvatar/VAvatar.tsx
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.tsx
@@ -59,16 +59,14 @@ export const VAvatar = defineComponent({
           sizeStyles.value,
         ]}
       >
-        <>
-          { props.image
-            ? (<VImg src={ props.image } alt="" />)
-            : props.icon
-              ? (<VIcon icon={ props.icon } />)
-              : slots.default?.()
-          }
+        { props.image
+          ? (<VImg key="image" src={ props.image } alt="" />)
+          : props.icon
+            ? (<VIcon key="icon" icon={ props.icon } />)
+            : slots.default?.()
+        }
 
-          { genOverlays(false, 'v-avatar') }
-        </>
+        { genOverlays(false, 'v-avatar') }
       </props.tag>
     ))
 

--- a/packages/vuetify/src/components/VAvatar/_variables.scss
+++ b/packages/vuetify/src/components/VAvatar/_variables.scss
@@ -7,7 +7,7 @@ $avatar-background: var(--v-theme-surface) !default;
 $avatar-border-radius: map.get(variables.$rounded, 'circle') !default;
 $avatar-color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity)) !default;
 $avatar-density: ('default': 0, 'comfortable': -1, 'compact': -2) !default;
-$avatar-elevation: 4 !default;
+$avatar-elevation: 1 !default;
 $avatar-height: 40px !default;
 $avatar-line-height: normal !default;
 $avatar-plain-opacity: .62 !default;

--- a/packages/vuetify/src/components/VAvatar/_variables.scss
+++ b/packages/vuetify/src/components/VAvatar/_variables.scss
@@ -10,6 +10,7 @@ $avatar-density: ('default': 0, 'comfortable': -1, 'compact': -2) !default;
 $avatar-elevation: 4 !default;
 $avatar-height: 40px !default;
 $avatar-line-height: normal !default;
+$avatar-plain-opacity: .62 !default;
 $avatar-rounded-border-radius: variables.$border-radius-root !default;
 $avatar-vertical-align: middle !default;
 $avatar-width: 40px !default;
@@ -23,7 +24,10 @@ $avatar-sizes: functions.map-deep-merge(
   $avatar-sizes
 );
 
-$avatar-theme: (
+$avatar-variants: (
   $avatar-background,
-  $avatar-color
-) !default;
+  $avatar-color,
+  $avatar-elevation,
+  $avatar-plain-opacity,
+  'v-avatar'
+);

--- a/packages/vuetify/src/components/VAvatar/_variables.scss
+++ b/packages/vuetify/src/components/VAvatar/_variables.scss
@@ -3,10 +3,11 @@
 @use "../../styles/tools/functions";
 
 // Defaults
-$avatar-background: transparent !default;
+$avatar-background: var(--v-theme-surface) !default;
 $avatar-border-radius: map.get(variables.$rounded, 'circle') !default;
 $avatar-color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity)) !default;
 $avatar-density: ('default': 0, 'comfortable': -1, 'compact': -2) !default;
+$avatar-elevation: 4 !default;
 $avatar-height: 40px !default;
 $avatar-line-height: normal !default;
 $avatar-rounded-border-radius: variables.$border-radius-root !default;


### PR DESCRIPTION
## Motivation and Context
add variant support to `v-avatar`

closes #15593

## Markup:
<details>

```vue
<template>
  <div class="ma-4 pa-4">
    <v-avatar variant="outlined" color="primary" icon="mdi-vuetify" />
    <br>
    <br>
    <v-avatar variant="flat" color="primary" icon="mdi-vuetify" />
    <br>
    <br>
    <v-avatar variant="elevated" color="primary" icon="mdi-vuetify" />
    <br>
    <br>
    <v-avatar variant="tonal" color="primary" icon="mdi-vuetify" />
    <br>
    <br>
    <v-avatar variant="plain" color="primary" icon="mdi-vuetify" />
    <br>
    <br>
  </div>
</template>

```
</details>