### PR TITLE
fix: add types field to esm exports map

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -54,7 +54,8 @@
     ".": {
       "sass": "./lib/styles/main.sass",
       "style": "./lib/styles/main.css",
-      "default": "./lib/framework.mjs"
+      "default": "./lib/framework.mjs",
+      "types": "./lib/index.d.ts"
     },
     "./styles": {
       "sass": "./lib/styles/main.sass",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

When set `moduleResolution` to `nodenext` or `bundler`, import `vuetify` will shows an error:

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/49969959/236592230-8da9e024-01c1-46dd-9b5f-1819451c99d1.png">

Looks like we need to add types field to esm exports map to resolve this case.

related:

- https://github.com/microsoft/TypeScript/issues/50223
- https://github.com/chakra-ui/chakra-ui/pull/6945

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
