### PR TITLE
fix(locale): update Norwegian dateRangeInput.divider placeholder translation

### DIFF
--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -27,7 +27,7 @@ export default {
     pageText: '{0}-{1} av {2}',
   },
   dateRangeInput: {
-    divider: 'to',
+    divider: 'til',
   },
   datePicker: {
     ok: 'OK',


### PR DESCRIPTION
Just a minor correction on `dateRangeInput.divider`

## Description
fixes #17988