### PR TITLE
fix(VCombobox): close first chip correctly

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -372,6 +372,7 @@ export const VCombobox = genericComponent<new <
                   const slotProps = {
                     'onClick:close': onChipClose,
                     modelValue: true,
+                    'onUpdate:modelValue': undefined,
                   }
 
                   return (


### PR DESCRIPTION
## Description
fixes #15824 

## Motivation and Context
`VChip` uses `useProxiedModel`and manages `modelValue` internally, so when the first chip is closed, the remaining chips do not become Active properly and all disappear.
To solve this, specify `onUpdate:modelValue` for `VChip` in `VCombobox` to manage `modelValue` on `VCombobox` side.

## How Has This Been Tested?
visually (on Playground.vue)

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-row>
      <v-col>
        <v-combobox
            v-model="select"
            :items="items"
            label="I use chips"
            multiple
            chips
            closable-chips
          ></v-combobox>
      </v-col>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      select: ['Vuetify', 'Programming'],
      items: [
        'Programming',
        'Design',
        'Vue',
        'Vuetify',
      ],
    }),
  }
</script>

```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
