### PR TITLE
fix(forwardRefs): ref chain recursive search

### DIFF
--- a/packages/vuetify/src/composables/forwardRefs.ts
+++ b/packages/vuetify/src/composables/forwardRefs.ts
@@ -8,6 +8,16 @@ type OmitPrefix<T, P extends string> = [Extract<keyof T, `${P}${any}`>] extends 
 
 type OmitProps<T> = T extends { $props: any } ? Omit<T, keyof T['$props']> : never
 
+function getDescriptor (obj: any, key: PropertyKey) {
+  let currentObj = obj
+  while (currentObj) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(currentObj, key)
+    if (descriptor) return descriptor
+    currentObj = Object.getPrototypeOf(currentObj)
+  }
+  return undefined
+}
+
 export function forwardRefs<T extends {}, U extends Ref<HTMLElement | Omit<ComponentPublicInstance, '$emit'> | undefined>[]> (
   target: T,
   ...refs: U
@@ -38,35 +48,24 @@ export function forwardRefs<T extends {}, U extends Ref<HTMLElement | Omit<Compo
       // Check each ref's own properties
       for (const ref of refs) {
         if (!ref.value) continue
-        const descriptor = Reflect.getOwnPropertyDescriptor(ref.value, key)
+        const descriptor = getDescriptor(ref.value, key) ?? getDescriptor(ref.value._?.setupState, key)
         if (descriptor) return descriptor
-        if ('_' in ref.value && 'setupState' in ref.value._) {
-          const descriptor = Reflect.getOwnPropertyDescriptor(ref.value._.setupState, key)
-          if (descriptor) return descriptor
-        }
       }
+
       // Recursive search up each ref's prototype
-      for (const ref of refs) {
-        let obj = ref.value && Object.getPrototypeOf(ref.value)
-        while (obj) {
-          const descriptor = Reflect.getOwnPropertyDescriptor(obj, key)
-          if (descriptor) return descriptor
-          obj = Object.getPrototypeOf(obj)
-        }
-      }
-      // Call forwarded refs' proxies
       for (const ref of refs) {
         const childRefs = ref.value && (ref.value as any)[Refs]
         if (!childRefs) continue
         const queue = childRefs.slice()
         while (queue.length) {
           const ref = queue.shift()
-          const descriptor = Reflect.getOwnPropertyDescriptor(ref.value, key)
+          const descriptor = getDescriptor(ref.value, key)
           if (descriptor) return descriptor
           const childRefs = ref.value && (ref.value as any)[Refs]
           if (childRefs) queue.push(...childRefs)
         }
       }
+
       return undefined
     },
   }) as any

--- a/packages/vuetify/src/composables/forwardRefs.ts
+++ b/packages/vuetify/src/composables/forwardRefs.ts
@@ -48,7 +48,7 @@ export function forwardRefs<T extends {}, U extends Ref<HTMLElement | Omit<Compo
       // Check each ref's own properties
       for (const ref of refs) {
         if (!ref.value) continue
-        const descriptor = getDescriptor(ref.value, key) ?? getDescriptor(ref.value._?.setupState, key)
+        const descriptor = getDescriptor(ref.value, key) ?? ('_' in ref.value ? getDescriptor(ref.value._?.setupState, key) : undefined)
         if (descriptor) return descriptor
       }
 


### PR DESCRIPTION
## Motivation and Context
fixes #16035

## Markup:
<details>

```vue
<script setup>
  import { ref } from 'vue'

  const autocomplete = ref()

  function focus () {
    // autocomplete.value.focus()
    console.log(autocomplete.value.focus())
  }
</script>

<template>
  <v-app>
    <v-main>
      <v-autocomplete
        ref="autocomplete"
        label="Autocomplete"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming',
                 'Alaska', 'Arizona', 'Arkansas', 'Connecticut', 'Delaware', 'Hawaii',
                 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana',
                 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi',
                 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey',
                 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma',
                 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota',
                 'Tennessee', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia',
                 'Wisconsin', 'Wyoming']"
      />

      <v-btn @click="focus()">
        Focus
      </v-btn>
    </v-main>
  </v-app>
</template>

```
</details>
