### PR TITLE
fix(VSelect, VCombobox): prevent input overlaps prefix

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -128,6 +128,7 @@
   padding-inline-end: var(--v-field-padding-end)
   padding-top: var(--v-field-input-padding-top)
   padding-bottom: var(--v-field-input-padding-bottom)
+  position: relative 
   width: 100%
   --v-field-input-min-height: #{$field-input-min-height}
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

<img width="390" alt="image" src="https://github.com/vuetifyjs/vuetify/assets/5698884/93f26e16-32dc-4b26-b2d8-92863c99cb7c">

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container fluid>
      <v-combobox
        label="Combobox"
        variant="outlined"
        prefix="prefix"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-autocomplete
        label="Autocomplete"
        variant="outlined"
        prefix="prefix"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-select
        label="Select"
        variant="outlined"
        prefix="prefix"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
</script>
```
