### PR TITLE
fix(VField): make loader visible

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -424,7 +424,7 @@
 /* endregion */
 /* region LOADER */
 .v-field__loader
-  bottom: -1px
+  top: calc(100% - 1px)
   left: 0
   position: absolute
   right: 0

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -17,6 +17,7 @@
   contain: layout
   flex: 1 0
   grid-area: control
+  overflow: hidden
   position: relative
 
   &--disabled
@@ -424,7 +425,7 @@
 /* endregion */
 /* region LOADER */
 .v-field__loader
-  top: calc(100% - 1px)
+  top: calc(100% - 2px)
   left: 0
   position: absolute
   right: 0

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -431,6 +431,12 @@
   right: 0
   width: 100%
 
+  .v-field--variant-outlined &
+    top: calc(100% - 2px)
+
+  .v-field--variant-outlined.v-field--focused &
+    top: calc(100% - 3px)
+
 /* endregion */
 /* region OVERLAY */
 .v-field__overlay

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -424,7 +424,7 @@
 /* endregion */
 /* region LOADER */
 .v-field__loader
-  bottom: 0
+  bottom: -1px
   left: 0
   position: absolute
   right: 0


### PR DESCRIPTION
fixes #18146

Approach in v2:

![image](https://github.com/vuetifyjs/vuetify/assets/5698884/74e41939-7212-4b46-8656-0e93c6aa0407)


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model:search.trim="modelSearch"
        placeholder="good"
        :loading="loading"
        hide-no-data
      />
      <v-autocomplete
        v-model:search.trim="modelSearch"
        placeholder="bad"
        :loading="true"
        hide-no-data
        variant="outlined"
      />
      <v-text-field
        v-model:search.trim="modelSearch"
        placeholder="bad"
        :loading="true"
        hide-no-data
        variant="outlined"
      />
      <v-autocomplete
        class="fixed"
        placeholder="fixed"
        v-model:search.trim="modelSearch"
        :loading="loading"
        hide-no-data
        variant="outlined"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, watch } from 'vue'

  const model = ref()

  const modelSearch = ref('')
  const loading = ref(false)
  const items = ref([])

  watch(modelSearch, async () => {
    loading.value = true
    await new Promise(resolve => setTimeout(resolve, 2000))
    loading.value = false
  })
</script>
<style>
  .fixed .v-field--variant-outlined.v-field--focused .v-field__loader {
    z-index: 1;
  }
  .fixed
    .v-field--variant-outlined.v-field--focused
    .v-field__loader
    .v-progress-linear__indeterminate {
    background-color: rgb(var(--v-theme-on-primary), 0.75) !important;
  }
</style>


```
