### PR TITLE
fix(VList): prevent scroll on keyboard navigation

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -155,8 +155,10 @@ export const VAutocomplete = genericComponent<new <
       }
 
       if (e.key === 'ArrowDown') {
+        e.preventDefault()
         listRef.value?.focus('next')
       } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
         listRef.value?.focus('prev')
       }
     }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -201,8 +201,10 @@ export const VCombobox = genericComponent<new <
       }
 
       if (e.key === 'ArrowDown') {
+        e.preventDefault()
         listRef.value?.focus('next')
       } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
         listRef.value?.focus('prev')
       }
 

--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -181,7 +181,11 @@ export const VList = genericComponent<new <T>() => {
         focus('first')
       } else if (e.key === 'End') {
         focus('last')
+      } else {
+        return
       }
+
+      e.preventDefault()
     }
 
     function focus (location?: 'next' | 'prev' | 'first' | 'last') {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -143,6 +143,7 @@ export const VSelect = genericComponent<new <
       if (props.readonly) return
 
       if (['Enter', 'ArrowDown', ' '].includes(e.key)) {
+        e.preventDefault()
         menu.value = true
       }
 
@@ -153,10 +154,13 @@ export const VSelect = genericComponent<new <
       if (e.key === 'ArrowDown') {
         listRef.value?.focus('next')
       } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
         listRef.value?.focus('prev')
       } else if (e.key === 'Home') {
+        e.preventDefault()
         listRef.value?.focus('first')
       } else if (e.key === 'End') {
+        e.preventDefault()
         listRef.value?.focus('last')
       }
     }


### PR DESCRIPTION
## Description
fixes #16034

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div style="height: 2000px">
    <v-select
      v-model="select"
      :items="['foo', 'bar', 'baz', 'fizz', 'buzz']"
      label="Select"
    />
    <v-combobox
      v-model="select"
      :items="['foo', 'bar', 'baz', 'fizz', 'buzz']"
      label="Select"
    />
    <v-autocomplete
      v-model="select"
      :items="['foo', 'bar', 'baz', 'fizz', 'buzz']"
      label="Select"
    />
  </div>
</template>

<script setup>
  const select = null
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
