### PR TITLE
docs(images): add complex-grid example

### DIFF
--- a/packages/docs/src/examples/v-img/complex-grid.vue
+++ b/packages/docs/src/examples/v-img/complex-grid.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-row>
+    <template v-for="(image,imgIdx) in imageLayout" :key="imgIdx">
+      <v-col :cols="image.cols">
+        <v-img
+          :src="`https://picsum.photos/500/300?image=${image.cols * 20}`"
+          cover
+          height="100%"
+        ></v-img>
+      </v-col>
+
+      <v-col v-if="image.children" cols="6" class="d-flex flex-column">
+        <v-row>
+          <v-col v-for="(children,childIdx) in image.children" :key="childIdx" :cols="children.cols">
+            <v-img
+              :src="`https://picsum.photos/500/300?image=${children.cols + childIdx}`"
+              cover
+              height="100%"
+            ></v-img>
+          </v-col>
+        </v-row>
+      </v-col>
+    </template>
+  </v-row>
+</template>
+
+<script>
+  export default {
+    data: () => ({
+      imageLayout: [
+        { cols: 4 },
+        {
+          cols: 8,
+          children: [{ cols: 12 }, { cols: 12 }],
+        },
+        { cols: 6 },
+        { cols: 3 },
+        { cols: 9 },
+        { cols: 4 },
+        { cols: 8 },
+      ],
+    }),
+  }
+</script>

--- a/packages/docs/src/pages/en/components/images.md
+++ b/packages/docs/src/pages/en/components/images.md
@@ -86,3 +86,9 @@ This will behave similarly to:
 You can use `v-img` to make, for example, a picture gallery.
 
 <example file="v-img/misc-grid" />
+
+#### Complex Grid Layout
+
+Build a more complex picture gallery layout using ` flex-box` classes.
+
+<example file="v-img/complex-grid" />

--- a/packages/docs/src/pages/en/components/images.md
+++ b/packages/docs/src/pages/en/components/images.md
@@ -89,6 +89,6 @@ You can use `v-img` to make, for example, a picture gallery.
 
 #### Complex Grid Layout
 
-Build a more complex picture gallery layout using ` flex-box` classes.
+Build a more complex picture gallery layout using `flex-box` classes.
 
 <example file="v-img/complex-grid" />


### PR DESCRIPTION
Adding another use case for images in the docs (complex layout grid using responsve grid and flex-box) 