### PR TITLE
fix(VSelectionControl/VCheckbox/VSwitch): long label wrapping

### DIFF
--- a/packages/vuetify/.env.local
+++ b/packages/vuetify/.env.local
@@ -1,0 +1,3 @@
+# Development
+HOST=0.0.0.0
+PORT=8080

--- a/packages/vuetify/.env.local
+++ b/packages/vuetify/.env.local
@@ -1,3 +1,0 @@
-# Development
-HOST=0.0.0.0
-PORT=8080

--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.sass
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.sass
@@ -5,4 +5,4 @@
 
 .v-checkbox
   .v-selection-control
-    height: var(--v-input-control-height)
+    min-height: var(--v-input-control-height)

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -14,6 +14,8 @@
   user-select: none
 
   .v-label
+    white-space: normal
+    word-break: break-word
     height: 100%
     width: 100%
 
@@ -33,6 +35,8 @@
   &--inline
     display: inline-flex
     flex: 0 0 auto
+    min-width: 0
+    max-width: 100%
 
     .v-label
       width: auto

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -56,7 +56,7 @@
   $switch-thumb-transform: $switch-track-width * .5 - $switch-thumb-width * .5 + $switch-thumb-offset
 
   .v-selection-control
-    height: var(--v-input-control-height)
+    min-height: var(--v-input-control-height)
 
   .v-selection-control__wrapper
     width: auto


### PR DESCRIPTION
## Motivation and Context
fixes #15708 

## Markup:
<details>

```vue
<template>
  <div class="ma-16 pa-16">
    <v-selection-control label="Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!" />
    <v-checkbox label="Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!" />
    <v-switch label="Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!" />

  </div>
</template>

<script setup>
  // import { computed, ref } from 'vue'
</script>

```
</details>