### PR TITLE
fix(VSelect): auto scroll to selected value

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -25,7 +25,17 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, getPropertyFromItem, matchesSelector, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import {
+  genericComponent,
+  getPropertyFromItem,
+  IN_BROWSER,
+  matchesSelector,
+  noop,
+  omit,
+  propsFactory,
+  useRender,
+  wrapInArray,
+} from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -379,7 +389,7 @@ export const VAutocomplete = genericComponent<new <
         const index = displayItems.value.findIndex(
           item => selections.value.some(s => item.value === s.value)
         )
-        setTimeout(() => {
+        IN_BROWSER && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -118,6 +118,7 @@ export const VAutocomplete = genericComponent<new <
     const isPristine = shallowRef(true)
     const listHasFocus = shallowRef(false)
     const vMenuRef = ref<VMenu>()
+    const vVirtualScrollRef = ref<VVirtualScroll>()
     const _menu = useProxiedModel(props, 'menu')
     const menu = computed({
       get: () => _menu.value,
@@ -373,6 +374,17 @@ export const VAutocomplete = genericComponent<new <
       isPristine.value = !val
     })
 
+    watch(menu, () => {
+      if (props.autoScroll && !props.hideSelected && menu.value && selections.value.length) {
+        const index = displayItems.value.findIndex(
+          item => selections.value.some(s => item.value === s.value)
+        )
+        setTimeout(() => {
+          index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
+        })
+      }
+    })
+
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
       const hasList = !!(
@@ -450,7 +462,7 @@ export const VAutocomplete = genericComponent<new <
                         <VListItem title={ t(props.noDataText) } />
                       ))}
 
-                      <VVirtualScroll renderless items={ displayItems.value }>
+                      <VVirtualScroll ref={ vVirtualScrollRef } renderless items={ displayItems.value }>
                         { ({ item, index, itemRef }) => {
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -375,7 +375,7 @@ export const VAutocomplete = genericComponent<new <
     })
 
     watch(menu, () => {
-      if (props.autoScroll && !props.hideSelected && menu.value && selections.value.length) {
+      if (!props.hideSelected && menu.value && selections.value.length) {
         const index = displayItems.value.findIndex(
           item => selections.value.some(s => item.value === s.value)
         )

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -119,6 +119,7 @@ export const VCombobox = genericComponent<new <
     const isPristine = shallowRef(true)
     const listHasFocus = shallowRef(false)
     const vMenuRef = ref<VMenu>()
+    const vVirtualScrollRef = ref<VVirtualScroll>()
     const _menu = useProxiedModel(props, 'menu')
     const menu = computed({
       get: () => _menu.value,
@@ -401,6 +402,17 @@ export const VCombobox = genericComponent<new <
       }
     })
 
+    watch(menu, () => {
+      if (props.autoScroll && !props.hideSelected && menu.value && selections.value.length) {
+        const index = displayItems.value.findIndex(
+          item => selections.value.some(s => item.value === s.value)
+        )
+        setTimeout(() => {
+          index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
+        })
+      }
+    })
+
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
       const hasList = !!(
@@ -476,7 +488,7 @@ export const VCombobox = genericComponent<new <
                         <VListItem title={ t(props.noDataText) } />
                       ))}
 
-                      <VVirtualScroll renderless items={ displayItems.value }>
+                      <VVirtualScroll ref={ vVirtualScrollRef } renderless items={ displayItems.value }>
                         { ({ item, index, itemRef }) => {
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -26,7 +26,7 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, getPropertyFromItem, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, getPropertyFromItem, IN_BROWSER, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -407,7 +407,7 @@ export const VCombobox = genericComponent<new <
         const index = displayItems.value.findIndex(
           item => selections.value.some(s => item.value === s.value)
         )
-        setTimeout(() => {
+        IN_BROWSER && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -403,7 +403,7 @@ export const VCombobox = genericComponent<new <
     })
 
     watch(menu, () => {
-      if (props.autoScroll && !props.hideSelected && menu.value && selections.value.length) {
+      if (!props.hideSelected && menu.value && selections.value.length) {
         const index = displayItems.value.findIndex(
           item => selections.value.some(s => item.value === s.value)
         )

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -24,7 +24,17 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, ref, shallowRef, watch } from 'vue'
-import { deepEqual, genericComponent, getPropertyFromItem, matchesSelector, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import {
+  deepEqual,
+  genericComponent,
+  getPropertyFromItem,
+  IN_BROWSER,
+  matchesSelector,
+  omit,
+  propsFactory,
+  useRender,
+  wrapInArray,
+} from '@/util'
 
 // Types
 import type { Component, PropType } from 'vue'
@@ -283,7 +293,7 @@ export const VSelect = genericComponent<new <
         const index = displayItems.value.findIndex(
           item => selections.value.some(s => item.value === s.value)
         )
-        setTimeout(() => {
+        IN_BROWSER && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -23,7 +23,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
-import { computed, mergeProps, ref, shallowRef } from 'vue'
+import { computed, mergeProps, ref, shallowRef, watch } from 'vue'
 import { deepEqual, genericComponent, getPropertyFromItem, matchesSelector, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
@@ -45,6 +45,7 @@ type Value <T, ReturnObject extends boolean, Multiple extends boolean> =
     : Val<T, ReturnObject> | null
 
 export const makeSelectProps = propsFactory({
+  autoScroll: Boolean,
   chips: Boolean,
   closableChips: Boolean,
   closeText: {
@@ -127,6 +128,7 @@ export const VSelect = genericComponent<new <
     const { t } = useLocale()
     const vTextFieldRef = ref()
     const vMenuRef = ref<VMenu>()
+    const vVirtualScrollRef = ref<VVirtualScroll>()
     const _menu = useProxiedModel(props, 'menu')
     const menu = computed({
       get: () => _menu.value,
@@ -277,6 +279,17 @@ export const VSelect = genericComponent<new <
       }
     }
 
+    watch(menu, () => {
+      if (props.autoScroll && !props.hideSelected && menu.value && selections.value.length) {
+        const index = displayItems.value.findIndex(
+          item => selections.value.some(s => item.value === s.value)
+        )
+        setTimeout(() => {
+          index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
+        })
+      }
+    })
+
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
       const hasList = !!(
@@ -360,7 +373,7 @@ export const VSelect = genericComponent<new <
                         <VListItem title={ t(props.noDataText) } />
                       ))}
 
-                      <VVirtualScroll renderless items={ displayItems.value }>
+                      <VVirtualScroll ref={ vVirtualScrollRef } renderless items={ displayItems.value }>
                         { ({ item, index, itemRef }) => {
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -45,7 +45,6 @@ type Value <T, ReturnObject extends boolean, Multiple extends boolean> =
     : Val<T, ReturnObject> | null
 
 export const makeSelectProps = propsFactory({
-  autoScroll: Boolean,
   chips: Boolean,
   closableChips: Boolean,
   closeText: {
@@ -280,7 +279,7 @@ export const VSelect = genericComponent<new <
     }
 
     watch(menu, () => {
-      if (props.autoScroll && !props.hideSelected && menu.value && selections.value.length) {
+      if (!props.hideSelected && menu.value && selections.value.length) {
         const index = displayItems.value.findIndex(
           item => selections.value.some(s => item.value === s.value)
         )


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #17881

implements the v2 functionality of scrolling to the selected value by setting `menuProps="auto"`. ~~Since this doesn't go through VMenu, prop was renamed to `autoScroll`.~~

Currently, if a user needs to select a new value in the middle of a long list, the dropdown always resets to the top of the list, even if the new value is only just after the existing value. This change takes advantage of the virtual scrolling added to VSelect to quickly scroll to the current location.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select v-model="selected2" label="Short Select" :items="[1, 2, 3]" />

      <v-select v-model="selected3" label="Value not in items" :items="[1, 2, 3]" />

      <v-select v-model="selected" label="Longer Select" :items="items" />

      <v-autocomplete v-model="selected" label="Autocomplete" :items="items" />

      <v-combobox v-model="selected" label="Combobox" :items="items" />

      <v-select
        v-model="fruit"
        label="Select with Objects"
        :items="fruits"
        item-title="name"
        item-value="id"
        :return-object="false"
      />
    </v-container>
  </v-app>
</template>

<script lang="ts" setup>
  import { ref } from 'vue'

  const selected = ref(1000)
  const selected2 = ref(2)
  const selected3 = ref(4)
  const items = Array.from({ length: 20000 }, (_, i) => i + 1)

  const fruits = [
    { name: 'John', id: 1, fruit: 'apple' },
    { name: 'Jane', id: 2, fruit: 'banana' },
    { name: 'Joe', id: 3, fruit: 'cantelope' },
    { name: 'Doug', id: 4, fruit: 'dragonfruit' },
    { name: 'Eddy', id: 5, fruit: 'orange' },
    { name: 'David', id: 6, fruit: 'mango' },
    { name: 'Sam', id: 7, fruit: 'durian' },
    { name: 'Sally', id: 8, fruit: 'lychee' },
    { name: 'Kyle', id: 9, fruit: 'tangerine' },
    { name: 'Kevin', id: 10, fruit: 'strawberry' },
    { name: 'Daniel', id: 11, fruit: 'watermelon' }
  ]
  const fruit = ref(8)
</script>
```
