### PR TITLE
fix v-checkbox @click:prepend and @click:append doesn't work

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -50,6 +50,8 @@ export const VCheckbox = genericComponent<VCheckboxSlots>()({
           { ...inputProps }
           id={ id.value }
           focused={ isFocused.value }
+          onClick:prepend={ props['onClick:prepend'] }
+          onClick:append={ props['onClick:append'] }
         >
           {{
             ...slots,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix `v-checkbox` `@click:prepend` and `@click:append` doesn't work
fixes #17070 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
#Playground
```vue
<template>
  <v-app>
    <v-container>
      <v-textarea
        label="Working fine with a v-textarea"
        prepend-icon="mdi-home"
        append-icon="mdi-home"
        @click:prepend="testAlert('clicked prepend icon')"
        @click:append="testAlert('clicked appended icon')"
      />
      <v-checkbox
        prepend-icon="mdi-home"
        append-icon="mdi-home"
        label="Not working with a v-checkbox"
        @click:prepend="testAlert('clicked prepended icon')"
        @click:append="testAlert('clicked appended icon')"
      />

    </v-container>
  </v-app>
</template>

<script>
  // import { ref } from 'vue'
  export default {
    name: 'Playground',
    setup () {
      function testAlert (text) {
        alert(text)
      }
      return {
        testAlert,
      }
    },
  }
</script>


```
