### PR TITLE
fix(VBtnToggle): del margin for BtnToggle in card

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -216,8 +216,8 @@
   .v-card-actions &
     padding: $button-card-actions-padding
 
-  ~ .v-btn
-    .v-card-actions :not(.v-btn-group) &
+  ~ .v-btn:not(.v-btn-toggle .v-btn)
+    .v-card-actions &
       margin-inline-start: $button-card-actions-margin
 
 // VBanner

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -217,7 +217,7 @@
     padding: $button-card-actions-padding
 
   ~ .v-btn
-    .v-card-actions &
+    .v-card-actions :not(.v-btn-group) &
       margin-inline-start: $button-card-actions-margin
 
 // VBanner


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #17414 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-card>
        <v-card-actions>
          Rate
          <v-spacer />
          <v-btn-toggle divided variant="outlined">
            <v-btn>+</v-btn>
            <v-btn>-</v-btn>
          </v-btn-toggle>
          <v-btn>+</v-btn>
          <v-btn>-</v-btn>
        </v-card-actions>
      </v-card>
    </v-main>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
