### PR TITLE
docs(VNavigationDrawer): add difference between v-model:rail and rail="true" props

### DIFF
--- a/packages/docs/src/pages/en/components/navigation-drawers.md
+++ b/packages/docs/src/pages/en/components/navigation-drawers.md
@@ -35,7 +35,7 @@ The navigation drawer is primarily used to house links to the pages in your appl
 
 <alert type="info">
 
-  The **expand-on-hover** prop does not alter the content area of **v-main**. To have content area respond to drawer expansion, instead of **expand-on-hover**, you can add create a data prop `rail` and then add this to your nav bar `:rail="rail"` followed by `@mouseover="rail = false"` and `@mouseleave="rail = true"`.
+  The **expand-on-hover** prop does not alter the content area of **v-main**. To have content area respond to **expand-on-hover**, bind **v-model:rail** to a data prop.
 
 </alert>
 

--- a/packages/docs/src/pages/en/components/navigation-drawers.md
+++ b/packages/docs/src/pages/en/components/navigation-drawers.md
@@ -35,7 +35,7 @@ The navigation drawer is primarily used to house links to the pages in your appl
 
 <alert type="info">
 
-  The **expand-on-hover** prop does not alter the content area of **v-main**. To have content area respond to **expand-on-hover**, bind **mini-variant.sync** to a data prop.
+  The **expand-on-hover** prop does not alter the content area of **v-main**. To have content area respond to drawer expansion, instead of **expand-on-hover**, you can add create a data prop `rail` and then add this to your nav bar `:rail="rail"` followed by `@mouseover="rail = false"` and `@mouseleave="rail = true"`.
 
 </alert>
 


### PR DESCRIPTION

## Description
There is a caveat on the docs page for navbar that alerts dev that main contents are do not respond to the resizing of the navbar when `rail` and `expand-on-hover` are set. The warning suggests using `mini-variant.sync` to a data prop, however that:

1. Does not seem to work with the latest version of vuetify / vuejs (was mini-variant replaced by `rail`?)
2. It seems not consistent with 
https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/examples/v-navigation-drawer/prop-mini-variant.vue#L6

What seems to work is:

```html
<v-navigation-drawer
     :rail="rail"
     @mouseover="rail = false"
     @mouseleave="rail = true">
</v-navigation-drawer>
```

and

```typescript
<script lang="ts">
export default {
  data() {
    return {
      rail: true
    }
  }
}
</script>
```
