### PR TITLE
docs(icon-fonts): improve accuracy of mdi-svg usage

### DIFF
--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -133,13 +133,9 @@ Use this tool to search for any Material Design Icons and copy them to your clip
 
 ### Material Design Icons - JS SVG
 
-Use the SVG paths as designated in [@mdi/js](https://www.npmjs.com/package/@mdi/js). This is the recommended installation when optimizing your application for production.
-
-```bash
-$ yarn add @mdi/js -D
-// OR
-$ npm install @mdi/js -D
-```
+This is the recommended installation when optimizing your application for production, as only icons used for
+Vuetify components internally will be imported into your application bundle. You will need to provide your
+own icons for the rest of the app.
 
 ```js { resource="src/plugins/vuetify.js" }
 import { createVuetify } from 'vuetify'
@@ -156,7 +152,18 @@ export default createVuetify({
 })
 ```
 
-To reduce bundle size, only import the icons that you need. The following example shows how to use an imported icon within a `.vue` template:
+`@mdi/js` or [unplugin-icons](https://github.com/antfu/unplugin-icons) are two alternatives to get the
+rest of the icons that you will need in your application.
+
+If you want to stick with `@mdi/js`, use the SVG paths as designated in [@mdi/js](https://www.npmjs.com/package/@mdi/js) and
+only import the icons that you need.
+The following example shows how to use an imported icon within a `.vue` SFC template:
+
+```bash
+$ yarn add @mdi/js -D
+// OR
+$ npm install @mdi/js -D
+```
 
 ```html
 <template>

--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -181,6 +181,33 @@ $ npm install @mdi/js -D
 </script>
 ```
 
+Or the icons you want to use can be added as aliases to simplify reuse:
+
+```js { resource="src/plugins/vuetify.js" }
+import { createVuetify } from 'vuetify'
+import { aliases, mdi } from 'vuetify/iconsets/mdi-svg'
+import { mdiAccount } from '@mdi/js'
+
+export default createVuetify({
+  icons: {
+    defaultSet: 'mdi',
+    aliases: {
+      ...aliases,
+      account: mdiAccount,
+    },
+    sets: {
+      mdi,
+    },
+  },
+})
+```
+
+```html
+<template>
+  <v-icon icon="$account" />
+</template>
+```
+
 ### Material Icons
 
 For projects without a build process, it is recommended to import the icons from CDN.


### PR DESCRIPTION
## Description
Improves the accuracy of the mdi-svg usage, explaining why it's the recommended method for production environments and mention the ability to use different icons components.

## Motivation and Context
As discussed in Discord (conversation starts [here](https://discord.com/channels/340160225338195969/660898563139567625/1045480458340810754)), I wanted to make sure I only used the minimum icon set for Vuetify to work, as I want to use unplugin-icons for the rest of the app. [Kael](https://discord.com/channels/340160225338195969/660898563139567625/1045930473446195230) confirmed that running the code snippet in this part of the documentation works as I intended.

Later on, #16168 was opened, so components can be passed as slots to ``v-icon``, further improving this usage.

This is the first part of the documentation improvements for this exact use-case (when #16168 is merged, I think a relevant full example with unplugin-icons should be included, as it will make it's usage much better).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [X] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
