### PR TITLE
docs(upgrade-guide): add info about missing components

### DIFF
--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -22,6 +22,8 @@ Many of these changes can be applied automatically by [eslint-plugin-vuetify](ht
 <alert type="warning">
 
   This page is incomplete. Please check back later for more information, or submit a PR if you notice something missing. If you have additional questions, reach out to us in [Discord](https://community.vuetifyjs.com/)
+  
+  Addtionally, not all components available for Vuetify 2 have been migrated to Vuetify 3. Most notibly the v-data-table. However, some are available in [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/). 
 
 </alert>
 

--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -29,15 +29,15 @@ Many of these changes can be applied automatically by [eslint-plugin-vuetify](ht
 
   Not all Vuetify 2 components are currently available in Vuetify 3; These components will be released as their development is completed via [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/).
 
-  - v-calendar
-  - v-date-picker
-  - v-data-table
-  - v-infinite-scroll
-  - v-skeleton-loader
-  - v-stepper
-  - v-time-picker
-  - v-treeview
-  - v-virtual-scroll
+- v-calendar
+- v-date-picker
+- v-data-table
+- v-infinite-scroll
+- v-skeleton-loader
+- v-stepper
+- v-time-picker
+- v-treeview
+- v-virtual-scroll
 
 </alert>
 

--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -23,7 +23,7 @@ Many of these changes can be applied automatically by [eslint-plugin-vuetify](ht
 
   This page is incomplete. Please check back later for more information, or submit a PR if you notice something missing. If you have additional questions, reach out to us in [Discord](https://community.vuetifyjs.com/)
   
-  Addtionally, not all components available for Vuetify 2 have been migrated to Vuetify 3. Most notibly the v-data-table. However, some are available in [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/). 
+  Additionally, not all components available for Vuetify 2 have been migrated to Vuetify 3; most notably the v-data-table. However, some are available in [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/). 
 
 </alert>
 

--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -23,7 +23,21 @@ Many of these changes can be applied automatically by [eslint-plugin-vuetify](ht
 
   This page is incomplete. Please check back later for more information, or submit a PR if you notice something missing. If you have additional questions, reach out to us in [Discord](https://community.vuetifyjs.com/)
   
-  Additionally, not all components available for Vuetify 2 have been migrated to Vuetify 3; most notably the v-data-table. However, some are available in [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/). 
+</alert>
+
+<alert type="warning">
+
+  Not all Vuetify 2 components are currently available in Vuetify 3; These components will be released as their development is completed via [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/).
+
+  - v-calendar
+  - v-date-picker
+  - v-data-table
+  - v-infinite-scroll
+  - v-skeleton-loader
+  - v-stepper
+  - v-time-picker
+  - v-treeview
+  - v-virtual-scroll
 
 </alert>
 


### PR DESCRIPTION
Add a warning about missing components in Vuetify 3, that were available in Vuetify 2. This cost me a considerable amount of time.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
