### PR TITLE
fix(vmenu): ignore key presses when disable-keys is true

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.ts
+++ b/packages/vuetify/src/components/VMenu/VMenu.ts
@@ -454,6 +454,8 @@ export default baseMixins.extend({
       if (tile.tabIndex === -1) this.nextTile()
     },
     onKeyDown (e: KeyboardEvent) {
+      if (this.disableKeys) return
+
       if (e.keyCode === keyCodes.esc) {
         // Wait for dependent elements to close first
         setTimeout(() => { this.isActive = false })

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.ts
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.ts
@@ -259,6 +259,37 @@ describe('VMenu.ts', () => {
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })
 
+  it('should be able to navigate the menu list with up and down keys', async () => {
+    const event = (keyCode: number) => new KeyboardEvent('keydown', { keyCode })
+    const wrapper = mountFunction({
+      propsData: { eager: true },
+      scopedSlots: {
+        default () {
+          return this.$createElement('div', [
+            this.$createElement(VListItem, { props: { link: true } }),
+            this.$createElement(VListItem, { props: { link: true } }),
+          ])
+        },
+      },
+    })
+
+    wrapper.setData({ isActive: true })
+
+    wrapper.vm.onKeyDown(event(keyCodes.down))
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.listIndex).toBe(0)
+
+    wrapper.vm.onKeyDown(event(keyCodes.up))
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.listIndex).toBe(1)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
   it('should select first or last item when pressing home or end on active menu', async () => {
     const event = (keyCode: number) => new KeyboardEvent('keydown', { keyCode })
     const wrapper = mountFunction({
@@ -288,6 +319,105 @@ describe('VMenu.ts', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.listIndex).toBe(1)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should deactivate when escape is pressed', async () => {
+    jest.useFakeTimers()
+    const event = (keyCode: number) => new KeyboardEvent('keydown', { keyCode })
+    const wrapper = mountFunction({
+      propsData: { eager: true },
+    })
+
+    wrapper.setData({ isActive: true })
+
+    wrapper.vm.onKeyDown(event(keyCodes.esc))
+
+    await wrapper.vm.$nextTick()
+    jest.runAllTimers()
+
+    expect(wrapper.vm.isActive).toBe(false)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+    jest.useRealTimers()
+  })
+
+  it('should disable escape key when disableKeys is true', async () => {
+    const event = (keyCode: number) => new KeyboardEvent('keydown', { keyCode })
+    const wrapper = mountFunction({
+      propsData: {
+        eager: true,
+        disableKeys: true,
+      },
+    })
+
+    wrapper.setData({ isActive: true })
+
+    wrapper.vm.onKeyDown(event(keyCodes.esc))
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.isActive).toBe(true)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should disable navigation keys when disableKeys is true', async () => {
+    const event = (keyCode: number) => new KeyboardEvent('keydown', { keyCode })
+    const wrapper = mountFunction({
+      propsData: {
+        eager: true,
+        disableKeys: true,
+      },
+      scopedSlots: {
+        default () {
+          return this.$createElement('div', [
+            this.$createElement(VListItem, { props: { link: true } }),
+          ])
+        },
+      },
+    })
+
+    wrapper.setData({ isActive: true })
+
+    wrapper.vm.onKeyDown(event(keyCodes.up))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.listIndex).toBe(-1)
+
+    wrapper.vm.onKeyDown(event(keyCodes.down))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.listIndex).toBe(-1)
+
+    wrapper.vm.onKeyDown(event(keyCodes.end))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.listIndex).toBe(-1)
+
+    wrapper.vm.onKeyDown(event(keyCodes.home))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.listIndex).toBe(-1)
+
+    expect('Unable to locate target [data-app]').toHaveBeenTipped()
+  })
+
+  it('should not open menu on up or down press when disableKeys is true', async () => {
+    const event = (keyCode: number) => new KeyboardEvent('keydown', { keyCode })
+    const wrapper = mountFunction({
+      propsData: {
+        eager: true,
+        disableKeys: true,
+      },
+    })
+
+    wrapper.vm.onKeyDown(event(keyCodes.up))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(wrapper.vm.listIndex).toBe(-1)
+
+    wrapper.vm.onKeyDown(event(keyCodes.down))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(wrapper.vm.listIndex).toBe(-1)
 
     expect('Unable to locate target [data-app]').toHaveBeenTipped()
   })


### PR DESCRIPTION
closes #12998

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

fixes #12998

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

New unit tests added for esc and menu navigation keys when `disable-keys` is true, plus added missing tests for navigation keys when `disable-keys` is false.

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <v-container>
    <v-menu offset-y :close-on-content-click="false">
      <template #activator="{on}">
        <v-btn v-on="on">Text Input</v-btn>
      </template>
      <v-card>
        <v-card-text>
          <v-text-field autofocus placeholder="Tap ESC when focused here" />
        </v-card-text>
      </v-card>
    </v-menu>

    <!-- from bug report -->
    <v-menu disable-keys offset-y :close-on-content-click="false">
      <template #activator="{on}">
        <v-btn v-on="on">Text Input - disable-keys</v-btn>
      </template>
      <v-card>
        <v-card-text>
          <v-text-field autofocus placeholder="Tap ESC when focused here" />
        </v-card-text>
      </v-card>
    </v-menu>


    <v-menu offset-y :close-on-content-click="false">
      <template #activator="{on}">
        <v-btn v-on="on">Menu - List</v-btn>
      </template>
      <v-list>
        <v-list-item v-for="item in items" :key="item" link>
          <v-list-item-title v-text="item"></v-list-item-title>
        </v-list-item>
      </v-list>
    </v-menu>

    <v-menu disable-keys offset-y :close-on-content-click="false">
      <template #activator="{on}">
        <v-btn v-on="on">Menu - List - disable-keys</v-btn>
      </template>
      <v-list>
        <v-list-item v-for="item in items" :key="item" link>
          <v-list-item-title v-text="item"></v-list-item-title>
        </v-list-item>
      </v-list>
    </v-menu>
  </v-container>
</template>

<script>
export default {
  data: () => ({
    items: [...Array(4)].map((_, i) => `Item ${i}`)
  })
};
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)