### PR TITLE
test(VCombobox): pass hide-no-data explicitly in filter items tests

### DIFF
--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -175,7 +175,7 @@ describe('VCombobox', () => {
         .should('have.length', 2)
       cy.get('input').clear()
       cy.get('input').type('Item 3')
-      cy.get('input').should('have.length', 0)
+      cy.get('.v-list-item').should('have.length', 0)
     })
 
     it('should filter items when using multiple', () => {

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -163,7 +163,7 @@ describe('VCombobox', () => {
       ]
 
       cy.mount(() => (
-        <VCombobox items={ items } />
+        <VCombobox items={ items } hide-no-data />
       ))
         .get('input')
         .type('Item')
@@ -175,7 +175,7 @@ describe('VCombobox', () => {
         .should('have.length', 2)
       cy.get('input').clear()
       cy.get('input').type('Item 3')
-      cy.get('input').should('have.length', 1)
+      cy.get('input').should('have.length', 0)
     })
 
     it('should filter items when using multiple', () => {
@@ -187,7 +187,7 @@ describe('VCombobox', () => {
       ]
 
       cy.mount(() => (
-        <VCombobox items={ items } multiple />
+        <VCombobox items={ items } multiple hide-no-data />
       ))
         .get('input')
         .type('Item')


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
In PR #17051 I made hide-no-data prop default value true to fix #17048 issue but cy test to filter items failed.
So I pass hide-no-data prop to VCombobox component when mounting in cy tests and expects length to be 0 when input text not found in items.


fixes #17048