### PR TITLE
fix(tab-transition): clamp NaN scale to 0

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTab.tsx
+++ b/packages/vuetify/src/components/VTabs/VTab.tsx
@@ -81,8 +81,8 @@ export const VTab = genericComponent()({
           : Math.sign(delta) < 0 ? (isHorizontal.value ? 'left' : 'top')
           : 'center'
         const size = Math.abs(delta) + (Math.sign(delta) < 0 ? prevBox[widthHeight] : nextBox[widthHeight])
-        const scale = size / Math.max(prevBox[widthHeight], nextBox[widthHeight])
-        const initialScale = prevBox[widthHeight] / nextBox[widthHeight]
+        const scale = size / Math.max(prevBox[widthHeight], nextBox[widthHeight]) || 0
+        const initialScale = prevBox[widthHeight] / nextBox[widthHeight] || 0
 
         const sigma = 1.5
         animate(nextEl, {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
fixes #18177

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes tab transition clamp NaN scale to 0

This is a similar issue, so the same approach was taken to address it.
https://github.com/vuetifyjs/vuetify/commit/266f54837e297bbc9b2418338151d86cd9d10315

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
