### PR TITLE
fix(VSelect): Always align the input with chips

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -71,13 +71,16 @@
     &.v-text-field input
       flex: 1 1
       position: absolute
-      top: calc(50% - var(--v-input-chips-margin-top))
-      transform: translateY(-50%)
       left: 0
       right: 0
       width: 100%
       padding-inline-start: inherit
       padding-inline-end: inherit
+
+    .v-field--variant-outlined 
+      input
+        top: calc(50% - var(--v-input-chips-margin-top))
+        transform: translateY(-50%)
 
     .v-field--active
       input

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -44,6 +44,7 @@
 
   &__selection
     display: inline-flex
+    align-items: center
     letter-spacing: inherit
     line-height: inherit
     max-width: 100%

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -49,7 +49,6 @@
     line-height: inherit
     max-width: 100%
 
-  input,
   &__selection
     margin-top: var(--v-input-chips-margin-top)
     margin-bottom: var(--v-input-chips-margin-bottom)

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -71,6 +71,8 @@
     &.v-text-field input
       flex: 1 1
       position: absolute
+      top: calc(50% - var(--v-input-chips-margin-top))
+      transform: translateY(-50%)
       left: 0
       right: 0
       width: 100%

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -77,7 +77,7 @@
       padding-inline-start: inherit
       padding-inline-end: inherit
 
-    .v-field--variant-outlined 
+    .v-field--variant-outlined
       input
         top: calc(50% - var(--v-input-chips-margin-top))
         transform: translateY(-50%)

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -71,13 +71,16 @@
     &.v-text-field input
       flex: 1 1
       position: absolute
-      top: calc(50% - var(--v-input-chips-margin-top))
-      transform: translateY(-50%)
       left: 0
       right: 0
       width: 100%
       padding-inline-start: inherit
       padding-inline-end: inherit
+
+    .v-field--variant-outlined 
+      input
+        top: calc(50% - var(--v-input-chips-margin-top))
+        transform: translateY(-50%)
 
     .v-field--active
       input

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -44,6 +44,7 @@
 
   &__selection
     display: inline-flex
+    align-items: center
     letter-spacing: inherit
     line-height: inherit
     max-width: 100%

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -49,7 +49,6 @@
     line-height: inherit
     max-width: 100%
 
-  input,
   &__selection
     margin-top: var(--v-input-chips-margin-top)
     margin-bottom: var(--v-input-chips-margin-bottom)

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -71,6 +71,8 @@
     &.v-text-field input
       flex: 1 1
       position: absolute
+      top: calc(50% - var(--v-input-chips-margin-top))
+      transform: translateY(-50%)
       left: 0
       right: 0
       width: 100%

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -77,7 +77,7 @@
       padding-inline-start: inherit
       padding-inline-end: inherit
 
-    .v-field--variant-outlined 
+    .v-field--variant-outlined
       input
         top: calc(50% - var(--v-input-chips-margin-top))
         transform: translateY(-50%)

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -41,6 +41,7 @@
 
   &__selection
     display: inline-flex
+    align-items: center
     letter-spacing: inherit
     line-height: inherit
     max-width: 100%

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -46,7 +46,6 @@
     line-height: inherit
     max-width: 100%
 
-  input,
   .v-select__selection
     margin-top: var(--v-input-chips-margin-top)
     margin-bottom: var(--v-input-chips-margin-bottom)

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -45,14 +45,13 @@
     line-height: inherit
     max-width: 100%
 
-  &--chips,
-  &--selection-slot
-    .v-select__selection
-      margin-top: var(--v-input-chips-margin-top)
-      margin-bottom: var(--v-input-chips-margin-bottom)
+  input,
+  .v-select__selection
+    margin-top: var(--v-input-chips-margin-top)
+    margin-bottom: var(--v-input-chips-margin-bottom)
 
-      &:first-child
-        margin-inline-start: 0
+    &:first-child
+      margin-inline-start: 0
 
   &--selected
     .v-field

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -10,7 +10,9 @@
     flex: $text-field-input-flex
     transition: $text-field-input-transition
     min-width: 0
-
+    margin-top: var(--v-input-chips-margin-top)
+    margin-bottom: var(--v-input-chips-margin-bottom)
+ 
     &:focus,
     &:active
       outline: none

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -237,7 +237,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                             { props.prefix }
                           </span>
                         )}
-                        
+
                         <div
                           class={ fieldClass }
                           data-no-activator=""

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -237,16 +237,19 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                             { props.prefix }
                           </span>
                         )}
-
-                        { slots.default ? (
-                          <div
-                            class={ fieldClass }
-                            data-no-activator=""
-                          >
-                            { slots.default() }
-                            { inputNode }
-                          </div>
-                        ) : cloneVNode(inputNode, { class: fieldClass })}
+                        
+                        <div
+                          class={ fieldClass }
+                          data-no-activator=""
+                        >
+                          { slots.default ? (
+                            <>
+                              { slots.default() }
+                              { inputNode }
+                            </>
+                          ) : cloneVNode(inputNode)
+                        }
+                        </div>
 
                         { props.suffix && (
                           <span class="v-text-field__suffix">


### PR DESCRIPTION
fixes #17604

Input heights in select components are the same as when having chips (always include chip margin top/bottom). Therefore, input alignment should be consistent with chips.

This has been implemented in VCombobox and VAutocomplete but missed in VSelect

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container style="width: 250px">
      <v-text-field placeholder="Hello" variant="outlined" density="compact" />
      <v-select 
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        placeholder="Hello" variant="outlined" density="compact" />
      <v-select
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        chips
        placeholder="Hello"
        variant="outlined"
        density="compact"
      />
      <v-autocomplete
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        placeholder="Hello"
        variant="outlined"
        density="compact"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>
```
