### PR TITLE
fix(VDataTable): pass hover prop in Server and Virtual data tables

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
@@ -118,6 +118,7 @@ export const VDataTableServer = genericComponent<VDataTableSlots>()({
         fixedHeader={ props.fixedHeader }
         fixedFooter={ props.fixedFooter }
         height={ props.height }
+        hover={ props.hover }
       >
         {{
           top: slots.top,

--- a/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
@@ -120,6 +120,7 @@ export const VDataTableVirtual = genericComponent<VDataTableVirtualSlots>()({
         }}
         height={ props.height }
         fixedHeader={ props.fixedHeader }
+        hover={ props.hover }
       >
         {{
           top: slots.top,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
[hover](https://vuetifyjs.com/en/api/v-data-table-server/#props-hover) prop does not have effect in `v-data-table-server` and `v-data-table-virtual` because, unlike in regular [`v-data-table`](https://github.com/vuetifyjs/vuetify/blob/ce41893ab8494f3cd004b773211a5bac7a2c78a3/packages/vuetify/src/labs/VDataTable/VDataTable.tsx#L143), it is not passed down to the underlying `VTable` component.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script setup>
const items = new Array(10).fill({});
</script>

<template>
  <v-data-table-server hover :headers="[]" :items="items"></v-data-table-server>
</template>
```
