### PR TITLE
fix(VAutoComplete): v auto complete does not hide placeholder when multiple property is defined

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -209,7 +209,7 @@ export const VTextField = genericComponent<new () => {
                         readonly={ isReadonly.value }
                         disabled={ isDisabled.value }
                         name={ props.name }
-                        placeholder={ props.placeholder }
+                        placeholder={ isDirty.value ? '' : props.placeholder }
                         size={ 1 }
                         type={ props.type }
                         onFocus={ onFocus }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Hide placeholder in VAutoComplete component when multiple property is defiend and at least one item is selected.
I solve it using isDirty value in VTextField component.

fixes #16519

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
         <v-autocomplete
            v-model="values"
            :items="items"
            placeholder="Select Item"
            multiple
          ></v-autocomplete>
    </v-main>
  </v-app>
</template>
<script>
  export default {
    data: () => ({
      items: ['foo', 'bar', 'fizz', 'buzz'],
      values: ['foo', 'bar'],
    }),
  }
</script>
```
