### PR TITLE
fix(VOtpInput): form data support

### DIFF
--- a/packages/vuetify/src/labs/VOtpInput/VOtpInput.sass
+++ b/packages/vuetify/src/labs/VOtpInput/VOtpInput.sass
@@ -16,9 +16,6 @@
     height: 100%
     margin: 0 .25rem
 
-.v-otp-input-input
-  display: none
-
 .v-otp-input__divider
   margin: 0 8px
 

--- a/packages/vuetify/src/labs/VOtpInput/VOtpInput.sass
+++ b/packages/vuetify/src/labs/VOtpInput/VOtpInput.sass
@@ -16,6 +16,9 @@
     height: 100%
     margin: 0 .25rem
 
+.v-otp-input-input
+  display: none
+
 .v-otp-input__divider
   margin: 0 8px
 

--- a/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
@@ -268,6 +268,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
 
             <input
               class="v-otp-input-input"
+              type="hidden"
               { ...inputAttrs }
               value={ model.value.join('') }
             />

--- a/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
@@ -15,7 +15,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref, watch } from 'vue'
-import { focusChild, genericComponent, IN_BROWSER, only, propsFactory, useRender } from '@/util'
+import { filterInputAttrs, focusChild, genericComponent, IN_BROWSER, only, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -78,7 +78,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     'update:modelValue': (val: string) => true,
   },
 
-  setup (props, { emit, slots }) {
+  setup (props, { attrs, emit, slots }) {
     const { dimensionStyles } = useDimension(props)
     const { isFocused, focus, blur } = useFocus(props)
     const model = useProxiedModel(
@@ -202,6 +202,8 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     })
 
     useRender(() => {
+      const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
+
       return (
         <div
           class={[
@@ -214,6 +216,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
           style={[
             props.style,
           ]}
+          { ...rootAttrs }
         >
           <div
             ref={ contentRef }
@@ -262,6 +265,12 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                 </VField>
               </>
             ))}
+
+            <input
+              class="v-otp-input-input"
+              { ...inputAttrs }
+              value={ model.value.join('') }
+            />
 
             <VOverlay
               contained


### PR DESCRIPTION
## Motivation and Context

reference: https://discord.com/channels/340160225338195969/660898563139567625/1136629895330533406

## Markup:
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <form id="form" ref="form">
        <v-otp-input v-model="model" name="otp" @input="onInput" />
      </form>
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const form = ref()
  const model = ref('')

  function onInput () {
    const news = new FormData(form.value)

    console.log(news.get('otp'))
  }
</script>

```
</details>