### PR TITLE
fix(VAutocomplete): clip long text

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -15,6 +15,7 @@
     .v-field__input,
     &.v-field
       cursor: text
+      overflow: clip
 
   .v-field
     .v-field__input


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When an item with long uninterrupted text is selected, the text would overflow outside of the autocomplete.
This fix aims to clip all text so it never overflows.

fixes #16173
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-row>
      <v-col cols="6">
        <v-autocomplete
          v-model="friends"
          :items="people"
        />
      </v-col>
    </v-row>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    data () {
      return {
        friends: 'Sandra Adams',
        people: [
          'Sandra Adams',
          'Ali Connors',
          'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',
          'Tucker Smith',
          'Britta Holt',
          'Jane Smith ',
          'John Smith',
          'Sandra Williams',
        ],
      }
    },
  }
</script>

```
