### PR TITLE
fix(VDataTable): fix sort table with nullable column

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/__tests__/sort.spec.ts
+++ b/packages/vuetify/src/labs/VDataTable/__tests__/sort.spec.ts
@@ -202,4 +202,42 @@ describe('VDataTable - sorting', () => {
       { string: 'foo', number: 1 },
     ])
   })
+
+  it('should sort items with nullable column', () => {
+    const items = transformItems({} as any, [
+      { string: 'foo', number: 1 },
+      { string: 'bar', number: null },
+      { string: 'baz', number: 4 },
+      { string: 'fizzbuzz', number: 3 },
+      { string: 'foobar', number: 5 },
+      { string: 'barbaz', number: undefined },
+      { string: 'foobarbuzz', number: '' },
+    ])
+
+    expect(
+      sortItems(items, [{ key: 'number', order: 'asc' }], 'en')
+        .map(i => i.raw)
+    ).toStrictEqual([
+      { string: 'bar', number: null },
+      { string: 'barbaz', number: undefined },
+      { string: 'foobarbuzz', number: '' },
+      { string: 'foo', number: 1 },
+      { string: 'fizzbuzz', number: 3 },
+      { string: 'baz', number: 4 },
+      { string: 'foobar', number: 5 },
+    ])
+
+    expect(
+      sortItems(items, [{ key: 'number', order: 'desc' }], 'en')
+        .map(i => i.raw)
+    ).toStrictEqual([
+      { string: 'foobar', number: 5 },
+      { string: 'baz', number: 4 },
+      { string: 'fizzbuzz', number: 3 },
+      { string: 'foo', number: 1 },
+      { string: 'bar', number: null },
+      { string: 'barbaz', number: undefined },
+      { string: 'foobarbuzz', number: '' },
+    ])
+  })
 })

--- a/packages/vuetify/src/labs/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/sort.ts
@@ -4,7 +4,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, inject, provide, toRef } from 'vue'
-import { getObjectValueByPath, propsFactory } from '@/util'
+import { getObjectValueByPath, isEmpty, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -144,6 +144,9 @@ export function sortItems<T extends Record<string, any>> (
       [sortA, sortB] = [sortA, sortB].map(s => s != null ? s.toString().toLocaleLowerCase() : s)
 
       if (sortA !== sortB) {
+        if (isEmpty(sortA) && isEmpty(sortB)) return 0
+        if (isEmpty(sortA)) return -1
+        if (isEmpty(sortB)) return 1
         if (!isNaN(sortA) && !isNaN(sortB)) return Number(sortA) - Number(sortB)
         return stringCollator.compare(sortA, sortB)
       }

--- a/packages/vuetify/src/util/__tests__/helpers.spec.ts
+++ b/packages/vuetify/src/util/__tests__/helpers.spec.ts
@@ -7,6 +7,7 @@ import {
   getObjectValueByPath,
   getPropertyFromItem,
   humanReadableFileSize,
+  isEmpty,
   mergeDeep,
 } from '../helpers'
 
@@ -317,6 +318,17 @@ describe('helpers', () => {
       val.value = 'bar'
 
       expect(obj.a.value).toBe('bar')
+    })
+  })
+
+  describe('isEmpty', () => {
+    it('should be empty value', () => {
+      expect(isEmpty(null)).toBeTruthy()
+      expect(isEmpty(undefined)).toBeTruthy()
+      expect(isEmpty('')).toBeTruthy()
+      expect(isEmpty(' ')).toBeTruthy()
+      expect(isEmpty('sample text')).toBeFalsy()
+      expect(isEmpty(12345)).toBeFalsy()
     })
   })
 })

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -596,4 +596,8 @@ export function focusChild (el: Element, location?: 'next' | 'prev' | 'first' | 
   }
 }
 
+export function isEmpty (val: any): boolean {
+  return val === null || val === undefined || (typeof val === 'string' && val.trim() === '')
+}
+
 export function noop () {}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #17563 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    v-model:items-per-page="itemsPerPage"
    :headers="headers"
    :items="desserts"
    item-value="name"
    class="elevation-1"
  ></v-data-table>
</template>
<script>
  export default {
    data() {
      return {
        itemsPerPage: 10,
        headers: [
          {
            title: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            key: 'name',
          },
          { title: 'Calories', align: 'end', key: 'calories' },
          { title: 'Fat (g)', align: 'end', key: 'fat' },
          { title: 'Carbs (g)', align: 'end', key: 'carbs' },
          { title: 'Protein (g)', align: 'end', key: 'protein' },
          { title: 'Iron (%)', align: 'end', key: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1',
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0',
          },
          {
            name: 'KitKat',
            calories: 518,
            carbs: 65,
            protein: 7,
            iron: '6',
          },
          {
            name: 'Eclair',
            calories: 262,
            carbs: 23,
            protein: 6.0,
            iron: '7',
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16',
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1',
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2',
          },
          {
            name: 'Lollipop1',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2',
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: null,
            carbs: 67,
            protein: 4.3,
            iron: '8',
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: undefined,
            carbs: 87,
            protein: 6.5,
            iron: '45',
          },
          {
            name: 'Donut',
            calories: 452,
            fat: '',
            carbs: 51,
            protein: 4.9,
            iron: '22',
          },
        ],
      }
    },
  }
</script>

```
