### PR TITLE
chore: resolve linting errors

### DIFF
--- a/packages/vuetify/src/labs/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePickerMonth.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local-rules/sort-imports */
 // Styles
 import './VDatePickerMonth.sass'
 
@@ -15,9 +14,9 @@ import { genericComponent, omit, propsFactory } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
+import { getWeek, toIso } from '../date/date'
 import { dateEmits, makeDateProps } from '../VDateInput/composables'
 import { useDate } from '@/labs/date'
-import { getWeek, toIso } from '../date/date'
 
 export const makeVDatePickerMonthProps = propsFactory({
   color: String,

--- a/packages/vuetify/src/labs/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePickerMonth.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable local-rules/sort-imports */
 // Styles
 import './VDatePickerMonth.sass'
 

--- a/packages/vuetify/src/labs/date/date.ts
+++ b/packages/vuetify/src/labs/date/date.ts
@@ -118,7 +118,6 @@ export function toIso (adapter: DateAdapter<any>, value: any) {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
 }
 
-
 function getMondayOfFirstWeekOfYear (year: number) {
   return new Date(year, 0, 1)
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix following eslint errors.

labs/date/date.tx:  
`More than 1 blank line not allowed.`  

labs/VDatePicker/VDatePickerMonth.tsx:  
`Imports should be sorted
  ../date/date should appear before ../VDateInput/composables`


These are causing the CI for #17578 to fail.
https://github.com/vuetifyjs/vuetify/actions/runs/5229429506/jobs/9442432104?pr=17578


## Markdown
``` vue
Nothing
```

