### PR TITLE
fix(VComboBox): add "allow-overflow" prop

### DIFF
--- a/packages/api-generator/src/locale/en/generic.json
+++ b/packages/api-generator/src/locale/en/generic.json
@@ -11,7 +11,8 @@
     "tag": "Specify a custom tag used on the root element.",
     "textColor": "Applies a specified color to the control text",
     "trueValue": "Sets value for truthy state",
-    "width": "Sets the width for the component."
+    "width": "Sets the width for the component.",
+    "allow-overflow": "Turns on or off scrolling for the items list"
   },
   "slots": {
     "activator": "When used, will activate the component when clicked (or hover for specific components). This manually stops the event propagation. Without this slot, if you open the component through its model, you will need to manually stop the event propagation",

--- a/packages/docs/src/examples/v-combobox/allow-overflow.vue
+++ b/packages/docs/src/examples/v-combobox/allow-overflow.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12">
+        <v-combobox
+          v-model="select"
+          :items="items"
+          label="Combobox"
+          multiple
+          outlined
+          :allow-overflow="false"
+        ></v-combobox>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+  export default {
+    data () {
+      return {
+        select: ['Vuetify', 'Programming'],
+        items: [
+          'Programming',
+          'Design',
+          'Vue',
+          'Vuetify',
+        ],
+      }
+    },
+  }
+</script>

--- a/packages/docs/src/pages/en/components/combobox.md
+++ b/packages/docs/src/pages/en/components/combobox.md
@@ -57,6 +57,12 @@ You can use `dense` prop to reduce combobox height and lower max height of list 
 
 <example file="v-combobox/prop-dense" />
 
+#### Allow Overflow
+
+You can use the `allow-overflow` prop to turn on or off scrolling of the list items.
+
+<example file="v-combobox/allow-overflow" />
+
 #### Multiple combobox
 
 Previously known as **tags** - user is allowed to enter more than 1 value

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -133,6 +133,7 @@ export default VSelect.extend({
       return {
         ...defaultMenuProps,
         ...props,
+        allowOverflow: this.allowOverflow !== undefined ? this.allowOverflow : false,
       }
     },
     searchIsDirty (): boolean {

--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -61,6 +61,10 @@ export default baseMixins.extend({
       type: Boolean,
       default: true,
     },
+    allowOverflow: {
+      type: Boolean,
+      default: false,
+    },
     closeOnContentClick: {
       type: Boolean,
       default: true,
@@ -150,7 +154,7 @@ export default baseMixins.extend({
     },
     styles (): object {
       return {
-        maxHeight: this.calculatedMaxHeight,
+        maxHeight: this.allowOverflow ? this.calculatedMaxHeight : 'auto',
         minWidth: this.calculatedMinWidth,
         maxWidth: this.calculatedMaxWidth,
         top: this.calculatedTop,

--- a/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect3.spec.ts.snap
+++ b/packages/vuetify/src/components/VSelect/__tests__/__snapshots__/VSelect3.spec.ts.snap
@@ -56,7 +56,7 @@ exports[`VSelect.ts should open the select is multiple and key down is pressed 1
 >
   <div
     class="v-menu__content theme--light menuable__content__active "
-    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
+    style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
   >
     <div
       class="v-list v-select-list v-sheet theme--light theme--light"
@@ -145,7 +145,7 @@ exports[`VSelect.ts should open the select is multiple and key up is pressed 1`]
 >
   <div
     class="v-menu__content theme--light menuable__content__active "
-    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
+    style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
   >
     <div
       class="v-list v-select-list v-sheet theme--light theme--light"
@@ -234,7 +234,7 @@ exports[`VSelect.ts should open the select when enter is pressed 1`] = `
 >
   <div
     class="v-menu__content theme--light menuable__content__active "
-    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
+    style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
   >
     <div
       class="v-list v-select-list v-sheet theme--light theme--light"
@@ -287,7 +287,7 @@ exports[`VSelect.ts should open the select when space is pressed 1`] = `
 >
   <div
     class="v-menu__content theme--light menuable__content__active "
-    style="max-height: 304px; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
+    style="max-height: auto; min-width: 0px; max-width: auto; top: 12px; left: 0px; transform-origin: top left; z-index: 8; display: none;"
   >
     <div
       class="v-list v-select-list v-sheet theme--light theme--light"


### PR DESCRIPTION
## Description
Before this change, adding "allow-overflow" as a prop to v-combobox would do nothing.
But with this change, setting allow-overflow to true will allow overflow (scrolling), this is also the default if this prop isnt passed through.
Upon setting allow overflow to false, scrolling is turned off.

**Resolves issue: #16008** 

## Motivation and Context
This would be needed because alot of people would like to display the combo list in its entirety instead of requiring the user to scroll through the list to see everything.

## How Has This Been Tested?
I have tested this with both the prop set to false, true and also without the prop.
I also ran the tests included in vuetify.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)