### PR TITLE
fix(VAutocomplete): show selections slot and the input side-by-side like v2 does

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -85,5 +85,10 @@
         opacity: 0
 
     .v-field--focused
-      .v-autocomplete__selection
+      .v-autocomplete__selection-text
         opacity: 0
+
+  &--selection-slot
+    &.v-text-field input
+      position: relative
+      padding-inline-start: 0

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -85,10 +85,5 @@
         opacity: 0
 
     .v-field--focused
-      .v-autocomplete__selection-text
+      .v-autocomplete__selection
         opacity: 0
-
-  &--slection-slot
-    &.v-text-field input
-      position: relative
-      padding-inline-start: 0

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -85,5 +85,10 @@
         opacity: 0
 
     .v-field--focused
-      .v-autocomplete__selection
+      .v-autocomplete__selection-text
         opacity: 0
+
+  &--slection-slot
+    &.v-text-field input
+      position: relative
+      padding-inline-start: 0

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -223,7 +223,6 @@ export const VAutocomplete = genericComponent<new <
               'v-autocomplete--active-menu': menu.value,
               'v-autocomplete--chips': !!props.chips,
               [`v-autocomplete--${props.multiple ? 'multiple' : 'single'}`]: true,
-              'v-autocomplete--slection-slot': !!slots.selection,
             },
           ]}
           appendInnerIcon={ props.menuIcon }

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -223,6 +223,7 @@ export const VAutocomplete = genericComponent<new <
               'v-autocomplete--active-menu': menu.value,
               'v-autocomplete--chips': !!props.chips,
               [`v-autocomplete--${props.multiple ? 'multiple' : 'single'}`]: true,
+              'v-autocomplete--slection-slot': !!slots.selection,
             },
           ]}
           appendInnerIcon={ props.menuIcon }

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -177,7 +177,10 @@ export const VAutocomplete = genericComponent<new <
 
         isSelecting.value = true
 
-        search.value = item.title
+        if (!slots.selection) {
+          search.value = item.title
+        }
+
         menu.value = false
         isPristine.value = true
 
@@ -188,7 +191,7 @@ export const VAutocomplete = genericComponent<new <
     watch(isFocused, val => {
       if (val) {
         isSelecting.value = true
-        search.value = props.multiple ? '' : String(selections.value.at(-1)?.props.title ?? '')
+        search.value = props.multiple || !!slots.selection ? '' : String(selections.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)
@@ -223,6 +226,7 @@ export const VAutocomplete = genericComponent<new <
               'v-autocomplete--active-menu': menu.value,
               'v-autocomplete--chips': !!props.chips,
               [`v-autocomplete--${props.multiple ? 'multiple' : 'single'}`]: true,
+              'v-autocomplete--selection-slot': !!slots.selection,
             },
           ]}
           appendInnerIcon={ props.menuIcon }


### PR DESCRIPTION
fixes #15756


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #15756

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-app>
    <v-container>
      <v-autocomplete :items="countries" item-title="name" item-value="code" >
        <template #selection="{ item }">
          {{ item.raw.code }} {{ item.raw.name }}
        </template>
        <template #item="{ props, item }">
          <v-list-item v-bind="props" title="">
          {{ item.raw.code }} {{ item.raw.name }}
          </v-list-item>
        </template>
      </v-autocomplete>

      <v-autocomplete
        :items="items"
        dense
        small-chips
        label="Solo"
        solo
      ></v-autocomplete>
      
      <h1>Select</h1>      
      <v-select :items="countries" item-title="name" item-value="code">
        <template #selection="{ item }">
          {{ item.raw.code }} {{ item.raw.name }}
        </template>
        <template #item="{ props, item }">
          <v-list-item v-bind="props" title="">
          {{ item.raw.code }} {{ item.raw.name }}
          </v-list-item>
        </template>
      </v-select>
      
      <h1>combobox</h1>      
      <v-combobox multiple :items="items">
        <template #selection="data">
          {{ data.item.title }}
        </template>
        <template #item="{props, item }">
          <v-list-item v-bind="props">
          </v-list-item>
        </template>
      </v-combobox>

      <v-combobox
        :items="items"
        dense
        small-chips
        multiple
        label="Solo"
        solo
      ></v-combobox>

    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
    methods: {
      alertListener() {
        alert('Hello')
      }
    },
    data: () => ({
      countries: [
        {
          name: "AAA",
          code: "1",
        },
        {
          name: "BBB",
          code: "2",
        },
        {
          name: "CCC",
          code: "3",
        },
        {
          name: "DDD",
          code: "4",
        },
      ],
      items: ['foo', 'bar', 'fizz', 'buzz'],
      values: ['foo', 'bar'],
      value: null,
  }),
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
