### PR TITLE
fix(VOverlay): position on LTR/RTL after locale switch

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -131,6 +131,12 @@ function getIntrinsicSize (el: HTMLElement, isRtl: boolean) {
   // el.style.removeProperty('max-width')
   // el.style.removeProperty('max-height')
 
+  if (isRtl) {
+    el.style.removeProperty('left')
+  } else {
+    el.style.removeProperty('right')
+  }
+
   /* eslint-disable-next-line sonarjs/prefer-immediate-return */
   const contentBox = nullifyTransforms(el)
 


### PR DESCRIPTION
## Description
close #17314 

- The issue affect the overlay, such as tooltips, menus, etc...
- The issue is very specific, when switching locale, after opening a overlay (The overlay would still have a `left` or `right` attribute) thus cause it to not be displayed correctly after switching the language.
- A refresh fixes the issue, since the overlay no longer would have a `right` or `left` attribute in its styling.
- This should fix the issue without calling a second `updatelocation` call


## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-locale-provider :locale="toggle ? 'ar' : 'en'">
        <v-switch v-model="toggle" label="Toggle Locale" />
        <v-main style="margin-top: 100px;">
          {{ toggle ? 'RTL:' : 'LTR:' }}
          <VTooltip text="Tooltip" location="top">
            <template #activator="{ props }">
              <VBtn class="mx-3" v-bind="props">Tooltip</VBtn>
            </template>
          </VTooltip>
          <VTooltip text="Tooltip" location="bottom">
            <template #activator="{ props }">
              <VBtn class="mx-3" v-bind="props">Tooltip</VBtn>
            </template>
          </VTooltip>
          <VTooltip class="mx-3" text="Tooltip" location="start">
            <template #activator="{ props }">
              <VBtn class="mx-3" v-bind="props">Tooltip</VBtn>
            </template>
          </VTooltip>
          <VTooltip class="mx-3" text="Tooltip" location="end">
            <template #activator="{ props }">
              <VBtn class="mx-3" v-bind="props">Tooltip</VBtn>
            </template>
          </VTooltip>
          <VBtn class="mx-3" color="primary">
            Open Menu
            <VMenu activator="parent">
              <VList>
                <VListItem>Item 1</VListItem>
                <VListItem>Item 2</VListItem>
                <VListItem>Item 3</VListItem>
                <VListItem>Item 4</VListItem>
              </VList>
            </VMenu>
          </VBtn>
        </v-main>
      </v-locale-provider>
    </v-container>
  </v-app>
</template>

<script>
 /* */
  export default {
    name: 'Playground',
    setup () {
      return {
      }
    },
    data () {
      return {
        toggle: false,
      }
    },
  }
</script>

```
