### PR TITLE
fix(VSelects): add missing open / close labels and update roles

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -72,6 +72,7 @@ export const makeVAutocompleteProps = propsFactory({
   ...makeSelectProps(),
   ...omit(makeVTextFieldProps({
     modelValue: null,
+    role: 'combobox',
   }), ['validationValue', 'dirty', 'appendInnerIcon']),
   ...makeTransitionProps({ transition: false }),
 }, 'VAutocomplete')
@@ -127,6 +128,7 @@ export const VAutocomplete = genericComponent<new <
     })
     const selectionIndex = shallowRef(-1)
     const color = computed(() => vTextFieldRef.value?.color)
+    const label = computed(() => menu.value ? props.closeText : props.openText)
     const { items, transformIn, transformOut } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(color)
     const search = useProxiedModel(props, 'search', '')
@@ -557,6 +559,8 @@ export const VAutocomplete = genericComponent<new <
                     icon={ props.menuIcon }
                     onMousedown={ onMousedownMenuIcon }
                     onClick={ noop }
+                    aria-label={ t(label.value) }
+                    title={ t(label.value) }
                   />
                 ) : undefined }
               </>

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -73,6 +73,7 @@ export const makeVComboboxProps = propsFactory({
   ...makeSelectProps({ hideNoData: true, returnObject: true }),
   ...omit(makeVTextFieldProps({
     modelValue: null,
+    role: 'combobox',
   }), ['validationValue', 'dirty', 'appendInnerIcon']),
   ...makeTransitionProps({ transition: false }),
 }, 'VCombobox')
@@ -129,6 +130,7 @@ export const VCombobox = genericComponent<new <
     const selectionIndex = shallowRef(-1)
     let cleared = false
     const color = computed(() => vTextFieldRef.value?.color)
+    const label = computed(() => menu.value ? props.closeText : props.openText)
     const { items, transformIn, transformOut } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(color)
     const model = useProxiedModel(
@@ -589,6 +591,8 @@ export const VCombobox = genericComponent<new <
                     icon={ props.menuIcon }
                     onMousedown={ onMousedownMenuIcon }
                     onClick={ noop }
+                    aria-label={ t(label.value) }
+                    title={ t(label.value) }
                   />
                 ) : undefined }
               </>

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -47,6 +47,14 @@ type Value <T, ReturnObject extends boolean, Multiple extends boolean> =
 export const makeSelectProps = propsFactory({
   chips: Boolean,
   closableChips: Boolean,
+  closeText: {
+    type: String,
+    default: '$vuetify.close',
+  },
+  openText: {
+    type: String,
+    default: '$vuetify.open',
+  },
   eager: Boolean,
   hideNoData: Boolean,
   hideSelected: Boolean,
@@ -76,6 +84,7 @@ export const makeVSelectProps = propsFactory({
   ...makeSelectProps(),
   ...omit(makeVTextFieldProps({
     modelValue: null,
+    role: 'button',
   }), ['validationValue', 'dirty', 'appendInnerIcon']),
   ...makeTransitionProps({ transition: { component: VDialogTransition as Component } }),
 }, 'VSelect')
@@ -144,6 +153,7 @@ export const VSelect = genericComponent<new <
     })
     const selected = computed(() => selections.value.map(selection => selection.props.value))
     const isFocused = shallowRef(false)
+    const label = computed(() => menu.value ? props.closeText : props.openText)
 
     let keyboardLookupPrefix = ''
     let keyboardLookupLastTime: number
@@ -290,6 +300,8 @@ export const VSelect = genericComponent<new <
           onMousedown:control={ onMousedownControl }
           onBlur={ onBlur }
           onKeydown={ onKeydown }
+          aria-label={ t(label.value) }
+          title={ t(label.value) }
         >
           {{
             ...slots,

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -35,6 +35,7 @@ export const makeVTextFieldProps = propsFactory({
   persistentPlaceholder: Boolean,
   persistentCounter: Boolean,
   suffix: String,
+  role: String,
   type: {
     type: String,
     default: 'text',
@@ -194,7 +195,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                 onClick:clear={ onClear }
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
-                role="textbox"
+                role={ props.role }
                 { ...fieldProps }
                 id={ id.value }
                 active={ isActive.value || isDirty.value }

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -249,7 +249,6 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                 onClick:clear={ onClear }
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
-                role="textbox"
                 { ...fieldProps }
                 active={ isActive.value || isDirty.value }
                 centerAffix={ rows.value === 1 && !isPlainOrUnderlined.value }

--- a/packages/vuetify/src/locale/af.ts
+++ b/packages/vuetify/src/locale/af.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'badge',
+  open: 'Open',
   close: 'Close',
   dataIterator: {
     noResultsText: 'Geen ooreenstemmende resultate is gevind nie',

--- a/packages/vuetify/src/locale/ar.ts
+++ b/packages/vuetify/src/locale/ar.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'شارة',
+  open: 'Open',
   close: 'إغلاق',
   dataIterator: {
     noResultsText: 'لم يتم إيجاد نتائج',

--- a/packages/vuetify/src/locale/az.ts
+++ b/packages/vuetify/src/locale/az.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'nişan',
+  open: 'Open',
   close: 'Bağla',
   dataIterator: {
     noResultsText: 'Uyğun məlumat tapılmadı',

--- a/packages/vuetify/src/locale/bg.ts
+++ b/packages/vuetify/src/locale/bg.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Значка',
+  open: 'Open',
   close: 'Затвори',
   dataIterator: {
     noResultsText: 'Не са намерени записи',

--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Insígnia',
+  open: 'Open',
   close: 'Tancar',
   dataIterator: {
     noResultsText: 'Sense dades per mostrar',

--- a/packages/vuetify/src/locale/ckb.ts
+++ b/packages/vuetify/src/locale/ckb.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'باج',
+  open: 'Open',
   close: 'داخستن',
   dataIterator: {
     noResultsText: 'هیچ تۆمارێکی هاوتا نەدۆزرایەوە',

--- a/packages/vuetify/src/locale/cs.ts
+++ b/packages/vuetify/src/locale/cs.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Odznak',
+  open: 'Open',
   close: 'Zavřít',
   dataIterator: {
     noResultsText: 'Nenalezeny žádné záznamy',

--- a/packages/vuetify/src/locale/da.ts
+++ b/packages/vuetify/src/locale/da.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Emblem',
+  open: 'Open',
   close: 'Luk',
   dataIterator: {
     noResultsText: 'Ingen matchende data fundet',

--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Abzeichen',
+  open: 'Open',
   close: 'Schließen',
   dataIterator: {
     noResultsText: 'Keine Elemente gefunden',

--- a/packages/vuetify/src/locale/el.ts
+++ b/packages/vuetify/src/locale/el.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Σήμα',
+  open: 'Open',
   close: 'Close',
   dataIterator: {
     noResultsText: 'Δε βρέθηκαν αποτελέσματα',

--- a/packages/vuetify/src/locale/en.ts
+++ b/packages/vuetify/src/locale/en.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Badge',
+  open: 'Open',
   close: 'Close',
   dataIterator: {
     noResultsText: 'No matching records found',

--- a/packages/vuetify/src/locale/es.ts
+++ b/packages/vuetify/src/locale/es.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Placa',
+  open: 'Open',
   close: 'Cerrar',
   dataIterator: {
     noResultsText: 'Ningún elemento coincide con la búsqueda',

--- a/packages/vuetify/src/locale/et.ts
+++ b/packages/vuetify/src/locale/et.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Märk',
+  open: 'Open',
   close: 'Sulge',
   dataIterator: {
     noResultsText: 'Vastavaid kirjeid ei leitud',

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'نشان',
+  open: 'Open',
   close: 'بستن',
   dataIterator: {
     noResultsText: 'نتیجه‌ای یافت نشد',

--- a/packages/vuetify/src/locale/fi.ts
+++ b/packages/vuetify/src/locale/fi.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Infopiste',
+  open: 'Open',
   close: 'Sulje',
   dataIterator: {
     noResultsText: 'Ei osumia',

--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Badge',
+  open: 'Open',
   close: 'Fermer',
   dataIterator: {
     noResultsText: 'Aucun enregistrement correspondant trouvé',

--- a/packages/vuetify/src/locale/he.ts
+++ b/packages/vuetify/src/locale/he.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'תג',
+  open: 'Open',
   close: 'סגור',
   dataIterator: {
     noResultsText: 'לא נמצאו תוצאות מתאימות',

--- a/packages/vuetify/src/locale/hr.ts
+++ b/packages/vuetify/src/locale/hr.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Bedž',
+  open: 'Open',
   close: 'Zatvori',
   dataIterator: {
     noResultsText: 'Nisu pronađene odgovarajuće stavke',

--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Jelvény',
+  open: 'Open',
   close: 'Bezárás',
   dataIterator: {
     noResultsText: 'Nincs egyező találat',

--- a/packages/vuetify/src/locale/id.ts
+++ b/packages/vuetify/src/locale/id.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Lencana',
+  open: 'Open',
   close: 'Tutup',
   dataIterator: {
     noResultsText: 'Tidak ditemukan catatan yang cocok',

--- a/packages/vuetify/src/locale/it.ts
+++ b/packages/vuetify/src/locale/it.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Distintivo',
+  open: 'Open',
   close: 'Chiudi',
   dataIterator: {
     noResultsText: 'Nessun risultato trovato',

--- a/packages/vuetify/src/locale/ja.ts
+++ b/packages/vuetify/src/locale/ja.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'バッジ',
+  open: 'Open',
   close: '閉じる',
   dataIterator: {
     noResultsText: '検索結果が見つかりません。',

--- a/packages/vuetify/src/locale/ko.ts
+++ b/packages/vuetify/src/locale/ko.ts
@@ -1,5 +1,6 @@
 export default {
   badge: '배지',
+  open: 'Open',
   close: '닫기',
   dataIterator: {
     noResultsText: '일치하는 항목이 없습니다.',

--- a/packages/vuetify/src/locale/lt.ts
+++ b/packages/vuetify/src/locale/lt.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Ženklelis',
+  open: 'Open',
   close: 'Uždaryti',
   dataIterator: {
     noResultsText: 'Nerasta atitinkančių įrašų',

--- a/packages/vuetify/src/locale/lv.ts
+++ b/packages/vuetify/src/locale/lv.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Žetons',
+  open: 'Open',
   close: 'Aizvērt',
   dataIterator: {
     noResultsText: 'Nekas netika atrasts',

--- a/packages/vuetify/src/locale/nl.ts
+++ b/packages/vuetify/src/locale/nl.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'insigne',
+  open: 'Open',
   close: 'Sluiten',
   dataIterator: {
     noResultsText: 'Geen overeenkomende resultaten gevonden',

--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Skilt',
+  open: 'Open',
   close: 'Lukk',
   dataIterator: {
     noResultsText: 'Fant ingen matchende elementer.',

--- a/packages/vuetify/src/locale/pl.ts
+++ b/packages/vuetify/src/locale/pl.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Odznaka',
+  open: 'Open',
   close: 'Zamknij',
   dataIterator: {
     noResultsText: 'Nie znaleziono danych odpowiadających wyszukiwaniu',

--- a/packages/vuetify/src/locale/pt.ts
+++ b/packages/vuetify/src/locale/pt.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Distintivo',
+  open: 'Open',
   close: 'Fechar',
   dataIterator: {
     noResultsText: 'Nenhum dado encontrado',

--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Insignă',
+  open: 'Open',
   close: 'Închideți',
   dataIterator: {
     noResultsText: 'Nu s-au găsit înregistrări corespunzătoare',

--- a/packages/vuetify/src/locale/ru.ts
+++ b/packages/vuetify/src/locale/ru.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'знак',
+  open: 'Open',
   close: 'Закрыть',
   dataIterator: {
     noResultsText: 'Не найдено подходящих записей',

--- a/packages/vuetify/src/locale/sk.ts
+++ b/packages/vuetify/src/locale/sk.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Odznak',
+  open: 'Open',
   close: 'Zavrieť',
   dataIterator: {
     noResultsText: 'Neboli nájdené žiadne záznamy',

--- a/packages/vuetify/src/locale/sl.ts
+++ b/packages/vuetify/src/locale/sl.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Značka',
+  open: 'Open',
   close: 'Zapri',
   dataIterator: {
     noResultsText: 'Ni iskanega zapisa',

--- a/packages/vuetify/src/locale/sr-Cyrl.ts
+++ b/packages/vuetify/src/locale/sr-Cyrl.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Значка',
+  open: 'Open',
   close: 'Затвори',
   dataIterator: {
     noResultsText: 'Ни један запис није пронађен',

--- a/packages/vuetify/src/locale/sr-Latn.ts
+++ b/packages/vuetify/src/locale/sr-Latn.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Značka',
+  open: 'Open',
   close: 'Zatvori',
   dataIterator: {
     noResultsText: 'Nijedan zapis nije pronađen',

--- a/packages/vuetify/src/locale/sv.ts
+++ b/packages/vuetify/src/locale/sv.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Bricka',
+  open: 'Open',
   close: 'Stäng',
   dataIterator: {
     noResultsText: 'Hittade inga poster',

--- a/packages/vuetify/src/locale/th.ts
+++ b/packages/vuetify/src/locale/th.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'สัญลักษณ์',
+  open: 'Open',
   close: 'ปิด',
   dataIterator: {
     noResultsText: 'ไม่พบข้อมูลที่ค้นหา',

--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'rozet',
+  open: 'Open',
   close: 'Kapat',
   dataIterator: {
     noResultsText: 'Eşleşen veri bulunamadı',

--- a/packages/vuetify/src/locale/uk.ts
+++ b/packages/vuetify/src/locale/uk.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Знак',
+  open: 'Open',
   close: 'Закрити',
   dataIterator: {
     noResultsText: 'В результаті пошуку нічого не знайдено',

--- a/packages/vuetify/src/locale/vi.ts
+++ b/packages/vuetify/src/locale/vi.ts
@@ -1,5 +1,6 @@
 export default {
   badge: 'Huy hiệu',
+  open: 'Open',
   close: 'Đóng',
   dataIterator: {
     noResultsText: 'Không tìm thấy kết quả nào',

--- a/packages/vuetify/src/locale/zh-Hans.ts
+++ b/packages/vuetify/src/locale/zh-Hans.ts
@@ -1,5 +1,6 @@
 export default {
   badge: '徽章',
+  open: 'Open',
   close: '关闭',
   dataIterator: {
     noResultsText: '没有符合条件的结果',

--- a/packages/vuetify/src/locale/zh-Hant.ts
+++ b/packages/vuetify/src/locale/zh-Hant.ts
@@ -1,5 +1,6 @@
 export default {
   badge: '徽章',
+  open: 'Open',
   close: '關閉',
   dataIterator: {
     noResultsText: '沒有符合條件的結果',


### PR DESCRIPTION
## Motivation and Context
Improve selects a11y

## Markup:
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <v-autocomplete
        placeholder="Placeholder"
        name="autocomplete"
        :items="[1, 2, 3]"
      />
      <v-combobox
        placeholder="Placeholder"
        name="combobox"
        :items="[1, 2, 3]"
      />
      <v-select
        placeholder="Placeholder"
        name="select"
        :items="[1, 2, 3]"
      />

      <v-text-field
        placeholder="Placeholder"
        name="text-field"
      />

      <v-textarea
        placeholder="Placeholder"
        name="textarea"
      />
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
</script>
```
</details>