### PR TITLE
fix(theme): correct emphasis opacity in default dark theme

### DIFF
--- a/packages/vuetify/src/composables/__tests__/__snapshots__/theme.spec.ts.snap
+++ b/packages/vuetify/src/composables/__tests__/__snapshots__/theme.spec.ts.snap
@@ -146,9 +146,9 @@ exports[`createTheme should create style element 1`] = `
       --v-theme-on-warning: 255,255,255;
       --v-border-color: 255, 255, 255;
       --v-border-opacity: 0.12;
-      --v-high-emphasis-opacity: 0.87;
-      --v-medium-emphasis-opacity: 0.6;
-      --v-disabled-opacity: 0.38;
+      --v-high-emphasis-opacity: 1;
+      --v-medium-emphasis-opacity: 0.7;
+      --v-disabled-opacity: 0.5;
       --v-idle-opacity: 0.1;
       --v-hover-opacity: 0.04;
       --v-focus-opacity: 0.12;

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -163,9 +163,9 @@ const defaultThemeOptions: Exclude<ThemeOptions, false> = {
       variables: {
         'border-color': '#FFFFFF',
         'border-opacity': 0.12,
-        'high-emphasis-opacity': 0.87,
-        'medium-emphasis-opacity': 0.60,
-        'disabled-opacity': 0.38,
+        'high-emphasis-opacity': 1,
+        'medium-emphasis-opacity': 0.70,
+        'disabled-opacity': 0.50,
         'idle-opacity': 0.10,
         'hover-opacity': 0.04,
         'focus-opacity': 0.12,


### PR DESCRIPTION
Matched the opacity of the emphasis CSS variables to conform to the values stated in the documentation.

If this change is not wanted, the documentation should instead be updated to explain that there is no difference in opacity between the light and dark theme.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
The [documentation](https://vuetifyjs.com/en/styles/text-and-typography/#opacity) states different opacity values for high, medium and disabled opacity text between light and dark mode. However, the theme only uses the values of the light theme. I've set the correct values as stated in the documentation for the dark theme (and the corresponding snapshot test). 

The PR that added these variables: https://github.com/vuetifyjs/vuetify/pull/13674/files#diff-53b5523de35fefbb957b3194ca376f52e49b1562b8715abbeec14437966fb0c6

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-card theme="light">
        <v-card-text>
          light theme default (high emphasis)
          <div class="text-high-emphasis">high emphasis</div>
          <div class="text-medium-emphasis">medium emphasis</div>
          <div class="text-disabled">disabled emphasis</div>
        </v-card-text>
      </v-card>
      <v-card theme="dark">
        <v-card-text>
          dark theme default (high emphasis)
          <div class="text-high-emphasis">high emphasis</div>
          <div class="text-medium-emphasis">medium emphasis</div>
          <div class="text-disabled">disabled emphasis</div>
        </v-card-text>
        <v-card-text class="old-emphasis">
          dark theme before this PR (emphasis like in light theme)
          <div class="text-high-emphasis">high emphasis</div>
          <div class="text-medium-emphasis">medium emphasis</div>
          <div class="text-disabled">disabled emphasis</div>
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>

<style>
.old-emphasis {
  --v-high-emphasis-opacity: 0.87;
  --v-medium-emphasis-opacity: 0.6;
  --v-disabled-opacity: 0.38;
}
</style>
```
