### PR TITLE
fix(headers): enforce nullish column key to empty string

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/composables/headers.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/headers.ts
@@ -68,7 +68,7 @@ export function createHeaders (
     const fixedOffsets = createRange(rowCount).fill(0)
 
     flat.forEach(({ column, row }) => {
-      const key = column.key
+      const key = column.key ?? ''
       for (let i = row; i <= row + (column.rowspan ?? 1) - 1; i++) {
         fixedRows[i].push({
           ...column,

--- a/packages/vuetify/src/labs/VDataTable/composables/headers.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/headers.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { inject, provide, ref, watchEffect } from 'vue'
-import { createRange, propsFactory } from '@/util'
+import { createRange, consoleWarn, propsFactory } from '@/util'
 
 // Types
 import type { DeepReadonly, InjectionKey, PropType, Ref } from 'vue'
@@ -68,7 +68,11 @@ export function createHeaders (
     const fixedOffsets = createRange(rowCount).fill(0)
 
     flat.forEach(({ column, row }) => {
-      const key = column.key ?? ''
+      let key = column.key
+      if (key == null) {
+        consoleWarn('The header key value must not be null or undefined')
+        key = ''
+      }
       for (let i = row; i <= row + (column.rowspan ?? 1) - 1; i++) {
         fixedRows[i].push({
           ...column,

--- a/packages/vuetify/src/labs/VDataTable/composables/headers.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/headers.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { inject, provide, ref, watchEffect } from 'vue'
-import { createRange, consoleWarn, propsFactory } from '@/util'
+import { consoleWarn, createRange, propsFactory } from '@/util'
 
 // Types
 import type { DeepReadonly, InjectionKey, PropType, Ref } from 'vue'


### PR DESCRIPTION
fixes #17672

column key is string type, nullish values should be converted to empty string
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    v-model:items-per-page="itemsPerPage"
    :headers="headers"
    :items="desserts"
    item-value="name"
    class="elevation-1"
  />
</template>

<script lang="ts">
  export default {
    data () {
      return {
        itemsPerPage: 5,
        headers: [
          {
            title: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            key: null,
          },
          { title: 'Calories', align: 'end', key: 'calories' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
          },
          {
            name: 'Jelly bean',
            calories: 375,
          },
          {
            name: 'KitKat',
            calories: 518,
          },
          {
            name: 'Eclair',
            calories: 262,
          },
          {
            name: 'Gingerbread',
            calories: 356,
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
          },
          {
            name: 'Lollipop',
            calories: 392,
          },
          {
            name: 'Cupcake',
            calories: 305,
          },
          {
            name: 'Honeycomb',
            calories: 408,
          },
          {
            name: 'Donut',
            calories: 452,
          },
        ],
      }
    },
  }
</script>


```
