### PR TITLE
docs: fix vuetify playground url

### DIFF
--- a/packages/docs/src/components/app/bar/EcosystemMenu.vue
+++ b/packages/docs/src/components/app/bar/EcosystemMenu.vue
@@ -65,7 +65,7 @@
     },
     {
       title: 'playground',
-      href: 'https://playground.vuetifyjs.com/',
+      href: 'https://play.vuetifyjs.com/',
       appendIcon: 'mdi-play-circle',
     },
     { divider: true },


### PR DESCRIPTION
Changed playground url because the old one is not working.

## Description
The playground url in the Appbar points to https://playground.vuetifyjs.com which does not work.
Changed to https://play.vuetifyjs.com 