### PR TITLE
fix(VField): correctly calculate outline__start width

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -358,10 +358,17 @@
       transition: opacity $field-subtle-transition-timing
 
     &__start
-      flex: 0 0 $field-control-affixed-padding
       border-top-width: var(--v-field-border-width)
       border-bottom-width: var(--v-field-border-width)
       border-inline-start-width: var(--v-field-border-width)
+
+      $root: &
+
+      @at-root
+        @include tools.density('v-input', $input-density) using ($modifier)
+          @at-root #{selector.nest(&, $root)}
+            flex: 0 0 #{$field-control-outlined-start-width + $modifier * .5}
+
 
       @include tools.ltr()
         border-top-left-radius: inherit

--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -18,6 +18,7 @@ $field-clearable-margin: 4px !default;
 $field-clearable-transition: .15s opacity, .15s width settings.$standard-easing !default;
 
 // CONTROL
+$field-control-outlined-start-width: 29px !default;
 $field-control-solo-background: rgb(var(--v-theme-surface)) !default;
 $field-control-solo-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !default;
 $field-control-solo-elevation: 2 !default;


### PR DESCRIPTION
fixes #17838

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        prepend-inner-icon="$vuetify"
        variant="outlined"
        rounded
      />
      <v-text-field
        prepend-inner-icon="$vuetify"
        density="comfortable"
        variant="outlined"
        rounded
      />
      <v-text-field
        prepend-inner-icon="$vuetify"
        density="compact"
        variant="outlined"
        rounded
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>


```
