### PR TITLE
fix: change _isVue references to vue3's __isVue

### DIFF
--- a/packages/vuetify/src/services/goto/util.ts
+++ b/packages/vuetify/src/services/goto/util.ts
@@ -42,7 +42,7 @@ function type (el: any) {
 function $ (el: any): HTMLElement | null {
   if (typeof el === 'string') {
     return document.querySelector<HTMLElement>(el)
-  } else if (el && el._isVue) {
+  } else if (el && el.__isVue) {
     return (el as Vue).$el as HTMLElement
   } else if (el instanceof HTMLElement) {
     return el

--- a/packages/vuetify/src/util/__tests__/console.spec.ts
+++ b/packages/vuetify/src/util/__tests__/console.spec.ts
@@ -6,7 +6,7 @@ describe('console', () => {
     consoleWarn('foo')
     expect('[Vuetify] foo').toHaveBeenTipped()
 
-    consoleWarn('bar', { _isVue: true, $options: { name: 'baz' } })
+    consoleWarn('bar', { __isVue: true, $options: { name: 'baz' } })
     expect('[Vuetify] bar\n\n(found in <Baz>)').toHaveBeenTipped()
   })
 
@@ -14,7 +14,7 @@ describe('console', () => {
     consoleError('foo')
     expect('[Vuetify] foo').toHaveBeenWarned()
 
-    consoleError('bar', { _isVue: true, $options: { name: 'baz' } })
+    consoleError('bar', { __isVue: true, $options: { name: 'baz' } })
     expect('[Vuetify] bar\n\n(found in <Baz>)').toHaveBeenWarned()
   })
 })

--- a/packages/vuetify/src/util/console.ts
+++ b/packages/vuetify/src/util/console.ts
@@ -6,7 +6,7 @@ function createMessage (message: string, vm?: any, parent?: any): string | void 
 
   if (parent) {
     vm = {
-      _isVue: true,
+      __isVue: true,
       $parent: parent,
       $options: vm,
     }
@@ -64,7 +64,7 @@ function formatComponentName (vm: any, includeFile?: boolean): string {
   }
   const options = typeof vm === 'function' && vm.cid != null
     ? vm.options
-    : vm._isVue
+    : vm.__isVue
       ? vm.$options || vm.constructor.options
       : vm || {}
   let name = options.name || options._componentTag
@@ -81,7 +81,7 @@ function formatComponentName (vm: any, includeFile?: boolean): string {
 }
 
 function generateComponentTrace (vm: any): string {
-  if (vm._isVue && vm.$parent) {
+  if (vm.__isVue && vm.$parent) {
     const tree: any[] = []
     let currentRecursiveSequence = 0
     while (vm) {


### PR DESCRIPTION
## Description
In Vue3 `_isVue` has been renamed to `__isVue`.

References:
https://github.com/vuejs/vue-next/search?q=__isVue
https://github.com/vuejs/vue/search?q=_isVue

## Motivation and Context
I had warnings from Vue3's compatibility mode saying :
`Property "_isVue" was accessed during render but is not defined on instance.`

## How Has This Been Tested?
All relevant unit tests have been amended in this PR.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
