### PR TITLE
fix(date): reconstruct date value to local tz

### DIFF
--- a/packages/vuetify/src/labs/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/labs/date/adapters/vuetify.ts
@@ -204,13 +204,33 @@ function endOfMonth (date: Date) {
   return new Date(date.getFullYear(), date.getMonth() + 1, 0)
 }
 
+function formatYyyyMmDd (value: string): string {
+  const formattedValue = value.split('-')
+    .map(d => d.padStart(2, '0'))
+    .join('-')
+
+  const offsetMin = (new Date().getTimezoneOffset() / -60)
+  const offsetSign = offsetMin < 0 ? '-' : '+'
+  const offsetValue = Math.abs(offsetMin).toString().padStart(2, '0')
+
+  return `${formattedValue}T00:00:00.000${offsetSign}${offsetValue}:00`
+}
+
+const _YYYMMDD = /([12]\d{3}-([1-9]|0[1-9]|1[0-2])-([1-9]|0[1-9]|[12]\d|3[01]))/
+
 function date (value?: any): Date | null {
   if (value == null) return new Date()
 
   if (value instanceof Date) return value
 
   if (typeof value === 'string') {
-    const parsed = Date.parse(value)
+    let parsed
+
+    if (_YYYMMDD.test(value)) {
+      parsed = Date.parse(formatYyyyMmDd(value))
+    } else {
+      parsed = Date.parse(value)
+    }
 
     if (!isNaN(parsed)) return new Date(parsed)
   }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes #17613

The date picker passes a standard date format like `2023-6-20` to the date utility method. Since it's a standard format, `Date.parse()` treats it as UTC time. If you're several time zones away this can result in the date picker selecting an incorrect date (one day before or, presumably, after). This update checks if the date format is that kind of standard date format and completes the date string to include GMT offset before parsing.

If the date is non-standard, it is passed through as-is, resulting in the current behavior. For example, the VDatePicker `watch(inputModel)` handler passes a value like `6/20/2023` instead.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    Date: {{ myDate || 'None yet' }}
    <v-date-picker
      v-model="myDate"
    />
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      myDate: undefined
    }),
  }
</script>

```
