### PR TITLE
feat(VDataTable): add cellClass to header

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
@@ -50,6 +50,9 @@ export const VDataTableRow = defineComponent({
             lastFixed={ column.lastFixed }
             noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
             width={ column.width }
+            class={[
+              column.cellClass,
+            ]}
           >
             {{
               default: () => {

--- a/packages/vuetify/src/labs/VDataTable/types.ts
+++ b/packages/vuetify/src/labs/VDataTable/types.ts
@@ -15,6 +15,7 @@ export type DataTableHeader = {
 
   fixed?: boolean
   align?: 'start' | 'end' | 'center'
+  cellClass?: any
 
   width?: number | string
   minWidth?: string


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Closes #17515

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :headers="headers" :items="desserts" item-value="name" />
    </v-container>
  </v-app>
</template>

<script setup>
const headers = [
  {
    title: "Dessert (100g serving)",
    align: "start",
    key: "name",
    sortable: false,
    cellClass: "text-primary",
  },
  {
    title: "Calories",
    key: "calories",
    cellClass: ["bg-grey-lighten-3", "text-secondary"],
  },
  { title: "Fat (g)", key: "fat" },
];

const desserts = [
  {
    name: "Frozen Yogurt",
    calories: 159,
    fat: 6.0,
  },
  {
    name: "Ice cream sandwich",
    calories: 237,
    fat: 9.0,
  },
  {
    name: "Eclair",
    calories: 262,
    fat: 16.0,
  },
];
</script>

```
