### PR TITLE
revert(VTextField): only show clear icon on hover or when focused

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -504,15 +504,6 @@
   &.v-input--has-state > .v-input__control > .v-input__slot:before
     border-color: currentColor
 
-  .v-input__icon--clear
-    opacity: 0
-    transition: opacity $primary-transition
-
-  &.v-input--is-focused,
-  &.v-input--is-dirty:hover
-    .v-input__icon--clear
-      opacity: 1
-
   // TODO: where are the corresponding rules for LTR?
   //
   // +rtl()


### PR DESCRIPTION
## Description
This is reverting commit https://github.com/vuetifyjs/vuetify/commit/7a51ad0140dd17f9d718f6ceb84226d305c2c379 and therefore a fix for #15830.

## Motivation and Context
The change to only show the clear icon on hover or when focused in VTextField isn't a desired change in UX and breaking usability on touch devices.
It is not obvious in first sight that the VTextField can be cleared (e.g. if VTextField was prefilled) and on touch devices two touches are required.

## How Has This Been Tested?
it is a revert

## Markup:

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
