### PR TITLE
feat(validation composable): add validate immediately option

### DIFF
--- a/packages/vuetify/src/components/VRating/VRating.tsx
+++ b/packages/vuetify/src/components/VRating/VRating.tsx
@@ -186,7 +186,7 @@ export const VRating = genericComponent<VRatingSlots>()({
             type="radio"
             value={ value }
             checked={ normalizedValue.value === value }
-            tabindex={-1}
+            tabindex={ -1 }
             readonly={ props.readonly }
             disabled={ props.disabled }
           />

--- a/packages/vuetify/src/components/VRating/__tests__/VRating.spec.cy.tsx
+++ b/packages/vuetify/src/components/VRating/__tests__/VRating.spec.cy.tsx
@@ -100,7 +100,7 @@ describe('VRating', () => {
         <VRating>
           {{
             item: ({ value, rating }) => (
-              <VBtn variant="tonal" class="mx-1" color={rating === value ? 'primary' : undefined}>{ value }</VBtn>
+              <VBtn variant="tonal" class="mx-1" color={ rating === value ? 'primary' : undefined }>{ value }</VBtn>
             ),
           }}
         </VRating>

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -32,6 +32,7 @@ export interface ValidationProps {
   modelValue: any
   'onUpdate:modelValue': ((val: any) => void) | undefined
   validateOn?: 'blur' | 'input' | 'submit'
+  validateImmediately?: boolean
   validationValue: any
 }
 
@@ -55,6 +56,10 @@ export const makeValidationProps = propsFactory({
   },
   modelValue: null,
   validateOn: String as PropType<ValidationProps['validateOn']>,
+  validateImmediately: {
+    type: Boolean,
+    default: false,
+  },
   validationValue: null,
 
   ...makeFocusProps(),
@@ -128,13 +133,13 @@ export function useValidation (
           unwatch()
         })
       }
-    })
+    }, { immediate: props.validateImmediately })
   })
 
   useToggleScope(() => validateOn.value === 'blur', () => {
     watch(() => props.focused, val => {
       if (!val) validate()
-    })
+    }, { immediate: props.validateImmediately })
   })
 
   watch(isValid, () => {
@@ -157,7 +162,7 @@ export function useValidation (
     isValidating.value = true
 
     for (const rule of props.rules) {
-      if (results.length >= (props.maxErrors ?? 1)) {
+      if (results.length >= +(props.maxErrors ?? 1)) {
         break
       }
 


### PR DESCRIPTION
## Description
Add a new option to `useValidation.props` called  `validateImmediately` that is optional and receives a boolean (defaults to `false`).

It has effect only if the `validateOn` option is `'blur'` or `'input`' since this behavior is not necessary when validation runs only on submit

## Motivation and Context

Without this feature there was no easy and intuitive way to achieve this behavior so we needed to write some workarounds like this:

```vue
<template>
  <v-app theme="dark">
    <v-container class="my-auto">
      <v-textarea
        v-model="text"
      	variant="outlined"
        label="Validate on input and immediately"
        :rules="validationRules"
        validate-on="input"
       @vue:mounted="forceVTextareaImmediateValidation"
      />
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: 'Playground'
};
</script>

<script setup>
import { ref, nextTick } from 'vue';

const validationRules = [text => (text.length > 10 ? 'error' : true)];

const text = ref('a'.repeat(100));
  
async function forceVTextareaImmediateValidation() {
  text.value += ' ';
  await nextTick();
  text.value += text.value.trim();
}
</script>
```

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="my-auto">
      <v-row>
        <v-col>
          <v-textarea
            variant="outlined"
            label="Validate on input"
            v-model="text"
            :rules="validationRules"
            validate-on="input"
          />
        </v-col>

        <v-col>
          <v-textarea
            variant="outlined"
            label="Validate on input and immediately"
            v-model="text"
            :rules="validationRules"
            validate-on="input"
            validate-immediately
          />
        </v-col>
      </v-row>

      <v-row>
        <v-col>
          <v-textarea
            variant="outlined"
            label="Validate on blur"
            v-model="text"
            :rules="validationRules"
            validate-on="blur"
          />
        </v-col>
        <v-col>
          <v-textarea
            variant="outlined"
            label="Validate on blur and immediately"
            v-model="text"
            :rules="validationRules"
            validate-on="blur"
            validate-immediately
          />
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: 'Playground'
};
</script>

<script setup>
import { ref } from 'vue';

const validationRules = [text => (text.length > 10 ? 'error' : true)];

const text = ref('a'.repeat(100));
</script>
```
