### PR TITLE
docs: fix vuetify-loader npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,12 +240,12 @@ Vuetify supports all **modern browsers**, including Safari 13+ (using [polyfills
         </a>
       </td>
       <td>
-        <a href="https://www.npmjs.com/package/@vuetify/cli-plugin-utils">
-          <img src="https://img.shields.io/npm/v/@vuetify/cli-plugin-utils.svg" alt="Version">
+        <a href="https://www.npmjs.com/package/vuetify-loader">
+          <img src="https://img.shields.io/npm/v/vuetify-loader.svg" alt="Version">
         </a>
       </td>
       <td>
-        A collection of helper utilities for creating Vue CLI plugins
+        Compiler plugins for autoloading Vuetify components
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Fix `vuetify-loader` npm link and badge in README