### PR TITLE
fix(types): unwrap refs in `this.$vuetify`

### DIFF
--- a/packages/vuetify/src/shims.d.ts
+++ b/packages/vuetify/src/shims.d.ts
@@ -28,9 +28,9 @@ declare module '@vue/runtime-core' {
   interface Vuetify {
     defaults: DefaultsInstance
     display: UnwrapNestedRefs<DisplayInstance>
-    theme: ThemeInstance
+    theme: UnwrapNestedRefs<ThemeInstance>
     icons: IconOptions
-    locale: LocaleInstance & RtlInstance
+    locale: UnwrapNestedRefs<LocaleInstance & RtlInstance>
   }
 
   export interface ComponentCustomProperties {


### PR DESCRIPTION
## Description
Typing for `this.$vuetify` doesn't unwrap refs
Discussion on discord: https://discord.com/channels/340160225338195969/660898563139567625/1047548064866521110

## How Has This Been Tested?
wasn't (due to some unrelated technical problems)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)


## Alternative solution

```ts
  interface Vuetify {
    defaults: DefaultsInstance
    display: DisplayInstance
    theme: ThemeInstance
    icons: IconOptions
    locale: LocaleInstance & RtlInstance
  }

  export interface ComponentCustomProperties {
    $vuetify: UnwrapNestedRefs<Vuetify>
  }
```