### PR TITLE
fix(VField): label opacity flicker

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -207,7 +207,6 @@
   .v-field--active &
     visibility: hidden
 
-  .v-field--disabled &,
   .v-field--focused &,
   .v-field--error &
     opacity: 1


### PR DESCRIPTION
## Motivation and Context
closes #15481

## Markup:
<details>

```vue
<template>
  <div class="ma-4 pa-4">

    <v-card>
      <v-card-text>
        <div class="d-flex pa-4">
          <v-checkbox-btn
            v-model="includeFiles"
            class="pr-2"
          />
          <v-text-field
            label="Include files"
            hide-details
          />
        </div>
        <div class="d-flex pa-4">
          <v-checkbox-btn
            v-model="enabled"
            class="pr-2"
          />
          <v-text-field
            :disabled="!enabled"
            hide-details
            color="primary"
            label="I only work if you check the box"
          />
        </div>
      </v-card-text>
    </v-card>
  </div>
</template>

<script>
  export default {
    data: () => ({
      includeFiles: true,
      enabled: false,
    }),
  }
</script>

```
</details>