### PR TITLE
fix(VNavigationDrawer): collapse v-list-group elements when drawer is not expanded

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -148,6 +148,9 @@
   &--rounded
     @include tools.rounded($button-rounded-border-radius)
 
+    &.v-btn--icon
+      @include tools.rounded($button-border-radius)
+
   .v-icon
     --v-icon-size-multiplier: #{calc(18/21)}
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Collapse elements in v-list-group when the navigation drawer is not expanded.
Fixes #17962

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-navigation-drawer v-model="drawer" rail permanent expand-on-hover>
      <v-list>
        <v-list-group>
          <template #activator="{props}">
            <v-list-item
              v-bind="props"
              prepend-icon="mdi-train"
            >
              Element 1
            </v-list-item>
          </template>

          <v-list-item prepend-icon="mdi-tram">Element 1.1</v-list-item>
          <v-list-item prepend-icon="mdi-tram">Element 1.2</v-list-item>
          <v-list-item prepend-icon="mdi-tram">Element 1.3</v-list-item>
        </v-list-group>

        <v-list-group>
          <template #activator="{props}">
            <v-list-item
              v-bind="props"
              prepend-icon="mdi-train"
            >
              Element 2
            </v-list-item>
          </template>

          <v-list-item prepend-icon="mdi-tram">Element 2.1</v-list-item>
          <v-list-item prepend-icon="mdi-tram">Element 2.2</v-list-item>
          <v-list-item prepend-icon="mdi-tram">Element 2.3</v-list-item>
        </v-list-group>
      </v-list>
    </v-navigation-drawer>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const drawer = ref(true)
</script>
```
