### PR TITLE
fix(VCombobox): no-data slot not shown

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -91,7 +91,7 @@ export const VCombobox = genericComponent<new <
     delimiters: Array as PropType<string[]>,
 
     ...makeFilterProps({ filterKeys: ['title'] }),
-    ...makeSelectProps({ hideNoData: true, returnObject: true }),
+    ...makeSelectProps({ hideNoData: false, returnObject: true }),
     ...omit(makeVTextFieldProps({
       modelValue: null,
     }), ['validationValue', 'dirty', 'appendInnerIcon']),


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Fix not showing no-data slot by making hideNoData props false by default.

fixes #17048 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-combobox v-model="msg" :items="itmes" hide-details hide-no-data>
      </v-combobox>
      <v-combobox v-model="msg" class="mt-16" :items="itmes" hide-details>
        <template #no-data>
          No data
        </template>
      </v-combobox>
      <v-combobox class="mt-16" v-model="msg" :items="itmes" hide-details>
        <template #details>
          No data
        </template>
      </v-combobox>
    </v-main>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const msg = ref(null)
const itmes = ['1', '2', '3']
</script>
```
