### PR TITLE
fix: improve accessibility of inputs' messages

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -49,12 +49,14 @@ export const VCheckbox = defineComponent({
             ...slots,
             default: ({
               id,
+              messagesId,
               isDisabled,
               isReadonly,
             }) => (
               <VCheckboxBtn
                 { ...checkboxProps }
                 id={ id.value }
+                aria-describedby={ messagesId.value }
                 disabled={ isDisabled.value }
                 readonly={ isReadonly.value }
                 { ...controlAttrs }

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -125,6 +125,7 @@ export const VField = genericComponent<new <T>() => {
 
     const uid = getUid()
     const id = computed(() => props.id || `input-${uid}`)
+    const messagesId = computed(() => `${id.value}-messages`)
 
     const labelRef = ref<VFieldLabel>()
     const floatingLabelRef = ref<VFieldLabel>()
@@ -278,6 +279,7 @@ export const VField = genericComponent<new <T>() => {
               props: {
                 id: id.value,
                 class: 'v-field__input',
+                'aria-describedby': messagesId.value,
               },
               focus,
               blur,

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -154,6 +154,7 @@ export const VFileInput = defineComponent({
           {{
             ...slots,
             default: ({
+              id,
               isDisabled,
               isDirty,
               isReadonly,
@@ -167,6 +168,7 @@ export const VFileInput = defineComponent({
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
                 { ...fieldProps }
+                id={ id.value }
                 active={ isDirty.value || isFocused.value }
                 dirty={ isDirty.value }
                 focused={ isFocused.value }

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -20,6 +20,7 @@ import { useInputIcon } from '@/components/VInput/InputIcon'
 
 export interface VInputSlot {
   id: ComputedRef<string>
+  messagesId: ComputedRef<string>
   isDirty: ComputedRef<boolean>
   isDisabled: ComputedRef<boolean>
   isReadonly: ComputedRef<boolean>
@@ -79,6 +80,7 @@ export const VInput = genericComponent<new () => {
 
     const uid = getUid()
     const id = computed(() => props.id || `input-${uid}`)
+    const messagesId = computed(() => `${id.value}-messages`)
 
     const {
       errorMessages,
@@ -96,6 +98,7 @@ export const VInput = genericComponent<new () => {
 
     const slotProps = computed<VInputSlot>(() => ({
       id,
+      messagesId,
       isDirty,
       isDisabled,
       isReadonly,
@@ -162,6 +165,7 @@ export const VInput = genericComponent<new () => {
           { hasDetails && (
             <div class="v-input__details">
               <VMessages
+                id={ messagesId.value }
                 active={ hasMessages }
                 messages={ errorMessages.value.length > 0
                   ? errorMessages.value

--- a/packages/vuetify/src/components/VMessages/VMessages.tsx
+++ b/packages/vuetify/src/components/VMessages/VMessages.tsx
@@ -48,6 +48,8 @@ export const VMessages = defineComponent({
           textColorClasses.value,
         ]}
         style={ textColorStyles.value }
+        role="alert"
+        aria-live="polite"
       >
         { props.active && (
           messages.value.map((message, i) => (

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -78,6 +78,7 @@ export const VRadioGroup = defineComponent({
             ...slots,
             default: ({
               id,
+              messagesId,
               isDisabled,
               isReadonly,
             }) => (
@@ -91,6 +92,7 @@ export const VRadioGroup = defineComponent({
                 <VSelectionControlGroup
                   { ...controlProps }
                   id={ id.value }
+                  aria-describedby={ messagesId.value }
                   defaultsTarget="VRadio"
                   trueIcon={ props.trueIcon }
                   falseIcon={ props.falseIcon }

--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
@@ -142,7 +142,7 @@ export const VRangeSlider = defineComponent({
                 { slots.prepend?.(slotProps) }
               </>
             ) : undefined,
-            default: ({ id }) => (
+            default: ({ id, messagesId }) => (
               <div
                 class="v-slider__container"
                 onMousedown={ onSliderMousedown }
@@ -176,6 +176,7 @@ export const VRangeSlider = defineComponent({
 
                 <VSliderThumb
                   ref={ startThumbRef }
+                  aria-describedby={ messagesId.value }
                   focused={ isFocused && activeThumbRef.value === startThumbRef.value?.$el }
                   modelValue={ model.value[0] }
                   onUpdate:modelValue={ v => (model.value = [v, model.value[1]]) }
@@ -209,6 +210,7 @@ export const VRangeSlider = defineComponent({
 
                 <VSliderThumb
                   ref={ stopThumbRef }
+                  aria-describedby={ messagesId.value }
                   focused={ isFocused && activeThumbRef.value === stopThumbRef.value?.$el }
                   modelValue={ model.value[1] }
                   onUpdate:modelValue={ v => (model.value = [model.value[0], v]) }

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -97,6 +97,7 @@ export const VSlider = defineComponent({
                 { slots.label?.(slotProps) ?? props.label
                   ? (
                     <VLabel
+                      id={ slotProps.id }
                       class="v-slider__label"
                       text={ props.label }
                     />
@@ -106,7 +107,7 @@ export const VSlider = defineComponent({
                 { slots.prepend?.(slotProps) }
               </>
             ) : undefined,
-            default: ({ id }) => (
+            default: ({ id, messagesId }) => (
               <div
                 class="v-slider__container"
                 onMousedown={ !readonly.value ? onSliderMousedown : undefined }
@@ -131,6 +132,7 @@ export const VSlider = defineComponent({
 
                 <VSliderThumb
                   ref={ thumbContainerRef }
+                  aria-describedby={ messagesId.value }
                   focused={ isFocused.value }
                   min={ min.value }
                   max={ max.value }

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -87,6 +87,7 @@ export const VSwitch = defineComponent({
             ...slots,
             default: ({
               id,
+              messagesId,
               isDisabled,
               isReadonly,
               isValid,
@@ -96,6 +97,7 @@ export const VSwitch = defineComponent({
                 { ...controlProps }
                 v-model={ model.value }
                 id={ id.value }
+                aria-describedby={ messagesId.value }
                 type="checkbox"
                 onUpdate:modelValue={ onChange }
                 aria-checked={ indeterminate.value ? 'mixed' : undefined }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
This PR proposes improvements on inputs' messages by adding a unique ID and ARIA attributes to the messages wrapper div (`role="alert"` and `aria-live="polite"`) and referencing those messages on input using `aria-describedby`.
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Currently, the messages are not "connected" to the input for screen readers. Messages are not even read by SR when alerting on an error inside input.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This have been tested using the Vuetify playground when developping on various framework's inputs. See the test markup bellow.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <h1>Input messages accessibility</h1>
      <template
        v-for="id in testIds"
        :key="`${id}`"
      >
        <h2>With ID: {{ id ?? 'undefined' }}</h2>
        <template
          v-for="(component, index) in testComponents"
          :key="`${id}-${index}`"
        >
          <component
            :is="component"
            :id="id ? `${id}-${index}` : undefined"
            label="My label"
            messages="My messages"
            class="my-5"
          />
        </template>
        <v-radio-group
          :id="id ? `${id}-radio-group` : undefined"
          label="My label"
          messages="My messages"
          class="my-5"
        >
          <v-radio
            label="My label 1"
            value="1"
          />
          <v-radio
            label="My label 2"
            value="2"
          />
        </v-radio-group>
      </template>
    </v-container>
  </v-app>
</template>

<script setup>
import {
  VAutocomplete,
  VCheckbox,
  VCombobox,
  VFileInput,
  VRadio,
  VRangeSlider,
  VSelect,
  VSlider,
  VSwitch,
  VTextarea,
  VTextField,
} from '../src/components';

const testIds = [
  undefined,
  'my-input',
];

const testComponents = [
  VTextField,
  VTextarea,
  VSelect,
  VAutocomplete,
  VCombobox,
  VFileInput,
  VSlider,
  VRangeSlider,
  VSwitch,
  VCheckbox,
  VRadio,
];
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
