### PR TITLE
feat(VFIeld): use ControlRef to access input dom in default slot and check if it's rendered as multiline

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -19,10 +19,6 @@
     &--variant-outlined
       --autocomplete-chips-margin-bottom: #{$autocomplete-chips-margin-top}
 
-  .v-label.v-field-label:not(.v-field-label--floating)
-    top: 50%
-    transform: translateY(-50%)
-
   .v-field
     .v-field__input
       > input

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -19,10 +19,6 @@
     &--variant-outlined
       --combobox-chips-margin-bottom: #{$combobox-chips-margin-top}
 
-  .v-label.v-field-label:not(.v-field-label--floating)
-    top: 50%
-    transform: translateY(-50%)
-
   .v-field
     .v-field__input
       > input

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -237,6 +237,13 @@
   .v-field--error:not(.v-field--disabled) &
     color: rgb(var(--v-theme-error))
 
+  .v-field--single-line-input &
+    top: 50%
+    transform: translateY(-50%)
+    &--floating
+      top: var(--v-input-padding-top)
+      transform: none
+
   &--floating
     --v-field-label-scale: #{$field-label-floating-scale}em
     font-size: var(--v-field-label-scale)

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -163,6 +163,7 @@
   grid-area: prepend-inner
   padding-inline-end: var(--v-field-padding-after)
 
+
 .v-field__clearable
   grid-area: clear
 

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -163,7 +163,6 @@
   grid-area: prepend-inner
   padding-inline-end: var(--v-field-padding-after)
 
-
 .v-field__clearable
   grid-area: clear
 

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -34,7 +34,7 @@ import {
 // Types
 import type { LoaderSlotProps } from '@/composables/loader'
 import type { GenericProps } from '@/util'
-import type { ComponentPublicInstance, PropType, Ref } from 'vue'
+import type { PropType, Ref } from 'vue'
 import type { VInputSlot } from '@/components/VInput/VInput'
 
 const allowedVariants = ['underlined', 'outlined', 'filled', 'solo', 'solo-inverted', 'solo-filled', 'plain'] as const
@@ -43,7 +43,7 @@ type Variant = typeof allowedVariants[number]
 export interface DefaultInputSlot {
   isActive: Ref<boolean>
   isFocused: Ref<boolean>
-  controlRef: (ref: Element | ComponentPublicInstance | null) => void
+  controlRef: (ref: Element | null) => void
   focus: () => void
   blur: () => void
 }
@@ -135,7 +135,7 @@ export const VField = genericComponent<new <T>(props: {
 
     const labelRef = ref<VFieldLabel>()
     const floatingLabelRef = ref<VFieldLabel>()
-    const controlRef = (el: Element | ComponentPublicInstance | null) => {
+    const controlRef = (el: Element | null) => {
       textAreaEle = el
     }
 

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -124,7 +124,7 @@ export const VField = genericComponent<new <T>(props: {
     const { InputIcon } = useInputIcon(props)
     const { roundedClasses } = useRounded(props)
 
-    let textAreaEle: any
+    let controlEl: Element | null
 
     const isActive = computed(() => props.dirty || props.active)
     const hasLabel = computed(() => !props.singleLine && !!(props.label || slots.label))
@@ -136,7 +136,7 @@ export const VField = genericComponent<new <T>(props: {
     const labelRef = ref<VFieldLabel>()
     const floatingLabelRef = ref<VFieldLabel>()
     const controlRef = (el: Element | null) => {
-      textAreaEle = el
+      controlEl = el
     }
 
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'bgColor'))
@@ -203,9 +203,9 @@ export const VField = genericComponent<new <T>(props: {
     }
 
     onMounted(() => {
-      if (textAreaEle) {
-        const { lineHeight, paddingTop, paddingBottom } = getComputedStyle(textAreaEle)
-        const contentHeight = textAreaEle.scrollHeight - parseInt(paddingTop, 10) - parseInt(paddingBottom, 10)
+      if (controlEl) {
+        const { lineHeight, paddingTop, paddingBottom } = getComputedStyle(controlEl)
+        const contentHeight = controlEl.scrollHeight - parseInt(paddingTop, 10) - parseInt(paddingBottom, 10)
         singleLineInput.value = contentHeight / parseInt(lineHeight, 10) < 2
       }
     })

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -204,11 +204,9 @@ export const VField = genericComponent<new <T>(props: {
 
     onMounted(() => {
       if (textAreaEle) {
-        const { lineHeight } = getComputedStyle(textAreaEle)
-        const lines = Math.floor(textAreaEle.scrollHeight / parseInt(lineHeight, 10))
-        if (lines === 1) {
-          singleLineInput.value = true
-        }
+        const { lineHeight, paddingTop, paddingBottom } = getComputedStyle(textAreaEle)
+        const contentHeight = textAreaEle.scrollHeight - parseInt(paddingTop, 10) - parseInt(paddingBottom, 10)
+        singleLineInput.value = contentHeight / parseInt(lineHeight, 10) < 2
       }
     })
 

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -19,10 +19,6 @@
     &--variant-outlined
       --select-chips-margin-bottom: #{$select-chips-margin-top}
 
-  .v-label.v-field-label:not(.v-field-label--floating)
-    top: 50%
-    transform: translateY(-50%)
-
   .v-field
     .v-field__input
       > input

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -19,11 +19,6 @@
     &:invalid
       box-shadow: none
 
-  &:not(.v-textarea)
-    .v-label.v-field-label:not(.v-field-label--floating)
-      top: 50%
-      transform: translateY(-50%)
-
   .v-field
     cursor: text
 

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -205,7 +205,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                       <input
                         ref={ (e: Element | ComponentPublicInstance | null) => {
                           inputRef.value = e as HTMLInputElement
-                          controlRef(e as Element)
+                          controlRef(e as HTMLInputElement)
                         }}
                         value={ model.value }
                         onInput={ onInput }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -19,7 +19,7 @@ import { cloneVNode, computed, nextTick, ref } from 'vue'
 import { callEvent, filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
-import type { PropType } from 'vue'
+import type { ComponentPublicInstance, PropType } from 'vue'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 
@@ -199,10 +199,14 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                   ...slots,
                   default: ({
                     props: { class: fieldClass, ...slotProps },
+                    controlRef,
                   }) => {
                     const inputNode = (
                       <input
-                        ref={ inputRef }
+                        ref={ (e: Element | ComponentPublicInstance | null) => {
+                          inputRef.value = e as HTMLInputElement
+                          controlRef(e)
+                        }}
                         value={ model.value }
                         onInput={ onInput }
                         v-intersect={[{

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -205,7 +205,7 @@ export const VTextField = genericComponent<Omit<VInputSlots & VFieldSlots, 'defa
                       <input
                         ref={ (e: Element | ComponentPublicInstance | null) => {
                           inputRef.value = e as HTMLInputElement
-                          controlRef(e)
+                          controlRef(e as Element)
                         }}
                         value={ model.value }
                         onInput={ onInput }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

- When VField has one line, label should be vertically centre aligned
- When VField has multiple lines, label should be top aligned

Notes:

- Changes are designed to be done on top of #17175, so base branch is `fix-16901`
- I think should be in a separate PR  because we can develop/test it independently


### Proposed solution:

- use existing VField `ControlRef` to  access rendered control dom in default slot
- user can allow VField to access the dom in slot via `:ref="e => controlRef(e)"` 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card>
    <h3>single row textarea, label should be vertically center</h3>
    <v-row>
      <v-col cols="3">
      </v-col>
      <v-col cols="6">
        <v-input>
          <v-field label="test">
            <template #default="{ props, controlRef }">
              <textarea
                :ref="e => controlRef(e)"
                rows="1"
                :class="props.class"
              />
            </template>
          </v-field>
        </v-input>
      </v-col>
    </v-row>
  </v-card>
</template>

<script setup>
</script>

<style>
textarea {
  width: 100%;
  line-height: 100px !important;
}
</style>






```
