### PR TITLE
fix(VDataTableRows): creating new prop to get key independently from itemValue

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/composables/items.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/items.ts
@@ -11,26 +11,30 @@ export interface DataTableItemProps {
   items: any[]
   itemValue: SelectItemKey
   returnObject: boolean
+  itemKey: SelectItemKey
 }
 
 // Composables
-export const makeDataTableItemProps = propsFactory({
-  items: {
-    type: Array as PropType<DataTableItemProps['items']>,
-    default: () => ([]),
+export const makeDataTableItemProps = propsFactory(
+  {
+    items: {
+      type: Array as PropType<DataTableItemProps['items']>,
+      default: () => [],
+    },
+    itemValue: {
+      type: [String, Array, Function] as PropType<SelectItemKey>,
+      default: 'value',
+    },
+    returnObject: Boolean,
+    itemKey: {
+      type: [String, Array, Function] as PropType<SelectItemKey>,
+      default: 'id',
+    },
   },
-  itemValue: {
-    type: [String, Array, Function] as PropType<SelectItemKey>,
-    default: 'value',
-  },
-  returnObject: Boolean,
-}, 'v-data-table-item')
+  'v-data-table-item'
+)
 
-export function transformItem (
-  props: Omit<DataTableItemProps, 'items'>,
-  item: any,
-  columns: InternalDataTableHeader[]
-): DataTableItem {
+export function transformItem (props: Omit<DataTableItemProps, 'items'>, item: any, columns: InternalDataTableHeader[]): DataTableItem {
   const value = props.returnObject ? item : getPropertyFromItem(item, props.itemValue)
   const itemColumns = columns.reduce((obj, column) => {
     obj[column.key] = getPropertyFromItem(item, column.value ?? column.key)
@@ -42,6 +46,7 @@ export function transformItem (
     value,
     columns: itemColumns,
     raw: item,
+    key: getPropertyFromItem(item, props.itemKey),
   }
 }
 

--- a/packages/vuetify/src/labs/VDataTable/types.ts
+++ b/packages/vuetify/src/labs/VDataTable/types.ts
@@ -33,4 +33,5 @@ export interface DataTableItem<T = any> extends GroupableItem<T> {
   columns: {
     [key: string]: any
   }
+  key: string
 }


### PR DESCRIPTION
Fix #17748 

The problem was that the same item.value was used for the key of the VDataTableRow. And since you can use that attribute to select items in the table, and change what item.value is, it could not satisfy the purpose of the "key" when you iterate components (v-for). On the other hand, when you use the returnObject prop in VDataTable, or VDataTableServer, the key yields the same "item_[object Object]" value for every component here [VDataTableRows:149](https://github.com/vuetifyjs/vuetify/blob/eb235561b867fed0b94b2273843f2e1cf7a957c6/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx#L149)
