### PR TITLE
docs: fix broken useDisplay link

### DIFF
--- a/packages/docs/src/pages/en/features/display-and-platform.md
+++ b/packages/docs/src/pages/en/features/display-and-platform.md
@@ -57,7 +57,7 @@ If you are still using the Options API, you can access the display information o
 
 | Component | Description |
 | - | - |
-| [useDisplay](/api/useDisplay/) | Composable |
+| [useDisplay](/api/use-display/) | Composable |
 
 ## Options
 


### PR DESCRIPTION
Fix broken `useDisplay` link in [Display & Platform](https://vuetifyjs.com/en/features/display-and-platform/).