### PR TITLE
fix(VTable) set z-index to fixed header and footer elements

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -144,6 +144,7 @@
       > thead
         position: sticky
         top: 0
+        z-index: 1
         > tr
           > th
             border-bottom: 0px !important
@@ -155,6 +156,7 @@
         > tr
           position: sticky
           bottom: 0
+          z-index: 1
           > td,
           > th
               border-top: 0px !important


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
Extra patch for https://github.com/vuetifyjs/vuetify/pull/17821/files
```vue


<template>
  <v-table fixed-header height="500">
    <thead>
      <tr>
        <th colspan="2">Header of col 1 and 2</th>
      </tr>
      <tr>
        <th>Col 1</th>
        <th>Col 2</th>
      </tr>
    </thead>
    <tbody>
      <tr v-for="(item, index) in data" :key="index">
        <td>
          <v-text-field />
        </td>
        <td>{{ index }} in col 2</td>
      </tr>
    </tbody>
  </v-table>
</template>

<script setup lang="ts">
  import { ref } from "vue";

  const data = ref(Array(100).fill(null));
</script>

```
