### PR TITLE
fix(VField): align label with input when rounded not applied

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -364,7 +364,7 @@
       flex: 0 0 12px
 
       $v-field-outline-start-root: &
-      
+
       @at-root
         @include tools.density('v-input', $input-density) using ($modifier)
           @at-root #{selector.nest(&, selector.append("[class*='rounded']", $v-field-outline-start-root))}

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -358,18 +358,15 @@
       transition: opacity $field-subtle-transition-timing
 
     &__start
+      flex: 0 0 $field-control-affixed-padding
       border-top-width: var(--v-field-border-width)
       border-bottom-width: var(--v-field-border-width)
       border-inline-start-width: var(--v-field-border-width)
-      flex: 0 0 12px
-
-      $v-field-outline-start-root: &
 
       @at-root
-        @include tools.density('v-input', $input-density) using ($modifier)
-          @at-root #{selector.nest(&, selector.append("[class*='rounded']", $v-field-outline-start-root))}
-            flex: 0 0 #{$field-control-outlined-start-width + $modifier * .5}
-
+        #{selector.append('.v-field--rounded', &)},
+        #{selector.append('[class^="rounded-"]', &)}
+          flex-basis: calc(var(--v-input-control-height) / 2 + 2px)
 
       @include tools.ltr()
         border-top-left-radius: inherit

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -361,12 +361,13 @@
       border-top-width: var(--v-field-border-width)
       border-bottom-width: var(--v-field-border-width)
       border-inline-start-width: var(--v-field-border-width)
+      flex: 0 0 12px
 
-      $root: &
-
+      $v-field-outline-start-root: &
+      
       @at-root
         @include tools.density('v-input', $input-density) using ($modifier)
-          @at-root #{selector.nest(&, $root)}
+          @at-root #{selector.nest(&, selector.append("[class*='rounded']", $v-field-outline-start-root))}
             flex: 0 0 #{$field-control-outlined-start-width + $modifier * .5}
 
 

--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -18,7 +18,6 @@ $field-clearable-margin: 4px !default;
 $field-clearable-transition: .15s opacity, .15s width settings.$standard-easing !default;
 
 // CONTROL
-$field-control-outlined-start-width: 29px !default;
 $field-control-solo-background: rgb(var(--v-theme-surface)) !default;
 $field-control-solo-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !default;
 $field-control-solo-elevation: 2 !default;


### PR DESCRIPTION
fixes: #18182

regression from #17995: label position has been moved to right

Good (<= v3.3.13)
![image](https://github.com/vuetifyjs/vuetify/assets/5698884/c8c7cf6b-0afd-4469-b2c6-4fa9eaecbfd6)

Bad (<= v3.3.14)
![image](https://github.com/vuetifyjs/vuetify/assets/5698884/4a933196-48be-450e-a750-74a020dbbd23)



<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select
        :model-value="'California'"
        placeholder="Hello"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        variant="outlined"
        label="Compact"
        density="compact"
      />
    </v-container>
  </v-app>
</template>

```
