### PR TITLE
feat(VDataTable): backport filterMode prop from v3

### DIFF
--- a/packages/api-generator/src/locale/en/v-data-table.json
+++ b/packages/api-generator/src/locale/en/v-data-table.json
@@ -11,6 +11,7 @@
     "disablePagination": "Disables pagination completely",
     "disableSort": "Disables sorting completely",
     "expandIcon": "Icon used for expand toggle button.",
+    "filterMode": "Controls how how custom column filters are combined with the default filtering. Both modes only apply the default filter to columns not specified in `customKeyFilter`.\n\n- **union**: There is at least one match from the default filter, OR all custom column filters match.\n- **intersection**: There is at least one match from the default filter, AND all custom column filters match.",
     "fixedHeader": "Fixed header to top of table. **NOTE:** Does not work in IE11",
     "groupBy": "Changes which item property should be used for grouping items. Currently only supports a single grouping in the format: `group` or `['group']`. When using an array, only the first element is considered. Can be used with `.sync` modifier",
     "groupDesc": "Changes which direction grouping is done. Can be used with `.sync` modifier",

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -957,11 +957,12 @@ describe('VDataTable.ts', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  // https://github.com/vuetifyjs/vuetify/issues/11179
-  it('should return rows from columns that exclusively match custom filters', async () => {
+  // https://github.com/vuetifyjs/vuetify/issues/11600
+  it('should return rows from columns that match custom filters', async () => {
     const wrapper = mountFunction({
       propsData: {
         items: testItems,
+        filterMode: 'union',
         headers: [
           { text: 'Dessert (100g serving)', align: 'left', value: 'name' },
           { text: 'Calories', value: 'calories', filter: value => value === 159 },
@@ -973,6 +974,33 @@ describe('VDataTable.ts', () => {
       },
     })
 
+    wrapper.setProps({ search: 'eclair' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(2)
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/11179
+  it('should return rows from columns that exclusively match custom filters', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: testItems,
+        filterMode: 'intersection',
+        headers: [
+          { text: 'Dessert (100g serving)', align: 'left', value: 'name' },
+          { text: 'Calories', value: 'calories', filter: value => value === 159 },
+          { text: 'Fat (g)', value: 'fat' },
+          { text: 'Carbs (g)', value: 'carbs' },
+          { text: 'Protein (g)', value: 'protein' },
+          { text: 'Iron (%)', value: 'iron' },
+        ],
+      },
+    })
+
+    wrapper.setProps({ search: 'eclair' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.internalCurrentItems).toHaveLength(0)
+
+    wrapper.setProps({ search: 'frozen' })
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.internalCurrentItems).toHaveLength(1)
   })

--- a/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
+++ b/packages/vuetify/src/components/VDataTable/__tests__/__snapshots__/VDataTable.spec.ts.snap
@@ -2874,18 +2874,18 @@ exports[`VDataTable.ts should hide group button when column is not groupable 1`]
                   <div role="button"
                        aria-haspopup="listbox"
                        aria-expanded="false"
-                       aria-owns="list-747"
+                       aria-owns="list-763"
                        class="v-input__slot"
                   >
                     <div class="v-select__slot">
-                      <label for="input-747"
+                      <label for="input-763"
                              class="v-label theme--light"
                              style="left: 0px; position: absolute;"
                       >
                         Sort by
                       </label>
                       <div class="v-select__selections">
-                        <input id="input-747"
+                        <input id="input-763"
                                readonly="readonly"
                                type="text"
                                aria-readonly="false"
@@ -3424,7 +3424,7 @@ exports[`VDataTable.ts should hide group button when column is not groupable 1`]
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-751"
+               aria-owns="list-767"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -3433,7 +3433,7 @@ exports[`VDataTable.ts should hide group button when column is not groupable 1`]
                   10
                 </div>
                 <input aria-label="Rows per page:"
-                       id="input-751"
+                       id="input-767"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"
@@ -11354,18 +11354,18 @@ exports[`VDataTable.ts should respect mustSort property on options 1`] = `
                   <div role="button"
                        aria-haspopup="listbox"
                        aria-expanded="false"
-                       aria-owns="list-731"
+                       aria-owns="list-747"
                        class="v-input__slot"
                   >
                     <div class="v-select__slot">
-                      <label for="input-731"
+                      <label for="input-747"
                              class="v-label theme--light"
                              style="left: 0px; position: absolute;"
                       >
                         Sort by
                       </label>
                       <div class="v-select__selections">
-                        <input id="input-731"
+                        <input id="input-747"
                                readonly="readonly"
                                type="text"
                                aria-readonly="false"
@@ -11504,7 +11504,7 @@ exports[`VDataTable.ts should respect mustSort property on options 1`] = `
           <div role="button"
                aria-haspopup="listbox"
                aria-expanded="false"
-               aria-owns="list-735"
+               aria-owns="list-751"
                class="v-input__slot"
           >
             <div class="v-select__slot">
@@ -11513,7 +11513,7 @@ exports[`VDataTable.ts should respect mustSort property on options 1`] = `
                   10
                 </div>
                 <input aria-label="Rows per page:"
-                       id="input-735"
+                       id="input-751"
                        readonly="readonly"
                        type="text"
                        aria-readonly="false"

--- a/packages/vuetify/types/index.d.ts
+++ b/packages/vuetify/types/index.d.ts
@@ -296,6 +296,8 @@ export interface DataTableHeader<T extends any = any> {
   sort?: DataTableCompareFunction<T>
 }
 
+export type DataTableFilterMode = 'union' | 'intersection'
+
 export type DataItemsPerPageOption = (number | {
   text: string
   value: number


### PR DESCRIPTION
Closes #11600

I pretty much just restored the code from before #11575 as "union", keeping the current behaviour as "intersection"