### PR TITLE
docs(v-combobox): remove unused variable 'value' in example

### DIFF
--- a/packages/docs/src/examples/v-combobox/prop-density.vue
+++ b/packages/docs/src/examples/v-combobox/prop-density.vue
@@ -4,14 +4,14 @@
       <v-row>
         <v-col cols="12">
           <v-combobox
-            v-model="values"
+            v-model="value"
             :items="items"
             label="Default"
           ></v-combobox>
         </v-col>
         <v-col cols="12">
           <v-combobox
-            v-model="values"
+            v-model="value"
             :items="items"
             density="comfortable"
             label="Comfortable"
@@ -19,7 +19,7 @@
         </v-col>
         <v-col cols="12">
           <v-combobox
-            v-model="values"
+            v-model="value"
             :items="items"
             density="compact"
             label="Compact"
@@ -34,8 +34,7 @@
   export default {
     data: () => ({
       items: ['foo', 'bar', 'fizz', 'buzz'],
-      values: 'foo',
-      value: null,
+      value: 'foo',
     }),
   }
 </script>


### PR DESCRIPTION
Remove unused variable 'value'