### PR TITLE
fix(VTable): fixed-header with multiple tr headers

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -142,19 +142,19 @@
   > .v-table__wrapper
     > table
       > thead
+        position: sticky
+        top: 0
         > tr
           > th
             border-bottom: 0px !important
-            position: sticky
-            top: 0
 
 .v-table--fixed-footer
   > .v-table__wrapper
     > table
       > tfoot
         > tr
+          position: sticky
+          bottom: 0
           > td,
           > th
               border-top: 0px !important
-              position: sticky
-              bottom: 0


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Position sticky should apply to all elements in tbody & thead

Issue
https://github.com/vuetifyjs/vuetify/issues/17806

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-table fixed-header height="500">
    <thead>
      <tr>
        <th colspan="2">Header of col 1 and 2</th>
      </tr>
      <tr>
        <th>Col 1</th>
        <th>Col 2</th>
      </tr>
    </thead>
    <tbody>
      <tr v-for="(item, index) in data" :key="index">
        <td>{{ index }} in col 1</td>
        <td>{{ index }} in col 2</td>
      </tr>
    </tbody>
  </v-table>
</template>

<script setup lang="ts">
  import { ref } from "vue";

  const data = ref(Array(100).fill(null));
</script>

```
