### PR TITLE
feat(VList, VSelect): add support for test IDs

### DIFF
--- a/packages/api-generator/src/locale/en/list-items.json
+++ b/packages/api-generator/src/locale/en/list-items.json
@@ -2,6 +2,7 @@
   "props": {
     "itemTitle": "Property on supplied `items` that contains its title",
     "itemValue": "Property on supplied `items` that contains its value",
+    "itemTestId": "Property on supplied `items` that contains its test ID",
     "itemChildren": "Property on supplied `items` that contains its children",
     "itemProps": "Props object that will be applied to each item component. `true` will treat the original object as raw props and pass it directly to the component.",
     "returnObject": "Changes the selection behavior to return the object directly rather than the value specified with **item-value**"

--- a/packages/vuetify/cypress/support/selector.ts
+++ b/packages/vuetify/cypress/support/selector.ts
@@ -1,5 +1,5 @@
 /// <reference types="../../types/cypress" />
 
 Cypress.Commands.add('getBySel', (selector, ...args) => {
-  return cy.get(`[data-test=${selector}]`, ...args) as any
+  return cy.get(`[data-test="${selector}"]`, ...args) as any;
 })

--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -42,12 +42,14 @@ function transformItem (props: ItemProps & { itemType: string }, item: any): Int
   const type = getPropertyFromItem(item, props.itemType, 'item')
   const title = isPrimitive(item) ? item : getPropertyFromItem(item, props.itemTitle)
   const value = getPropertyFromItem(item, props.itemValue, undefined)
+  const testId = getPropertyFromItem(item, props.itemTestId, title)
   const children = getPropertyFromItem(item, props.itemChildren)
   const itemProps = props.itemProps === true ? pick(item, ['children'])[1] : getPropertyFromItem(item, props.itemProps)
 
   const _props = {
     title,
     value,
+    testId,
     ...itemProps,
   }
 
@@ -55,6 +57,7 @@ function transformItem (props: ItemProps & { itemType: string }, item: any): Int
     type,
     title: _props.title,
     value: _props.value,
+    testId: _props.testId,
     props: _props,
     children: type === 'item' && children ? transformItems(props, children) : undefined,
     raw: item,

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -81,6 +81,7 @@ export const makeVListItemProps = propsFactory({
     default: true,
   },
   subtitle: [String, Number, Boolean],
+  testId: [String, Number, Boolean],
   title: [String, Number, Boolean],
   value: null,
 
@@ -222,6 +223,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
           onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && props.ripple }
+          data-test={ props.testId }
         >
           { genOverlays(isClickable.value || isActive.value, 'v-list-item') }
 

--- a/packages/vuetify/src/components/VList/__tests__/VList.spec.cy.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VList.spec.cy.tsx
@@ -229,4 +229,60 @@ describe('VList', () => {
 
     cy.get('.v-list-item').eq(1).should('not.have.class', 'v-list-item--active')
   })
+
+  context('test ID', () => {
+    context('when no explicit test ID is given', () => {
+      it('should add an implicit test ID to each item', () => {
+        const items = [
+          { title: 'Item #1', value: 1 },
+          { title: 'Item #2', value: 2 },
+          { title: 'Item #3', value: 3 },
+        ]
+
+        mountFunction((
+          <CenteredGrid width="200px">
+            <VList items={ items } />
+          </CenteredGrid>
+        ))
+
+        cy.getBySel('Item #1').should('have.text', 'Item #1')
+      })
+    })
+
+    context('when an explicit test ID is given', () => {
+      it('should add the explicit test ID to each item', () => {
+        const items = [
+          { title: 'Item #1', value: 1, testId: 'first' },
+          { title: 'Item #2', value: 2, testId: 'second' },
+          { title: 'Item #3', value: 3, testId: 'third' },
+        ]
+
+        mountFunction((
+          <CenteredGrid width="200px">
+            <VList items={ items } />
+          </CenteredGrid>
+        ))
+
+        cy.getBySel('second').should('have.text', 'Item #2')
+      })
+    })
+
+    context('when a non-default test ID property is used', () => {
+      it('should add the test ID to each item using the specified property', () => {
+        const items = [
+          { title: 'Item #1', value: 1, testSelector: 'first' },
+          { title: 'Item #2', value: 2, testSelector: 'second' },
+          { title: 'Item #3', value: 3, testSelector: 'third' },
+        ]
+
+        mountFunction((
+          <CenteredGrid width="200px">
+            <VList items={ items } item-test-id="testSelector" />
+          </CenteredGrid>
+        ))
+
+        cy.getBySel('third').should('have.text', 'Item #3')
+      })
+    })
+  })
 })

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -394,4 +394,71 @@ describe('VSelect', () => {
       .trigger('keydown', { key: keyValues.esc })
       .should('not.have.class', 'v-select--active-menu')
   })
+
+  context('test ID', () => {
+    context('when no explicit test ID is given', () => {
+      it('should add an implicit test ID to each item', () => {
+        cy.mount(() => (
+          <VSelect
+            items={['California', 'Colorado', 'Florida', 'Georgia']}
+            data-test="select"
+          />
+        ))
+
+        cy.getBySel('select').click()
+        cy.get('.v-overlay__content').within(() => {
+          cy.getBySel('Colorado').should('have.text', 'Colorado')
+        })
+      })
+    })
+
+    context('when an explicit test ID is given', () => {
+      it('should add the explicit test ID to each item', () => {
+        const items = [
+          { title: 'Florida', value: 'FL', testId: 'florida' },
+          { title: 'Georgia', value: 'GA', testId: 'georgia' },
+          { title: 'Nebraska', value: 'NE', testId: 'nebraska' },
+          { title: 'California', value: 'CA', testId: 'california' },
+          { title: 'New York', value: 'NY', testId: 'new_york' },
+        ]
+
+        cy.mount(() => (
+          <VSelect
+            items={ items }
+            data-test="select"
+          />
+        ))
+
+        cy.getBySel('select').click()
+        cy.get('.v-overlay__content').within(() => {
+          cy.getBySel('new_york').should('have.text', 'New York')
+        })
+      })
+    })
+
+    describe('when a non-default test ID property is used', () => {
+      it('should add the test ID to each item using the specified property', () => {
+        const items = [
+          { title: 'Florida', value: 'FL', testSelector: 'florida' },
+          { title: 'Georgia', value: 'GA', testSelector: 'georgia' },
+          { title: 'Nebraska', value: 'NE', testSelector: 'nebraska' },
+          { title: 'California', value: 'CA', testSelector: 'california' },
+          { title: 'New York', value: 'NY', testSelector: 'new_york' },
+        ]
+
+        cy.mount(() => (
+          <VSelect
+            items={ items }
+            data-test="select"
+            item-test-id="testSelector"
+          />
+        ))
+
+        cy.getBySel('select').click()
+        cy.get('.v-overlay__content').within(() => {
+          cy.getBySel('new_york').should('have.text', 'New York')
+        })
+      })
+    })
+  })
 })

--- a/packages/vuetify/src/composables/__tests__/filter.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/filter.spec.ts
@@ -109,6 +109,7 @@ describe('filter', () => {
     const itemProps = {
       itemTitle: 'title',
       itemValue: 'value',
+      itemTestId: 'testId',
       itemChildren: 'children',
       itemProps: 'props',
       returnObject: false,

--- a/packages/vuetify/src/composables/__tests__/items.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/items.spec.ts
@@ -8,6 +8,7 @@ describe('items', () => {
   const defaults = {
     itemTitle: 'title',
     itemValue: 'value',
+    itemTestId: 'testId',
     itemChildren: 'children',
     itemProps: () => ({}),
     returnObject: false,
@@ -25,9 +26,11 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 'Foo',
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 'Foo',
+          testId: 'Foo',
         },
         raw: 'Foo',
       },
@@ -40,9 +43,28 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 'Foo',
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 'Foo',
+          testId: 'Foo',
+        },
+        raw: { title: 'Foo' },
+      },
+    ])
+  })
+
+  it('should use title as testId if testId is missing', () => {
+    const { items } = useItems({ ...defaults, items: [{ title: 'Foo' }] })
+    expect(items.value).toEqual([
+      {
+        title: 'Foo',
+        value: 'Foo',
+        testId: 'Foo',
+        props: {
+          title: 'Foo',
+          value: 'Foo',
+          testId: 'Foo',
         },
         raw: { title: 'Foo' },
       },
@@ -55,9 +77,11 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 'Foo',
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 'Foo',
+          testId: 'Foo',
         },
         raw: { text: 'Foo' },
       },
@@ -70,11 +94,30 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 1,
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 1,
+          testId: 'Foo',
         },
         raw: { title: 'Foo', id: 1 },
+      },
+    ])
+  })
+
+  it('should support custom itemTestId property', () => {
+    const { items } = useItems({ ...defaults, itemTestId: 'testSelector', items: [{ title: 'Foo', testSelector: 'foo' }] })
+    expect(items.value).toEqual([
+      {
+        title: 'Foo',
+        value: 'Foo',
+        testId: 'foo',
+        props: {
+          title: 'Foo',
+          value: 'Foo',
+          testId: 'foo',
+        },
+        raw: { title: 'Foo', testSelector: 'foo' },
       },
     ])
   })
@@ -95,17 +138,21 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 'Foo',
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 'Foo',
+          testId: 'Foo',
         },
         children: [
           {
             title: 'Bar',
             value: 'Bar',
+            testId: 'Bar',
             props: {
               title: 'Bar',
               value: 'Bar',
+              testId: 'Bar',
             },
             raw: rawItems[0].children[0],
           },
@@ -131,17 +178,21 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 'Foo',
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 'Foo',
+          testId: 'Foo',
         },
         children: [
           {
             title: 'Bar',
             value: 'Bar',
+            testId: 'Bar',
             props: {
               title: 'Bar',
               value: 'Bar',
+              testId: 'Bar',
             },
             raw: rawItems[0].labels[0],
           },
@@ -172,9 +223,11 @@ describe('items', () => {
       {
         title: 'Foo',
         value: 'Foo',
+        testId: 'Foo',
         props: {
           title: 'Foo',
           value: 'Foo',
+          testId: 'Foo',
           prop: 1,
           status: true,
         },
@@ -183,9 +236,11 @@ describe('items', () => {
       {
         title: 'Bar',
         value: 'Bar',
+        testId: 'Bar',
         props: {
           title: 'Bar',
           value: 'Bar',
+          testId: 'Bar',
           prop: 2,
           status: true,
         },

--- a/packages/vuetify/src/composables/list-items.ts
+++ b/packages/vuetify/src/composables/list-items.ts
@@ -9,10 +9,12 @@ import type { SelectItemKey } from '@/util'
 export interface ListItem<T = any> {
   title: string
   value: any
+  testId: string
   props: {
     [key: string]: any
     title: string
     value: any
+    testId: string
   }
   children?: ListItem<T>[]
   raw: T
@@ -22,6 +24,7 @@ export interface ItemProps {
   items: any[]
   itemTitle: SelectItemKey
   itemValue: SelectItemKey
+  itemTestId: SelectItemKey
   itemChildren: SelectItemKey
   itemProps: SelectItemKey
   returnObject: boolean
@@ -41,6 +44,10 @@ export const makeItemsProps = propsFactory({
     type: [String, Array, Function] as PropType<SelectItemKey>,
     default: 'value',
   },
+  itemTestId: {
+    type: [String, Array, Function] as PropType<SelectItemKey>,
+    default: 'testId',
+  },
   itemChildren: {
     type: [Boolean, String, Array, Function] as PropType<SelectItemKey>,
     default: 'children',
@@ -55,6 +62,7 @@ export const makeItemsProps = propsFactory({
 export function transformItem (props: Omit<ItemProps, 'items'>, item: any): ListItem {
   const title = getPropertyFromItem(item, props.itemTitle, item)
   const value = props.returnObject ? item : getPropertyFromItem(item, props.itemValue, title)
+  const testId = getPropertyFromItem(item, props.itemTestId, title)
   const children = getPropertyFromItem(item, props.itemChildren)
   const itemProps = props.itemProps === true
     ? typeof item === 'object' && item != null && !Array.isArray(item)
@@ -67,12 +75,14 @@ export function transformItem (props: Omit<ItemProps, 'items'>, item: any): List
   const _props = {
     title,
     value,
+    testId,
     ...itemProps,
   }
 
   return {
     title: String(_props.title ?? ''),
     value: _props.value,
+    testId: _props.testId,
     props: _props,
     children: Array.isArray(children) ? transformItems(props, children) : undefined,
     raw: item,


### PR DESCRIPTION
Test IDs are added to provide stable points in the rendered HTML which tests can rely on when creating selectors. The test will be less dependent on the exact structure of the HTML and not having to rely on CSS classes, which are primarily used for styling. I primarily thinking of tests for sites which uses Vuetify components and not necessarily testing of Vuetify itself (but it can be used for that as well).

I would normally create separate pull requests but the internal types for `VList` and `VSelect` are so tightly coupled that it would be difficult.

Ideally I would like to create a new section in the API documentation which would list a component's test IDs and a description, but I did not managed to do that. I don't understand enough about how the documentation is generated.

Related: https://github.com/vuetifyjs/vuetify/issues/7295.