### PR TITLE
fix(group): respect selection order in v-model

### DIFF
--- a/packages/vuetify/src/composables/__tests__/group.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/group.spec.ts
@@ -162,7 +162,7 @@ describe('group', () => {
 
       expect(wrapper.emitted()['update:modelValue']).toEqual([
         [['two']],
-        [['one', 'two']],
+        [['two', 'one']],
       ])
     })
 
@@ -314,7 +314,7 @@ describe('group', () => {
 
       expect(wrapper.emitted('update:modelValue')).toStrictEqual([
         [[1]],
-        [[0, 1]],
+        [[1, 0]],
       ])
     })
 

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -323,7 +323,7 @@ function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
 }
 
 function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
-  const values: {}[] = []
+  const values: object[] = []
 
   ids.forEach(id => {
     const item = items.find(item => item.id === id)

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -306,16 +306,32 @@ function getItemIndex (items: UnwrapRef<GroupItem[]>, value: unknown) {
 }
 
 function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
-  return modelValue.map(value => {
-    const item = items.find(item => deepEqual(value, item.value))
-    if (item != null) return item.id
+  const ids: number[] = []
 
-    return null
+  modelValue.forEach(value => {
+    const item = items.find(item => deepEqual(value, item.value))
+    const itemByIndex = items[value]
+
+    if (item?.value != null) {
+      ids.push(item.id)
+    } else if (itemByIndex != null) {
+      ids.push(itemByIndex.id)
+    }
   })
+
+  return ids
 }
 
 function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
-  return ids
-    .map(id => items.find(item => item.id === id))
-    .map((item, i) => item?.value != null ? item.value : i)
+  const values: {}[] = []
+
+  ids.forEach(id => {
+    const item = items.find(item => item.id === id)
+    if (item) {
+      const itemIndex = items.indexOf(item)
+      values.push(item.value != null ? item.value : itemIndex)
+    }
+  })
+
+  return values
 }

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -315,11 +315,7 @@ function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
 }
 
 function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
-  let values = []
-
-  values = ids
+  return ids
     .map(id => items.find(item => item.id === id))
     .map((item, i) => item?.value != null ? item.value : i)
-
-  return values
 }

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -306,32 +306,20 @@ function getItemIndex (items: UnwrapRef<GroupItem[]>, value: unknown) {
 }
 
 function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
-  const ids = []
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i]
+  return modelValue.map(value => {
+    const item = items.find(item => deepEqual(value, item.value))
+    if (item != null) return item.id
 
-    if (item.value != null) {
-      if (modelValue.find(value => deepEqual(value, item.value)) != null) {
-        ids.push(item.id)
-      }
-    } else if (modelValue.includes(i)) {
-      ids.push(item.id)
-    }
-  }
-
-  return ids
+    return null
+  })
 }
 
 function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
-  const values = []
+  let values = []
 
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i]
-
-    if (ids.includes(item.id)) {
-      values.push(item.value != null ? item.value : i)
-    }
-  }
+  values = ids
+    .map(id => items.find(item => item.id === id))
+    .map((item, i) => item?.value != null ? item.value : i)
 
   return values
 }

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -326,9 +326,9 @@ function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
   const values: unknown[] = []
 
   ids.forEach(id => {
-    const item = items.find(item => item.id === id)
-    if (item) {
-      const itemIndex = items.indexOf(item)
+    const itemIndex = items.findIndex(item => item.id === id)
+    if (~itemIndex) {
+      const item = items[itemIndex]
       values.push(item.value != null ? item.value : itemIndex)
     }
   })

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -323,7 +323,7 @@ function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
 }
 
 function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
-  const values: object[] = []
+  const values: unknown[] = []
 
   ids.forEach(id => {
     const item = items.find(item => item.id === id)


### PR DESCRIPTION
fixes #17227

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
   <v-app>
    <div class="d-flex flex-column align-center bg-grey-lighten-4 pa-6">
      <v-btn-toggle
        v-model="toggle"
        multiple
      >
        <v-btn  value="left">left</v-btn>
        <v-btn  value="center">center</v-btn>
        <v-btn  value="right">right</v-btn>
        <v-btn  value="justify">just</v-btn>
      </v-btn-toggle>
  
      <pre class="pt-2">{{ toggle }}</pre>
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const toggle = ref([])
</script>

```
