### PR TITLE
fix: unreliable dependencies of `useProxiedModel()`

### DIFF
--- a/packages/vuetify/src/composables/proxiedModel.ts
+++ b/packages/vuetify/src/composables/proxiedModel.ts
@@ -46,8 +46,8 @@ export function useProxiedModel<
 
   const model = computed({
     get (): any {
-      void props[prop]
-      return transformIn(isControlled.value ? props[prop] : internal.value)
+      const externalValue = props[prop]
+      return transformIn(isControlled.value ? externalValue : internal.value)
     },
     set (internalValue) {
       const newValue = transformOut(internalValue)

--- a/packages/vuetify/src/composables/proxiedModel.ts
+++ b/packages/vuetify/src/composables/proxiedModel.ts
@@ -46,6 +46,7 @@ export function useProxiedModel<
 
   const model = computed({
     get (): any {
+      void props[prop]
       return transformIn(isControlled.value ? props[prop] : internal.value)
     },
     set (internalValue) {


### PR DESCRIPTION
`model` is relying on `isControlled` to propagate the dirty event. After https://github.com/vuejs/core/pull/5912, the dirty event will no longer be propagated if the new value of `isControlled` hasn't changed. This has caused some tests to fail.