### PR TITLE
fix(VFileInput): readonly prop not working

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -119,13 +119,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       props.active
     ))
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
-    const isReadOnly = computed(() => inputRef.value?.readOnly)
-    function onFocus (e: Event) {
-      if (isReadOnly.value) {
-        e.preventDefault()
-        return
-      }
-
+    function onFocus () {
       if (inputRef.value !== document.activeElement) {
         inputRef.value?.focus()
       }
@@ -144,13 +138,9 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       emit('click:control', e)
     }
     function onClear (e: MouseEvent) {
-      if (inputRef.value?.readOnly) {
-        e.preventDefault()
-        return
-      }
       e.stopPropagation()
 
-      onFocus(e)
+      onFocus()
 
       nextTick(() => {
         model.value = []
@@ -233,15 +223,17 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                         onClick={ e => {
                           e.stopPropagation()
 
-                          onFocus(e)
+                          if (isReadonly.value) e.preventDefault()
+
+                          onFocus()
                         }}
                         onChange={ e => {
-                          if (!e.target || isReadonly.value) return
+                          if (!e.target) return
 
                           const target = e.target as HTMLInputElement
                           model.value = [...target.files ?? []]
                         }}
-                        onFocus={ e => onFocus(e) }
+                        onFocus={ onFocus }
                         onBlur={ blur }
                         { ...slotProps }
                         { ...inputAttrs }

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -119,7 +119,13 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       props.active
     ))
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
-    function onFocus () {
+    const isReadOnly = computed(() => inputRef.value?.readOnly)
+    function onFocus (e: Event) {
+      if (isReadOnly.value) {
+        e.preventDefault()
+        return
+      }
+
       if (inputRef.value !== document.activeElement) {
         inputRef.value?.focus()
       }
@@ -138,9 +144,13 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       emit('click:control', e)
     }
     function onClear (e: MouseEvent) {
+      if (inputRef.value?.readOnly) {
+        e.preventDefault()
+        return
+      }
       e.stopPropagation()
 
-      onFocus()
+      onFocus(e)
 
       nextTick(() => {
         model.value = []
@@ -223,15 +233,15 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                         onClick={ e => {
                           e.stopPropagation()
 
-                          onFocus()
+                          onFocus(e)
                         }}
                         onChange={ e => {
-                          if (!e.target) return
+                          if (!e.target || isReadonly.value) return
 
                           const target = e.target as HTMLInputElement
                           model.value = [...target.files ?? []]
                         }}
-                        onFocus={ onFocus }
+                        onFocus={ e => onFocus(e) }
                         onBlur={ blur }
                         { ...slotProps }
                         { ...inputAttrs }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
readonly prop did not work in VFileInput component. I solve this issue by checking readonly prop in events like onFocus, onChange & onClear.

resolves #17851 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-file-input
        accept="image/*" 
        label="File input"
      >
      </v-file-input>
    </v-container>
  </v-app>
</template>
```
