### PR TITLE
fix(VBtn): accept value prop for underlying DOM element 

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -112,6 +112,12 @@ export const VBtn = defineComponent({
     const isElevated = computed(() => {
       return props.variant === 'elevated' && !(props.disabled || props.flat || props.border)
     })
+    const valueAttr = computed(() => {
+      if (props.value === undefined) return undefined
+
+      return Object(props.value) === props.value
+        ? JSON.stringify(props.value, null, 0) : props.value
+    })
 
     useSelectLink(link, group?.select)
 
@@ -168,6 +174,7 @@ export const VBtn = defineComponent({
             link.navigate?.(e)
             group?.toggle()
           } }
+          value={ valueAttr.value }
         >
           { genOverlays(true, 'v-btn') }
 

--- a/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.cy.tsx
+++ b/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.cy.tsx
@@ -219,18 +219,40 @@ describe('VBtn', () => {
     })
   })
 
-  describe.skip('value', () => {
-    // none of the "value" props are implemented yet
-    it('should stringify non string|number values', () => {
-      const objectValue = { value: { hello: 'world' } }
-      const numberValue = { value: 2 }
+  describe('value', () => {
+    it('should pass string values', () => {
+      const stringValue = 'Foobar'
 
-      cy.mount(<VBtn value={ objectValue }></VBtn>)
+      cy.mount(<VBtn value={stringValue}></VBtn>)
         .get('button')
-        .should('contain.text', JSON.stringify(objectValue, null, 0))
-        .mount(<VBtn value={ numberValue } />)
+        .should('have.value', stringValue)
+    })
+
+    it('should stringify object', () => {
+      const objectValue = { value: {} }
+      cy.mount(<VBtn value={objectValue}></VBtn>)
         .get('button')
-        .should('contain.text', numberValue.value)
+        .should('have.value', JSON.stringify(objectValue, null, 0))
+    })
+
+    it('should stringify number', () => {
+      const numberValue = 15
+      cy.mount(<VBtn value={numberValue}></VBtn>)
+        .get('button')
+        .should('have.value', JSON.stringify(numberValue, null, 0))
+    })
+
+    it('should stringify array', () => {
+      const arrayValue = ['foo', 'bar']
+      cy.mount(<VBtn value={arrayValue}></VBtn>)
+        .get('button')
+        .should('have.value', JSON.stringify(arrayValue, null, 0))
+    })
+
+    it('should not generate a fallback value when not provided', () => {
+      cy.mount(<VBtn></VBtn>)
+        .get('button')
+        .should('not.have.value')
     })
   })
 


### PR DESCRIPTION
## Description

- Implements the logic to allow consumers to provide a `value` prop that will be attached as Node attribute to the underlying DOM element.

## Motivation and Context

fix #16188

## How Has This Been Tested?

Added Cypress Component testing

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
