### PR TITLE
fix(VFooter): pass missing height style

### DIFF
--- a/packages/vuetify/src/components/VFooter/VFooter.tsx
+++ b/packages/vuetify/src/components/VFooter/VFooter.tsx
@@ -75,8 +75,9 @@ export const VFooter = genericComponent()({
         ]}
         style={[
           backgroundColorStyles.value,
-          props.app ? layoutItemStyles.value : undefined,
-          { height: convertToUnit(props.height) },
+          props.app ? layoutItemStyles.value : {
+            height: convertToUnit(props.height),
+          },
           props.style,
         ]}
         v-slots={ slots }

--- a/packages/vuetify/src/components/VFooter/VFooter.tsx
+++ b/packages/vuetify/src/components/VFooter/VFooter.tsx
@@ -14,7 +14,7 @@ import { useResizeObserver } from '@/composables/resizeObserver'
 
 // Utilities
 import { computed, shallowRef, toRef } from 'vue'
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 export const makeVFooterProps = propsFactory({
   app: Boolean,
@@ -76,6 +76,7 @@ export const VFooter = genericComponent()({
         style={[
           backgroundColorStyles.value,
           props.app ? layoutItemStyles.value : undefined,
+          { height: convertToUnit(props.height) },
           props.style,
         ]}
         v-slots={ slots }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
Pass missing height style to the component

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #17370 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-footer color="red" height="100px" />
    </v-main>
  </v-app>
</template>

```
