### PR TITLE
feat(VTooltip): add eager prop support

### DIFF
--- a/packages/vuetify/src/components/VTooltip/VTooltip.tsx
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.tsx
@@ -29,6 +29,7 @@ export const VTooltip = genericComponent<OverlaySlots>()({
       closeOnBack: false,
       location: 'end' as const,
       locationStrategy: 'connected' as const,
+      eager: true,
       minWidth: 0,
       offset: 10,
       openOnClick: false,
@@ -40,7 +41,6 @@ export const VTooltip = genericComponent<OverlaySlots>()({
     }), [
       'absolute',
       'persistent',
-      'eager',
     ]),
   },
 
@@ -102,7 +102,6 @@ export const VTooltip = genericComponent<OverlaySlots>()({
           origin={ origin.value }
           persistent
           role="tooltip"
-          eager
           activatorProps={ activatorProps.value }
           _disableGlobalStack
           { ...scopeId }


### PR DESCRIPTION
## Motivation and Context

For performance reasons this should have **eager** support. Tested with 250 tooltips. Reduced render time by almost 50%.

| Eager | Avg Render Time |
| - | - |
|  true |  280ms |
| false | 143ms |

## Markup:
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <template v-for="n in 100" :key="n">
        <v-tooltip :eager="false">
          <template #activator="{ props }">
            <button v-bind="props">Tooltip</button>
          </template>

          Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!
        </v-tooltip>
      </template>

    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
</script>

```
</details>