### PR TITLE
fix(VCombobox): mobile browser UX issue on focus

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -166,7 +166,6 @@ export default VSelect.extend({
     isFocused (val) {
       if (val) {
         document.addEventListener('copy', this.onCopy)
-        this.$refs.input && this.$refs.input.select()
       } else {
         document.removeEventListener('copy', this.onCopy)
         this.blur()

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.ts
@@ -404,29 +404,6 @@ describe('VAutocomplete.ts', () => {
     expect(wrapper.vm.lazySearch).toBeNull()
   })
 
-  it('should select input text on focus', async () => {
-    const wrapper = mountFunction({
-      attachToDocument: true,
-    })
-    const select = jest.fn()
-    wrapper.vm.$refs.input.select = select
-
-    const input = wrapper.find('input')
-    input.trigger('focus')
-
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.vm.isFocused).toBe(true)
-    expect(select).toHaveBeenCalledTimes(1)
-
-    input.trigger('keydown.tab')
-
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.vm.isFocused).toBe(false)
-    expect(select).toHaveBeenCalledTimes(1)
-  })
-
   it('should not respond to click', () => {
     const onFocus = jest.fn()
     const wrapper = mountFunction({


### PR DESCRIPTION
fixes #13562

## Description
1. Android Chrome user enters text **NOT from item list** into a combobox, then de-focus from the component.
2. With previous input text in place, user taps that combobox again for changing input. On focus, the component will auto selects the input text.
2. This auto input text selection triggers mobile browser's context menu for text selection (with options like copy, cut, select all, translate, etc.)
3. As this context menu popup interrupts the UI, user has to manually dismiss it before proceeding her/his action, thus poor UX.

This auto input text selection feature seems have been removed from v3. I'm unable to reproduce it in v3. This PR is only for v2.

Refer discussion #13562 for more background. Another dev reported this issue on iOS Safari.

## Markup:

```vue
<template>
  <v-container>
    <v-combobox></v-combobox>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
    }),
  }
</script>
```