### PR TITLE
fix(scroll-offset): remove usage

### DIFF
--- a/packages/vuetify/src/components/VAppBar/VAppBar.sass
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.sass
@@ -9,6 +9,3 @@
 
     &:not(.v-toolbar--flat)
       @include tools.elevation($app-bar-elevation)
-
-  &:not(.v-toolbar--absolute)
-    padding-inline-end: var(--v-scrollbar-offset)

--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -17,7 +17,6 @@
 
     > .v-card,
     > .v-sheet
-      --v-scrollbar-offset: 0px
       border-radius: $dialog-border-radius
       overflow-y: auto
 
@@ -40,8 +39,6 @@
         padding: $dialog-card-text-padding
 
 .v-dialog--fullscreen
-  --v-scrollbar-offset: 0px
-
   > .v-overlay__content
     border-radius: 0
     margin: 0

--- a/packages/vuetify/src/components/VLayout/VLayout.sass
+++ b/packages/vuetify/src/components/VLayout/VLayout.sass
@@ -1,8 +1,6 @@
 .v-layout
-  --v-scrollbar-offset: 0px
   display: flex
   flex: 1 1 auto
 
   &--full-height
-    --v-scrollbar-offset: inherit
     height: 100%

--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -11,9 +11,6 @@
   display: contents
 
 .v-overlay-scroll-blocked
-  padding-inline-end: var(--v-scrollbar-offset)
-  overflow-y: hidden !important
-
   @at-root #{selector.append(html, &)}
     position: fixed
     top: var(--v-body-scroll-y)
@@ -55,6 +52,3 @@
 
 .v-overlay--contained .v-overlay__scrim
   position: absolute
-
-.v-overlay--scroll-blocked
-  padding-inline-end: var(--v-scrollbar-offset)

--- a/packages/vuetify/src/components/VOverlay/scrollStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/scrollStrategies.ts
@@ -78,7 +78,6 @@ function blockScrollStrategy (data: ScrollStrategyData, props: StrategyProps) {
     ...getScrollParents(data.activatorEl.value, props.contained ? offsetParent : undefined),
     ...getScrollParents(data.contentEl.value, props.contained ? offsetParent : undefined),
   ])].filter(el => !el.classList.contains('v-overlay-scroll-blocked'))
-  const scrollbarWidth = window.innerWidth - document.documentElement.offsetWidth
 
   const scrollableParent = (el => hasScrollbar(el) && el)(offsetParent || document.documentElement)
   if (scrollableParent) {
@@ -88,7 +87,6 @@ function blockScrollStrategy (data: ScrollStrategyData, props: StrategyProps) {
   scrollElements.forEach((el, i) => {
     el.style.setProperty('--v-body-scroll-x', convertToUnit(-el.scrollLeft))
     el.style.setProperty('--v-body-scroll-y', convertToUnit(-el.scrollTop))
-    el.style.setProperty('--v-scrollbar-offset', convertToUnit(scrollbarWidth))
     el.classList.add('v-overlay-scroll-blocked')
   })
 
@@ -99,7 +97,6 @@ function blockScrollStrategy (data: ScrollStrategyData, props: StrategyProps) {
 
       el.style.removeProperty('--v-body-scroll-x')
       el.style.removeProperty('--v-body-scroll-y')
-      el.style.removeProperty('--v-scrollbar-offset')
       el.classList.remove('v-overlay-scroll-blocked')
 
       el.scrollLeft = -x

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -6,7 +6,6 @@
   justify-content: center
   z-index: $snackbar-z-index
   margin: $snackbar-wrapper-margin
-  margin-inline-end: calc(#{$snackbar-wrapper-margin} + var(--v-scrollbar-offset))
 
   &:not(.v-snackbar--centered):not(.v-snackbar--top)
     align-items: flex-end

--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
@@ -27,6 +27,3 @@
 
   &--window
     height: $system-bar-window-height
-
-  &:not(.v-system-bar--absolute)
-    padding-inline-end: calc(var(--v-scrollbar-offset) + #{$system-bar-padding-x})

--- a/packages/vuetify/src/styles/elements/_global.sass
+++ b/packages/vuetify/src/styles/elements/_global.sass
@@ -15,7 +15,6 @@ html.overflow-y-hidden
 
 :root
   --v-theme-overlay-multiplier: 1
-  --v-scrollbar-offset: 0px
 
 // iOS Safari hack to allow click events on body
 @supports (-webkit-touch-callout: none)


### PR DESCRIPTION
## Motivation and Context

**TODO**: this currently breaks temporary nav drawer scroll

As far as I can tell, if you don't touch the overflow when blocking scroll, scroll offset isn't needed for VDialog. Without the fix, it causes the content on the right side of the screen to jerk back and forth when opening / closing a dialog. This is most notable on the buttons doc page when opening a dialog and the TOC is either sticky top, absolute top; Opening and closing the [Cookies example](https://vuetifyjs.com/components/buttons/#cookie-settings) in various states of scroll show the content move:

![see](https://github.com/vuetifyjs/vuetify/assets/9064066/9dda0677-8401-469a-8d29-7321888189f4)
9291114759934122/see.gif

I added a small Playground but it's best to look at it in the docs. Make sure you run **yarn watch** in the vuetify package before loading them up.

## Markup:
<details>

```vue
<template>
  <v-app style="min-height: 500vh;">
    <v-system-bar>content</v-system-bar>

    <v-app-bar>
      <v-spacer />
      <v-btn>
        Click me

        <v-dialog activator="parent">
          <v-card title="title" text="lorem itspm dle imor edia dkf a" />
        </v-dialog>
      </v-btn>
    </v-app-bar>

    <v-navigation-drawer permanent location="right">
      <v-list-item title="Item" />
      <v-list-item title="Item" />
      <v-list-item title="Item" />
      <v-list-item title="Item" />
      <v-list-item title="Item" />
      <v-list-item title="Item" />
    </v-navigation-drawer>

    <v-main>
      <v-layout class="ma-12" full-height>
        <v-main>
          <v-btn
            color="orange-darken-2"
            @click="snackbar = true"
          >
            Open Snackbar
          </v-btn>

          <v-snackbar
            v-model="snackbar"
            :timeout="timeout"
            location="bottom end"
          >
            {{ text }}

            <template #actions>
              <v-btn
                color="blue"
                variant="text"
                @click="snackbar = false"
              >
                Close
              </v-btn>
            </template>
          </v-snackbar>
        </v-main>

        <v-navigation-drawer permanent location="left">
          <v-list-item title="Item" />
          <v-list-item title="Item" />
          <v-list-item title="Item" />
          <v-list-item title="Item" />
          <v-list-item title="Item" />
          <v-list-item title="Item" />
        </v-navigation-drawer>
      </v-layout>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const snackbar = ref(false)
  const text = ref('My timeout is set to 2000.')
  const timeout = ref(-1)
</script>

```
</details>