### PR TITLE
fix(VAutocomplete,VCombobox): unselected items checked

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -319,13 +319,12 @@ export const VAutocomplete = genericComponent<new <
 
                       { slots['prepend-item']?.() }
 
-                      { displayItems.value.map((item, index) => slots.item?.({
+                      { displayItems.value.map(item => slots.item?.({
                         item,
-                        index,
                         props: mergeProps(item.props, { onClick: () => select(item) }),
                       }) ?? (
                         <VListItem
-                          key={ index }
+                          key={ item.value }
                           { ...item.props }
                           onClick={ () => select(item) }
                         >

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -399,13 +399,12 @@ export const VCombobox = genericComponent<new <
 
                       { slots['prepend-item']?.() }
 
-                      { displayItems.value.map((item, index) => slots.item?.({
+                      { displayItems.value.map(item => slots.item?.({
                         item,
-                        index,
                         props: mergeProps(item.props, { onClick: () => select(item) }),
                       }) ?? (
                         <VListItem
-                          key={ index }
+                          key={ item.value }
                           { ...item.props }
                           onClick={ () => select(item) }
                         >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #16153
This issue also happens to VComboBox.
Fixed VListItem to be re-rendered after search. 
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-card class="pa-4 ma-8" width=400>
      <v-autocomplete
        label="Autocomplete"
        :items="items"
        multiple
        variant="outlined"
        chips
        closable-chips
        :menu-props="{ maxHeight: 300 }"
        ></v-autocomplete>
    </v-card>
    <v-row>
      <v-col cols="12">
        <v-combobox
          v-model="comboSelect"
          :items="comboItems"
          multiple
          label="Select a favorite activity or create a new one"
        ></v-combobox>
      </v-col>
    </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from "vue";
const items = [
  "item-0",
  "item-1",
  "item-2",
  "item-21",
  "item-22",
  "item-23",
];
const comboSelect =  ref(['Programming']);
const comboItems = [
  'Programming',
  'Design',
  'Vue',
  'Vuetify',
];

</script>
```
