### PR TITLE
docs(VSkeletonLoaders) In docs we use not existing type card-header

### DIFF
--- a/packages/docs/src/pages/en/components/skeleton-loaders.md
+++ b/packages/docs/src/pages/en/components/skeleton-loaders.md
@@ -61,7 +61,7 @@ The `v-skeleton-loader` component has a small API mainly used to configure the r
 
 #### Type
 
-The **type** property is used to define the type of skeleton loader. Types can be combined to create more complex skeletons. For example, the **card** type is a combination of the **image** and **card-heading** types.
+The **type** property is used to define the type of skeleton loader. Types can be combined to create more complex skeletons. For example, the **card** type is a combination of the **image** and **heading** types.
 
 <example file="v-skeleton-loader/prop-type" />
 
@@ -73,11 +73,10 @@ The following built-in types are available:
 | **article** | heading, paragraph |
 | **avatar** | avatar |
 | **button** | button |
-| **card** | image, card-heading |
+| **card** | image, heading |
 | **card-avatar** | image, list-item-avatar |
-| **card-heading** | heading |
 | **chip** | chip |
-| **date-picker** | list-item, card-heading, divider, date-picker-options, date-picker-days, actions |
+| **date-picker** | list-item, heading, divider, date-picker-options, date-picker-days, actions |
 | **date-picker-options** | text, avatar@2 |
 | **date-picker-days** | avatar@28 |
 | **divider** | divider |


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
According to documentation we can use type="card-header" but this is not true, because we have type "header".
https://vuetifyjs.com/en/components/skeleton-loaders/

This PR fix incorrect documentation.


This issue can be related but I am not sure
https://github.com/vuetifyjs/vuetify/issues/17156

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
