### PR TITLE
fix(VDataTableServer): add groupBy functionality

### DIFF
--- a/packages/docs/src/examples/v-data-table/misc-server-side-paginate-and-sort.vue
+++ b/packages/docs/src/examples/v-data-table/misc-server-side-paginate-and-sort.vue
@@ -29,16 +29,16 @@
         options: {},
         headers: [
           {
-            text: 'Dessert (100g serving)',
+            title: 'Dessert (100g serving)',
             align: 'start',
             sortable: false,
-            value: 'name',
+            key: 'name',
           },
-          { text: 'Calories', value: 'calories' },
-          { text: 'Fat (g)', value: 'fat' },
-          { text: 'Carbs (g)', value: 'carbs' },
-          { text: 'Protein (g)', value: 'protein' },
-          { text: 'Iron (%)', value: 'iron' },
+          { title: 'Calories', key: 'calories' },
+          { title: 'Fat (g)', key: 'fat' },
+          { title: 'Carbs (g)', key: 'carbs' },
+          { title: 'Protein (g)', key: 'protein' },
+          { title: 'Iron (%)', key: 'iron' },
         ],
       }
     },

--- a/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
@@ -103,6 +103,7 @@ export const VDataTable = defineComponent({
       pageCount,
       startIndex,
       stopIndex,
+      groupBy,
     })
 
     provideDefaults({

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -114,7 +114,7 @@ export const VDataTableRows = defineComponent({
                 />
               ) }
 
-              { isExpanded(item.value) && slots['expanded-row']?.({ item, columns: columns.value }) }
+              { isExpanded(item) && slots['expanded-row']?.({ item, columns: columns.value }) }
             </>
           )
         }) }

--- a/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
@@ -21,6 +21,8 @@ import { makeVDataTableProps } from './VDataTable'
 
 // Types
 import type { DataTableItem } from './types'
+import { useProxiedModel } from '@/composables/proxiedModel'
+import { createGroupBy, makeDataTableGroupProps, useGroupedItems } from './composables/group'
 
 export const VDataTableServer = defineComponent({
   name: 'VDataTableServer',
@@ -41,6 +43,7 @@ export const VDataTableServer = defineComponent({
     ...makeDataTableSelectProps(),
     ...makeDataTableSortProps(),
     ...makeDataTablePaginateProps(),
+    ...makeDataTableGroupProps(),
   },
 
   emits: {
@@ -50,13 +53,17 @@ export const VDataTableServer = defineComponent({
     'update:sortBy': (sortBy: any) => true,
     'update:options': (options: any) => true,
     'update:expanded': (options: any) => true,
+    'update:groupBy': (value: any) => true,
     'click:row': (event: Event, value: { item: DataTableItem }) => true,
   },
 
   setup (props, { emit, slots }) {
+    const groupBy = useProxiedModel(props, 'groupBy')
+
     createExpanded(props)
 
     const { columns } = createHeaders(props, {
+      groupBy,
       showSelect: toRef(props, 'showSelect'),
       showExpand: toRef(props, 'showExpand'),
     })
@@ -65,7 +72,11 @@ export const VDataTableServer = defineComponent({
 
     const { sortBy, toggleSort } = createSort(props)
 
+    const { opened } = createGroupBy(props, groupBy, sortBy)
+
     const { page, itemsPerPage, startIndex, stopIndex, pageCount } = createPagination(props, items)
+
+    const { flatItems } = useGroupedItems(items, groupBy, opened)
 
     createSelection(props, items)
 
@@ -76,6 +87,7 @@ export const VDataTableServer = defineComponent({
       startIndex,
       stopIndex,
       pageCount,
+      groupBy,
     })
 
     provide('v-data-table', {
@@ -121,7 +133,7 @@ export const VDataTableServer = defineComponent({
               <tbody class="v-data-table__tbody" role="rowgroup">
                 { slots.body ? slots.body() : (
                   <VDataTableRows
-                    items={ items.value }
+                    items={ flatItems.value }
                     onClick:row={ (event, value) => emit('click:row', event, value) }
                     v-slots={ slots }
                   />

--- a/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
@@ -5,14 +5,16 @@ import { VDataTableHeaders } from './VDataTableHeaders'
 import { VDataTableRows } from './VDataTableRows'
 
 // Composables
+import { provideDefaults } from '@/composables/defaults'
+import { useProxiedModel } from '@/composables/proxiedModel'
 import { createExpanded, makeDataTableExpandProps } from './composables/expand'
+import { createGroupBy, makeDataTableGroupProps, useGroupedItems } from './composables/group'
 import { createHeaders, makeDataTableHeaderProps } from './composables/headers'
 import { makeDataTableItemProps, useDataTableItems } from './composables/items'
-import { createSort, makeDataTableSortProps } from './composables/sort'
+import { useOptions } from './composables/options'
 import { createPagination, makeDataTablePaginateProps } from './composables/paginate'
 import { createSelection, makeDataTableSelectProps } from './composables/select'
-import { useOptions } from './composables/options'
-import { provideDefaults } from '@/composables/defaults'
+import { createSort, makeDataTableSortProps } from './composables/sort'
 
 // Utilities
 import { provide, toRef } from 'vue'
@@ -21,8 +23,6 @@ import { makeVDataTableProps } from './VDataTable'
 
 // Types
 import type { DataTableItem } from './types'
-import { useProxiedModel } from '@/composables/proxiedModel'
-import { createGroupBy, makeDataTableGroupProps, useGroupedItems } from './composables/group'
 
 export const VDataTableServer = defineComponent({
   name: 'VDataTableServer',

--- a/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
@@ -95,6 +95,7 @@ export const VDataTableVirtual = defineComponent({
       stopIndex: computed(() => flatItems.value.length - 1),
       pageCount: ref(1),
       itemsPerPage: ref(-1),
+      groupBy,
     })
 
     provideDefaults({

--- a/packages/vuetify/src/labs/VDataTable/__tests__/VDataTableServer.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VDataTable/__tests__/VDataTableServer.spec.cy.tsx
@@ -1,0 +1,112 @@
+/// <reference types="../../../../types/cypress" />
+
+import { VDataTableServer } from '..'
+
+const DESSERT_HEADERS = [
+  { title: 'Dessert (100g serving)', key: 'name' },
+  { title: 'Calories', key: 'calories' },
+  { title: 'Fat (g)', key: 'fat' },
+  { title: 'Carbs (g)', key: 'carbs' },
+  { title: 'Protein (g)', key: 'protein' },
+  { title: 'Iron (%)', key: 'iron' },
+]
+
+const DESSERT_ITEMS = [
+  {
+    name: 'Frozen Yogurt',
+    calories: 159,
+    fat: 6.0,
+    carbs: 24,
+    protein: 4.0,
+    iron: '1%',
+  },
+  {
+    name: 'Ice cream sandwich',
+    calories: 237,
+    fat: 9.0,
+    carbs: 37,
+    protein: 4.3,
+    iron: '1%',
+  },
+  {
+    name: 'Eclair',
+    calories: 262,
+    fat: 16.0,
+    carbs: 23,
+    protein: 6.0,
+    iron: '7%',
+  },
+  {
+    name: 'Cupcake',
+    calories: 305,
+    fat: 3.7,
+    carbs: 67,
+    protein: 4.3,
+    iron: '8%',
+  },
+  {
+    name: 'Gingerbread',
+    calories: 356,
+    fat: 16.0,
+    carbs: 49,
+    protein: 3.9,
+    iron: '16%',
+  },
+  {
+    name: 'Jelly bean',
+    calories: 375,
+    fat: 0.0,
+    carbs: 94,
+    protein: 0.0,
+    iron: '0%',
+  },
+  {
+    name: 'Lollipop',
+    calories: 392,
+    fat: 0.2,
+    carbs: 98,
+    protein: 0,
+    iron: '2%',
+  },
+  {
+    name: 'Honeycomb',
+    calories: 408,
+    fat: 3.2,
+    carbs: 87,
+    protein: 6.5,
+    iron: '45%',
+  },
+  {
+    name: 'Donut',
+    calories: 452,
+    fat: 25.0,
+    carbs: 51,
+    protein: 4.9,
+    iron: '22%',
+  },
+  {
+    name: 'KitKat',
+    calories: 518,
+    fat: 26.0,
+    carbs: 65,
+    protein: 7,
+    iron: '6%',
+  },
+]
+
+describe('VDataTableServer', () => {
+  it('should render table', () => {
+    const itemsLength = 2
+
+    cy.mount(() => (
+      <VDataTableServer
+        headers={ DESSERT_HEADERS }
+        items={ DESSERT_ITEMS.slice(0, itemsLength) }
+        items-length={ itemsLength }
+      ></VDataTableServer>
+    ))
+
+    cy.get('.v-data-table thead th').should('have.length', DESSERT_HEADERS.length)
+    cy.get('.v-data-table tbody tr').should('have.length', itemsLength)
+  })
+})

--- a/packages/vuetify/src/labs/VDataTable/composables/options.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/options.ts
@@ -13,6 +13,7 @@ export function useOptions ({
   startIndex,
   stopIndex,
   pageCount,
+  groupBy,
 }: {
   page: Ref<number>
   itemsPerPage: Ref<number>
@@ -20,6 +21,7 @@ export function useOptions ({
   startIndex: Ref<number>
   stopIndex: Ref<number>
   pageCount: Ref<number>
+  groupBy: Ref<readonly SortItem[]>
 }) {
   const vm = getCurrentInstance('VDataTable')
 
@@ -30,6 +32,7 @@ export function useOptions ({
     stopIndex: stopIndex.value,
     pageCount: pageCount.value,
     sortBy: sortBy.value,
+    groupBy: groupBy.value,
   }))
 
   // Reset page when sorting changes


### PR DESCRIPTION
needed to fix regression caused by VDataTableRows injecting group to pass to slot

closes #16468

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

<!-- We use conventional-changelog-angular for all commit structures -->
<!-- https://vuetifyjs.com/getting-started/contributing#commit-guidelines-w-commitizen -->


## Description
<!-- Describe your changes in detail -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #4213 or fixes #2312 -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!-- All PR's should implement unit tests if possible -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | e2e | none -->

## Markup:
<!-- Information on how to setup your local development environment can be found here: -->
<!-- https://vuetifyjs.com/getting-started/contributing#setup-dev-environment -->

<!-- Paste markup for testing your change --->
<details>

```vue
<template>
  <div>
    <v-data-table-server
      :headers="headers"
      :items="desserts"
      :items-length="totalDesserts"
      :loading="loading"
      :items-per-page="2"
      item-value="name"
      show-select
      show-expand
      class="elevation-1"
      @update:options="options = $event"
    >
      <template v-slot:expanded-row>
        This is an expanded row
      </template>
    </v-data-table-server>
  </div>
</template>

<script>
  export default {
    data () {
      return {
        totalDesserts: 0,
        desserts: [],
        loading: true,
        options: {},
        headers: [
          {
            title: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            key: 'name',
          },
          { title: 'Calories', key: 'calories' },
          { title: 'Fat (g)', key: 'fat' },
          { title: 'Carbs (g)', key: 'carbs' },
          { title: 'Protein (g)', key: 'protein' },
          { title: 'Iron (%)', key: 'iron' },
        ],
      }
    },
    watch: {
      options: {
        handler () {
          this.getDataFromApi()
        },
        deep: true,
      },
    },
    methods: {
      getDataFromApi () {
        this.loading = true
        this.fakeApiCall().then(data => {
          this.desserts = data.items
          this.totalDesserts = data.total
          this.loading = false
        })
      },
      /**
       * In a real application this would be a call to fetch() or axios.get()
       */
      fakeApiCall () {
        return new Promise((resolve, reject) => {
          const { sortBy = [], page, itemsPerPage } = this.options

          let items = this.getDesserts()
          const total = items.length

          if (sortBy.length) {
            items = items.sort((a, b) => {
              const sortA = a[sortBy[0].key]
              const sortB = b[sortBy[0].key]

              if (sortBy[0].order) {
                if (sortA < sortB) return 1
                if (sortA > sortB) return -1
                return 0
              } else {
                if (sortA < sortB) return -1
                if (sortA > sortB) return 1
                return 0
              }
            })
          }

          if (itemsPerPage > 0) {
            items = items.slice((page - 1) * itemsPerPage, page * itemsPerPage)
          }

          setTimeout(() => {
            resolve({
              items,
              total,
            })
          }, 1000)
        })
      },
      getDesserts () {
        return [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ]
      },
    },
  }
</script>
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title is no longer than 64 characters.
- [ ] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [ ] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
