### PR TITLE
fix(VSlider): correct thumb-label and tick label slot types

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -19,11 +19,11 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { VInputSlot, VInputSlots } from '@/components/VInput/VInput'
+import type { VSliderThumbSlots } from './VSliderThumb'
+import type { VSliderTrackSlots } from './VSliderTrack'
 
-export type VSliderSlots = VInputSlots & {
+export type VSliderSlots = VInputSlots & VSliderThumbSlots & VSliderTrackSlots & {
   label: VInputSlot
-  'tick-label': never
-  'thumb-label': never
 }
 
 export const makeVSliderProps = propsFactory({

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -18,9 +18,9 @@ import { computed, ref } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
-import type { VInputSlot, VInputSlots } from '@/components/VInput/VInput'
 import type { VSliderThumbSlots } from './VSliderThumb'
 import type { VSliderTrackSlots } from './VSliderTrack'
+import type { VInputSlot, VInputSlots } from '@/components/VInput/VInput'
 
 export type VSliderSlots = VInputSlots & VSliderThumbSlots & VSliderTrackSlots & {
   label: VInputSlot


### PR DESCRIPTION
fixes #18043

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-slider v-model="v" class="mt-8" thumb-label>
    <template #thumb-label="{modelValue}">
      {{ modelValue.toFixed(1) }}
    </template>
    <template #tick-label="{tick, index}">
      {{ tick }} {{ index }}
    </template>
  </v-slider>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const v = ref(1)
</script>


```
