### PR TITLE
fix(VProgressLinear): hide from accessibility tree if not active

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -146,6 +146,7 @@ export const VCard = defineComponent({
           ) }
 
           <LoaderSlot
+            v-if={props.loading !== undefined || slots.loader}
             name="v-card"
             active={ !!props.loading }
             color={ typeof props.loading === 'boolean' ? undefined : props.loading }

--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -146,7 +146,6 @@ export const VCard = defineComponent({
           ) }
 
           <LoaderSlot
-            v-if={props.loading !== undefined || slots.loader}
             name="v-card"
             active={ !!props.loading }
             color={ typeof props.loading === 'boolean' ? undefined : props.loading }

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
@@ -108,6 +108,7 @@ export const VProgressLinear = defineComponent({
           '--v-progress-linear-height': convertToUnit(height.value),
         }}
         role="progressbar"
+        aria-hidden={ props.active ? 'false' : 'true' }
         aria-valuemin="0"
         aria-valuemax={ props.max }
         aria-valuenow={ props.indeterminate ? undefined : normalizedValue.value }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
This PR proposal is to conditionaly hide the linear progress from the accessibility: it is hidden when the `active` prop value is `falsy` through a new `aria-hidden` attribute binding.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
The loader is currently rendered in the page with a tricky method (height of 0). This create an accessibility problem: the progress is not visible, but is still read by screen reader (as it is still in the accessibility tree).
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has been tested through the Playground with direct use of `VProgressLinear` (with or without `active` and `aria-hidden`).

<details>
<summary>My `Playground.vue` code</summary>

```vue
<template>
  <v-app>
    <v-container>
      <div class="my-5">
        <v-progress-linear :active="loading" indeterminate />
      </div>
      <div class="my-5">
        <v-progress-linear :active="true" aria-hidden="true" indeterminate />
      </div>
      <div class="my-5">
        <v-progress-linear :active="false" aria-hidden="false" indeterminate />
      </div>
      <div class="my-5">
        <v-card
          :loading="loading"
          title="Hello World!"
        >
          <v-card-text>
            Hello World.
          </v-card-text>
        </v-card>
      </div>
      <v-btn @click="onToggleLoading">
        TOGGLE
      </v-btn>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const loading = ref(false)
      const onToggleLoading = () => {
        loading.value = !loading.value
      }

      return {
        loading,
        onToggleLoading,
      }
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
