### PR TITLE
feat(VRating): add showZero prop

### DIFF
--- a/packages/vuetify/src/components/VRating/__tests__/VRating.spec.cy.tsx
+++ b/packages/vuetify/src/components/VRating/__tests__/VRating.spec.cy.tsx
@@ -176,4 +176,34 @@ describe('VRating', () => {
       .emitted(VRating, 'update:modelValue')
       .should('deep.equal', [[1], [3], [2]])
   })
+
+  it('should show zero rating', () => {
+    cy.mount(() => (
+      <Application>
+        <VRating showZero clearable zeroEmptyValue={false}>
+          {{
+            item: ({ rating, value }) => (
+              <VBtn
+                variant="tonal"
+                class="mx-1 px-1"
+                min-width="36"
+                max-width="36"
+                color={value === rating ? 'primary' : undefined}
+              >{ value }</VBtn>
+            ),
+          }}
+        </VRating>
+      </Application>
+    ))
+
+    cy.get('.v-btn')
+      .eq(1)
+      .click()
+      .get('.v-btn')
+      .eq(0)
+      .click()
+      .click()
+      .emitted(VRating, 'update:modelValue')
+      .should('deep.equal', [[1], [0], [undefined]])
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Adds prop `show-zero` for displaying 0 rating. Also adds `zero-empty-value` (could have better name?) so that it can work with clearable.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <div class="pa-10">
        <v-rating :length="10" v-model="zxc" show-zero clearable :zero-empty-value="false">
          <template #item="{ value, rating }">
            <v-btn :color="rating === value ? 'primary' : undefined" variant="tonal" class="mx-1 px-2" min-width="36" max-width="36">{{ value }}</v-btn>
          </template>
        </v-rating>
        {{ zxc }}
        <v-rating :length="10" v-model="foo" show-zero half-increments clearable></v-rating>
        {{ foo }}
        <v-rating :length="10" v-model="foo" half-increments clearable></v-rating>
        <v-rating :length="10" v-model="bar" ripple clearable></v-rating>
        {{ bar }}
      </div>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const foo = ref()
  const bar = ref()
  const zxc = ref()
</script>

```
