### PR TITLE
feat(VTab): add tabValue prop

### DIFF
--- a/packages/api-generator/src/locale/en/v-tab.json
+++ b/packages/api-generator/src/locale/en/v-tab.json
@@ -1,5 +1,6 @@
 {
   "events": {
+    "tabValue": "Value of the tab. Exposed through v-model on v-tabs. To be used to coordinate current tab with v-tabs-items",
     "change": "Emitted when tab becomes active",
     "click": "Emitted when the component is clicked",
     "keydown": "Emitted when **enter** key is pressed"

--- a/packages/vuetify/src/components/VTabs/VTab.ts
+++ b/packages/vuetify/src/components/VTabs/VTab.ts
@@ -39,6 +39,9 @@ export default baseMixins.extend<options>().extend(
       type: [Boolean, Object],
       default: true,
     },
+    tabValue: {
+      required: false,
+    },
   },
 
   data: () => ({
@@ -55,6 +58,8 @@ export default baseMixins.extend<options>().extend(
       }
     },
     value (): any {
+      if (this.tabValue) return this.tabValue
+
       let to = this.to || this.href
 
       if (to == null) return to

--- a/packages/vuetify/src/components/VTabs/VTab.ts
+++ b/packages/vuetify/src/components/VTabs/VTab.ts
@@ -58,7 +58,7 @@ export default baseMixins.extend<options>().extend(
       }
     },
     value (): any {
-      if (this.tabValue) return this.tabValue
+      if (this.tabValue != null) return this.tabValue
 
       let to = this.to || this.href
 

--- a/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.ts
+++ b/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.ts
@@ -180,4 +180,26 @@ describe('VTabs.ts', () => {
     expect(wrapper.vm.slider.height).toBe(99)
     expect(wrapper.vm.slider.width).toBe(4)
   })
+
+  it('should use tabValue if it exists', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        value: 'first',
+      },
+      slots: {
+        default: {
+          render: h => h('div', [
+            h(VTab, { props: { tabValue: 'first' } }),
+            h(VTab, { props: { tabValue: 'second' } }),
+          ]),
+        },
+      },
+    })
+
+    const tab = wrapper.findAll('.v-tab').at(1).trigger('click')
+
+    const emitted = wrapper.emitted('change')
+
+    expect(emitted).toStrictEqual([['second']])
+  })
 })


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->
Potential solution..

Unfortunately we can't use `value` as prop name because it collides with an existing computed prop in the component that is tied to several levels of mixins, that in turn are used in multiple other components.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
closes #10540

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

playground, unit test

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-card>
    <v-tabs
      v-model="tab"
      @change="onChange"
      background-color="primary"
      dark
    >
      <v-tab
        v-for="item in items"
        :key="item.tab"
        :tab-value="item.tab"
      >
        {{ item.tab }}
      </v-tab>
    </v-tabs>
    <v-tabs-items v-model="tab">
      <v-tab-item
        v-for="item in items"
        :key="item.tab"
        :value="item.tab"
      >
        {{ item.tab }}
        <v-card flat>
          <v-card-text>{{ item.content }}</v-card-text>
        </v-card>
      </v-tab-item>
    </v-tabs-items>
    <pre>{{ tab }}</pre>
  </v-card>
  <!-- <div>
    <v-tabs>
      <v-tab to="/">zxc</v-tab>
      <v-tab to="/page1">test</v-tab>
      <v-tab to="/page2">asd</v-tab>
    </v-tabs>
    <router-view></router-view>
  </div> -->

</template>

<script>
  export default {
    data () {
      return {
        tab: null,
        items: [
          { tab: 'One', content: 'Tab 1 Content' },
          { tab: 'Two', content: 'Tab 2 Content' },
          { tab: 'Three', content: 'Tab 3 Content' },
          { tab: 'Four', content: 'Tab 4 Content' },
          { tab: 'Five', content: 'Tab 5 Content' },
          { tab: 'Six', content: 'Tab 6 Content' },
          { tab: 'Seven', content: 'Tab 7 Content' },
          { tab: 'Eight', content: 'Tab 8 Content' },
          { tab: 'Nine', content: 'Tab 9 Content' },
          { tab: 'Ten', content: 'Tab 10 Content' },
        ],
      }
    },
    methods: {
      onChange () {
        if (Number.isInteger(this.tab)) {
          console.log('Value: ' + this.tab + ' / Expecting: ' + this.items[this.tab].tab)
        } else {
          console.log(this.tab)
        }
      }
    }
  }
</script>

```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
