### PR TITLE
chore(injectSelf): return from all paths

### DIFF
--- a/packages/vuetify/src/util/injectSelf.ts
+++ b/packages/vuetify/src/util/injectSelf.ts
@@ -9,4 +9,5 @@ export function injectSelf (key: InjectionKey<any> | string) {
     // TS doesn't allow symbol as index type
     return provides[key as string]
   }
+  return undefined;
 }


### PR DESCRIPTION
TypeScript 5.1 has improved checking for noImplicitReturns, and this function indeed has an implicit return of `undefined` off the bottom end.