### PR TITLE
feat(VSwitch): add thumb slot

### DIFF
--- a/packages/api-generator/src/locale/en/VSelectionControl.json
+++ b/packages/api-generator/src/locale/en/VSelectionControl.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "baseColor": "Sets the color of the input when it is not focused.",
     "value": "The value used when the component is selected in a group. If not provided, a unique ID will be used."
   },
   "slots": {

--- a/packages/api-generator/src/locale/en/VSwitch.json
+++ b/packages/api-generator/src/locale/en/VSwitch.json
@@ -2,6 +2,7 @@
   "props": {
     "flat": "Display component without elevation. Default elevation for thumb is 4dp, `flat` resets it.",
     "inputValue": "The **v-model** bound value.",
+    "indeterminate": "Sets an indeterminate state for the switch.",
     "inset": "Enlarge the `v-switch` track to encompass the thumb.",
     "loading": "Displays circular progress bar. Can either be a String which specifies which color is applied to the progress bar (any material color or theme color - primary, secondary, success, info, warning, error) or a Boolean which uses the component color (set by color prop - if it's supported by the component) or the primary color.",
     "multiple": "Changes expected model to an array."
@@ -10,5 +11,10 @@
     "change": "Emitted when the input is changed by user interaction.",
     "update:indeterminate": "Event that is emitted when the component's indeterminate state changes.",
     "click": "Emitted when input is clicked. **Note:** the **change** event should be used instead of **click** when monitoring state change."
+  },
+  "slots": {
+    "thumb": "Slot for custom thumb content.",
+    "track-true": "Slot for custom track content when value is true.",
+    "track-false": "Slot for custom track content when value is false."
   }
 }

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -25,6 +25,13 @@
       "end": "3.2.0"
     }
   },
+  "VSwitch": {
+    "slots": {
+      "thumb": "3.5.0",
+      "track-false": "3.5.0",
+      "track-true": "3.5.0"
+    }
+  },
   "VTab": {
     "props": {
       "text": "3.2.0"

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -25,24 +25,42 @@
     background-color: $switch-error-background-color
     color: $switch-error-color
 
+.v-switch__prepend-inner
+  margin-inline-end: auto
+
+  .v-selection-control:not(.v-selection-control--dirty) &
+    opacity: 0
+
+.v-switch__append-inner
+  margin-inline-start: auto
+
+  .v-selection-control--dirty &
+    opacity: 0
+
 .v-switch__track
+  display: inline-flex
+  align-items: center
+  font-size: .5rem
+  padding: 0 5px
   background-color: $switch-track-background
   border-radius: $switch-track-radius
   height: $switch-track-height
   opacity: $switch-track-opacity
-  width: $switch-track-width
+  min-width: $switch-track-width
   cursor: pointer
   transition: $switch-track-transition
 
   .v-switch--inset &
     border-radius: $switch-inset-track-border-radius
+    font-size: .75rem
     height: $switch-inset-track-height
-    width: $switch-inset-track-width
+    min-width: $switch-inset-track-width
 
 .v-switch__thumb
   align-items: center
   border-radius: $switch-thumb-radius
   display: flex
+  font-size: .75rem
   height: $switch-thumb-height
   justify-content: center
   width: $switch-thumb-width

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -25,13 +25,13 @@
     background-color: $switch-error-background-color
     color: $switch-error-color
 
-.v-switch__prepend-inner
+.v-switch__track-true
   margin-inline-end: auto
 
   .v-selection-control:not(.v-selection-control--dirty) &
     opacity: 0
 
-.v-switch__append-inner
+.v-switch__track-false
   margin-inline-start: auto
 
   .v-selection-control--dirty &

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -3,6 +3,7 @@ import './VSwitch.sass'
 
 // Components
 import { VScaleTransition } from '@/components/transitions'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvider'
 import { VIcon } from '@/components/VIcon'
 import { makeVInputProps, VInput } from '@/components/VInput/VInput'
 import { VProgressCircular } from '@/components/VProgressCircular'
@@ -20,6 +21,7 @@ import { filterInputAttrs, genericComponent, getUid, propsFactory, useRender } f
 // Types
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { VSelectionControlSlots } from '@/components/VSelectionControl/VSelectionControl'
+import type { IconValue } from '@/composables/icons'
 import type { LoaderSlotProps } from '@/composables/loader'
 import type { GenericProps } from '@/util'
 
@@ -27,6 +29,9 @@ export type VSwitchSlots =
   & VInputSlots
   & VSelectionControlSlots
   & { loader: LoaderSlotProps }
+  & {
+    thumb: { icon?: IconValue }
+  }
 
 export const makeVSwitchProps = propsFactory({
   indeterminate: Boolean,
@@ -155,31 +160,44 @@ export const VSwitch = genericComponent<new <T>(
                         ]}
                         style={ props.inset ? undefined : backgroundColorStyles.value }
                       >
-                        <VScaleTransition>
-                          { !props.loading ? (
-                            icon && <VIcon key={ icon as any } icon={ icon } size="x-small" />
-                          ) : (
-                            <LoaderSlot
-                              name="v-switch"
-                              active
-                              color={ isValid.value === false ? undefined : loaderColor.value }
-                            >
-                              { slotProps => (
-                                slots.loader
-                                  ? slots.loader(slotProps)
-                                  : (
-                                    <VProgressCircular
-                                      active={ slotProps.isActive }
-                                      color={ slotProps.color }
-                                      indeterminate
-                                      size="16"
-                                      width="2"
-                                    />
-                                  )
-                              )}
-                            </LoaderSlot>
-                          )}
-                        </VScaleTransition>
+                        { slots.thumb ? (
+                          <VDefaultsProvider
+                            defaults={{
+                              VIcon: {
+                                icon,
+                                size: 'x-small',
+                              },
+                            }}
+                          >
+                            { slots.thumb?.({ icon }) }
+                          </VDefaultsProvider>
+                        ) : (
+                          <VScaleTransition>
+                            { !props.loading ? (
+                              (icon && (<VIcon key={ icon as any } icon={ icon } size="x-small" />))
+                            ) : (
+                              <LoaderSlot
+                                name="v-switch"
+                                active
+                                color={ isValid.value === false ? undefined : loaderColor.value }
+                              >
+                                { slotProps => (
+                                  slots.loader
+                                    ? slots.loader(slotProps)
+                                    : (
+                                      <VProgressCircular
+                                        active={ slotProps.isActive }
+                                        color={ slotProps.color }
+                                        indeterminate
+                                        size="16"
+                                        width="2"
+                                      />
+                                    )
+                                )}
+                              </LoaderSlot>
+                            )}
+                          </VScaleTransition>
+                        )}
                       </div>
                     </>
                   ),

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -19,6 +19,7 @@ import { computed, ref } from 'vue'
 import { filterInputAttrs, genericComponent, getUid, propsFactory, useRender } from '@/util'
 
 // Types
+import type { ComputedRef, Ref } from 'vue'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { VSelectionControlSlots } from '@/components/VSelectionControl/VSelectionControl'
 import type { IconValue } from '@/composables/icons'
@@ -26,8 +27,8 @@ import type { LoaderSlotProps } from '@/composables/loader'
 import type { GenericProps } from '@/util'
 
 export type VSwitchSlot = {
-  model: boolean
-  isValid: boolean | null
+  model: Ref<boolean>
+  isValid: ComputedRef<boolean | null>
 }
 
 export type VSwitchSlots =
@@ -130,8 +131,8 @@ export const VSwitch = genericComponent<new <T>(
               isValid,
             }) => {
               const slotProps = {
-                model: model.value,
-                isValid: isValid.value,
+                model,
+                isValid,
               }
 
               return (
@@ -199,8 +200,13 @@ export const VSwitch = genericComponent<new <T>(
                           ) : (
                             <VScaleTransition>
                               { !props.loading ? (
-                                (icon && (<VIcon key={ icon as any } icon={ icon } size="x-small" />))
-                              ) : (
+                                (icon && (
+                                  <VIcon
+                                    key={ String(icon) }
+                                    icon={ icon }
+                                    size="x-small"
+                                  />
+                                ))) : (
                                 <LoaderSlot
                                   name="v-switch"
                                   active

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -25,14 +25,19 @@ import type { IconValue } from '@/composables/icons'
 import type { LoaderSlotProps } from '@/composables/loader'
 import type { GenericProps } from '@/util'
 
+export type VSwitchSlot = {
+  model: boolean
+  isValid: boolean | null
+}
+
 export type VSwitchSlots =
   & VInputSlots
   & VSelectionControlSlots
-  & { loader: LoaderSlotProps }
   & {
-    'prepend-inner': never
-    'append-inner': never
-    thumb: { icon?: IconValue }
+    loader: LoaderSlotProps
+    thumb: { icon: IconValue | undefined } & VSwitchSlot
+    'track-false': VSwitchSlot
+    'track-true': VSwitchSlot
   }
 
 export const makeVSwitchProps = propsFactory({
@@ -123,101 +128,108 @@ export const VSwitch = genericComponent<new <T>(
               isDisabled,
               isReadonly,
               isValid,
-            }) => (
-              <VSelectionControl
-                ref={ control }
-                { ...controlProps }
-                v-model={ model.value }
-                id={ id.value }
-                aria-describedby={ messagesId.value }
-                type="checkbox"
-                onUpdate:modelValue={ onChange }
-                aria-checked={ indeterminate.value ? 'mixed' : undefined }
-                disabled={ isDisabled.value }
-                readonly={ isReadonly.value }
-                onFocus={ focus }
-                onBlur={ blur }
-                { ...controlAttrs }
-              >
-                {{
-                  ...slots,
-                  default: ({ backgroundColorClasses, backgroundColorStyles }) => (
-                    <div
-                      class={[
-                        'v-switch__track',
-                        ...backgroundColorClasses.value,
-                      ]}
-                      style={ backgroundColorStyles.value }
-                      onClick={ onTrackClick }
-                    >
-                      { slots['prepend-inner'] && (
-                        <div key="prepend" class="v-switch__prepend-inner">
-                          { slots['prepend-inner']() }
-                        </div>
-                      )}
+            }) => {
+              const slotProps = {
+                model: model.value,
+                isValid: isValid.value,
+              }
 
-                      { slots['append-inner'] && (
-                        <div key="append" class="v-switch__append-inner">
-                          { slots['append-inner']() }
-                        </div>
-                      )}
-                    </div>
-                  ),
-                  input: ({ inputNode, icon, backgroundColorClasses, backgroundColorStyles }) => (
-                    <>
-                      { inputNode }
+              return (
+                <VSelectionControl
+                  ref={ control }
+                  { ...controlProps }
+                  v-model={ model.value }
+                  id={ id.value }
+                  aria-describedby={ messagesId.value }
+                  type="checkbox"
+                  onUpdate:modelValue={ onChange }
+                  aria-checked={ indeterminate.value ? 'mixed' : undefined }
+                  disabled={ isDisabled.value }
+                  readonly={ isReadonly.value }
+                  onFocus={ focus }
+                  onBlur={ blur }
+                  { ...controlAttrs }
+                >
+                  {{
+                    ...slots,
+                    default: ({ backgroundColorClasses, backgroundColorStyles }) => (
                       <div
                         class={[
-                          'v-switch__thumb',
-                          { 'v-switch__thumb--filled': icon || props.loading },
-                          props.inset ? undefined : backgroundColorClasses.value,
+                          'v-switch__track',
+                          ...backgroundColorClasses.value,
                         ]}
-                        style={ props.inset ? undefined : backgroundColorStyles.value }
+                        style={ backgroundColorStyles.value }
+                        onClick={ onTrackClick }
                       >
-                        { slots.thumb ? (
-                          <VDefaultsProvider
-                            defaults={{
-                              VIcon: {
-                                icon,
-                                size: 'x-small',
-                              },
-                            }}
-                          >
-                            { slots.thumb?.({ icon }) }
-                          </VDefaultsProvider>
-                        ) : (
-                          <VScaleTransition>
-                            { !props.loading ? (
-                              (icon && (<VIcon key={ icon as any } icon={ icon } size="x-small" />))
-                            ) : (
-                              <LoaderSlot
-                                name="v-switch"
-                                active
-                                color={ isValid.value === false ? undefined : loaderColor.value }
-                              >
-                                { slotProps => (
-                                  slots.loader
-                                    ? slots.loader(slotProps)
-                                    : (
-                                      <VProgressCircular
-                                        active={ slotProps.isActive }
-                                        color={ slotProps.color }
-                                        indeterminate
-                                        size="16"
-                                        width="2"
-                                      />
-                                    )
-                                )}
-                              </LoaderSlot>
-                            )}
-                          </VScaleTransition>
+                        { slots['track-true'] && (
+                          <div key="prepend" class="v-switch__track-true">
+                            { slots['track-true'](slotProps) }
+                          </div>
+                        )}
+
+                        { slots['track-false'] && (
+                          <div key="append" class="v-switch__track-false">
+                            { slots['track-false'](slotProps) }
+                          </div>
                         )}
                       </div>
-                    </>
-                  ),
-                }}
-              </VSelectionControl>
-            ),
+                    ),
+                    input: ({ inputNode, icon, backgroundColorClasses, backgroundColorStyles }) => (
+                      <>
+                        { inputNode }
+                        <div
+                          class={[
+                            'v-switch__thumb',
+                            { 'v-switch__thumb--filled': icon || props.loading },
+                            props.inset ? undefined : backgroundColorClasses.value,
+                          ]}
+                          style={ props.inset ? undefined : backgroundColorStyles.value }
+                        >
+                          { slots.thumb ? (
+                            <VDefaultsProvider
+                              defaults={{
+                                VIcon: {
+                                  icon,
+                                  size: 'x-small',
+                                },
+                              }}
+                            >
+                              { slots.thumb({ ...slotProps, icon }) }
+                            </VDefaultsProvider>
+                          ) : (
+                            <VScaleTransition>
+                              { !props.loading ? (
+                                (icon && (<VIcon key={ icon as any } icon={ icon } size="x-small" />))
+                              ) : (
+                                <LoaderSlot
+                                  name="v-switch"
+                                  active
+                                  color={ isValid.value === false ? undefined : loaderColor.value }
+                                >
+                                  { slotProps => (
+                                    slots.loader
+                                      ? slots.loader(slotProps)
+                                      : (
+                                        <VProgressCircular
+                                          active={ slotProps.isActive }
+                                          color={ slotProps.color }
+                                          indeterminate
+                                          size="16"
+                                          width="2"
+                                        />
+                                      )
+                                  )}
+                                </LoaderSlot>
+                              )}
+                            </VScaleTransition>
+                          )}
+                        </div>
+                      </>
+                    ),
+                  }}
+                </VSelectionControl>
+              )
+            },
           }}
         </VInput>
       )

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -30,6 +30,8 @@ export type VSwitchSlots =
   & VSelectionControlSlots
   & { loader: LoaderSlotProps }
   & {
+    'prepend-inner': never
+    'append-inner': never
     thumb: { icon?: IconValue }
   }
 
@@ -147,7 +149,19 @@ export const VSwitch = genericComponent<new <T>(
                       ]}
                       style={ backgroundColorStyles.value }
                       onClick={ onTrackClick }
-                    ></div>
+                    >
+                      { slots['prepend-inner'] && (
+                        <div key="prepend" class="v-switch__prepend-inner">
+                          { slots['prepend-inner']() }
+                        </div>
+                      )}
+
+                      { slots['append-inner'] && (
+                        <div key="append" class="v-switch__append-inner">
+                          { slots['append-inner']() }
+                        </div>
+                      )}
+                    </div>
                   ),
                   input: ({ inputNode, icon, backgroundColorClasses, backgroundColorStyles }) => (
                     <>


### PR DESCRIPTION
## Motivation and Context


## Markup:
<details>

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <v-switch
        v-model="model"
        label="Testing"
        true-icon="mdi-check"
        false-icon="mdi-close"
        inset
        color="primary"
      >
        <template #thumb="{ icon }">
          <v-scale-transition>
            <v-icon :key="icon" :color="model ? 'primary' : 'disabled'" size="12" />
          </v-scale-transition>
        </template>
      </v-switch>
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const model = ref(false)
</script>

```
</details>