### PR TITLE
chore: improve stack logic to better serve a convincible cy test

### DIFF
--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -9,6 +9,7 @@ import { VListItem } from '@/components/VList'
 import { cloneVNode, ref } from 'vue'
 import { generate } from '../../../../cypress/templates'
 import { keyValues } from '@/util'
+import { VAutocomplete, VCol, VCombobox, VRow } from '@/components'
 
 const variants = ['underlined', 'outlined', 'filled', 'solo', 'plain'] as const
 const densities = ['default', 'comfortable', 'compact'] as const
@@ -434,6 +435,46 @@ describe('VSelect', () => {
       .should('have.class', 'v-select--active-menu')
       .trigger('keydown', { key: keyValues.esc })
       .should('not.have.class', 'v-select--active-menu')
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/17488
+  it('should close its open menu when the menu of another select component is opened via a click', () => {
+    cy
+      .mount(() => (
+        <VRow>
+          <VCol>
+            <VSelect
+              items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+            />
+          </VCol>
+          <VCol>
+            <VAutocomplete
+              items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+            />
+          </VCol>
+          <VCol>
+            <VCombobox
+              items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+            />
+          </VCol>
+        </VRow> 
+      ))
+      cy.get('.v-select')
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .click()
+        .get('.v-overlay__content.v-select__content')
+        .should('exist')
+
+      cy.get('.v-autocomplete')
+        .click()
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .trigger('keydown', { key: keyValues.down, waitForAnimations: false })
+        .get('.v-overlay__content.v-select__content')
+        .should('not.exist')
+        .get('.v-overlay__content.v-autocomplete__content')
+        .should('exist')
+
   })
 
   describe('Showcase', () => {

--- a/packages/vuetify/src/composables/stack.ts
+++ b/packages/vuetify/src/composables/stack.ts
@@ -2,7 +2,7 @@
 import { useToggleScope } from '@/composables/toggleScope'
 
 // Utilities
-import { computed, inject, onScopeDispose, provide, reactive, readonly, shallowRef, toRaw, watchEffect } from 'vue'
+import { computed, inject, nextTick, onScopeDispose, provide, reactive, readonly, shallowRef, toRaw, watchEffect } from 'vue'
 import { getCurrentInstance } from '@/util'
 
 // Types
@@ -55,7 +55,7 @@ export function useStack (
   if (createStackEntry) {
     watchEffect(() => {
       const _isTop = globalStack.at(-1)?.[0] === vm.uid
-      setTimeout(() => globalTop.value = _isTop)
+      nextTick(() => globalTop.value = _isTop)
     })
   }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

This PR is opened because found a hidden issue in stack when constructing a convincible cy test case for #17448

The test case should fail on master branch, but it's successful, this is because `globalTop` inside setTimeout behaves differently in cypress from normal user behaviour

I'm not entirely sure the initial purpose of using `setTimeout` here but replacing it with `nextTick` performs more safely

The purpose of opening this PR is to start conversation around and get feedback
