### PR TITLE
refactor(VSnackbar): remove redundant wrapper element

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -22,8 +22,6 @@
     min-height: $snackbar-wrapper-min-height
     min-width: $snackbar-wrapper-min-width
     padding: $snackbar-wrapper-padding
-    pointer-events: auto
-    position: relative
 
     @include tools.rounded($snackbar-border-radius)
 

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -103,7 +103,19 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
           { ...overlayProps }
           v-model={ isActive.value }
           contentProps={ mergeProps({
-            style: locationStyles.value,
+            class: [
+              'v-snackbar__wrapper',
+              themeClasses.value,
+              colorClasses.value,
+              roundedClasses.value,
+              variantClasses.value,
+            ],
+            style: [
+              locationStyles.value,
+              colorStyles.value,
+            ],
+            onPointerenter,
+            onPointerleave: startTimeout,
           }, overlayProps.contentProps) }
           persistent
           noClickAnimation
@@ -112,45 +124,32 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
           { ...scopeId }
           v-slots={{ activator: slots.activator }}
         >
-          <div
-            class={[
-              'v-snackbar__wrapper',
-              themeClasses.value,
-              colorClasses.value,
-              roundedClasses.value,
-              variantClasses.value,
-            ]}
-            style={[colorStyles.value]}
-            onPointerenter={ onPointerenter }
-            onPointerleave={ startTimeout }
-          >
-            { genOverlays(false, 'v-snackbar') }
+          { genOverlays(false, 'v-snackbar') }
 
-            { slots.default && (
-              <div
-                class="v-snackbar__content"
-                role="status"
-                aria-live="polite"
-              >
-                { slots.default() }
+          { slots.default && (
+            <div
+              class="v-snackbar__content"
+              role="status"
+              aria-live="polite"
+            >
+              { slots.default() }
+            </div>
+          ) }
+
+          { slots.actions && (
+            <VDefaultsProvider
+              defaults={{
+                VBtn: {
+                  variant: 'text',
+                  ripple: false,
+                },
+              }}
+            >
+              <div class="v-snackbar__actions">
+                { slots.actions() }
               </div>
-            ) }
-
-            { slots.actions && (
-              <VDefaultsProvider
-                defaults={{
-                  VBtn: {
-                    variant: 'text',
-                    ripple: false,
-                  },
-                }}
-              >
-                <div class="v-snackbar__actions">
-                  { slots.actions() }
-                </div>
-              </VDefaultsProvider>
-            ) }
-          </div>
+            </VDefaultsProvider>
+          )}
         </VOverlay>
       )
     })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Allows for `content-class="elevation-xx"`

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="text-center ma-2">
    <v-btn
      @click="snackbar = true"
    >
      Open Snackbar
    </v-btn>
    <v-snackbar
      v-model="snackbar"
      timeout="-1"
    >
      {{ text }}

      <template #actions>
        <v-btn
          color="pink"
          variant="text"
          @click="snackbar = false"
        >
          Close
        </v-btn>
      </template>
    </v-snackbar>
  </div>
</template>

<script>
  export default {
    data: () => ({
      snackbar: false,
      text: `Hello, I'm a snackbar`,
    }),
  }
</script>
```
