### PR TITLE
docs: add missing VAppBar/VToolbar slots

### DIFF
--- a/packages/api-generator/src/locale/en/v-app-bar.json
+++ b/packages/api-generator/src/locale/en/v-app-bar.json
@@ -16,7 +16,10 @@
     "image": "The `src` used for `v-img`. For additional customization options, use the **image** slot."
   },
   "slots": {
-    "extension": "Slot positioned directly under the main content of the toolbar. Height of this slot can be set explicitly with the **extension-height** prop.",
-    "image": "Expects the [`v-img`](/components/images/) component."
+    "append": "Adds an item before the app bar content",
+    "extension": "Slot positioned directly under the main content of the app bar. Height of this slot can be set explicitly with the **extension-height** prop.",
+    "image": "Expects the [`v-img`](/components/images/) component.",
+    "prepend": "Adds an item after the app bar content",
+    "title": "Slot containing the app bar title"
   }
 }

--- a/packages/api-generator/src/locale/en/v-toolbar.json
+++ b/packages/api-generator/src/locale/en/v-toolbar.json
@@ -14,7 +14,10 @@
     "src": "Specifies a [v-img](/components/images) as the component's background."
   },
   "slots": {
-    "extension": "Slot positioned directly under the main content of the toolbar. Height of this slot can be set explicitly with the **extension-height** prop. If this slot has no content, the **extended** prop may be used instead.",
-    "img": "Expects the [v-img](/components/images) component. Scoped **props** should be applied with `v-bind=\"props\"`."
+    "append": "Adds an item before the toolbar content",
+    "extension": "Slot positioned directly under the main content of the toolbar. Height of this slot can be set explicitly with the **extension-height** prop.",
+    "image": "Expects the [`v-img`](/components/images/) component.",
+    "prepend": "Adds an item after the toolbar content",
+    "title": "Slot containing the toolbar title"
   }
 }

--- a/packages/vuetify/src/components/VAppBar/VAppBar.tsx
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.tsx
@@ -10,12 +10,16 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref, toRef } from 'vue'
-import { defineComponent, useRender } from '@/util'
+import { genericComponent, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
+import type { SlotsToProps } from '@/util'
+import type { VToolbarSlots } from '@/components/VToolbar/VToolbar'
 
-export const VAppBar = defineComponent({
+export const VAppBar = genericComponent<new () => {
+  $props: SlotsToProps<VToolbarSlots>
+}>()({
   name: 'VAppBar',
 
   props: {

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -22,7 +22,7 @@ import { convertToUnit, genericComponent, pick, propsFactory, useRender } from '
 
 // Types
 import type { ExtractPropTypes, PropType } from 'vue'
-import type { SlotsToProps } from '@/util'
+import type { MakeSlots, SlotsToProps } from '@/util'
 
 const allowedDensities = [null, 'prominent', 'default', 'comfortable', 'compact'] as const
 
@@ -58,15 +58,17 @@ export const makeVToolbarProps = propsFactory({
   ...makeThemeProps(),
 }, 'v-toolbar')
 
+export type VToolbarSlots = MakeSlots<{
+  default: []
+  image: []
+  prepend: []
+  append: []
+  title: []
+  extension: []
+}>
+
 export const VToolbar = genericComponent<new () => {
-  $props: SlotsToProps<{
-    default: []
-    image: []
-    prepend: []
-    append: []
-    title: []
-    extension: []
-  }>
+  $props: SlotsToProps<VToolbarSlots>
 }>()({
   name: 'VToolbar',
 


### PR DESCRIPTION
fixes #16141

## How Has This Been Tested?
playground/docs

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-main>
    <v-app-bar>
      <template #title>Title slot (VAppBar)</template>
      <template #prepend>Prepend slot (VAppBar)</template>
      <template #append>Append slot (VAppBar)</template>
    </v-app-bar>
    <v-app-bar title="Title prop (VAppBar)" />

    <v-toolbar>
      <template #title>Title slot (VToolbar)</template>
      <template #prepend>Prepend slot (VToolbar)</template>
      <template #append>Append slot (VToolbar)</template>
    </v-toolbar>
    <v-toolbar title="Title prop (VToolbar)" />
  </v-main>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
