### PR TITLE
fix(theme): custom color key variants and default merge

### DIFF
--- a/packages/vuetify/src/composables/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/theme.spec.ts
@@ -109,6 +109,40 @@ describe('createTheme', () => {
     expect(styleElement?.getAttribute('nonce')).toBeNull()
   })
 
+  it('should merge custom theme based upon the supplied dark property', async () => {
+    for (const dark of [true, false, undefined]) {
+      const theme = createTheme({
+        defaultTheme: 'myTheme',
+        themes: { myTheme: { dark } },
+      })
+
+      theme.install(app)
+
+      expect(theme.computedThemes.value.myTheme.dark).toBe(dark)
+      expect(theme.computedThemes.value.myTheme.colors).toHaveProperty('primary')
+    }
+  })
+
+  it('should generate variations for custom color keys', async () => {
+    const theme = createTheme({
+      themes: {
+        light: {
+          colors: { color2: '#1697f6' },
+        },
+      },
+      variations: {
+        colors: ['color2'],
+        lighten: 1,
+        darken: 1,
+      },
+    })
+
+    theme.install(app)
+
+    expect(theme.computedThemes.value.light.colors).toHaveProperty('color2-darken-1')
+    expect(theme.computedThemes.value.light.colors).toHaveProperty('color2-lighten-1')
+  })
+
   // it('should use vue-meta@2.3 functionality', () => {
   //   const theme = createTheme()
   //   const set = jest.fn()

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -185,8 +185,12 @@ function parseThemeOptions (options: ThemeOptions = defaultThemeOptions): Intern
   if (!options) return { ...defaultThemeOptions, isDisabled: true } as InternalThemeOptions
 
   const themes: Record<string, InternalThemeDefinition> = {}
+  const defaultThemeKey = options.defaultTheme ?? defaultThemeOptions.defaultTheme ?? 'light'
+
   for (const [key, theme] of Object.entries(options.themes ?? {})) {
-    const defaultTheme = theme.dark
+    const isDark = theme.dark ?? defaultThemeOptions?.themes?.[defaultThemeKey]?.dark ?? false
+
+    const defaultTheme = isDark
       ? defaultThemeOptions.themes?.dark
       : defaultThemeOptions.themes?.light
     themes[key] = mergeDeep(defaultTheme, theme) as InternalThemeDefinition
@@ -217,6 +221,9 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
       if (parsedOptions.variations) {
         for (const name of parsedOptions.variations.colors) {
           const color = theme.colors[name]
+
+          if (!color) continue
+
           for (const variation of (['lighten', 'darken'] as const)) {
             const fn = variation === 'lighten' ? lighten : darken
             for (const amount of createRange(parsedOptions.variations[variation], 1)) {

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -185,12 +185,8 @@ function parseThemeOptions (options: ThemeOptions = defaultThemeOptions): Intern
   if (!options) return { ...defaultThemeOptions, isDisabled: true } as InternalThemeOptions
 
   const themes: Record<string, InternalThemeDefinition> = {}
-  const defaultThemeKey = options.defaultTheme ?? defaultThemeOptions.defaultTheme ?? 'light'
-
   for (const [key, theme] of Object.entries(options.themes ?? {})) {
-    const isDark = theme.dark ?? defaultThemeOptions?.themes?.[defaultThemeKey]?.dark ?? false
-
-    const defaultTheme = isDark
+    const defaultTheme = theme.dark || key === 'dark'
       ? defaultThemeOptions.themes?.dark
       : defaultThemeOptions.themes?.light
     themes[key] = mergeDeep(defaultTheme, theme) as InternalThemeDefinition


### PR DESCRIPTION
## Motivation and Context
closes #15850

## Markup:
<details>

```js
// dev/vuetify.js

import '@mdi/font/css/materialdesignicons.css'
import { createVuetify } from 'vuetify/src/entry-bundler'
import { aliases, mdi } from 'vuetify/src/iconsets/mdi'
import { fa } from 'vuetify/src/iconsets/fa-svg'
import { ar, en, ja, sv } from 'vuetify/src/locale'

const theme = {
  dark: false,
  colors: {
    background: '#FFFFFF',
    surface: '#FFFFFF',
    color2: '#024452',
    gradient: '#EFF5F7',
    error: '#FF5252',
    info: '#2196F3',
    success: '#4CAF50',
    warning: '#FFC107',
  },
}

export default createVuetify({
  ssr: !!process.env.VITE_SSR,
  locale: {
    messages: {
      en,
      ar,
      sv,
      ja,
    },
  },
  icons: {
    defaultSet: 'mdi',
    aliases,
    sets: {
      mdi,
      fa,
    },
  },
  theme: {
    defaultTheme: 'myColors',
    themes: { myColors: theme },
    variations: {
      colors: ['color2'],
      lighten: 4,
      darken: 0,
    },
  },
})
```
</details>