### PR TITLE
fix(VDataTable): pagination arrow buttons active when items is empty

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableFooter.tsx
@@ -90,13 +90,13 @@ export const VDataTableFooter = defineComponent({
             icon={ props.nextIcon }
             variant="plain"
             onClick={ () => page.value = Math.min(pageCount.value, page.value + 1) }
-            disabled={ page.value === pageCount.value }
+            disabled={ page.value >= pageCount.value }
           />
           <VBtn
             icon={ props.lastIcon }
             variant="plain"
             onClick={ () => page.value = pageCount.value }
-            disabled={ page.value === pageCount.value }
+            disabled={ page.value >= pageCount.value }
           />
         </div>
       </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Disable next and last pagination buttons when items is empty.
I changed the disabled condition `page.value === pageCount.value` to `page.value >= pageCount.value` in next and last buttons.

fixes #16560 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :items="items"/>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const items = ref([])

</script>

```
