### PR TITLE
refactor: update fontawesome sort icons to match mdi icons defaults

### DIFF
--- a/packages/vuetify/src/iconsets/fa.ts
+++ b/packages/vuetify/src/iconsets/fa.ts
@@ -21,8 +21,8 @@ const aliases: IconAliases = {
   checkboxOff: 'far fa-square', // note 'far'
   checkboxIndeterminate: 'fas fa-minus-square',
   delimiter: 'fas fa-circle', // for carousel
-  sortAsc: 'fas fa-sort-up',
-  sortDesc: 'fas fa-sort-down',
+  sortAsc: 'fas fa-arrow-up',
+  sortDesc: 'fas fa-arrow-down',
   expand: 'fas fa-chevron-down',
   menu: 'fas fa-bars',
   subgroup: 'fas fa-caret-down',

--- a/packages/vuetify/src/iconsets/fa4.ts
+++ b/packages/vuetify/src/iconsets/fa4.ts
@@ -24,8 +24,8 @@ const aliases: IconAliases = {
   checkboxOff: 'fa-square-o',
   checkboxIndeterminate: 'fa-minus-square',
   delimiter: 'fa-circle', // for carousel
-  sortAsc: 'fa-sort-up',
-  sortDesc: 'fa-sort-down',
+  sortAsc: 'fa-arrow-up',
+  sortDesc: 'fa-arrow-down',
   expand: 'fa-chevron-down',
   menu: 'fa-bars',
   subgroup: 'fa-caret-down',


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Update fontawesome sort icons to match mdi icon defaults. 

**References:**

MDI:
https://pictogrammers.com/library/mdi/icon/arrow-up/
https://pictogrammers.com/library/mdi/icon/arrow-down/

Fontawesome:
v5
https://fontawesome.com/v5/icons/arrow-down?f=classic&s=solid
https://fontawesome.com/v5/icons/arrow-up?f=classic&s=solid

v4
https://fontawesome.com/v4/icon/arrow-down
https://fontawesome.com/v4/icon/arrow-up

<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
v5
```typescript
const aliases: IconAliases = {
  collapse: 'fas fa-chevron-up',
  complete: 'fas fa-check',
  cancel: 'fas fa-times-circle',
  close: 'fas fa-times',
  delete: 'fas fa-times-circle', // delete (e.g. v-chip close)
  clear: 'fas fa-times-circle', // delete (e.g. v-chip close)
  success: 'fas fa-check-circle',
  info: 'fas fa-info-circle',
  warning: 'fas fa-exclamation',
  error: 'fas fa-exclamation-triangle',
  prev: 'fas fa-chevron-left',
  next: 'fas fa-chevron-right',
  checkboxOn: 'fas fa-check-square',
  checkboxOff: 'far fa-square', // note 'far'
  checkboxIndeterminate: 'fas fa-minus-square',
  delimiter: 'fas fa-circle', // for carousel
  sortAsc: 'fas fa-arrow-up',
  sortDesc: 'fas fa-arrow-down',
  expand: 'fas fa-chevron-down',
  menu: 'fas fa-bars',
  subgroup: 'fas fa-caret-down',
  dropdown: 'fas fa-caret-down',
  radioOn: 'far fa-dot-circle',
  radioOff: 'far fa-circle',
  edit: 'fas fa-edit',
  ratingEmpty: 'far fa-star',
  ratingFull: 'fas fa-star',
  ratingHalf: 'fas fa-star-half',
  loading: 'fas fa-sync',
  first: 'fas fa-step-backward',
  last: 'fas fa-step-forward',
  unfold: 'fas fa-arrows-alt-v',
  file: 'fas fa-paperclip',
  plus: 'fas fa-plus',
  minus: 'fas fa-minus',
  calendar: 'fas fa-calendar',
}
```
v4
```typescript
const aliases: IconAliases = {
  collapse: 'fa-chevron-up',
  complete: 'fa-check',
  cancel: 'fa-times-circle',
  close: 'fa-times',
  delete: 'fa-times-circle', // delete (e.g. v-chip close)
  clear: 'fa-check-circle', // delete (e.g. v-chip close)
  success: 'fa-check-circle',
  info: 'fa-info-circle',
  warning: 'fa-exclamation',
  error: 'fa-exclamation-triangle',
  prev: 'fa-chevron-left',
  next: 'fa-chevron-right',
  checkboxOn: 'fa-check-square',
  checkboxOff: 'fa-square-o',
  checkboxIndeterminate: 'fa-minus-square',
  delimiter: 'fa-circle', // for carousel
  sortAsc: 'fa-arrow-up',
  sortDesc: 'fa-arrow-down',
  expand: 'fa-chevron-down',
  menu: 'fa-bars',
  subgroup: 'fa-caret-down',
  dropdown: 'fa-caret-down',
  radioOn: 'fa-dot-circle-o',
  radioOff: 'fa-circle-o',
  edit: 'fa-pencil',
  ratingEmpty: 'fa-star-o',
  ratingFull: 'fa-star',
  ratingHalf: 'fa-star-half-o',
  loading: 'fa-refresh',
  first: 'fa-step-backward',
  last: 'fa-step-forward',
  unfold: 'fa-angle-double-down',
  file: 'fa-paperclip',
  plus: 'fa-plus',
  minus: 'fa-minus',
  calendar: 'fa-calendar',
}
```
