### PR TITLE
fix(VImg): add content-class

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -210,7 +210,7 @@ export const VImg = genericComponent<VImgSlots>()({
 
       const img = (
         <img
-          class={['v-img__img', containClasses.value]}
+          class={['v-img__img', containClasses.value, props.contentClass]}
           src={ normalisedSrc.value.src }
           srcset={ normalisedSrc.value.srcset }
           alt={ props.alt }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

`content-class` value is not set as a class on `<img />`. Fixes https://github.com/vuetifyjs/vuetify/issues/17933
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-img
        width="100"
        src="https://play.vuetifyjs.com/assets/vuetify-play.41631d9c.svg"
        content-class="my-class"
      />
    </v-container>
  </v-app>
</template>

<script setup></script>
```
