### PR TITLE
fix(types): remove redundant slot types

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -85,12 +85,12 @@ export const makeVAlertProps = propsFactory({
 }, 'v-alert')
 
 export type VAlertSlots = {
-  default: []
-  prepend: []
-  title: []
-  text: []
-  append: []
-  close: [{ props: Record<string, any> }]
+  default: never
+  prepend: never
+  title: never
+  text: never
+  append: never
+  close: { props: Record<string, any> }
 }
 
 export const VAlert = genericComponent<VAlertSlots>()({

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -90,12 +90,12 @@ export const VAutocomplete = genericComponent<new <
     'onUpdate:modelValue'?: (val: V) => void
   },
   slots: Omit<VInputSlots & VFieldSlots, 'default'> & {
-    item: [{ item: ListItem<Item>, index: number, props: Record<string, unknown> }]
-    chip: [{ item: ListItem<Item>, index: number, props: Record<string, unknown> }]
-    selection: [{ item: ListItem<Item>, index: number }]
-    'prepend-item': []
-    'append-item': []
-    'no-data': []
+    item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
+    chip: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
+    selection: { item: ListItem<Item>, index: number }
+    'prepend-item': never
+    'append-item': never
+    'no-data': never
   }
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VAutocomplete',

--- a/packages/vuetify/src/components/VBadge/VBadge.tsx
+++ b/packages/vuetify/src/components/VBadge/VBadge.tsx
@@ -20,8 +20,8 @@ import { genericComponent, pick, propsFactory, useRender } from '@/util'
 import { toRef } from 'vue'
 
 export type VBadgeSlots = {
-  default: []
-  badge: []
+  default: never
+  badge: never
 }
 
 export const makeVBadgeProps = propsFactory({

--- a/packages/vuetify/src/components/VBanner/VBanner.tsx
+++ b/packages/vuetify/src/components/VBanner/VBanner.tsx
@@ -30,10 +30,10 @@ import { toRef } from 'vue'
 import type { PropType } from 'vue'
 
 export type VBannerSlots = {
-  default: []
-  prepend: []
-  text: []
-  actions: []
+  default: never
+  prepend: never
+  text: never
+  actions: never
 }
 
 export const makeVBannerProps = propsFactory({

--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.tsx
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.tsx
@@ -57,10 +57,10 @@ export const VBreadcrumbs = genericComponent<new <T extends BreadcrumbItem>(
     items?: T[]
   },
   slots: {
-    prepend: []
-    title: [{ item: T, index: number }]
-    divider: [{ item: T, index: number }]
-    default: []
+    prepend: never
+    title: { item: T, index: number }
+    divider: { item: T, index: number }
+    default: never
   }
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VBreadcrumbs',

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -37,10 +37,10 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 import type { PropType } from 'vue'
 
 export type VBtnSlots = {
-  default: []
-  prepend: []
-  append: []
-  loader: []
+  default: never
+  prepend: never
+  append: never
+  loader: never
 }
 
 export const makeVBtnProps = propsFactory({

--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.tsx
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.tsx
@@ -20,7 +20,7 @@ export interface DefaultBtnToggleSlot extends Pick<GroupProvide, BtnToggleSlotPr
 export const VBtnToggleSymbol: InjectionKey<GroupProvide> = Symbol.for('vuetify:v-btn-toggle')
 
 type VBtnToggleSlots = {
-  default: [DefaultBtnToggleSlot]
+  default: DefaultBtnToggleSlot
 }
 
 export const makeVBtnToggleProps = propsFactory({

--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -74,12 +74,12 @@ export const makeVCardProps = propsFactory({
 }, 'v-card')
 
 export type VCardSlots = VCardItemSlots & {
-  default: []
-  actions: []
-  text: []
-  loader: [LoaderSlotProps]
-  image: []
-  item: []
+  default: never
+  actions: never
+  text: never
+  loader: LoaderSlotProps
+  image: never
+  item: never
 }
 
 export const VCard = genericComponent<VCardSlots>()({

--- a/packages/vuetify/src/components/VCard/VCardItem.tsx
+++ b/packages/vuetify/src/components/VCard/VCardItem.tsx
@@ -13,11 +13,11 @@ import { makeDensityProps } from '@/composables/density'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 export type VCardItemSlots = {
-  default: []
-  prepend: []
-  append: []
-  title: []
-  subtitle: []
+  default: never
+  prepend: never
+  append: never
+  title: never
+  subtitle: never
 }
 
 export const makeCardItemProps = propsFactory({

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -49,14 +49,14 @@ export const makeVCarouselProps = propsFactory({
 }, 'v-carousel')
 
 type VCarouselSlots = VWindowSlots & {
-  item: [{
+  item: {
     props: Record<string, any>
     item: {
       id: number
       value: unknown
       disabled: boolean | undefined
     }
-  }]
+  }
 }
 
 export const VCarousel = genericComponent<VCarouselSlots>()({

--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -33,19 +33,19 @@ import { EventProp, genericComponent, propsFactory } from '@/util'
 import { computed } from 'vue'
 
 export type VChipSlots = {
-  default: [{
+  default: {
     isSelected: boolean | undefined
     selectedClass: boolean | (string | undefined)[] | undefined
     select: ((value: boolean) => void) | undefined
     toggle: (() => void) | undefined
     value: unknown
     disabled: boolean
-  }]
-  label: []
-  prepend: []
-  append: []
-  close: []
-  filter: []
+  }
+  label: never
+  prepend: never
+  append: never
+  close: never
+  filter: never
 }
 
 export const makeVChipProps = propsFactory({

--- a/packages/vuetify/src/components/VChipGroup/VChipGroup.tsx
+++ b/packages/vuetify/src/components/VChipGroup/VChipGroup.tsx
@@ -33,17 +33,17 @@ export const makeVChipGroupProps = propsFactory({
   ...makeVariantProps({ variant: 'tonal' } as const),
 }, 'v-chip-group')
 
-type VChipGroupProps = {
-  default: [{
+type VChipGroupSlots = {
+  default: {
     isSelected: (id: number) => boolean
     select: (id: number, value: boolean) => void
     next: () => void
     prev: () => void
     selected: readonly number[]
-  }]
+  }
 }
 
-export const VChipGroup = genericComponent<VChipGroupProps>()({
+export const VChipGroup = genericComponent<VChipGroupSlots>()({
   name: 'VChipGroup',
 
   props: makeVChipGroupProps(),

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -90,12 +90,12 @@ export const VCombobox = genericComponent<new <
     'onUpdate:modelValue'?: (val: V) => void
   },
   slots: Omit<VInputSlots & VFieldSlots, 'default'> & {
-    item: [{ item: ListItem<Item>, index: number, props: Record<string, unknown> }]
-    chip: [{ item: ListItem<Item>, index: number, props: Record<string, unknown> }]
-    selection: [{ item: ListItem<Item>, index: number }]
-    'prepend-item': []
-    'append-item': []
-    'no-data': []
+    item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
+    chip: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
+    selection: { item: ListItem<Item>, index: number }
+    'prepend-item': never
+    'append-item': never
+    'no-data': never
   }
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VCombobox',

--- a/packages/vuetify/src/components/VCounter/VCounter.tsx
+++ b/packages/vuetify/src/components/VCounter/VCounter.tsx
@@ -33,7 +33,7 @@ export type VCounterSlot = {
 }
 
 type VCounterSlots = {
-  default: [VCounterSlot]
+  default: VCounterSlot
 }
 
 export const VCounter = genericComponent<VCounterSlots>()({

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.tsx
@@ -31,9 +31,9 @@ export const makeVExpansionPanelProps = propsFactory({
 }, 'v-expansion-panel')
 
 export type VExpansionPanelSlots = {
-  default: []
-  title: []
-  text: []
+  default: never
+  title: never
+  text: never
 }
 
 export const VExpansionPanel = genericComponent<VExpansionPanelSlots>()({

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelTitle.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelTitle.tsx
@@ -23,8 +23,8 @@ interface ExpansionPanelTitleSlot {
 }
 
 export type VExpansionPanelTitleSlots = {
-  default: [ExpansionPanelTitleSlot]
-  actions: [ExpansionPanelTitleSlot]
+  default: ExpansionPanelTitleSlot
+  actions: ExpansionPanelTitleSlot
 }
 
 export const makeVExpansionPanelTitleProps = propsFactory({

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -96,12 +96,12 @@ export const makeVFieldProps = propsFactory({
 }, 'v-field')
 
 export type VFieldSlots = {
-  clear: []
-  'prepend-inner': [DefaultInputSlot]
-  'append-inner': [DefaultInputSlot]
-  label: [DefaultInputSlot & { label: string | undefined, props: Record<string, any> }]
-  loader: [LoaderSlotProps]
-  default: [VFieldSlot]
+  clear: never
+  'prepend-inner': DefaultInputSlot
+  'append-inner': DefaultInputSlot
+  label: DefaultInputSlot & { label: string | undefined, props: Record<string, any> }
+  loader: LoaderSlotProps
+  default: VFieldSlot
 }
 
 export const VField = genericComponent<new <T>(

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -32,12 +32,12 @@ import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 
 export type VFileInputSlots = VInputSlots & VFieldSlots & {
-  counter: []
-  selection: [{
+  counter: never
+  selection: {
     fileNames: string[]
     totalBytes: number
     totalBytesReadable: string
-  }]
+  }
 }
 
 export const makeVFileInputProps = propsFactory({

--- a/packages/vuetify/src/components/VForm/VForm.tsx
+++ b/packages/vuetify/src/components/VForm/VForm.tsx
@@ -16,7 +16,7 @@ export const makeVFormProps = propsFactory({
 }, 'v-form')
 
 type VFormSlots = {
-  default: [ReturnType<typeof createForm>]
+  default: ReturnType<typeof createForm>
 }
 
 export const VForm = genericComponent<VFormSlots>()({

--- a/packages/vuetify/src/components/VHover/VHover.tsx
+++ b/packages/vuetify/src/components/VHover/VHover.tsx
@@ -6,10 +6,10 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 import { genericComponent, propsFactory } from '@/util'
 
 type VHoverSlots = {
-  default: [{
+  default: {
     isHovering: boolean | undefined
     props: Record<string, unknown>
-  }]
+  }
 }
 
 export const makeVHoverProps = propsFactory({

--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -40,10 +40,10 @@ export interface srcObject {
 }
 
 export type VImgSlots = {
-  default: []
-  placeholder: []
-  error: []
-  sources: []
+  default: never
+  placeholder: never
+  error: never
+  sources: never
 }
 
 export const makeVImgProps = propsFactory({

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -62,11 +62,11 @@ export const makeVInputProps = propsFactory({
 }, 'v-input')
 
 export type VInputSlots = {
-  default: [VInputSlot]
-  prepend: [VInputSlot]
-  append: [VInputSlot]
-  details: [VInputSlot]
-  message: [VMessageSlot]
+  default: VInputSlot
+  prepend: VInputSlot
+  append: VInputSlot
+  details: VInputSlot
+  message: VMessageSlot
 }
 
 export const VInput = genericComponent<VInputSlots>()({

--- a/packages/vuetify/src/components/VItemGroup/VItem.tsx
+++ b/packages/vuetify/src/components/VItemGroup/VItem.tsx
@@ -6,14 +6,14 @@ import { VItemGroupSymbol } from './VItemGroup'
 import { genericComponent } from '@/util'
 
 type VItemSlots = {
-  default: [{
+  default: {
     isSelected: boolean | undefined
     selectedClass: boolean | (string | undefined)[] | undefined
     select: ((value: boolean) => void) | undefined
     toggle: (() => void) | undefined
     value: unknown
     disabled: boolean | undefined
-  }]
+  }
 }
 
 export const VItem = genericComponent<VItemSlots>()({

--- a/packages/vuetify/src/components/VItemGroup/VItemGroup.tsx
+++ b/packages/vuetify/src/components/VItemGroup/VItemGroup.tsx
@@ -22,13 +22,13 @@ export const makeVItemGroupProps = propsFactory({
 }, 'v-item-group')
 
 type VItemGroupSlots = {
-  default: [{
+  default: {
     isSelected: (id: number) => boolean
     select: (id: number, value: boolean) => void
     next: () => void
     prev: () => void
     selected: readonly number[]
-  }]
+  }
 }
 
 export const VItemGroup = genericComponent<VItemGroupSlots>()({

--- a/packages/vuetify/src/components/VList/VListChildren.tsx
+++ b/packages/vuetify/src/components/VList/VListChildren.tsx
@@ -15,13 +15,13 @@ import type { GenericProps } from '@/util'
 import type { PropType } from 'vue'
 
 export type VListChildrenSlots<T> = {
-  [K in keyof Omit<VListItemSlots, 'default'>]: VListItemSlots[K] & [{ item: T }]
+  [K in keyof Omit<VListItemSlots, 'default'>]: VListItemSlots[K] & { item: T }
 } & {
-  default: []
-  item: [{ props: InternalListItem['props'] }]
-  divider: [{ props: InternalListItem['props'] }]
-  subheader: [{ props: InternalListItem['props'] }]
-  header: [{ props: InternalListItem['props'] }]
+  default: never
+  item: { props: InternalListItem['props'] }
+  divider: { props: InternalListItem['props'] }
+  subheader: { props: InternalListItem['props'] }
+  header: { props: InternalListItem['props'] }
 }
 
 export const makeVListChildrenProps = propsFactory({

--- a/packages/vuetify/src/components/VList/VListGroup.tsx
+++ b/packages/vuetify/src/components/VList/VListGroup.tsx
@@ -16,8 +16,8 @@ import { computed, toRef } from 'vue'
 import { defineComponent, genericComponent, propsFactory, useRender } from '@/util'
 
 export type VListGroupSlots = {
-  default: []
-  activator: [{ isOpen: boolean, props: Record<string, unknown> }]
+  default: never
+  activator: { isOpen: boolean, props: Record<string, unknown> }
 }
 
 const VListGroupActivator = defineComponent({

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -49,11 +49,11 @@ export type ListItemSubtitleSlot = {
 }
 
 export type VListItemSlots = {
-  prepend: [ListItemSlot]
-  append: [ListItemSlot]
-  default: [ListItemSlot]
-  title: [ListItemTitleSlot]
-  subtitle: [ListItemSubtitleSlot]
+  prepend: ListItemSlot
+  append: ListItemSlot
+  default: ListItemSlot
+  title: ListItemTitleSlot
+  subtitle: ListItemSubtitleSlot
 }
 
 export const makeVListItemProps = propsFactory({

--- a/packages/vuetify/src/components/VMessages/VMessages.tsx
+++ b/packages/vuetify/src/components/VMessages/VMessages.tsx
@@ -21,7 +21,7 @@ export type VMessageSlot = {
 }
 
 export type VMessagesSlots = {
-  message: [VMessageSlot]
+  message: VMessageSlot
 }
 
 export const makeVMessagesProps = propsFactory({

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -31,10 +31,10 @@ export type VNavigationDrawerImageSlot = {
 }
 
 export type VNavigationDrawerSlots = {
-  default: []
-  prepend: []
-  append: []
-  image: [VNavigationDrawerImageSlot]
+  default: never
+  prepend: never
+  append: never
+  image: VNavigationDrawerImageSlot
 }
 
 const locations = ['start', 'end', 'left', 'right', 'top', 'bottom'] as const

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -73,8 +73,8 @@ function Scrim (props: ScrimProps) {
 }
 
 export type OverlaySlots = {
-  default: [{ isActive: Ref<boolean> }]
-  activator: [{ isActive: boolean, props: Record<string, any> }]
+  default: { isActive: Ref<boolean> }
+  activator: { isActive: boolean, props: Record<string, any> }
 }
 
 export const makeVOverlayProps = propsFactory({

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -45,11 +45,11 @@ type ControlSlot = {
 }
 
 export type VPaginationSlots = {
-  item: [ItemSlot]
-  first: [ControlSlot]
-  prev: [ControlSlot]
-  next: [ControlSlot]
-  last: [ControlSlot]
+  item: ItemSlot
+  first: ControlSlot
+  prev: ControlSlot
+  next: ControlSlot
+  last: ControlSlot
 }
 
 export const makeVPaginationProps = propsFactory({

--- a/packages/vuetify/src/components/VProgressCircular/VProgressCircular.tsx
+++ b/packages/vuetify/src/components/VProgressCircular/VProgressCircular.tsx
@@ -41,7 +41,7 @@ export const makeVProgressCircularProps = propsFactory({
 }, 'v-progress-circular')
 
 type VProgressCircularSlots = {
-  default: [{ value: number }]
+  default: { value: number }
 }
 
 export const VProgressCircular = genericComponent<VProgressCircularSlots>()({

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
@@ -17,7 +17,7 @@ import { computed, Transition } from 'vue'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 type VProgressLinearSlots = {
-  default: [{ value: number, buffer: number }]
+  default: { value: number, buffer: number }
 }
 
 export const makeVProgressLinearProps = propsFactory({

--- a/packages/vuetify/src/components/VRating/VRating.tsx
+++ b/packages/vuetify/src/components/VRating/VRating.tsx
@@ -40,8 +40,8 @@ type VRatingItemLabelSlot = {
 }
 
 type VRatingSlots = {
-  item: [VRatingItemSlot]
-  'item-label': [VRatingItemLabelSlot]
+  item: VRatingItemSlot
+  'item-label': VRatingItemLabelSlot
 }
 
 export const makeVRatingProps = propsFactory({

--- a/packages/vuetify/src/components/VResponsive/VResponsive.tsx
+++ b/packages/vuetify/src/components/VResponsive/VResponsive.tsx
@@ -10,8 +10,8 @@ import { computed } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 export type VResponsiveSlots = {
-  default: []
-  additional: []
+  default: never
+  additional: never
 }
 
 export function useAspectStyles (props: { aspectRatio?: string | number }) {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -95,12 +95,12 @@ export const VSelect = genericComponent<new <
     'onUpdate:modelValue'?: (val: V) => void
   },
   slots: Omit<VInputSlots & VFieldSlots, 'default'> & {
-    item: [{ item: ListItem<Item>, index: number, props: Record<string, unknown> }]
-    chip: [{ item: ListItem<Item>, index: number, props: Record<string, unknown> }]
-    selection: [{ item: ListItem<Item>, index: number }]
-    'prepend-item': []
-    'append-item': []
-    'no-data': []
+    item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
+    chip: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
+    selection: { item: ListItem<Item>, index: number }
+    'prepend-item': never
+    'append-item': never
+    'no-data': never
   }
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VSelect',

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -43,9 +43,9 @@ export type SelectionControlSlot = {
 }
 
 export type VSelectionControlSlots = {
-  default: []
-  label: [{ label: string | undefined, props: Record<string, unknown> }]
-  input: [SelectionControlSlot]
+  default: never
+  label: { label: string | undefined, props: Record<string, unknown> }
+  input: SelectionControlSlot
 }
 
 export const makeSelectionControlProps = propsFactory({

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -33,9 +33,9 @@ interface SlideGroupSlot {
 }
 
 type VSlideGroupSlots = {
-  default: [SlideGroupSlot]
-  prev: [SlideGroupSlot]
-  next: [SlideGroupSlot]
+  default: SlideGroupSlot
+  prev: SlideGroupSlot
+  next: SlideGroupSlot
 }
 
 export const makeVSlideGroupProps = propsFactory({

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroupItem.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroupItem.tsx
@@ -10,12 +10,12 @@ import type { UnwrapRef } from 'vue'
 import type { GroupItemProvide } from '@/composables/group'
 
 type VSlideGroupItemSlots = {
-  default: [{
+  default: {
     isSelected: UnwrapRef<GroupItemProvide['isSelected']>
     select: GroupItemProvide['select']
     toggle: GroupItemProvide['toggle']
     selectedClass: UnwrapRef<GroupItemProvide['selectedClass']>
-  }]
+  }
 }
 
 export const VSlideGroupItem = genericComponent<VSlideGroupItemSlots>()({

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -21,9 +21,9 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 import type { VInputSlot, VInputSlots } from '@/components/VInput/VInput'
 
 export type VSliderSlots = VInputSlots & {
-  label: [VInputSlot]
-  'tick-label': []
-  'thumb-label': []
+  label: VInputSlot
+  'tick-label': never
+  'thumb-label': never
 }
 
 export const makeVSliderProps = propsFactory({

--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -18,7 +18,7 @@ import { computed, inject } from 'vue'
 import { convertToUnit, genericComponent, keyValues, propsFactory, useRender } from '@/util'
 
 export type VSliderThumbSlots = {
-  'thumb-label': [{ modelValue: number }]
+  'thumb-label': { modelValue: number }
 }
 
 export const makeVSliderThumbProps = propsFactory({

--- a/packages/vuetify/src/components/VSlider/VSliderTrack.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderTrack.tsx
@@ -14,7 +14,7 @@ import { computed, inject } from 'vue'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 export type VSliderTrackSlots = {
-  'tick-label': [{ tick: Tick, index: number }]
+  'tick-label': { tick: Tick, index: number }
 }
 
 export const makeVSliderTrackProps = propsFactory({

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -21,9 +21,9 @@ import { genericComponent, omit, propsFactory, useRender } from '@/util'
 import { makeVOverlayProps } from '@/components/VOverlay/VOverlay'
 
 type VSnackbarSlots = {
-  activator: [{ isActive: boolean, props: Record<string, any> }]
-  default: []
-  actions: []
+  activator: { isActive: boolean, props: Record<string, any> }
+  default: never
+  actions: never
 }
 
 export const makeVSnackbarProps = propsFactory({

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -23,7 +23,7 @@ import type { LoaderSlotProps } from '@/composables/loader'
 export type VSwitchSlots =
   & VInputSlots
   & VSelectionControlSlots
-  & { loader: [LoaderSlotProps] }
+  & { loader: LoaderSlotProps }
 
 export const makeVSwitchProps = propsFactory({
   indeterminate: Boolean,

--- a/packages/vuetify/src/components/VTable/VTable.tsx
+++ b/packages/vuetify/src/components/VTable/VTable.tsx
@@ -11,10 +11,10 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 export type VTableSlots = {
-  default: []
-  top: []
-  bottom: []
-  wrapper: []
+  default: never
+  top: never
+  bottom: never
+  wrapper: never
 }
 
 export const makeVTableProps = propsFactory({

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -45,8 +45,8 @@ export const makeVTextFieldProps = propsFactory({
 }, 'v-text-field')
 
 export type VTextFieldSlots = Omit<VInputSlots & VFieldSlots, 'default'> & {
-  default: []
-  counter: [VCounterSlot]
+  default: never
+  counter: VCounterSlot
 }
 
 export const VTextField = genericComponent<VTextFieldSlots>()({

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -52,7 +52,7 @@ export const makeVTextareaProps = propsFactory({
 }, 'v-textarea')
 
 type VTextareaSlots = Omit<VInputSlots & VFieldSlots, 'default'> & {
-  counter: [VCounterSlot]
+  counter: VCounterSlot
 }
 
 export const VTextarea = genericComponent<VTextareaSlots>()({

--- a/packages/vuetify/src/components/VTimeline/VTimelineItem.tsx
+++ b/packages/vuetify/src/components/VTimeline/VTimelineItem.tsx
@@ -19,9 +19,9 @@ import type { PropType } from 'vue'
 
 // Types
 export type VTimelineItemSlots = {
-  default: []
-  icon: []
-  opposite: []
+  default: never
+  icon: never
+  opposite: never
 }
 
 export const makeVTimelineItemProps = propsFactory({

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -61,12 +61,12 @@ export const makeVToolbarProps = propsFactory({
 }, 'v-toolbar')
 
 export type VToolbarSlots = {
-  default: []
-  image: []
-  prepend: []
-  append: []
-  title: []
-  extension: []
+  default: never
+  image: never
+  prepend: never
+  append: never
+  title: never
+  extension: never
 }
 
 export const VToolbar = genericComponent<VToolbarSlots>()({

--- a/packages/vuetify/src/components/VToolbar/VToolbarTitle.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbarTitle.tsx
@@ -13,8 +13,8 @@ export const makeVToolbarTitleProps = propsFactory({
 }, 'v-toolbar-title')
 
 export type VToolbarTitleSlots = {
-  default: []
-  text: []
+  default: never
+  text: never
 }
 
 export const VToolbarTitle = genericComponent<VToolbarTitleSlots>()({

--- a/packages/vuetify/src/components/VValidation/VValidation.tsx
+++ b/packages/vuetify/src/components/VValidation/VValidation.tsx
@@ -5,7 +5,7 @@ import { makeValidationProps, useValidation } from '@/composables/validation'
 import { genericComponent } from '@/util'
 
 export type VValidationSlots = {
-  default: [ReturnType<typeof useValidation>]
+  default: ReturnType<typeof useValidation>
 }
 
 export const VValidation = genericComponent<VValidationSlots>()({

--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
@@ -48,7 +48,7 @@ export const VVirtualScroll = genericComponent<new <T>(
     items?: readonly T[]
   },
   slots: {
-    default: [VVirtualScrollSlot<T>]
+    default: VVirtualScrollSlot<T>
   }
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VVirtualScroll',

--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -25,10 +25,10 @@ import type { IconValue } from '@/composables/icons'
 import type { TouchHandlers } from '@/directives/touch'
 
 export type VWindowSlots = {
-  default: [{ group: GroupProvide }]
-  additional: [{ group: GroupProvide }]
-  prev: [{ props: ControlProps }]
-  next: [{ props: ControlProps }]
+  default: { group: GroupProvide }
+  additional: { group: GroupProvide }
+  prev: { props: ControlProps }
+  next: { props: ControlProps }
 }
 
 type WindowProvide = {

--- a/packages/vuetify/src/composables/loader.tsx
+++ b/packages/vuetify/src/composables/loader.tsx
@@ -40,7 +40,7 @@ export function LoaderSlot (
     name: string
     color?: string
   } & ExtractPropTypes<SlotsToProps<{
-    default: [LoaderSlotProps]
+    default: LoaderSlotProps
   }>>,
   { slots }: SetupContext,
 ) {

--- a/packages/vuetify/src/labs/VDataIterator/VDataIterator.tsx
+++ b/packages/vuetify/src/labs/VDataIterator/VDataIterator.tsx
@@ -44,10 +44,10 @@ type VDataIteratorSlotProps = {
 }
 
 export type VDataIteratorSlots = {
-  default: [VDataIteratorSlotProps]
-  header: [VDataIteratorSlotProps]
-  footer: [VDataIteratorSlotProps]
-  'no-data': []
+  default: VDataIteratorSlotProps
+  header: VDataIteratorSlotProps
+  footer: VDataIteratorSlotProps
+  'no-data': never
 }
 
 export const makeVDataIteratorProps = propsFactory({

--- a/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
@@ -54,15 +54,15 @@ export type VDataTableSlotProps = {
 }
 
 export type VDataTableSlots = VDataTableRowsSlots & VDataTableHeadersSlots & {
-  default: [VDataTableSlotProps]
-  colgroup: [VDataTableSlotProps]
-  top: [VDataTableSlotProps]
-  body: [VDataTableSlotProps]
-  tbody: [VDataTableSlotProps]
-  thead: [VDataTableSlotProps]
-  tfoot: [VDataTableSlotProps]
-  bottom: [VDataTableSlotProps]
-  'footer.prepend': []
+  default: VDataTableSlotProps
+  colgroup: VDataTableSlotProps
+  top: VDataTableSlotProps
+  body: VDataTableSlotProps
+  tbody: VDataTableSlotProps
+  thead: VDataTableSlotProps
+  tfoot: VDataTableSlotProps
+  bottom: VDataTableSlotProps
+  'footer.prepend': never
 }
 
 export const makeDataTableProps = propsFactory({

--- a/packages/vuetify/src/labs/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableFooter.tsx
@@ -70,7 +70,7 @@ export const makeVDataTableFooterProps = propsFactory({
   showCurrentPage: Boolean,
 }, 'v-data-table-footer')
 
-export const VDataTableFooter = genericComponent<{ prepend: [] }>()({
+export const VDataTableFooter = genericComponent<{ prepend: never }>()({
   name: 'VDataTableFooter',
 
   props: makeVDataTableFooterProps(),

--- a/packages/vuetify/src/labs/VDataTable/VDataTableGroupHeaderRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableGroupHeaderRow.tsx
@@ -17,8 +17,8 @@ import type { PropType } from 'vue'
 import type { Group } from './composables/group'
 
 export type VDataTableGroupHeaderRowSlots = {
-  'data-table-group': [{ item: Group, count: number, props: Record<string, unknown> }]
-  'data-table-select': [{ props: Record<string, unknown> }]
+  'data-table-group': { item: Group, count: number, props: Record<string, unknown> }
+  'data-table-select': { props: Record<string, unknown> }
 }
 
 export const makeVDataTableGroupHeaderRowProps = propsFactory({

--- a/packages/vuetify/src/labs/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableHeaders.tsx
@@ -47,11 +47,11 @@ type VDataTableHeaderCellColumnSlotProps = {
 }
 
 export type VDataTableHeadersSlots = {
-  headers: [HeadersSlotProps]
-  loader: [LoaderSlotProps]
-  'column.data-table-select': [VDataTableHeaderCellColumnSlotProps]
-  'column.data-table-expand': [VDataTableHeaderCellColumnSlotProps]
-} & { [key: `column.${string}`]: [VDataTableHeaderCellColumnSlotProps] }
+  headers: HeadersSlotProps
+  loader: LoaderSlotProps
+  'column.data-table-select': VDataTableHeaderCellColumnSlotProps
+  'column.data-table-expand': VDataTableHeaderCellColumnSlotProps
+} & { [key: `column.${string}`]: VDataTableHeaderCellColumnSlotProps }
 
 export const makeVDataTableHeadersProps = propsFactory({
   color: String,

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -42,14 +42,14 @@ type ItemSlot = {
 }
 
 export type VDataTableRowsSlots = VDataTableGroupHeaderRowSlots & {
-  item: [ItemSlot]
-  loading: []
-  'group-header': [GroupHeaderSlot]
-  'no-data': []
-  'expanded-row': [ItemSlot]
-  'item.data-table-select': [ItemSlot]
-  'item.data-table-expand': [ItemSlot]
-} & { [key: `item.${string}`]: [ItemSlot] }
+  item: ItemSlot
+  loading: never
+  'group-header': GroupHeaderSlot
+  'no-data': never
+  'expanded-row': ItemSlot
+  'item.data-table-select': ItemSlot
+  'item.data-table-expand': ItemSlot
+} & { [key: `item.${string}`]: ItemSlot }
 
 export const makeVDataTableRowsProps = propsFactory({
   loading: [Boolean, String],

--- a/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
@@ -29,9 +29,9 @@ import type { VDataTableHeadersSlots } from './VDataTableHeaders'
 type VDataTableVirtualSlotProps = Omit<VDataTableSlotProps, 'setItemsPerPage' | 'page' | 'pageCount' | 'itemsPerPage'>
 
 export type VDataTableVirtualSlots = VDataTableRowsSlots & VDataTableHeadersSlots & {
-  top: [VDataTableVirtualSlotProps]
+  top: VDataTableVirtualSlotProps
   headers: VDataTableHeadersSlots['headers']
-  bottom: [VDataTableVirtualSlotProps]
+  bottom: VDataTableVirtualSlotProps
 }
 
 export const makeVDataTableVirtualProps = propsFactory({

--- a/packages/vuetify/src/labs/VInfiniteScroll/VInfiniteScroll.tsx
+++ b/packages/vuetify/src/labs/VInfiniteScroll/VInfiniteScroll.tsx
@@ -27,11 +27,11 @@ type InfiniteScrollSlot = {
 }
 
 type VInfiniteScrollSlots = {
-  default: []
-  loading: [InfiniteScrollSlot]
-  error: [InfiniteScrollSlot]
-  empty: [InfiniteScrollSlot]
-  'load-more': [InfiniteScrollSlot]
+  default: never
+  loading: InfiniteScrollSlot
+  error: InfiniteScrollSlot
+  empty: InfiniteScrollSlot
+  'load-more': InfiniteScrollSlot
 }
 
 export const makeVInfiniteScrollProps = propsFactory({

--- a/packages/vuetify/src/labs/VSkeletonLoader/VSkeletonLoader.tsx
+++ b/packages/vuetify/src/labs/VSkeletonLoader/VSkeletonLoader.tsx
@@ -19,9 +19,6 @@ type VSkeletonBone<T> = T | VSkeletonBone<T>[]
 
 export type VSkeletonBones = VSkeletonBone<VNode>
 export type VSkeletonLoaderType = keyof typeof rootTypes
-export type VSkeletonLoaderSlots = {
-  default: []
-}
 
 export const rootTypes = {
   actions: 'button@2',
@@ -126,7 +123,7 @@ export const makeVSkeletonLoaderProps = propsFactory({
   ...makeThemeProps(),
 }, 'v-skeleton-loader')
 
-export const VSkeletonLoader = genericComponent<VSkeletonLoaderSlots>()({
+export const VSkeletonLoader = genericComponent()({
   name: 'VSkeletonLoader',
 
   props: makeVSkeletonLoaderProps(),

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -135,8 +135,7 @@ type ToListeners<T extends string | number | symbol> = { [K in T]: K extends `on
 
 export type SlotsToProps<
   U extends RawSlots,
-  Generic extends boolean = false,
-  T = U extends Record<string, any[]> ? MakeInternalSlots<U> : U
+  T = MakeInternalSlots<U>
 > = {
   $children?: (
     | VNodeChild
@@ -148,18 +147,18 @@ export type SlotsToProps<
   [K in keyof T as `v-slot:${K & string}`]?: T[K] | false
 }
 
-type RawSlots = Record<string, any[]> | Record<string, Slot>
-type Slot<T = any> = [T] extends [never] ? () => VNodeChild : (arg: T) => VNodeChild
-type VueSlot<T = any> = [T] extends [never] ? () => VNode[] : (arg: T) => VNode[]
-export type MakeInternalSlots<T extends RawSlots> = {
-  [K in keyof T]: T[K] extends any[] ? Slot<T[K][number]> : T[K]
+type RawSlots = Record<string, unknown>
+type Slot<T> = [T] extends [never] ? () => VNodeChild : (arg: T) => VNodeChild
+type VueSlot<T> = [T] extends [never] ? () => VNode[] : (arg: T) => VNode[]
+type MakeInternalSlots<T extends RawSlots> = {
+  [K in keyof T]: Slot<T[K]>
 }
 type MakeSlots<T extends RawSlots> = {
-  [K in keyof T]: T[K] extends any[] ? VueSlot<T[K][number]> : T[K]
+  [K in keyof T]: VueSlot<T[K]>
 }
 
-export type GenericProps<Props, Slots extends Record<string, any[]>> = {
-  $props: Props & SlotsToProps<Slots, true>
+export type GenericProps<Props, Slots extends Record<string, unknown>> = {
+  $props: Props & SlotsToProps<Slots>
   $slots: MakeSlots<Slots>
 }
 
@@ -235,7 +234,7 @@ type DefineComponentWithSlots<Slots extends RawSlots> = <
 > & FilterPropsOptions<PropsOptions>
 
 // No argument - simple default slot
-export function genericComponent (exposeDefaults?: boolean): DefineComponentWithSlots<{ default: [] }>
+export function genericComponent (exposeDefaults?: boolean): DefineComponentWithSlots<{ default: never }>
 
 // Generic constructor argument - generic props and slots
 export function genericComponent<T extends (new (props: Record<string, any>, slots: any) => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-input>
    <template v-for="(_, slotName) in slots" :key="slotName" #[slotName]="slotProps">
      <slot :name="slotName" v-bind="(slotProps as UnionToIntersection<typeof slotProps>) || {}" />
    </template>
  </v-input>
</template>

<script setup lang="ts">
  import { VInput } from '@/components/VInput'

  type Slots = VInput['$slots'];
  type UnionToIntersection<U> =
    (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never

  const slots = defineSlots<Slots>()
</script>

```
