### PR TITLE
fix(VBtn): don't toggle group if button should open new tab/window

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -133,13 +133,18 @@ export const VBtn = genericComponent<VBtnSlots>()({
     })
 
     function onClick (e: MouseEvent) {
-      if (isDisabled.value) return
+      if (
+        isDisabled.value ||
+        (link.isLink.value && (
+          e.metaKey ||
+          e.ctrlKey ||
+          e.shiftKey ||
+          (e.button !== 0) ||
+          attrs.target === '_blank'
+        ))
+      ) return
 
       link.navigate?.(e)
-
-      const shouldOpenInNewWindow = e.metaKey || attrs.target === '_blank'
-      if (shouldOpenInNewWindow) return
-
       group?.toggle()
     }
 

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -136,6 +136,10 @@ export const VBtn = genericComponent<VBtnSlots>()({
       if (isDisabled.value) return
 
       link.navigate?.(e)
+
+      const shouldOpenInNewWindow = e.metaKey || attrs.target === '_blank'
+      if (shouldOpenInNewWindow) return
+
       group?.toggle()
     }
 


### PR DESCRIPTION
## Description
### Problem
- When clicking on a `v-tab` with `href`/`to` property that opens in a new window/tab (via either `meta + click` or `target='__blank'`), the slider moves to the clicked tab rather than staying on the currently active tab.

![img](https://github.com/vuetifyjs/vuetify/assets/7105857/2227df78-3b00-4892-9840-20d44ac564c1)

### Fix
- Since `v-tab` uses `v-btn` and `v-btn` renders as an `a` tag if `href` or `to` is passed to it, we can check when the button is being clicked if a link will open in a new window/tab and return early before the `group.toggle` is called to set that button as active and move the slider to it.

#### gifs with bug fix
![meta-click](https://github.com/vuetifyjs/vuetify/assets/7105857/081ec9e6-d310-4e9b-8c0f-6454ca9a2d86)
![target-blank](https://github.com/vuetifyjs/vuetify/assets/7105857/8bb2b608-f2d3-4c8b-b626-0a47e8538410)


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
Here is a repro to show the issue:
https://github.com/BenGu3/vuetify-btn-link-bug

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script lang="ts" setup>
import { ref } from 'vue'

enum Option {
  One = 'one',
  Two = 'two',
  Three = 'three',
  Four = 'four',
}

const activeTab = ref<Option>()
</script>

<template>
  <div class="d-flex flex-row">
    <v-tabs v-model="activeTab" direction="vertical" color="primary">
      <v-tab :value="Option.One" to="/one">
        Anchor to /one route
      </v-tab>
      <v-tab :value="Option.Two" to="/two">
        Anchor to /two route
      </v-tab>
      <v-tab :value="Option.Three" target="_blank" href="https://google.com" append-icon="mdi-launch">
        Anchor to Google
      </v-tab>
      <v-tab :value="Option.Four">
        Button, so can't open in a new tab :(
      </v-tab>
    </v-tabs>

    <v-card-text v-if="activeTab === Option.One">Card One</v-card-text>
    <v-card-text v-if="activeTab === Option.Two">Card Two</v-card-text>
    <v-card-text v-if="activeTab === Option.Three">You should never see this</v-card-text>
    <v-card-text v-if="activeTab === Option.Four">Card Four</v-card-text>
  </div>
</template>
```
