### PR TITLE
feat(VList): add lazy mode to VListGroup

### DIFF
--- a/packages/api-generator/src/locale/en/VListGroup.json
+++ b/packages/api-generator/src/locale/en/VListGroup.json
@@ -11,6 +11,7 @@
     "expandIcon": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-group.json))",
     "fluid": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-group.json))",
     "subgroup": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-group.json))",
-    "items": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-group.json))"
+    "items": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-group.json))",
+    "lazy": "Lazilly render children"
   }
 }

--- a/packages/docs/src/examples/v-list/misc-lazy-rendering.vue
+++ b/packages/docs/src/examples/v-list/misc-lazy-rendering.vue
@@ -1,0 +1,68 @@
+<template>
+  <v-card>
+    <v-card-title>List with {{ size }} elements</v-card-title>
+
+    <v-card-text v-if="data">
+      <v-list>
+        <recursive-list :entry="data"></recursive-list>
+      </v-list>
+    </v-card-text>
+    <v-card-actions v-else class="justify-center">
+      <v-btn @click="data = MakeEntries()">Prepare</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts" setup>
+  import { computed, h, ref, VNode } from 'vue'
+  import { VListGroup, VListItem } from 'vuetify/components'
+
+  export type Entry = {
+    name: string,
+    children?: Entry[],
+  }
+
+  /*
+  <VListGroup v-if="entry.children" lazy>
+    <template v-slot:activator="{ props }">
+      <VListItem v-bind="props">
+        {{ p.val.name }}
+      </VListItem>
+    </template>
+
+    <RecursiveList :val="e" v-for="e in p.val.children" />
+  </VListGroup>
+
+  <VListItem v-else>
+    {{ p.val.name }}
+  </VListItem>
+  */
+  const RecursiveList = ({ entry }: { entry: Entry }): VNode =>
+    entry.children
+      ? h(VListGroup, { lazy: true }, {
+        default: () => entry.children?.map(entry => RecursiveList({ entry })),
+        activator: ({ props }: any) => h(VListItem, props, { default: () => entry.name }),
+      })
+      : h(VListItem, null, { default: () => entry.name })
+
+  function MakeEntries (prefix = 'Prop', depth = 5): Entry {
+    let children
+
+    if (depth > 0) {
+      children = []
+
+      for (let i = 0; i < 5; ++i) {
+        children.push(MakeEntries(prefix + '.' + i, depth - 1))
+      }
+    }
+
+    return { name: prefix, children }
+  }
+
+  function GetSize (v: Entry): number {
+    return v.children?.map(GetSize).reduce((acc, v) => acc + v, 1) ?? 1
+  }
+
+  const data = ref<Entry>()
+  const size = computed(() => data.value ? GetSize(data.value) : 0)
+</script>

--- a/packages/docs/src/pages/en/components/lists.md
+++ b/packages/docs/src/pages/en/components/lists.md
@@ -125,3 +125,9 @@ Lists can contain subheaders, dividers, and can contain 1 or more lines. The sub
 A **three-line** list with actions. Utilizing **v-list-group**, easily connect actions to your tiles.
 
 <example file="v-list/misc-action-and-item-groups" />
+
+#### Lazy rendering
+
+A big list rendered instantly using *lazy* option.
+
+<example file="v-list/misc-lazy-rendering" />

--- a/packages/vuetify/src/components/VList/__tests__/VListGroup.spec.cy.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VListGroup.spec.cy.tsx
@@ -5,6 +5,28 @@ import { VListGroup } from '../VListGroup'
 import { VListItem } from '../VListItem'
 import { VList } from '../VList'
 
+function ListGroup (lazy: boolean, open: boolean): JSX.Element {
+  return (
+    <CenteredGrid width="200px">
+      <h2 class="mt-8">ListGroup</h2>
+
+      <VList opened={ open ? ['group'] : [] }>
+        <VListGroup value="group" lazy={ lazy }>
+          {{
+            activator: ({ props }) => <VListItem { ...props } title="Group" />,
+            default: () => (
+              <>
+                <VListItem title="Child 1" />
+                <VListItem title="Child 2" />
+              </>
+            ),
+          }}
+        </VListGroup>
+      </VList>
+    </CenteredGrid>
+  )
+}
+
 describe('VListGroup', () => {
   function mountFunction (content: JSX.Element) {
     return cy.mount(() => content)
@@ -27,26 +49,24 @@ describe('VListGroup', () => {
   })
 
   it('supports children', () => {
-    const wrapper = mountFunction((
-      <CenteredGrid width="200px">
-        <h2 class="mt-8">ListGroup</h2>
-
-        <VList opened={['group']}>
-          <VListGroup value="group">
-            {{
-              activator: props => <VListItem { ...props } title="Group" />,
-              default: () => (
-                <>
-                  <VListItem title="Child 1" />
-                  <VListItem title="Child 2" />
-                </>
-              ),
-            }}
-          </VListGroup>
-        </VList>
-      </CenteredGrid>
-    ))
-
+    const wrapper = mountFunction(ListGroup(false, true))
     wrapper.get('.v-list-item-title').contains('Group')
+  })
+
+  describe('lazy', () => {
+    it('open on click', () => {
+      const wrapper = mountFunction(ListGroup(true, false))
+
+      const group = wrapper.get('.v-list-group')
+      group.get('.v-list-group__items .v-list-item').should('have.length', 0)
+      group.get('.v-list-item').click()
+      group.get('.v-list-group__items .v-list-item').should('have.length', 2)
+    })
+
+    it('already opened children', () => {
+      const wrapper = mountFunction(ListGroup(true, true))
+
+      wrapper.get('.v-list-group__items .v-list-item').should('have.length', 2)
+    })
   })
 })


### PR DESCRIPTION
## Description
Add a `lazy` props to skip the rendering of children if the group has never been opened

## Motivation and Context
This allows to render instantly a list with ~1k elements (see example in docs)

## How Has This Been Tested?
Manually (patched in my project, used to crash Chrome and Firefox, now work instantly).
Also added 2 Cypress test.

## Markup:
Available in the documentation
<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-card>
    <v-card-title>List with {{ size }} elements</v-card-title>

    <v-card-text v-if="data">
      <v-list>
        <recursive-list :entry="data"></recursive-list>
      </v-list>
    </v-card-text>
    <v-card-actions v-else class="justify-center">
      <v-btn @click="data = MakeEntries()">Prepare</v-btn>
    </v-card-actions>
  </v-card>
</template>

<script lang="ts" setup>
  import { computed, h, ref, VNode } from 'vue'
  import { VListGroup, VListItem } from 'vuetify/components'
  export type Entry = {
    name: string,
    children?: Entry[],
  }
  /*
  <VListGroup v-if="entry.children" lazy>
    <template v-slot:activator="{ props }">
      <VListItem v-bind="props">
        {{ p.val.name }}
      </VListItem>
    </template>
    <RecursiveList :val="e" v-for="e in p.val.children" />
  </VListGroup>
  <VListItem v-else>
    {{ p.val.name }}
  </VListItem>
  */
  const RecursiveList = ({ entry }: { entry: Entry }): VNode =>
    entry.children
      ? h(VListGroup, { lazy: true }, {
        default: () => entry.children?.map(entry => RecursiveList({ entry })),
        activator: ({ props }: any) => h(VListItem, props, { default: () => entry.name }),
      })
      : h(VListItem, null, { default: () => entry.name })
  function MakeEntries (prefix = 'Prop', depth = 5): Entry {
    let children
    if (depth > 0) {
      children = []
      for (let i = 0; i < 5; ++i) {
        children.push(MakeEntries(prefix + '.' + i, depth - 1))
      }
    }
    return { name: prefix, children }
  }
  function GetSize (v: Entry): number {
    return v.children?.map(GetSize).reduce((acc, v) => acc + v, 1) ?? 1
  }
  const data = ref<Entry>()
  const size = computed(() => data.value ? GetSize(data.value) : 0)
</script>
```
</details>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [X] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
