### PR TITLE
fix(VOverlay): allow click outside even if content is not on top

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -415,6 +415,7 @@ export const VAutocomplete = genericComponent<new <
                   closeOnContentClick={ false }
                   transition={ props.transition }
                   onAfterLeave={ onAfterLeave }
+                  onClick:outside={ () => { isFocused.value = false } }
                   { ...props.menuProps }
                 >
                   { hasList && (

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -23,7 +23,7 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -178,12 +178,12 @@ export const VAutocomplete = genericComponent<new <
 
       search.value = ''
     }
-    function onClickControl () {
+    function onMousedownControl () {
       if (menuDisabled.value) return
 
       menu.value = true
     }
-    function onClickMenuIcon (e: MouseEvent) {
+    function onMousedownMenuIcon (e: MouseEvent) {
       if (menuDisabled.value) return
 
       if (isFocused.value) {
@@ -396,7 +396,7 @@ export const VAutocomplete = genericComponent<new <
           readonly={ props.readonly }
           placeholder={ isDirty ? undefined : props.placeholder }
           onClick:clear={ onClear }
-          onClick:control={ onClickControl }
+          onMousedown:control={ onMousedownControl }
           onKeydown={ onKeydown }
         >
           {{
@@ -555,7 +555,8 @@ export const VAutocomplete = genericComponent<new <
                   <VIcon
                     class="v-autocomplete__menu-icon"
                     icon={ props.menuIcon }
-                    onClick={ onClickMenuIcon }
+                    onMousedown={ onMousedownMenuIcon }
+                    onClick={ noop }
                   />
                 ) : undefined }
               </>

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -23,7 +23,7 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -178,12 +178,12 @@ export const VAutocomplete = genericComponent<new <
 
       search.value = ''
     }
-    function onMousedownControl () {
+    function onClickControl () {
       if (menuDisabled.value) return
 
       menu.value = true
     }
-    function onMousedownMenuIcon (e: MouseEvent) {
+    function onClickMenuIcon (e: MouseEvent) {
       if (menuDisabled.value) return
 
       if (isFocused.value) {
@@ -396,7 +396,7 @@ export const VAutocomplete = genericComponent<new <
           readonly={ props.readonly }
           placeholder={ isDirty ? undefined : props.placeholder }
           onClick:clear={ onClear }
-          onMousedown:control={ onMousedownControl }
+          onClick:control={ onClickControl }
           onKeydown={ onKeydown }
         >
           {{
@@ -554,8 +554,7 @@ export const VAutocomplete = genericComponent<new <
                   <VIcon
                     class="v-autocomplete__menu-icon"
                     icon={ props.menuIcon }
-                    onMousedown={ onMousedownMenuIcon }
-                    onClick={ noop }
+                    onClick={ onClickMenuIcon }
                   />
                 ) : undefined }
               </>

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -24,7 +24,7 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -224,12 +224,12 @@ export const VCombobox = genericComponent<new <
         menu.value = true
       }
     }
-    function onClickControl () {
+    function onMousedownControl () {
       if (menuDisabled.value) return
 
       menu.value = true
     }
-    function onClickMenuIcon (e: MouseEvent) {
+    function onMousedownMenuIcon (e: MouseEvent) {
       if (menuDisabled.value) return
 
       if (isFocused.value) {
@@ -428,7 +428,7 @@ export const VCombobox = genericComponent<new <
           readonly={ props.readonly }
           placeholder={ isDirty ? undefined : props.placeholder }
           onClick:clear={ onClear }
-          onClick:control={ onClickControl }
+          onMousedown:control={ onMousedownControl }
           onKeydown={ onKeydown }
         >
           {{
@@ -587,7 +587,8 @@ export const VCombobox = genericComponent<new <
                   <VIcon
                     class="v-combobox__menu-icon"
                     icon={ props.menuIcon }
-                    onClick={ onClickMenuIcon }
+                    onMousedown={ onMousedownMenuIcon }
+                    onClick={ noop }
                   />
                 ) : undefined }
               </>

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -24,7 +24,7 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -224,12 +224,12 @@ export const VCombobox = genericComponent<new <
         menu.value = true
       }
     }
-    function onMousedownControl () {
+    function onClickControl () {
       if (menuDisabled.value) return
 
       menu.value = true
     }
-    function onMousedownMenuIcon (e: MouseEvent) {
+    function onClickMenuIcon (e: MouseEvent) {
       if (menuDisabled.value) return
 
       if (isFocused.value) {
@@ -428,7 +428,7 @@ export const VCombobox = genericComponent<new <
           readonly={ props.readonly }
           placeholder={ isDirty ? undefined : props.placeholder }
           onClick:clear={ onClear }
-          onMousedown:control={ onMousedownControl }
+          onClick:control={ onClickControl }
           onKeydown={ onKeydown }
         >
           {{
@@ -447,6 +447,7 @@ export const VCombobox = genericComponent<new <
                   closeOnContentClick={ false }
                   transition={ props.transition }
                   onAfterLeave={ onAfterLeave }
+                  onClick:outside={ () => { isFocused.value = false } }
                   { ...props.menuProps }
                 >
                   { hasList && (
@@ -586,8 +587,7 @@ export const VCombobox = genericComponent<new <
                   <VIcon
                     class="v-combobox__menu-icon"
                     icon={ props.menuIcon }
-                    onMousedown={ onMousedownMenuIcon }
-                    onClick={ noop }
+                    onClick={ onClickMenuIcon }
                   />
                 ) : undefined }
               </>

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -43,10 +43,11 @@ export const VMenu = genericComponent<OverlaySlots>()({
   props: makeVMenuProps(),
 
   emits: {
+    'click:outside': (e: MouseEvent) => true,
     'update:modelValue': (value: boolean) => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { slots, emit }) {
     const isActive = useProxiedModel(props, 'modelValue')
     const { scopeId } = useScopeId()
 
@@ -78,7 +79,8 @@ export const VMenu = genericComponent<OverlaySlots>()({
       val ? parent?.register() : parent?.unregister()
     })
 
-    function onClickOutside () {
+    function onClickOutside (e: MouseEvent) {
+      emit('click:outside', e)
       parent?.closeParents()
     }
 

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -177,7 +177,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional () {
-      return isActive.value || globalTop.value
+      return isActive.value && globalTop.value
     }
 
     IN_BROWSER && watch(isActive, val => {

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -177,7 +177,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional () {
-      return isActive.value && globalTop.value
+      return isActive.value || globalTop.value
     }
 
     IN_BROWSER && watch(isActive, val => {

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -287,7 +287,11 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                   <div
                     ref={ contentEl }
                     v-show={ isActive.value }
-                    v-click-outside={{ handler: onClickOutside, closeConditional, include: () => [activatorEl.value] }}
+                    v-click-outside={{ 
+                      handler: onClickOutside, 
+                      closeConditional,
+                      closeByMousedown: true,
+                      include: () => [activatorEl.value] }}
                     class={[
                       'v-overlay__content',
                       props.contentClass,

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -166,7 +166,7 @@ export const VSelect = genericComponent<new <
         menu.value = true
       }
     }
-    function onMousedownControl () {
+    function onClickControl () {
       if (menuDisabled.value) return
 
       menu.value = !menu.value
@@ -291,8 +291,8 @@ export const VSelect = genericComponent<new <
           readonly
           placeholder={ placeholder }
           onClick:clear={ onClear }
+          onClick:control={ onClickControl }
           onBlur={ onBlur }
-          onMousedown:control={ onMousedownControl }
           onKeydown={ onKeydown }
         >
           {{

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -236,6 +236,11 @@ export const VSelect = genericComponent<new <
         menu.value = false
       }
     }
+    function onBlur (e: FocusEvent) {
+      if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
+        menu.value = false
+      }
+    }
     function onAfterLeave () {
       if (isFocused.value) {
         vTextFieldRef.value?.focus()
@@ -286,6 +291,7 @@ export const VSelect = genericComponent<new <
           readonly
           placeholder={ placeholder }
           onClick:clear={ onClear }
+          onBlur={ onBlur }
           onMousedown:control={ onMousedownControl }
           onKeydown={ onKeydown }
         >
@@ -305,6 +311,7 @@ export const VSelect = genericComponent<new <
                   closeOnContentClick={ false }
                   transition={ props.transition }
                   onAfterLeave={ onAfterLeave }
+                  onClick:outside={ () => { isFocused.value = false } }
                   { ...props.menuProps }
                 >
                   { hasList && (

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -236,11 +236,6 @@ export const VSelect = genericComponent<new <
         menu.value = false
       }
     }
-    function onBlur (e: FocusEvent) {
-      if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
-        menu.value = false
-      }
-    }
     function onAfterLeave () {
       if (isFocused.value) {
         vTextFieldRef.value?.focus()
@@ -292,7 +287,6 @@ export const VSelect = genericComponent<new <
           placeholder={ placeholder }
           onClick:clear={ onClear }
           onMousedown:control={ onMousedownControl }
-          onBlur={ onBlur }
           onKeydown={ onKeydown }
         >
           {{

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -166,7 +166,7 @@ export const VSelect = genericComponent<new <
         menu.value = true
       }
     }
-    function onClickControl () {
+    function onMousedownControl () {
       if (menuDisabled.value) return
 
       menu.value = !menu.value
@@ -291,7 +291,7 @@ export const VSelect = genericComponent<new <
           readonly
           placeholder={ placeholder }
           onClick:clear={ onClear }
-          onClick:control={ onClickControl }
+          onMousedown:control={ onMousedownControl }
           onBlur={ onBlur }
           onKeydown={ onKeydown }
         >

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -1,9 +1,13 @@
 /// <reference types="../../../../types/cypress" />
 
 // Components
+import { VAutocomplete } from '@/components/VAutocomplete/VAutocomplete'
+import { VCombobox } from '@/components/VCombobox/VCombobox'
+import { VCol } from '@/components/VGrid/VCol'
 import { VSelect } from '../VSelect'
 import { VForm } from '@/components/VForm'
 import { VListItem } from '@/components/VList'
+import { VRow } from '@/components/VGrid/VRow'
 
 // Utilities
 import { cloneVNode, ref } from 'vue'
@@ -434,6 +438,61 @@ describe('VSelect', () => {
       .should('have.class', 'v-select--active-menu')
       .trigger('keydown', { key: keyValues.esc })
       .should('not.have.class', 'v-select--active-menu')
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/17488
+  it('should close its open menu when the menu of another select component is opened via a click', () => {
+    cy
+      .mount(() => (
+        <VRow>
+          <VCol>
+            <VSelect
+              items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+            />
+          </VCol>
+          <VCol>
+            <VAutocomplete
+              items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+            />
+          </VCol>
+          <VCol>
+            <VCombobox
+              items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+            />
+          </VCol>
+        </VRow> 
+      ))
+      cy.get('.v-select')
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .click()
+        .get('.v-overlay__content.v-select__content')
+        .should('exist')
+
+      cy.get('.v-autocomplete')
+        .click()
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .get('.v-overlay__content.v-select__content')
+        .should('not.exist')
+        .get('.v-overlay__content.v-autocomplete__content')
+        .should('exist')
+
+      cy.get('.v-combobox')
+        .click()
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .get('.v-overlay__content.v-autocomplete__content')
+        .should('not.exist')
+        .get('.v-overlay__content.v-combobox__content')
+        .should('exist')
+  
+      cy.get('.v-select')
+        .click()
+        .get('.v-overlay__content.v-combobox__content')
+        .should('not.exist')
+        .get('.v-overlay__content.v-select__content')
+        .should('exist')
   })
 
   describe('Showcase', () => {

--- a/packages/vuetify/src/composables/stack.ts
+++ b/packages/vuetify/src/composables/stack.ts
@@ -2,7 +2,7 @@
 import { useToggleScope } from '@/composables/toggleScope'
 
 // Utilities
-import { computed, inject, onScopeDispose, provide, reactive, readonly, shallowRef, toRaw, watchEffect } from 'vue'
+import { computed, inject, nextTick, onScopeDispose, provide, reactive, readonly, shallowRef, toRaw, watchEffect } from 'vue'
 import { getCurrentInstance } from '@/util'
 
 // Types
@@ -55,7 +55,7 @@ export function useStack (
   if (createStackEntry) {
     watchEffect(() => {
       const _isTop = globalStack.at(-1)?.[0] === vm.uid
-      setTimeout(() => globalTop.value = _isTop)
+      nextTick(() => globalTop.value = _isTop)
     })
   }
 

--- a/packages/vuetify/src/directives/click-outside/index.ts
+++ b/packages/vuetify/src/directives/click-outside/index.ts
@@ -7,6 +7,7 @@ import type { DirectiveBinding } from 'vue'
 interface ClickOutsideBindingArgs {
   handler: (e: MouseEvent) => void
   closeConditional?: (e: Event) => boolean
+  closeByMousedown?: boolean 
   include?: () => HTMLElement[]
 }
 
@@ -83,6 +84,9 @@ export const ClickOutside = {
     const onClick = (e: Event) => directive(e as MouseEvent, el, binding)
     const onMousedown = (e: Event) => {
       el._clickOutside!.lastMousedownWasOutside = checkEvent(e as MouseEvent, el, binding)
+      if (typeof binding.value === 'object' && binding.value.closeByMousedown) {
+        return directive(e as MouseEvent, el, binding)
+      }
     }
 
     handleShadow(el, (app: HTMLElement) => {


### PR DESCRIPTION
fixes #17488

tested #15475, #15276

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <v-col>
          <v-select
            class="item"
            placeholder="Select1"
            :menu-props="{ }"
            :items="[
              { key: 1, title: 'title1' },
              { key: 2, title: 'title2' },
            ]"
          />
        </v-col>
        <v-col>
          <v-autocomplete
            class="item"
            placeholder="Select2"
            :items="[
              { key: 3, title: 'title3' },
              { key: 4, title: 'title4' },
            ]"
          />
        </v-col>
      </v-row>

      <div class="d-flex justify-space-around">
        <v-btn>
          click me and press tab
          <v-tooltip activator="parent" location="start">Tooltip</v-tooltip>
        </v-btn>

        <v-btn>
          default
          <v-tooltip activator="parent" location="end">Tooltip</v-tooltip>
        </v-btn>

        <v-btn>
          open on focus
          <v-tooltip
            activator="parent"
            location="top"
            open-on-focus
          >Tooltip</v-tooltip>
        </v-btn>

        <v-btn>
          default
          <v-tooltip activator="parent" location="bottom">Tooltip</v-tooltip>
        </v-btn>
      </div>
      <v-tooltip text="I'm a cool tip">
        <template #activator="{ props }">
          <v-btn color="primary" @click="snackbar = true" v-bind="props">Click Me</v-btn>
        </template>
      </v-tooltip>
    </v-container>

    <v-snackbar v-model="snackbar" :timeout="-1">
      Snackbar content
      <template #actions>
        <v-btn @click="snackbar = false">Close</v-btn>
      </template>
    </v-snackbar>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const snackbar = ref(false)
</script>


```
