### PR TITLE
fix(VDataTable): Added missing props

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
@@ -156,7 +156,7 @@ export const VDataTable = genericComponent<VDataTableSlots>()({
                     v-slots={ slots }
                   />
                 </thead>
-                { slots.thead?.() }
+                { slots.thead?.({ ...dataTableHeadersProps, columns: columns.value }) }
                 <tbody>
                   { slots.body ? slots.body() : (
                     <VDataTableRows
@@ -167,7 +167,7 @@ export const VDataTable = genericComponent<VDataTableSlots>()({
                   )}
                 </tbody>
                 { slots.tbody?.() }
-                { slots.tfoot?.() }
+                { slots.tfoot?.({ columns: columns.value }) }
               </>
             )),
             bottom: slots.bottom ?? (() => (

--- a/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableServer.tsx
@@ -129,7 +129,7 @@ export const VDataTableServer = genericComponent<VDataTableSlots>()({
                     v-slots={ slots }
                   />
                 </thead>
-                { slots.thead?.() }
+                { slots.thead?.({ ...dataTableHeadersProps, columns: columns.value }) }
                 <tbody class="v-data-table__tbody" role="rowgroup">
                   { slots.body ? slots.body() : (
                     <VDataTableRows
@@ -140,7 +140,7 @@ export const VDataTableServer = genericComponent<VDataTableSlots>()({
                   )}
                 </tbody>
                 { slots.tbody?.() }
-                { slots.tfoot?.() }
+                { slots.tfoot?.({ columns: columns.value }) }
               </>
             )),
             bottom: slots.bottom ?? (() => (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
* Add dataTableHeadersProps and columns props to thead slot.
* Add columns prop to tfoot

fixes #17148
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<v-data-table
  :items="desserts"
  :headers="headers"
>
  <template #thead="props">
    <thead>
      <tr>

        <th
          v-for="column in props.columns"
          :key="column"
        >
          {{ column.title }}
        </th>
      </tr>
    </thead>
  </template>

  <template #tfoot="props">
    <tfoot>
      <tr>
        <td
          v-for="column in props.columns"
          :key="column"
        >
          {{ column.title }}
        </td>
      </tr>
    </tfoot>
  </template>
</v-data-table>
```
