### PR TITLE
fix(VOverlay): expose AfterEnter event

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -119,6 +119,7 @@ export const VOverlay = genericComponent<new () => {
     'click:outside': (e: MouseEvent) => true,
     'update:modelValue': (value: boolean) => true,
     afterLeave: () => true,
+    afterEnter: () => true,
   },
 
   setup (props, { slots, attrs, emit }) {
@@ -264,6 +265,7 @@ export const VOverlay = genericComponent<new () => {
                   persisted
                   transition={ props.transition }
                   target={ activatorEl.value }
+                  onAfterEnter={() => { emit('afterEnter') }}
                   onAfterLeave={() => { onAfterLeave(); emit('afterLeave') }}
                 >
                   <div


### PR DESCRIPTION
fix #15773



<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Cause: 
According to [W3C standard](https://www.w3.org/TR/resize-observer/#intro) for `ResiveObserver`
> Observations will not be triggered by CSS transforms

`ResizeObserver` will not fire after `transition` change in parent `VOverlay`, so theoretically it is impossible for `VPagination` to know when its width becomes stable and start render its content during parent css transform

There could be multiple solutions, but the best solution that I found so far is:

Expose a new event named `afterEnter` from `VDialog` and let user decide when to render their custom components in default slot. I got issue resolved by update its sample to follow (hide paginator until dialog is fully opened):
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-app>
    <v-container>
      <v-dialog
        v-model="dialog"
        transition="fab-transition"
        :fullscreen="fullscreen"
        @after-enter="dialogOpened=true"
        @after-leave="dialogOpened=false"
      >
        <template #activator="{ props: dialogProps }">
          <v-btn
            variant="outlined"
            color="secondary"
            rounded="lg"
            v-bind="dialogProps"
          >
            Open Dialog
          </v-btn>
        </template>
        <v-card>
          <v-card-title>
            Card in dialog
          </v-card-title>
          <v-card-text>
            <template v-if="fullscreen">
              You see my only in fullscreen but the pagination overflowed.
              <br>Press escape to close the dialog.
              <br>Side note : When you resize the windows the pagination is fixed. Only in fullscreen.
            </template>
            <template v-else>
              You probably don't see me because the pagination overflowed.
            </template>
          </v-card-text>
          <v-card-actions>
            <v-pagination
              v-show="dialogOpened"
              v-model="current"
              class="pa-2 w-100"
              :length="100"
              rounded="circle"
            />
          </v-card-actions>
        </v-card>
      </v-dialog>
      <v-checkbox
            v-model="fullscreen"
            label="Fullscreen"
          ></v-checkbox>
      <v-card>
        <v-card-title>
          Card not in dialog
        </v-card-title>
        <v-card-text>
          The pagination stay in the card.
        </v-card-text>
        <v-card-actions>
        </v-card-actions>
      </v-card>
    </v-container>
    
  </v-app>
</template>

<script>
export default {
  data: () => ({
    current : 50,
    dialog : false,
    fullscreen : false,
    dialogOpened: false // new change
  }),
}
</script>


```

</details>


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fix #15773

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-app>
    <v-container>
      <v-dialog
        v-model="dialog"
        transition="fab-transition"
        :fullscreen="fullscreen"
        @after-enter="dialogOpened=true"
        @after-leave="dialogOpened=false"
      >
        <template #activator="{ props: dialogProps }">
          <v-btn
            variant="outlined"
            color="secondary"
            rounded="lg"
            v-bind="dialogProps"
          >
            Open Dialog
          </v-btn>
        </template>
        <v-card>
          <v-card-title>
            Card in dialog
          </v-card-title>
          <v-card-text>
            <template v-if="fullscreen">
              You see my only in fullscreen but the pagination overflowed.
              <br>Press escape to close the dialog.
              <br>Side note : When you resize the windows the pagination is fixed. Only in fullscreen.
            </template>
            <template v-else>
              You probably don't see me because the pagination overflowed.
            </template>
          </v-card-text>
          <v-card-actions>
            <v-pagination
              v-show="dialogOpened"
              v-model="current"
              class="pa-2 w-100"
              :length="100"
              rounded="circle"
            />
          </v-card-actions>
        </v-card>
      </v-dialog>
      <v-checkbox
            v-model="fullscreen"
            label="Fullscreen"
          ></v-checkbox>
      <v-card>
        <v-card-title>
          Card not in dialog
        </v-card-title>
        <v-card-text>
          The pagination stay in the card.
        </v-card-text>
        <v-card-actions>
        </v-card-actions>
      </v-card>
    </v-container>
    
  </v-app>
</template>

<script>
export default {
  data: () => ({
    current : 50,
    dialog : false,
    fullscreen : false,
    dialogOpened: false
  }),
}
</script>


```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
