### PR TITLE
fix(VSelect): return-object with plain items

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -166,7 +166,7 @@ export const VCombobox = genericComponent<new <
 
     const selections = computed(() => {
       return model.value.map(v => {
-        return items.value.find(item => props.valueComparator(item.value, v.value)) || v
+        return items.value.find(item => props.valueComparator(item.title, v.title)) || v
       })
     })
 

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -263,4 +263,77 @@ describe('VSelect', () => {
       cy.get('.v-overlay__content .v-list-item .v-list-item-title').eq(1).should('have.text', 'Item 4')
     })
   })
+
+  describe('return-object', () => {
+    it('should return whole object', () => {
+      const items = ref([
+        {
+          title: 'Item 1',
+          value: 1,
+        },
+        {
+          title: 'Item 2',
+          value: 2,
+        },
+        {
+          title: 'Item 3',
+          value: 3,
+        },
+      ])
+
+      const selected = ref([])
+
+      cy.mount(() => (
+        <div class="ma-10">
+          <VSelect label="Select" v-model={selected.value} items={items.value} multiple returnObject />
+        </div>
+      ))
+        .get('.v-select')
+        .click()
+        .get('.v-list-item')
+        .eq(1)
+        .click()
+        .then(() => {
+          expect(selected.value).deep.equal([{ title: 'Item 2', value: 2 }])
+        })
+        .find('.v-checkbox-btn input')
+        .should('be.checked')
+    })
+
+    // https://github.com/vuetifyjs/vuetify/issues/16512
+    it('should work with plain items array', () => {
+      const items = [
+        {
+          title: 'Item 1',
+          value: 1,
+        },
+        {
+          title: 'Item 2',
+          value: 2,
+        },
+        {
+          title: 'Item 3',
+          value: 3,
+        },
+      ]
+
+      const selected = ref([])
+
+      cy.mount(() => (
+        <div class="ma-10">
+          <VSelect label="Select" v-model={selected.value} items={items} multiple returnObject />
+        </div>
+      ))
+        .get('.v-select')
+        .click()
+        .get('.v-list-item')
+        .eq(1)
+        .click()
+        .then(() => {
+          expect(selected.value).deep.equal([{ title: 'Item 2', value: 2 }])
+        })
+        .find('.v-checkbox-btn input')
+        .should('be.checked')
+    })
+  })
 })

--- a/packages/vuetify/src/composables/items.ts
+++ b/packages/vuetify/src/composables/items.ts
@@ -54,7 +54,7 @@ export const makeItemsProps = propsFactory({
 
 export function transformItem (props: Omit<ItemProps, 'items'>, item: any) {
   const title = getPropertyFromItem(item, props.itemTitle, item)
-  const value = props.returnObject ? item : getPropertyFromItem(item, props.itemValue, title)
+  const value = getPropertyFromItem(item, props.itemValue, title)
   const children = getPropertyFromItem(item, props.itemChildren)
   const itemProps = props.itemProps === true
     ? typeof item === 'object' && item != null && !Array.isArray(item)
@@ -97,7 +97,7 @@ export function useItems (props: ItemProps) {
   }
 
   function transformOut (value: InternalItem[]) {
-    return value.map(({ props }) => props.value)
+    return value.map(item => props.returnObject ? item.raw : item.value)
   }
 
   return { items, transformIn, transformOut }


### PR DESCRIPTION
closes #16512

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-select v-model="selected" :items="values" multiple return-object />

      <v-select v-model="selectedPlain" :items="valuesPlain" multiple return-object />

      <v-combobox
        v-model="foo"
        v-model:search="search"
        :items="items"
      />

      <pre>{{ foo }}</pre>
      <pre>{{ search }}</pre>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref([{title: 'test', value: 'red'}])
  const selectedPlain = ref([{title:'test', value: 'red'}])
  const values = ref([{title: 'test', value:'red'}])
  const valuesPlain = [{title: 'test', value:'red'}]
  const items = [
    { title: 'Item 1', value: 'item1' },
    { title: 'Item 2', value: 'item2' },
    { title: 'Item 3', value: 'item3' },
    { title: 'Item 4', value: 'item4' },
  ]
  const foo = ref()
  const search = ref()
</script>
```
