### PR TITLE
chore: fix importMap paths on windows

### DIFF
--- a/packages/vuetify/build/rollup.config.js
+++ b/packages/vuetify/build/rollup.config.js
@@ -107,7 +107,7 @@ export default {
           )
           await Promise.all(importedIds.map(async id => {
             // Fix for Windows
-            const importFrom = path.relative(path.resolve(__dirname, '../src'), id.replace(/.*:\\/, '\\').replaceAll('\\', '/')).replace(/\.ts$/, '.mjs')
+            const importFrom = path.relative(path.resolve(__dirname, '../src'), id.replace(/^[^:]+:\\/, '\\').replaceAll('\\', '/')).replace(/\.ts$/, '.mjs')
 
             if (await this.resolve(path.join(id, '../_variables.scss')) != null) {
               variables.push(id)

--- a/packages/vuetify/build/rollup.config.js
+++ b/packages/vuetify/build/rollup.config.js
@@ -106,6 +106,8 @@ export default {
             (await this.resolve('src/components/index.ts')).id
           )
           await Promise.all(importedIds.map(async id => {
+            // Fix for Windows
+            id = id.replace(/.*:\\/, '\\').replaceAll('\\', '/')
             const importFrom = path.relative(path.resolve(__dirname, '../src'), id).replace(/\.ts$/, '.mjs')
 
             if (await this.resolve(path.join(id, '../_variables.scss')) != null) {

--- a/packages/vuetify/build/rollup.config.js
+++ b/packages/vuetify/build/rollup.config.js
@@ -107,8 +107,7 @@ export default {
           )
           await Promise.all(importedIds.map(async id => {
             // Fix for Windows
-            id = id.replace(/.*:\\/, '\\').replaceAll('\\', '/')
-            const importFrom = path.relative(path.resolve(__dirname, '../src'), id).replace(/\.ts$/, '.mjs')
+            const importFrom = path.relative(path.resolve(__dirname, '../src'), id.replace(/.*:\\/, '\\').replaceAll('\\', '/')).replace(/\.ts$/, '.mjs')
 
             if (await this.resolve(path.join(id, '../_variables.scss')) != null) {
               variables.push(id)

--- a/packages/vuetify/build/rollup.config.js
+++ b/packages/vuetify/build/rollup.config.js
@@ -22,6 +22,10 @@ const banner = `/*!
 * Released under the MIT License.
 */\n`
 
+function fixWindowsPath(path) {
+  return path.replace(/^[^:]+:\\/, '\\').replaceAll('\\', '/')
+}
+
 export default {
   input: 'src/entry-bundler.ts',
   output: [
@@ -80,7 +84,7 @@ export default {
 
         // Individual CSS files
         for (const { id, content } of styleNodes) {
-          const out = path.parse(id.replace(
+          const out = path.parse(fixWindowsPath(id).replace(
             path.resolve(__dirname, '../src'),
             path.resolve(__dirname, '../lib')
           ))
@@ -107,7 +111,7 @@ export default {
           )
           await Promise.all(importedIds.map(async id => {
             // Fix for Windows
-            const importFrom = path.relative(path.resolve(__dirname, '../src'), id.replace(/^[^:]+:\\/, '\\').replaceAll('\\', '/')).replace(/\.ts$/, '.mjs')
+            const importFrom = path.relative(path.resolve(__dirname, '../src'), fixWindowsPath(id)).replace(/\.ts$/, '.mjs')
 
             if (await this.resolve(path.join(id, '../_variables.scss')) != null) {
               variables.push(id)


### PR DESCRIPTION
Building Vuetify on windows was producing incorrect paths in importMap ~~(+ few eslint fixes because autofix on save)~~

Also fixed generating .css files in wrong folder when building Vuetify

### steps
- build vuetify
- build api
- check api-generator/src/attributes.json (should not be empty)