### PR TITLE
fix(VTab) Changed classes from v-slide-group to v-tabs

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTab.sass
+++ b/packages/vuetify/src/components/VTabs/VTab.sass
@@ -6,10 +6,10 @@
     --v-btn-height: var(--v-tabs-height)
     min-width: $tab-min-width
 
-  .v-slide-group--horizontal &
+  .v-tabs--horizontal &
     max-width: $tab-max-width
 
-  .v-slide-group--vertical &
+  .v-tabs--vertical &
     justify-content: start
 
 .v-tab__slider
@@ -25,7 +25,7 @@
   .v-tab--selected &
     opacity: 1
 
-  .v-slide-group--vertical &
+  .v-tabs--vertical &
     top: 0
     height: 100%
     width: $tab-slider-size

--- a/packages/vuetify/src/components/VTabs/VTabs.sass
+++ b/packages/vuetify/src/components/VTabs/VTabs.sass
@@ -15,7 +15,7 @@
       &.v-tabs--stacked
         --v-tabs-height: #{$tabs-stacked-height + $modifier}
 
-  &.v-slide-group--vertical
+  &.v-tabs--vertical
     height: auto
     flex: none
     --v-tabs-height: #{$tabs-height}
@@ -47,7 +47,7 @@
     margin-inline-end: 0
 
 @media #{map-get(settings.$display-breakpoints, 'md-and-down')}
-  .v-tabs.v-slide-group--is-overflowing.v-slide-group--horizontal:not(.v-slide-group--has-affixes)
+  .v-tabs.v-slide-group--is-overflowing.v-tabs--horizontal:not(.v-slide-group--has-affixes)
     .v-tab:first-child
       margin-inline-start: 52px
     .v-tab:last-child


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
This PR changes SCSS customization of VTab, which previously used classes such as `.v-slide-group--horizontal` and `.v-slide-group--vertical`. Now it accomplishes the same by using classes such as `.v-tabs--horizontal` and `.v-tabs--vertical`. These classes are already being added by Vuetify, but previously there weren't any uses for them.

resolves #17975

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

Instead of setting up [treeshaking](https://vuetifyjs.com/en/features/treeshaking/) and [component specific variables](https://vuetifyjs.com/en/features/sass-variables/#component-specific-variables), I made a playground which edits these styles using component scoped styles. The first one works only for `direction="horizontal"` and, since the `max-width` style could not specified before this fix, doesn't require `!important` to work. The other three styles work only for `direction="vertical"` and were already working before this change, hence `!important`. I added these to the PR because I think it would help with code consistency. 

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-tabs direction="horizontal">
        <v-tab>Iteeeeeeeem 1</v-tab>
        <v-tab>Item 2</v-tab>
        <v-tab>Item 3</v-tab>
      </v-tabs>
    </v-container>
  </v-app>
</template>

<style>
  /* Requires setting direction='horizontal' */
  .v-tabs--horizontal .v-tab {
    max-width: 100px;
  }

  /* Requires setting direction='vertical' */
  .v-tabs--vertical .v-tab {
    justify-content: end !important;
  }

  .v-tabs--vertical .v-tab__slider {
    width: 10px !important;
  }

  .v-tabs.v-tabs--vertical {
    --v-tabs-height: 100px !important;
  }
</style>
```
