### PR TITLE
fix(VChip): overflow text in chip selections

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.sass
+++ b/packages/vuetify/src/components/VChip/VChip.sass
@@ -6,8 +6,10 @@
   align-items: center
   cursor: default
   display: inline-flex
+  flex: 1 0
   font-weight: $chip-font-weight
   max-width: $chip-max-width
+  min-width: 0
   overflow: hidden
   position: relative
   text-decoration: none
@@ -36,6 +38,14 @@
     @include tools.rounded($chip-label-border-radius)
 
 // Elements
+.v-chip__content
+  .v-autocomplete__selection &,
+  .v-combobox__selection &,
+  .v-select__selection &
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
+
 .v-chip__filter,
 .v-chip__prepend,
 .v-chip__append,

--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -259,14 +259,16 @@ export const VChip = genericComponent<VChipSlots>()({
             </div>
           )}
 
-          { slots.default?.({
-            isSelected: group?.isSelected.value,
-            selectedClass: group?.selectedClass.value,
-            select: group?.select,
-            toggle: group?.toggle,
-            value: group?.value.value,
-            disabled: props.disabled,
-          }) ?? props.text }
+          <div class="v-chip__content">
+            { slots.default?.({
+              isSelected: group?.isSelected.value,
+              selectedClass: group?.selectedClass.value,
+              select: group?.select,
+              toggle: group?.toggle,
+              value: group?.value.value,
+              disabled: props.disabled,
+            }) ?? props.text }
+          </div>
 
           { hasAppend && (
             <div key="append" class="v-chip__append">


### PR DESCRIPTION
fixes #16472

Ideally this would exist on `v-chip` all of the time but it causes a breaking change when using icons/avatars with the **start** or **end** prop for alignment.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <VCombobox
        v-model="chips"
        chips
        multiple
        clearable
        closable-chips
        clear-icon="mdi-close-circle-outline"
        :items="items"
        label="Your favorite hobbies"
        prepend-icon="mdi-filter-variant"
      />

      <v-card
        class="mx-auto"
        max-width="250"
      >
        <v-row
          align="center"
          class="pa-6"
        >
          <span class="me-4">To</span>

          <v-menu
            v-model="menu"
            location="top start"
            origin="top start"
            transition="scale-transition"
          >
            <template #activator="{ props }">
              <v-chip
                pill
                v-bind="props"
                link
              >
                <!-- <template #prepend> -->
                <v-avatar start>
                  <v-img src="https://cdn.vuetifyjs.com/images/john.png" />
                </v-avatar>
                <!-- </template> -->

                John Leider lorem ipsum
              </v-chip>
            </template>

            <v-card width="300">
              <v-list bg-color="black">
                <v-list-item>
                  <template #prepend>
                    <v-avatar image="https://cdn.vuetifyjs.com/images/john.png" />
                  </template>

                  <v-list-item-title>John Leider</v-list-item-title>

                  <v-list-item-subtitle>john@google.com</v-list-item-subtitle>

                  <template #append>
                    <v-list-item-action>
                      <v-btn
                        icon
                        variant="text"
                        @click="menu = false"
                      >
                        <v-icon>mdi-close-circle</v-icon>
                      </v-btn>
                    </v-list-item-action>
                  </template>
                </v-list-item>
              </v-list>

              <v-list>
                <v-list-item link prepend-icon="mdi-briefcase">
                  <v-list-item-subtitle>john@gmail.com</v-list-item-subtitle>
                </v-list-item>
              </v-list>
            </v-card>
          </v-menu>
        </v-row>

        <v-divider />

        <div class="pa-3">
          <v-text-field
            label="Subject"
            model-value="Re: Vacation Request"
            single-line
            variant="underlined"
          />

          <v-textarea
            label="Message"
            single-line
            variant="underlined"
          />
        </div>
      </v-card>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const chips = ref(['Programming', 'Playing video games', 'Sleeping'])
  const items = ref(['Streaming', 'Eating', 'Programming', 'Playing video games for many long time', 'Sleeping'])
  const menu = ref(false)
</script>

```
