### PR TITLE
Doc(tables): Early in v-table, link to v-data-table

### DIFF
--- a/packages/docs/src/pages/en/components/tables.md
+++ b/packages/docs/src/pages/en/components/tables.md
@@ -12,7 +12,9 @@ related:
 
 # Tables
 
-The `v-table` component is a simple wrapper component around the `<table>` element. Inside the component you can use all the regular table elements such as `<thead>`, `<tbody>`, `<tr>`, etc.
+The simpler of the table components is `v-table`, a simple wrapper component around the HTML `<table>` element. Inside the component you can use all the regular table elements such as `<thead>`, `<tbody>`, `<tr>`, etc. 
+
+The more advanced table component is [`v-data-table`](/api/v-data-table/), which allows sorting, searching, pagination, grouping, and row selection.
 
 <!-- ![Table Entry](https://cdn.vuetifyjs.com/docs/images/components-temp/v-table/v-table-entry.png) -->
 


### PR DESCRIPTION
I wanted a Vue3 framework with good table support, and looked at Vuetify. I saw a heading "Data and display" and a single entry "Tables". When I clicked that, I came to https://vuetifyjs.com/en/components/tables/, which implied that there was _only_ the `v-table` component. I almost abandoned Vuetify, but by chance googled for "Vuetify Sortable Table" looking for a 3rd party component, and via that discovered the `vue-data-table` component. 

It is vital that _either_ both tables are listed in the left-hand menu of "components", or the `v-table` entry clearly links to the `v-data-table` component very early in the text. Currently the only link is at the bottom, but entitled "Basics" which I did not see any reason to click, because I thought it would be _even more basic_ than v-table, 8-)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
