### PR TITLE
fix(VSelectionControlGroup): provided props & defaults target

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx
@@ -1,9 +1,10 @@
 // Components
-import { makeSelectionControlProps, VSelectionControl } from '../VSelectionControl/VSelectionControl'
+import { VSelectionControl } from '@/components/VSelectionControl'
 
 // Composables
-import { useProxiedModel } from '@/composables/proxiedModel'
 import { IconValue } from '@/composables/icons'
+import { makeSelectionControlProps } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
+import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed } from 'vue'

--- a/packages/vuetify/src/components/VRadio/VRadio.tsx
+++ b/packages/vuetify/src/components/VRadio/VRadio.tsx
@@ -1,5 +1,8 @@
 // Components
-import { makeSelectionControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
+import { VSelectionControl } from '@/components/VSelectionControl'
+
+// Composables
+import { makeSelectionControlProps } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
 
 // Utilities
 import { defineComponent, useRender } from '@/util'

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -2,18 +2,17 @@
 import './VRadioGroup.sass'
 
 // Components
-import { filterControlProps, makeSelectionControlProps } from '@/components/VSelectionControl/VSelectionControl'
+import { filterControlProps } from '@/components/VSelectionControl/VSelectionControl'
 import { filterInputProps, makeVInputProps, VInput } from '@/components/VInput/VInput'
+import { makeSelectionControlProps, VSelectionControlGroup } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
 import { VLabel } from '@/components/VLabel'
-import { VSelectionControlGroup } from '@/components/VSelectionControlGroup'
 
 // Composables
 import { IconValue } from '@/composables/icons'
-import { provideDefaults } from '@/composables/defaults'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, toRef } from 'vue'
+import { computed } from 'vue'
 import { defineComponent, excludeProps, filterInputAttrs, getUid, useRender } from '@/util'
 
 export const VRadioGroup = defineComponent({
@@ -52,13 +51,6 @@ export const VRadioGroup = defineComponent({
     const uid = getUid()
     const id = computed(() => props.id || `radio-group-${uid}`)
     const model = useProxiedModel(props, 'modelValue')
-
-    provideDefaults({
-      VRadio: {
-        color: toRef(props, 'color'),
-        density: toRef(props, 'density'),
-      },
-    })
 
     useRender(() => {
       const [inputAttrs, controlAttrs] = filterInputAttrs(attrs)
@@ -99,6 +91,7 @@ export const VRadioGroup = defineComponent({
                 <VSelectionControlGroup
                   { ...controlProps }
                   id={ id.value }
+                  defaultsTarget="VRadio"
                   trueIcon={ props.trueIcon }
                   falseIcon={ props.falseIcon }
                   type={ props.type }

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -4,34 +4,30 @@ import './VSelectionControl.sass'
 // Components
 import { VIcon } from '@/components/VIcon'
 import { VLabel } from '@/components/VLabel'
-import { VSelectionControlGroupSymbol } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
+import { makeSelectionControlProps, VSelectionControlGroupSymbol } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
 
 // Directives
 import { Ripple } from '@/directives/ripple'
 
 // Composables
-import { IconValue } from '@/composables/icons'
-import { makeDensityProps, useDensity } from '@/composables/density'
-import { makeThemeProps } from '@/composables/theme'
+import { useDensity } from '@/composables/density'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { useTextColor } from '@/composables/color'
 
 // Utilities
 import { computed, inject, ref } from 'vue'
 import {
-  deepEqual,
   filterInputAttrs,
   genericComponent,
   getUid,
   pick,
-  propsFactory,
   SUPPORTS_FOCUS_VISIBLE,
   useRender,
   wrapInArray,
 } from '@/util'
 
 // Types
-import type { ComputedRef, ExtractPropTypes, PropType, Ref, WritableComputedRef } from 'vue'
+import type { ComputedRef, ExtractPropTypes, Ref, WritableComputedRef } from 'vue'
 import type { SlotsToProps } from '@/util'
 
 export type SelectionControlSlot = {
@@ -45,39 +41,6 @@ export type SelectionControlSlot = {
     id: string
   }
 }
-
-export const makeSelectionControlProps = propsFactory({
-  color: String,
-  disabled: Boolean,
-  error: Boolean,
-  id: String,
-  inline: Boolean,
-  label: String,
-  falseIcon: IconValue,
-  trueIcon: IconValue,
-  ripple: {
-    type: Boolean,
-    default: true,
-  },
-  multiple: {
-    type: Boolean as PropType<boolean | null>,
-    default: null,
-  },
-  name: String,
-  readonly: Boolean,
-  trueValue: null,
-  falseValue: null,
-  modelValue: null,
-  type: String,
-  value: null,
-  valueComparator: {
-    type: Function as PropType<typeof deepEqual>,
-    default: deepEqual,
-  },
-
-  ...makeThemeProps(),
-  ...makeDensityProps(),
-}, 'VSelectionControl')
 
 export function useSelectionControl (
   props: ExtractPropTypes<ReturnType<typeof makeSelectionControlProps>> & {
@@ -94,7 +57,6 @@ export function useSelectionControl (
   ))
   const falseValue = computed(() => props.falseValue !== undefined ? props.falseValue : false)
   const isMultiple = computed(() => (
-    group?.multiple.value ||
     !!props.multiple ||
     (props.multiple == null && Array.isArray(modelValue.value))
   ))
@@ -133,11 +95,7 @@ export function useSelectionControl (
       !props.disabled
     ) ? props.color : undefined
   }))
-  const icon = computed(() => {
-    return model.value
-      ? group?.trueIcon.value ?? props.trueIcon
-      : group?.falseIcon.value ?? props.falseIcon
-  })
+  const icon = computed(() => model.value ? props.trueIcon : props.falseIcon)
 
   return {
     group,
@@ -175,7 +133,6 @@ export const VSelectionControl = genericComponent<new <T>() => {
   setup (props, { attrs, slots }) {
     const {
       densityClasses,
-      group,
       icon,
       model,
       textColorClasses,
@@ -214,7 +171,6 @@ export const VSelectionControl = genericComponent<new <T>() => {
           props: { for: id.value },
         })
         : props.label
-      const type = group?.type.value ?? props.type
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
 
       return (
@@ -227,7 +183,7 @@ export const VSelectionControl = genericComponent<new <T>() => {
               'v-selection-control--error': props.error,
               'v-selection-control--focused': isFocused.value,
               'v-selection-control--focus-visible': isFocusVisible.value,
-              'v-selection-control--inline': group?.inline.value || props.inline,
+              'v-selection-control--inline': props.inline,
             },
             densityClasses.value,
           ]}
@@ -263,10 +219,10 @@ export const VSelectionControl = genericComponent<new <T>() => {
                 onFocus={ onFocus }
                 onInput={ onInput }
                 aria-readonly={ props.readonly }
-                type={ type }
+                type={ props.type }
                 value={ trueValue.value }
-                name={ group?.name.value ?? props.name }
-                aria-checked={ type === 'checkbox' ? model.value : undefined }
+                name={ props.name }
+                aria-checked={ props.type === 'checkbox' ? model.value : undefined }
                 { ...inputAttrs }
               />
 

--- a/packages/vuetify/src/components/VSelectionControl/__tests__/VSelectionControl.spec.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/__tests__/VSelectionControl.spec.tsx
@@ -1,5 +1,8 @@
 // Components
-import { makeSelectionControlProps, useSelectionControl } from '../VSelectionControl'
+import { useSelectionControl } from '../VSelectionControl'
+
+// Composables
+import { makeSelectionControlProps } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
 
 // Utilities
 import { createVuetify } from '@/framework'

--- a/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
+++ b/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
@@ -3,47 +3,65 @@ import './VSelectionControlGroup.sass'
 
 // Composables
 import { IconValue } from '@/composables/icons'
+import { makeDensityProps } from '@/composables/density'
+import { makeThemeProps } from '@/composables/theme'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, provide, toRef } from 'vue'
-import { defineComponent, getUid, useRender } from '@/util'
+import { deepEqual, defineComponent, getUid, propsFactory, useRender } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
+import { provideDefaults } from '@/composables/defaults'
 
 export interface VSelectionGroupContext {
-  disabled: Ref<boolean>
-  inline: Ref<boolean>
-  name: Ref<string | undefined>
   modelValue: Ref<any>
-  multiple: Ref<boolean>
-  trueIcon: Ref<IconValue | undefined>
-  falseIcon: Ref<IconValue | undefined>
-  readonly: Ref<boolean>
-  type: Ref<string | undefined>
 }
 
 export const VSelectionControlGroupSymbol: InjectionKey<VSelectionGroupContext> = Symbol.for('vuetify:selection-control-group')
 
+export const makeSelectionControlProps = propsFactory({
+  color: String,
+  disabled: Boolean,
+  defaultsTarget: {
+    type: String,
+    default: 'VSelectionControl',
+  },
+  error: Boolean,
+  id: String,
+  inline: Boolean,
+  label: String,
+  falseIcon: IconValue,
+  trueIcon: IconValue,
+  ripple: {
+    type: Boolean,
+    default: true,
+  },
+  multiple: {
+    type: Boolean as PropType<boolean | null>,
+    default: null,
+  },
+  name: String,
+  readonly: Boolean,
+  trueValue: null,
+  falseValue: null,
+  modelValue: null,
+  type: String,
+  value: null,
+  valueComparator: {
+    type: Function as PropType<typeof deepEqual>,
+    default: deepEqual,
+  },
+
+  ...makeThemeProps(),
+  ...makeDensityProps(),
+}, 'VSelectionControl')
+
 export const VSelectionControlGroup = defineComponent({
   name: 'VSelectionControlGroup',
 
-  props: {
-    disabled: Boolean,
-    id: String,
-    inline: Boolean,
-    name: String,
-    falseIcon: IconValue,
-    trueIcon: IconValue,
-    multiple: {
-      type: Boolean as PropType<boolean | null>,
-      default: null,
-    },
-    readonly: Boolean,
-    type: String,
-    modelValue: null,
-  },
+  props: makeSelectionControlProps(),
 
   emits: {
     'update:modelValue': (val: any) => true,
@@ -55,16 +73,27 @@ export const VSelectionControlGroup = defineComponent({
     const id = computed(() => props.id || `v-selection-control-group-${uid}`)
     const name = computed(() => props.name || id.value)
 
-    provide(VSelectionControlGroupSymbol, {
-      disabled: toRef(props, 'disabled'),
-      inline: toRef(props, 'inline'),
-      modelValue,
-      multiple: computed(() => !!props.multiple || (props.multiple == null && Array.isArray(modelValue.value))),
-      name,
-      falseIcon: toRef(props, 'falseIcon'),
-      trueIcon: toRef(props, 'trueIcon'),
-      readonly: toRef(props, 'readonly'),
-      type: toRef(props, 'type'),
+    provide(VSelectionControlGroupSymbol, { modelValue })
+
+    provideDefaults({
+      [props.defaultsTarget]: {
+        color: toRef(props, 'color'),
+        disabled: toRef(props, 'disabled'),
+        density: toRef(props, 'density'),
+        error: toRef(props, 'error'),
+        inline: toRef(props, 'inline'),
+        modelValue,
+        multiple: computed(() => !!props.multiple || (props.multiple == null && Array.isArray(modelValue.value))),
+        name,
+        falseIcon: toRef(props, 'falseIcon'),
+        trueIcon: toRef(props, 'trueIcon'),
+        trueValue: toRef(props, 'trueValue'),
+        falseValue: toRef(props, 'falseValue'),
+        readonly: toRef(props, 'readonly'),
+        ripple: toRef(props, 'ripple'),
+        type: toRef(props, 'type'),
+        valueComparator: toRef(props, 'valueComparator'),
+      },
     })
 
     useRender(() => (

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -2,13 +2,14 @@
 import './VSwitch.sass'
 
 // Components
-import { filterControlProps, makeSelectionControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
+import { filterControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
 import { filterInputProps, makeVInputProps, VInput } from '@/components/VInput/VInput'
 import { VProgressCircular } from '@/components/VProgressCircular'
 
 // Composables
 import { LoaderSlot, useLoader } from '@/composables/loader'
 import { useProxiedModel } from '@/composables/proxiedModel'
+import { makeSelectionControlProps } from '@/components/VSelectionControlGroup/VSelectionControlGroup'
 
 // Utility
 import { computed, ref } from 'vue'


### PR DESCRIPTION
## Motivation and Context

fixes #15896

## Markup:
<details>

```vue
<template>
  <div class="ma-4 pa-4">
    <v-radio-group v-model="model">
      <v-radio label="A" value="a" />
      <v-radio label="B" value="b" />
    </v-radio-group>
  </div>
</template>

<script setup>
  import { ref } from 'vue'
  const model = ref('a')
</script>

```
</details>