### PR TITLE
docs(frequently-asked): fix broken link

### DIFF
--- a/packages/docs/src/pages/en/getting-started/frequently-asked-questions.md
+++ b/packages/docs/src/pages/en/getting-started/frequently-asked-questions.md
@@ -162,7 +162,7 @@ export default {
 
 - **My _/_ link is active when I'm on _/home_ page.**{ #link-active-home }
 
-  Add the **exact** to the link that points to absolute /. For more information on this, you can visit the official Vue router [documentation](https://router.vuejs.org/en/api/router-link.html).
+  Add the **exact** to the link that points to absolute /. For more information on this, you can visit the official Vue router [documentation](https://router.vuejs.org/api/#routerlink).
 
 <br>
 

--- a/packages/docs/src/pages/en/styles/display.md
+++ b/packages/docs/src/pages/en/styles/display.md
@@ -73,18 +73,6 @@ The _condition_ applies the class base on:
 
 Additionally, **media types** can be targeted using the `only` condition. Both `hidden-screen-only` and `hidden-print-only` are currently supported.
 
-### Drawbacks
-
-It is important to note that using any of the display classes above will result in any display style previously added being overwritten.
-
-This is because of the classes using `!important` in their display styling.
-
-#### Example
-
-If you have an element which already has `display: block` in it's style.
-
-If you then were to add the class `d-flex` to it, this would be overwritten and it would now use the style from `d-flex` instead of the original one (`display: flex!important`)
-
 ## Display in print
 
 You can also change the display property when printing.

--- a/packages/docs/src/pages/en/styles/display.md
+++ b/packages/docs/src/pages/en/styles/display.md
@@ -73,6 +73,18 @@ The _condition_ applies the class base on:
 
 Additionally, **media types** can be targeted using the `only` condition. Both `hidden-screen-only` and `hidden-print-only` are currently supported.
 
+### Drawbacks
+
+It is important to note that using any of the display classes above will result in any display style previously added being overwritten.
+
+This is because of the classes using `!important` in their display styling.
+
+#### Example
+
+If you have an element which already has `display: block` in it's style.
+
+If you then were to add the class `d-flex` to it, this would be overwritten and it would now use the style from `d-flex` instead of the original one (`display: flex!important`)
+
 ## Display in print
 
 You can also change the display property when printing.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The link for vue-router, router-link documentation has been changed and therefore the current link is no longer valid, this PR changes the link to the current and updated vue-router link.

<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
#15084

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
It is quite obvious why this is required, the link is outdated which makes that part of the documentation worthless without updating it.

<!-- If it fixes an open issue, please link to the issue here. -->
#15084

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
Since this is just documentation, it has been tested locally on my computer, both with a dev server and after building.

## Markup:
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
