### PR TITLE
fix: check if CSS.supports exists

### DIFF
--- a/packages/vuetify/src/util/globals.ts
+++ b/packages/vuetify/src/util/globals.ts
@@ -1,4 +1,4 @@
 export const IN_BROWSER = typeof window !== 'undefined'
 export const SUPPORTS_INTERSECTION = IN_BROWSER && 'IntersectionObserver' in window
 export const SUPPORTS_TOUCH = IN_BROWSER && ('ontouchstart' in window || window.navigator.maxTouchPoints > 0)
-export const SUPPORTS_FOCUS_VISIBLE = IN_BROWSER && typeof CSS !== 'undefined' && CSS.supports('selector(:focus-visible)')
+export const SUPPORTS_FOCUS_VISIBLE = IN_BROWSER && typeof CSS !== 'undefined' && typeof CSS.supports !== 'undefined' && CSS.supports('selector(:focus-visible)')


### PR DESCRIPTION
## Description
`CSS.support` checkup now fails with some environments. I suggest adding an extra check on its existence similar to the way it's done in many other projects.

Specifically, I was checking it with `nuxt-vitest` (it uses `happy-dom`). 

The issue it produces is similar to that one https://github.com/wojtekmaj/react-fit/issues/2

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/101798/227026993-b09c6601-6db1-48ea-aecf-be78b83993b8.png">

This fix made earlier seems to be not enough
https://github.com/vuetifyjs/vuetify/commit/59370b0ebd7ad9029c9ec14ad0c580435af6b967

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
