### PR TITLE
feat(VBtn): add iconSize prop

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -191,7 +191,7 @@ export const VBtn = defineComponent({
               }}
             >
               <span class="v-btn__prepend">
-                { slots.prepend?.() ?? (<VIcon />) }
+                {slots.prepend?.() ?? (<VIcon size={ props.iconSize } />) }
               </span>
             </VDefaultsProvider>
           ) }
@@ -207,7 +207,7 @@ export const VBtn = defineComponent({
             >
               { slots.default?.() ?? (
                 hasIcon && (
-                  <VIcon key="icon" />
+                  <VIcon key="icon" size={ props.iconSize } />
                 )
               ) }
             </VDefaultsProvider>
@@ -223,7 +223,7 @@ export const VBtn = defineComponent({
               }}
             >
               <span class="v-btn__append">
-                { slots.append?.() ?? (<VIcon />) }
+                { slots.append?.() ?? (<VIcon size={ props.iconSize } />) }
               </span>
             </VDefaultsProvider>
           ) }

--- a/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.cy.tsx
+++ b/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.cy.tsx
@@ -3,6 +3,7 @@
 import { VBtn } from '../VBtn'
 import { generate, gridOn } from '@/../cypress/templates'
 import { createRouter, createWebHistory } from 'vue-router'
+import { VIcon } from '@/components/VIcon'
 
 const anchor = {
   href: '#my-anchor',
@@ -83,6 +84,30 @@ describe('VBtn', () => {
       cy.mount(<VBtn icon><span style="font-size: 1.5rem;">🐻</span></VBtn>)
         .get('button')
         .should('have.text', '🐻')
+    })
+
+    it('renders an icon as default slot and pass the iconSize prop to it', () => {
+      cy.mount(<VBtn icon="$ratingEmpty" iconSize={100}></VBtn>)
+        .get('.v-btn__content > i')
+        .should('have.css', 'font-size', '100px')
+    })
+
+    it('renders a VIcon with the correct size', () => {
+      cy.mount(<VBtn><VIcon size={58}>mdi-heart</VIcon></VBtn>)
+        .get('.v-btn__content > i')
+        .should('have.css', 'font-size', '58px')
+    })
+
+    it('renders a prepended icon and pass the size prop to it', () => {
+      cy.mount(<VBtn prependIcon="$ratingEmpty" iconSize={210}>Click Me</VBtn>)
+        .get('.mdi-star-outline')
+        .should('have.css', 'font-size', '210px')
+    })
+
+    it('renders an appended icon and pass the size prop to it', () => {
+      cy.mount(<VBtn iconSize={200} appendIcon="$ratingEmpty">Click Me</VBtn>)
+        .get('.mdi-star-outline')
+        .should('have.css', 'font-size', '200px')
     })
   })
 

--- a/packages/vuetify/src/components/VIcon/VIcon.tsx
+++ b/packages/vuetify/src/components/VIcon/VIcon.tsx
@@ -46,7 +46,7 @@ export const VIcon = defineComponent({
 
     const { themeClasses } = provideTheme(props)
     const { iconData } = useIcon(slotIcon || props)
-    const { sizeClasses } = useSize(props)
+    const { sizeClasses } = useSize(props, 'iconSize')
     const { textColorClasses, textColorStyles } = useTextColor(toRef(props, 'color'))
 
     useRender(() => (

--- a/packages/vuetify/src/composables/size.ts
+++ b/packages/vuetify/src/composables/size.ts
@@ -5,8 +5,11 @@ import { convertToUnit, destructComputed, getCurrentInstanceName, includes, prop
 const predefinedSizes = ['x-small', 'small', 'default', 'large', 'x-large']
 
 export interface SizeProps {
-  size?: string | number
+  size?: number | string
+  iconSize?: number | string
 }
+
+type Prop = 'size' | 'iconSize'
 
 // Composables
 export const makeSizeProps = propsFactory({
@@ -14,21 +17,25 @@ export const makeSizeProps = propsFactory({
     type: [String, Number],
     default: 'default',
   },
+  iconSize: {
+    type: [String, Number],
+  },
 }, 'size')
 
 export function useSize (
   props: SizeProps,
+  prop: Prop = 'size',
   name = getCurrentInstanceName(),
 ) {
   return destructComputed(() => {
     let sizeClasses
     let sizeStyles
-    if (includes(predefinedSizes, props.size)) {
-      sizeClasses = `${name}--size-${props.size}`
-    } else if (props.size) {
+    if (includes(predefinedSizes, props[prop])) {
+      sizeClasses = `${name}--size-${props[prop]}`
+    } else if (props[prop]) {
       sizeStyles = {
-        width: convertToUnit(props.size),
-        height: convertToUnit(props.size),
+        width: convertToUnit(props[prop]),
+        height: convertToUnit(props[prop]),
       }
     }
     return { sizeClasses, sizeStyles }


### PR DESCRIPTION
## Description

Starting point to discuss the potential implementation of `iconSize` prop and its behaviour

# The problem

Currently, `<VIcon />` rendered from the `<VBtn />` do not receive any `size` prop, and therefore they don't scale accordingly to the users' needs.

One potential approach would be to automatically scale with the same sizes provided to the `<VBtn />`, but it would limit the ability for the user to customize the look for built-in icons.

The alternative approach is to add a new `iconSize` prop to the `<VBtn />` (and potentially replicate this approach to other components that leverage icons?).

Open to thoughts and considerations.

# Related issues

closes #16288 
