### PR TITLE
feat(VImg): Add prop to set crossorigin attr on v-img

### DIFF
--- a/packages/api-generator/src/locale/en/VImg.json
+++ b/packages/api-generator/src/locale/en/VImg.json
@@ -4,6 +4,7 @@
     "aspectRatio": "Calculated as `width/height`, so for a 1920x1080px image this will be `1.7778`. Will be calculated automatically if omitted.",
     "cover": "Resizes the background image to cover the entire container.",
     "lazySrc": "Something to show while waiting for the main image to load, typically a small base64-encoded thumbnail. Has a slight blur filter applied.\n\nUse [vuetify-loader](https://github.com/vuetifyjs/vuetify-loader) to generate automatically. NOTE: This prop has no effect unless either `height` or `aspect-ratio` are provided.",
+    "crossorigin": "Allowing cross-origin use of images and canvas [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image)",
     "options": "Options that are passed to the [Intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) constructor.",
     "position": "Overrides the default to change which parts get cropped off. Uses the same syntax as [`background-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position).",
     "sizes": "For use with `srcset`, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes).",

--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -69,6 +69,10 @@ export const makeVImgProps = propsFactory({
     type: [String, Object] as PropType<string | srcObject>,
     default: '',
   },
+  crossorigin: {
+    type: String as PropType<'anonymous' | 'use-credentials'>,
+    default: 'anonymous',
+  },
   srcset: String,
 
   ...makeVResponsiveProps(),
@@ -214,6 +218,7 @@ export const VImg = genericComponent<VImgSlots>()({
           src={ normalisedSrc.value.src }
           srcset={ normalisedSrc.value.srcset }
           alt={ props.alt }
+          crossorigin={ props.crossorigin }
           sizes={ props.sizes }
           ref={ image }
           onLoad={ onLoad }
@@ -244,6 +249,7 @@ export const VImg = genericComponent<VImgSlots>()({
             class={['v-img__img', 'v-img__img--preload', containClasses.value]}
             src={ normalisedSrc.value.lazySrc }
             alt={ props.alt }
+            crossorigin={ props.crossorigin }
           />
         )}
       </MaybeTransition>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
https://github.com/vuetifyjs/vuetify/issues/17848

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

  <v-app>
      <v-img src="https://t3.ftcdn.net/jpg/00/92/53/56/360_F_92535664_IvFsQeHjBzfE6sD4VHdO8u5OHUSc6yHF.jpg" />
</v-app>
  <v-app>
      <v-img  crossorigin="use-credentials" src="https://t3.ftcdn.net/jpg/00/92/53/56/360_F_92535664_IvFsQeHjBzfE6sD4VHdO8u5OHUSc6yHF.jpg" />
</v-app>
```
