### PR TITLE
docs(VDatePicker): use `substring` instead of `substr`in misc-birthday.vue

### DIFF
--- a/packages/docs/src/examples/v-date-picker/misc-birthday.vue
+++ b/packages/docs/src/examples/v-date-picker/misc-birthday.vue
@@ -22,7 +22,7 @@
       <v-date-picker
         v-model="date"
         :active-picker.sync="activePicker"
-        :max="(new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substr(0, 10)"
+        :max="(new Date(Date.now() - (new Date()).getTimezoneOffset() * 60000)).toISOString().substring(0, 10)"
         min="1950-01-01"
         @change="save"
       ></v-date-picker>


### PR DESCRIPTION
Avoid using deprecated method to substring

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Updating the example so that it avoids using deprecated method to substring 

