### PR TITLE
fix(VDataTableVirtual): render expanded and grouped rows correctly

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -27,9 +27,10 @@
 
       > tfoot
         > tr
+          &:not(:last-child)
             > td,
             > th
-              border-top: $table-border
+              border-bottom: $table-border
 
 
   &.v-table--hover

--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
@@ -10,7 +10,7 @@ import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeVirtualProps, useVirtual } from '@/composables/virtual'
 
 // Utilities
-import { ref, toRef } from 'vue'
+import { toRef } from 'vue'
 import {
   convertToUnit,
   genericComponent,
@@ -59,7 +59,7 @@ export const VVirtualScroll = genericComponent<new <T>(
       paddingTop,
       paddingBottom,
       virtualItems,
-    } = useVirtual(props, toRef(props, 'items'), ref(0), false)
+    } = useVirtual(props, toRef(props, 'items'))
 
     useRender(() => (
       <div
@@ -83,8 +83,8 @@ export const VVirtualScroll = genericComponent<new <T>(
         >
           { virtualItems.value.map((item, index) => (
             <VVirtualScrollItem
-              key={ index }
-              id={ index }
+              key={ item.key }
+              virtualKey={ item.key }
               dynamicHeight={ !props.itemHeight }
             >
               { slots.default?.({ item, index }) }

--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
@@ -10,7 +10,7 @@ import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeVirtualProps, useVirtual } from '@/composables/virtual'
 
 // Utilities
-import { toRef } from 'vue'
+import { ref, toRef } from 'vue'
 import {
   convertToUnit,
   genericComponent,
@@ -55,12 +55,11 @@ export const VVirtualScroll = genericComponent<new <T>(
     const {
       containerRef,
       handleScroll,
-      handleItemResize,
       scrollToIndex,
       paddingTop,
       paddingBottom,
-      computedItems,
-    } = useVirtual(props, toRef(props, 'items'))
+      virtualItems,
+    } = useVirtual(props, toRef(props, 'items'), ref(0), false)
 
     useRender(() => (
       <div
@@ -82,13 +81,13 @@ export const VVirtualScroll = genericComponent<new <T>(
             paddingBottom: convertToUnit(paddingBottom.value),
           }}
         >
-          { computedItems.value.map(item => (
+          { virtualItems.value.map((item, index) => (
             <VVirtualScrollItem
-              key={ item.index }
+              key={ index }
+              id={ index }
               dynamicHeight={ !props.itemHeight }
-              onUpdate:height={ height => handleItemResize(item.index, height) }
             >
-              { slots.default?.({ item: item.raw, index: item.index }) }
+              { slots.default?.({ item, index }) }
             </VVirtualScrollItem>
           ))}
         </div>

--- a/packages/vuetify/src/composables/resizeObserver.ts
+++ b/packages/vuetify/src/composables/resizeObserver.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { onBeforeUnmount, readonly, ref, watch } from 'vue'
+import { ComponentPublicInstance, onBeforeUnmount, readonly, ref, watch } from 'vue'
 import { refElement } from '@/util'
 import { IN_BROWSER } from '@/util/globals'
 
@@ -7,7 +7,7 @@ import { IN_BROWSER } from '@/util/globals'
 import type { DeepReadonly, Ref } from 'vue'
 
 interface ResizeState {
-  resizeRef: Ref<HTMLElement | undefined>
+  resizeRef: Ref<HTMLElement | ComponentPublicInstance | undefined>
   contentRect: DeepReadonly<Ref<DOMRectReadOnly | undefined>>
 }
 

--- a/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
@@ -8,7 +8,7 @@ import { makeVDataTableRowsProps, VDataTableRows } from './VDataTableRows'
 import { makeVTableProps, VTable } from '@/components/VTable/VTable'
 
 // Composables
-import { makeDataTableExpandProps, provideExpanded } from './composables/expand'
+import { Expanded, makeDataTableExpandProps, provideExpanded, useExpandedItems } from './composables/expand'
 import { createGroupBy, makeDataTableGroupProps, provideGroupBy, useGroupedItems } from './composables/group'
 import { createHeaders, makeDataTableHeaderProps } from './composables/headers'
 import { makeDataTableItemsProps, useDataTableItems } from './composables/items'
@@ -48,7 +48,7 @@ export type VDataTableSlotProps = {
   isGroupOpen: ReturnType<typeof provideGroupBy>['isGroupOpen']
   toggleGroup: ReturnType<typeof provideGroupBy>['toggleGroup']
   items: readonly DataTableItem[]
-  groupedItems: readonly (DataTableItem | Group<DataTableItem>)[]
+  groupedItems: readonly (DataTableItem | Group<DataTableItem> | Expanded<DataTableItem>)[]
   columns: InternalDataTableHeader[]
   headers: InternalDataTableHeader[][]
 }
@@ -140,7 +140,8 @@ export const VDataTable = genericComponent<VDataTableSlots>()({
       allSelected,
     } = provideSelection(props, { allItems: items, currentPage: paginatedItemsWithoutGroups })
 
-    const { isExpanded, toggleExpand } = provideExpanded(props)
+    const { expanded, isExpanded, toggleExpand } = provideExpanded(props)
+    const { expandedItems } = useExpandedItems(paginatedItemsWithoutGroups, expanded)
 
     useOptions({
       page,
@@ -217,7 +218,7 @@ export const VDataTable = genericComponent<VDataTableSlots>()({
                   { slots.body ? slots.body(slotProps.value) : (
                     <VDataTableRows
                       { ...dataTableRowsProps }
-                      items={ paginatedItems.value }
+                      items={ expandedItems.value }
                       v-slots={ slots }
                     />
                   )}

--- a/packages/vuetify/src/labs/VDataTable/VDataTableGroupHeaderRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableGroupHeaderRow.tsx
@@ -17,8 +17,8 @@ import type { PropType } from 'vue'
 import type { Group } from './composables/group'
 
 export type VDataTableGroupHeaderRowSlots = {
-  'data-table-group': { item: Group, count: number, props: Record<string, unknown> }
-  'data-table-select': { props: Record<string, unknown> }
+  'group.data-table-group': { item: Group, count: number, props: Record<string, unknown> }
+  'group.data-table-select': { props: Record<string, unknown> }
 }
 
 export const makeVDataTableGroupHeaderRowProps = propsFactory({
@@ -54,7 +54,7 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
             const icon = isGroupOpen(props.item) ? '$expand' : '$next'
             const onClick = () => toggleGroup(props.item)
 
-            return slots['data-table-group']?.({ item: props.item, count: rows.value.length, props: { icon, onClick } }) ?? (
+            return slots['group.data-table-group']?.({ item: props.item, count: rows.value.length, props: { icon, onClick } }) ?? (
               <VDataTableColumn class="v-data-table-group-header-row__column">
                 <VBtn
                   size="small"
@@ -72,7 +72,7 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
             const modelValue = isSelected(rows.value)
             const indeterminate = isSomeSelected(rows.value) && !modelValue
             const selectGroup = (v: boolean) => select(rows.value, v)
-            return slots['data-table-select']?.({ props: { modelValue, indeterminate, 'onUpdate:modelValue': selectGroup } }) ?? (
+            return slots['group.data-table-select']?.({ props: { modelValue, indeterminate, 'onUpdate:modelValue': selectGroup } }) ?? (
               <td>
                 <VCheckboxBtn
                   modelValue={ modelValue }

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
@@ -1,100 +1,134 @@
 // Components
 import { VBtn } from '@/components/VBtn'
 import { VCheckboxBtn } from '@/components/VCheckbox'
+import { VDataTableColumn } from './VDataTableColumn'
 
 // Composables
 import { useExpanded } from './composables/expand'
 import { useHeaders } from './composables/headers'
 import { useSelection } from './composables/select'
-import { VDataTableColumn } from './VDataTableColumn'
+import { useGroupBy } from './composables/group'
 
 // Utilities
-import { withModifiers } from 'vue'
-import { defineComponent, getPropertyFromItem, propsFactory, useRender } from '@/util'
+import { computed, withModifiers } from 'vue'
+import { genericComponent, getPropertyFromItem, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
-import type { DataTableItem } from './types'
+import type { DataTableItem, InternalDataTableHeader } from './types'
+
+export type VDataTableRowItemColumnSlot = {
+  index: number
+  item: DataTableItem
+  columns: InternalDataTableHeader[]
+  isExpanded: ReturnType<typeof useExpanded>['isExpanded']
+  toggleExpand: ReturnType<typeof useExpanded>['toggleExpand']
+  isSelected: ReturnType<typeof useSelection>['isSelected']
+  toggleSelect: ReturnType<typeof useSelection>['toggleSelect']
+  toggleGroup: ReturnType<typeof useGroupBy>['toggleGroup']
+  isGroupOpen: ReturnType<typeof useGroupBy>['toggleGroup']
+}
+
+export type VDataTableRowSlots = {
+  'item.data-table-select': VDataTableRowItemColumnSlot
+  'item.data-table-expand': VDataTableRowItemColumnSlot
+} & { [key: `item.${string}`]: VDataTableRowItemColumnSlot }
 
 export const makeVDataTableRowProps = propsFactory({
-  index: Number as PropType<Number>,
-  item: Object as PropType<DataTableItem>,
-  onClick: Function as PropType<(e: MouseEvent) => void>,
+  item: {
+    type: Object as PropType<DataTableItem>,
+    required: true,
+  },
+  onClick: Function as PropType<(e: Event, value: { item: DataTableItem }) => void>,
 }, 'VDataTableRow')
 
-export const VDataTableRow = defineComponent({
+export const VDataTableRow = genericComponent<VDataTableRowSlots>()({
   name: 'VDataTableRow',
 
   props: makeVDataTableRowProps(),
 
   setup (props, { slots }) {
     const { isSelected, toggleSelect } = useSelection()
-    const { isExpanded, toggleExpand } = useExpanded()
+    const { expandOnClick, isExpanded, toggleExpand } = useExpanded()
+    const { isGroupOpen, toggleGroup } = useGroupBy()
     const { columns } = useHeaders()
 
-    useRender(() => (
-      <tr
-        class={[
-          'v-data-table__tr',
-          {
-            'v-data-table__tr--clickable': !!props.onClick,
-          },
-        ]}
-        onClick={ props.onClick }
-      >
-        { props.item && columns.value.map((column, i) => (
-          <VDataTableColumn
-            align={ column.align }
-            fixed={ column.fixed }
-            fixedOffset={ column.fixedOffset }
-            lastFixed={ column.lastFixed }
-            noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
-            width={ column.width }
-          >
-            {{
-              default: () => {
-                const item = props.item!
-                const slotName = `item.${column.key}`
-                const slotProps = {
-                  index: props.index,
-                  item: props.item,
-                  columns: columns.value,
-                  isSelected,
-                  toggleSelect,
-                  isExpanded,
-                  toggleExpand,
-                }
+    const slotProps = computed(() => ({
+      index: props.item.index,
+      item: props.item,
+      columns: columns.value,
+      isExpanded,
+      toggleExpand,
+      isSelected,
+      toggleSelect,
+      isGroupOpen,
+      toggleGroup,
+      props: {
+        onClick: expandOnClick.value || props.onClick ? (event: MouseEvent) => {
+          if (expandOnClick.value) {
+            toggleExpand(props.item)
+          }
 
-                if (slots[slotName]) return slots[slotName]!(slotProps)
+          props.onClick?.(event, { item: props.item })
+        } : undefined
+      }
+    }))
 
-                if (column.key === 'data-table-select') {
-                  return slots['item.data-table-select']?.(slotProps) ?? (
-                    <VCheckboxBtn
-                      disabled={ !item.selectable }
-                      modelValue={ isSelected([item]) }
-                      onClick={ withModifiers(() => toggleSelect(item), ['stop']) }
-                    />
-                  )
-                }
+    useRender(() => {
+      return (
+        <tr
+          class={[
+            'v-data-table__tr',
+            {
+              'v-data-table__tr--clickable': !!props.onClick,
+            },
+          ]}
+          { ...slotProps.value.props }
+        >
+          { props.item && columns.value.map((column, i) => (
+            <VDataTableColumn
+              align={ column.align }
+              fixed={ column.fixed }
+              fixedOffset={ column.fixedOffset }
+              lastFixed={ column.lastFixed }
+              noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
+              width={ column.width }
+            >
+              {{
+                default: () => {
+                  const slotName = `item.${column.key}` as const
 
-                if (column.key === 'data-table-expand') {
-                  return slots['item.data-table-expand']?.(slotProps) ?? (
-                    <VBtn
-                      icon={ isExpanded(item) ? '$collapse' : '$expand' }
-                      size="small"
-                      variant="text"
-                      onClick={ withModifiers(() => toggleExpand(item), ['stop']) }
-                    />
-                  )
-                }
+                  if (slots[slotName]) return slots[slotName]!(slotProps.value)
 
-                return getPropertyFromItem(item.columns, column.key)
-              },
-            }}
-          </VDataTableColumn>
-        ))}
-      </tr>
-    ))
+                  if (column.key === 'data-table-select') {
+                    return slots['item.data-table-select']?.(slotProps.value) ?? (
+                      <VCheckboxBtn
+                        disabled={ !props.item.selectable }
+                        modelValue={ isSelected([props.item]) }
+                        onClick={ withModifiers(() => toggleSelect(props.item), ['stop']) }
+                      />
+                    )
+                  }
+
+                  if (column.key === 'data-table-expand') {
+                    return slots['item.data-table-expand']?.(slotProps.value) ?? (
+                      <VBtn
+                        icon={ isExpanded(props.item) ? '$collapse' : '$expand' }
+                        size="small"
+                        variant="text"
+                        onClick={ withModifiers(() => toggleExpand(props.item), ['stop']) }
+                      />
+                    )
+                  }
+
+                  return getPropertyFromItem(props.item.columns, column.key)
+                },
+              }}
+            </VDataTableColumn>
+          ))}
+        </tr>
+      )
+    })
   },
 })
 

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -10,7 +10,7 @@ import { useSelection } from './composables/select'
 import { useLocale } from '@/composables/locale'
 
 // Utilities
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { GenericProps, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -44,7 +44,7 @@ export const makeVDataTableRowsProps = propsFactory({
   },
   hideNoData: Boolean,
   items: {
-    type: Array as PropType<readonly (DataTableItem | Group | Expanded)[]>,
+    type: Array as PropType<readonly any[]>,
     default: () => ([]),
   },
   noDataText: {
@@ -56,7 +56,19 @@ export const makeVDataTableRowsProps = propsFactory({
   virtual: Boolean,
 }, 'VDataTableRows')
 
-export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
+type Keyed<T> = { key: number | string, item: T }
+
+export const VDataTableRows = genericComponent<new <
+  T extends DataTableItem | Group<DataTableItem> | Expanded<DataTableItem>,
+  Virtual extends boolean = false,
+  Item = Virtual extends true ? Keyed<T> : T,
+>(
+props: {
+  items?: Item[]
+  virtual?: Virtual
+},
+slots: VDataTableRowsSlots
+) => GenericProps<typeof props, typeof slots>>()({
   name: 'VDataTableRows',
 
   props: makeVDataTableRowsProps(),
@@ -140,12 +152,11 @@ export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
             if (props.virtual) {
               return (
                 <VVirtualScrollItem
-                  key={ item.key }
-                  id={ item.key }
+                  virtualKey={ item.key }
                   dynamicHeight
                   renderless
                 >
-                  { slotProps => makeRow(item, slotProps) }
+                  { slotProps => makeRow(item.item, slotProps) }
                 </VVirtualScrollItem>
               )
             }

--- a/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
@@ -92,7 +92,7 @@ export const VDataTableVirtual = genericComponent<VDataTableVirtualSlots>()({
       paddingBottom,
       virtualItems,
       handleScroll,
-    } = useVirtual(props, expandedItems, headerHeight, true)
+    } = useVirtual(props, expandedItems, headerHeight, item => item.key)
 
     useOptions({
       sortBy,
@@ -173,8 +173,8 @@ export const VDataTableVirtual = genericComponent<VDataTableVirtualSlots>()({
 
                     <VDataTableRows
                       { ...dataTableRowsProps }
-                      items={ virtualItems.value }
                       virtual
+                      items={ virtualItems.value }
                       v-slots={ slots }
                     ></VDataTableRows>
 

--- a/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableVirtual.tsx
@@ -1,22 +1,20 @@
 // Components
 import { makeDataTableProps } from './VDataTable'
 import { VDataTableHeaders } from './VDataTableHeaders'
-import { VDataTableRow } from './VDataTableRow'
 import { VDataTableRows } from './VDataTableRows'
 import { VTable } from '@/components/VTable'
-import { VVirtualScrollItem } from '@/components/VVirtualScroll/VVirtualScrollItem'
 
 // Composables
-import { provideExpanded } from './composables/expand'
 import { createGroupBy, makeDataTableGroupProps, provideGroupBy, useGroupedItems } from './composables/group'
+import { provideExpanded, useExpandedItems } from './composables/expand'
+import { provideSelection } from './composables/select'
+import { makeVirtualProps, useVirtual } from '@/composables/virtual'
 import { createHeaders } from './composables/headers'
 import { useDataTableItems } from './composables/items'
 import { useOptions } from './composables/options'
-import { provideSelection } from './composables/select'
 import { createSort, provideSort, useSortedItems } from './composables/sort'
 import { provideDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
-import { makeVirtualProps, useVirtual } from '@/composables/virtual'
 
 // Utilities
 import { computed, shallowRef, toRef } from 'vue'
@@ -83,7 +81,8 @@ export const VDataTableVirtual = genericComponent<VDataTableVirtualSlots>()({
       allItems,
       currentPage: allItems,
     })
-    const { isExpanded, toggleExpand } = provideExpanded(props)
+    const { isExpanded, toggleExpand, expanded } = provideExpanded(props)
+    const { expandedItems } = useExpandedItems(flatItems, expanded)
 
     const headerHeight = computed(() => headers.value.length * 56)
 
@@ -91,11 +90,9 @@ export const VDataTableVirtual = genericComponent<VDataTableVirtualSlots>()({
       containerRef,
       paddingTop,
       paddingBottom,
-      computedItems,
-      handleItemResize,
+      virtualItems,
       handleScroll,
-    } = useVirtual(props, flatItems, headerHeight)
-    const displayItems = computed(() => computedItems.value.map(item => item.raw))
+    } = useVirtual(props, expandedItems, headerHeight, true)
 
     useOptions({
       sortBy,
@@ -176,31 +173,10 @@ export const VDataTableVirtual = genericComponent<VDataTableVirtualSlots>()({
 
                     <VDataTableRows
                       { ...dataTableRowsProps }
-                      items={ displayItems.value }
-                    >
-                      {{
-                        ...slots,
-                        item: itemSlotProps => {
-                          return slots.item?.(itemSlotProps) ?? (
-                            <VVirtualScrollItem
-                              key={ itemSlotProps.item.index }
-                              dynamicHeight
-                              renderless
-                              onUpdate:height={ height => handleItemResize(itemSlotProps.item.index, height) }
-                            >
-                              { slotProps => (
-                                <VDataTableRow
-                                  { ...itemSlotProps.props }
-                                  { ...slotProps?.props }
-                                  key={ itemSlotProps.item.index }
-                                  v-slots={ slots }
-                                />
-                              )}
-                            </VVirtualScrollItem>
-                          )
-                        },
-                      }}
-                    </VDataTableRows>
+                      items={ virtualItems.value }
+                      virtual
+                      v-slots={ slots }
+                    ></VDataTableRows>
 
                     <tr style={{ height: convertToUnit(paddingBottom.value), border: 0 }}>
                       <td colspan={ columns.value.length } style={{ height: convertToUnit(paddingBottom.value), border: 0 }}></td>

--- a/packages/vuetify/src/labs/VDataTable/composables/items.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/items.ts
@@ -47,6 +47,7 @@ export function transformItem (
   return {
     type: 'item',
     index,
+    key: `item-${index}`,
     value,
     selectable,
     columns: itemColumns,

--- a/packages/vuetify/src/labs/VDataTable/types.ts
+++ b/packages/vuetify/src/labs/VDataTable/types.ts
@@ -32,6 +32,7 @@ export type InternalDataTableHeader = DataTableHeader & {
 
 export interface DataTableItem<T = any> extends GroupableItem<T>, SelectableItem {
   index: number
+  key: string
   columns: {
     [key: string]: any
   }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Change how expanded rows work so that they also can use virtual scroll item.

## TODO

This can probably be cleaned up a bit. Not super happy about the `hasKey` thing in virtual composable.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<v-data-table-virtual
    :headers="headers"
    :items="virtualDesserts"
    class="elevation-1"
    height="500"
    show-expand
    :group-by="[{ key: 'name', order: 'asc'}]"
  >
    <template #expanded-row="{ props }">
      <tr v-bind="props">
        <td colspan="7">
          <div>-> expanded</div>
        </td>
      </tr>
    </template>
    <template #item="{ item, props }">
      <tr v-bind="props">
        <td>FOOO</td>
      </tr>
    </template>
  </v-data-table-virtual>
```
