### PR TITLE
docs: load optimize ad tag as carbon fallback

### DIFF
--- a/packages/docs/src/components/promoted/Base.vue
+++ b/packages/docs/src/components/promoted/Base.vue
@@ -2,7 +2,6 @@
   <v-lazy
     :min-height="minHeight"
     class="d-flex"
-    id="sponsoredContainer"
   >
     <v-sheet
       v-bind="$attrs"

--- a/packages/docs/src/components/promoted/Base.vue
+++ b/packages/docs/src/components/promoted/Base.vue
@@ -2,6 +2,7 @@
   <v-lazy
     :min-height="minHeight"
     class="d-flex"
+    id="sponsoredContainer"
   >
     <v-sheet
       v-bind="$attrs"

--- a/packages/docs/src/components/promoted/Carbon.vue
+++ b/packages/docs/src/components/promoted/Carbon.vue
@@ -1,31 +1,36 @@
 <template>
-  <promoted-base
-    v-if="!error2"
-    ref="script"
-    :class="[
-      isDark ? 'theme--dark' : 'theme--light',
-    ]"
-    border
+  <v-responsive
+    class="align-center"
     min-height="118"
-    max-width="360"
   >
-    <promoted-script
-      id="carbonads-script"
-      script-id="_carbonads_js"
-      src="//cdn.carbonads.com/carbon.js?serve=CWYDC27W&placement=v3vuetifyjscom"
-      @script:error="error1 = true"
-    />
+    <template v-if="!error1 && !error2">
+      <promoted-base
+        ref="script"
+        :class="[
+          isDark ? 'theme--dark' : 'theme--light',
+        ]"
+        border
+        max-width="360"
+      >
+        <promoted-script
+          id="carbonads-script"
+          script-id="_carbonads_js"
+          src="//cdn.carbonads.com/carbon.js?serve=CWYDC27W&placement=v3vuetifyjscom"
+          @script:error="error1 = true"
+        />
 
-    <promoted-script
-      v-if="error1"
-      id="bsa-optimize"
-      :src="`https://cdn4.buysellads.net/pub/vuetifyjs.js?${(Date.now() - Date.now()) % 600000}`"
-      script-id="bsa-optimize"
-      @script:error="error2 = true"
-    />
-  </promoted-base>
+        <promoted-script
+          v-if="error1"
+          id="bsa-zone_1691166982595-9_123456"
+          :src="`https://cdn4.buysellads.net/pub/vuetifyjs.js?${Date.now() % 600000}`"
+          script-id="bsa-optimize"
+          @script:error="error2 = true"
+        />
+      </promoted-base>
+    </template>
 
-  <promoted v-else />
+    <promoted v-else />
+  </v-responsive>
 
   <br>
 </template>
@@ -40,17 +45,41 @@
   import { useTheme } from 'vuetify'
 
   // Utilities
-  import { computed, onBeforeUnmount, shallowRef } from 'vue'
+  import { computed, onBeforeUnmount, onMounted, shallowRef } from 'vue'
 
   const error1 = shallowRef(false)
   const error2 = shallowRef(false)
   const script = shallowRef(null)
+  let timer1 = 0 as any
+  let timer2 = 0 as any
 
   onBeforeUnmount(() => {
-    const script = document.getElementById('carbonads-script')
+    document.getElementById('carbonads-script')?.remove()
+    document.getElementById('bsa-zone_1691166982595-9_123456')?.remove()
 
-    script?.remove()
+    clearTimeout(timer1)
+    clearTimeout(timer2)
   })
+
+  onMounted(check1)
+
+  function check1 () {
+    timer1 = setTimeout(() => {
+      if (document.getElementById('carbonads')) return
+
+      clearTimeout(timer2)
+      error1.value = true
+      check2()
+    }, 2000)
+  }
+
+  function check2 () {
+    timer2 = setTimeout(() => {
+      if (document.getElementById('bsa-zone_1691166982595-9_123456')) return
+
+      error2.value = true
+    }, 2000)
+  }
 
   const theme = useTheme()
 

--- a/packages/docs/src/components/promoted/Carbon.vue
+++ b/packages/docs/src/components/promoted/Carbon.vue
@@ -1,12 +1,11 @@
 <template>
   <promoted-base
-    v-if="!error"
+    v-if="!error2"
     ref="script"
     :class="[
       isDark ? 'theme--dark' : 'theme--light',
     ]"
     border
-    id="carbonContainer"
     min-height="118"
     max-width="360"
   >
@@ -14,7 +13,15 @@
       id="carbonads-script"
       script-id="_carbonads_js"
       src="//cdn.carbonads.com/carbon.js?serve=CWYDC27W&placement=v3vuetifyjscom"
-      @script:error="error = true"
+      @script:error="error1 = true"
+    />
+
+    <promoted-script
+      v-if="error1"
+      id="bsa-optimize"
+      :src="`https://cdn4.buysellads.net/pub/vuetifyjs.js?${(Date.now() - Date.now()) % 600000}`"
+      script-id="bsa-optimize"
+      @script:error="error2 = true"
     />
   </promoted-base>
 
@@ -33,39 +40,16 @@
   import { useTheme } from 'vuetify'
 
   // Utilities
-  import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
+  import { computed, onBeforeUnmount, shallowRef } from 'vue'
 
-  const error = ref(false)
-  const script = ref(null)
+  const error1 = shallowRef(false)
+  const error2 = shallowRef(false)
+  const script = shallowRef(null)
 
   onBeforeUnmount(() => {
     const script = document.getElementById('carbonads-script')
 
     script?.remove()
-  })
-
-  onMounted(() => {
-
-    setTimeout(()=> {
-      const isCarbonVisible = !!document.getElementById('carbonads');
-
-      const optimizeEl = document.createElement("div");
-      optimizeEl.id = "bsa-zone_1691166982595-9_123456";
-
-      if(!isCarbonVisible) {
-        document.querySelector("#sponsoredContainer").appendChild(optimizeEl);
-        document.querySelector("#carbonContainer").remove();
-
-        (function(){
-          var bsa_optimize=document.createElement('script');
-          bsa_optimize.type='text/javascript';
-          bsa_optimize.async=true;
-          bsa_optimize.src='https://cdn4.buysellads.net/pub/vuetifyjs.js?'+(new Date()-new Date()%600000);
-          (document.getElementsByTagName('head')[0]||document.getElementsByTagName('body')[0]).appendChild(bsa_optimize);
-        })();
-      }
-    }, 2000)
-
   })
 
   const theme = useTheme()
@@ -79,12 +63,10 @@
       min-width: 300px
       min-height: 250px
 
-  
   @media only screen and (min-width: 760px) and (min-height: 0px)
     div[id^="bsa-zone_1691166982595-9_123456"]
       min-width: 728px
       min-height: 90px
-
 
   #carbonads-script
     width: 100%

--- a/packages/docs/src/components/promoted/Carbon.vue
+++ b/packages/docs/src/components/promoted/Carbon.vue
@@ -6,6 +6,7 @@
       isDark ? 'theme--dark' : 'theme--light',
     ]"
     border
+    id="carbonContainer"
     min-height="118"
     max-width="360"
   >
@@ -32,7 +33,7 @@
   import { useTheme } from 'vuetify'
 
   // Utilities
-  import { computed, onBeforeUnmount, ref } from 'vue'
+  import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
 
   const error = ref(false)
   const script = ref(null)
@@ -43,12 +44,48 @@
     script?.remove()
   })
 
+  onMounted(() => {
+
+    setTimeout(()=> {
+      const isCarbonVisible = !!document.getElementById('carbonads');
+
+      const optimizeEl = document.createElement("div");
+      optimizeEl.id = "bsa-zone_1691166982595-9_123456";
+
+      if(!isCarbonVisible) {
+        document.querySelector("#sponsoredContainer").appendChild(optimizeEl);
+        document.querySelector("#carbonContainer").remove();
+
+        (function(){
+          var bsa_optimize=document.createElement('script');
+          bsa_optimize.type='text/javascript';
+          bsa_optimize.async=true;
+          bsa_optimize.src='https://cdn4.buysellads.net/pub/vuetifyjs.js?'+(new Date()-new Date()%600000);
+          (document.getElementsByTagName('head')[0]||document.getElementsByTagName('body')[0]).appendChild(bsa_optimize);
+        })();
+      }
+    }, 2000)
+
+  })
+
   const theme = useTheme()
 
   const isDark = computed(() => theme.current.value.dark)
 </script>
 
 <style lang="sass">
+  @media only screen and (min-width: 0px) and (min-height: 0px)
+    div[id^="bsa-zone_1691166982595-9_123456"]
+      min-width: 300px
+      min-height: 250px
+
+  
+  @media only screen and (min-width: 760px) and (min-height: 0px)
+    div[id^="bsa-zone_1691166982595-9_123456"]
+      min-width: 728px
+      min-height: 90px
+
+
   #carbonads-script
     width: 100%
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

This PR loads Optimize ad tag as the fallback when Carbon is not available. There is no way to test the function locally because the domain has to be approved to load ads from demand partners, however I have made sure that the viewport is being set for each ad format.

- 300 × 250 banner if the viewport is less than 640px
- 728 × 90 banner if the viewport size is greater than 640px
