### PR TITLE
fix(defaults): assume capital first is nested component

### DIFF
--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -61,11 +61,7 @@ export const defineComponent = (function defineComponent (options: ComponentOpti
         const componentDefaults = defaults.value[props._as ?? options.name!]
 
         if (componentDefaults) {
-          const subComponents = Object.entries(componentDefaults).filter(([key]) => {
-            const char = key.charAt(0)
-
-            return char.toUpperCase() === char
-          })
+          const subComponents = Object.entries(componentDefaults).filter(([key]) => key[0] === key[0].toUpperCase())
           if (subComponents.length) _subcomponentDefaults.value = Object.fromEntries(subComponents)
         }
 

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -61,7 +61,11 @@ export const defineComponent = (function defineComponent (options: ComponentOpti
         const componentDefaults = defaults.value[props._as ?? options.name!]
 
         if (componentDefaults) {
-          const subComponents = Object.entries(componentDefaults).filter(([key]) => key.startsWith('V'))
+          const subComponents = Object.entries(componentDefaults).filter(([key]) => {
+            const char = key.charAt(0)
+
+            return char.toUpperCase() === char
+          })
           if (subComponents.length) _subcomponentDefaults.value = Object.fromEntries(subComponents)
         }
 


### PR DESCRIPTION
## Motivation and Context

fix support for nested aliased components 

## Markup:
<details>

```js
// vuetify.js
import '@mdi/font/css/materialdesignicons.css'
import { createVuetify } from 'vuetify/src/entry-bundler'
import { aliases, mdi } from 'vuetify/src/iconsets/mdi'
import { fa } from 'vuetify/src/iconsets/fa-svg'
import { ar, en, ja, sv } from 'vuetify/src/locale'
import { VBtn, VCard } from '../src/components'

export default createVuetify({
  aliases: {
    ZBtn: VBtn,
    ZCard: VCard,
  },
  defaults: {
    ZCard: {
      variant: 'outlined',
      ZBtn: {
        color: 'primary',
      },
    },
  },
  ssr: !!process.env.VITE_SSR,
  locale: {
    messages: {
      en,
      ar,
      sv,
      ja,
    },
  },
  icons: {
    defaultSet: 'mdi',
    aliases,
    sets: {
      mdi,
      fa,
    },
  },
})
```
</details>