### PR TITLE
fix(VDataTable): missing index item[col] slots

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.sass
@@ -32,6 +32,12 @@
 
               .v-data-table-header__content
                 flex-direction: row-reverse
+            
+            &.v-data-table-column--align-center
+              text-align: center
+
+              .v-data-table-header__content
+                justify-content: center
 
             &.v-data-table-column--no-padding
               padding: 0 8px

--- a/packages/vuetify/src/labs/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.sass
@@ -32,12 +32,6 @@
 
               .v-data-table-header__content
                 flex-direction: row-reverse
-            
-            &.v-data-table-column--align-center
-              text-align: center
-
-              .v-data-table-header__content
-                justify-content: center
 
             &.v-data-table-column--no-padding
               padding: 0 8px

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
@@ -19,6 +19,7 @@ export const VDataTableRow = defineComponent({
   name: 'VDataTableRow',
 
   props: {
+    index: Number as PropType<Number>,
     item: Object as PropType<DataTableItem>,
     onClick: Function as PropType<(e: MouseEvent) => void>,
   },
@@ -59,6 +60,7 @@ export const VDataTableRow = defineComponent({
                 const item = props.item!
                 const slotName = `item.${column.key}`
                 const slotProps = {
+                  index: props.index,
                   item: props.item,
                   columns: columns.value,
                   isSelected,

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -144,6 +144,7 @@ export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
 
                     emit('click:row', event, { item })
                   }}
+                  index={ index }
                   item={ item }
                   v-slots={ slots }
                 />


### PR DESCRIPTION

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :headers="headers" :items="items">
        <template #item.one="{ index }">
          {{ index }}
        </template>
      </v-data-table>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const headers = ref([
        { title: 'One', key: 'one', sortable: true, align: 'start' },
        { title: 'Two', key: 'two', sortable: true, align: 'center' },
        { title: 'Three', key: 'three', sortable: true, align: 'end' },
      ])
      const items = ref([
        { one: 'One', two: 'Two', three: 'Three' },
      ])
      return { headers, items }
    },
  }
</script>
```
