### PR TITLE
fix(VAutocomplete): wrong behavior on chip close

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -298,7 +298,7 @@ export const VAutocomplete = genericComponent<new <
                   }
 
                   return (
-                    <div key={ index } class="v-autocomplete__selection">
+                    <div key={ item.value } class="v-autocomplete__selection">
                       { hasChips ? (
                         <VDefaultsProvider
                           defaults={{


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
This change uses `item.value` instead of `index` for the Vue item key for items in multiple selection.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Because of the use of indexes as a Vue key, if you use VAutocomplete with "chips, closable-chips, and multiple" properties set to true, after clicking the close button on a VChip when multiple chips were selected, the chip next to the deleted one would also disappear.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Visually
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model="assignedUsers"
        :items="existingUsers"
        item-title="name"
        item-value="id"
        return-object
        clearable
        chips
        closable-chips
        multiple
      />
    </v-container>
  </v-app>
</template>

<script lang="ts">
  import { ref } from 'vue'

  interface IUser {
    id: string,
    name: string,
  }

  export default {
    name: 'Playground',
    setup () {
      const assignedUsers = ref<IUser[]>([{ id: '1', name: 'a' }, { id: '2', name: 'b' }, { id: '3', name: 'c' }])
      const existingUsers: IUser[] = [{ id: '1', name: 'a' }, { id: '2', name: 'b' }, { id: '3', name: 'c' }, { id: '4', name: 'd' }]

      return {
        assignedUsers, existingUsers,
      }
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
