### PR TITLE
fix(VAutocomplete): improve ux

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -85,15 +85,11 @@
       input
         transition: none
 
-    .v-field--dirty:not(.v-field--focused)
-      input
-        opacity: 0
-
     .v-field--focused
       .v-autocomplete__selection-text
         opacity: 0
 
-  &--selection-slot
+  &--selection-slot,&--chips.v-input--dirty
     &.v-text-field input
       position: relative
       padding-inline-start: 0

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -179,6 +179,10 @@ export const VAutocomplete = genericComponent<new <
       } else if (e.key === 'ArrowUp') {
         listRef.value?.focus('prev')
       }
+
+      if (e.key === 'Backspace' && search.value === '') {
+        model.value = model.value.slice(0, -1)
+      }
     }
 
     function onInput (e: InputEvent) {
@@ -195,6 +199,12 @@ export const VAutocomplete = genericComponent<new <
 
     function onFocusout (e: FocusEvent) {
       if (e.relatedTarget == null) {
+        vTextFieldRef.value?.focus()
+      }
+    }
+
+    function onListKeydown (e: KeyboardEvent) {
+      if (/^.$/u.test(e.key)) {
         vTextFieldRef.value?.focus()
       }
     }
@@ -218,7 +228,7 @@ export const VAutocomplete = genericComponent<new <
 
         isSelecting.value = true
 
-        if (!slots.selection) {
+        if (!slots.selection && !props.chips) {
           search.value = item.title
         }
 
@@ -232,7 +242,7 @@ export const VAutocomplete = genericComponent<new <
     watch(isFocused, val => {
       if (val) {
         isSelecting.value = true
-        search.value = props.multiple || !!slots.selection ? '' : String(selections.value.at(-1)?.props.title ?? '')
+        search.value = props.chips || props.multiple || !!slots.selection ? '' : String(selections.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)
@@ -266,10 +276,10 @@ export const VAutocomplete = genericComponent<new <
           onInput={ onInput }
           class={[
             'v-autocomplete',
+            `v-autocomplete--${props.multiple ? 'multiple' : 'single'}`,
             {
               'v-autocomplete--active-menu': menu.value,
               'v-autocomplete--chips': !!props.chips,
-              [`v-autocomplete--${props.multiple ? 'multiple' : 'single'}`]: true,
               'v-autocomplete--selection-slot': !!slots.selection,
             },
           ]}
@@ -304,6 +314,7 @@ export const VAutocomplete = genericComponent<new <
                       selected={ selected.value }
                       selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                       onMousedown={ (e: MouseEvent) => e.preventDefault() }
+                      onKeydown={ onListKeydown }
                       onFocusin={ onFocusin }
                       onFocusout={ onFocusout }
                     >
@@ -363,6 +374,7 @@ export const VAutocomplete = genericComponent<new <
                             VChip: {
                               closable: props.closableChips,
                               size: 'small',
+                              density: 'comfortable',
                               text: item.title,
                             },
                           }}


### PR DESCRIPTION
closes #16186

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

TODO: add some tests

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
- Remove items by pressing Backspace
- Ability to keep typing when list is focused
- Fix bug where both value and search showed at the same time

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-autocomplete
        class="ma-10"
        clearable
        chips
        label="Autocomplete"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      ></v-autocomplete>

      <v-autocomplete
        class="ma-10"
        clearable
        label="Autocomplete"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      ></v-autocomplete>

      <v-autocomplete
        class="ma-10"
        clearable
        multiple
        label="Autocomplete"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      ></v-autocomplete>

      <v-autocomplete
        class="ma-10"
        clearable
        multiple
        chips
        label="Autocomplete"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      ></v-autocomplete>
    </v-main>
  </v-app>
</template>

<script setup>
</script>

```
