### PR TITLE
fix(VSkeletonLoader): add missing divider type

### DIFF
--- a/packages/docs/src/pages/en/components/skeleton-loaders.md
+++ b/packages/docs/src/pages/en/components/skeleton-loaders.md
@@ -80,6 +80,7 @@ The following built-in types are available:
 | **date-picker** | list-item, card-heading, divider, date-picker-options, date-picker-days, actions |
 | **date-picker-options** | text, avatar@2 |
 | **date-picker-days** | avatar@28 |
+| **divider** | divider |
 | **heading** | heading |
 | **image** | image |
 | **list-item** | text |

--- a/packages/vuetify/src/labs/VSkeletonLoader/VSkeletonLoader.tsx
+++ b/packages/vuetify/src/labs/VSkeletonLoader/VSkeletonLoader.tsx
@@ -34,6 +34,7 @@ export const rootTypes = {
   'date-picker': 'list-item, heading, divider, date-picker-options, date-picker-days, actions',
   'date-picker-options': 'text, avatar@2',
   'date-picker-days': 'avatar@28',
+  divider: 'divider',
   heading: 'heading',
   image: 'image',
   'list-item': 'text',


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #17107

VSkeletonLoader does not work when "table", "table-tbody", "table-row-divider", or "date-picker" is specified for the type because there is no "divider" in the type.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <template v-for="skeletonType in types" :key="skeletonType">
        <v-chip class="mt-10" color="primary">{{ skeletonType }}</v-chip>
        <v-skeleton-loader class="border mt-1" max-width="300" :type="skeletonType" />
      </template>
    </v-container>
  </v-app>
</template>

<script setup>
  // test all types
  const types = ['actions', 'article', 'avatar', 'button', 'card', 'card-avatar', 'chip', 'date-picker', 'date-picker-options', 'date-picker-days', 'heading', 'image', 'list-item', 'list-item-avatar', 'list-item-two-line', 'list-item-avatar-two-line', 'list-item-three-line', 'list-item-avatar-three-line', 'paragraph', 'sentences', 'subtitle', 'table', 'table-heading', 'table-thead', 'table-tbody', 'table-row-divider', 'table-row', 'table-tfoot', 'text']
</script>

```
