### PR TITLE
fix(VRatingItem): add missing aria label

### DIFF
--- a/packages/vuetify/src/components/VRating/VRating.tsx
+++ b/packages/vuetify/src/components/VRating/VRating.tsx
@@ -178,7 +178,10 @@ export const VRating = genericComponent<VRatingSlots>()({
                 rating: normalizedValue.value,
               })
               : (
-                <VBtn { ...btnProps } />
+                <VBtn
+                  aria-label={ t(props.itemAriaLabel, value, props.length) }
+                  { ...btnProps }
+                />
               )
             }
           </label>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Add missing `aria-label` to `VRatingItem` button. Fixes #17903 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-rating v-model="rating" />
</template>

<script setup>
  import { ref } from 'vue'

  const rating = ref(5)
</script>
```
