### PR TITLE
fix(VFileInput): expose InputHTMLAttributes type

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -40,6 +40,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
   inheritAttrs: false,
 
   props: {
+    accept: String,
     chips: Boolean,
     counter: Boolean,
     counterSizeString: {
@@ -207,6 +208,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                       <input
                         ref={ inputRef }
                         type="file"
+                        accept={ props.accept }
                         readonly={ isReadonly.value }
                         disabled={ isDisabled.value }
                         multiple={ props.multiple }

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -35,9 +35,7 @@ export type VFileInputSlots = VInputSlots & VFieldSlots & MakeSlots<{
 }>
 
 export const VFileInput = genericComponent<new () => {
-  $props: InputHTMLAttributes & SlotsToProps<{
-    default: [VFileInputSlots]
-  }>
+  $props: InputHTMLAttributes & SlotsToProps<VFileInputSlots>
 }>()({
   name: 'VFileInput',
 

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -25,8 +25,8 @@ import {
 } from '@/util'
 
 // Types
-import type { PropType } from 'vue'
-import type { MakeSlots } from '@/util'
+import type { InputHTMLAttributes, PropType } from 'vue'
+import type { MakeSlots, SlotsToProps } from '@/util'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 
@@ -34,7 +34,11 @@ export type VFileInputSlots = VInputSlots & VFieldSlots & MakeSlots<{
   counter: []
 }>
 
-export const VFileInput = genericComponent<VFileInputSlots>()({
+export const VFileInput = genericComponent<new () => {
+  $props: InputHTMLAttributes & SlotsToProps<{
+    default: [VFileInputSlots]
+  }>
+}>()({
   name: 'VFileInput',
 
   inheritAttrs: false,

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -40,7 +40,6 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
   inheritAttrs: false,
 
   props: {
-    accept: String,
     chips: Boolean,
     counter: Boolean,
     counterSizeString: {
@@ -208,7 +207,6 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                       <input
                         ref={ inputRef }
                         type="file"
-                        accept={ props.accept }
                         readonly={ isReadonly.value }
                         disabled={ isDisabled.value }
                         multiple={ props.multiple }


### PR DESCRIPTION
fix #17069 

It is supported in [v2](https://v2.vuetifyjs.com/en/components/file-inputs/#accept)

`InputHTMLAttributes` including `accept` should be type supported in VFileInput.

input attributes like `accept` will be passed to input via attributes

Allows users to safely specify any legit input(file) attributes. e.g. autofocus, accept ...


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fix #17069
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      
      <v-file-input id="a" autofocus accept="image/png, image/jpeg"></v-file-input>
    </v-main>
  </v-app>
</template>

<script lang="ts">

</script>


```
