### PR TITLE
docs: unnecessary escaping

### DIFF
--- a/packages/docs/src/pages/en/components/data-tables.md
+++ b/packages/docs/src/pages/en/components/data-tables.md
@@ -109,11 +109,11 @@ The data table exposes a **search** prop that allows you to filter your data.
 
 ### Slots
 
-The `v-data-table` provides a large number of slots for customizing the table. This example showcases some of these slots and what you can do with each. It is important to note some slot (eg: `item`/`body`/`header`) will completely takes over the internal rendering of the component which will require you to re-implement functionalities such as selection and expansion. Some slots will override each other such as: `body` > `item` > `item.<name>` and `header`/`header.\<name\>`.
+The `v-data-table` provides a large number of slots for customizing the table. This example showcases some of these slots and what you can do with each. It is important to note some slot (eg: `item`/`body`/`header`) will completely takes over the internal rendering of the component which will require you to re-implement functionalities such as selection and expansion. Some slots will override each other such as: `body` > `item` > `item.<name>` and `header`/`header.<name>`.
 
 <alert type="info">
 
-  Some slots such as `item.\<name\>` and `header.\<name\>` use modifiers to target more scoped slots. Eslint by default will throw errors when slots use modifiers. To disable these errors, add the following rule to your eslint configuration: `"vue/valid-v-slot": ["error", { "allowModifiers": true }]`.
+  Some slots such as `item.<name>` and `header.<name>` use modifiers to target more scoped slots. Eslint by default will throw errors when slots use modifiers. To disable these errors, add the following rule to your eslint configuration: `"vue/valid-v-slot": ["error", { "allowModifiers": true }]`.
 
 </alert>
 
@@ -121,7 +121,7 @@ The `v-data-table` provides a large number of slots for customizing the table. T
 
 #### Header
 
-You can use the dynamic slots `header.\<name\>` to customize only certain columns. `\<name\>` is the name of the `value` property in the corresponding header item sent to **headers**.
+You can use the dynamic slots `header.<name>` to customize only certain columns. `<name>` is the name of the `value` property in the corresponding header item sent to **headers**.
 
 <example file="v-data-table/slot-header" />
 

--- a/packages/docs/src/pages/en/getting-started/contributing.md
+++ b/packages/docs/src/pages/en/getting-started/contributing.md
@@ -251,7 +251,7 @@ For more information regarding RFCs, see the official repository: https://github
 
 All commit messages are required to follow the [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) standard using the _angular_ preset. This standard format consists of 2 types of commits:
 
-- With scope: `\<type\>(scope): \<subject\>`
+- With scope: `<type>(scope): <subject>`
 
   ```bash
   fix(VSelect): don't close when a detachable child is clicked
@@ -259,7 +259,7 @@ All commit messages are required to follow the [conventional-changelog](https://
   fixes #12354
   ```
 
-- Without scope: `\<type\>: \<subject\>`
+- Without scope: `<type>: <subject>`
 
   ```bash
   docs: restructure nav components


### PR DESCRIPTION
## Description
```
`\<type\>: \<subject\>`
```

changed to
```
`<type>: <subject>`
```

https://next.vuetifyjs.com/en/getting-started/contributing/
https://next.vuetifyjs.com/en/components/data-tables/

## How Has This Been Tested?
visually

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
