### PR TITLE
fix(VSwitch): Add background color to VIcon

### DIFF
--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -72,7 +72,7 @@
     position: absolute
 
     .v-icon
-      background: white
+      background: $switch-control-icon-background-color
       border-radius: 50%
       overflow: hidden
 

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -54,7 +54,7 @@
     @include tools.elevation(0)
 
   .v-switch:not(.v-switch--loading) .v-icon ~ &
-    display: none
+    overflow: hidden
 
 .v-switch--loading .v-selection-control__input > .v-icon
   display: none
@@ -72,13 +72,14 @@
     position: absolute
 
     .v-icon
-      background: $switch-control-icon-background-color
-      border-radius: 50%
-      overflow: hidden
+      position: absolute
 
   .v-selection-control--dirty
     .v-selection-control__input
       transform: translateX($switch-thumb-transform)
+
+    .v-icon
+      color: rgb(var(--v-theme-surface))
 
   &.v-switch--indeterminate
     .v-selection-control__input

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -71,6 +71,11 @@
     transform: translateX(-$switch-thumb-transform)
     position: absolute
 
+    .v-icon
+      background: white
+      border-radius: 50%
+      overflow: hidden
+
   .v-selection-control--dirty
     .v-selection-control__input
       transform: translateX($switch-thumb-transform)

--- a/packages/vuetify/src/components/VSwitch/_variables.scss
+++ b/packages/vuetify/src/components/VSwitch/_variables.scss
@@ -17,3 +17,4 @@ $switch-track-radius: 8px !default;
 $switch-track-height: 14px !default;
 $switch-track-opacity: .6 !default;
 $switch-track-width: 36px !default;
+$switch-control-icon-background-color: rgb(var(--v-theme-surface)) !default;

--- a/packages/vuetify/src/components/VSwitch/_variables.scss
+++ b/packages/vuetify/src/components/VSwitch/_variables.scss
@@ -2,7 +2,6 @@
 
 // VSwitch
 $switch-control-input-transition: .15s transform settings.$standard-easing !default;
-$switch-control-icon-background-color: rgb(var(--v-theme-surface)) !default;
 $switch-error-background-color: rgb(var(--v-theme-error)) !default;
 $switch-inset-track-border-radius: 14px !default;
 $switch-inset-track-height: 28px !default;

--- a/packages/vuetify/src/components/VSwitch/_variables.scss
+++ b/packages/vuetify/src/components/VSwitch/_variables.scss
@@ -2,6 +2,7 @@
 
 // VSwitch
 $switch-control-input-transition: .15s transform settings.$standard-easing !default;
+$switch-control-icon-background-color: rgb(var(--v-theme-surface)) !default;
 $switch-error-background-color: rgb(var(--v-theme-error)) !default;
 $switch-inset-track-border-radius: 14px !default;
 $switch-inset-track-height: 28px !default;
@@ -17,4 +18,3 @@ $switch-track-radius: 8px !default;
 $switch-track-height: 14px !default;
 $switch-track-opacity: .6 !default;
 $switch-track-width: 36px !default;
-$switch-control-icon-background-color: rgb(var(--v-theme-surface)) !default;


### PR DESCRIPTION
resolves #17638

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->


## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
**VSwitch** : Added `switch-control-icon-background-color` sass variable for VIcon background color

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-row><v-col>
      <v-switch
        color="primary"
        :model-value="true"
        label="on"
        true-icon="mdi-check"
        false-icon="mdi-close"
        inset
      ></v-switch>
    </v-col></v-row>
    <v-row><v-col>
      <v-switch
        color="red"
        :model-value="true"
        label="on"
        true-icon="mdi-check"
        false-icon="mdi-close"
      ></v-switch>
    </v-col></v-row>
  </v-container>
</template>

```
