### PR TITLE
fix(VListItem): render subtitle properly in navigation-drawer rail variant

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -125,8 +125,8 @@
     margin-bottom: $list-item-media-three-line-margin-bottom
 
 .v-list-item-subtitle
-  -webkit-box-orient: vertical
-  display: -webkit-box
+  flex-direction: row
+  display: flex
   opacity: $list-item-subtitle-opacity
   overflow: hidden
   padding: $list-item-subtitle-padding


### PR DESCRIPTION
fix(VListItem): renders incorrectly when used with a subtitle in a VNavigationDrawer (rail variant).

fixes #17954 

## Markup:
<details>

```vue
<template>
  <v-card>
    <v-layout>
      <v-navigation-drawer
        v-model="drawer"
        :rail="rail"
        permanent
        @click="rail = false"
      >
        <v-list-item
          prepend-avatar="https://randomuser.me/api/portraits/men/85.jpg"
          title="John Leider"
          subtitle="Lorem ipsum dolor"
          nav
        >
          <template v-slot:append>
            <v-btn
              variant="text"
              icon="mdi-chevron-left"
              @click.stop="rail = !rail"
            ></v-btn>
          </template>
        </v-list-item>

        <v-divider></v-divider>

        <v-list density="compact" nav>
          <v-list-item
            prepend-icon="mdi-home-city"
            title="Home"
            value="home"
          ></v-list-item>
          <v-list-item
            prepend-icon="mdi-account"
            title="My Account"
            value="account"
          ></v-list-item>
          <v-list-item
            prepend-icon="mdi-account-group-outline"
            title="Users"
            value="users"
          ></v-list-item>
        </v-list>
      </v-navigation-drawer>
      <v-main style="height: 250px"></v-main>
    </v-layout>
  </v-card>
</template>

<script>
  export default {
    data() {
      return {
        drawer: true,
        rail: true,
      }
    },
  }
</script>

```
</details>