### PR TITLE
fix(types): change update:focused event type to boolean

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -59,6 +59,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
   emits: {
     'click:control': (e: MouseEvent) => true,
     'mousedown:control': (e: MouseEvent) => true,
+    'update:focused': (focused: boolean) => true,
     'update:modelValue': (val: string) => true,
   },
 

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -59,7 +59,6 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
   emits: {
     'click:control': (e: MouseEvent) => true,
     'mousedown:control': (e: MouseEvent) => true,
-    'update:focused': (focused: boolean) => true,
     'update:modelValue': (val: string) => true,
   },
 

--- a/packages/vuetify/src/composables/focus.ts
+++ b/packages/vuetify/src/composables/focus.ts
@@ -14,7 +14,7 @@ export interface FocusProps {
 // Composables
 export const makeFocusProps = propsFactory({
   focused: Boolean,
-  'onUpdate:focused': EventProp<[FocusEvent]>(),
+  'onUpdate:focused': EventProp<[boolean]>(),
 }, 'focus')
 
 export function useFocus (


### PR DESCRIPTION
fixes #17197

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

- `focused: boolean` so `onUpdate:focused` event type is also boolean
- should be a hiding issue which shows up after [strictly type EventProp events commit](https://github.com/vuetifyjs/vuetify/commit/d226a0f69c8b5955d7162e7692465dab76e9d366)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-text-field @update:focused="updateFocus" />
    </v-main>
  </v-app>
</template>

<script setup lang="ts">
  function updateFocus (focus: boolean) {
  }
</script>

```
