### PR TITLE
fix(VNavigationDrawer): correct scrim position

### DIFF
--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.sass
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.sass
@@ -78,6 +78,8 @@
 
 .v-navigation-drawer__scrim
   position: absolute
+  top: 0
+  left: 0
   width: 100%
   height: 100%
   background: black

--- a/packages/vuetify/src/components/VNavigationDrawer/__tests__/VNavigationDrawer.spec.cy.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/__tests__/VNavigationDrawer.spec.cy.tsx
@@ -2,6 +2,7 @@
 
 import { VLayout } from '@/components/VLayout'
 import { VMain } from '@/components/VMain'
+import { VLocaleProvider } from '@/components/VLocaleProvider'
 import { VNavigationDrawer } from '..'
 import { ref } from 'vue'
 
@@ -137,5 +138,39 @@ describe('VNavigationDrawer', () => {
     ))
 
     cy.get('.v-navigation-drawer').should('have.css', 'bottom', '0px')
+  })
+
+  it('should position drawer scrim correctly', () => {
+    const visible = ref(false)
+    cy.mount((props: any) => (
+      <VLayout>
+        <VNavigationDrawer v-model={ visible.value } temporary />
+      </VLayout>
+    ))
+    cy.get('.v-navigation-drawer__scrim').should('not.exist')
+      .then(() => {
+        visible.value = true
+      })
+      .get('.v-navigation-drawer__scrim').should('be.visible')
+      .get('.v-navigation-drawer__scrim').should('have.css', 'top', '0px')
+      .get('.v-navigation-drawer__scrim').should('have.css', 'left', '0px')
+  })
+
+  it('should position drawer scrim correctly in rtl locale', () => {
+    const visible = ref(false)
+    cy.mount(() => (
+      <VLocaleProvider rtl>
+        <VLayout>
+          <VNavigationDrawer v-model={ visible.value } temporary />
+        </VLayout>
+      </VLocaleProvider>
+    ))
+      .get('.v-navigation-drawer__scrim').should('not.exist')
+      .then(() => {
+        visible.value = true
+      })
+      .get('.v-navigation-drawer__scrim').should('be.visible')
+      .get('.v-navigation-drawer__scrim').should('have.css', 'top', '0px')
+      .get('.v-navigation-drawer__scrim').should('have.css', 'left', '0px')
   })
 })


### PR DESCRIPTION
fixes #17367

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fix `VNavigationDrawer` scrim position incorrect

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-btn color="primary" @click.stop="visible = !visible">
        Toggle
      </v-btn>
      <v-navigation-drawer v-model="visible" temporary>
        <h1>Drawer</h1>
      </v-navigation-drawer>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'
  export default {
    name: 'Playground',
    setup () {
      const visible = ref(true)
      return {
        visible,
      }
    },
  }
</script>

```
