### PR TITLE
fix(VTimeline): vertical divider overlapping

### DIFF
--- a/packages/vuetify/src/components/VTimeline/VTimeline.sass
+++ b/packages/vuetify/src/components/VTimeline/VTimeline.sass
@@ -205,6 +205,11 @@ $timeline-line-size-first-last: calc(var(--v-timeline-line-size-base) - var(--v-
         left: 0
         right: initial
 
+.v-timeline-item:only-child
+  .v-timeline-divider__after
+    @include vertical
+      height: calc(var(--v-timeline-line-size-base) - var(--v-timeline-line-inset))
+
 .v-timeline-divider__dot
   z-index: 1
   flex-shrink: 0


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #18008

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-timeline direction="vertical" side="end">
        <v-timeline-item hide-dot>
          <div>
            <div class="text-h6">Content title</div>
            <p>
              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
              eiusmod tempor incididunt ut labore et dolore magna aliqua.
            </p>
          </div>
        </v-timeline-item>
      </v-timeline>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
