### PR TITLE
fix(VBtn): isActive calc priorities

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -117,7 +117,7 @@ export const VBtn = defineComponent({
 
     useRender(() => {
       const Tag = (link.isLink.value) ? 'a' : props.tag
-      const hasColor = !group || group.isSelected.value
+      const hasColor = !group || (isActive.value && group.isSelected.value)
       const hasPrepend = !!(props.prependIcon || slots.prepend)
       const hasAppend = !!(props.appendIcon || slots.append)
       const hasIcon = !!(props.icon && props.icon !== true)

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -97,10 +97,17 @@ export const VBtn = defineComponent({
     const group = useGroupItem(props, props.symbol, false)
     const link = useLink(props, attrs)
 
-    const isActive = computed(() =>
-      props.active !== false &&
-      (props.active || link.isActive?.value || group?.isSelected.value)
-    )
+    const isActive = computed(() => {
+      if (props.active !== undefined) {
+        return props.active
+      }
+
+      if (link.isLink.value) {
+        return link.isActive?.value
+      }
+
+      return group?.isSelected.value
+    })
     const isDisabled = computed(() => group?.disabled.value || props.disabled)
     const isElevated = computed(() => {
       return props.variant === 'elevated' && !(props.disabled || props.flat || props.border)

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -117,7 +117,7 @@ export const VBtn = defineComponent({
 
     useRender(() => {
       const Tag = (link.isLink.value) ? 'a' : props.tag
-      const hasColor = !group || (isActive.value && group.isSelected.value)
+      const hasColor = !group || isActive.value
       const hasPrepend = !!(props.prependIcon || slots.prepend)
       const hasAppend = !!(props.appendIcon || slots.append)
       const hasIcon = !!(props.icon && props.icon !== true)


### PR DESCRIPTION
fixes #15833 & #15982

Cause: `v-bottom-navigation` adds `group?.isSelected`, which returns `isActive` as true even if VBtn's `link.isActive` becomes false

Solution: 

- `props.active` takes highest priority when it is explicitly set as `true` or `false`
- `link.active` takes second priority when it is a link
- `group.active` performs as the lowest priority when previous two are not valid

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
fixes #15833 & #15982

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
visually 

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
Firstly, config routes in `packages/vuetify/dev/index.js`

```js
// import { routes } from './router'
const Home = { template: '<div>Home</div>' }
const About = { template: '<div>About</div>' }
const Help = { template: '<div>Help</div>' }
const Login = { template: '<div>Login</div>' }

const routes = [
  { path: '/', component: Home },
  { path: '/about', component: About },
  { path: '/help', component: Help },
  { path: '/login', component: Login },
]
```

<details>

```vue
// Paste your FULL Playground.vue here
<template>
  <v-app>
    <v-main>
      <v-container>
        
        <v-card
          title="Unable to make VBottomNavigation non-active on inactive route"
          class="my-4"
        >
        <v-btn-toggle
        v-model="text"
        color="deep-purple accent-3"
      >
        <v-btn value="left" >
          Left
        </v-btn>

        <v-btn value="center" >
          Center
        </v-btn>

        <v-btn value="right" :active="false">
          Right
        </v-btn>

        <v-btn value="justify" :active="false">
          Justify
        </v-btn>
      </v-btn-toggle>
          <v-card-actions>
            <v-spacer />
            <v-btn
              v-for="{ path } of [
                { path: '/' },
                { path: '/help' },
                { path: '/about' },
              ]"
              color="primary"
              :active="true"
              variant="text"
              :to="path"
              class="text-none"
            >
              {{ path }}
            </v-btn>
          </v-card-actions>
        </v-card>
      </v-container>
    </v-main>

    <!-- How to make it non-active on /about? -->
    <v-bottom-navigation color="primary" :mandatory="false">
      <v-btn
        v-for="{ value, to, label } in [
          {
            value: 'home',
            to: '/',
            label: 'Home',
          },
          {
            value: 'help',
            to: '/help',
            label: 'Help',
          },
          {
            value: 'login',
            to: '/login',
            label: 'Login',
          },
        ]"
        :value="value"
        :to="to"
      >
        <span>{{ label }}</span>
      </v-btn>
    </v-bottom-navigation>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from 'vue'

const text = ref()
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
