### PR TITLE
docs: change global configuration order wording

### DIFF
--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -39,8 +39,9 @@ export default createVuetify({
 
 When creating and mounting a component, Vuetify uses the following priority in determining which default prop value to use:
 
-1. Value defined in global section of `defaults` configuration object
-2. Value defined in component specific section of `defaults` configuration object
-3. Value defined in the component definition
+1. Value set as prop value to the component itself
+2. Value defined in component specific section of defaults configuration object
+3. Value defined in global section of defaults configuration object
+4. Value defined in the component definition by Vuetify
 
 <backmatter />

--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -37,11 +37,11 @@ export default createVuetify({
 
 ## Priority
 
-When creating and mounting a component, Vuetify uses the following priority in determining which default prop value to use:
+When creating and mounting a component, Vuetify uses the following priority in determining which prop value to use:
 
 1. Value set as prop value to the component itself
 2. Value defined in component specific section of defaults configuration object
 3. Value defined in global section of defaults configuration object
-4. Value defined in the component definition by Vuetify
+4. Value defined in the prop definition of the Vueitfy component itself.
 
 <backmatter />

--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -43,5 +43,4 @@ When creating and mounting a component, Vuetify uses the following priority in d
 2. Value defined in component specific section of `defaults` configuration object
 3. Value defined in the component definition
 
-
 <backmatter />

--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -39,8 +39,9 @@ export default createVuetify({
 
 When creating and mounting a component, Vuetify uses the following priority in determining which default prop value to use:
 
-1. Value defined in component specific section of `defaults` configuration object
-2. Value defined in global section of `defaults` configuration object
+1. Value defined in global section of `defaults` configuration object
+2. Value defined in component specific section of `defaults` configuration object
 3. Value defined in the component definition
+
 
 <backmatter />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
The order of global-configuration was wrong. When i read it, it seemed odd to me since you'd think that the component specific would overwrite the global section. After testing it i saw that it indeed had a logical order and that's why the update to the docs is needed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
