### PR TITLE
docs(VNavigationDrawer): update prop description

### DIFF
--- a/packages/api-generator/src/locale/en/VNavigationDrawer.json
+++ b/packages/api-generator/src/locale/en/VNavigationDrawer.json
@@ -2,7 +2,7 @@
   "props": {
     "bottom": "Expands from the bottom of the screen on mobile devices",
     "clipped": "A clipped drawer rests under the application toolbar. **Note:** requires the **clipped-left** or **clipped-right** prop on `v-app-bar` to work as intended",
-    "disableResizeWatcher": "Disables automatically opening/closing drawer when resized depending if mobile or desktop.",
+    "disableResizeWatcher": "Prevents the automatic opening or closing of the drawer when resized, based on whether the device is mobile or desktop.",
     "disableRouteWatcher": "Disables opening of navigation drawer when route changes",
     "expandOnHover": "Collapses the drawer to a **mini-variant** until hovering with the mouse",
     "floating": "A floating drawer has no visible container (no border-right)",

--- a/packages/api-generator/src/locale/en/VNavigationDrawer.json
+++ b/packages/api-generator/src/locale/en/VNavigationDrawer.json
@@ -2,7 +2,7 @@
   "props": {
     "bottom": "Expands from the bottom of the screen on mobile devices",
     "clipped": "A clipped drawer rests under the application toolbar. **Note:** requires the **clipped-left** or **clipped-right** prop on `v-app-bar` to work as intended",
-    "disableResizeWatcher": "Will automatically open/close drawer when resized depending if mobile or desktop.",
+    "disableResizeWatcher": "Disables automatically opening/closing drawer when resized depending if mobile or desktop.",
     "disableRouteWatcher": "Disables opening of navigation drawer when route changes",
     "expandOnHover": "Collapses the drawer to a **mini-variant** until hovering with the mouse",
     "floating": "A floating drawer has no visible container (no border-right)",


### PR DESCRIPTION
## Description

Make documentation description message for `disableResizeWatcher` more coherent with other messages such as `disableRouteWatcher`


See : https://vuetifyjs.com/en/api/v-navigation-drawer/