### PR TITLE
fix(VAppBar/VSystemBar/VBottomNavigation): add ssr boot styling

### DIFF
--- a/packages/vuetify/src/components/VAppBar/VAppBar.tsx
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.tsx
@@ -7,6 +7,7 @@ import { filterToolbarProps, makeVToolbarProps, VToolbar } from '@/components/VT
 // Composables
 import { makeLayoutItemProps, useLayoutItem } from '@/composables/layout'
 import { useProxiedModel } from '@/composables/proxiedModel'
+import { useSsrBoot } from '@/composables/ssrBoot'
 
 // Utilities
 import { computed, ref, toRef } from 'vue'
@@ -59,6 +60,7 @@ export const VAppBar = genericComponent<VToolbarSlots>()({
 
       return (height + extensionHeight)
     })
+    const { ssrBootStyles } = useSsrBoot()
     const { layoutItemStyles } = useLayoutItem({
       id: props.name,
       order: computed(() => parseInt(props.order, 10)),
@@ -84,6 +86,7 @@ export const VAppBar = genericComponent<VToolbarSlots>()({
           style={{
             ...layoutItemStyles.value,
             height: undefined,
+            ...ssrBootStyles.value,
           }}
           { ...toolbarProps }
           v-slots={ slots }

--- a/packages/vuetify/src/components/VBottomNavigation/VBottomNavigation.tsx
+++ b/packages/vuetify/src/components/VBottomNavigation/VBottomNavigation.tsx
@@ -12,6 +12,7 @@ import { makeTagProps } from '@/composables/tag'
 import { makeThemeProps, useTheme } from '@/composables/theme'
 import { provideDefaults } from '@/composables/defaults'
 import { useBackgroundColor } from '@/composables/color'
+import { useSsrBoot } from '@/composables/ssrBoot'
 
 // Utilities
 import { computed, toRef } from 'vue'
@@ -64,6 +65,7 @@ export const VBottomNavigation = genericComponent()({
     const { densityClasses } = useDensity(props)
     const { elevationClasses } = useElevation(props)
     const { roundedClasses } = useRounded(props)
+    const { ssrBootStyles } = useSsrBoot()
     const height = computed(() => (
       Number(props.height) -
       (props.density === 'comfortable' ? 8 : 0) -
@@ -115,6 +117,7 @@ export const VBottomNavigation = genericComponent()({
               height: convertToUnit(height.value),
               transform: `translateY(${convertToUnit(!isActive.value ? 100 : 0, '%')})`,
             },
+            ssrBootStyles.value,
           ]}
         >
           { slots.default && (

--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.tsx
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.tsx
@@ -8,6 +8,7 @@ import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { useBackgroundColor } from '@/composables/color'
+import { useSsrBoot } from '@/composables/ssrBoot'
 
 // Utilities
 import { computed, ref, toRef } from 'vue'
@@ -33,6 +34,7 @@ export const VSystemBar = genericComponent()({
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
     const { elevationClasses } = useElevation(props)
     const { roundedClasses } = useRounded(props)
+    const { ssrBootStyles } = useSsrBoot()
     const height = computed(() => props.height ?? (props.window ? 32 : 24))
     const { layoutItemStyles } = useLayoutItem({
       id: props.name,
@@ -57,6 +59,7 @@ export const VSystemBar = genericComponent()({
         style={[
           backgroundColorStyles.value,
           layoutItemStyles.value,
+          ssrBootStyles.value,
         ]}
         v-slots={ slots }
       />


### PR DESCRIPTION
## Motivation and Context
When moving between layouts the application app-bar has an entry animation.

![app-bar entry animated](https://user-images.githubusercontent.com/9064066/218343078-cfe96231-8c80-413b-aac5-7c5fcac5403d.gif)
