### PR TITLE
fix(VIcon): center button icon in system bar

### DIFF
--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
@@ -22,6 +22,10 @@
     font-size: $system-bar-icon-font-size
     margin-right: $system-bar-icon-margin-right
 
+  .v-btn
+    .v-icon
+      margin-right: 0
+
   &--fixed, &--absolute
     left: 0
     top: 0


### PR DESCRIPTION
## Description
fixes #14975

## Motivation and Context
VIcon was not centered in VBtn in VSystemBar.

## How Has This Been Tested?
visually

## Markup:
<details>

```vue
<template>
  <v-container>
    <v-system-bar
      dark
      color="primary"
    >
      <v-btn icon class="red">
        <v-icon>mdi-wifi-strength-4</v-icon>
      </v-btn>
    </v-system-bar>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    drawer: true,
    }),
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
