### PR TITLE
fix(date): parse string dates in local time zone

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -164,6 +164,7 @@
     "rollup-plugin-sass": "^1.2.19",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^7.0.2",
+    "timezone-mock": "^1.3.6",
     "ts-json-schema-generator": "^1.2.0",
     "vite": "^4.3.5",
     "vite-ssr": "^0.17.1",

--- a/packages/vuetify/src/labs/date/adapters/__tests__/vuetify.spec.ts
+++ b/packages/vuetify/src/labs/date/adapters/__tests__/vuetify.spec.ts
@@ -1,5 +1,6 @@
 // Utilities
 import { describe, expect, it } from '@jest/globals'
+import timezoneMock, { TimeZone } from 'timezone-mock'
 import { VuetifyDateAdapter } from '../vuetify'
 
 describe('vuetify date adapter', () => {
@@ -21,5 +22,31 @@ describe('vuetify date adapter', () => {
     instance = new VuetifyDateAdapter({ locale: 'sv-SE' })
 
     expect(instance.format(new Date(2000, 0, 1), 'fullDateWithWeekday')).toBe('lördag 1 januari 2000')
+  })
+
+  it.each([
+    'UTC',
+    'US/Pacific',
+    'Europe/London',
+    'Brazil/East',
+    'Australia/Adelaide',
+    'Etc/GMT-2',
+    'Etc/GMT-4',
+    'Etc/GMT+4',
+  ])('should handle timezone %s when parsing date without time', (timezone) => {
+    // locale option here has no impact on timezone
+    let instance = new VuetifyDateAdapter({ locale: 'en-us' })
+
+    const str = "2001-01-01"
+
+    timezoneMock.register(timezone as TimeZone)
+
+    const date = instance.date(str)
+
+    expect(date?.getFullYear()).toBe(2001)
+    expect(date?.getDate()).toBe(1)
+    expect(date?.getMonth()).toBe(0)
+
+    timezoneMock.unregister()
   })
 })

--- a/packages/vuetify/src/labs/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/labs/date/adapters/vuetify.ts
@@ -204,16 +204,11 @@ function endOfMonth (date: Date) {
   return new Date(date.getFullYear(), date.getMonth() + 1, 0)
 }
 
-function formatYyyyMmDd (value: string): string {
-  const formattedValue = value.split('-')
-    .map(d => d.padStart(2, '0'))
-    .join('-')
+function parseLocalDate (value: string): Date {
+  const parts = value.split('-').map(Number)
 
-  const offsetMin = (new Date().getTimezoneOffset() / -60)
-  const offsetSign = offsetMin < 0 ? '-' : '+'
-  const offsetValue = Math.abs(offsetMin).toString().padStart(2, '0')
-
-  return `${formattedValue}T00:00:00.000${offsetSign}${offsetValue}:00`
+  // new Date() uses local time zone when passing individual date component values
+  return new Date(parts[0], parts[1] - 1, parts[2])
 }
 
 const _YYYMMDD = /([12]\d{3}-([1-9]|0[1-9]|1[0-2])-([1-9]|0[1-9]|[12]\d|3[01]))/
@@ -227,7 +222,7 @@ function date (value?: any): Date | null {
     let parsed
 
     if (_YYYMMDD.test(value)) {
-      parsed = Date.parse(formatYyyyMmDd(value))
+      return parseLocalDate(value)
     } else {
       parsed = Date.parse(value)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13413,6 +13413,11 @@ timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==
 
+timezone-mock@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.3.6.tgz#44e4c5aeb57e6c07ae630a05c528fc4d9aab86f4"
+  integrity sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==
+
 tinybench@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.4.0.tgz#83f60d9e5545353610fe7993bd783120bc20c7a7"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

I was still having issues with date picker selecting incorrect date after https://github.com/vuetifyjs/vuetify/pull/17721. This _should_ work, but Date is a pain so who knows. @abea please check if I haven't broken anything.

I feel like we're going to regret using Date instead of plain strings :) 

Should fix https://github.com/vuetifyjs/vuetify/issues/17874

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker v-model="selectedDate" hide-actions />
      {{ selectedDate }}
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selectedDate = ref(new Date(2023, 0, 1))
</script>
```
