### PR TITLE
fix(VDatePicker): set correct max year

### DIFF
--- a/packages/vuetify/src/labs/VDatePicker/VDatePickerControls.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePickerControls.tsx
@@ -15,7 +15,7 @@ import type { PropType } from 'vue'
 export const makeVDatePickerControlsProps = propsFactory({
   displayDate: String,
   disabled: {
-    type: [Boolean, Array<String>] as PropType<boolean | string[]>,
+    type: [Boolean, String] as PropType<boolean | string[]>,
     default: false,
   },
   nextIcon: {

--- a/packages/vuetify/src/labs/VDatePicker/VDatePickerControls.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePickerControls.tsx
@@ -15,7 +15,7 @@ import type { PropType } from 'vue'
 export const makeVDatePickerControlsProps = propsFactory({
   displayDate: String,
   disabled: {
-    type: [Boolean, String] as PropType<boolean | string[]>,
+    type: [Boolean, Array<String>] as PropType<boolean | string[]>,
     default: false,
   },
   nextIcon: {

--- a/packages/vuetify/src/labs/VDatePicker/VDatePickerYears.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePickerYears.tsx
@@ -36,7 +36,7 @@ export const VDatePickerYears = genericComponent()({
       const min = props.min ? adapter.date(props.min).getFullYear() : displayYear.value - 100
       const max = props.max ? adapter.date(props.max).getFullYear() : displayYear.value + 50
 
-      return createRange(max - min, min)
+      return createRange(max - min + 1, min)
     })
 
     const yearRef = ref<VBtn>()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Solving the issue by calculating years range correctly. 

fixes #18112 #18132

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker v-model="date" :max="max" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const date = ref(new Date())
  const max = new Date('2024-07-01');
</script>

```
