### PR TITLE
chore: fixed height rows in percy tests for field components

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -24,7 +24,7 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
           { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -24,16 +24,15 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
-          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }
+        <div class="d-flex align-start" style="gap: 0.4rem; height: 100px;">
+          { cloneVNode(v, { variant, density }) }
+          { cloneVNode(v, { variant, density, modelValue: ['California'] }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'] }) }
           <VAutocomplete
             variant={ variant }
             density={ density }
             modelValue={['California']}
             { ...v.props }
-            class="align-self-start"
           >{{
             selection: ({ item }) => {
               return item.title

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -24,15 +24,16 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem">
-          { cloneVNode(v, { variant, density }) }
-          { cloneVNode(v, { variant, density, modelValue: ['California'] }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'] }) }
+        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }
           <VAutocomplete
             variant={ variant }
             density={ density }
             modelValue={['California']}
             { ...v.props }
+            class="align-self-start"
           >{{
             selection: ({ item }) => {
               return item.title

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -24,7 +24,7 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
           { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -24,15 +24,16 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem">
-          { cloneVNode(v, { variant, density }) }
-          { cloneVNode(v, { variant, density, modelValue: ['California'] }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'] }) }
+        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }
           <VCombobox
             variant={ variant }
             density={ density }
             modelValue={['California']}
             { ...v.props }
+            class="align-self-start"
           >{{
             selection: ({ item }) => {
               return item.title

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -24,16 +24,15 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
-          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }
+        <div class="d-flex align-start" style="gap: 0.4rem; height: 100px;">
+          { cloneVNode(v, { variant, density }) }
+          { cloneVNode(v, { variant, density, modelValue: ['California'] }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'] }) }
           <VCombobox
             variant={ variant }
             density={ density }
             modelValue={['California']}
             { ...v.props }
-            class="align-self-start"
           >{{
             selection: ({ item }) => {
               return item.title

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
@@ -26,15 +26,16 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem">
-          { cloneVNode(v, { variant, density }) }
-          { cloneVNode(v, { variant, density, modelValue: [oneMBFile, twoMBFile] }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: [oneMBFile, twoMBFile] }) }
+        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, modelValue: [oneMBFile, twoMBFile], class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: [oneMBFile, twoMBFile], class: 'align-self-start' }) }
           <VFileInput
             variant={ variant }
             density={ density }
             modelValue={[oneMBFile, twoMBFile]}
             { ...v.props }
+            class="align-self-start"
           >{{
             selection: ({ fileNames }) => {
               return fileNames.map(f => f)

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
@@ -26,16 +26,15 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
-          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, modelValue: [oneMBFile, twoMBFile], class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: [oneMBFile, twoMBFile], class: 'align-self-start' }) }
+        <div class="d-flex align-start" style="gap: 0.4rem; height: 100px;">
+          { cloneVNode(v, { variant, density }) }
+          { cloneVNode(v, { variant, density, modelValue: [oneMBFile, twoMBFile] }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: [oneMBFile, twoMBFile] }) }
           <VFileInput
             variant={ variant }
             density={ density }
             modelValue={[oneMBFile, twoMBFile]}
             { ...v.props }
-            class="align-self-start"
           >{{
             selection: ({ fileNames }) => {
               return fileNames.map(f => f)

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.cy.tsx
@@ -26,7 +26,7 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
           { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, modelValue: [oneMBFile, twoMBFile], class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, chips: true, modelValue: [oneMBFile, twoMBFile], class: 'align-self-start' }) }

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -25,7 +25,7 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
           { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -25,15 +25,16 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem">
-          { cloneVNode(v, { variant, density }) }
-          { cloneVNode(v, { variant, density, modelValue: ['California'] }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'] }) }
+        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }
           <VSelect
             variant={ variant }
             density={ density }
             modelValue={['California']}
             { ...v.props }
+            class="align-self-start"
           >{{
             selection: ({ item }) => {
               return item.title

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -25,16 +25,15 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
-          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, modelValue: ['California'], class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'], class: 'align-self-start' }) }
+        <div class="d-flex align-start" style="gap: 0.4rem; height: 100px;">
+          { cloneVNode(v, { variant, density }) }
+          { cloneVNode(v, { variant, density, modelValue: ['California'] }) }
+          { cloneVNode(v, { variant, density, chips: true, modelValue: ['California'] }) }
           <VSelect
             variant={ variant }
             density={ density }
             modelValue={['California']}
             { ...v.props }
-            class="align-self-start"
           >{{
             selection: ({ item }) => {
               return item.title

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
@@ -20,9 +20,9 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem">
-          { cloneVNode(v, { variant, density }) }
-          { cloneVNode(v, { variant, density, modelValue: 'Value' }) }
+        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
+          { cloneVNode(v, { variant, density, modelValue: 'Value', class: 'align-self-start' }) }
         </div>
       ))
     )).flat()}

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
@@ -20,9 +20,9 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
-          { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
-          { cloneVNode(v, { variant, density, modelValue: 'Value', class: 'align-self-start' }) }
+        <div class="d-flex align-start" style="gap: 0.4rem; height: 100px;">
+          { cloneVNode(v, { variant, density }) }
+          { cloneVNode(v, { variant, density, modelValue: 'Value' }) }
         </div>
       ))
     )).flat()}

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.cy.tsx
@@ -20,7 +20,7 @@ const stories = Object.fromEntries(Object.entries({
   <div class="d-flex flex-column flex-grow-1">
     { variants.map(variant => (
       densities.map(density => (
-        <div class="d-flex" style="gap: 0.4rem; height: 150px;">
+        <div class="d-flex" style="gap: 0.4rem; height: 100px;">
           { cloneVNode(v, { variant, density, class: 'align-self-start' }) }
           { cloneVNode(v, { variant, density, modelValue: 'Value', class: 'align-self-start' }) }
         </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

Problem in current percy snapshots:

Snapshot has everything and height increase from previous row push all following rows down. So only the first row makes sense but the remaining 90%ish doesn't. [demo link](https://percy.io/c458cb73/vuetify/builds/27716003/changed/1541889333?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1280&widths=375%2C1280)

## Solution:

Fixed height for each row