### PR TITLE
fix(validation): don't truncate error message passed as string

### DIFF
--- a/packages/vuetify/src/composables/__tests__/validation.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/validation.spec.ts
@@ -41,6 +41,7 @@ describe('validation', () => {
 
   it.each([
     [undefined, 1],
+    [0, 0],
     [1, 1],
     [2, 2],
     [3, 3],
@@ -59,6 +60,7 @@ describe('validation', () => {
 
   it.each([
     [undefined, 1],
+    [0, 0],
     [1, 1],
     [2, 2],
     [3, 3],
@@ -73,6 +75,22 @@ describe('validation', () => {
     await wrapper.vm.validate()
 
     expect(wrapper.vm.errorMessages).toHaveLength(expected)
+  })
+
+  it.each([
+    [undefined, ['foo']],
+    [0, []],
+    [1, ['foo']],
+    [2, ['foo']],
+  ])('should not trim error message if passed as text', async (maxErrors, expected) => {
+    const wrapper = mountFunction({
+      maxErrors,
+      errorMessages: 'foo',
+    })
+
+    await wrapper.vm.validate()
+
+    expect(wrapper.vm.errorMessages).toStrictEqual(expected)
   })
 
   it('should warn the user when using an improper rule fn', async () => {

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -78,7 +78,7 @@ export function useValidation (
   const isReadonly = computed(() => !!(props.readonly || form?.isReadonly.value))
   const errorMessages = computed(() => {
     return props.errorMessages.length
-      ? wrapInArray(props.errorMessages.slice(0, Math.max(0, +props.maxErrors)))
+      ? wrapInArray(wrapInArray(props.errorMessages).slice(0, Math.max(0, +props.maxErrors)))
       : internalErrorMessages.value
   })
   const isValid = computed(() => {
@@ -157,7 +157,7 @@ export function useValidation (
     isValidating.value = true
 
     for (const rule of props.rules) {
-      if (results.length >= (props.maxErrors || 1)) {
+      if (results.length >= (props.maxErrors ?? 1)) {
         break
       }
 

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -78,7 +78,7 @@ export function useValidation (
   const isReadonly = computed(() => !!(props.readonly || form?.isReadonly.value))
   const errorMessages = computed(() => {
     return props.errorMessages.length
-      ? wrapInArray(wrapInArray(props.errorMessages).slice(0, Math.max(0, +props.maxErrors)))
+      ? wrapInArray(props.errorMessages).slice(0, Math.max(0, +props.maxErrors))
       : internalErrorMessages.value
   })
   const isValid = computed(() => {


### PR DESCRIPTION
Also allows 0 max messages

fixes #16242
## How Has This Been Tested?
playground, unit

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-16 pa-16">
    <v-text-field error-messages="Foo" />
    <v-text-field error-messages="Foo" max-errors="0" />
    <v-text-field error-messages="Foo" max-errors="1" />
  </div>
</template>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
