### PR TITLE
feat(nested): add open-on-mount prop

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -132,7 +132,7 @@ export const VList = genericComponent<new <T>() => {
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
     const { roundedClasses } = useRounded(props)
-    const { open, select } = useNested(props)
+    const { open, select, getPath } = useNested(props)
     const lineClasses = computed(() => props.lines ? `v-list--${props.lines}-line` : undefined)
     const activeColor = toRef(props, 'activeColor')
     const color = toRef(props, 'color')
@@ -258,6 +258,7 @@ export const VList = genericComponent<new <T>() => {
       open,
       select,
       focus,
+      getPath,
     }
   },
 })

--- a/packages/vuetify/src/components/VList/__tests__/VList.spec.cy.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VList.spec.cy.tsx
@@ -229,4 +229,82 @@ describe('VList', () => {
 
     cy.get('.v-list-item').eq(1).should('not.have.class', 'v-list-item--active')
   })
+
+  it('should open selected items on mount', () => {
+    const items = [
+      {
+        title: 'Foo',
+        subtitle: 'Bar',
+        value: 'foo',
+      },
+      {
+        title: 'Group',
+        value: 'group',
+        children: [
+          {
+            title: 'Child',
+            subtitle: 'Subtitle',
+            value: 'child',
+            children: [
+              {
+                title: 'Another Child',
+                value: 'another_child',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const wrapper = mountFunction((
+      <CenteredGrid width="200px">
+        <VList items={items} selected={['another_child']} openOnMount="selected" />
+      </CenteredGrid>
+    ))
+
+    wrapper.get('.v-list-item')
+      .should('have.length', 4)
+      .contains('Another Child')
+      .should('be.visible')
+  })
+
+  it('should open all items on mount', () => {
+    const items = [
+      {
+        title: 'Foo',
+        subtitle: 'Bar',
+        value: 'foo',
+        children: [
+          {
+            title: 'First',
+            value: 'first',
+          },
+        ],
+      },
+      {
+        title: 'Group',
+        value: 'group',
+        children: [
+          {
+            title: 'Second',
+            value: 'second',
+          },
+        ],
+      },
+    ]
+
+    const wrapper = mountFunction((
+      <CenteredGrid width="200px">
+        <VList items={items} openOnMount="all" />
+      </CenteredGrid>
+    ))
+
+    wrapper.get('.v-list-item')
+      .should('have.length', 4)
+      .contains('First')
+      .should('be.visible')
+      .get('.v-list-item')
+      .contains('Second')
+      .should('be.visible')
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
adds prop to open items on mount, either selected or all items.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card
    class="mx-auto"
    width="300"
  >
    <v-list v-model:selected="selected" v-model:opened="open" open-on-mount="selected" select-strategy="multiple">
      <v-list-item prepend-icon="mdi-home" title="Home"></v-list-item>

      <v-list-group value="Users">
        <template v-slot:activator="{ props }">
          <v-list-item
            v-bind="props"
            prepend-icon="mdi-account-circle"
            title="Users"
          ></v-list-item>
        </template>

        <v-list-group value="Admin">
          <template v-slot:activator="{ props }">
            <v-list-item
              v-bind="props"
              title="Admin"
            ></v-list-item>
          </template>

          <v-list-item
            v-for="([title, icon], i) in admins"
            :key="i"
            :title="title"
            :prepend-icon="icon"
            :value="title"
          ></v-list-item>
        </v-list-group>

        <v-list-group value="Actions">
          <template v-slot:activator="{ props }">
            <v-list-item
              v-bind="props"
              title="Actions"
            ></v-list-item>
          </template>

          <v-list-item
            v-for="([title, icon], i) in cruds"
            :key="i"
            :value="title"
            :title="title"
            :prepend-icon="icon"
          ></v-list-item>
        </v-list-group>
      </v-list-group>
    </v-list>
  </v-card>
</template>
<script>
  export default {
    data: () => ({
      selected: ['Settings', 'Read'],
      open: [],
      admins: [
        ['Management', 'mdi-account-multiple-outline'],
        ['Settings', 'mdi-cog-outline'],
      ],
      cruds: [
        ['Create', 'mdi-plus-outline'],
        ['Read', 'mdi-file-outline'],
        ['Update', 'mdi-update'],
        ['Delete', 'mdi-delete'],
      ],
    }),
  }
</script>

```
