### PR TITLE
docs(VAutocomplete): prop for filtering is "custom-filter"

### DIFF
--- a/packages/docs/src/pages/en/components/autocompletes.md
+++ b/packages/docs/src/pages/en/components/autocompletes.md
@@ -58,7 +58,7 @@ You can use `density` prop to adjusts vertical spacing within the component.
 
 #### Filter
 
-The `filter` prop can be used to filter each individual item with custom logic. In this example we filter items by name.
+The `custom-filter` prop can be used to filter each individual item with custom logic. In this example we filter items by name.
 
 <example file="v-autocomplete/prop-filter" />
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

Fixes docs for VAutocomplete refering to non-existing prop `filter`, instead the prop is called `custom-filter`.
