### PR TITLE
docs: fix typo in flex-align-self.vue example

### DIFF
--- a/packages/docs/src/examples/flex/flex-align-self.vue
+++ b/packages/docs/src/examples/flex/flex-align-self.vue
@@ -22,7 +22,7 @@
     height="100"
   >
     <v-sheet class="ma-2 pa-2">Flex item</v-sheet>
-    <v-sheet class="ma-2 pa-2 align-self-center">align-self-start</v-sheet>
+    <v-sheet class="ma-2 pa-2 align-self-center">align-self-center</v-sheet>
     <v-sheet class="ma-2 pa-2">Flex item</v-sheet>
   </v-sheet>
 


### PR DESCRIPTION
## Description
The box with the class align-self-center had the textual content align-self-start.
Updated the text to match the class.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
