### PR TITLE
fix(VOverlay): overlay location in RTL mode

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { computed, nextTick, onScopeDispose, ref, watch } from 'vue'
+import { computed, effectScope, nextTick, onScopeDispose, ref, watch, watchEffect } from 'vue'
 import {
   clamp,
   consoleError,
@@ -19,11 +19,8 @@ import {
 import { Box, getOverflow } from '@/util/box'
 import { anchorToPoint, getOffset } from './util/point'
 
-// Composables
-import { useToggleScope } from '@/composables/toggleScope'
-
 // Types
-import type { PropType, Ref } from 'vue'
+import type { EffectScope, PropType, Ref } from 'vue'
 import type { Anchor } from '@/util'
 
 export interface LocationStrategyData {
@@ -79,27 +76,31 @@ export function useLocationStrategies (
   const contentStyles = ref({})
   const updateLocation = ref<(e: Event) => void>()
 
-  if (IN_BROWSER) {
-    useToggleScope(() => !!(data.isActive.value && props.locationStrategy), reset => {
-      watch(() => props.locationStrategy, reset)
-      onScopeDispose(() => {
-        updateLocation.value = undefined
-      })
+  let scope: EffectScope | undefined
+  watchEffect(async () => {
+    scope?.stop()
+    updateLocation.value = undefined
 
+    if (!(IN_BROWSER && data.isActive.value && props.locationStrategy)) return
+
+    scope = effectScope()
+    if (!(props.locationStrategy === 'connected')) { await nextTick() }
+    scope.run(() => {
       if (typeof props.locationStrategy === 'function') {
         updateLocation.value = props.locationStrategy(data, props, contentStyles)?.updateLocation
       } else {
         updateLocation.value = locationStrategies[props.locationStrategy](data, props, contentStyles)?.updateLocation
       }
     })
+  })
 
-    window.addEventListener('resize', onResize, { passive: true })
+  IN_BROWSER && window.addEventListener('resize', onResize, { passive: true })
 
-    onScopeDispose(() => {
-      window.removeEventListener('resize', onResize)
-      updateLocation.value = undefined
-    })
-  }
+  onScopeDispose(() => {
+    IN_BROWSER && window.removeEventListener('resize', onResize)
+    updateLocation.value = undefined
+    scope?.stop()
+  })
 
   function onResize (e: Event) {
     updateLocation.value?.(e)
@@ -325,7 +326,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
         ;['x', 'y'].forEach(key => {
           if (
             (key === 'x' && hasOverflowX && !flipped.x) ||
-            (key === 'y' && hasOverflowY && !flipped.y)
+          (key === 'y' && hasOverflowY && !flipped.y)
           ) {
             const newPlacement = { anchor: { ...placement.anchor }, origin: { ...placement.origin } }
             const flip = key === 'x'
@@ -336,9 +337,9 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
             const { overflows: newOverflows } = checkOverflow(newPlacement)
             if (
               (newOverflows[key].before <= overflows[key].before &&
-                newOverflows[key].after <= overflows[key].after) ||
-              (newOverflows[key].before + newOverflows[key].after <
-                (overflows[key].before + overflows[key].after) / 2)
+              newOverflows[key].after <= overflows[key].after) ||
+            (newOverflows[key].before + newOverflows[key].after <
+              (overflows[key].before + overflows[key].after) / 2)
             ) {
               placement = newPlacement
               reset = flipped[key] = true
@@ -393,11 +394,6 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       maxWidth: convertToUnit(pixelCeil(clamp(available.x, minWidth.value === Infinity ? 0 : minWidth.value, maxWidth.value))),
       maxHeight: convertToUnit(pixelCeil(clamp(available.y, minHeight.value === Infinity ? 0 : minHeight.value, maxHeight.value))),
     })
-
-    return {
-      available,
-      contentBox,
-    }
   }
 
   watch(
@@ -411,23 +407,12 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       props.maxHeight,
     ],
     () => updateLocation(),
+    { immediate: !activatorFixed }
   )
 
-  nextTick(() => {
-    const result = updateLocation()
-
-    // TODO: overflowing content should only require a single updateLocation call
-    // Icky hack to make sure the content is positioned consistently
-    if (!result) return
-    const { available, contentBox } = result
-    if (contentBox.height > available.y) {
-      requestAnimationFrame(() => {
-        updateLocation()
-        requestAnimationFrame(() => {
-          updateLocation()
-        })
-      })
-    }
+  if (activatorFixed) nextTick(() => updateLocation())
+  requestAnimationFrame(() => {
+    if (contentStyles.value.maxHeight) updateLocation()
   })
 
   return { updateLocation }


### PR DESCRIPTION
Overlay location in RTL is showing outside the screen because locationStrategies.ts is not calling updateLocation when direction is changed.

rollback the locationStrategies.ts vuetifyjs/vuetify@a11138e to vuetifyjs/vuetify@33ab244 