### PR TITLE
fix(VDataTable): use DataTableItem interface for item slots

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -30,7 +30,7 @@ type GroupHeaderSlot = {
 
 type ItemSlot = {
   index: number
-  item: InternalDataTableItem
+  item: DataTableItem
   columns: InternalDataTableHeader[]
   isExpanded: (item: DataTableItem) => boolean
   toggleExpand: (item: DataTableItem) => void


### PR DESCRIPTION
fixes #17067

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-data-table
            height="230px"
            :items="_data"
            show-expand
            :expanded="expanded"
            fixed-header
            class="!tw-text-xs"
          >
            <template v-slot:item.serverType="{ item }">
              <span> {{ item.raw.serverType }}</span>
              <v-chip
                size="x-small"
                variant="outlined"
                :color="getColor(item.raw.requestType)"
              >
                {{ item.raw.requestType }}
              </v-chip>
            </template>
            <template v-slot:expanded-row="{ columns, item }">
              <tr>
                <td :colspan="columns.length">
                  Permission Groups:
                  <span class="tw-text-indigo-400">{{ item.raw.groups }}</span>
                </td>
              </tr>
            </template>
          </v-data-table>
    </v-main>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from 'vue'
const expanded = ref([]);
const _data = [
    {
      id: 1,
      serverType: "Gerrit",
      productline: "SmartPhone",
      requestType: "department",
      count: 3,
      groups: "Core",
    },
    {
      id: 2,
      serverType: "Gerrit",
      productline: "Box",
      requestType: "employee",
      count: 2,
      groups: "BeyondCore",
    },
    {
      id: 3,
      serverType: "Gerrit",
      productline: "Auto",
      requestType: "employee",
      count: 4,
      groups: "Kernel",
    },
    {
      id: 4,
      serverType: "Perforce",
      productline: "4010",
      requestType: "department",
      count: 2,
      groups: "subsidary",
    },
    {
      id: 5,
      serverType: "Perforce",
      productline: "4010",
      requestType: "service account",
      count: 1,
      groups: "subsidary",
    },
  ];
// const headers = ref([
//   {
//     title: "Sever Type",
//     align: "start",
//     sortable: true,
//     key: "serverType",
//   },
//   {
//     title: "DB/Productline",
//     align: "start",
//     sortable: true,
//     key: "productline",
//   },
//   {
//     title: "Count",
//     align: "start",
//     sortable: true,
//     key: "count",
//   },
//   {
//     title: "Groups Detail",
//     align: "start",
//     sortable: true,
//     key: "data-table-expand",
//   },
// ]);
  
function getColor(name: string) {
  switch (name) {
    case "employee":
      return "red";
    case "department":
      return "orange";
    case "service account":
      return "green";
    default:
      return "black";
  }
}
</script>


```
