### PR TITLE
fix(VSelect): add text-truncate to the title

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -402,7 +402,7 @@ export const VSelect = genericComponent<new <
                         )
                       ) : (
                         slots.selection?.({ item, index }) ?? (
-                          <span class="v-select__selection-text">
+                          <span class="v-select__selection-text text-truncate">
                             { item.title }
                             { props.multiple && (index < selections.value.length - 1) && (
                               <span class="v-select__selection-comma">,</span>


### PR DESCRIPTION
fixes: https://github.com/vuetifyjs/vuetify/issues/17348

## Description
I changed the overflow text of v-select to be hidden, just like in Vuetify 2.

## Markup:
```
<template>
  <v-app>
    <v-container>
      <v-select
        v-model="select"
        :hint="`${select.state}, ${select.abbr}`"
        :items="items"
        item-title="state"
        item-value="abbr"
        label="Select"
        persistent-hint
        return-object
        style="width: 200px;"
      />
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'
  export default {
    name: 'Playground',
    setup () {
      const select = ref({ state: 'Floridaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', abbr: 'FL' })
      return {
        select,
        items: [
          { state: 'Florida aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', abbr: 'FL' },
          { state: 'Georgia', abbr: 'GA' },
          { state: 'Nebraska', abbr: 'NE' },
          { state: 'California', abbr: 'CA' },
          { state: 'New York', abbr: 'NY' },
        ],
      }
    },
  }
</script>
```
## Visually
- before
<img width="1383" alt="スクリーンショット 2023-05-13 16 28 15" src="https://github.com/vuetifyjs/vuetify/assets/61488647/5dc6f501-24ad-414e-96ee-63e380dacce8">

- after
<img width="1383" alt="スクリーンショット 2023-05-13 16 27 16" src="https://github.com/vuetifyjs/vuetify/assets/61488647/cc6a32a4-b9c6-42fa-8212-4cd2eb7ebdda">

