### PR TITLE
fix(VTooltip): display intrinsic maximum width content

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -77,14 +77,13 @@ export function useLocationStrategies (
   const updateLocation = ref<(e: Event) => void>()
 
   let scope: EffectScope | undefined
-  watchEffect(async () => {
+  watchEffect(() => {
     scope?.stop()
     updateLocation.value = undefined
 
     if (!(IN_BROWSER && data.isActive.value && props.locationStrategy)) return
 
     scope = effectScope()
-    if (!(props.locationStrategy === 'connected')) { await nextTick() }
     scope.run(() => {
       if (typeof props.locationStrategy === 'function') {
         updateLocation.value = props.locationStrategy(data, props, contentStyles)?.updateLocation
@@ -407,13 +406,9 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       props.maxHeight,
     ],
     () => updateLocation(),
-    { immediate: !activatorFixed }
   )
 
-  if (activatorFixed) nextTick(() => updateLocation())
-  requestAnimationFrame(() => {
-    if (contentStyles.value.maxHeight) updateLocation()
-  })
+  nextTick(() => updateLocation())
 
   return { updateLocation }
 }


### PR DESCRIPTION
fixes #16321


**Cause**: `offsetWidth` & `offsetHeight` returns different values between first activate and second activate. 

- When hover the first time, text displays as one line, everything calculates correctly
- Due to `contentBox.x -= parseFloat(el.style.left || 0)`. when hover from the second time and afterwards, contentBox will be initially rendered outside page and tooltip overlay initially shows as two lines so `offsetWidth` & `offsetHeight` returns inconsistent values



**Solution so far**: 

display intrinsic maximum width content

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
<script setup>
import { ref } from 'vue'

const show = ref(false);

</script>

<template>
  <v-app class="pa-4">
    <v-container
      fluid
      class="text-center"
    >
      <v-row
        class="flex"
        justify="space-between"
      >
        <v-col cols="12">
          <v-btn @click="show = !show">
            toggle
          </v-btn>
        </v-col>
  
        <v-col
          cols="12"
          class="mt-12"
        >
          <v-tooltip
            v-model="show"
            location="top"
          >
            <template v-slot:activator="{ props }">
              <v-btn
                icon
                v-bind="props"
              >
                <v-icon color="grey-lighten-1">
                  mdi-cart
                </v-icon>
              </v-btn>
            </template>
            <span>Programmatic tooltip</span>
          </v-tooltip>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>


```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
