### PR TITLE
feat(VBtn): set default transform to none

### DIFF
--- a/packages/vuetify/src/styles/settings/_variables.scss
+++ b/packages/vuetify/src/styles/settings/_variables.scss
@@ -262,7 +262,7 @@ $typography: map-deep-merge(
       'line-height': 2.25rem,
       'letter-spacing': .0892857143em,
       'font-family': $body-font-family,
-      'text-transform': uppercase
+      'text-transform': none
     ),
     'caption': (
       'size': .75rem,


### PR DESCRIPTION
## Motivation and Context

Remove button text transform modification.

## Markup:
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <v-btn>Hello</v-btn>
      <v-btn>HELLO</v-btn>
      <v-btn>hello</v-btn>
      <v-btn class="text-uppercase">Hello</v-btn>
      <v-btn>{{ 'hello'.toUpperCase() }}</v-btn>
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
</script>

```
</details>