### PR TITLE
fix(VTextField): inherit outlined border radius

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -362,10 +362,16 @@
       border-inline-start-width: var(--v-field-border-width)
 
       @include tools.ltr()
-        border-radius: $field-border-radius 0 0 $field-border-radius
+        border-top-left-radius: inherit
+        border-top-right-radius: 0
+        border-bottom-right-radius: 0
+        border-bottom-left-radius: inherit
 
       @include tools.rtl()
-        border-radius: 0 $field-border-radius $field-border-radius 0
+        border-top-left-radius: 0
+        border-top-right-radius: inherit
+        border-bottom-right-radius: inherit
+        border-bottom-left-radius: 0
 
     &__notch
       flex: none
@@ -396,10 +402,16 @@
       border-inline-end-width: var(--v-field-border-width)
 
       @include tools.ltr()
-        border-radius: 0 $field-border-radius $field-border-radius 0
+        border-top-left-radius: 0
+        border-top-right-radius: inherit
+        border-bottom-right-radius: inherit
+        border-bottom-left-radius: 0
 
       @include tools.rtl()
-        border-radius: $field-border-radius 0 0 $field-border-radius
+        border-top-left-radius: inherit
+        border-top-right-radius: 0
+        border-bottom-right-radius: 0
+        border-bottom-left-radius: inherit
 /* endregion */
 /* region LOADER */
 .v-field__loader


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #17380

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-locale-provider rtl>
        <v-text-field v-model="msg" variant="outlined" rounded="lg" />
      </v-locale-provider>

      <v-text-field v-model="msg" variant="outlined" rounded="lg" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>

```
