### PR TITLE
fix(VTextField): messages not announced correctly by screen readers

### DIFF
--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -6154,7 +6154,7 @@ exports[`VDataTable.ts should not search column with filterable set to false and
 `;
 
 exports[`VDataTable.ts should not select item that is not selectable 1`] = `
-<div class="v-data-table v-data-table--has-bottom v-data-table--selectable theme--light v-data-table--mobile">
+<div class="v-data-table v-data-table--has-bottom theme--light v-data-table--mobile v-data-table--selectable">
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>
@@ -10846,7 +10846,7 @@ exports[`VDataTable.ts should render with showExpand 2`] = `
 `;
 
 exports[`VDataTable.ts should render with showSelect 1`] = `
-<div class="v-data-table v-data-table--has-bottom v-data-table--selectable theme--light v-data-table--mobile">
+<div class="v-data-table v-data-table--has-bottom theme--light v-data-table--mobile v-data-table--selectable">
   <div class="v-data-table__wrapper">
     <table>
       <colgroup>

--- a/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VFileInput/__tests__/__snapshots__/VFileInput.spec.ts.snap
@@ -149,6 +149,7 @@ exports[`VFileInput.ts should display total size in counter 1`] = `
         </div>
         <input id="input-23"
                type="file"
+               aria-describedby="input-23-messages"
         >
       </div>
       <div class="v-input__append-inner">
@@ -164,7 +165,9 @@ exports[`VFileInput.ts should display total size in counter 1`] = `
       </div>
     </div>
     <div class="v-text-field__details">
-      <div class="v-messages theme--light">
+      <div class="v-messages theme--light"
+           id="input-23-messages"
+      >
         <span name="message-transition"
               tag="div"
               class="v-messages__wrapper"
@@ -199,6 +202,7 @@ exports[`VFileInput.ts should display total size in counter 2`] = `
         </div>
         <input id="input-23"
                type="file"
+               aria-describedby="input-23-messages"
         >
       </div>
       <div class="v-input__append-inner">
@@ -214,7 +218,9 @@ exports[`VFileInput.ts should display total size in counter 2`] = `
       </div>
     </div>
     <div class="v-text-field__details">
-      <div class="v-messages theme--light">
+      <div class="v-messages theme--light"
+           id="input-23-messages"
+      >
         <span name="message-transition"
               tag="div"
               class="v-messages__wrapper"
@@ -339,6 +345,7 @@ exports[`VFileInput.ts should render counter 1`] = `
         </div>
         <input id="input-11"
                type="file"
+               aria-describedby="input-11-messages"
         >
       </div>
       <div class="v-input__append-inner">
@@ -354,7 +361,9 @@ exports[`VFileInput.ts should render counter 1`] = `
       </div>
     </div>
     <div class="v-text-field__details">
-      <div class="v-messages theme--light">
+      <div class="v-messages theme--light"
+           id="input-11-messages"
+      >
         <span name="message-transition"
               tag="div"
               class="v-messages__wrapper"

--- a/packages/vuetify/src/components/VInput/VInput.ts
+++ b/packages/vuetify/src/components/VInput/VInput.ts
@@ -254,6 +254,7 @@ export default baseMixins.extend<options>().extend({
         },
         attrs: {
           role: this.hasMessages ? 'alert' : null,
+          id: this.hasDetails ? this.computedId + '-messages' : null,
         },
         scopedSlots: {
           default: props => getSlot(this, 'message', props),

--- a/packages/vuetify/src/components/VInput/__tests__/__snapshots__/VInput.spec.ts.snap
+++ b/packages/vuetify/src/components/VInput/__tests__/__snapshots__/VInput.spec.ts.snap
@@ -20,7 +20,9 @@ exports[`VInput.ts should apply theme to label, counter, messages and icons 1`] 
         foo
       </label>
     </div>
-    <div class="v-messages theme--light">
+    <div class="v-messages theme--light"
+         id="input-68-messages"
+    >
       <span name="message-transition"
             tag="div"
             class="v-messages__wrapper"
@@ -66,6 +68,7 @@ exports[`VInput.ts should be in an error state 2`] = `
     </div>
     <div class="v-messages theme--light error--text"
          role="alert"
+         id="input-47-messages"
     >
       <span name="message-transition"
             tag="div"

--- a/packages/vuetify/src/components/VTextField/VTextField.ts
+++ b/packages/vuetify/src/components/VTextField/VTextField.ts
@@ -405,6 +405,7 @@ export default baseMixins.extend<options>().extend({
           placeholder: this.persistentPlaceholder || this.isFocused || !this.hasLabel ? this.placeholder : undefined,
           readonly: this.isReadonly,
           type: this.type,
+          'aria-describedby': this.hasDetails ? this.computedId + '-messages' : null,
         },
         on: Object.assign(listeners, {
           blur: this.onBlur,

--- a/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
+++ b/packages/vuetify/src/components/VTextField/__tests__/__snapshots__/VTextField.spec.ts.snap
@@ -30,6 +30,7 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
         </label>
         <input id="input-129"
                type="text"
+               aria-describedby="input-129-messages"
         >
       </div>
       <div class="v-input__append-inner">
@@ -43,7 +44,9 @@ exports[`VTextField.ts should apply theme to label, counter, messages and icons 
       </div>
     </div>
     <div class="v-text-field__details">
-      <div class="v-messages theme--light">
+      <div class="v-messages theme--light"
+           id="input-129-messages"
+      >
         <span name="message-transition"
               tag="div"
               class="v-messages__wrapper"
@@ -119,11 +122,14 @@ exports[`VTextField.ts should hide messages if no messages and hide-details is a
       <div class="v-text-field__slot">
         <input id="input-141"
                type="text"
+               aria-describedby="input-141-messages"
         >
       </div>
     </div>
     <div class="v-text-field__details">
-      <div class="v-messages theme--light">
+      <div class="v-messages theme--light"
+           id="input-141-messages"
+      >
         <span name="message-transition"
               tag="div"
               class="v-messages__wrapper"
@@ -145,11 +151,13 @@ exports[`VTextField.ts should hide messages if no messages and hide-details is a
       <div class="v-text-field__slot">
         <input id="input-141"
                type="text"
+               aria-describedby="input-141-messages"
         >
       </div>
     </div>
     <div class="v-text-field__details">
       <div class="v-messages theme--light error--text"
+           id="input-141-messages"
            role="alert"
       >
         <span name="message-transition"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Fixes #13874 by adding the `aria-describedby` property on the `input` element and an `id` on `VMessages`.
I've not added `aria-describedby` in `VInput` since it needs to be applied to the `input` element in order to be announced.

I'v tested this with NVDA on Windows.

<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div>
    <v-form>
      <v-text-field
        label="Use Screen reader"
        hint="For example, flowers or used cars"
      ></v-text-field>

      <v-text-field
        label="Use Screen reader"
        hint="sample hint message to check if screen reader reads this"
        persistent-hint
      ></v-text-field>

      <v-text-field
        :rules="[rules.required, rules.counter]"
        label="Use Screen reader"
        hint="sample hint message to check if screen reader reads this"
        persistent-hint
      ></v-text-field>
    </v-form>
  </div>
</template>

<script>
  export default {
    data: () => ({
      rules: {
        required: value => !!value || 'Required.',
        counter: value => value?.length <= 2 || 'Max 2 characters',
      },
    }),
  }
</script>
```
