### PR TITLE
docs(VAvatar): update page content

### DIFF
--- a/packages/docs/src/pages/en/components/avatars.md
+++ b/packages/docs/src/pages/en/components/avatars.md
@@ -87,6 +87,6 @@ Another example combining avatar with menu.
 
 #### Profile Card
 
-Using the **rounded** prop set to `0`, we can create a sleek hard-lined profile card.
+Using the **rounded** prop value `0`, we can create a sleek hard-lined profile card.
 
 <example file="v-avatar/misc-profile-card" />

--- a/packages/docs/src/pages/en/components/avatars.md
+++ b/packages/docs/src/pages/en/components/avatars.md
@@ -12,7 +12,7 @@ related:
 
 # Avatars
 
-The `v-avatar` component is typically used to display circular user profile pictures. This component will allow you to dynamically size and add a border radius of responsive images, icons, and text. A **tile** variation is available for displaying an avatar without border radius.
+The `v-avatar` component is typically used to display circular user profile pictures. This component will allow you to dynamically size and add a border radius of responsive images, icons, and text.  When **rounded** prop set to `0` will display an avatar without border radius.
 
 ![Avatar Entry](https://cdn.vuetifyjs.com/docs/images/components-temp/v-avatar/v-avatar-entry.png)
 
@@ -87,6 +87,6 @@ Another example combining avatar with menu.
 
 #### Profile Card
 
-Using the **tile** prop, we can create a sleek hard-lined profile card.
+Using the **rounded** prop set to `0`, we can create a sleek hard-lined profile card.
 
 <example file="v-avatar/misc-profile-card" />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

In the docs of [V-Avatar](https://vuetifyjs.com/en/components/avatars/#profile-card), it mentioned we can use `tile` prop to control the border radius of avatar, but in the example code it gives, using `rounded="0"`。and we tried to use `tile` prop in playground, seems it has no effect. 

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
So I change the description of [V-Avatar](https://vuetifyjs.com/en/components/avatars/), replace all the text about `tile` with `rounded="0"`
