### PR TITLE
docs(VForm): fix typo in the example code

### DIFF
--- a/packages/docs/src/examples/v-form/usage.vue
+++ b/packages/docs/src/examples/v-form/usage.vue
@@ -54,7 +54,7 @@
         value => {
           if (value) return true
 
-          return 'Name is requred.'
+          return 'Name is required.'
         },
         value => {
           if (value?.length <= 10) return true


### PR DESCRIPTION
Small typo in the example code in the docs (https://vuetifyjs.com/en/components/forms/#usage)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
