### PR TITLE
fix(VExpansionPanel): provide eager prop via defaults

### DIFF
--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.tsx
@@ -6,6 +6,7 @@ import { makeVExpansionPanelTitleProps, VExpansionPanelTitle } from './VExpansio
 // Composables
 import { useBackgroundColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
+import { provideDefaults } from '@/composables/defaults'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { makeGroupItemProps, useGroupItem } from '@/composables/group'
 import { makeLazyProps } from '@/composables/lazy'
@@ -13,7 +14,7 @@ import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
 
 // Utilities
-import { computed, provide } from 'vue'
+import { computed, provide, toRef } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 export const makeVExpansionPanelProps = propsFactory({
@@ -71,6 +72,12 @@ export const VExpansionPanel = genericComponent<VExpansionPanelSlots>()({
 
     provide(VExpansionPanelSymbol, groupItem)
 
+    provideDefaults({
+      VExpansionPanelText: {
+        eager: toRef(props, 'eager'),
+      },
+    })
+
     useRender(() => {
       const hasText = !!(slots.text || props.text)
       const hasTitle = !!(slots.title || props.title)
@@ -115,7 +122,7 @@ export const VExpansionPanel = genericComponent<VExpansionPanelSlots>()({
           )}
 
           { hasText && (
-            <VExpansionPanelText key="text" eager={ props.eager }>
+            <VExpansionPanelText key="text">
               { slots.text ? slots.text() : props.text }
             </VExpansionPanelText>
           )}


### PR DESCRIPTION
fixes #17890

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Provide eager prop to VExpansionPanelText from VExpansionPanel via provideDefaults.


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <VExpansionPanels>
        <VExpansionPanel title="Panel" eager>
          <VExpansionPanelText>Text</VExpansionPanelText>
        </VExpansionPanel>
      </VExpansionPanels>
    </v-container>
  </v-app>
</template>

<script setup></script>
```
