### PR TITLE
feat(VAutocomplete/Combobox): add auto-select-first prop

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -82,7 +82,7 @@ export const VAutocomplete = genericComponent<new <
 
   props: {
     // TODO: implement post keyboard support
-    // autoSelectFirst: Boolean,
+    autoSelectFirst: Boolean,
     search: String,
 
     ...makeFilterProps({ filterKeys: ['title'] }),
@@ -146,6 +146,11 @@ export const VAutocomplete = genericComponent<new <
 
     const selected = computed(() => selections.value.map(selection => selection.props.value))
     const selection = computed(() => selections.value[selectionIndex.value])
+    const highlightFirst = computed(() => (
+      props.autoSelectFirst &&
+      filteredItems.value.length > 0 &&
+      !isPristine.value
+    ))
     const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
@@ -185,6 +190,10 @@ export const VAutocomplete = genericComponent<new <
       }
 
       if (['Enter', 'Escape', 'Tab'].includes(e.key)) {
+        if (e.key === 'Enter' && highlightFirst.value) {
+          select(filteredItems.value[0])
+        }
+
         isPristine.value = true
       }
 
@@ -376,12 +385,13 @@ export const VAutocomplete = genericComponent<new <
 
                       { slots['prepend-item']?.() }
 
-                      { displayItems.value.map(item => slots.item?.({
+                      { displayItems.value.map((item, index) => slots.item?.({
                         item,
                         props: mergeProps(item.props, { onClick: () => select(item) }),
                       }) ?? (
                         <VListItem
                           key={ item.value }
+                          active={ (highlightFirst.value && index === 0) ? true : undefined }
                           { ...item.props }
                           onClick={ () => select(item) }
                         >

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -273,4 +273,27 @@ describe('VAutocomplete', () => {
 
     cy.get('.v-field').should('have.class', 'v-field--focused')
   })
+
+  it('should auto-select-first item when pressing enter', () => {
+    cy
+      .mount(() => (
+        <VAutocomplete
+          items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+          multiple
+          autoSelectFirst
+        />
+      ))
+      .get('.v-autocomplete')
+      .click()
+      .get('.v-list-item')
+      .should('have.length', 6)
+      .get('.v-autocomplete input')
+      .type('Cal')
+      .get('.v-list-item').eq(0)
+      .should('have.class', 'v-list-item--active')
+      .get('.v-autocomplete input')
+      .trigger('keydown', { key: keyValues.enter, waitForAnimations: false })
+      .get('.v-list-item')
+      .should('have.length', 6)
+  })
 })

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -83,7 +83,7 @@ export const VCombobox = genericComponent<new <
 
   props: {
     // TODO: implement post keyboard support
-    // autoSelectFirst: Boolean,
+    autoSelectFirst: Boolean,
     delimiters: Array as PropType<string[]>,
 
     ...makeFilterProps({ filterKeys: ['title'] }),
@@ -192,6 +192,11 @@ export const VCombobox = genericComponent<new <
 
     const selected = computed(() => selections.value.map(selection => selection.props.value))
     const selection = computed(() => selections.value[selectionIndex.value])
+    const highlightFirst = computed(() => (
+      props.autoSelectFirst &&
+      filteredItems.value.length > 0 &&
+      !isPristine.value
+    ))
     const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
@@ -231,6 +236,10 @@ export const VCombobox = genericComponent<new <
       }
 
       if (['Enter', 'Escape', 'Tab'].includes(e.key)) {
+        if (e.key === 'Enter' && highlightFirst.value) {
+          select(filteredItems.value[0])
+        }
+
         isPristine.value = true
       }
 
@@ -411,12 +420,13 @@ export const VCombobox = genericComponent<new <
 
                       { slots['prepend-item']?.() }
 
-                      { displayItems.value.map(item => slots.item?.({
+                      { displayItems.value.map((item, index) => slots.item?.({
                         item,
                         props: mergeProps(item.props, { onClick: () => select(item) }),
                       }) ?? (
                         <VListItem
                           key={ item.value }
+                          active={ (highlightFirst.value && index === 0) ? true : undefined }
                           { ...item.props }
                           onClick={ () => select(item) }
                         >

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -467,4 +467,27 @@ describe('VCombobox', () => {
 
     cy.get('.v-field').should('have.class', 'v-field--focused')
   })
+
+  it('should auto-select-first item when pressing enter', () => {
+    cy
+      .mount(() => (
+        <VCombobox
+          items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+          multiple
+          autoSelectFirst
+        />
+      ))
+      .get('.v-combobox')
+      .click()
+      .get('.v-list-item')
+      .should('have.length', 6)
+      .get('.v-combobox input')
+      .type('Cal')
+      .get('.v-list-item').eq(0)
+      .should('have.class', 'v-list-item--active')
+      .get('.v-combobox input')
+      .trigger('keydown', { key: keyValues.enter, waitForAnimations: false })
+      .get('.v-list-item')
+      .should('have.length', 6)
+  })
 })


### PR DESCRIPTION
## Motivation and Context
this prop existed in v2

Should we keep the name? I thought **auto-focus-first** might be more descriptive.

## Markup:
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">

      <div>
        <v-card>
          <v-card-text>
            <form>
              <v-autocomplete
                label="Autocomplete"
                :items="items"
                multiple
                variant="outlined"
                chips
                auto-select-first
                closable-chips
                :menu-props="{ maxHeight: 300 }"
              />

              <br>
              <br>
              <br>

              <v-combobox
                label="Combobox"
                :items="items2"
                multiple
                variant="outlined"
                chips
                auto-select-first
                closable-chips
                :menu-props="{ maxHeight: 300 }"
              />
            </form>
          </v-card-text>
        </v-card>
      </div>
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const a1 = ref()
  const items = ['bar', 'baz', 'foo', 'foo-bar', 'foo-baz', 'foo-foo']
  const items2 = [
    'item-0',
    'item-1',
    'item-2',
    'item-3',
    'item-4',
    'item-5',
    'item-6',
    'item-7',
    'item-8',
    'item-9',
    'item-10',
    'item-11',
    'item-12',
    'item-13',
    'item-14',
    'item-15',
    'item-16',
    'item-17',
    'item-18',
    'item-19',
    'item-20',
    'item-21',
    'item-22',
    'item-23',
    'item-24',
    'item-25',
    'item-26',
    'item-27',
    'item-28',
    'item-29',
    'item-30',
    'item-31',
    'item-32',
    'item-33',
    'item-34',
    'item-35',
    'item-36',
    'item-37',
    'item-38',
    'item-39',
    'item-40',
    'item-41',
    'item-42',
    'item-43',
    'item-44',
    'item-45',
    'item-46',
    'item-47',
    'item-48',
    'item-49',
  ]
  const filter = (item, queryText, itemText) => itemText.startsWith(queryText)
</script>

```
</details>