### PR TITLE
fix(VSwitch): Alternate color scheme for thumb in dark mode

### DIFF
--- a/packages/vuetify/dev/vuetify.js
+++ b/packages/vuetify/dev/vuetify.js
@@ -16,4 +16,5 @@ export default createVuetify({
   defaults,
   icons,
   locale,
+  theme: { defaultTheme: 'light' },
 })

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -7,6 +7,23 @@
   .v-label
     padding-inline-start: $switch-label-margin-inline-start
 
+  &--dark
+    .v-switch__thumb
+      background-color: currentColor
+
+      .v-icon
+        color: $switch-thumb-background
+
+    .v-selection-control--dirty
+      .v-icon
+        color: $switch-thumb-color
+
+
+  &:not(.v-switch--dark)
+    .v-switch__thumb
+      color: currentColor
+      background-color: $switch-thumb-background
+
 .v-switch__loader
   display: flex
 
@@ -38,8 +55,6 @@
 .v-switch__thumb
   align-items: center
   border-radius: $switch-thumb-radius
-  background: $switch-thumb-background
-  color: $switch-thumb-color
   display: flex
   height: $switch-thumb-height
   justify-content: center

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -12,6 +12,7 @@ import { makeVSelectionControlProps, VSelectionControl } from '@/components/VSel
 import { useFocus } from '@/composables/focus'
 import { LoaderSlot, useLoader } from '@/composables/loader'
 import { useProxiedModel } from '@/composables/proxiedModel'
+import { useTheme } from '@/composables/theme'
 
 // Utilities
 import { computed, ref } from 'vue'
@@ -84,6 +85,7 @@ export const VSwitch = genericComponent<VSwitchSlots>()({
       const [rootAttrs, controlAttrs] = filterInputAttrs(attrs)
       const [inputProps, _1] = VInput.filterProps(props)
       const [controlProps, _2] = VSelectionControl.filterProps(props)
+      const { current } = useTheme()
 
       return (
         <VInput
@@ -91,6 +93,7 @@ export const VSwitch = genericComponent<VSwitchSlots>()({
             'v-switch',
             { 'v-switch--inset': props.inset },
             { 'v-switch--indeterminate': indeterminate.value },
+            { 'v-switch--dark' : current.value.dark },
             loaderClasses.value,
             props.class,
           ]}


### PR DESCRIPTION
fixes #18089

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Have tried to fix based on https://m3.material.io/components/switch/specs#4530313e-e0b6-4dab-b99a-43b25eb484fd

![image](https://github.com/vuetifyjs/vuetify/assets/57935926/30cbde1c-6629-49c6-8659-ff295093453c)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container fluid>
    <p>{{ people }}</p>
    <v-switch
      v-model="people"
      label="John"
      value="John"
      hide-details
      true-icon="mdi-check"
      false-icon="mdi-close"
      color="primary"
    ></v-switch>
    <v-switch
      v-model="people"
      label="John"
      value="John"
      hide-details
      true-icon="mdi-check"
      false-icon="mdi-close"
      inset
      color="primary"
    ></v-switch>
    <v-switch
      v-model="people"
      label="Jacob"
      value="Jacob"
      hide-details
      color="primary"
    ></v-switch>
    <v-switch
      v-model="people"
      label="Jacob"
      value="Jacob"
      hide-details
      inset
      color="primary"
    ></v-switch>
  </v-container>
</template>

<script>
  export default {
    data() {
      return {
        people: ['John'],
      }
    },
  }
</script>
```

```vue
import '@mdi/font/css/materialdesignicons.css'
import 'vuetify/src/styles/main.sass'

import { createVuetify } from 'vuetify/src/framework'
import * as directives from 'vuetify/src/directives'

import date from './vuetify/date'
import defaults from './vuetify/defaults'
import icons from './vuetify/icons'
import locale from './vuetify/locale'

export default createVuetify({
  directives,
  ssr: !!process.env.VITE_SSR,
  date,
  defaults,
  icons,
  locale,
  theme: { defaultTheme: 'dark' },
})
```
