### PR TITLE
docs(VNavigationDrawer): increase height of bottom example

### DIFF
--- a/packages/docs/src/examples/v-navigation-drawer/prop-bottom-drawer.vue
+++ b/packages/docs/src/examples/v-navigation-drawer/prop-bottom-drawer.vue
@@ -30,7 +30,7 @@
         ></v-list>
       </v-navigation-drawer>
 
-      <v-main>
+      <v-main style="height: 500px;">
         <v-card-text>
           The navigation drawer will appear from the bottom on smaller size screens.
         </v-card-text>


### PR DESCRIPTION
## Description
updated drawer height because currently it's just so small that no one can tell what's the example is being showed.

## Motivation and Context


## How Has This Been Tested?

## Markup:
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
