### PR TITLE
docs(autocomplete): fix asynchronous example

### DIFF
--- a/packages/docs/src/examples/v-autocomplete/misc-asynchronous-items.vue
+++ b/packages/docs/src/examples/v-autocomplete/misc-asynchronous-items.vue
@@ -6,7 +6,7 @@
     <v-toolbar-title>State selection</v-toolbar-title>
     <v-autocomplete
       v-model="select"
-      v-model:search-input="search"
+      v-model:search="search"
       :loading="loading"
       :items="items"
       cache-items


### PR DESCRIPTION
## Description
The "Asynchronous example" in the "Autocompletes" section is broken here: https://next.vuetifyjs.com/en/components/autocompletes/

## How Has This Been Tested?
I was creating this component locally, and it wasn't working after I copied the example. After the change, it works as it should.

The API here is correct: https://next.vuetifyjs.com/en/api/v-autocomplete/#props-search

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
