### PR TITLE
fix(VSelects): keep field focused when menu open

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -256,6 +256,12 @@ export const VAutocomplete = genericComponent<new <
       isPristine.value = !val
     })
 
+    watch(menu, value => {
+      if (!model.value?.length) {
+        isFocused.value = value
+      }
+    })
+
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
       const hasList = !!((!props.hideNoData || displayItems.value.length) || slots.prepend || slots.append || slots['no-data'])
@@ -268,6 +274,7 @@ export const VAutocomplete = genericComponent<new <
           { ...textFieldProps }
           modelValue={ search.value }
           onUpdate:modelValue={ v => { if (v == null) model.value = [] } }
+          v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
           dirty={ isDirty }
           onInput={ onInput }
@@ -285,8 +292,6 @@ export const VAutocomplete = genericComponent<new <
           placeholder={ isDirty ? undefined : props.placeholder }
           onClick:clear={ onClear }
           onMousedown:control={ onMousedownControl }
-          onFocus={ () => isFocused.value = true }
-          onBlur={ () => isFocused.value = false }
           onKeydown={ onKeydown }
         >
           {{

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -256,12 +256,6 @@ export const VAutocomplete = genericComponent<new <
       isPristine.value = !val
     })
 
-    watch(menu, value => {
-      if (!model.value?.length) {
-        isFocused.value = value
-      }
-    })
-
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
       const hasList = !!((!props.hideNoData || displayItems.value.length) || slots.prepend || slots.append || slots['no-data'])

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -3,6 +3,7 @@
 import { VForm } from '@/components/VForm'
 import { ref } from 'vue'
 import { VAutocomplete } from '../VAutocomplete'
+import { keyValues } from '@/util'
 
 describe('VAutocomplete', () => {
   it('should close only first chip', () => {
@@ -216,5 +217,24 @@ describe('VAutocomplete', () => {
       .setProps({ multiple: true, modelValue: ['Foobar'] })
       .get('.v-autocomplete input')
       .should('not.have.attr', 'placeholder')
+  })
+
+  it('should keep TextField focused while selecting items from open menu', () => {
+    cy.mount(() => (
+      <VAutocomplete
+        multiple
+        items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+      />
+    ))
+
+    cy.get('.v-autocomplete')
+      .click()
+
+    cy.get('.v-list')
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+
+    cy.get('.v-field').should('have.class', 'v-field--focused')
   })
 })

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -178,12 +178,6 @@ export const VCombobox = genericComponent<new <
       }
     })
 
-    watch(menu, value => {
-      if (!model.value?.length) {
-        isFocused.value = value
-      }
-    })
-
     const { filteredItems, getMatches } = useFilter(props, items, computed(() => isPristine.value ? undefined : search.value))
 
     const selections = computed(() => {

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -178,6 +178,12 @@ export const VCombobox = genericComponent<new <
       }
     })
 
+    watch(menu, value => {
+      if (!model.value?.length) {
+        isFocused.value = value
+      }
+    })
+
     const { filteredItems, getMatches } = useFilter(props, items, computed(() => isPristine.value ? undefined : search.value))
 
     const selections = computed(() => {
@@ -359,6 +365,7 @@ export const VCombobox = genericComponent<new <
           { ...textFieldProps }
           v-model={ search.value }
           onUpdate:modelValue={ v => { if (v == null) model.value = [] } }
+          v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
           dirty={ isDirty }
           class={[
@@ -375,8 +382,6 @@ export const VCombobox = genericComponent<new <
           placeholder={ isDirty ? undefined : props.placeholder }
           onClick:clear={ onClear }
           onMousedown:control={ onMousedownControl }
-          onFocus={ () => isFocused.value = true }
-          onBlur={ () => isFocused.value = false }
           onKeydown={ onKeydown }
         >
           {{

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -3,6 +3,7 @@
 import { VForm } from '@/components/VForm'
 import { VCombobox } from '../VCombobox'
 import { ref } from 'vue'
+import { keyValues } from '@/util'
 
 describe('VCombobox', () => {
   describe('closableChips', () => {
@@ -446,5 +447,24 @@ describe('VCombobox', () => {
       .setProps({ multiple: true, modelValue: ['Foobar'] })
       .get('.v-combobox input')
       .should('not.have.attr', 'placeholder')
+  })
+
+  it('should keep TextField focused while selecting items from open menu', () => {
+    cy.mount(() => (
+      <VCombobox
+        multiple
+        items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+      />
+    ))
+
+    cy.get('.v-combobox')
+      .click()
+
+    cy.get('.v-list')
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+
+    cy.get('.v-field').should('have.class', 'v-field--focused')
   })
 })

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -21,7 +21,7 @@ import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
-import { computed, mergeProps, ref } from 'vue'
+import { computed, mergeProps, ref, watch } from 'vue'
 import { deepEqual, genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -239,6 +239,12 @@ export const VSelect = genericComponent<new <
         vTextFieldRef.value?.focus()
       }
     }
+
+    watch(menu, value => {
+      if (!model.value?.length) {
+        isFocused.value = value
+      }
+    })
 
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -21,7 +21,7 @@ import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utility
-import { computed, mergeProps, ref, watch } from 'vue'
+import { computed, mergeProps, ref } from 'vue'
 import { deepEqual, genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -234,17 +234,14 @@ export const VSelect = genericComponent<new <
         menu.value = false
       }
     }
+    function onFocusin (e: FocusEvent) {
+      isFocused.value = true
+    }
     function onFocusout (e: FocusEvent) {
       if (e.relatedTarget == null) {
         vTextFieldRef.value?.focus()
       }
     }
-
-    watch(menu, value => {
-      if (!model.value?.length) {
-        isFocused.value = value
-      }
-    })
 
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
@@ -306,6 +303,7 @@ export const VSelect = genericComponent<new <
                       selected={ selected.value }
                       selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                       onMousedown={ (e: MouseEvent) => e.preventDefault() }
+                      onFocusin={ onFocusin }
                       onFocusout={ onFocusout }
                     >
                       { !displayItems.value.length && !props.hideNoData && (slots['no-data']?.() ?? (

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -4,6 +4,7 @@ import { VForm } from '@/components/VForm'
 import { VListItem } from '@/components/VList'
 import { ref } from 'vue'
 import { VSelect } from '../VSelect'
+import { keyValues } from '@/util'
 
 describe('VSelect', () => {
   it('should render selection slot', () => {
@@ -310,5 +311,23 @@ describe('VSelect', () => {
       .then(_ => {
         expect(selectedItems.value).equal('foo')
       })
+  })
+
+  it('should keep TextField focused while selecting items from open menu', () => {
+    cy.mount(() => (
+      <VSelect
+        items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+      />
+    ))
+
+    cy.get('.v-select')
+      .click()
+
+    cy.get('.v-list')
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+      .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+
+    cy.get('.v-field').should('have.class', 'v-field--focused')
   })
 })

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -159,7 +159,6 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const [{ modelValue: _, ...inputProps }] = filterInputProps(props)
       const [fieldProps] = filterFieldProps(props)
-      const isMenuActive = typeof rootAttrs.class === 'string' && rootAttrs.class.includes('--active-menu')
 
       return (
         <VInput
@@ -225,7 +224,8 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                         placeholder={ props.placeholder }
                         size={ 1 }
                         type={ props.type }
-                        onBlur={ () => isMenuActive || blur() }
+                        onFocus={ onFocus }
+                        onBlur={ blur }
                         { ...slotProps }
                         { ...inputAttrs }
                       />

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -159,6 +159,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const [{ modelValue: _, ...inputProps }] = filterInputProps(props)
       const [fieldProps] = filterFieldProps(props)
+      const isMenuActive = typeof rootAttrs.class === 'string' && rootAttrs.class.includes('--active-menu')
 
       return (
         <VInput
@@ -224,8 +225,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                         placeholder={ props.placeholder }
                         size={ 1 }
                         type={ props.type }
-                        onFocus={ onFocus }
-                        onBlur={ blur }
+                        onBlur={ () => isMenuActive || blur() }
                         { ...slotProps }
                         { ...inputAttrs }
                       />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
Resolve the issue shown in video (select in open menu should keep text field stay focused)

![select](https://user-images.githubusercontent.com/5698884/232184146-ec51e9c7-6d0f-4d78-9dd3-a4d16b1c6beb.gif)


## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-select
        label="Select"
        color="purple"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-autocomplete
        label="Select"
        color="purple"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-combobox
        color="purple"
        label="Select"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
    </v-main>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

</script>
```
