### PR TITLE
feat: add value prop to proxiedModel components

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -19,7 +19,7 @@ import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
-import { computed, mergeProps, nextTick, ref, watch } from 'vue'
+import { computed, mergeProps, nextTick, ref, toRef, watch } from 'vue'
 import { genericComponent, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -102,7 +102,7 @@ export const VAutocomplete = genericComponent<new <
     const model = useProxiedModel(
       props,
       'modelValue',
-      [],
+      toRef(props, 'value'),
       v => transformIn(wrapInArray(v)),
       v => {
         const transformed = transformOut(v)

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -14,7 +14,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { convertToUnit, defineComponent, useRender } from '@/util'
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, ref, toRef, watch } from 'vue'
 
 // Types
 import type { GroupProvide } from '@/composables/group'
@@ -41,6 +41,7 @@ export const VCarousel = defineComponent({
       default: 6000,
       validator: (value: string | number) => value > 0,
     },
+    value: null,
     modelValue: null,
     progress: [Boolean, String],
     showArrows: {
@@ -56,7 +57,7 @@ export const VCarousel = defineComponent({
   },
 
   setup (props, { slots }) {
-    const model = useProxiedModel(props, 'modelValue')
+    const model = useProxiedModel(props, 'modelValue', toRef(props, 'value'))
     const { t } = useLocale()
     const windowRef = ref<typeof VWindow>()
 

--- a/packages/vuetify/src/components/VColorPicker/VColorPicker.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPicker.tsx
@@ -17,7 +17,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 // Utilities
 import { defineComponent, HSVAtoCSS, useRender } from '@/util'
 import { extractColor, modes, nullColor, parseColor } from './util'
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, toRef } from 'vue'
 
 // Types
 import type { PropType } from 'vue'
@@ -57,9 +57,8 @@ export const VColorPicker = defineComponent({
       type: [Number, String],
       default: 150,
     },
-    modelValue: {
-      type: [Object, String] as PropType<Record<string, unknown> | string | undefined | null>,
-    },
+    value: [Object, String] as PropType<Record<string, unknown> | string | undefined | null>,
+    modelValue: [Object, String] as PropType<Record<string, unknown> | string | undefined | null>,
     width: {
       type: [Number, String],
       default: 300,
@@ -81,7 +80,7 @@ export const VColorPicker = defineComponent({
     const currentColor = useProxiedModel(
       props,
       'modelValue',
-      undefined,
+      toRef(props, 'value'),
       v => {
         let c = parseColor(v)
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -20,7 +20,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 import { useTextColor } from '@/composables/color'
 
 // Utility
-import { computed, mergeProps, nextTick, ref, watch } from 'vue'
+import { computed, mergeProps, nextTick, ref, toRef, watch } from 'vue'
 import { genericComponent, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -107,7 +107,7 @@ export const VCombobox = genericComponent<new <
     const model = useProxiedModel(
       props,
       'modelValue',
-      [],
+      toRef(props, 'value'),
       v => transformIn(wrapInArray(v || [])),
       v => {
         const transformed = transformOut(v)

--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
@@ -12,7 +12,7 @@ import { makeFocusProps, useFocus } from '@/composables/focus'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, ref } from 'vue'
+import { computed, ref, toRef } from 'vue'
 import { defineComponent, useRender } from '@/util'
 
 // Types
@@ -27,6 +27,7 @@ export const VRangeSlider = defineComponent({
     ...makeSliderProps(),
 
     strict: Boolean,
+    value: Array as PropType<number[]>,
     modelValue: {
       type: Array as PropType<number[]>,
       default: () => ([0, 0]),
@@ -93,7 +94,7 @@ export const VRangeSlider = defineComponent({
     const model = useProxiedModel(
       props,
       'modelValue',
-      undefined,
+      toRef(props, 'value'),
       arr => {
         if (!arr || !arr.length) return [0, 0]
 

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -19,7 +19,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 import { IconValue } from '@/composables/icons'
 
 // Utility
-import { computed, mergeProps, ref } from 'vue'
+import { computed, mergeProps, ref, toRef } from 'vue'
 import { genericComponent, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -43,6 +43,7 @@ export const makeSelectProps = propsFactory({
   menuProps: {
     type: Object as PropType<VMenu['$props']>,
   },
+  value: null,
   modelValue: {
     type: null,
     default: () => ([]),
@@ -109,7 +110,7 @@ export const VSelect = genericComponent<new <
     const model = useProxiedModel(
       props,
       'modelValue',
-      [],
+      toRef(props, 'value'),
       v => transformIn(wrapInArray(v)),
       v => {
         const transformed = transformOut(v)

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -12,7 +12,7 @@ import { makeSliderProps, useSlider } from './slider'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Util
-import { computed, ref } from 'vue'
+import { computed, ref, toRef } from 'vue'
 import { defineComponent, useRender } from '@/util'
 
 export const VSlider = defineComponent({
@@ -23,6 +23,7 @@ export const VSlider = defineComponent({
     ...makeSliderProps(),
     ...makeVInputProps(),
 
+    value: [Number, String],
     modelValue: {
       type: [Number, String],
       default: 0,
@@ -60,7 +61,7 @@ export const VSlider = defineComponent({
     const model = useProxiedModel(
       props,
       'modelValue',
-      undefined,
+      toRef(props, 'value'),
       v => {
         const value = typeof v === 'string' ? parseFloat(v) : v == null ? min.value : v
 

--- a/packages/vuetify/src/components/VTabs/VTabs.tsx
+++ b/packages/vuetify/src/components/VTabs/VTabs.tsx
@@ -59,6 +59,7 @@ export const VTabs = defineComponent({
     optional: Boolean,
     end: Boolean,
     sliderColor: String,
+    value: null,
     modelValue: null,
 
     ...makeDensityProps(),
@@ -70,7 +71,7 @@ export const VTabs = defineComponent({
   },
 
   setup (props, { slots }) {
-    const model = useProxiedModel(props, 'modelValue')
+    const model = useProxiedModel(props, 'modelValue', toRef(props, 'value'))
     const parsedItems = computed(() => parseItems(props.items))
     const { densityClasses } = useDensity(props)
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'bgColor'))

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -14,7 +14,7 @@ import { forwardRefs } from '@/composables/forwardRefs'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { cloneVNode, computed, nextTick, ref } from 'vue'
+import { cloneVNode, computed, nextTick, ref, toRef } from 'vue'
 import { callEvent, filterInputAttrs, genericComponent, useRender } from '@/util'
 
 // Types
@@ -54,6 +54,7 @@ export const VTextField = genericComponent<new <T>() => {
       type: String,
       default: 'text',
     },
+    value: null,
 
     ...makeVInputProps(),
     ...makeVFieldProps(),
@@ -66,7 +67,7 @@ export const VTextField = genericComponent<new <T>() => {
   },
 
   setup (props, { attrs, emit, slots }) {
-    const model = useProxiedModel(props, 'modelValue')
+    const model = useProxiedModel(props, 'modelValue', toRef(props, 'value'))
     const counterValue = computed(() => {
       return typeof props.counterValue === 'function'
         ? props.counterValue(model.value)

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -16,7 +16,7 @@ import { forwardRefs } from '@/composables/forwardRefs'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue'
 import { callEvent, clamp, convertToUnit, defineComponent, filterInputAttrs, useRender } from '@/util'
 
 // Types
@@ -51,6 +51,7 @@ export const VTextarea = defineComponent({
       validator: (v: any) => !isNaN(parseFloat(v)),
     },
     suffix: String,
+    value: null,
 
     ...makeVInputProps(),
     ...makeVFieldProps(),
@@ -62,7 +63,7 @@ export const VTextarea = defineComponent({
   },
 
   setup (props, { attrs, emit, slots }) {
-    const model = useProxiedModel(props, 'modelValue')
+    const model = useProxiedModel(props, 'modelValue', toRef(props, 'value'))
     const counterValue = computed(() => {
       return typeof props.counterValue === 'function'
         ? props.counterValue(model.value)

--- a/packages/vuetify/src/composables/__tests__/__snapshots__/proxiedModel.spec.ts.snap
+++ b/packages/vuetify/src/composables/__tests__/__snapshots__/proxiedModel.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`useProxiedModel should always use prop value if defined 3`] = `
 
 exports[`useProxiedModel should switch to using prop when it is defined 1`] = `
 <div>
-  ,
+  ,syncDefaultValue
 </div>
 `;
 
@@ -38,7 +38,7 @@ exports[`useProxiedModel should switch to using prop when it is defined 3`] = `
 
 exports[`useProxiedModel should use default prop value as first value if defined 1`] = `
 <div>
-  propDefaultValue,propDefaultValue
+  propDefaultValue,syncDefaultValue
 </div>
 `;
 
@@ -50,7 +50,7 @@ exports[`useProxiedModel should use default prop value as first value if defined
 
 exports[`useProxiedModel should use internal value if prop not defined 1`] = `
 <div>
-  ,
+  ,syncDefaultValue
 </div>
 `;
 

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -155,7 +155,7 @@ export function useGroup (
   const selected = useProxiedModel(
     props,
     'modelValue',
-    [],
+    undefined,
     v => {
       if (v == null) return []
 

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -76,7 +76,7 @@ export const useNested = (props: NestedProps) => {
   const children = ref(new Map<string, string[]>())
   const parents = ref(new Map<string, string>())
 
-  const opened = useProxiedModel(props, 'opened', props.opened, v => new Set(v), v => [...v.values()])
+  const opened = useProxiedModel(props, 'opened', undefined, v => new Set(v), v => [...v.values()])
 
   const selectStrategy = computed(() => {
     if (typeof props.selectStrategy === 'object') return props.selectStrategy
@@ -105,7 +105,7 @@ export const useNested = (props: NestedProps) => {
   const selected = useProxiedModel(
     props,
     'selected',
-    props.selected,
+    undefined,
     v => selectStrategy.value.in(v, children.value, parents.value),
     v => selectStrategy.value.out(v, children.value, parents.value),
   )

--- a/packages/vuetify/src/composables/proxiedModel.ts
+++ b/packages/vuetify/src/composables/proxiedModel.ts
@@ -29,9 +29,9 @@ export function useProxiedModel<
 
   const initialValue = unref(defaultValue)
   const internal = ref(
-    propIsDefined.value ? transformIn(props[prop])
-    : initialValue !== undefined ? transformIn(initialValue)
-    : undefined
+    propIsDefined.value || initialValue === undefined
+      ? transformIn(props[prop])
+      : transformIn(initialValue)
   ) as Ref<Inner>
 
   if (isRef(defaultValue)) {


### PR DESCRIPTION
Current behaviour:
- proxiedModel requires the use of v-model to set an initial value, if you only set modelValue it will basically be readonly
- native input elements already have a value attribute, currently we're just passing that through which results in unexpected behaviour

No way to have an uncontrolled model
`model-value="foo"` - controlled, readonly
`:model-value="foo" @update:model-value="foo = $event"` - editable

---

This PR:
`value="foo"` - uncontrolled
`model-value="foo"` - controlled, readonly
`:model-value="foo" @update:model-value="foo = $event"` - editable

---

An alternative would be to only make proxiedModel controlled if both the prop and event are specified, so "controlled, readonly" could be done with an empty event handler instead:

`model-value="foo"` - uncontrolled
`model-value="foo" @update:model-value=""` - controlled, readonly
`:model-value="foo" @update:model-value="foo = $event"` - editable

We should probably do something with `value` for input components either way, currently it will appear to work but the label won't active properly and the displayed value resets on blur. 