### PR TITLE
fix(VInfiniteScroll): always use viewpoint as IntersectionObserver root

### DIFF
--- a/packages/vuetify/src/labs/VInfiniteScroll/VInfiniteScroll.tsx
+++ b/packages/vuetify/src/labs/VInfiniteScroll/VInfiniteScroll.tsx
@@ -84,7 +84,6 @@ export const VInfiniteScrollIntersect = defineComponent({
   setup (props, { emit }) {
     const { intersectionRef, isIntersecting } = useIntersectionObserver(entries => {
     }, props.rootMargin ? {
-      root: props.rootRef,
       rootMargin: props.rootMargin,
     } : undefined)
 


### PR DESCRIPTION
fixes #17583

When `margin: 0`, `IntersectionObserver` becomes closest scrollable div, then it keep loading items forever as intersectionRef is always intersecting scrollable div

[reproduction link](https://play.vuetifyjs.com/#eNqlVMtu2zAQ/JWterCMmlICt4caTpCgpxxaFE3RS5QDI61i1hJJkJQCw9C/d0nJlWynQIDexH3M7OxDD/voVuukbTBaRWubG6EdWHSNhorL56sscjaLrjMJIGqtjIM9KPlVNdJhsQCD5QJeuMs30EFpVA0zgppl0ifkSloHwmFt72teVXcyN1ijdHDlE+NbY/gu8VnxHiqUz26zgiV0C4i3C2jncHUNLXyAy/n8GO47mi+EF0AHrCWFjEGV4sUZJbc7mQNRFUoidAF+73PAC/4palSNi+OpnUSfV5+0vGow0Y3dxIcwgCRJJnpGO1DDDtpOa++RSPA0/Fj7v/m5i9nl3LdnzA59Gj4On15tPFPb2eCk9l5+urgIry6T67QfOo2YHsSmK+4wDHzdMq51+AwP6q3jQqIZTGQsROvbT2tSKvUDS1qVdUrGMeIdY/BNQc3Ns5CgjdIJwK87WQpJ2u5zo2iG1H8LjUULrcCXsGbcglHKAVb9/BgbMVsmhnxGxRPA2IFaFUjVCFpPYzF3WTT6Vn0R5L6Ymm/8tpDxfGnGqL/cgb0S1jE/GWhZqQzlxv41B1L4ysCyCFZb3PmyyDlc02twzAlX4TXceej3+30Ag66DdXoeNalo6h27RNaTNh1GSZ7jWXpLP+p1OlmBaBH1R89qrpPfVkn6SYTTICnBQf+G1eFYsohO37+zaOOctqs0zQtJaQVWojWJRJdKXac3FJYa+oHQxbFC1TfLZJl8pK2xbmpO0NbsyagXi4ZAsmi4kkDjRLl7A9UQGRg+9wyDiVX8yXqKM+iU+Fo0zKAs0KB5q6KTtKmqE9eZsuEUO+p3JeTWnrQ6t6HND4ci/0tyAPNIj56wW0ShTmIOCdHjHwJE9IU=)


As per discussion in #17583, always using viewpoint as root should cover all multiple scrollable ancester divs cases

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script setup lang="ts">
  import { onMounted, ref, watch } from 'vue'

  const itemsSmallIncrement = ref(Array.from({ length: 3 }, (k, v) => v + 1))
  const itemPerCallSmall = ref(3)

  const loadSmallIncrement = async ({ done }) => {
    setTimeout(() => {
      itemsSmallIncrement.value.push(
        ...Array.from(
          { length: itemPerCallSmall.value },
          (k, v) => v + itemsSmallIncrement.value.at(-1) + 1
        )
      )

      done('ok')
    }, 1500)
  }
</script>

<template>
  <v-app>
    <v-container>
      <div ref="fooRef"></div>
      <!-- No margin prop.  VInfiniteScroll sets uses viewport as root element -->
      <v-infinite-scroll
        mode="intersect"
        :margin="0"
        @load="loadSmallIncrement"
        >
        <v-list-item v-for="(item) in itemsSmallIncrement" :key="item">
          <v-list-item-title> Item #{{ item }} </v-list-item-title>
        </v-list-item>
      </v-infinite-scroll>
    </v-container>
  </v-app>
</template>


```
