### PR TITLE
docs(activator): update slot prop binding information

### DIFF
--- a/packages/docs/src/pages/en/features/accessibility.md
+++ b/packages/docs/src/pages/en/features/accessibility.md
@@ -27,10 +27,9 @@ Vuetify uses activator slots for many components such as `v-menu`, `v-dialog` an
 
 <template>
   <v-menu>
-    <template v-slot:activator="{ on, attrs }">
+    <template v-slot:activator="{ props }">
       <v-btn
-        v-bind="attrs"
-        v-on="on"
+        v-bind="props"
       >
         Click me
       </v-btn>


### PR DESCRIPTION
The code snippet is update to be consistent with the upgrade guide section in the documentation: https://vuetifyjs.com/en/getting-started/upgrade-guide/#general-changes

## Description

I am upgrading a project from Vuetify v2 to v3. [This section of the upgrade guide](https://vuetifyjs.com/en/getting-started/upgrade-guide/#general-changes) on Vuetify docs indicates that the API for using `#activator` slots has changed, yet [the associated documentation page](https://vuetifyjs.com/en/features/accessibility/#activator-slots) does not reflect that.

**Note**: I didn't find an easy way to report documentation issues, hence submitting a PR for what is probably the appropriate correction, but I am not 100% sure. 
There's no way to open a GitHub issue, and the Vuetify bug/feature reporting tool expects a replication URL, which doesn't make sense for docs. Please make it clear how the project is collecting documentation errata.