### PR TITLE
fix(VCombobox): filter transformed items

### DIFF
--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -210,6 +210,40 @@ describe('VCombobox', () => {
         .type('Item 3')
         .should('have.length', 1)
     })
+
+    it('should filter with custom item shape', () => {
+      const items = [
+        {
+          id: 1,
+          name: 'Test1',
+        },
+        {
+          id: 2,
+          name: 'Antonsen PK',
+        },
+      ]
+
+      cy.mount(() => (
+        <VCombobox
+          items={items}
+          item-value="id"
+          item-title="name"
+        />
+      ))
+        .get('input')
+        .type('test')
+        .get('.v-list-item')
+        .should('have.length', 1)
+        .eq(0)
+        .should('have.text', 'Test1')
+        .get('input')
+        .clear()
+        .type('antonsen')
+        .get('.v-list-item')
+        .should('have.length', 1)
+        .eq(0)
+        .should('have.text', 'Antonsen PK')
+    })
   })
 
   describe('prefilled data', () => {

--- a/packages/vuetify/src/composables/__tests__/filter.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/filter.spec.ts
@@ -51,7 +51,7 @@ describe('filter', () => {
         title: (s: string, q: string) => s === q,
         value: (s: string) => s === '1',
       }
-      const items = transformItems({} as any, [
+      const items = [
         {
           title: 'foo',
           subtitle: 'bar',
@@ -76,7 +76,7 @@ describe('filter', () => {
           value: '1',
           custom: 'buzz',
         },
-      ])
+      ] as any
       const filterKeys = ['title', 'value', 'subtitle', 'custom']
 
       expect(filterItems(items, 'foo', {

--- a/packages/vuetify/src/composables/filter.ts
+++ b/packages/vuetify/src/composables/filter.ts
@@ -69,7 +69,7 @@ export function filterItems (
 
   loop:
   for (let i = 0; i < items.length; i++) {
-    const item = items[i].raw
+    const item = items[i]
     const customMatches: Record<string, FilterMatch> = {}
     const defaultMatches: Record<string, FilterMatch> = {}
     let match: FilterMatch = -1
@@ -129,7 +129,10 @@ export function filterItems (
 export function useFilter <T extends InternalItem> (
   props: FilterProps,
   items: MaybeRef<T[]>,
-  query?: Ref<string | undefined>,
+  query: Ref<string | undefined>,
+  options?: {
+    filterKeys?: MaybeRef<FilterKeys>
+  }
 ) {
   const strQuery = computed(() => (
     typeof query?.value !== 'string' &&
@@ -150,7 +153,7 @@ export function useFilter <T extends InternalItem> (
       {
         customKeyFilter: props.customKeyFilter,
         default: props.customFilter,
-        filterKeys: props.filterKeys,
+        filterKeys: unref(options?.filterKeys) ?? props.filterKeys,
         filterMode: props.filterMode,
         noFilter: props.noFilter,
       },

--- a/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
@@ -78,7 +78,8 @@ export const VDataTable = defineComponent({
 
     const { items } = useDataTableItems(props, columns)
 
-    const { filteredItems } = useFilter<DataTableItem>(props, items, toRef(props, 'search'))
+    const filterKeys = computed(() => columns.value.map(c => 'columns.' + c.key))
+    const { filteredItems } = useFilter<DataTableItem>(props, items, toRef(props, 'search'), { filterKeys })
 
     const { sortBy } = createSort(props)
     const { sortByWithGroups, opened, extractRows } = createGroupBy(props, groupBy, sortBy)

--- a/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
@@ -60,7 +60,8 @@ export const VDataTableVirtual = defineComponent({
     })
     const { items } = useDataTableItems(props, columns)
 
-    const { filteredItems } = useFilter<DataTableItem>(props, items, toRef(props, 'search'))
+    const filterKeys = computed(() => columns.value.map(c => 'columns.' + c.key))
+    const { filteredItems } = useFilter<DataTableItem>(props, items, toRef(props, 'search'), { filterKeys })
 
     const { sortBy } = createSort(props)
     const { sortByWithGroups, opened, extractRows } = createGroupBy(props, groupBy, sortBy)


### PR DESCRIPTION
fixes #16403
closes #16411

Kinda a temporary fix, I think tables need a separate InternalItem interface because some of the list stuff doesn't make sense for tables.
I also prefer this approach over #16411 as it doesn't run itemTitle multiple times, and still works with itemTitle as a function.

## Markup:
```vue
<template>
  <v-container>
    <v-combobox v-model:search="search" :items="items" item-title="name" />
    <!--    <v-text-field v-model="search" />-->

    <v-data-table :search="search" :items="items" :headers="headers" />
  </v-container>
</template>

<script setup>
  import { computed, ref } from 'vue'

  const search = ref('')
  const headers = [
    {
      title: 'Dessert (100g serving)',
      align: 'start',
      sortable: false,
      key: 'name',
    },
    { title: 'Calories', align: 'end', key: 'calories' },
    { title: 'Fat (g)', align: 'end', key: 'fat' },
    { title: 'Carbs (g)', align: 'end', key: 'carbs' },
    { title: 'Protein (g)', align: 'end', key: 'protein' },
    { title: 'Iron (%)', align: 'end', key: 'iron' },
  ]
  const items = [
    {
      name: 'Frozen Yogurt',
      calories: 159,
      fat: 6.0,
      carbs: 24,
      protein: 4.0,
      iron: '1',
    },
    {
      name: 'Jelly bean',
      calories: 375,
      fat: 0.0,
      carbs: 94,
      protein: 0.0,
      iron: '0',
    },
    {
      name: 'KitKat',
      calories: 518,
      fat: 26.0,
      carbs: 65,
      protein: 7,
      iron: '6',
    },
    {
      name: 'Eclair',
      calories: 262,
      fat: 16.0,
      carbs: 23,
      protein: 6.0,
      iron: '7',
    },
    {
      name: 'Gingerbread',
      calories: 356,
      fat: 16.0,
      carbs: 49,
      protein: 3.9,
      iron: '16',
    },
    {
      name: 'Ice cream sandwich',
      calories: 237,
      fat: 9.0,
      carbs: 37,
      protein: 4.3,
      iron: '1',
    },
    {
      name: 'Lollipop',
      calories: 392,
      fat: 0.2,
      carbs: 98,
      protein: 0,
      iron: '2',
    },
    {
      name: 'Cupcake',
      calories: 305,
      fat: 3.7,
      carbs: 67,
      protein: 4.3,
      iron: '8',
    },
    {
      name: 'Honeycomb',
      calories: 408,
      fat: 3.2,
      carbs: 87,
      protein: 6.5,
      iron: '45',
    },
    {
      name: 'Donut',
      calories: 452,
      fat: 25.0,
      carbs: 51,
      protein: 4.9,
      iron: '22',
    },
  ]
</script>
```

