### PR TITLE
docs: Fix code example for upgrade guide docs

### DIFF
--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -39,7 +39,7 @@ const app = new Vue({
 ```
 
 ```js { resource="3.0" }
-const app = createVue()
+const app = createApp()
 
 const vuetify = createVuetify({ ... })
 


### PR DESCRIPTION
Just a small documentation fix.

Changed `createVue()` to `createApp()` in the code example because this is the correct usage.


## Description
This change will ensure people looking to migrate will not be confused. Especially for those unfamiliar with Vue3.
[Reference from Vue docs](https://vuejs.org/guide/essentials/application.html#the-application-instance)
