### PR TITLE
fix(VDataTableRow): show no-data table row

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
@@ -40,12 +40,11 @@ export const VDataTableRow = defineComponent({
         ]}
         onClick={ props.onClick }
       >
-        { !columns.value.length && (
-          <VDataTableColumn
-            key="no-data"
-            v-slots={ slots }
-          />
-        )}
+
+        <VDataTableColumn
+          key="no-data"
+          v-slots={ slots }
+        />
 
         { props.item && columns.value.map((column, i) => (
           <VDataTableColumn


### PR DESCRIPTION
fixes #17168

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
I removed the length of `columns` condition to let `no-data` part show from passing `noDataText`.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <VDataTable
      :headers="headers"
      :items="desserts"
      class="elevation-1"
      density="compact"
      item-key="name"
      no-data-text="no stuff here"
    />
  </v-app>
</template>

<script setup lang="ts">
  import { VDataTable } from '@/labs/VDataTable'
  import { DataTableHeader } from '@/labs/VDataTable/types'
  import { ref } from 'vue'

  const headers = ref<DataTableHeader[]>([
    {
      key: 'name',
      title: 'Dessert (100g serving)',
      align: 'start',
      sortable: false,
    },
    { title: 'Calories', align: 'end', key: 'calories' },
    { title: 'Fat (g)', align: 'end', key: 'fat' },
    { title: 'Carbs (g)', align: 'end', key: 'carbs' },
    { title: 'Protein (g)', align: 'end', key: 'protein' },
    { title: 'Iron (%)', align: 'end', key: 'iron' },
  ])

  const desserts = ref([
    {
      name: 'Frozen Yogurt',
      calories: 159,
      fat: 6.0,
      carbs: 24,
      protein: 4.0,
      iron: '1',
    },
    {
      name: 'Jelly bean',
      calories: 375,
      fat: 0.0,
      carbs: 94,
      protein: 0.0,
      iron: '0',
    },
    {
      name: 'KitKat',
      calories: 518,
      fat: 26.0,
      carbs: 65,
      protein: 7,
      iron: '6',
    },
    {
      name: 'Eclair',
      calories: 262,
      fat: 16.0,
      carbs: 23,
      protein: 6.0,
      iron: '7',
    },
    {
      name: 'Gingerbread',
      calories: 356,
      fat: 16.0,
      carbs: 49,
      protein: 3.9,
      iron: '16',
    },
    {
      name: 'Ice cream sandwich',
      calories: 237,
      fat: 9.0,
      carbs: 37,
      protein: 4.3,
      iron: '1',
    },
    {
      name: 'Lollipop',
      calories: 392,
      fat: 0.2,
      carbs: 98,
      protein: 0,
      iron: '2',
    },
    {
      name: 'Cupcake',
      calories: 305,
      fat: 3.7,
      carbs: 67,
      protein: 4.3,
      iron: '8',
    },
    {
      name: 'Honeycomb',
      calories: 408,
      fat: 3.2,
      carbs: 87,
      protein: 6.5,
      iron: '45',
    },
    {
      name: 'Donut',
      calories: 452,
      fat: 25.0,
      carbs: 51,
      protein: 4.9,
      iron: '22',
    },
  ])
</script>

```
