### PR TITLE
fix(proxiedModel): don't pass reactive objects to transformIn()

### DIFF
--- a/packages/vuetify/src/composables/proxiedModel.ts
+++ b/packages/vuetify/src/composables/proxiedModel.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { computed, ref, watch } from 'vue'
+import { computed, ref, toRaw, watch } from 'vue'
 import { getCurrentInstance, toKebabCase } from '@/util'
 import { useToggleScope } from '@/composables/toggleScope'
 
@@ -46,14 +46,12 @@ export function useProxiedModel<
 
   const model = computed({
     get (): any {
-      return transformIn(isControlled.value ? props[prop] : internal.value)
+      return transformIn(toRaw(isControlled.value ? props[prop] : internal.value))
     },
-    set (value) {
-      const newValue = transformOut(value)
-      if (
-        (isControlled.value ? props[prop] : internal.value) === newValue ||
-        transformIn(isControlled.value ? props[prop] : internal.value) === value
-      ) {
+    set (internalValue) {
+      const newValue = transformOut(internalValue)
+      const value = toRaw(isControlled.value ? props[prop] : internal.value)
+      if (value === newValue || transformIn(value) === internalValue) {
         return
       }
       internal.value = newValue


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #16512
alternative to #16546

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-select v-model="selected" :items="values" multiple return-object />

      <v-select v-model="selectedPlain" :items="valuesPlain" multiple return-object />

      <v-combobox
        v-model="foo"
        v-model:search="search"
        :items="items"
      />

      <pre>{{ foo }}</pre>
      <pre>{{ search }}</pre>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref([{ title: 'test', value: 'red' }])
  const selectedPlain = ref([{ title: 'test', value: 'red' }])
  const values = ref([{ title: 'test', value: 'red' }])
  const valuesPlain = [{ title: 'test', value: 'red' }]
  const items = [
    { title: 'Item 1', value: 'item1' },
    { title: 'Item 2', value: 'item2' },
    { title: 'Item 3', value: 'item3' },
    { title: 'Item 4', value: 'item4' },
  ]
  const foo = ref()
  const search = ref()
</script>
```
