### PR TITLE
fix(VAutocomplete): make hide-selected work with auto-select-first

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -227,7 +227,7 @@ export const VAutocomplete = genericComponent<new <
       }
 
       if (highlightFirst.value && ['Enter', 'Tab'].includes(e.key)) {
-        select(filteredItems.value[0])
+        select(displayItems.value[0])
       }
 
       if (e.key === 'ArrowDown' && highlightFirst.value) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #18050

Fixes a problem with the VAutocomplete component when both the auto-select-first and hide-selected props are set to true.  Hitting enter twice on a single search value that matches more than one item in the suggest list toggles the selected state of the first original item in the list, instead of adding additional item selections.  See reproduction here for more details:

https://play.vuetifyjs.com/#eNqlU8Fu2zAM/RVCl3RAbKNNdwnaocPWSzFgBbZb3YNiM7VWWxIk2m1R5N9HSXHjJIcF2MGA9fjIRz5RD+/iq7X50KNYiivCzraS8EupAa6GTFobf+OhMpqk0ui2UGL0ZCrDWUg4wgBD1pka2+tSeGyxIqzv0XmjS7HjLBWreaZYNJw+DXV9SypgH0iQyVKtbK2cp12oUTVuQ1jv4KpR1o/HXcfFfsvjdAzvjxeJcfqrYuIKH33llCXwSH0yR3XWOIJ3cLiGDayd6WDGhs4CnRsx2hOkIeEaHmZ3ptHwq1PUzOaQTt8Nzh6n9H3bOI1rn+m+bT8lVlHAeQ7fWlU9g9JkgBpMJk0vg1kXOfx+swiluDPJYgYXOdw79J7RW03oSgFnP1ce3YBcSFJkj01yUHmQdY01TIRGnY9WoVWeuL2ocJnDD5RcLumC9DHRo3RVA4Sv8QKZ+Pm4FfnE1/DPhhx2ZmDVaPdpTd2+2gSusJGDMm451mX/uapvTN/WwDFkCupTh56H8RTBi4wLx0qB36inpuUvsPZyw96DXPOw4AktLMKOpa3ifRJzkRYq66TN//Dt88N8D3XLbcCXYgkRCRgvWjiXoiGyflkUVa05jV+fGlyukQptu+KGaYXrNakOs9p0N4t8kV8WNXc/hXP0XbZy5oWt5yKlmE9kSK3fTpDaMqPC+UWS2GJZK1c+aBzVLuJdu8yhrtGFNThtpIO06VgHoaPRgvqm1Bs2vFX62R94Xfno88PY5P/NHKuFUvzKN2IzF7FRlk4Z4vEv8uTWSw==

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model="selectedPerson"
        :items="people"
        multiple
        auto-select-first
        hide-selected
        chips
      />
    </v-container>
  </v-app>
</template>

<script lang="ts" setup>
  import { ref } from 'vue'

  const people = ['John Smith', 'John Doe']

  const selectedPerson = ref(null)
</script>

```
