### PR TITLE
fix(package): reorder default exports condition

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -54,8 +54,8 @@
     ".": {
       "sass": "./lib/styles/main.sass",
       "style": "./lib/styles/main.css",
-      "default": "./lib/framework.mjs",
-      "types": "./lib/index.d.mts"
+      "types": "./lib/index.d.mts",
+      "default": "./lib/framework.mjs"
     },
     "./styles": {
       "sass": "./lib/styles/main.sass",


### PR DESCRIPTION
Fixes #17436

Reordered the default condition inside the package.json to be the last one. Vuetify-projects that use webpack will throw an error and won't compile otherwise.

Error thrown by webpack:
`Module not found: Error: Default condition should be last one Did you mean './vuetify'?"`