### PR TITLE
fix(VDataTable): add missing types

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/types.ts
+++ b/packages/vuetify/src/labs/VDataTable/types.ts
@@ -13,9 +13,9 @@ export type DataTableHeader = {
   rowspan?: number
 
   fixed?: boolean
-  align?: 'start' | 'end'
+  align?: 'start' | 'end' | 'center'
 
-  width?: number
+  width?: number | string
   minWidth?: string
   maxWidth?: string
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
`DataTableHeader` type lacks several parameter types:
* `width` header parameter supports `string` type, which can be used with a percentage value. Adding the type resolves #17385
  * This functionality is already supported, as both `width` and `minWidth` parameters of `style` call `convertToUnit` function: https://github.com/vuetifyjs/vuetify/blob/06815ef96240fc808388995e838ef43d7c63f344/packages/vuetify/src/labs/VDataTable/VDataTableHeaders.tsx#LL133C17-L133C17. 
* `align` header parameter supports `'center'` value, which correctly sets the center style to the row cells.

I have **one more request** for a discussion: there is an issue #16897 that should be still open, also referenced at #16680: please consider exporting the `DataTableHeader` type directly. (The `export type` in `types.ts` isn't sufficient.)

## Usage example (no repro needed):
```vue
<v-data-table :headers="headers"> <!-- Type is not assignable --->
```

```ts
@Component({
  components: {
    VDataTable,
  },
})
export default class TableExample extends Vue {
  get headers(): {
        // TODO: import DataTableHeader type once Vuetify exports it
        title: string
        key: string
        width?: number | string
        align?: 'start' | 'end' | 'center'
      }[] {
    return (
      [
        {
          title: 'Name',
          key: 'name',
          width: '30%',
        },
        {
          title: 'Created',
          key: 'creationDate',
          align: 'center' as const,
        },
      ]
    )
  }
}
```
