### PR TITLE
fix(VDataTableHeader): add center value to align

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/types.ts
+++ b/packages/vuetify/src/labs/VDataTable/types.ts
@@ -12,7 +12,7 @@ export type DataTableHeader = {
   rowspan?: number
 
   fixed?: boolean
-  align?: 'start' | 'end'
+  align?: 'start' | 'center' | 'end'
 
   width?: number
   minWidth?: string


### PR DESCRIPTION
## Description
The VDataTableColumn align can be one of the three values : 'start', 'center' and 'end'. The interface does not implement the center one.

## Markup:


<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
export type DataTableHeader = {
  key: string
  value?: SelectItemKey
  title: string

  colspan?: number
  rowspan?: number

  fixed?: boolean
  align?: 'start' | 'center' | 'end'

  width?: number
  minWidth?: string
  maxWidth?: string

  sortable?: boolean
  sort?: DataTableCompareFunction
}

export const VDataTableColumn = defineFunctionalComponent({
  align: {
    type: String as PropType<'start' | 'center' | 'end'>,
    default: 'start',
  },
...
}
```
