### PR TITLE
fix(VVirtualScroll): reset cached sizes on items length change

### DIFF
--- a/packages/vuetify/src/labs/VVirtualScroll/VVirtualScroll.tsx
+++ b/packages/vuetify/src/labs/VVirtualScroll/VVirtualScroll.tsx
@@ -10,7 +10,7 @@ import { useDisplay } from '@/composables/display'
 import { useResizeObserver } from '@/composables/resizeObserver'
 
 // Utilities
-import { computed, onMounted, ref, watchEffect } from 'vue'
+import { computed, onMounted, ref, watch, watchEffect } from 'vue'
 import {
   convertToUnit,
   createRange,
@@ -65,7 +65,8 @@ export const VVirtualScroll = genericComponent<new <T>() => {
     })
     const display = useDisplay()
 
-    const sizes = createRange(props.items.length).map(() => itemHeight.value)
+    const sizeMap = new Map<any, number>()
+    let sizes = createRange(props.items.length).map(() => itemHeight.value)
     const visibleItems = computed(() => {
       return props.visibleItems
         ? parseInt(props.visibleItems, 10)
@@ -77,6 +78,7 @@ export const VVirtualScroll = genericComponent<new <T>() => {
     function handleItemResize (index: number, height: number) {
       itemHeight.value = Math.max(itemHeight.value, height)
       sizes[index] = height
+      sizeMap.set(props.items[index], height)
     }
 
     function calculateOffset (index: number) {
@@ -141,6 +143,18 @@ export const VVirtualScroll = genericComponent<new <T>() => {
         // If itemHeight prop is not set, then calculate an estimated height from the average of inital items
         itemHeight.value = sizes.slice(first.value, last.value).reduce((curr, height) => curr + height, 0) / (visibleItems.value)
       }
+    })
+
+    watch(() => props.items.length, () => {
+      sizes = createRange(props.items.length).map(() => itemHeight.value)
+      sizeMap.forEach((height, item) => {
+        const index = props.items.indexOf(item)
+        if (index === -1) {
+          sizeMap.delete(item)
+        } else {
+          sizes[index] = height
+        }
+      })
     })
 
     useRender(() => (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes #16725
Replaces #16726

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <VApp>
    <VMain>
      <VSheet class="mx-5">
        <VVirtualScroll :items="items" height="300">
          <template #default="{ item, index }">
            <p>
              {{ index + 1 }} - {{ item }}
            </p>
          </template>
        </VVirtualScroll>
        <p class="mt-3">Total: {{ items.length }}</p>
      </VSheet>
    </VMain>
  </VApp>
</template>

<script setup>
  import { onMounted, onUnmounted, ref } from 'vue'

  const items = ref([
    'sentence The rough teacher sadly dodged because some teacher humbly rolled below a rough hamster which, became a dumb, lovely old lady.',
    'The soft hamster elegantly kicked because some old lady proudly died above a vibrating boy which, became a lazy, beautiful clock.',
    'The soft plastic calmly died because some old lady proudly died above a lovely old lady which, became a vibrating, soft hamster.',
    'The professional professor proudly rolled because some boy precisely flew up a hot dog which, became a soft, rough bird.',
    'The vibrating old lady slowly rolled because some hamster calmly slept across a soft teacher which, became a beautiful, rough old lady.',
    'sentence The rough teacher sadly dodged because some teacher humbly rolled below a rough hamster which, became a dumb, lovely old lady.',
    'The soft hamster elegantly kicked because some old lady proudly died above a vibrating boy which, became a lazy, beautiful clock.',
    'The soft plastic calmly died because some old lady proudly died above a lovely old lady which, became a vibrating, soft hamster.',
    'The professional professor proudly rolled because some boy precisely flew up a hot dog which, became a soft, rough bird.',
    'The vibrating old lady slowly rolled because some hamster calmly slept across a soft teacher which, became a beautiful, rough old lady.',
  ])

  const nouns = ['bird', 'clock', 'boy', 'plastic', 'duck', 'teacher', 'old lady', 'professor', 'hamster', 'dog']
  const verbs = ['kicked', 'ran', 'flew', 'dodged', 'sliced', 'rolled', 'died', 'breathed', 'slept', 'killed']
  const adjectives = ['beautiful', 'lazy', 'professional', 'lovely', 'dumb', 'rough', 'soft', 'hot', 'vibrating', 'slimy']
  const adverbs = ['slowly', 'elegantly', 'precisely', 'quickly', 'sadly', 'humbly', 'proudly', 'shockingly', 'calmly', 'passionately']
  const preposition = ['down', 'into', 'up', 'on', 'upon', 'below', 'above', 'through', 'across', 'towards']

  function sentence () {
    const rand1 = Math.floor(Math.random() * 10)
    const rand2 = Math.floor(Math.random() * 10)
    const rand3 = Math.floor(Math.random() * 10)
    const rand4 = Math.floor(Math.random() * 10)
    const rand5 = Math.floor(Math.random() * 10)
    const rand6 = Math.floor(Math.random() * 10)
    return 'The ' + adjectives[rand1] + ' ' + nouns[rand2] + ' ' + adverbs[rand3] + ' ' + verbs[rand4] + ' because some ' + nouns[rand1] + ' ' + adverbs[rand1] + ' ' + verbs[rand1] + ' ' + preposition[rand1] + ' a ' + adjectives[rand2] + ' ' + nouns[rand5] + ' which, became a ' + adjectives[rand3] + ', ' + adjectives[rand4] + ' ' + nouns[rand6] + '.'
  }

  const interval = setInterval(() => {
    // console.log('adding more sentences')
    for (let i = 0; i < 5; i++) {
      items.value.push(sentence())
    }
  }, 2000)

  onUnmounted(() => {
    clearInterval(interval)
  })
</script>
```
