### PR TITLE
fix(VColorPicker): consistent output values

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.tsx
@@ -173,15 +173,17 @@ export const VColorPickerCanvas = defineComponent({
           width={ props.width }
           height={ props.height }
         />
-        <div
-          class={[
-            'v-color-picker-canvas__dot',
-            {
-              'v-color-picker-canvas__dot--disabled': props.disabled,
-            },
-          ]}
-          style={ dotStyles.value }
-        />
+        { props.color && (
+          <div
+            class={[
+              'v-color-picker-canvas__dot',
+              {
+                'v-color-picker-canvas__dot--disabled': props.disabled,
+              },
+            ]}
+            style={ dotStyles.value }
+          />
+        )}
       </div>
     ))
 

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.tsx
@@ -7,7 +7,7 @@ import { VBtn } from '@/components/VBtn'
 // Utilities
 import { computed } from 'vue'
 import { defineComponent, useRender } from '@/util'
-import { modes } from './util'
+import { modes, nullColor } from './util'
 
 // Types
 import type { PropType } from 'vue'
@@ -57,20 +57,20 @@ export const VColorPickerEdit = defineComponent({
 
       if (!mode) return []
 
-      const color = props.color ? mode.to(props.color) : {}
+      const color = props.color ? mode.to(props.color) : null
 
       return mode.inputs?.map(({ getValue, getColor, ...inputProps }) => {
         return {
           ...mode.inputProps,
           ...inputProps,
           disabled: props.disabled,
-          value: getValue(color),
+          value: color && getValue(color),
           onChange: (e: InputEvent) => {
             const target = e.target as HTMLInputElement | null
 
             if (!target) return
 
-            emit('update:color', mode.from(getColor(color, target.value)))
+            emit('update:color', mode.from(getColor(color ?? nullColor, target.value)))
           },
         }
       })

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
@@ -59,9 +59,9 @@ export const VColorPickerPreview = defineComponent({
           { !props.hideAlpha && (
             <VSlider
               class="v-color-picker-preview__track v-color-picker-preview__alpha"
-              modelValue={ props.color?.a }
+              modelValue={ props.color?.a ?? 1 }
               onUpdate:modelValue={ a => emit('update:color', { ...(props.color ?? nullColor), a }) }
-              step={ 0 }
+              step={ 1 / 256 }
               min={ 0 }
               max={ 1 }
               disabled={ props.disabled }

--- a/packages/vuetify/src/components/VColorPicker/__tests__/VColorPicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VColorPicker/__tests__/VColorPicker.spec.cy.tsx
@@ -307,4 +307,41 @@ describe('VColorPicker', () => {
     cy.get('.bg-primary').should('not.exist')
     cy.get('.text-primary').should('not.exist')
   })
+
+  it('should not show dot or input values if no color is set', () => {
+    cy.mount(() => (
+      <Application>
+        <VColorPicker />
+      </Application>
+    ))
+
+    cy.get('.v-color-picker-canvas__dot').should('not.exist')
+      .get('.v-color-picker-edit__input input').should('have.value', '')
+      .get('.v-color-picker-canvas canvas').then(canvas => {
+        const width = canvas.width() ?? 0
+        const height = canvas.height() ?? 0
+
+        cy.wrap(canvas).click(width / 2, height / 2)
+      })
+      .get('.v-color-picker-canvas__dot').should('exist')
+      .get('.v-color-picker-edit__input input').invoke('val').should('not.be.empty')
+  })
+
+  it('should emit correct color when typing in hex field', () => {
+    cy.mount(() => (
+      <Application>
+        <VColorPicker mode="hexa" />
+      </Application>
+    ))
+
+    cy.get('.v-color-picker-edit__input input')
+      .type('FF00CC')
+      .blur()
+      .vue()
+      .then(({ wrapper }) => {
+        const picker = wrapper.findComponent(VColorPicker)
+        const emitted = picker.emitted('update:modelValue')
+        expect(emitted).to.deep.equal([['#FF00CC']])
+      })
+  })
 })

--- a/packages/vuetify/src/components/VColorPicker/util/__tests__/index.spec.ts
+++ b/packages/vuetify/src/components/VColorPicker/util/__tests__/index.spec.ts
@@ -15,7 +15,6 @@ describe('VColorPicker Utils', () => {
         h: expect.any(Number),
         s: expect.any(Number),
         v: expect.any(Number),
-        a: 1,
       }))
       expect(parseColor('FF00FF00')).toEqual(expect.objectContaining({
         h: expect.any(Number),
@@ -31,7 +30,6 @@ describe('VColorPicker Utils', () => {
         h: expect.any(Number),
         s: expect.any(Number),
         v: expect.any(Number),
-        a: 1,
       }))
 
       const rgba = { r: 128, g: 0, b: 255, a: 0.2 }
@@ -49,7 +47,6 @@ describe('VColorPicker Utils', () => {
         h: expect.any(Number),
         s: expect.any(Number),
         v: expect.any(Number),
-        a: 1,
       }))
 
       const hsla = { h: 220, s: 0.5, l: 1, a: 0.4 }
@@ -67,7 +64,6 @@ describe('VColorPicker Utils', () => {
         h: expect.any(Number),
         s: expect.any(Number),
         v: expect.any(Number),
-        a: 1,
       }))
 
       const hsva = { h: 220, s: 0.5, v: 1, a: 0.4 }

--- a/packages/vuetify/src/components/VColorPicker/util/index.ts
+++ b/packages/vuetify/src/components/VColorPicker/util/index.ts
@@ -37,7 +37,7 @@ export function parseColor (color: any): HSV | null {
     }
   }
 
-  return hsva != null ? { ...hsva, a: hsva.a ?? 1 } : null
+  return hsva
 }
 
 function stripAlpha (color: any, stripAlpha: boolean) {
@@ -65,7 +65,7 @@ export function extractColor (color: HSV, input: any) {
     else if (has(input, ['h', 's', 'l'])) converted = HSVtoHSL(color)
     else if (has(input, ['h', 's', 'v'])) converted = color
 
-    return stripAlpha(converted, !has(input, ['a']))
+    return stripAlpha(converted, !has(input, ['a']) && color.a === 1)
   }
 
   return color

--- a/packages/vuetify/src/util/colorUtils.ts
+++ b/packages/vuetify/src/util/colorUtils.ts
@@ -157,13 +157,14 @@ export function RGBtoHex ({ r, g, b, a }: RGB): Hex {
     toHex(r),
     toHex(g),
     toHex(b),
-    a !== undefined ? toHex(Math.round(a * 255)) : 'FF',
+    a !== undefined ? toHex(Math.round(a * 255)) : '',
   ].join('')}` as Hex
 }
 
 export function HexToRGB (hex: Hex): RGB {
+  hex = parseHex(hex)
   let [r, g, b, a] = chunk(hex, 2).map((c: string) => parseInt(c, 16))
-  a = a === undefined ? a : Math.round((a / 255) * 100) / 100
+  a = a === undefined ? a : (a / 255)
 
   return { r, g, b, a }
 }
@@ -188,9 +189,7 @@ export function parseHex (hex: string): Hex {
     hex = hex.split('').map(x => x + x).join('')
   }
 
-  if (hex.length === 6) {
-    hex = padEnd(hex, 8, 'F')
-  } else {
+  if (hex.length !== 6) {
     hex = padEnd(padEnd(hex, 6), 8, 'F')
   }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes #16672

- hex now parses with or without leading `#`
- alpha value is removed instead of resetting to FF

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-color-picker
          v-model="pickedColor"
          elevation="15"
          mode="rgba"
          :modes="['hex', 'hexa', 'rgb', 'rgba']"
        />
        <div class="mt-3">
          Selected color: {{ pickedColor }}
        </div>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const pickedColor = ref('#00FF00')
</script>
```
