### PR TITLE
fix(VDatePicker): enforce min/max on keyboard input

### DIFF
--- a/packages/vuetify/src/labs/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePicker.tsx
@@ -139,9 +139,14 @@ export const VDatePicker = genericComponent<VDatePickerSlots>()({
     })
 
     function updateFromInput (input: string, index: number) {
-      const { isValid, date } = adapter
+      const { isValid, date, isAfter } = adapter
+      const inputDate = date(input)
 
-      if (isValid(input)) {
+      if (
+        isValid(input) &&
+        (!minDate.value || !isAfter(minDate.value, inputDate)) &&
+        (!maxDate.value || !isAfter(inputDate, maxDate.value))
+      ) {
         const newModel = model.value.slice()
         newModel[index] = date(input)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #18113

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker v-model="date" min="2023-08-01" max="2023-09-01" input-mode="keyboard" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const date = ref(new Date())
</script>

```
