### PR TITLE
fix(theme): only apply head watchers on client

### DIFF
--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -312,7 +312,9 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
     if (head) {
       if (head.push) {
         const entry = head.push(getHead)
-        watch(styles, () => { entry.patch(getHead) })
+        if (IN_BROWSER) {
+          watch(styles, () => { entry.patch(getHead) })
+        }
       } else {
         if (IN_BROWSER) {
           head.addHeadObjs(computed(getHead))
@@ -326,7 +328,11 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
         ? document.getElementById('vuetify-theme-stylesheet')
         : null
 
-      watch(styles, updateStyles, { immediate: true })
+      if (IN_BROWSER) {
+        watch(styles, updateStyles, { immediate: true })
+      } else {
+        updateStyles()
+      }
 
       function updateStyles () {
         if (typeof document !== 'undefined' && !styleEl) {


### PR DESCRIPTION
## Description
These changes fix #17917 and #16156. Watch should only be used on client side because they cannot be automatically unwatched by vue since the watch is being called outside of the vue context. My performance testing showed that these changes finally fix the leaking problem.

