### PR TITLE
fix(VListItem): add anchor title

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -220,6 +220,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
           ]}
           href={ link.href.value }
           tabindex={ isClickable.value ? (list ? -2 : 0) : undefined }
+          title={ slots.title?.({ title: props.title }) ?? props.title }
           onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && props.ripple }

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -220,7 +220,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
           ]}
           href={ link.href.value }
           tabindex={ isClickable.value ? (list ? -2 : 0) : undefined }
-          title={ slots.title?.({ title: props.title }) ?? props.title }
+          title={ props.title }
           onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && props.ripple }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
`VListItem` anchor is missing the `title` prop. Fixes: https://github.com/vuetifyjs/vuetify/issues/17908

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-card>
        <v-list>
          <v-list-item
            v-for="(item, index) in items"
            :key="index"
            :title="item.title"
            :href="item.href"
          />
        </v-list>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const items = ref([
    {
      title: 'Vuetify',
      href: 'https://vuetifyjs.com/en/',
    },
    {
      title: 'Vue',
      href: 'https://vuejs.org/',
    },
  ])
</script>
```
