### PR TITLE
fix(VBtn): On loading button is no longer focused by keyboard.

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -195,6 +195,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
             props.icon ? ['center'] : null,
           ]}
           onClick={ onClick }
+          tabindex={ props.loading ? -1 : undefined }
           value={ valueAttr.value }
         >
           { genOverlays(true, 'v-btn') }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #17396 
Loading state button to be skipped when using tab key.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <p>
          Focus the button in the loading state using tab
        </p>
        <br>
        <v-btn @click="onClick">Button 1</v-btn>
        <v-btn disabled @click="onClick">Button 2</v-btn>
        <v-btn loading @click="onClick">Button 3</v-btn>
        <v-btn @click="onClick">Button 4</v-btn>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup lang="ts">
const onClick = () => alert()
</script>
```
