### PR TITLE
fix(validation): maxErrors is ignored when using errorMessages prop

### DIFF
--- a/packages/vuetify/src/composables/__tests__/validation.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/validation.spec.ts
@@ -57,6 +57,24 @@ describe('validation', () => {
     expect(wrapper.vm.errorMessages).toHaveLength(expected)
   })
 
+  it.each([
+    [undefined, 1],
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [4, 4],
+    [5, 4],
+  ])('only display up to the maximum error count %s', async (maxErrors, expected) => {
+    const wrapper = mountFunction({
+      maxErrors,
+      errorMessages: ['foo', 'bar', 'fizz', 'buzz'],
+    })
+
+    await wrapper.vm.validate()
+
+    expect(wrapper.vm.errorMessages).toHaveLength(expected)
+  })
+
   it('should warn the user when using an improper rule fn', async () => {
     const rule = (v: any) => !!v || 1234
     const wrapper = mountFunction({

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -78,7 +78,7 @@ export function useValidation (
   const isReadonly = computed(() => !!(props.readonly || form?.isReadonly.value))
   const errorMessages = computed(() => {
     return props.errorMessages.length
-      ? wrapInArray(props.errorMessages)
+      ? wrapInArray(props.errorMessages.slice(0, Math.max(0, +props.maxErrors)))
       : internalErrorMessages.value
   })
   const isValid = computed(() => {


### PR DESCRIPTION
## Description
fixes #16197

## How Has This Been Tested?
playground, unit

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<script setup>
  import { ref } from 'vue'

  const errors = ref(['error 1', 'error 2'])
  const rules = ['error 1', 'error 2']
</script>

<template>
  <v-app>
    <v-main>
      <v-text-field label="Error 2 should not be visible" :error-messages="errors" :max-errors="1" />
      <v-text-field label="Error 2 should not be visible" placeholder="Edit me" persistent-placeholder :rules="rules" :max-errors="1" />
    </v-main>
  </v-app>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
