### PR TITLE
fix(VTabs): remove quotes from text-transform

### DIFF
--- a/packages/vuetify/src/components/VTabs/_variables.scss
+++ b/packages/vuetify/src/components/VTabs/_variables.scss
@@ -3,7 +3,7 @@
 $tab-disabled-opacity: .5 !default;
 $tab-font-size: map-deep-get($headings, 'subtitle-2', 'size') !default;
 $tab-font-weight: map-deep-get($headings, 'subtitle-2', 'weight') !default;
-$tab-text-transform: 'uppercase' !default;
+$tab-text-transform: uppercase !default;
 $tab-line-height: normal !default;
 $tabs-bar-background-color: 'cards' !default;
 $tabs-bar-height: 48px !default;


### PR DESCRIPTION
## Description

Resolves regression introdued in [#8253c7e](https://github.com/vuetifyjs/vuetify/commit/8253c7e6774345cc1cc85e35846403568f822aaa) where `uppercase` text transform should not be quoted for property to be applited correctly.
