### PR TITLE
feat: add support for Google Material Design font icon variants

### DIFF
--- a/packages/vuetify/src/composables/icons.tsx
+++ b/packages/vuetify/src/composables/icons.tsx
@@ -53,6 +53,7 @@ export interface IconProps {
   tag: string
   icon?: IconValue
   disabled?: Boolean
+  variant?: string
 }
 
 type IconComponent = JSXComponent<IconProps>

--- a/packages/vuetify/src/iconsets/md.ts
+++ b/packages/vuetify/src/iconsets/md.ts
@@ -47,7 +47,7 @@ const aliases: IconAliases = {
 
 const md: IconSet = {
   // Not using mergeProps here, functional components merge props by default (?)
-  component: props => h(VLigatureIcon, { ...props, class: 'material-icons' }),
+  component: props => h(VLigatureIcon, { ...props, class: props.variant ? `material-icons-${props.variant}` : 'material-icons' }),
 }
 
 export { aliases, md }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
[Google Material Icon](https://fonts.google.com/icons) have several variants available including: outlined, filled, rounded, sharp, and two-tone, however prior to this change Vuetify only supported the default.

This change makes the others available by setting a variant prop on the VIcon component. So...

```
<v-icon icon="fiber_new" variant="outlined"></v-icon>
```
 
![image](https://user-images.githubusercontent.com/11353590/217330114-2988ecf9-6183-463e-9389-3a84d94b8b3c.png)
vs the default
![image](https://user-images.githubusercontent.com/11353590/217330454-8a1e86bf-fc74-40f7-a24d-afd118440a5d.png)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
