### PR TITLE
fix: add locale/ro missing translations

### DIFF
--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -27,25 +27,25 @@ export default {
     pageText: '{0}-{1} din {2}',
   },
   dateRangeInput: {
-    divider: 'to',
+    divider: 'până la',
   },
   datePicker: {
     ok: 'OK',
-    cancel: 'Cancel',
+    cancel: 'Anulează',
     range: {
-      title: 'Select dates',
-      header: 'Enter dates',
+      title: 'Selectați datele',
+      header: 'Introduceți datele',
     },
-    title: 'Select date',
-    header: 'Enter date',
+    title: 'Selectați data',
+    header: 'Introduceți data',
     input: {
-      placeholder: 'Enter date',
+      placeholder: 'Introduceți data',
     },
   },
   noDataText: 'Nu există date disponibile',
   carousel: {
-    prev: 'Grafica anterioară',
-    next: 'Grafica următoare',
+    prev: 'Vizualul anterior',
+    next: 'Vizualul următor',
     ariaLabel: {
       delimiter: 'Slide carusel {0} din {1}',
     },
@@ -54,9 +54,9 @@ export default {
     moreEvents: 'încă {0}',
   },
   input: {
-    clear: 'Clear {0}',
-    prependAction: '{0} prepended action',
-    appendAction: '{0} appended action',
+    clear: 'Șterge {0}',
+    prependAction: '{0} acțiune de inserare la început',
+    appendAction: '{0} acțiune de inserare la sfârșit',
   },
   fileInput: {
     counter: '{0} fișiere',
@@ -68,13 +68,13 @@ export default {
   },
   pagination: {
     ariaLabel: {
-      root: 'Navigare prin paginare',
+      root: 'Navigare prin pagini',
       next: 'Pagina următoare',
       previous: 'Pagina anterioară',
       page: 'Mergeți la pagina {0}',
       currentPage: 'Pagina curentă, pagina {0}',
-      first: 'First page',
-      last: 'Last page',
+      first: 'Prima pagină',
+      last: 'Ultima pagină',
     },
   },
   rating: {
@@ -82,9 +82,9 @@ export default {
       item: 'Rating de {0} din {1}',
     },
   },
-  loading: 'Loading...',
+  loading: 'Se încarcă...',
   infiniteScroll: {
-    loadMore: 'Load more',
-    empty: 'No more',
+    loadMore: 'Încarcă mai multe',
+    empty: 'Nu mai există',
   },
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Add `locale/ro.ts` missing translations. Fixes #17905 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker></v-date-picker>
    </v-container>
  </v-app>
</template>

<script setup></script>
```
