### PR TITLE
Align prepend, append slot on nested list

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -56,6 +56,10 @@
   .v-list-item--two-line &,
   .v-list-item--three-line &
     align-self: start
+    
+    .v-list-item--one-line
+      .v-list-item__prepend
+        align-items: center
 
 .v-list-item__append
   align-self: center
@@ -72,6 +76,10 @@
   .v-list-item--two-line &,
   .v-list-item--three-line &
     align-self: start
+    
+    .v-list-item--one-line
+      .v-list-item__append
+        align-items: center
 
 .v-list-item__content
   align-self: center


### PR DESCRIPTION
## Description
When parent list with two or three lines has a child list with one line, prepend and append slots must be re aligned to center.
