### PR TITLE
fix(VListGroup): improve accessibility

### DIFF
--- a/packages/vuetify/src/components/VList/VListGroup.tsx
+++ b/packages/vuetify/src/components/VList/VListGroup.tsx
@@ -73,6 +73,7 @@ export const VListGroup = genericComponent<new <T extends InternalListItem>() =>
   setup (props, { slots }) {
     const { isOpen, open, id: _id } = useNestedItem(toRef(props, 'value'), true)
     const id = computed(() => `v-list-group--id-${String(_id.value)}`)
+    const contentId = computed(() => `${id.value}-content`)
     const list = useList()
 
     function onClick (e: Event) {
@@ -83,6 +84,8 @@ export const VListGroup = genericComponent<new <T extends InternalListItem>() =>
       onClick,
       class: 'v-list-group__header',
       id: id.value,
+      'aria-expanded': String(isOpen.value),
+      'aria-owns': contentId.value,
     }))
 
     const toggleIcon = computed(() => isOpen.value ? props.collapseIcon : props.expandIcon)
@@ -119,7 +122,13 @@ export const VListGroup = genericComponent<new <T extends InternalListItem>() =>
         ) }
 
         <VExpandTransition>
-          <div class="v-list-group__items" role="group" aria-labelledby={ id.value } v-show={ isOpen.value }>
+          <div
+            id={ contentId.value }
+            class="v-list-group__items"
+            role="group"
+            aria-labelledby={ id.value }
+            v-show={ isOpen.value }
+          >
             { slots.default?.() }
           </div>
         </VExpandTransition>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
This PR proposes to improve VListGroup accessibility by adding appropriate ARIA attributes (`aria-expanded` and `aria-owns`).
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
Currently, the VListGroup is not threaten by screen readers as an openable menu. This might confuse users when placed in a list of VListItem and VListGroup.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This have been tested using the Vuetify playground. See the test markup bellow.
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-app>
    <v-container>
      <v-list v-model:opened="opened">
        <v-list-group value="group">
          <template #activator="{ props }">
            <v-list-item
              title="My group"
              v-bind="props"
            />
          </template>
          <v-list-item title="My child 1" />
          <v-list-item title="My child 2" />
        </v-list-group>
      </v-list>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from 'vue';

const opened = ref();
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
