### PR TITLE
feat(v-data-table): added ondblclick event

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
@@ -20,6 +20,7 @@ export const makeVDataTableRowProps = propsFactory({
   index: Number as PropType<Number>,
   item: Object as PropType<DataTableItem>,
   onClick: Function as PropType<(e: MouseEvent) => void>,
+  onDblclick: Function as PropType<(e: MouseEvent) => void>,
 }, 'VDataTableRow')
 
 export const VDataTableRow = defineComponent({
@@ -41,6 +42,7 @@ export const VDataTableRow = defineComponent({
           },
         ]}
         onClick={ props.onClick }
+        onDblclick={ props.onDblclick }
       >
         { props.item && columns.value.map((column, i) => (
           <VDataTableColumn

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -69,6 +69,7 @@ export const makeVDataTableRowsProps = propsFactory({
   },
   rowHeight: Number,
   'onClick:row': Function as PropType<(e: Event, value: { item: DataTableItem }) => void>,
+  'onDblclick:row': Function as PropType<(e: Event, value: { item: DataTableItem }) => void>,
 }, 'VDataTableRows')
 
 export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
@@ -152,6 +153,9 @@ export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
                     toggleExpand(item)
                   }
                   props['onClick:row']?.(event, { item })
+                } : undefined,
+                onDblclick: props['onDblclick:row'] ? (event: Event) => {
+                  props['onDblclick:row']?.(event, { item })
                 } : undefined,
                 index,
                 item,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Added onDblclick:row event to VDataTable.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table
        :headers="state.headers"
        :items="state.desserts"
        @dblclick:row="onClick"
      />
    </v-container>
  </v-app>
</template>

<script setup>

  import { reactive } from 'vue'

  const state = reactive({
    headers: [
      {
        title: 'Dessert (100g serving)',
        align: 'start',
        sortable: false,
        key: 'name',
      },
      { title: 'Calories', align: 'end', key: 'calories' },
      { title: 'Fat (g)', align: 'end', key: 'fat' },
      { title: 'Carbs (g)', align: 'end', key: 'carbs' },
      { title: 'Protein (g)', align: 'end', key: 'protein' },
      { title: 'Iron (%)', align: 'end', key: 'iron' },
    ],
    desserts: [
      {
        name: 'Frozen Yogurt',
        calories: 159,
        fat: 6.0,
        carbs: 24,
        protein: 4.0,
        iron: '1%',
      },
      {
        name: 'Ice cream sandwich',
        calories: 237,
        fat: 9.0,
        carbs: 37,
        protein: 4.3,
        iron: '1%',
      },
      {
        name: 'Eclair',
        calories: 262,
        fat: 16.0,
        carbs: 23,
        protein: 6.0,
        iron: '7%',
      },
      {
        name: 'Cupcake',
        calories: 305,
        fat: 3.7,
        carbs: 67,
        protein: 4.3,
        iron: '8%',
      },
      {
        name: 'Gingerbread',
        calories: 356,
        fat: 16.0,
        carbs: 49,
        protein: 3.9,
        iron: '16%',
      },
      {
        name: 'Jelly bean',
        calories: 375,
        fat: 0.0,
        carbs: 94,
        protein: 0.0,
        iron: '0%',
      },
      {
        name: 'Lollipop',
        calories: 392,
        fat: 0.2,
        carbs: 98,
        protein: 0,
        iron: '2%',
      },
      {
        name: 'Honeycomb',
        calories: 408,
        fat: 3.2,
        carbs: 87,
        protein: 6.5,
        iron: '45%',
      },
      {
        name: 'Donut',
        calories: 452,
        fat: 25.0,
        carbs: 51,
        protein: 4.9,
        iron: '22%',
      },
      {
        name: 'KitKat',
        calories: 518,
        fat: 26.0,
        carbs: 65,
        protein: 7,
        iron: '6%',
      },
    ],
  })

  function onClick (event, item) {
    console.log(event, item);
  }

</script>

```
