### PR TITLE
fix(VDataTable): add css to align headers center

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.sass
@@ -32,6 +32,12 @@
 
               .v-data-table-header__content
                 flex-direction: row-reverse
+            
+            &.v-data-table-column--align-center
+              text-align: center
+
+              .v-data-table-header__content
+                justify-content: center
 
             &.v-data-table-column--no-padding
               padding: 0 8px


### PR DESCRIPTION
<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :headers="headers" :items="items" />
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const headers = ref([
        { title: 'One', key: 'one', sortable: true, align: 'start' },
        { title: 'Two', key: 'two', sortable: true, align: 'center' },
        { title: 'Three', key: 'three', sortable: true, align: 'end' },
      ])
      const items = ref([
        { one: 'One', two: 'Two', three: 'Three' },
      ])
      return { headers, items }
    },
  }
</script>
```
