### PR TITLE
fix(VCombobox): prevent menu opening when readonly

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -163,9 +163,13 @@ export const VAutocomplete = genericComponent<new <
         !isPristine.value &&
         !listHasFocus.value
     })
-    const listRef = ref<VList>()
 
-    const shouldSkipMenuToggle = computed(() => (props.hideNoData && !items.value.length) || props.readonly || form?.isReadonly.value)
+    const menuDisabled = computed(() => (
+      (props.hideNoData && !items.value.length) ||
+      props.readonly || form?.isReadonly.value
+    ))
+
+    const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
       if (props.openOnClear) {
@@ -175,12 +179,12 @@ export const VAutocomplete = genericComponent<new <
       search.value = ''
     }
     function onMousedownControl () {
-      if (shouldSkipMenuToggle.value) return
+      if (menuDisabled.value) return
 
       menu.value = true
     }
     function onMousedownMenuIcon (e: MouseEvent) {
-      if (shouldSkipMenuToggle.value) return
+      if (menuDisabled.value) return
 
       if (isFocused.value) {
         e.preventDefault()

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -165,6 +165,8 @@ export const VAutocomplete = genericComponent<new <
     })
     const listRef = ref<VList>()
 
+    const shouldSkipMenuToggle = computed(() => (props.hideNoData && !items.value.length) || props.readonly || form?.isReadonly.value)
+
     function onClear (e: MouseEvent) {
       if (props.openOnClear) {
         menu.value = true
@@ -173,14 +175,13 @@ export const VAutocomplete = genericComponent<new <
       search.value = ''
     }
     function onMousedownControl () {
-      if (
-        (props.hideNoData && !items.value.length) ||
-        props.readonly || form?.isReadonly.value
-      ) return
+      if (shouldSkipMenuToggle.value) return
 
       menu.value = true
     }
     function onMousedownMenuIcon (e: MouseEvent) {
+      if (shouldSkipMenuToggle.value) return
+
       if (isFocused.value) {
         e.preventDefault()
         e.stopPropagation()

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -209,9 +209,13 @@ export const VCombobox = genericComponent<new <
         !isPristine.value &&
         !listHasFocus.value
     })
-    const listRef = ref<VList>()
 
-    const shouldSkipMenuToggle = computed(() => (props.hideNoData && !items.value.length) || props.readonly || form?.isReadonly.value)
+    const menuDisabled = computed(() => (
+      (props.hideNoData && !items.value.length) ||
+      props.readonly || form?.isReadonly.value
+    ))
+
+    const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
       cleared = true
@@ -221,12 +225,12 @@ export const VCombobox = genericComponent<new <
       }
     }
     function onMousedownControl () {
-      if (shouldSkipMenuToggle.value) return
+      if (menuDisabled.value) return
 
       menu.value = true
     }
     function onMousedownMenuIcon (e: MouseEvent) {
-      if (shouldSkipMenuToggle.value) return
+      if (menuDisabled.value) return
 
       if (isFocused.value) {
         e.preventDefault()

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -211,6 +211,8 @@ export const VCombobox = genericComponent<new <
     })
     const listRef = ref<VList>()
 
+    const shouldSkipMenuToggle = computed(() => (props.hideNoData && !items.value.length) || props.readonly || form?.isReadonly.value)
+
     function onClear (e: MouseEvent) {
       cleared = true
 
@@ -219,14 +221,13 @@ export const VCombobox = genericComponent<new <
       }
     }
     function onMousedownControl () {
-      if (
-        (props.hideNoData && !items.value.length) ||
-        props.readonly || form?.isReadonly.value
-      ) return
+      if (shouldSkipMenuToggle.value) return
 
       menu.value = true
     }
     function onMousedownMenuIcon (e: MouseEvent) {
+      if (shouldSkipMenuToggle.value) return
+
       if (isFocused.value) {
         e.preventDefault()
         e.stopPropagation()

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -154,6 +154,11 @@ export const VSelect = genericComponent<new <
       return items.value
     })
 
+    const menuDisabled = computed(() => (
+      (props.hideNoData && !items.value.length) ||
+      props.readonly || form?.isReadonly.value
+    ))
+
     const listRef = ref<VList>()
 
     function onClear (e: MouseEvent) {
@@ -162,10 +167,7 @@ export const VSelect = genericComponent<new <
       }
     }
     function onMousedownControl () {
-      if (
-        (props.hideNoData && !items.value.length) ||
-        props.readonly || form?.isReadonly.value
-      ) return
+      if (menuDisabled.value) return
 
       menu.value = !menu.value
     }


### PR DESCRIPTION

fixes #17526

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row>
    <v-col>
      <v-autocomplete
        :items="items"
        density="compact"
        hide-details
        readonly
        variant="solo-filled"
      />
      <v-combobox
        :items="items"
        density="compact"
        hide-details
        readonly
        variant="solo-filled"
      />
    </v-col>
  </v-row>
</template>
<script>
  export default {
    data: () => ({
      items: ['foo', 'bar', 'fizz', 'buzz'],
    }),
  }
</script>
```
