### PR TITLE
fix(VDialog): replace `aria-role` with `role`

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -117,9 +117,9 @@ export const VDialog = genericComponent<OverlaySlots>()({
           ]}
           { ...overlayProps }
           v-model={ isActive.value }
-          aria-role="dialog"
           aria-modal="true"
           activatorProps={ activatorProps.value }
+          role="dialog"
           { ...scopeId }
         >
           {{


### PR DESCRIPTION
## Description
This PR resolves the issue with VDialog accessibility. Instead of using the `role` attribute, `aria-role` was used.

