### PR TITLE
docs(VOverlay): add missing api descriptions

### DIFF
--- a/packages/api-generator/src/locale/en/v-overlay.json
+++ b/packages/api-generator/src/locale/en/v-overlay.json
@@ -6,12 +6,12 @@
     "opacity": "Sets the overlay opacity",
     "zIndex": "The z-index used for the component",
     "contentProps": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))",
-    "noClickAnimation": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))",
-    "persistent": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))",
-    "scrim": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))"
+    "noClickAnimation": "Disables the bounce effect when clicking outside of a `v-dialog`'s content when using the persistent prop.",
+    "persistent": "Clicking outside of the element or pressing esc key will not deactivate it.",
+    "scrim": "Accepts true/false to enable background, and string to define color."
   },
   "events": {
-    "click:outside": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))",
+    "click:outside": "Event that fires when clicking outside an active dialog.",
     "afterLeave": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))"
   },
   "exposed": {

--- a/packages/api-generator/src/locale/en/v-overlay.json
+++ b/packages/api-generator/src/locale/en/v-overlay.json
@@ -6,7 +6,7 @@
     "opacity": "Sets the overlay opacity",
     "zIndex": "The z-index used for the component",
     "contentProps": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))",
-    "noClickAnimation": "Disables the bounce effect when clicking outside of a `v-dialog`'s content when using the persistent prop.",
+    "noClickAnimation": "Disables the bounce effect when clicking outside of the content element when using the persistent prop.",
     "persistent": "Clicking outside of the element or pressing esc key will not deactivate it.",
     "scrim": "Accepts true/false to enable background, and string to define color."
   },

--- a/packages/api-generator/src/locale/en/v-overlay.json
+++ b/packages/api-generator/src/locale/en/v-overlay.json
@@ -11,7 +11,7 @@
     "scrim": "Accepts true/false to enable background, and string to define color."
   },
   "events": {
-    "click:outside": "Event that fires when clicking outside an active dialog.",
+    "click:outside": "Event that fires when clicking outside an active overlay.",
     "afterLeave": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-overlay.json))"
   },
   "exposed": {


### PR DESCRIPTION
## Description
Added `scrim`, `persistent`, and `noClickAnimation` prop descriptions. 

Referenced: 
https://github.com/vuetifyjs/vuetify/issues/16580
https://v2.vuetifyjs.com/en/api/v-dialog/#props

## Markup:
n/a