### PR TITLE
docs(images.md): added lazy-src clarification

### DIFF
--- a/packages/api-generator/src/locale/en/v-img.json
+++ b/packages/api-generator/src/locale/en/v-img.json
@@ -3,7 +3,7 @@
     "alt": "Alternate text for screen readers. Leave empty for decorative images.",
     "aspectRatio": "Calculated as `width/height`, so for a 1920x1080px image this will be `1.7778`. Will be calculated automatically if omitted.",
     "cover": "Resizes the background image to cover the entire container.",
-    "lazySrc": "Something to show while waiting for the main image to load, typically a small base64-encoded thumbnail. Has a slight blur filter applied.\n\nUse [vuetify-loader](https://github.com/vuetifyjs/vuetify-loader) to generate automatically.",
+    "lazySrc": "Something to show while waiting for the main image to load, typically a small base64-encoded thumbnail. Has a slight blur filter applied.\n\nUse [vuetify-loader](https://github.com/vuetifyjs/vuetify-loader) to generate automatically. NOTE: This prop will have no effect unless either `height` or `aspect-ratio` are provided.",
     "options": "Options that are passed to the [Intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) constructor.",
     "position": "Overrides the default to change which parts get cropped off. Uses the same syntax as [`background-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position).",
     "sizes": "For use with `srcset`, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes).",

--- a/packages/api-generator/src/locale/en/v-img.json
+++ b/packages/api-generator/src/locale/en/v-img.json
@@ -3,7 +3,7 @@
     "alt": "Alternate text for screen readers. Leave empty for decorative images.",
     "aspectRatio": "Calculated as `width/height`, so for a 1920x1080px image this will be `1.7778`. Will be calculated automatically if omitted.",
     "cover": "Resizes the background image to cover the entire container.",
-    "lazySrc": "Something to show while waiting for the main image to load, typically a small base64-encoded thumbnail. Has a slight blur filter applied.\n\nUse [vuetify-loader](https://github.com/vuetifyjs/vuetify-loader) to generate automatically. NOTE: This prop will have no effect unless either `height` or `aspect-ratio` are provided.",
+    "lazySrc": "Something to show while waiting for the main image to load, typically a small base64-encoded thumbnail. Has a slight blur filter applied.\n\nUse [vuetify-loader](https://github.com/vuetifyjs/vuetify-loader) to generate automatically. NOTE: This prop has no effect unless either `height` or `aspect-ratio` are provided.",
     "options": "Options that are passed to the [Intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) constructor.",
     "position": "Overrides the default to change which parts get cropped off. Uses the same syntax as [`background-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position).",
     "sizes": "For use with `srcset`, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes).",

--- a/packages/docs/src/pages/en/components/images.md
+++ b/packages/docs/src/pages/en/components/images.md
@@ -36,7 +36,7 @@ The `v-img` component is packed with features to support rich media. Combined wi
 
 <alert type="warning">
 
-  The **lazy-src** property will have no effect unless either **height** or **aspect-ratio** are provided. This is because
+  The **lazy-src** property has no effect unless either **height** or **aspect-ratio** are provided. This is because
   the image container needs a non-zero height in order for the temporary image to be shown.
 
 </alert>

--- a/packages/docs/src/pages/en/components/images.md
+++ b/packages/docs/src/pages/en/components/images.md
@@ -32,6 +32,15 @@ The `v-img` component is packed with features to support rich media. Combined wi
 
 <api-inline hide-links />
 
+## Caveats
+
+<alert type="warning">
+
+  The **lazy-src** property will have no effect unless either **height** or **aspect-ratio** are provided. This is because
+  the image container needs a non-zero height in order for the temporary image to be shown.
+
+</alert>
+
 ## Examples
 
 ### Props


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
This clarifies a point about `lazy-src` needing a fixed height in order to show the placeholder/lazy image.

