### PR TITLE
feat(VWindow): set class when window is transitioning

### DIFF
--- a/packages/vuetify/src/components/VWindow/VWindow.sass
+++ b/packages/vuetify/src/components/VWindow/VWindow.sass
@@ -10,6 +10,9 @@
     position: relative
     transition: $window-transition
 
+    &--is-active
+      overflow: hidden
+
   &__controls
     position: absolute
     left: 0

--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -230,7 +230,12 @@ export const VWindow = genericComponent<VWindowSlots>()({
         v-touch={ touchOptions.value }
       >
         <div
-          class="v-window__container"
+          class={[
+            'v-window__container',
+            {
+              'v-window__container--is-active': transitionCount.value > 0,
+            },
+          ]}
           style={{
             height: transitionHeight.value,
           }}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This PR adds the css class 'v-window__container--is-active' when the window is in transitioning. this existed in vuetify 2 but didn't make to vuetify 3. 

My use case: I have a window that contains elements with shadows, I needed to make the shadows overflow the container in normal state by setting `overflow: visible`. but this breaks the ui when navigating the windows. and there's no class to apply styling to without this PR.
I'm sure there are more advanced use cases that would need style when the windos are transitioning

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
Test this markup in before and after the PR to notice the difference
<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container style="max-width: 500px">
      <v-window show-arrows>
        <v-window-item>
          <v-row>
            <v-col cols="12" xl="8">
              <v-card class="mb-10 pa-10" elevation="10" />
              <v-card elevation="10" class="mb-10 pa-10" />
            </v-col>
            <v-col cols="12" xl="4">
              <v-card class="mb-10 pa-10" elevation="10" />
              <v-card elevation="10" class="mb-10 pa-10" />
            </v-col>
          </v-row>
        </v-window-item>
        <v-window-item>
          <v-row>
            <v-col cols="12" xl="8">
              <v-card class="mb-10 pa-10" elevation="10" />
              <v-card elevation="10" class="mb-10 pa-10" />
            </v-col>
            <v-col cols="12" xl="4">
              <v-card class="mb-10 pa-10" elevation="10" />
              <v-card elevation="10" class="mb-10 pa-10" />
            </v-col>
          </v-row>
        </v-window-item>
      </v-window>
    </v-container>
  </v-app>
</template>

<style>
.v-window {
  overflow: visible;
}
</style>

```
