### PR TITLE
fix(VAutocomplete): stop forcing to be pristine when pressing enter, escpe and tab

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -224,12 +224,8 @@ export const VAutocomplete = genericComponent<new <
         menu.value = false
       }
 
-      if (['Enter', 'Escape', 'Tab'].includes(e.key)) {
-        if (highlightFirst.value && ['Enter', 'Tab'].includes(e.key)) {
-          select(filteredItems.value[0])
-        }
-
-        isPristine.value = true
+      if (highlightFirst.value && ['Enter', 'Tab'].includes(e.key)) {
+        select(filteredItems.value[0])
       }
 
       if (e.key === 'ArrowDown' && highlightFirst.value) {

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -465,9 +465,8 @@ describe('VAutocomplete', () => {
   })
 
   it('should auto-select-first item when pressing enter', () => {
-    
     const selectedItems = ref(undefined)
-    
+
     cy
       .mount(() => (
         <VAutocomplete

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -465,9 +465,13 @@ describe('VAutocomplete', () => {
   })
 
   it('should auto-select-first item when pressing enter', () => {
+    
+    const selectedItems = ref(undefined)
+    
     cy
       .mount(() => (
         <VAutocomplete
+          v-model={ selectedItems.value }
           items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
           multiple
           autoSelectFirst
@@ -484,7 +488,10 @@ describe('VAutocomplete', () => {
       .get('.v-autocomplete input')
       .trigger('keydown', { key: keyValues.enter, waitForAnimations: false })
       .get('.v-list-item')
-      .should('have.length', 6)
+      .should('have.length', 1)
+      .then(_ => {
+        expect(selectedItems.value).to.deep.equal(['California'])
+      })
   })
 
   describe('Showcase', () => {


### PR DESCRIPTION
fixes #17910

- "tab" key shouldn't be related to `isPristine` for both VCombobox and VAutocomplete
- It makes sense to set `VCombobox` to pristine when pressing "Enter" & "Escape" keys as input value will become a concrete value and existing select items are still available to be selected 
- But for `VAutocomplete`,  "Escape" closes the menu which sets it to pristine, "Enter" shouldn't impact its `isPristine`

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card>
    <v-container fluid>
      <v-row>
        <v-col cols="12">
          <v-autocomplete
            :items="items"
            autoSelectFirst
            label="Default"
          ></v-autocomplete>
        </v-col>
        <v-col cols="12">
          <v-combobox
            multiple
            :items="items"
            label="Default"
          ></v-combobox>
        </v-col>
      </v-row>
    </v-container>
  </v-card>
</template>

<script>
  export default {
    data: () => ({
      items: ['foo', 'bar', 'fizz', 'buzz'],
    }),
  }
</script>

```
