### PR TITLE
fix(VFileInput): reset internal input when model is cleared

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -124,19 +124,16 @@ export const VFileInput = defineComponent({
       nextTick(() => {
         model.value = []
 
-        if (inputRef?.value) {
-          inputRef.value.value = ''
-        }
-
         callEvent(props['onClick:clear'], e)
       })
     }
 
-    watch(model, updatedModel => {
-      const hasModelReset = !Array.isArray(updatedModel) || updatedModel.length === 0
+    watch(model, newValue => {
+      const hasModelReset = !Array.isArray(newValue) || !newValue.length
 
       if (hasModelReset && inputRef.value) {
         inputRef.value.value = ''
+        console.log('cleared')
       }
     })
 

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -133,7 +133,6 @@ export const VFileInput = defineComponent({
 
       if (hasModelReset && inputRef.value) {
         inputRef.value.value = ''
-        console.log('cleared')
       }
     })
 

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -14,7 +14,7 @@ import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { callEvent, defineComponent, filterInputAttrs, humanReadableFileSize, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -131,6 +131,14 @@ export const VFileInput = defineComponent({
         callEvent(props['onClick:clear'], e)
       })
     }
+
+    watch(model, updatedModel => {
+      const hasModelReset = !Array.isArray(updatedModel) || updatedModel.length === 0
+
+      if (hasModelReset && inputRef.value) {
+        inputRef.value.value = ''
+      }
+    })
 
     useRender(() => {
       const hasCounter = !!(slots.counter || props.counter)

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
@@ -136,4 +136,57 @@ describe('VFileInput', () => {
       .get('.v-file-input input')
       .should('have.attr', 'accept', 'image/*')
   })
+
+  /**
+   * https://github.com/vuetifyjs/vuetify/issues/16486
+   */
+  it('should reset the underlying HTMLInput when model is controlled input', () => {
+    function TestWrapper () {
+      const files = ref<File[]>([])
+      const onReset = () => {
+        files.value = []
+      }
+      return (
+        <CenteredGrid width="400px">
+          <VFileInput modelValue={ files.value } />
+          <button onClick={ onReset }>Reset Model Value</button>
+        </CenteredGrid>
+      )
+    }
+
+    cy.mount(() => (
+      <TestWrapper />
+    ))
+      .get('.v-file-input input')
+      .should($res => {
+        const input = $res[0] as HTMLInputElement
+        expect(input.files).to.have.length(0)
+      })
+    // add file
+      .attachFile('text.txt')
+      .should($res => {
+        const input = $res[0] as HTMLInputElement
+        expect(input.files).to.have.length(1)
+      })
+    // reset input from wrapper/parent component
+      .get('button').click()
+      .get('.v-file-input input')
+      .should($res => {
+        const input = $res[0] as HTMLInputElement
+        expect(input.files).to.have.length(0)
+      })
+    // add same file again
+      .attachFile('text.txt')
+      .should($res => {
+        const input = $res[0] as HTMLInputElement
+        expect(input.files).to.have.length(1)
+      })
+    // reset input from wrapper/parent component
+      .get('button').click()
+      .get('.v-file-input input')
+      .should($res => {
+        const input = $res[0] as HTMLInputElement
+        expect(input.files).to.have.length(0)
+      })
+  })
 })


### PR DESCRIPTION
## Description

fix #16167

Currently, when the input is reset programmatically outside the VFileInput, the underlying `HTMLInputElement` is not reset, which prevents the same file from being reselected.


### What's missing from this PR

- implementing a Component testing to verify behaviour

Currently, in Cypress Component testing the Input doesn't update correctly. I might not be too familiar with the `cy` API and would require some help

## Markup:

```vue
<template>
  <v-app>
    <v-main>
      <v-file-input v-model="files" />
      <v-btn @click="onClick">remove input files</v-btn>
      <ol class="pl-4">
        <li>add a file</li>
        <li>click remove button</li>
        <li>add the same file</li>
      </ol>
    </v-main>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const files = ref([])
const onClick = () => {
  files.value = []
}
</script>

```

## TODOS

* [ ] Add Cypress Component Test to verify correct behaviour

# Types of changes

* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

# Checklist:

* [x]  The PR title is no longer than 64 characters.
* [x]  The PR is submitted to the correct branch (master for bug fixes and documentation updates, dev for new features and backwards compatible changes and next for non-backwards compatible changes).
* [x]  My code follows the code style of this project.
* []  I've added relevant changes to the documentation (applies to new features and breaking changes in core library)

