### PR TITLE
docs(flex): add .justify-space-evenly to example

### DIFF
--- a/packages/docs/src/examples/flex/flex-justify.vue
+++ b/packages/docs/src/examples/flex/flex-justify.vue
@@ -49,5 +49,15 @@
         justify-space-around
       </v-sheet>
     </div>
+
+    <div class="d-flex justify-space-evenly mb-6 bg-surface-variant">
+      <v-sheet
+        v-for="n in 3"
+        :key="n"
+        class="ma-2 pa-2"
+      >
+        justify-space-evenly
+      </v-sheet>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
