### PR TITLE
fix(VOverlay): fix positioning in RTL

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -420,7 +420,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     // Icky hack to make sure the content is positioned consistently
     if (!result) return
     const { available, contentBox } = result
-    if (contentBox.height > available.y) {
+    if (contentBox.height > available.y || contentStyles.value.maxHeight) {
       requestAnimationFrame(() => {
         updateLocation()
         requestAnimationFrame(() => {

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -420,7 +420,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     // Icky hack to make sure the content is positioned consistently
     if (!result) return
     const { available, contentBox } = result
-    if (contentBox.height > available.y || contentStyles.value.maxHeight) {
+    if (contentBox.height > available.y || data.isRtl.value) {
       requestAnimationFrame(() => {
         updateLocation()
         requestAnimationFrame(() => {


### PR DESCRIPTION


## Description
Add an arg to the already existing if check to call updateLocation twice to make sure overlay is positioned correctly on RTL.
This PR should be considered as a temporary small fix. as there is this following TODO comment:
```
// TODO: overflowing content should only require a single updateLocation call
// Icky hack to make sure the content is positioned consistently
```
Until updateLocation works with single call

fixes #16628

I prefer this fix over [this one](https://github.com/vuetifyjs/vuetify/pull/17099), because it keeps using the same css 'left' attribute, and therefore styling attributes are consistent on both LTR and RTL. Vuetify v2 also uses 'left' in both.


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-locale-provider locale="ar">
      <v-container>
        <v-btn id="button" color="primary">
          Parent activator
        </v-btn>
        <v-menu v-model="menu" location="bottom" activator="#button">
          <v-card class="pa-4" />
        </v-menu>
      </v-container>
    </v-locale-provider>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
    data () {
      return {
        menu: false,
      }
    },
  }
</script>


```
