### PR TITLE
fix(VNavigationDrawer): wait for nextTick in isTemporary watch

### DIFF
--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -19,7 +19,7 @@ import { useSticky } from './sticky'
 import { useTouch } from './touch'
 
 // Utilities
-import { computed, onBeforeMount, ref, toRef, Transition, watch } from 'vue'
+import { computed, nextTick, onBeforeMount, ref, toRef, Transition, watch } from 'vue'
 import { convertToUnit, defineComponent, toPhysical, useRender } from '@/util'
 
 // Types
@@ -107,7 +107,7 @@ export const VNavigationDrawer = defineComponent({
     )
 
     if (!props.disableResizeWatcher) {
-      watch(isTemporary, val => !props.permanent && (isActive.value = !val))
+      watch(isTemporary, val => !props.permanent && (nextTick(() => isActive.value = !val)))
     }
 
     if (!props.disableRouteWatcher && router) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
When having rail as a prop and v-model i noticed that while resizing the drawer scrim stayed on top and application became unusable because isActive value stayed benig true. Thats why I added nextTick on the update of isActive so when all resizing is done and DOM is updated, we update isActive.

Not 100% sure why this was happening only when you had rail as a prop, but like I said I noticed `isActive` state being `true` when you resize.

fix #15807

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->
I tested visially but I can also maybe create tests checking if scrim is on top when resizing the window

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
