### PR TITLE
fix(VSelect, VCombobox, VAutocomplete): truncate selection text regardless of singline-line

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -20,7 +20,7 @@
 
   .v-field
     input
-      min-width: 64px 
+      min-width: $autocomplete-focused-input
     &:not(.v-field--focused)
       input
         min-width: 0

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -18,9 +18,12 @@
         align-self: flex-start
         flex: 1 1
 
-  .v-field:not(.v-field--focused)
+  .v-field
     input
-      min-width: 0
+      min-width: 64px 
+    &:not(.v-field--focused)
+      input
+        min-width: 0
 
   .v-field--dirty
     .v-autocomplete__selection
@@ -45,7 +48,7 @@
     display: inline-flex
     letter-spacing: inherit
     line-height: inherit
-    max-width: 100%
+    max-width: 90%
 
   input,
   &__selection

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -21,6 +21,7 @@
   .v-field
     input
       min-width: $autocomplete-focused-input
+
     &:not(.v-field--focused)
       input
         min-width: 0

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -26,11 +26,10 @@
     .v-autocomplete__selection
       margin-inline-end: 2px
 
-  .v-field--single-line
-    .v-autocomplete__selection-text
-      overflow: hidden
-      text-overflow: ellipsis
-      white-space: nowrap
+  .v-autocomplete__selection-text
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
 
 .v-autocomplete
   &__content

--- a/packages/vuetify/src/components/VAutocomplete/_variables.scss
+++ b/packages/vuetify/src/components/VAutocomplete/_variables.scss
@@ -3,6 +3,7 @@
 // Defaults
 $autocomplete-content-border-radius: 4px !default;
 $autocomplete-content-elevation: 4 !default;
+$autocomplete-focused-input: 64px !default;
 $autocomplete-line-height: 1.75 !default;
 $autocomplete-transition: .2s settings.$standard-easing !default;
 $autocomplete-chips-control-min-height: 64px !default;

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -26,11 +26,10 @@
     .v-combobox__selection
       margin-inline-end: 2px
 
-  .v-field--single-line
-    .v-combobox__selection-text
-      overflow: hidden
-      text-overflow: ellipsis
-      white-space: nowrap
+  .v-combobox__selection-text
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
 
 .v-combobox
   &__content

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -18,9 +18,12 @@
         align-self: flex-start
         flex: 1 1
 
-  .v-field:not(.v-field--focused)
+  .v-field
     input
-      min-width: 0
+      min-width: 64px 
+    &:not(.v-field--focused)
+      input
+        min-width: 0
 
   .v-field--dirty
     .v-combobox__selection
@@ -45,7 +48,7 @@
     display: inline-flex
     letter-spacing: inherit
     line-height: inherit
-    max-width: 100%
+    max-width: 90%
 
   input,
   &__selection

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -20,7 +20,7 @@
 
   .v-field
     input
-      min-width: 64px 
+      min-width: $combobox-focused-input
     &:not(.v-field--focused)
       input
         min-width: 0

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -21,6 +21,7 @@
   .v-field
     input
       min-width: $combobox-focused-input
+
     &:not(.v-field--focused)
       input
         min-width: 0

--- a/packages/vuetify/src/components/VCombobox/_variables.scss
+++ b/packages/vuetify/src/components/VCombobox/_variables.scss
@@ -3,6 +3,7 @@
 // Defaults
 $combobox-content-border-radius: 4px !default;
 $combobox-content-elevation: 4 !default;
+$combobox-focused-input: 64px !default;
 $combobox-line-height: 1.75 !default;
 $combobox-transition: .2s settings.$standard-easing !default;
 $combobox-chips-control-min-height: null !default;

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -27,11 +27,10 @@
     .v-select__selection
       margin-inline-end: 2px
 
-  .v-field--single-line
-    .v-select__selection-text
-      overflow: hidden
-      text-overflow: ellipsis
-      white-space: nowrap
+  .v-select__selection-text
+    overflow: hidden
+    text-overflow: ellipsis
+    white-space: nowrap
 
   &__content
     overflow: hidden


### PR DESCRIPTION
fixes #17627

In addition, VAutocomplete/VCombobx focused input should behaves the same as [v2](https://codepen.io/yuchaosydney/pen/eYQgQpL?editors=101)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <div style="width: 200px">
      <v-autocomplete
        :items="['Hello i am a very very very very veeeeeery long text', 'bar', 'fizz', 'buzz']"
        density="compact"
        multiple
        variant="outlined"
        clearable
      />
      <v-select
        :items="['Hello i am a very very very very veeeeeery long text', 'bar', 'fizz', 'buzz']"
        density="compact"
        multiple
        variant="outlined"
        clearable
      />
      <v-combobox
        :items="['Hello i am a very very very very veeeeeery long text', 'bar', 'fizz', 'buzz']"
        density="compact"
        multiple
        variant="outlined"
        clearable
      />
    </div>
  </v-app>
</template>
```
