### PR TITLE
fix(VRadioGroup): remove clickable from label

### DIFF
--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -83,7 +83,7 @@ export const VRadioGroup = defineComponent({
             }) => (
               <>
                 { label && (
-                  <VLabel for={ id.value } clickable>
+                  <VLabel for={ id.value }>
                     { label }
                   </VLabel>
                 ) }


### PR DESCRIPTION
## Description
VRadioGroup label should not be clickable (it isn't in Vuetify 2)

## How Has This Been Tested?
playground

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-16 pa-16">
    <v-radio-group label="Lorem ipsum">
      <v-radio label="Lorem ipsum" value="0" />
      <v-radio label="Lorem ipsum" value="1" />
    </v-radio-group>
  </div>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
