### PR TITLE
docs: add missing links to v-toolbar-items, -title

### DIFF
--- a/packages/docs/src/data/page-to-api.json
+++ b/packages/docs/src/data/page-to-api.json
@@ -162,7 +162,11 @@
     "v-timeline",
     "v-timeline-item"
   ],
-  "components/toolbars": ["v-toolbar"],
+  "components/toolbars": [
+    "v-toolbar",
+    "v-toolbar-items",
+    "v-toolbar-title"
+  ],
   "components/tooltips": ["v-tooltip"],
   "components/treeview": ["v-treeview"],
   "components/virtual-scroller": ["v-virtual-scroll"],


### PR DESCRIPTION
The links to the v-toolbar-items, v-toolbar-title are missing in the v3 documentation

v2 docs : https://vuetifyjs.com/en/components/toolbars/#api 

<img width="661" alt="Screenshot 2023-02-13 at 10 27 31" src="https://user-images.githubusercontent.com/80677/218421367-fd017e53-094d-46ba-8fde-a2370d1d390e.png">


v3 docs : https://next.vuetifyjs.com/en/components/toolbars/#api 

<img width="696" alt="Screenshot 2023-02-13 at 10 28 16" src="https://user-images.githubusercontent.com/80677/218421381-14d6d992-2c0a-40f1-a4ec-f0b273fc4b83.png">

I added the missing information to display the links

