### PR TITLE
fix(lists): wrong padding for lists (ul, ol) in RTL

### DIFF
--- a/packages/vuetify/src/styles/elements/_lists.sass
+++ b/packages/vuetify/src/styles/elements/_lists.sass
@@ -1,3 +1,9 @@
-.v-application
-  ul, ol
+// Imports
+@import '../styles.sass'
+
+ul, ol
+  +ltr()
     padding-left: $spacer * 6
+
+  +rtl()
+    padding-right: $spacer * 6


### PR DESCRIPTION
### Environment
**Vuetify Version:** 2.6.14
**Vue Version:** 2.7.14
**Browsers:** Chrome 109.0.0.0
**OS:** Mac OS 10.15.7

### Steps to reproduce
There no paddings for lists in RTL direciton

### Expected Behavior
*packages/vuetify/src/styles/elements/_lists.sass*:

```
// Imports
@import '../styles.sass'

ul, ol
  +ltr()
    padding-left: $spacer * 6

  +rtl()
    padding-right: $spacer * 6

```

### Actual Behavior
*packages/vuetify/src/styles/elements/_lists.sass*:

```
.v-application
  ul, ol
    padding-left: $spacer * 6
```

### Reproduction Link
[https://codepen.io/AndrewBeznosko/pen/KKBYyro?editors=1010](https://codepen.io/AndrewBeznosko/pen/KKBYyro?editors=1010)


<!-- generated by vuetify-issue-helper. DO NOT REMOVE -->