### PR TITLE
fix(VTextField/VTextarea): VTextarea prop 'reverse' work correctly

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -353,7 +353,7 @@
       margin-bottom: $text-field-details-margin-bottom
 
   &--reverse
-    input
+    input, textarea
       +ltr()
         text-align: right
 

--- a/packages/vuetify/src/components/VTextarea/VTextarea.sass
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.sass
@@ -102,3 +102,12 @@
 
         +rtl()
           padding-left: $textarea-enclosed-text-slot-padding
+
+    &.v-text-field--reverse
+      .v-text-field__slot
+        .v-label
+          +ltr()
+            margin-right: -$textarea-enclosed-text-slot-margin
+
+          +rtl()
+            margin-left: -$textarea-enclosed-text-slot-margin


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
VTextarea prop 'reverse' doesn't work correctly neither in LTR nor is RTL mode.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves [#15432](https://github.com/vuetifyjs/vuetify/issues/15432)

## How Has This Been Tested?
visually tested

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container fluid>
    <v-row>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          name="input-7-1"
          label="Default style"
          value="The Woodman set to work at once, and so sharp was his axe that the tree was soon chopped nearly through."
          hint="Hint text"
        ></v-textarea>
      </v-col>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          solo
          name="input-7-4"
          label="Solo textarea"
        ></v-textarea>
      </v-col>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          filled
          name="input-7-4"
          label="Filled textarea"
          value="The Woodman set to work at once, and so sharp was his axe that the tree was soon chopped nearly through."
        ></v-textarea>
      </v-col>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          outlined
          name="input-7-4"
          label="Outlined textarea"
          value="The Woodman set to work at once, and so sharp was his axe that the tree was soon chopped nearly through."
        ></v-textarea>
      </v-col>
    </v-row>
    <v-row>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          name="input-7-1"
          label="Default style"
          value="The Woodman set to work at once, and so sharp was his axe that the tree was soon chopped nearly through."
          hint="Hint text"
          reverse
        ></v-textarea>
      </v-col>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          solo
          name="input-7-4"
          label="Solo textarea"
          reverse
        ></v-textarea>
      </v-col>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          filled
          name="input-7-4"
          label="Filled textarea"
          value="The Woodman set to work at once, and so sharp was his axe that the tree was soon chopped nearly through."
          reverse
        ></v-textarea>
      </v-col>
      <v-col
        cols="12"
        md="6"
      >
        <v-textarea
          outlined
          name="input-7-4"
          label="Outlined textarea"
          value="The Woodman set to work at once, and so sharp was his axe that the tree was soon chopped nearly through."
          reverse
        ></v-textarea>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      slider: 0,
    }),

    methods: {},
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
