### PR TITLE
fix(VIcon): enforce to display icon both vertically and horizontally in container

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.sass
+++ b/packages/vuetify/src/components/VIcon/VIcon.sass
@@ -7,13 +7,19 @@
   align-items: center
   display: inline-flex
   font-feature-settings: 'liga'
+  height: $icon-size
   justify-content: center
   letter-spacing: $icon-letter-spacing
   line-height: $icon-line-height
   position: relative
   text-indent: $icon-text-indent
+  text-align: center
   user-select: none
   vertical-align: $icon-vertical-align
+  width: $icon-size
+  &::before
+    max-height: 100%
+    display: block
 
   &--clickable
     cursor: pointer

--- a/packages/vuetify/src/components/VIcon/VIcon.sass
+++ b/packages/vuetify/src/components/VIcon/VIcon.sass
@@ -7,7 +7,6 @@
   align-items: center
   display: inline-flex
   font-feature-settings: 'liga'
-  height: $icon-size
   justify-content: center
   letter-spacing: $icon-letter-spacing
   line-height: $icon-line-height
@@ -15,7 +14,6 @@
   text-indent: $icon-text-indent
   user-select: none
   vertical-align: $icon-vertical-align
-  width: $icon-size
 
   &--clickable
     cursor: pointer

--- a/packages/vuetify/src/components/VIcon/VIcon.sass
+++ b/packages/vuetify/src/components/VIcon/VIcon.sass
@@ -17,9 +17,6 @@
   user-select: none
   vertical-align: $icon-vertical-align
   width: $icon-size
-  &::before
-    max-height: 100%
-    display: block
 
   &--clickable
     cursor: pointer


### PR DESCRIPTION
fixes #17693

Not every icon is a square shape
<img width="862" alt="image" src="https://github.com/vuetifyjs/vuetify/assets/5698884/eb94903f-54d7-441e-8453-f153475415a8">


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div>
    <v-autocomplete :items="items" density="compact" label="Compact" />

    <v-select
      :items="items"
      density="comfortable"
      label="Comfortable"
    ></v-select>

    <v-select :items="items" label="Default"></v-select>
  </div>

</template>

<script>
  export default {
    data: () => ({
      items: ['Foo', 'Bar', 'Fizz', 'Buzz'],
    }),
  }
</script>




```
