### PR TITLE
docs: pass v-icon name as prop instead of slot

### DIFF
--- a/packages/docs/src/examples/v-btn/prop-icon.vue
+++ b/packages/docs/src/examples/v-btn/prop-icon.vue
@@ -2,68 +2,44 @@
   <v-container>
     <v-row justify="space-between" class="text-center">
       <v-col>
-        <v-btn
-          icon="mdi-heart"
-          color="primary"
-        ></v-btn>
+        <v-btn icon="mdi-heart" color="primary"></v-btn>
       </v-col>
 
       <v-col>
-        <v-btn
-          icon="mdi-star"
-          color="secondary"
-        ></v-btn>
+        <v-btn icon="mdi-star" color="secondary"></v-btn>
       </v-col>
 
       <v-col>
-        <v-btn
-          icon="mdi-cached"
-          color="info"
-        ></v-btn>
+        <v-btn icon="mdi-cached" color="info"></v-btn>
       </v-col>
 
       <v-col>
-        <v-btn
-          icon="mdi-thumb-up"
-          color="success"
-        ></v-btn>
+        <v-btn icon="mdi-thumb-up" color="success"></v-btn>
       </v-col>
     </v-row>
 
     <v-row justify="space-between" class="text-center">
       <v-col>
-        <v-btn
-          icon
-          color="primary"
-        >
-          <v-icon>mdi-heart</v-icon>
+        <v-btn icon color="primary">
+          <v-icon icon="mdi-heart"></v-icon>
         </v-btn>
       </v-col>
 
       <v-col>
-        <v-btn
-          icon
-          color="secondary"
-        >
-          <v-icon>mdi-star</v-icon>
+        <v-btn icon color="secondary">
+          <v-icon icon="mdi-star"></v-icon>
         </v-btn>
       </v-col>
 
       <v-col>
-        <v-btn
-          icon
-          color="info"
-        >
-          <v-icon>mdi-cached</v-icon>
+        <v-btn icon color="info">
+          <v-icon icon="mdi-cached"></v-icon>
         </v-btn>
       </v-col>
 
       <v-col>
-        <v-btn
-          icon
-          color="success"
-        >
-          <v-icon>mdi-thumb-up</v-icon>
+        <v-btn icon color="success">
+          <v-icon icon="mdi-thumb-up"></v-icon>
         </v-btn>
       </v-col>
     </v-row>


### PR DESCRIPTION
## Description

docs: pass icon name as prop and not as slot - as recommended in [Vuetify docs on icon usage]
(https://vuetifyjs.com/en/features/icon-fonts/#usage)

docs: collapse v-btn to one line for readability
