### PR TITLE
feat(display): add local mobile-breakpoint support

### DIFF
--- a/packages/docs/src/pages/en/features/display-and-platform.md
+++ b/packages/docs/src/pages/en/features/display-and-platform.md
@@ -242,7 +242,7 @@ The following components have built in support for the **mobile-breakpoint** pro
 
 By default, **mobileBreakpoint** is set to **lg**, which means that if the window is less than _1280_ pixels in width (which is the default value for the **lg** threshold), then the **useDisplay** composable will update its **mobile** value to `true`.
 
-For example, the [v-banner](/components/banners/) component implements different styling based upon the value of **isLocalMobile** from the **useDisplay** composable. In the following example, The first banner uses the global **mobile-breakpoint** value of **lg** while the second overrides this default with **580**:
+For example, the [v-banner](/components/banners/) component implements different styling when its mobile versus desktop. In the following example, The first banner uses the global **mobile-breakpoint** value of **lg** while the second overrides this default with **580**:
 
 ```html { resource="Component.vue" }
 <template>
@@ -274,19 +274,18 @@ If the screen width is 1024 pixels, the second banner would not convert into its
 
 ### useDisplay overrides
 
-Specify a custom **mobileBreakpoint** value directly to the [useDisplay](/api/use-display/) composable. This allows you to track the applications global mobile value as well as a local value. The following example uses a custom mobileBreakpoint value of **580**:
+Specify a custom **mobileBreakpoint** value directly to the [useDisplay](/api/use-display/) composable and override the global value. In the following example we use a custom mobileBreakpoint value of **580**:
 
 ```html { resource="Component.vue" }
 <script setup>
   import { onMounted } from 'vue'
   import { useDisplay } from 'vuetify'
 
-  const { mobile, isLocalMobile } = useDisplay({ mobileBreakpoint })
+  const { mobile } = useDisplay({ mobileBreakpoint })
 
   // Given a viewport width of 960px
   onMounted(() => {
-    console.log(mobile.value) // true
-    console.log(isLocalMobile.value) // false
+    console.log(mobile.value) // false
   })
 </script>
 ```

--- a/packages/docs/src/pages/en/features/display-and-platform.md
+++ b/packages/docs/src/pages/en/features/display-and-platform.md
@@ -224,9 +224,25 @@ Using the _dynamic_ display values, we are able to adjust the minimum height of 
 
 ## Component Mobile Breakpoints
 
-Some components within Vuetify have a **mobile-breakpoint** property which allows you to override the default value. These components reference the global mobileBreakpoint value that is generated at runtime using the provided options in the `vuetify.js` file. By default, **mobileBreakpoint** is set to `md`, which means that if the window is less than _1280_ pixels in width (which is the default value for the **md** threshold), then the **useDisplay** composable will update its **mobile** value to `true`.
+::: success
 
-For example, the [v-banner](/components/banners/) component implements different styling based upon the value of **mobile** on the **useDisplay** composable. In the following example, The first banner uses the global **mobile-breakpoint** value of `md` while the second overrides this default with `580`. If the screen width is 1024 pixels, the second banner would not convert into its mobile state:
+This feature requires [v3.4.0 (Blackguard)](/getting-started/release-notes/?version=v3.4.0)
+
+:::
+
+Some components within Vuetify have a **mobile-breakpoint** property which allows you to override the default value. These components reference the global mobileBreakpoint value that is generated at runtime using the provided options in the `vuetify.js` file.
+
+The following components have built in support for the **mobile-breakpoint** property:
+
+| Component |
+| - |
+| [v-banner](/components/banners/) |
+| [v-navigation-drawer](/components/navigation-drawers/) |
+| [v-slide-group](/components/slide-groups/) |
+
+By default, **mobileBreakpoint** is set to **lg**, which means that if the window is less than _1280_ pixels in width (which is the default value for the **lg** threshold), then the **useDisplay** composable will update its **mobile** value to `true`.
+
+For example, the [v-banner](/components/banners/) component implements different styling based upon the value of **isLocalMobile** from the **useDisplay** composable. In the following example, The first banner uses the global **mobile-breakpoint** value of **lg** while the second overrides this default with **580**:
 
 ```html { resource="Component.vue" }
 <template>
@@ -251,5 +267,68 @@ For example, the [v-banner](/components/banners/) component implements different
     console.log(width.value) // 960
     console.log(mobile.value) // true
   })
+</script>
+```
+
+If the screen width is 1024 pixels, the second banner would not convert into its mobile state.
+
+### useDisplay overrides
+
+Specify a custom **mobileBreakpoint** value directly to the [useDisplay](/api/use-display/) composable. This allows you to track the applications global mobile value as well as a local value. The following example uses a custom mobileBreakpoint value of **580**:
+
+```html { resource="Component.vue" }
+<script setup>
+  import { onMounted } from 'vue'
+  import { useDisplay } from 'vuetify'
+
+  const { mobile, isLocalMobile } = useDisplay({ mobileBreakpoint })
+
+  // Given a viewport width of 960px
+  onMounted(() => {
+    console.log(mobile.value) // true
+    console.log(isLocalMobile.value) // false
+  })
+</script>
+```
+
+If you supply a value for the **name** argument, utilize the **displayClasses** property to apply the appropriate classes to your component. In the next example, the following classes would be applied to the root element of the component:
+
+```html { resource="Component.vue" }
+<template>
+  <div
+    :class="[
+      'v-component',
+      displayClasses,
+    ]"
+  >
+    <!-- v-component--mobile -->
+  </div>
+</template>
+
+<script setup>
+  import { defineName } from 'vue'
+  import { useDisplay } from 'vuetify'
+
+  const { displayClasses } = useDisplay({ mobileBreakpoint }, 'v-component')
+</script>
+```
+
+If you leave out the name argument, displayClasses will use the default name set by Vue. The following example uses the default name of the local component:
+
+```html { resource="AppDrawer.vue" }
+<template>
+  <v-navigation-drawer
+    :class="[
+      displayClasses, // 'app-drawer--mobile'
+    ]"
+  >
+    ...
+  </v-navigation-drawer>
+</template>
+
+<script setup>
+  import { useDisplay } from 'vuetify'
+
+  const { displayClasses } = useDisplay({ mobileBreakpoint })
 </script>
 ```

--- a/packages/vuetify/src/components/VBanner/VBanner.tsx
+++ b/packages/vuetify/src/components/VBanner/VBanner.tsx
@@ -66,7 +66,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
   setup (props, { slots }) {
     const { borderClasses } = useBorder(props)
     const { densityClasses } = useDensity(props)
-    const { isMobile } = useDisplay(props)
+    const { isLocalMobile } = useDisplay(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
     const { locationStyles } = useLocation(props)
@@ -90,7 +90,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
           class={[
             'v-banner',
             {
-              'v-banner--stacked': props.stacked || isMobile.value,
+              'v-banner--stacked': props.stacked || isLocalMobile.value,
               'v-banner--sticky': props.sticky,
               [`v-banner--${props.lines}-line`]: !!props.lines,
             },

--- a/packages/vuetify/src/components/VBanner/VBanner.tsx
+++ b/packages/vuetify/src/components/VBanner/VBanner.tsx
@@ -66,7 +66,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
   setup (props, { slots }) {
     const { borderClasses } = useBorder(props)
     const { densityClasses } = useDensity(props)
-    const { displayClasses, isLocalMobile } = useDisplay(props)
+    const { displayClasses, mobile } = useDisplay(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
     const { locationStyles } = useLocation(props)
@@ -90,7 +90,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
           class={[
             'v-banner',
             {
-              'v-banner--stacked': props.stacked || isLocalMobile.value,
+              'v-banner--stacked': props.stacked || mobile.value,
               'v-banner--sticky': props.sticky,
               [`v-banner--${props.lines}-line`]: !!props.lines,
             },

--- a/packages/vuetify/src/components/VBanner/VBanner.tsx
+++ b/packages/vuetify/src/components/VBanner/VBanner.tsx
@@ -13,7 +13,7 @@ import { makeComponentProps } from '@/composables/component'
 import { provideDefaults } from '@/composables/defaults'
 import { makeDensityProps, useDensity } from '@/composables/density'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
-import { useDisplay } from '@/composables/display'
+import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { IconValue } from '@/composables/icons'
 import { makeLocationProps, useLocation } from '@/composables/location'
@@ -49,6 +49,7 @@ export const makeVBannerProps = propsFactory({
   ...makeComponentProps(),
   ...makeDensityProps(),
   ...makeDimensionProps(),
+  ...makeDisplayProps(),
   ...makeElevationProps(),
   ...makeLocationProps(),
   ...makePositionProps(),
@@ -65,7 +66,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
   setup (props, { slots }) {
     const { borderClasses } = useBorder(props)
     const { densityClasses } = useDensity(props)
-    const { mobile } = useDisplay()
+    const { isMobile } = useDisplay(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
     const { locationStyles } = useLocation(props)
@@ -89,7 +90,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
           class={[
             'v-banner',
             {
-              'v-banner--stacked': props.stacked || mobile.value,
+              'v-banner--stacked': props.stacked || isMobile.value,
               'v-banner--sticky': props.sticky,
               [`v-banner--${props.lines}-line`]: !!props.lines,
             },

--- a/packages/vuetify/src/components/VBanner/VBanner.tsx
+++ b/packages/vuetify/src/components/VBanner/VBanner.tsx
@@ -66,7 +66,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
   setup (props, { slots }) {
     const { borderClasses } = useBorder(props)
     const { densityClasses } = useDensity(props)
-    const { isLocalMobile } = useDisplay(props)
+    const { displayClasses, isLocalMobile } = useDisplay(props)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
     const { locationStyles } = useLocation(props)
@@ -96,6 +96,7 @@ export const VBanner = genericComponent<VBannerSlots>()({
             },
             borderClasses.value,
             densityClasses.value,
+            displayClasses.value,
             elevationClasses.value,
             positionClasses.value,
             roundedClasses.value,

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -103,7 +103,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const { borderClasses } = useBorder(props)
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
     const { elevationClasses } = useElevation(props)
-    const { isLocalMobile } = useDisplay(props)
+    const { displayClasses, isLocalMobile } = useDisplay(props)
     const { roundedClasses } = useRounded(props)
     const router = useRouter()
     const isActive = useProxiedModel(props, 'modelValue', null, v => !!v)
@@ -230,6 +230,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
               themeClasses.value,
               backgroundColorClasses.value,
               borderClasses.value,
+              displayClasses.value,
               elevationClasses.value,
               roundedClasses.value,
               props.class,

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -103,7 +103,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const { borderClasses } = useBorder(props)
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
     const { elevationClasses } = useElevation(props)
-    const { displayClasses, isLocalMobile } = useDisplay(props)
+    const { displayClasses, mobile } = useDisplay(props)
     const { roundedClasses } = useRounded(props)
     const router = useRouter()
     const isActive = useProxiedModel(props, 'modelValue', null, v => !!v)
@@ -121,7 +121,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const location = computed(() => {
       return toPhysical(props.location, isRtl.value) as 'left' | 'right' | 'bottom'
     })
-    const isTemporary = computed(() => !props.permanent && (isLocalMobile.value || props.temporary))
+    const isTemporary = computed(() => !props.permanent && (mobile.value || props.temporary))
     const isSticky = computed(() =>
       props.sticky &&
       !isTemporary.value &&
@@ -147,7 +147,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     onBeforeMount(() => {
       if (props.modelValue != null || isTemporary.value) return
 
-      isActive.value = props.permanent || !isLocalMobile.value
+      isActive.value = props.permanent || !mobile.value
     })
 
     const { isDragging, dragProgress, dragStyles } = useTouch({

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -9,7 +9,7 @@ import { makeBorderProps, useBorder } from '@/composables/border'
 import { useBackgroundColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
 import { provideDefaults } from '@/composables/defaults'
-import { useDisplay } from '@/composables/display'
+import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { makeLayoutItemProps, useLayoutItem } from '@/composables/layout'
 import { useProxiedModel } from '@/composables/proxiedModel'
@@ -79,6 +79,7 @@ export const makeVNavigationDrawerProps = propsFactory({
 
   ...makeBorderProps(),
   ...makeComponentProps(),
+  ...makeDisplayProps(),
   ...makeElevationProps(),
   ...makeLayoutItemProps(),
   ...makeRoundedProps(),
@@ -102,7 +103,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const { borderClasses } = useBorder(props)
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
     const { elevationClasses } = useElevation(props)
-    const { mobile } = useDisplay()
+    const { isMobile } = useDisplay(props)
     const { roundedClasses } = useRounded(props)
     const router = useRouter()
     const isActive = useProxiedModel(props, 'modelValue', null, v => !!v)
@@ -120,7 +121,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const location = computed(() => {
       return toPhysical(props.location, isRtl.value) as 'left' | 'right' | 'bottom'
     })
-    const isTemporary = computed(() => !props.permanent && (mobile.value || props.temporary))
+    const isTemporary = computed(() => !props.permanent && (isMobile.value || props.temporary))
     const isSticky = computed(() =>
       props.sticky &&
       !isTemporary.value &&
@@ -146,7 +147,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     onBeforeMount(() => {
       if (props.modelValue != null || isTemporary.value) return
 
-      isActive.value = props.permanent || !mobile.value
+      isActive.value = props.permanent || !isMobile.value
     })
 
     const { isDragging, dragProgress, dragStyles } = useTouch({

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -103,7 +103,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const { borderClasses } = useBorder(props)
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'color'))
     const { elevationClasses } = useElevation(props)
-    const { isMobile } = useDisplay(props)
+    const { isLocalMobile } = useDisplay(props)
     const { roundedClasses } = useRounded(props)
     const router = useRouter()
     const isActive = useProxiedModel(props, 'modelValue', null, v => !!v)
@@ -121,7 +121,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const location = computed(() => {
       return toPhysical(props.location, isRtl.value) as 'left' | 'right' | 'bottom'
     })
-    const isTemporary = computed(() => !props.permanent && (isMobile.value || props.temporary))
+    const isTemporary = computed(() => !props.permanent && (isLocalMobile.value || props.temporary))
     const isSticky = computed(() =>
       props.sticky &&
       !isTemporary.value &&
@@ -147,7 +147,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     onBeforeMount(() => {
       if (props.modelValue != null || isTemporary.value) return
 
-      isActive.value = props.permanent || !isMobile.value
+      isActive.value = props.permanent || !isLocalMobile.value
     })
 
     const { isDragging, dragProgress, dragStyles } = useTouch({

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -86,7 +86,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
   setup (props, { slots }) {
     const { isRtl } = useRtl()
-    const { isLocalMobile } = useDisplay(props)
+    const { displayClasses, isLocalMobile } = useDisplay(props)
     const group = useGroup(props, props.symbol)
     const isOverflowing = shallowRef(false)
     const scrollOffset = shallowRef(0)
@@ -350,6 +350,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
             'v-slide-group--has-affixes': hasAffixes.value,
             'v-slide-group--is-overflowing': isOverflowing.value,
           },
+          displayClasses.value,
           props.class,
         ]}
         style={ props.style }

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -86,7 +86,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
   setup (props, { slots }) {
     const { isRtl } = useRtl()
-    const { displayClasses, isLocalMobile } = useDisplay(props)
+    const { displayClasses, mobile } = useDisplay(props)
     const group = useGroup(props, props.symbol)
     const isOverflowing = shallowRef(false)
     const scrollOffset = shallowRef(0)
@@ -310,7 +310,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
         case 'always': return true
 
         // Always show arrows on desktop
-        case 'desktop': return !isLocalMobile.value
+        case 'desktop': return !mobile.value
 
         // Show arrows on mobile when overflowing.
         // This matches the default 2.2 behavior
@@ -318,7 +318,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
         // Always show on mobile
         case 'mobile': return (
-          isLocalMobile.value ||
+          mobile.value ||
           (isOverflowing.value || Math.abs(scrollOffset.value) > 0)
         )
 
@@ -326,7 +326,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
         // Always show arrows when
         // overflowed on desktop
         default: return (
-          !isLocalMobile.value &&
+          !mobile.value &&
           (isOverflowing.value || Math.abs(scrollOffset.value) > 0)
         )
       }

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -86,7 +86,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
   setup (props, { slots }) {
     const { isRtl } = useRtl()
-    const { isMobile } = useDisplay(props)
+    const { isLocalMobile } = useDisplay(props)
     const group = useGroup(props, props.symbol)
     const isOverflowing = shallowRef(false)
     const scrollOffset = shallowRef(0)
@@ -310,7 +310,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
         case 'always': return true
 
         // Always show arrows on desktop
-        case 'desktop': return !isMobile.value
+        case 'desktop': return !isLocalMobile.value
 
         // Show arrows on mobile when overflowing.
         // This matches the default 2.2 behavior
@@ -318,7 +318,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
         // Always show on mobile
         case 'mobile': return (
-          isMobile.value ||
+          isLocalMobile.value ||
           (isOverflowing.value || Math.abs(scrollOffset.value) > 0)
         )
 
@@ -326,7 +326,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
         // Always show arrows when
         // overflowed on desktop
         default: return (
-          !isMobile.value &&
+          !isLocalMobile.value &&
           (isOverflowing.value || Math.abs(scrollOffset.value) > 0)
         )
       }

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -6,8 +6,8 @@ import { VFadeTransition } from '@/components/transitions'
 import { VIcon } from '@/components/VIcon'
 
 // Composables
-import { useDisplay } from '@/composables'
 import { makeComponentProps } from '@/composables/component'
+import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeGroupProps, useGroup } from '@/composables/group'
 import { IconValue } from '@/composables/icons'
 import { useRtl } from '@/composables/locale'
@@ -68,6 +68,7 @@ export const makeVSlideGroupProps = propsFactory({
   },
 
   ...makeComponentProps(),
+  ...makeDisplayProps(),
   ...makeTagProps(),
   ...makeGroupProps({
     selectedClass: 'v-slide-group-item--active',
@@ -85,7 +86,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
   setup (props, { slots }) {
     const { isRtl } = useRtl()
-    const { mobile } = useDisplay()
+    const { isMobile } = useDisplay(props)
     const group = useGroup(props, props.symbol)
     const isOverflowing = shallowRef(false)
     const scrollOffset = shallowRef(0)
@@ -309,7 +310,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
         case 'always': return true
 
         // Always show arrows on desktop
-        case 'desktop': return !mobile.value
+        case 'desktop': return !isMobile.value
 
         // Show arrows on mobile when overflowing.
         // This matches the default 2.2 behavior
@@ -317,7 +318,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
 
         // Always show on mobile
         case 'mobile': return (
-          mobile.value ||
+          isMobile.value ||
           (isOverflowing.value || Math.abs(scrollOffset.value) > 0)
         )
 
@@ -325,7 +326,7 @@ export const VSlideGroup = genericComponent<VSlideGroupSlots>()({
         // Always show arrows when
         // overflowed on desktop
         default: return (
-          !mobile.value &&
+          !isMobile.value &&
           (isOverflowing.value || Math.abs(scrollOffset.value) > 0)
         )
       }

--- a/packages/vuetify/src/composables/__tests__/display.spec.cy.tsx
+++ b/packages/vuetify/src/composables/__tests__/display.spec.cy.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable max-len */
+/// <reference types="../../../types/cypress" />
+
+// Components
+import { VBanner } from '@/components/VBanner/VBanner'
+import { VLayout } from '@/components/VLayout/VLayout'
+import { VMain } from '@/components/VMain'
+import { VNavigationDrawer } from '@/components/VNavigationDrawer/VNavigationDrawer'
+import { VSlideGroup } from '@/components/VSlideGroup/VSlideGroup'
+
+describe('VWindow', () => {
+  it('should render items', () => {
+    cy.viewport(960, 800)
+      .mount(({ mobileBreakpoint }: any) => (
+        <VLayout>
+          <VNavigationDrawer mobileBreakpoint={ mobileBreakpoint } />
+
+          <VMain>
+            <VBanner mobileBreakpoint={ mobileBreakpoint }>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Dicta quaerat fugit ratione totam magnam, beatae consequuntur qui quam enim et sapiente autem accusantium id nesciunt maiores obcaecati minus molestiae! Ipsa.
+            </VBanner>
+
+            <VSlideGroup mobileBreakpoint={ mobileBreakpoint } />
+          </VMain>
+        </VLayout>
+      ))
+
+    cy
+      .setProps({ mobileBreakpoint: 'lg' })
+      .get('.v-navigation-drawer').should('have.class', 'v-navigation-drawer--mobile')
+      .get('.v-banner').should('have.class', 'v-banner--mobile')
+      .get('.v-slide-group').should('have.class', 'v-slide-group--mobile')
+      .setProps({ mobileBreakpoint: 959 })
+      .get('.v-navigation-drawer').should('not.have.class', 'v-navigation-drawer--mobile')
+      .get('.v-banner').should('not.have.class', 'v-banner--mobile')
+      .get('.v-slide-group').should('not.have.class', 'v-slide-group--mobile')
+  })
+})

--- a/packages/vuetify/src/composables/__tests__/display.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/display.spec.ts
@@ -1,5 +1,5 @@
 // Composables
-import { createDisplay } from '../display'
+import { createDisplay, makeDisplayProps, useDisplay } from '../display'
 
 // Utilities
 import { describe, expect, it } from '@jest/globals'

--- a/packages/vuetify/src/composables/__tests__/display.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/display.spec.ts
@@ -1,5 +1,5 @@
 // Composables
-import { createDisplay, makeDisplayProps, useDisplay } from '../display'
+import { createDisplay } from '../display'
 
 // Utilities
 import { describe, expect, it } from '@jest/globals'

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -225,7 +225,7 @@ export function useDisplay (
 
   if (!display) throw new Error('Could not find Vuetify display injection')
 
-  const isLocalMobile = computed(() => {
+  const mobile = computed(() => {
     if (!props.mobileBreakpoint) return display.mobile.value
 
     const breakpointValue = typeof props.mobileBreakpoint === 'number'
@@ -238,8 +238,8 @@ export function useDisplay (
   const displayClasses = computed(() => {
     if (!name) return {}
 
-    return { [`${name}--mobile`]: isLocalMobile.value }
+    return { [`${name}--mobile`]: mobile.value }
   })
 
-  return { ...display, displayClasses, isLocalMobile }
+  return { ...display, displayClasses, mobile }
 }

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -222,7 +222,7 @@ export function useDisplay (props: DisplayProps = {}) {
 
   if (!display) throw new Error('Could not find Vuetify display injection')
 
-  const isMobile = computed(() => {
+  const isLocalMobile = computed(() => {
     if (!props.mobileBreakpoint) return display.mobile.value
 
     const breakpointValue = typeof props.mobileBreakpoint === 'number'
@@ -232,5 +232,5 @@ export function useDisplay (props: DisplayProps = {}) {
     return display.width.value < breakpointValue
   })
 
-  return { ...display, isMobile }
+  return { ...display, isLocalMobile }
 }

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -1,10 +1,10 @@
 // Utilities
-import { inject, reactive, shallowRef, toRefs, watchEffect } from 'vue'
-import { mergeDeep } from '@/util'
+import { computed, inject, reactive, shallowRef, toRefs, watchEffect } from 'vue'
+import { mergeDeep, propsFactory } from '@/util'
 import { IN_BROWSER, SUPPORTS_TOUCH } from '@/util/globals'
 
 // Types
-import type { InjectionKey, Ref } from 'vue'
+import type { InjectionKey, PropType, Ref } from 'vue'
 
 export const breakpoints = ['sm', 'md', 'lg', 'xl', 'xxl'] as const // no xs
 
@@ -14,6 +14,10 @@ export type DisplayBreakpoint = 'xs' | Breakpoint
 
 export type DisplayThresholds = {
   [key in DisplayBreakpoint]: number
+}
+
+export interface DisplayProps {
+  mobileBreakpoint?: number | DisplayBreakpoint
 }
 
 export interface DisplayOptions {
@@ -209,10 +213,24 @@ export function createDisplay (options?: DisplayOptions, ssr?: SSROptions): Disp
   return { ...toRefs(state), update, ssr: !!ssr }
 }
 
-export function useDisplay () {
+export const makeDisplayProps = propsFactory({
+  mobileBreakpoint: [Number, String] as PropType<number | DisplayBreakpoint>,
+}, 'display')
+
+export function useDisplay (props: DisplayProps = {}) {
   const display = inject(DisplaySymbol)
 
   if (!display) throw new Error('Could not find Vuetify display injection')
 
-  return display
+  const isMobile = computed(() => {
+    if (!props.mobileBreakpoint) return display.mobile.value
+
+    const breakpointValue = typeof props.mobileBreakpoint === 'number'
+      ? props.mobileBreakpoint
+      : display.thresholds.value[props.mobileBreakpoint]
+
+    return display.width.value < breakpointValue
+  })
+
+  return { ...display, isMobile }
 }

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { computed, inject, reactive, shallowRef, toRefs, watchEffect } from 'vue'
-import { mergeDeep, propsFactory } from '@/util'
+import { getCurrentInstanceName, mergeDeep, propsFactory } from '@/util'
 import { IN_BROWSER, SUPPORTS_TOUCH } from '@/util/globals'
 
 // Types
@@ -217,7 +217,10 @@ export const makeDisplayProps = propsFactory({
   mobileBreakpoint: [Number, String] as PropType<number | DisplayBreakpoint>,
 }, 'display')
 
-export function useDisplay (props: DisplayProps = {}) {
+export function useDisplay (
+  props: DisplayProps = {},
+  name = getCurrentInstanceName(),
+) {
   const display = inject(DisplaySymbol)
 
   if (!display) throw new Error('Could not find Vuetify display injection')
@@ -232,5 +235,11 @@ export function useDisplay (props: DisplayProps = {}) {
     return display.width.value < breakpointValue
   })
 
-  return { ...display, isLocalMobile }
+  const displayClasses = computed(() => {
+    if (!name) return {}
+
+    return { [`${name}--mobile`]: isLocalMobile.value }
+  })
+
+  return { ...display, displayClasses, isLocalMobile }
 }


### PR DESCRIPTION
## Motivation and Context
resolves #15381

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-navigation-drawer mobile-breakpoint="xl" color="purple" />
    <v-navigation-drawer location="end" color="primary" />
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  import { useDisplay } from '../src/composables/display'

  const { mobile, isLocalMobile, displayClasses } = useDisplay({
    mobileBreakpoint: 2156,
  }, 'v-my-class')

  console.log(mobile, isLocalMobile)
  console.log(displayClasses.value)
</script>

```
</details>