### PR TITLE
fix(VAutocomplete/VSelect/VCombobox): compare items using item value if passed

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -21,7 +21,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
 import { computed, mergeProps, nextTick, ref, watch } from 'vue'
-import { genericComponent, omit, useRender, wrapInArray } from '@/util'
+import {genericComponent, getPropertyFromItem, omit, useRender, wrapInArray} from '@/util';
 import { filterVTextFieldProps, makeVTextFieldProps } from '../VTextField/VTextField'
 
 // Types
@@ -132,7 +132,10 @@ export const VAutocomplete = genericComponent<new <
     const { filteredItems, getMatches } = useFilter(props, items, computed(() => isPristine.value ? undefined : search.value))
     const selections = computed(() => {
       return model.value.map(v => {
-        return items.value.find(item => props.valueComparator(item.value, v.value)) || v
+        return items.value.find(item => {
+          if(props.itemValue !== 'value') return props.valueComparator(getPropertyFromItem(item.value, props.itemValue), getPropertyFromItem(v.value, props.itemValue))
+          return props.valueComparator(item.value, v.value)
+        }) || v
       })
     })
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -22,7 +22,7 @@ import { useTextColor } from '@/composables/color'
 
 // Utility
 import { computed, mergeProps, nextTick, ref, watch } from 'vue'
-import { genericComponent, omit, useRender, wrapInArray } from '@/util'
+import {genericComponent, getPropertyFromItem, omit, useRender, wrapInArray} from '@/util';
 import { filterVTextFieldProps, makeVTextFieldProps } from '../VTextField/VTextField'
 
 // Types
@@ -174,7 +174,10 @@ export const VCombobox = genericComponent<new <
 
     const selections = computed(() => {
       return model.value.map(v => {
-        return items.value.find(item => props.valueComparator(item.value, v.value)) || v
+        return items.value.find(item => {
+          if(props.itemValue !== 'value') return props.valueComparator(getPropertyFromItem(item.value, props.itemValue), getPropertyFromItem(v.value, props.itemValue))
+          return props.valueComparator(item.value, v.value)
+        }) || v
       })
     })
 

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -22,7 +22,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
 import { computed, mergeProps, ref } from 'vue'
-import { deepEqual, genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import {deepEqual, genericComponent, getPropertyFromItem, omit, propsFactory, useRender, wrapInArray} from '@/util';
 
 // Types
 import type { VInputSlots } from '@/components/VInput/VInput'
@@ -134,7 +134,10 @@ export const VSelect = genericComponent<new <
     const form = useForm()
     const selections = computed(() => {
       return model.value.map(v => {
-        return items.value.find(item => props.valueComparator(item.value, v.value)) || v
+        return items.value.find(item => {
+          if(props.itemValue !== 'value') return props.valueComparator(getPropertyFromItem(item.value, props.itemValue), getPropertyFromItem(v.value, props.itemValue))
+          return props.valueComparator(item.value, v.value)
+        }) || v
       })
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))


### PR DESCRIPTION
fixes #16279

not sure if thats the best solution but I think it makes sense to what @ThomasCarbon said in the issue `if you set "item-value" props i expect it to rely on it in priority instead of anything else`. Thats why I made an if check to see whether itemValue is not default and to use the passed value as a priority when going through the items.

If this is ok as a solution I will add unit tests and fix formatting.
