### PR TITLE
fix(VList): don't render vlistgroup when children is empty array

### DIFF
--- a/packages/vuetify/src/components/VList/VListChildren.tsx
+++ b/packages/vuetify/src/components/VList/VListChildren.tsx
@@ -63,7 +63,7 @@ export const VListChildren = genericComponent<new <T extends InternalListItem>(
 
       const [listGroupProps, _1] = VListGroup.filterProps(itemProps)
 
-      return children ? (
+      return children && children.length > 0 ? (
         <VListGroup
           value={ itemProps?.value }
           { ...listGroupProps }


### PR DESCRIPTION
fixes #18172

## Description
The current implementation of ``VList`` is to render a ``VListGroup`` when the children property is an empty array. This change adds an additional check on the length of the array. When the array is empty a ``VListItem`` is rendered.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <code>{{ selection }}</code>
      <v-list v-model:selected="selection" :items="items" item-title="name" item-value="id" select-strategy="classic">
        <template #prepend="{ isSelected, select }">
          <v-checkbox-btn :model-value="isSelected" @update:model-value="select" />
        </template>
      </v-list>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from 'vue'

const selection = ref([])

const items = [
  {
    name: 'Item #1 (empty array)',
    id: 1,
    children: [
      {
        name: 'Item #1-1',
        id: 11,
        children: [],
      },
    ],
  },
  {
    name: 'Item #2 (undefined)',
    id: 2,
    children: [
      {
        name: 'Item #2-1',
        id: 21,
        children: undefined,
      },
    ],
  },
  {
    name: 'Item #3 (null)',
    id: 3,
    children: [
      {
        name: 'Item #3-1',
        id: 31,
        children: null,
      },
    ],
  },
]
</script>

```
