### PR TITLE
fix(VCombobox): allow falsy values in model

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -127,7 +127,7 @@ export const VCombobox = genericComponent<new <
       props,
       'modelValue',
       [],
-      v => transformIn(wrapInArray(v || [])),
+      v => transformIn(wrapInArray(v)),
       v => {
         const transformed = transformOut(v)
         return props.multiple ? transformed : (transformed[0] ?? null)

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -399,4 +399,26 @@ describe('VCombobox', () => {
       cy.get('.v-overlay__content .v-list-item .v-list-item-title').eq(1).should('have.text', 'Item 4')
     })
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/17120
+  it('should display 0 when selected', () => {
+    const items = [0, 1, 2, 3, 4]
+
+    const selectedItems = ref(undefined)
+
+    cy.mount(() => (
+      <VCombobox
+        items={ items }
+        v-model={ selectedItems.value }
+      />
+    ))
+      .get('.v-field input')
+      .click()
+
+    cy.get('.v-list-item').eq(0)
+      .click({ waitForAnimations: false })
+
+    cy.get('.v-combobox input')
+      .should('have.value', '0')
+  })
 })


### PR DESCRIPTION
fixes #17120

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-combobox v-model="msg" class="pb-16" :items="itmes" />
    </v-main>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const msg = ref(null)
const itmes = [...Array(40).keys()]
</script>


```
