### PR TITLE
fix(VSliderThumb): test for logical properties support

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -15,6 +15,7 @@ import { useTextColor } from '@/composables/color'
 // Utilities
 import { computed, inject } from 'vue'
 import { convertToUnit, defineComponent, keyValues, useRender } from '@/util'
+import { useRtl } from '@/composables'
 
 export const VSliderThumb = defineComponent({
   name: 'VSliderThumb',
@@ -107,10 +108,14 @@ export const VSliderThumb = defineComponent({
       newValue != null && emit('update:modelValue', newValue)
     }
 
+    const { isRtl } = useRtl()
+
     useRender(() => {
       const positionPercentage = convertToUnit(vertical.value ? 100 - props.position : props.position, '%')
       const inset = vertical.value ? 'block' : 'inline'
       const { elevationClasses } = useElevation(computed(() => !disabled.value ? elevation.value : undefined))
+      const supportsLogicalPositioning = CSS.supports('inset-inline-start: 0px')
+      const insetAlt = vertical.value ? 'top' : (isRtl.value ? 'right' : 'left')
 
       return (
         <div
@@ -122,7 +127,7 @@ export const VSliderThumb = defineComponent({
             },
           ]}
           style={{
-            [`inset-${inset}-start`]: `calc(${positionPercentage} - var(--v-slider-thumb-size) / 2)`,
+            [supportsLogicalPositioning ? `inset-${inset}-start` : insetAlt]: `calc(${positionPercentage} - var(--v-slider-thumb-size) / 2)`,
             '--v-slider-thumb-size': convertToUnit(thumbSize.value),
             direction: !vertical.value ? horizontalDirection.value : undefined,
           }}


### PR DESCRIPTION
## Description
Adds a check for CSS logical properties support in browser before styling the VSliderThumb element, falls back to standard positioning if that's not available.
fixes #16282

## Motivation and Context
VSlider failed to render the thumb element properly on older browsers which don't support CSS logical properties.

## How Has This Been Tested?
Not sure how to implement browser-specific tests! Can anyone help point me in the right direction? Will do some more digging too.

## Markup:
```vue
<template>
  <v-container>
    <v-row>
      <div>Her's some text</div>
      <v-slider
      v-model="val"
    ></v-slider>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data () {
      return {
        val: 25,
      }
    },
  }
</script>
```


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
