### PR TITLE
fix(VField): center input when singleLine or no label

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -48,25 +48,6 @@
     border-bottom-left-radius: 0
     border-bottom-right-radius: 0
 
-  &--variant-plain,
-  &--variant-underlined
-    border-radius: 0
-    padding: 0
-    --v-field-padding-start: 0px
-    --v-field-padding-end: 0px
-    --v-field-padding-top: 6px
-    --v-field-padding-bottom: 2px
-
-  &--variant-outlined,
-  &--single-line
-    --v-field-padding-top: 0px
-    $root: &
-
-    @at-root
-      @include tools.density('v-input', $input-density) using ($modifier)
-        @at-root #{selector.nest(&, $root)}
-          --v-field-padding-bottom: #{16px + $modifier * .5}
-
   &--variant-solo,
   &--variant-filled
     $root: &
@@ -77,9 +58,28 @@
           --v-input-control-height: #{$field-control-height + $modifier}
           --v-field-padding-bottom: #{$field-control-padding-bottom + $modifier * .5}
 
+  &--variant-outlined,
+  &--single-line,
+  &--no-label
+    --v-field-padding-top: 0px
+    $root: &
+
+    @at-root
+      @include tools.density('v-input', $input-density) using ($modifier)
+        @at-root #{selector.nest(&, $root)}
+          --v-field-padding-bottom: #{16px + $modifier * .5}
+
   &--variant-plain,
   &--variant-underlined
     $root: &
+    border-radius: 0
+    padding: 0
+
+    &.v-field
+      --v-field-padding-start: 0px
+      --v-field-padding-end: 0px
+      --v-field-padding-top: 6px
+      --v-field-padding-bottom: 2px
 
     @at-root
       @include tools.density('v-input', $input-density) using ($modifier)

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -223,7 +223,7 @@ export const VField = genericComponent<new <T>() => {
               'v-field--prepended': hasPrepend,
               'v-field--reverse': props.reverse,
               'v-field--single-line': props.singleLine,
-              'v-field--has-label': !!label,
+              'v-field--no-label': !label,
               [`v-field--variant-${props.variant}`]: true,
             },
             themeClasses.value,

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -6,6 +6,7 @@
 .v-text-field
   input
     color: inherit
+    opacity: 0
     flex: $text-field-input-flex
     transition: $text-field-input-transition
     min-width: 0
@@ -32,10 +33,7 @@
     padding-inline-start: $text-field-details-padding-inline
     padding-inline-end: $text-field-details-padding-inline
 
-  .v-field--has-label
-    input
-      opacity: 0
-
+  .v-field--no-label,
   .v-field--active
     input
       opacity: 1

--- a/packages/vuetify/src/components/VTextarea/VTextarea.sass
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.sass
@@ -5,6 +5,9 @@
 @use './variables' as *
 
 .v-textarea
+  .v-field
+    --v-textarea-control-height: var(--v-input-control-height)
+
   .v-field__field
     --v-input-control-height: var(--v-textarea-control-height)
 
@@ -34,15 +37,13 @@
     min-height: 0 !important
     pointer-events: none
 
-  .v-field--has-label
-    textarea
-      opacity: 0
-
+  .v-field--no-label,
   .v-field--active
     textarea
       opacity: 1
 
   textarea
+    opacity: 0
     flex: 1
     min-width: 0
     transition: .15s opacity settings.$standard-easing


### PR DESCRIPTION
fixes #15610

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <input v-model="density" type="radio" name="density" value="default">
      <input v-model="density" type="radio" name="density" value="comfortable">
      <input v-model="density" type="radio" name="density" value="compact">

      <template v-for="variant in variants">
        <v-defaults-provider :defaults="{ global: { density, variant, singleLine: false, rows: 1, maxRows: 2, autoGrow: true }}">
          <div class="my-6" />

          <v-row>
            <v-col>
              <v-text-field
                v-model="model"
                label="Basic"
              />
            </v-col>
            <v-col>
              <v-text-field
                v-model="model"
              />
            </v-col>
            <v-col>
              <v-textarea
                v-model="areaModel"
                label="Basic"
              />
            </v-col>
            <v-col>
              <v-textarea
                v-model="areaModel"
              />
            </v-col>
          </v-row>
          <v-row>
            <v-col>
              <v-text-field
                v-model="model"
                label="Prefix/suffix"
                prefix="prefix"
                suffix="suffix"
              />
            </v-col>
            <v-col>
              <v-text-field
                v-model="model"
                prefix="prefix"
                suffix="suffix"
              />
            </v-col>
            <v-col>
              <v-textarea
                v-model="areaModel"
                label="Prefix/suffix"
                prefix="prefix"
                suffix="suffix"
              />
            </v-col>
            <v-col>
              <v-textarea
                v-model="areaModel"
                prefix="prefix"
                suffix="suffix"
              />
            </v-col>
          </v-row>
          <v-row>
            <v-col>
              <v-text-field
                v-model="model"
                label="Prepend/append"
                prepend-inner-icon="mdi-vuetify"
                append-inner-icon="mdi-vuetify"
              />
            </v-col>
            <v-col>
              <v-text-field
                v-model="model"
                prepend-inner-icon="mdi-vuetify"
                append-inner-icon="mdi-vuetify"
              />
            </v-col>
            <v-col>
              <v-textarea
                v-model="areaModel"
                label="Prepend/append"
                prepend-inner-icon="mdi-vuetify"
                append-inner-icon="mdi-vuetify"
              />
            </v-col>
            <v-col>
              <v-textarea
                v-model="areaModel"
                prepend-inner-icon="mdi-vuetify"
                append-inner-icon="mdi-vuetify"
              />
            </v-col>
          </v-row>
        </v-defaults-provider>
      </template>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      model: 'text',
      areaModel: 'text',
      density: 'default',
      variants: ['underlined', 'outlined', 'filled', 'solo', 'plain'],
    }),
  }
</script>

<style lang="sass">
input[type="text"],
textarea
  background-color: rgba(red, 0.2) !important
  opacity: 1 !important
</style>
```
</details>

