### PR TITLE
fix(VSelect): replicate html select hotkeys

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -169,7 +169,7 @@ describe('VAutocomplete', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/16055
-  it('should not replicate html select hotkeys in v-autocomplete', async () => {
+  it('should not replicate html select hotkeys in v-autocomplete', () => {
     const items = ref(['aaa', 'foo', 'faa'])
 
     const selectedItems = ref(undefined)
@@ -187,7 +187,7 @@ describe('VAutocomplete', () => {
       .focus()
       .type('f', { force: true })
       .get('.v-list-item').should('have.length', 2)
-      .then( _  => {
+      .then(_ => {
         expect(selectedItems.value).equal(undefined)
       })
   })

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -167,4 +167,28 @@ describe('VAutocomplete', () => {
       cy.get('.v-overlay__content .v-list-item .v-list-item-title').eq(1).should('have.text', 'Item 4')
     })
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/16055
+  it('should not replicate html select hotkeys in v-autocomplete', async () => {
+    const items = ref(['aaa', 'foo', 'faa'])
+
+    const selectedItems = ref(undefined)
+
+    cy.mount(() => (
+      <VAutocomplete
+        modelValue={ selectedItems }
+        items={ items.value }
+      />
+    ))
+
+    cy.get('.v-autocomplete')
+      .click()
+      .get('.v-autocomplete input')
+      .focus()
+      .type('f', { force: true })
+      .get('.v-list-item').should('have.length', 2)
+      .then( _  => {
+        expect(selectedItems.value).equal(undefined)
+      })
+  })
 })

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -176,7 +176,7 @@ describe('VAutocomplete', () => {
 
     cy.mount(() => (
       <VAutocomplete
-        modelValue={ selectedItems }
+        v-model={ selectedItems }
         items={ items.value }
       />
     ))

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -176,7 +176,7 @@ describe('VAutocomplete', () => {
 
     cy.mount(() => (
       <VAutocomplete
-        v-model={ selectedItems }
+        v-model={ selectedItems.value }
         items={ items.value }
       />
     ))

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -188,7 +188,7 @@ export const VSelect = genericComponent<new <
       } else if (e.key === 'End') {
         listRef.value?.focus('last')
       }
-    
+
       // html select hotkeys
       ((e: KeyboardEvent) => {
         const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -189,22 +189,29 @@ export const VSelect = genericComponent<new <
       } else if (e.key === 'End') {
         listRef.value?.focus('last')
       }
-    }
-    // html select hotkeys
-    function onKeypress (e: KeyboardEvent) {
-      if (props.multiple) return
+    
+      // html select hotkeys
+      ((e: KeyboardEvent) => {
+        function checkPrintable (e: KeyboardEvent) {
+          const isPrintableChar = e.key.length === 1 && e.key !== ' '
+          const noModifier = !e.ctrlKey && !e.metaKey && !e.altKey
+          return isPrintableChar && noModifier
+        }
 
-      const now = performance.now()
-      if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
-        keyboardLookupPrefix = ''
-      }
-      keyboardLookupPrefix += e.key.toLowerCase()
-      keyboardLookupLastTime = now
+        if (props.multiple || !checkPrintable(e)) return
 
-      const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
-      if (item !== undefined) {
-        model.value = [item]
-      }
+        const now = performance.now()
+        if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
+          keyboardLookupPrefix = ''
+        }
+        keyboardLookupPrefix += e.key.toLowerCase()
+        keyboardLookupLastTime = now
+
+        const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
+        if (item !== undefined) {
+          model.value = [item]
+        }
+      })(e)
     }
     function select (item: InternalItem) {
       if (props.multiple) {
@@ -261,7 +268,6 @@ export const VSelect = genericComponent<new <
           onMousedown:control={ onMousedownControl }
           onBlur={ onBlur }
           onKeydown={ onKeydown }
-          onKeypress={ onKeypress }
         >
           {{
             ...slots,

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -191,19 +191,21 @@ export const VSelect = genericComponent<new <
       }
 
       // html select hotkeys
-      if (props.multiple) return
+      ((e: KeyboardEvent) => {
+        if (props.multiple) return
 
-      const now = performance.now()
-      if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
-        keyboardLookupPrefix = ''
-      }
-      keyboardLookupPrefix += e.key.toLowerCase()
-      keyboardLookupLastTime = now
+        const now = performance.now()
+        if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
+          keyboardLookupPrefix = ''
+        }
+        keyboardLookupPrefix += e.key.toLowerCase()
+        keyboardLookupLastTime = now
 
-      const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
-      if (item !== undefined) {
-        model.value = [item]
-      }
+        const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
+        if (item !== undefined) {
+          model.value = [item]
+        }
+      })(e)
     }
     function select (item: InternalItem) {
       if (props.multiple) {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -191,14 +191,14 @@ export const VSelect = genericComponent<new <
       }
     }
     // html select hotkeys
-    function onBeforeinput(e: InputEvent) {
-      if (props.multiple || !e.data) return
+    function onKeypress(e: KeyboardEvent) {
+      if (props.multiple) return
 
       const now = performance.now()
       if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
         keyboardLookupPrefix = ''
       }
-      keyboardLookupPrefix += e.data.toLowerCase()
+      keyboardLookupPrefix += e.key.toLowerCase()
       keyboardLookupLastTime = now
 
       const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
@@ -256,11 +256,12 @@ export const VSelect = genericComponent<new <
             },
           ]}
           appendInnerIcon={ props.menuIcon }
+          readonly
           onClick:clear={ onClear }
           onMousedown:control={ onMousedownControl }
           onBlur={ onBlur }
           onKeydown={ onKeydown }
-          onBeforeinput={ onBeforeinput }
+          onKeypress={ onKeypress }
         >
           {{
             ...slots,

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -139,6 +139,9 @@ export const VSelect = genericComponent<new <
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))
 
+    const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
+    let keyboardLookupPrefix = '', keyboardLookupLastTime: number
+
     const displayItems = computed(() => {
       if (props.hideSelected) {
         return items.value.filter(item => !selections.value.some(s => s === item))
@@ -187,9 +190,17 @@ export const VSelect = genericComponent<new <
       }
 
       // html select hotkeys
-      const keyboardLookupPrefix = e.key
+      if (props.multiple) return
+
+      const now = performance.now()
+      if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
+        keyboardLookupPrefix = ''
+      }
+      keyboardLookupPrefix += e.key.toLowerCase()
+      keyboardLookupLastTime = now
+
       const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
-      if (item) {
+      if (item !== undefined) {
         model.value = [item]
       }
     }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -185,6 +185,13 @@ export const VSelect = genericComponent<new <
       } else if (e.key === 'End') {
         listRef.value?.focus('last')
       }
+
+      // html select hotkeys
+      const keyboardLookupPrefix = e.key
+      const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
+      if (item) {
+        model.value = [item]
+      }
     }
     function select (item: InternalItem) {
       if (props.multiple) {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -189,23 +189,22 @@ export const VSelect = genericComponent<new <
       } else if (e.key === 'End') {
         listRef.value?.focus('last')
       }
+    }
+    // html select hotkeys
+    function onBeforeinput(e: InputEvent) {
+      if (props.multiple || !e.data) return
 
-      // html select hotkeys
-      ((e: KeyboardEvent) => {
-        if (props.multiple) return
+      const now = performance.now()
+      if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
+        keyboardLookupPrefix = ''
+      }
+      keyboardLookupPrefix += e.data.toLowerCase()
+      keyboardLookupLastTime = now
 
-        const now = performance.now()
-        if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
-          keyboardLookupPrefix = ''
-        }
-        keyboardLookupPrefix += e.key.toLowerCase()
-        keyboardLookupLastTime = now
-
-        const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
-        if (item !== undefined) {
-          model.value = [item]
-        }
-      })(e)
+      const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
+      if (item !== undefined) {
+        model.value = [item]
+      }
     }
     function select (item: InternalItem) {
       if (props.multiple) {
@@ -257,11 +256,11 @@ export const VSelect = genericComponent<new <
             },
           ]}
           appendInnerIcon={ props.menuIcon }
-          readonly
           onClick:clear={ onClear }
           onMousedown:control={ onMousedownControl }
           onBlur={ onBlur }
           onKeydown={ onKeydown }
+          onBeforeinput={ onBeforeinput }
         >
           {{
             ...slots,

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -191,7 +191,7 @@ export const VSelect = genericComponent<new <
       }
     }
     // html select hotkeys
-    function onKeypress(e: KeyboardEvent) {
+    function onKeypress (e: KeyboardEvent) {
       if (props.multiple) return
 
       const now = performance.now()

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -139,7 +139,6 @@ export const VSelect = genericComponent<new <
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))
 
-    const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
     let keyboardLookupPrefix = ''
     let keyboardLookupLastTime: number
 
@@ -192,6 +191,8 @@ export const VSelect = genericComponent<new <
     
       // html select hotkeys
       ((e: KeyboardEvent) => {
+        const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
+
         function checkPrintable (e: KeyboardEvent) {
           const isPrintableChar = e.key.length === 1 && e.key !== ' '
           const noModifier = !e.ctrlKey && !e.metaKey && !e.altKey

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -140,7 +140,8 @@ export const VSelect = genericComponent<new <
     const selected = computed(() => selections.value.map(selection => selection.props.value))
 
     const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
-    let keyboardLookupPrefix = '', keyboardLookupLastTime: number
+    let keyboardLookupPrefix = ''
+    let keyboardLookupLastTime: number
 
     const displayItems = computed(() => {
       if (props.hideSelected) {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -190,29 +190,27 @@ export const VSelect = genericComponent<new <
       }
 
       // html select hotkeys
-      ((e: KeyboardEvent) => {
-        const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
+      const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
 
-        function checkPrintable (e: KeyboardEvent) {
-          const isPrintableChar = e.key.length === 1 && e.key !== ' '
-          const noModifier = !e.ctrlKey && !e.metaKey && !e.altKey
-          return isPrintableChar && noModifier
-        }
+      function checkPrintable (e: KeyboardEvent) {
+        const isPrintableChar = e.key.length === 1
+        const noModifier = !e.ctrlKey && !e.metaKey && !e.altKey
+        return isPrintableChar && noModifier
+      }
 
-        if (props.multiple || !checkPrintable(e)) return
+      if (props.multiple || !checkPrintable(e)) return
 
-        const now = performance.now()
-        if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
-          keyboardLookupPrefix = ''
-        }
-        keyboardLookupPrefix += e.key.toLowerCase()
-        keyboardLookupLastTime = now
+      const now = performance.now()
+      if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {
+        keyboardLookupPrefix = ''
+      }
+      keyboardLookupPrefix += e.key.toLowerCase()
+      keyboardLookupLastTime = now
 
-        const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
-        if (item !== undefined) {
-          model.value = [item]
-        }
-      })(e)
+      const item = items.value.find(item => item.title.toLowerCase().startsWith(keyboardLookupPrefix))
+      if (item !== undefined) {
+        model.value = [item]
+      }
     }
     function select (item: InternalItem) {
       if (props.multiple) {

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -272,7 +272,7 @@ describe('VSelect', () => {
 
     cy.mount(() => (
       <VSelect
-        modelValue={ selectedItems }
+        v-model={ selectedItems }
         items={ items.value }
       />
     ))

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -263,4 +263,28 @@ describe('VSelect', () => {
       cy.get('.v-overlay__content .v-list-item .v-list-item-title').eq(1).should('have.text', 'Item 4')
     })
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/16055
+  it('should select item after typing its first few letters', async () => {
+    const items = ref(['aaa', 'foo', 'faa'])
+
+    const selectedItems = ref(undefined)
+
+    cy.mount(() => (
+      <VSelect
+        modelValue={ selectedItems }
+        items={ items.value }
+      />
+    ))
+
+    cy.get('.v-select')
+      .click()
+      .get('.v-select input')
+      .focus()
+      .type('f', { force: true })
+      .get('.v-list-item').should('have.length', 3)
+      .then( _  => {
+        expect(selectedItems.value).equal('foo')
+      })
+  })
 })

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -272,7 +272,7 @@ describe('VSelect', () => {
 
     cy.mount(() => (
       <VSelect
-        v-model={ selectedItems }
+        v-model={ selectedItems.value }
         items={ items.value }
       />
     ))

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -265,7 +265,7 @@ describe('VSelect', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/16055
-  it('should select item after typing its first few letters', async () => {
+  it('should select item after typing its first few letters', () => {
     const items = ref(['aaa', 'foo', 'faa'])
 
     const selectedItems = ref(undefined)
@@ -283,7 +283,7 @@ describe('VSelect', () => {
       .focus()
       .type('f', { force: true })
       .get('.v-list-item').should('have.length', 3)
-      .then( _  => {
+      .then(_ => {
         expect(selectedItems.value).equal('foo')
       })
   })

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -66,7 +66,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
     'mousedown:control': (e: MouseEvent) => true,
     'update:focused': (focused: boolean) => true,
     'update:modelValue': (val: string) => true,
-    'beforeinput': (e: InputEvent) => true,
+    beforeinput: (e: InputEvent) => true,
   },
 
   setup (props, { attrs, emit, slots }) {

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -66,6 +66,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
     'mousedown:control': (e: MouseEvent) => true,
     'update:focused': (focused: boolean) => true,
     'update:modelValue': (val: string) => true,
+    'beforeinput': (e: InputEvent) => true,
   },
 
   setup (props, { attrs, emit, slots }) {
@@ -229,6 +230,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                         type={ props.type }
                         onFocus={ onFocus }
                         onBlur={ blur }
+                        onBeforeinput={ e => emit('beforeinput', e as InputEvent) }
                         { ...slotProps }
                         { ...inputAttrs }
                       />

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -66,7 +66,6 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
     'mousedown:control': (e: MouseEvent) => true,
     'update:focused': (focused: boolean) => true,
     'update:modelValue': (val: string) => true,
-    beforeinput: (e: InputEvent) => true,
   },
 
   setup (props, { attrs, emit, slots }) {
@@ -230,7 +229,6 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                         type={ props.type }
                         onFocus={ onFocus }
                         onBlur={ blur }
-                        onBeforeinput={ e => emit('beforeinput', e as InputEvent) }
                         { ...slotProps }
                         { ...inputAttrs }
                       />


### PR DESCRIPTION
fixes #16055
fixes #7260

- Port #4853 to V3
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script setup>
import { ref } from 'vue' 
      
const items = ref(['Foo', 'Bar', 'Fizz', 'Buzz'])
  
</script>

<template>
  <v-select
    :items="items"
    label="Standard"
  ></v-select>
</template>

```
