### PR TITLE
docs: Update float documentation broken component

### DIFF
--- a/packages/docs/src/pages/en/styles/float.md
+++ b/packages/docs/src/pages/en/styles/float.md
@@ -19,7 +19,7 @@ Applies a custom float across any breakpoint with responsive float utilities.
 
 Float utility classes apply floating based upon the current viewport size using the [CSS float property](https://developer.mozilla.org/en-US/docs/Web/CSS/float).
 
-<breakpoints-table" />
+<breakpoints-table />
 
 ## Classes
 


### PR DESCRIPTION
## Description

`"` was added, disturbing the breakpoints-table component

![Screenshot 2023-01-18 091523](https://user-images.githubusercontent.com/78584173/213042068-458f91aa-e3ef-49b9-bb42-d83d07522909.png)

## Motivation and Context

The documentation was broken.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
