### PR TITLE
refactor(form): export interfaces used in createForm()

### DIFF
--- a/packages/vuetify/src/composables/form.ts
+++ b/packages/vuetify/src/composables/form.ts
@@ -23,7 +23,7 @@ export interface FormProvide {
   validateOn: Ref<FormProps['validateOn']>
 }
 
-interface FormField {
+export interface FormField {
   id: number | string
   validate: () => Promise<string[]>
   reset: () => void
@@ -32,12 +32,12 @@ interface FormField {
   errorMessages: string[]
 }
 
-interface FieldValidationResult {
+export interface FieldValidationResult {
   id: number | string
   errorMessages: string[]
 }
 
-interface FormValidationResult {
+export interface FormValidationResult {
   valid: boolean
   errors: FieldValidationResult[]
 }


### PR DESCRIPTION
```typescript
// src/composables/form.ts
interface FormField {
}

interface FormValidationResult {
  valid: boolean
  errors: FieldValidationResult[]
}

export function createForm (props: FormProps) {
  const items = ref<FormField[]>([])
  const errors = ref<FieldValidationResult[]>([])
}
```
There is an anti-pattern in `src/composables/form.ts`, where a `.d.ts` file is generated. The internal ref field is typed with an interface but not exported. However, the external field is exported using typeof and includes the interface. This is problematic and would result in a TypeScript error, even if not using vue.js.

For example, if you create a new TypeScript project with `"declaration": true` in tsconfig, and have two files: one file exports a function that uses an interface not exported in that file, and another file imports that function. TypeScript will report an error during the compilation process.

![180761678543229_ pic](https://user-images.githubusercontent.com/3074608/224491083-136e3094-b32d-42c7-98fa-e316339e2c64.jpg)

TypeScript will report this error only when the following four conditions all met:

1. The declaration flag is turned on to generate .d.ts files
2. An interface is used in the file but not exported
3. This interface is used as a type for a JavaScript variable and exported
4. The exported variable is used with typeof to retrieve its type.

Why wasn't this anti-pattern code reported as an error by TypeScript before? This is related to the previous implementation of the Vue.js generic type `UnwrapRef`, which adopts the implementation method of constantly deconstructing types. When `ref<T>()` is called, it happens to generate a brand-new type alias for types like `FormField ` and `FieldValidationResult`, and type alias will not trigger this issue, so it can just work properly.

But in fact, it's wrong, If the implementation of `UnwrapRef` is changed, this file will encounter typescript errors.

 There are two ways to rectify it: one is to export the corresponding interface and the other is to change the interface to a type declaration. Considering that other files use interfaces extensively, I adopted the first rectification approach.