### PR TITLE
docs(upgrade-guide): remove components that are now available

### DIFF
--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -27,7 +27,9 @@ Many of these changes can be applied automatically by [eslint-plugin-vuetify](ht
   Not all Vuetify 2 components are currently available in Vuetify 3; These components will be released as their development is completed via [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/).
 
 - v-calendar
+- [v-date-picker](/components/date-pickers/)
 - [v-data-table](/components/data-tables/basics/)
+- [v-skeleton-loader](/components/skeleton-loaders/)
 - v-stepper
 - v-time-picker
 - v-treeview

--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -27,9 +27,7 @@ Many of these changes can be applied automatically by [eslint-plugin-vuetify](ht
   Not all Vuetify 2 components are currently available in Vuetify 3; These components will be released as their development is completed via [Vuetify Labs](https://vuetifyjs.com/en/labs/introduction/).
 
 - v-calendar
-- v-date-picker
 - [v-data-table](/components/data-tables/basics/)
-- [v-skeleton-loader](/components/skeleton-loaders/)
 - v-stepper
 - v-time-picker
 - v-treeview
@@ -210,10 +208,6 @@ app.use(vuetify)
 - `internal-activator` prop has been removed without replacement
 - `offset-y` and `offset-x` props have been removed. Use `offset` prop instead
 - `absolute` variant has been removed. For absolute positioning use css instead
-
-### v-skeleton-loader
-
-- This component hasn't been migrated to vuetify 3
 
 ### v-snackbar
 


### PR DESCRIPTION
## Description
Some of the components listed in the upgrade guide are now available, so we should remove them from the list