### PR TITLE
docs: add v-img error slot

### DIFF
--- a/packages/docs/src/examples/v-img/slot-error.vue
+++ b/packages/docs/src/examples/v-img/slot-error.vue
@@ -1,0 +1,18 @@
+<template>
+  <v-img
+    class="mx-auto"
+    height="300"
+    max-width="500"
+    src="https://bad.src/not/valid"
+  >
+    <template v-slot:error>
+      <v-img
+      class="mx-auto"
+      height="300"
+      max-width="500"
+      src="https://picsum.photos/500/300?image=232"
+      >
+      </v-img>
+    </template>
+  </v-img>
+</template>

--- a/packages/docs/src/pages/en/components/images.md
+++ b/packages/docs/src/pages/en/components/images.md
@@ -63,6 +63,12 @@ If the provided aspect ratio doesn't match that of the actual image, the default
 
 <example file="v-img/slot-placeholder" />
 
+#### Error
+
+`v-img` has an `error` slot that can be used to display alternative content if an error occurs while loading your source image. A common use for this slot is to load a fallback image if your original image is not available.
+
+<example file="v-img/slot-error" />
+
 ### Misc
 
 #### Future image formats


### PR DESCRIPTION
## Description

Added information about the v-img error slot and included a common use-case for a fallback image if the source image is cannot be loaded.