### PR TITLE
docs(VOtp): fix broken link to api

### DIFF
--- a/packages/docs/src/pages/en/labs/introduction.md
+++ b/packages/docs/src/pages/en/labs/introduction.md
@@ -98,7 +98,7 @@ The following is a list of available and up-and-coming components for use with L
 | **Infinite scroll** | [Usage](/components/infinite-scroller/) | [v3.2.0 (Orion)](/getting-started/release-notes/?version=v3.2.0) |
 | [v-infinite-scroll](/api/v-infinite-scroll/) | Primary Component | |
 | **OTP input** | [Usage](/components/otp-input/) | [v3.3.11 (Icarus)](/getting-started/release-notes/?version=v3.3.11) |
-| [v-otp-input](/api/v-sotp-input/) | Primary Component | |
+| [v-otp-input](/api/v-otp-input/) | Primary Component | |
 | **Skeleton loader** | [Usage](/components/skeleton-loaders/) | [v3.2.0 (Orion)](/getting-started/release-notes/?version=v3.2.0) |
 | [v-skeleton-loader](/api/v-skeleton-loader/) | Primary Component | |
 | **Steppers** | [Usage](/components/steppers/) | [v3.3.11 (Icarus)](/getting-started/release-notes/?version=v3.3.11) |


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
This PR will fix the broken link from for VOtp on the lads introduction page
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This change is required because it sends users to a 404 page when clicked

