### PR TITLE
fix(VRadioGroup): remove `multiple` prop

### DIFF
--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -14,7 +14,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, toRef } from 'vue'
-import { defineComponent, filterInputAttrs, getUid, useRender } from '@/util'
+import { defineComponent, excludeProps, filterInputAttrs, getUid, useRender } from '@/util'
 
 export const VRadioGroup = defineComponent({
   name: 'VRadioGroup',
@@ -28,7 +28,7 @@ export const VRadioGroup = defineComponent({
     },
 
     ...makeVInputProps(),
-    ...makeSelectionControlProps(),
+    ...excludeProps(makeSelectionControlProps(), ['multiple']),
 
     trueIcon: {
       type: IconValue,
@@ -63,7 +63,10 @@ export const VRadioGroup = defineComponent({
     useRender(() => {
       const [inputAttrs, controlAttrs] = filterInputAttrs(attrs)
       const [inputProps, _1] = filterInputProps(props)
-      const [controlProps, _2] = filterControlProps(props)
+      const [controlProps, _2] = filterControlProps({
+        ...props,
+        multiple: false as const,
+      })
       const label = slots.label
         ? slots.label({
           label: props.label,

--- a/packages/vuetify/src/util/__tests__/propsFactory.spec.ts
+++ b/packages/vuetify/src/util/__tests__/propsFactory.spec.ts
@@ -1,4 +1,4 @@
-import { propsFactory } from '../propsFactory'
+import { excludeProps, propsFactory } from '../propsFactory'
 import { describe, expect, it } from '@jest/globals'
 
 describe('propsFactory', () => {
@@ -29,5 +29,14 @@ describe('propsFactory', () => {
     expect(
       propsFactory({ foo: definition }, source)()
     ).toStrictEqual({ foo: result })
+  })
+
+  it('should remove excluded props', () => {
+    const props = propsFactory({ foo: String, bar: Number })()
+
+    // @ts-expect-error
+    excludeProps(props, ['baz'])
+
+    expect(excludeProps(props, ['foo'])).toStrictEqual({ bar: { type: Number } })
   })
 })

--- a/packages/vuetify/src/util/propsFactory.ts
+++ b/packages/vuetify/src/util/propsFactory.ts
@@ -54,6 +54,17 @@ export function propsFactory<
   }
 }
 
+export function excludeProps<
+  PropsOptions extends ComponentObjectPropsOptions,
+  ExcludeProps extends keyof PropsOptions
+> (props: PropsOptions, exclude: ExcludeProps[]): Omit<PropsOptions, ExcludeProps> {
+  const clone = { ...props }
+
+  exclude.forEach(prop => delete clone[prop])
+
+  return clone
+}
+
 type AppendDefault<T extends ComponentObjectPropsOptions, D extends PartialKeys<T>> = {
   [P in keyof T]-?: unknown extends D[P]
     ? T[P]


### PR DESCRIPTION
## Description
Removes `multiple` prop

There are some other props that are passed as attr to VSelectionControlGroup (`density`, `error`, `ripple`, [`valuecomparator`](https://github.com/vuetifyjs/vuetify/issues/15896)), not sure if they should just be removed from props or somehow handled

![image](https://user-images.githubusercontent.com/15625235/196047707-6a3f6a78-c948-41a3-be76-d530e534c8cc.png)


## Motivation and Context
fixes #15559

## How Has This Been Tested?
`yarn test` + apigen

## Markup

```vue
<template>
  <v-main>
    <v-radio-group multiple>
      <v-radio value="1" label="1" />
      <v-radio value="2" label="2" />
    </v-radio-group>
  </v-main>
</template>
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
