### PR TITLE
fix(VAutocomplete): VAutocomplete with chips overlays search text on top of chips

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -81,7 +81,7 @@
     .v-field__input > input
       caret-color: transparent
 
-  &--single
+  &--single:not(.v-autocomplete--chips)
     &.v-text-field input
       flex: 1 1
       position: absolute

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -19,7 +19,7 @@
   .v-field
     .v-field__input
       > input
-        align-self: flex-start
+        align-self: center
         flex: 1 1
 
     .v-field__append-inner

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -290,12 +290,15 @@ export const VAutocomplete = genericComponent<new <
 
         nextTick(() => (isSelecting.value = false))
       }
+      if (props.chips && !props.multiple) {
+        search.value = ''
+      }
     }
 
     watch(isFocused, val => {
       if (val) {
         isSelecting.value = true
-        search.value = props.multiple || !!slots.selection ? '' : String(selections.value.at(-1)?.props.title ?? '')
+        search.value = props.multiple || props.chips || !!slots.selection ? '' : String(selections.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
In VAutocomplete with chips search text overlays on top of chip.
I just add :not(.v-autocomplete--chips) css selector to fix the problem.


fixes #16186 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-autocomplete
      hint="foobar"
      persistent-hint
      :items="items"
      v-model="msg"
      :search="search"
      chips
      />
    </v-main>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const msg = ref('Hello World!')
const items = ref([
  'Hello World!',
  'sad',
  'hgk',
  'pok',
  ])
const search = ref('')
</script>
```
