### PR TITLE
fix(VField): prevent input dom overflow v-field__input

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -128,6 +128,7 @@
   letter-spacing: $field-letter-spacing
   opacity: $field-input-opacity
   min-height: calc(var(--v-field-input-min-height) + var(--v-input-chips-margin-bottom) + $input-chips-margin-top)
+  min-width: 0
   padding-inline-start: var(--v-field-padding-start)
   padding-inline-end: var(--v-field-padding-end)
   padding-top: var(--v-field-input-padding-top)


### PR DESCRIPTION
fixes #17740

`min-width: 0` prevents input tag overflows its container (which is a flex child)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container fluid>
    <v-row>
      <v-col cols="4">
        <v-list-subheader>Suffix for weight</v-list-subheader>
      </v-col>

      <v-col cols="8">
        <v-text-field
          label="Weight"
          model-value="28.00"
          type="number"
          suffix="litres"
        />
      </v-col>
    </v-row>
  </v-container>
</template>


```
