### PR TITLE
docs(VDataTable): add density api description

### DIFF
--- a/packages/api-generator/src/locale/en/v-data-table.json
+++ b/packages/api-generator/src/locale/en/v-data-table.json
@@ -6,7 +6,7 @@
     "customGroup": "Function used to group items",
     "customSort": "Function used to sort items",
     "caption": "Set the caption (using `<caption>`)",
-    "density": "Adjusts the vertical height of the table rows.",
+    "density": "Adjusts the vertical height of the table rows",
     "disableFiltering": "Disables filtering completely",
     "disablePagination": "Disables pagination completely",
     "disableSort": "Disables sorting completely",

--- a/packages/api-generator/src/locale/en/v-data-table.json
+++ b/packages/api-generator/src/locale/en/v-data-table.json
@@ -6,7 +6,7 @@
     "customGroup": "Function used to group items",
     "customSort": "Function used to sort items",
     "caption": "Set the caption (using `<caption>`)",
-    "dense": "Decreases the height of rows",
+    "density": "Adjusts the vertical height of the table rows.",
     "disableFiltering": "Disables filtering completely",
     "disablePagination": "Disables pagination completely",
     "disableSort": "Disables sorting completely",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Changed the `dense` prop as it does not do anything. Instead I replaced it with `density` which does work on `v-data-table`, `v-data-table-server`, and `v-data-table-virtual`.
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```json
"density": "Adjusts the vertical height of the table rows.",
```
