### PR TITLE
feat(VList): add keyboard navigation

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -120,6 +120,7 @@ export const VAutocomplete = genericComponent<new <
       })
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))
+    const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
       model.value = []
@@ -152,6 +153,12 @@ export const VAutocomplete = genericComponent<new <
       if (['Enter', 'Escape', 'Tab'].includes(e.key)) {
         isPristine.value = true
       }
+
+      if (e.key === 'ArrowDown') {
+        listRef.value?.focus('next')
+      } else if (e.key === 'ArrowUp') {
+        listRef.value?.focus('prev')
+      }
     }
 
     function onInput (e: InputEvent) {
@@ -160,6 +167,16 @@ export const VAutocomplete = genericComponent<new <
 
     function onAfterLeave () {
       if (isFocused.value) isPristine.value = true
+    }
+
+    function onFocusin (e: FocusEvent) {
+      isFocused.value = true
+    }
+
+    function onFocusout (e: FocusEvent) {
+      if (e.relatedTarget == null) {
+        vTextFieldRef.value?.focus()
+      }
     }
 
     const isSelecting = ref(false)
@@ -258,9 +275,12 @@ export const VAutocomplete = genericComponent<new <
                   { ...props.menuProps }
                 >
                   <VList
+                    ref={ listRef }
                     selected={ selected.value }
                     selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                     onMousedown={ (e: MouseEvent) => e.preventDefault() }
+                    onFocusin={ onFocusin }
+                    onFocusout={ onFocusout }
                   >
                     { !filteredItems.value.length && !props.hideNoData && (slots['no-data']?.() ?? (
                       <VListItem title={ t(props.noDataText) } />

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -163,6 +163,7 @@ export const VCombobox = genericComponent<new <
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))
     const selection = computed(() => selections.value[selectionIndex.value])
+    const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
       model.value = []
@@ -197,6 +198,12 @@ export const VCombobox = genericComponent<new <
 
       if (['Enter', 'Escape', 'Tab'].includes(e.key)) {
         isPristine.value = true
+      }
+
+      if (e.key === 'ArrowDown') {
+        listRef.value?.focus('next')
+      } else if (e.key === 'ArrowUp') {
+        listRef.value?.focus('prev')
       }
 
       if (!props.multiple) return
@@ -276,6 +283,16 @@ export const VCombobox = genericComponent<new <
       }
     }
 
+    function onFocusin (e: FocusEvent) {
+      isFocused.value = true
+    }
+
+    function onFocusout (e: FocusEvent) {
+      if (e.relatedTarget == null) {
+        vTextFieldRef.value?.focus()
+      }
+    }
+
     watch(filteredItems, val => {
       if (!val.length && props.hideNoData) menu.value = false
     })
@@ -284,6 +301,7 @@ export const VCombobox = genericComponent<new <
       if (val) {
         selectionIndex.value = -1
       } else {
+        console.log('out')
         menu.value = false
 
         if (!props.multiple || !search.value) return
@@ -337,9 +355,12 @@ export const VCombobox = genericComponent<new <
                   { ...props.menuProps }
                 >
                   <VList
+                    ref={ listRef }
                     selected={ selected.value }
                     selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                     onMousedown={ (e: MouseEvent) => e.preventDefault() }
+                    onFocusin={ onFocusin }
+                    onFocusout={ onFocusout }
                   >
                     { !filteredItems.value.length && !props.hideNoData && (slots['no-data']?.() ?? (
                       <VListItem title={ t(props.noDataText) } />

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -301,7 +301,6 @@ export const VCombobox = genericComponent<new <
       if (val) {
         selectionIndex.value = -1
       } else {
-        console.log('out')
         menu.value = false
 
         if (!props.multiple || !search.value) return

--- a/packages/vuetify/src/components/VList/VListGroup.tsx
+++ b/packages/vuetify/src/components/VList/VListGroup.tsx
@@ -71,16 +71,26 @@ export const VListGroup = genericComponent<new <T extends InternalListItem>() =>
   },
 
   setup (props, { slots }) {
-    const { isOpen, open } = useNestedItem(toRef(props, 'value'), true)
+    const { isOpen, open, id: _id } = useNestedItem(toRef(props, 'value'), true)
+    const id = computed(() => `v-list-group--id-${String(id.value)}`)
     const list = useList()
 
-    const onClick = (e: Event) => {
+    function onClick (e: Event) {
       open(!isOpen.value, e)
+    }
+
+    function onKeydown (e: KeyboardEvent) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        onClick(e)
+      }
     }
 
     const activatorProps: Ref<ListGroupActivatorSlot['props']> = computed(() => ({
       onClick,
+      onKeydown,
       class: 'v-list-group__header',
+      id: id.value,
     }))
 
     const toggleIcon = computed(() => isOpen.value ? props.collapseIcon : props.expandIcon)
@@ -117,7 +127,7 @@ export const VListGroup = genericComponent<new <T extends InternalListItem>() =>
         ) }
 
         <VExpandTransition>
-          <div class="v-list-group__items" v-show={ isOpen.value }>
+          <div class="v-list-group__items" role="group" aria-labelledby={ id.value } v-show={ isOpen.value }>
             { slots.default?.() }
           </div>
         </VExpandTransition>

--- a/packages/vuetify/src/components/VList/VListGroup.tsx
+++ b/packages/vuetify/src/components/VList/VListGroup.tsx
@@ -72,23 +72,15 @@ export const VListGroup = genericComponent<new <T extends InternalListItem>() =>
 
   setup (props, { slots }) {
     const { isOpen, open, id: _id } = useNestedItem(toRef(props, 'value'), true)
-    const id = computed(() => `v-list-group--id-${String(id.value)}`)
+    const id = computed(() => `v-list-group--id-${String(_id.value)}`)
     const list = useList()
 
     function onClick (e: Event) {
       open(!isOpen.value, e)
     }
 
-    function onKeydown (e: KeyboardEvent) {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault()
-        onClick(e)
-      }
-    }
-
     const activatorProps: Ref<ListGroupActivatorSlot['props']> = computed(() => ({
       onClick,
-      onKeydown,
       class: 'v-list-group__header',
       id: id.value,
     }))

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -239,6 +239,6 @@ $base-padding: list.nth($list-item-padding, 2)
 .v-list-group__items .v-list-item
   padding-inline-start: calc(#{$base-padding} + var(--indent-padding)) !important
 
-.v-list-group__header.v-list-item--active
+.v-list-group__header.v-list-item--active:not(:focus-visible)
   .v-list-item__overlay
-    display: none
+    opacity: 0

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -94,7 +94,7 @@ export const VListItem = genericComponent<new () => {
     ...makeVariantProps({ variant: 'text' } as const),
   },
 
-  setup (props, { attrs, slots }) {
+  setup (props, { attrs, slots, emit }) {
     const link = useLink(props, attrs)
     const id = computed(() => props.value ?? link.href.value)
     const { select, isSelected, isIndeterminate, isGroupActivator, root, parent, openOnSelect } = useNestedItem(id, false)
@@ -142,6 +142,22 @@ export const VListItem = genericComponent<new () => {
       isIndeterminate: isIndeterminate.value,
     }))
 
+    function onClick (e: MouseEvent) {
+      emit('click', e)
+
+      if (isGroupActivator) return
+
+      link.navigate?.(e)
+      props.value != null && select(!isSelected.value, e)
+    }
+
+    function onKeyDown (e: KeyboardEvent) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        onClick(e as any as MouseEvent)
+      }
+    }
+
     useRender(() => {
       const Tag = isLink.value ? 'a' : props.tag
       const hasColor = !list || isSelected.value || isActive.value
@@ -162,7 +178,7 @@ export const VListItem = genericComponent<new () => {
               'v-list-item--link': isClickable.value,
               'v-list-item--nav': props.nav,
               'v-list-item--prepend': !hasPrepend && list?.hasPrepend.value,
-              [`${props.activeClass}`]: isActive.value,
+              [`${props.activeClass}`]: props.activeClass && isActive.value,
             },
             themeClasses.value,
             borderClasses.value,
@@ -179,12 +195,8 @@ export const VListItem = genericComponent<new () => {
           ]}
           href={ link.href.value }
           tabindex={ isClickable.value ? 0 : undefined }
-          onClick={ isClickable.value && ((e: MouseEvent) => {
-            if (isGroupActivator) return
-
-            link.navigate?.(e)
-            props.value != null && select(!isSelected.value, e)
-          })}
+          onClick={ isClickable.value && onClick }
+          onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value }
         >
           { genOverlays(isClickable.value || isActive.value, 'v-list-item') }

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -94,6 +94,10 @@ export const VListItem = genericComponent<new () => {
     ...makeVariantProps({ variant: 'text' } as const),
   },
 
+  emits: {
+    click: (e: Event) => true,
+  },
+
   setup (props, { attrs, slots, emit }) {
     const link = useLink(props, attrs)
     const id = computed(() => props.value ?? link.href.value)
@@ -145,7 +149,7 @@ export const VListItem = genericComponent<new () => {
     function onClick (e: MouseEvent) {
       emit('click', e)
 
-      if (isGroupActivator) return
+      if (isGroupActivator || !isClickable.value) return
 
       link.navigate?.(e)
       props.value != null && select(!isSelected.value, e)
@@ -195,7 +199,7 @@ export const VListItem = genericComponent<new () => {
           ]}
           href={ link.href.value }
           tabindex={ isClickable.value ? 0 : undefined }
-          onClick={ isClickable.value && onClick }
+          onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value }
         >

--- a/packages/vuetify/src/components/VList/__tests__/__snapshots__/VList.spec.ts.snap
+++ b/packages/vuetify/src/components/VList/__tests__/__snapshots__/VList.spec.ts.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`VList should match a snapshot 1`] = `
-<div class="v-list v-theme--light v-list--density-default v-list--one-line">
+<div class="v-list v-theme--light v-list--density-default v-list--one-line"
+     role="listbox"
+>
 </div>
 `;

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -103,7 +103,7 @@ export const VSelect = genericComponent<new <
 
   setup (props, { slots }) {
     const { t } = useLocale()
-    const vTextFieldRef = ref<VTextField>()
+    const vTextFieldRef = ref()
     const menu = useProxiedModel(props, 'menu')
     const { items, transformIn, transformOut } = useItems(props)
     const model = useProxiedModel(
@@ -183,12 +183,8 @@ export const VSelect = genericComponent<new <
     }
     function onFocusout (e: FocusEvent) {
       if (e.relatedTarget == null) {
-        console.log(menu.value)
         vTextFieldRef.value?.focus()
       }
-      // if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
-      //   menu.value = false
-      // }
     }
 
     useRender(() => {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -122,6 +122,7 @@ export const VSelect = genericComponent<new <
       })
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))
+    const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
       model.value = []
@@ -148,6 +149,16 @@ export const VSelect = genericComponent<new <
       if (['Escape', 'Tab'].includes(e.key)) {
         menu.value = false
       }
+
+      if (e.key === 'ArrowDown') {
+        listRef.value?.focus('next')
+      } else if (e.key === 'ArrowUp') {
+        listRef.value?.focus('prev')
+      } else if (e.key === 'Home') {
+        listRef.value?.focus('first')
+      } else if (e.key === 'End') {
+        listRef.value?.focus('last')
+      }
     }
     function select (item: InternalItem) {
       if (props.multiple) {
@@ -164,6 +175,20 @@ export const VSelect = genericComponent<new <
         model.value = [item]
         menu.value = false
       }
+    }
+    function onBlur (e: FocusEvent) {
+      if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
+        menu.value = false
+      }
+    }
+    function onFocusout (e: FocusEvent) {
+      if (e.relatedTarget == null) {
+        console.log(menu.value)
+        vTextFieldRef.value?.focus()
+      }
+      // if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
+      //   menu.value = false
+      // }
     }
 
     useRender(() => {
@@ -189,7 +214,7 @@ export const VSelect = genericComponent<new <
           readonly
           onClick:clear={ onClear }
           onClick:control={ onClickControl }
-          onBlur={ () => menu.value = false }
+          onBlur={ onBlur }
           onKeydown={ onKeydown }
         >
           {{
@@ -207,9 +232,11 @@ export const VSelect = genericComponent<new <
                   { ...props.menuProps }
                 >
                   <VList
+                    ref={ listRef }
                     selected={ selected.value }
                     selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                     onMousedown={ (e: MouseEvent) => e.preventDefault() }
+                    onFocusout={ onFocusout }
                   >
                     { !items.value.length && !props.hideNoData && (slots['no-data']?.() ?? (
                       <VListItem title={ t(props.noDataText) } />

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -251,7 +251,6 @@ export const VSlideGroup = genericComponent<new () => {
       if (!contentRef.value) return
 
       if (!location) {
-        contentRef.value.querySelector('[tabindex]')
         const focusable = [...contentRef.value.querySelectorAll(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         )].filter(el => !el.hasAttribute('disabled')) as HTMLElement[]

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -11,7 +11,7 @@ import {
 } from './selectStrategies'
 
 // Types
-import type { InjectionKey, Prop, Ref } from 'vue'
+import type { InjectionKey, PropType, Ref } from 'vue'
 import type { SelectStrategyFn } from './selectStrategies'
 import type { OpenStrategy } from './openStrategies'
 
@@ -64,10 +64,10 @@ export const emptyNested: NestedProvide = {
 }
 
 export const makeNestedProps = propsFactory({
-  selectStrategy: [String, Function] as Prop<SelectStrategy>,
-  openStrategy: [String, Function] as Prop<OpenStrategyProp>,
-  opened: Array as Prop<unknown[]>,
-  selected: Array as Prop<unknown[]>,
+  selectStrategy: [String, Function] as PropType<SelectStrategy>,
+  openStrategy: [String, Function] as PropType<OpenStrategyProp>,
+  opened: Array as PropType<unknown[]>,
+  selected: Array as PropType<unknown[]>,
   mandatory: Boolean,
 }, 'nested')
 
@@ -217,7 +217,7 @@ export const useNested = (props: NestedProps) => {
 export const useNestedItem = (id: Ref<unknown>, isGroup: boolean) => {
   const parent = inject(VNestedSymbol, emptyNested)
 
-  const computedId = computed(() => id.value ?? getUid().toString())
+  const computedId = computed(() => id.value ?? Symbol(getUid()))
 
   const item = {
     ...parent,


### PR DESCRIPTION
Closes #15428

https://w3c.github.io/aria-practices/examples/listbox/listbox-grouped.html
https://w3c.github.io/aria/#listbox
https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#x6-6-keyboard-navigation-inside-components
https://www.w3.org/WAI/ARIA/apg/example-index/menu-button/menu-button-actions.html

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-tabs>
        <v-tab>Tab 1</v-tab>
        <v-tab>Tab 2</v-tab>
        <v-tab>Tab 3</v-tab>
      </v-tabs>
      <br>
      <v-list :items="listItems" />
      <br>
      <v-select :items="selectItems" />
    </v-container>
  </v-app>
</template>

<script setup>
  const listItems = [
    { title: 'Item 1' },
    { title: 'Item 2' },
    {
      title: 'Item 3',
      // value: 'item-3',
      children: [
        { title: 'Item 3.1' },
        { title: 'Item 3.2', value: 'item-3.2' },
        { title: 'Item 3.3' },
      ],
    },
    { title: 'Item 4' },
    { title: 'Item 5', value: 'item-5' },
    { title: 'Item 6' },
  ]
  const selectItems = [
    { title: 'Item 1' },
    { title: 'Item 2' },
    { title: 'Item 3' },
    { title: 'Item 4' },
  ]
</script>
```
</details>

