### PR TITLE
chore(dev): allow to listen on the network

### DIFF
--- a/packages/vuetify/vite.config.mjs
+++ b/packages/vuetify/vite.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig(({ mode }) => {
   return {
     root: resolve('dev'),
     server: {
+      host: process.env.HOST,
       port: process.env.CYPRESS ? undefined : process.env.PORT,
       strictPort: !!process.env.PORT && !process.env.CYPRESS,
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
The dev server can now properly listen on another IP address if one is specified in the HOST environment variable in the .env file.

## Motivation and Context
When running `yarn dev`, I want to be able to access the dev server from another machine than localhost (specifically, I'm developing in a VM and accessing the project from my computer).

It used to be possible, in the main branch, to use the webpack dev server with a HOST environment variable for that purpose, but it seems to have disappeared in the new vite build system.

## How Has This Been Tested?
- Set `HOST=0.0.0.0` in the /packages/vuetify/.env file
- Run `yarn dev`
- See that `Network: use --host to expose` have disappeared, replaced by the actual IP addresses of your machines

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
// Paste your FULL Playground.vue here
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
