### PR TITLE
fix(VColorPicker): remove extra margin with hide-input

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.sass
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerEdit.sass
@@ -3,6 +3,7 @@
 
 .v-color-picker-edit
   display: flex
+  margin-top: $color-picker-input-margin-top
 
 .v-color-picker-edit__input
   width: 100%

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.sass
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.sass
@@ -65,4 +65,3 @@
 .v-color-picker-preview
   align-items: center
   display: flex
-  margin-bottom: $color-picker-preview-margin-bottom

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.sass
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.sass
@@ -65,3 +65,4 @@
 .v-color-picker-preview
   align-items: center
   display: flex
+  margin-bottom: $color-picker-preview-margin-bottom

--- a/packages/vuetify/src/components/VColorPicker/_variables.scss
+++ b/packages/vuetify/src/components/VColorPicker/_variables.scss
@@ -6,8 +6,9 @@ $color-picker-elevation: 2 !default;
 $color-picker-input-font-size: 0.75rem !default;
 $color-picker-input-height: 32px !default;
 $color-picker-input-margin: 8px !default;
-$color-picker-input-margin-top: 24px !default;
+$color-picker-preview-margin-bottom: 0 !default;
 $color-picker-input-margin-bottom: 8px !default;
+$color-picker-input-margin-top: 24px !default;
 
 // VColorPickerSwatch
 $color-picker-swatch-color-border-radius: 2px !default;

--- a/packages/vuetify/src/components/VColorPicker/_variables.scss
+++ b/packages/vuetify/src/components/VColorPicker/_variables.scss
@@ -6,7 +6,7 @@ $color-picker-elevation: 2 !default;
 $color-picker-input-font-size: 0.75rem !default;
 $color-picker-input-height: 32px !default;
 $color-picker-input-margin: 8px !default;
-$color-picker-preview-margin-bottom: 24px !default;
+$color-picker-input-margin-top: 24px !default;
 $color-picker-input-margin-bottom: 8px !default;
 
 // VColorPickerSwatch


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #16930

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script>
  export default {
    data() {
      return {
        slider: 100,
      }
    },
  }
</script>
<template>
  <div id="app">
    <v-app>
      <v-sheet class="pa-5">
        <v-color-picker width="265" canvas-height="120" :hide-inputs="false">
        </v-color-picker>
      </v-sheet>

      <v-sheet class="pa-5">
        <v-color-picker width="265" canvas-height="120" :hide-inputs="true">
        </v-color-picker>
      </v-sheet>
    </v-app>
  </div>
</template>
```
