### PR TITLE
docs: add sass installation information

### DIFF
--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -13,11 +13,15 @@ related:
 
 Vuetify uses **SASS/SCSS** to craft the style and appearance of all aspects of the framework.
 
+<entry />
+
 ## installation 
+
 When you do not use SASS/SCSS or vuetify's variables yourself, you don't have to install it. 
 Vuetify works out of the box. But when you do when you want to change SASS/SCSS variables or use it yourself.
 
 ### vite
+
 Vite does provide built-in support for .scss, .sass, .less, .styl and .stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
 ```bash
 npm install -D sass
@@ -25,13 +29,13 @@ npm install -D sass
 for more information: https://vitejs.dev/guide/features.html#css-pre-processors
 
 ### vue-cli
+
 You can select pre-processors (Sass/Less/Stylus) when creating the project. If you did not do so, the internal webpack config is still pre-configured to handle all of them. You just need to manually install the corresponding webpack loaders:
 ```bash
 npm install -D sass-loader sass
 ```
 for more information: https://cli.vuejs.org/guide/css.html#pre-processors
 
-<entry />
 
 ## Basic usage
 

--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -13,6 +13,24 @@ related:
 
 Vuetify uses **SASS/SCSS** to craft the style and appearance of all aspects of the framework.
 
+## installation 
+When you do not use SASS/SCSS or vuetify's variables yourself, you don't have to install it. 
+Vuetify works out of the box. But when you do when you want to change SASS/SCSS variables or use it yourself.
+
+### vite
+Vite does provide built-in support for .scss, .sass, .less, .styl and .stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
+```bash
+npm install -D sass
+```
+for more information: https://vitejs.dev/guide/features.html#css-pre-processors
+
+### vue-cli
+You can select pre-processors (Sass/Less/Stylus) when creating the project. If you did not do so, the internal webpack config is still pre-configured to handle all of them. You just need to manually install the corresponding webpack loaders:
+```bash
+npm install -D sass-loader sass
+```
+for more information: https://cli.vuejs.org/guide/css.html#pre-processors
+
 <entry />
 
 ## Basic usage

--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -15,27 +15,30 @@ Vuetify uses **SASS/SCSS** to craft the style and appearance of all aspects of t
 
 <entry />
 
-## installation 
+## installation
 
-When you do not use SASS/SCSS or vuetify's variables yourself, you don't have to install it. 
+When you do not use SASS/SCSS or vuetify's variables yourself, you don't have to install it.
 Vuetify works out of the box. But when you do when you want to change SASS/SCSS variables or use it yourself.
 
 ### vite
 
 Vite does provide built-in support for .scss, .sass, .less, .styl and .stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
+
 ```bash
 npm install -D sass
 ```
+
 for more information: https://vitejs.dev/guide/features.html#css-pre-processors
 
 ### vue-cli
 
 You can select pre-processors (Sass/Less/Stylus) when creating the project. If you did not do so, the internal webpack config is still pre-configured to handle all of them. You just need to manually install the corresponding webpack loaders:
+
 ```bash
 npm install -D sass-loader sass
 ```
-for more information: https://cli.vuejs.org/guide/css.html#pre-processors
 
+for more information: https://cli.vuejs.org/guide/css.html#pre-processors
 
 ## Basic usage
 

--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -15,14 +15,13 @@ Vuetify uses **SASS/SCSS** to craft the style and appearance of all aspects of t
 
 <entry />
 
-## installation
+## Installation
 
-When you do not use SASS/SCSS or vuetify's variables yourself, you don't have to install it.
-Vuetify works out of the box. But when you do when you want to change SASS/SCSS variables or use it yourself.
+Vuetify works out of the box without any additional compilers needing to be installed. Changing or using SASS variables though obviously requires the SASS compiler.
 
 ### vite
 
-Vite does provide built-in support for .scss, .sass, .less, .styl and .stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
+Vite provides built-in support for sass, less and stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
 
 ```bash
 npm install -D sass

--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -87,10 +87,6 @@ pnpm create vite my-vue-app -- --template vue
 </v-window>
 
 ----
-Vite does provide built-in support for .scss, .sass, .less, .styl and .stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
-```bash
-npm install -D sass
-```
 
 Once your project is created, navigate to the [Adding Vuetify](#adding-vuetify) section to continue.
 

--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -87,6 +87,10 @@ pnpm create vite my-vue-app -- --template vue
 </v-window>
 
 ----
+Vite does provide built-in support for .scss, .sass, .less, .styl and .stylus files. There is no need to install Vite-specific plugins for them, but the corresponding pre-processor itself must be installed. Vuetify needs sass as a preprocessor so install it:
+```bash
+npm install -D sass
+```
 
 Once your project is created, navigate to the [Adding Vuetify](#adding-vuetify) section to continue.
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
After following the installation guide sass is missing as an dependency. When installed globally this doesn't seem to be an issue. But for some coworkers of mine it was. Also in ci/cdlike githubactions this was an issue as wel.

```
vite v3.1.3 building for production...
transforming...
✓ 204 modules transformed.
[vite:css] Preprocessor dependency "sass" not found. Did you install it?
file: /home/runner/work/mobyyou-clubportal/mobyyou-clubportal/src/App.vue?vue&type=style&index=0&scoped=a9d3ab21&lang.scss
error during build:
Error: Preprocessor dependency "sass" not found. Did you install it?
```

## How Has This Been Tested?
not

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
