### PR TITLE
fix(VField): stopPropagation mousedown event on clearable icon

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -93,7 +93,6 @@ export const VCombobox = genericComponent<new <
     ...makeFilterProps({ filterKeys: ['title'] }),
     ...makeSelectProps({ hideNoData: true, returnObject: true }),
     ...omit(makeVTextFieldProps({
-      focusOnClear: false,
       modelValue: null,
     }), ['validationValue', 'dirty', 'appendInnerIcon']),
     ...makeTransitionProps({ transition: false }),

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -119,7 +119,7 @@ export const VCombobox = genericComponent<new <
       },
     })
     const selectionIndex = ref(-1)
-    const cleared = ref(false)
+    let cleared = false
     const color = computed(() => vTextFieldRef.value?.color)
     const { items, transformIn, transformOut } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(color)
@@ -162,11 +162,10 @@ export const VCombobox = genericComponent<new <
       },
     })
     watch(_search, value => {
-      if (cleared.value) {
-        // Implement open-on-clear (https://github.com/vuetifyjs/vuetify/issues/16925)
+      if (cleared) {
         // wait for clear to finish, VTextField sets _search to null
         // then search computed triggers and updates _search to ''
-        nextTick(() => (cleared.value = false))
+        nextTick(() => (cleared = false))
       } else if (isFocused.value && !menu.value) {
         menu.value = true
       }
@@ -199,7 +198,7 @@ export const VCombobox = genericComponent<new <
     const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
-      cleared.value = true
+      cleared = true
 
       if (props.openOnClear) {
         menu.value = true

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -163,6 +163,7 @@ export const VCombobox = genericComponent<new <
     })
     watch(_search, value => {
       if (cleared.value) {
+        // Implement open-on-clear (https://github.com/vuetifyjs/vuetify/issues/16925)
         // wait for clear to finish, VTextField sets _search to null
         // then search computed triggers and updates _search to ''
         nextTick(() => (cleared.value = false))

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -310,6 +310,10 @@ export const VCombobox = genericComponent<new <
       }
     }
 
+    function onInput (e: InputEvent) {
+      search.value = (e.target as HTMLInputElement).value
+    }
+
     function onFocusin (e: FocusEvent) {
       isFocused.value = true
     }
@@ -346,10 +350,11 @@ export const VCombobox = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
-          v-model={ search.value }
+          modelValue={ search.value }
           onUpdate:modelValue={ v => { if (v == null) model.value = [] } }
           validationValue={ model.externalValue }
           dirty={ model.value.length > 0 }
+          onInput={ onInput }
           class={[
             'v-combobox',
             {

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -291,6 +291,7 @@ export const VField = genericComponent<new <T>() => {
               <div
                 class="v-field__clearable"
                 v-show={ props.dirty }
+                onMousedown={ (e: MouseEvent) => e.stopPropagation() }
               >
                 { slots.clear
                   ? slots.clear()

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -291,7 +291,10 @@ export const VField = genericComponent<new <T>() => {
               <div
                 class="v-field__clearable"
                 v-show={ props.dirty }
-                onMousedown={ (e: MouseEvent) => e.stopPropagation() }
+                onMousedown={ (e: MouseEvent) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                }}
               >
                 { slots.clear
                   ? slots.clear()


### PR DESCRIPTION
fixes #16925

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #16925
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main class="pa-8 w-50">
      <v-card color="primary" class="d-flex flex-column w-100" title=":open-on-clear=default">

        <v-autocomplete :items="items" hide-details="auto" v-model="item[0]" :clearable="true" label="autocomplete" />
        <v-select :items="items" hide-details="auto" v-model="item[1]" :clearable="true" label="select" />
        <v-combobox :items="items" hide-details="auto" v-model="item[2]" :clearable="true" label="combobox" />
      </v-card>

      <v-card color="success" class="d-flex flex-column w-100" title=":open-on-clear=true">
        <v-autocomplete :items="items" hide-details="auto" v-model="item[3]" :clearable="true" label="autocomplete"
          :open-on-clear="true" />
        <v-select :items="items" hide-details="auto" v-model="item[4]" :clearable="true" label="select"
          :open-on-clear="true" />
        <v-combobox :items="items" hide-details="auto" v-model="item[5]" :clearable="true" label="combobox"
          :open-on-clear="true" />
      </v-card>

      <v-card color="error" class="d-flex flex-column w-100" title=":open-on-clear=false">
        <v-autocomplete :items="items" hide-details="auto" v-model="item[6]" :clearable="true" label="autocomplete"
          :open-on-clear="false" />
        <v-select :items="items" hide-details="auto" v-model="item[7]" :clearable="true" label="select"
          :open-on-clear="false" />
        <v-combobox :items="items" hide-details="auto" v-model="item[8]" :clearable="true" label="combobox"
          :open-on-clear="false" />
      </v-card>
    </v-main>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const item = ref([...Array(9).keys()])
const items = ref([1, 2, 3, 4, 5, 6])
</script>


```
