### PR TITLE
fix: Keyframe property value “” is invalid warning

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTab.tsx
+++ b/packages/vuetify/src/components/VTabs/VTab.tsx
@@ -86,11 +86,11 @@ export const VTab = genericComponent()({
 
         const sigma = 1.5
         animate(nextEl, {
-          backgroundColor: [color, ''],
+          backgroundColor: [color, 'transparent'],
           transform: [
             `translate${XY}(${delta}px) scale${XY}(${initialScale})`,
             `translate${XY}(${delta / sigma}px) scale${XY}(${(scale - 1) / sigma + 1})`,
-            '',
+            'none',
           ],
           transformOrigin: Array(3).fill(origin),
         }, {


### PR DESCRIPTION
Fixes #16258
