### PR TITLE
`<a>` is rendered with `to` attribute instead of `href`

### DIFF
--- a/packages/docs/src/components/app/Link.vue
+++ b/packages/docs/src/components/app/Link.vue
@@ -32,7 +32,7 @@
   const isSamePage = computed(() => !isExternal.value && props.href.startsWith('#'))
   const attrs = computed(() => {
     return isExternal.value
-      ? { to: props.href, target: '_blank', rel: 'noopener' }
+      ? { href: props.href, target: '_blank', rel: 'noopener' }
       : {
         to: isSamePage.value ? props.href : {
           path: rpath(props.href),


### PR DESCRIPTION
## Motivation and Context
Yes

## How Has This Been Tested?
dev

![image](https://user-images.githubusercontent.com/15625235/195980269-a5bf073d-5542-4c74-aae4-0fb074c6252e.png)
(and many others)

![image](https://user-images.githubusercontent.com/15625235/195980257-9b201ac6-0b8d-4c21-863b-79c3f86d1237.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
