### PR TITLE
feat(VListItem): support link title when rendered as anchor

### DIFF
--- a/packages/api-generator/src/locale/en/VListItem.json
+++ b/packages/api-generator/src/locale/en/VListItem.json
@@ -6,7 +6,8 @@
     "title": "Generates a `v-list-item-title` component with the supplied value",
     "value": "The value used for selection.",
     "nav": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-item.json))",
-    "lines": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-item.json))"
+    "lines": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-item.json))",
+    "linkTitle": "Specify the link title. Useful when the component is rendered as anchor"
   },
   "events": {
     "click": "MISSING DESCRIPTION ([edit in github](https://github.com/vuetifyjs/vuetify/tree/master/packages/api-generator/src/locale/en/v-list-item.json))",

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -74,6 +74,10 @@ export const makeVListItemProps = propsFactory({
     type: Boolean,
     default: undefined,
   },
+  linkTitle: {
+    type: String,
+    default: undefined,
+  },
   nav: Boolean,
   prependAvatar: String,
   prependIcon: IconValue,
@@ -220,6 +224,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
           ]}
           href={ link.href.value }
           tabindex={ isClickable.value ? (list ? -2 : 0) : undefined }
+          title={ isLink.value ? props.linkTitle : undefined }
           onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && props.ripple }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Fixes: #17908

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-card>
        <v-list>
          <v-list-item
            v-for="(item, index) in items"
            :key="index"
            :title="item.title"
            :link-title="item.linkTitle"
            :href="item.href"
          />
        </v-list>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const items = ref([
    {
      title: 'Vuetify',
      linkTitle: 'Vuetify Website',
      href: 'https://vuetifyjs.com/en/',
    },
    {
      title: 'Vue',
      linkTitle: 'Vue Website',
      href: 'https://vuejs.org/',
    },
  ])
</script>

```
