### PR TITLE
feat(VNavigationDrawer): add rail prop v-model support

### DIFF
--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -41,7 +41,10 @@ export const VNavigationDrawer = defineComponent({
       default: null,
     },
     permanent: Boolean,
-    rail: Boolean,
+    rail: {
+      type: Boolean as PropType<boolean | null>,
+      default: null,
+    },
     railWidth: {
       type: [Number, String],
       default: 56,
@@ -74,9 +77,10 @@ export const VNavigationDrawer = defineComponent({
 
   emits: {
     'update:modelValue': (val: boolean) => true,
+    'update:rail': (val: boolean) => true,
   },
 
-  setup (props, { attrs, slots }) {
+  setup (props, { attrs, emit, slots }) {
     const { isRtl } = useRtl()
     const { themeClasses } = provideTheme(props)
     const { borderClasses } = useBorder(props)
@@ -105,6 +109,10 @@ export const VNavigationDrawer = defineComponent({
       !isTemporary.value &&
       location.value !== 'bottom'
     )
+
+    if (props.expandOnHover && props.rail != null) {
+      watch(isHovering, val => emit('update:rail', !val))
+    }
 
     if (!props.disableResizeWatcher) {
       watch(isTemporary, val => !props.permanent && (nextTick(() => isActive.value = !val)))

--- a/packages/vuetify/src/components/VNavigationDrawer/__tests__/VNavigationDrawer.spec.cy.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/__tests__/VNavigationDrawer.spec.cy.tsx
@@ -1,7 +1,9 @@
 /// <reference types="../../../../types/cypress" />
 
 import { VLayout } from '@/components/VLayout'
+import { VMain } from '@/components/VMain'
 import { VNavigationDrawer } from '..'
+import { ref } from 'vue'
 
 describe('VNavigationDrawer', () => {
   beforeEach(() => {
@@ -46,6 +48,31 @@ describe('VNavigationDrawer', () => {
     cy.get('.v-navigation-drawer').trigger('mouseleave')
 
     cy.get('.v-navigation-drawer').should('have.css', 'width', '56px')
+  })
+
+  it('should change width when using bound and unbound rail and expandOnHover', () => {
+    const rail = ref(true)
+
+    cy.mount(() => (
+      <VLayout>
+        <VNavigationDrawer expand-on-hover v-model:rail={ rail.value } />
+
+        <VMain />
+      </VLayout>
+    ))
+
+    cy.get('.v-navigation-drawer').should('have.css', 'width', '56px')
+    cy.get('.v-main').should('have.css', 'padding-left', '56px')
+
+    cy.get('.v-navigation-drawer').trigger('mouseenter')
+
+    cy.get('.v-navigation-drawer').should('have.css', 'width', '256px')
+    cy.get('.v-main').should('have.css', 'padding-left', '256px')
+
+    cy.get('.v-navigation-drawer').trigger('mouseleave')
+
+    cy.get('.v-navigation-drawer').should('have.css', 'width', '56px')
+    cy.get('.v-main').should('have.css', 'padding-left', '56px')
   })
 
   it('should hide drawer if window resizes below mobile breakpoint', () => {


### PR DESCRIPTION
## Description
Add support for rail v-model. Allows the user to choose to have main content shift with or without the rail expand-on-hover.

## Motivation and Context
resolves #16022

## How Has This Been Tested?
e2e

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div class="ma-4 pa-4">
    <v-navigation-drawer
      id="drawer"
      v-model:rail="miniVariant"
      expand-on-hover
      app
      color="#8dca9d"
    >
      <v-list nav>
        <v-list-item>
          {{ myWidth }}
        </v-list-item>
      </v-list>
    </v-navigation-drawer>

    <v-main>
      <div>
        Mini: {{ miniVariant }}
      </div>
    </v-main>
  </div>
</template>

<script>
  export default {
    data: () => ({
      miniVariant: true,
      myWidth: 0,
      sidebar: null,
      observer: null,
    }),
    mounted () {
      this.sidebar = document.querySelector('#drawer')
      this.observer = new ResizeObserver(this.onResize)
      this.observer.observe(this.sidebar)
    },
    beforeUnmount () {
      if (this.observer) {
        this.observer.unobserve(this.sidebar)
      }
    },
    methods: {
      onResize () {
        if (this.sidebar.offsetWidth <= '56') {
          this.miniVariant = true
        } else {
          this.miniVariant = false
        }
      },
    },
  }
</script>

```
</details>