### PR TITLE
fix(Select): always use valueComparator to compare values

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -27,7 +27,6 @@ import { makeTransitionProps } from '@/composables/transition'
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
 import {
   genericComponent,
-  getPropertyFromItem,
   IN_BROWSER,
   matchesSelector,
   noop,
@@ -155,30 +154,16 @@ export const VAutocomplete = genericComponent<new <
     )
     const form = useForm()
     const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
-    const selections = computed(() => {
-      return model.value.map(v => {
-        return items.value.find(item => {
-          const itemRawValue = getPropertyFromItem(item.raw, props.itemValue)
-          const modelRawValue = getPropertyFromItem(v.raw, props.itemValue)
-
-          if (itemRawValue === undefined || modelRawValue === undefined) return false
-
-          return props.returnObject
-            ? props.valueComparator(itemRawValue, modelRawValue)
-            : props.valueComparator(item.value, v.value)
-        }) || v
-      })
-    })
 
     const displayItems = computed(() => {
       if (props.hideSelected) {
-        return filteredItems.value.filter(filteredItem => !selections.value.some(s => s.value === filteredItem.value))
+        return filteredItems.value.filter(filteredItem => !model.value.some(s => s.value === filteredItem.value))
       }
       return filteredItems.value
     })
 
-    const selected = computed(() => selections.value.map(selection => selection.props.value))
-    const selection = computed(() => selections.value[selectionIndex.value])
+    const selectedValues = computed(() => model.value.map(selection => selection.props.value))
+
     const highlightFirst = computed(() => {
       const selectFirst = props.autoSelectFirst === true ||
         (props.autoSelectFirst === 'exact' && search.value === displayItems.value[0]?.title)
@@ -220,7 +205,7 @@ export const VAutocomplete = genericComponent<new <
       if (props.readonly || form?.isReadonly.value) return
 
       const selectionStart = vTextFieldRef.value.selectionStart
-      const length = selected.value.length
+      const length = model.value.length
 
       if (
         selectionIndex.value > -1 ||
@@ -258,7 +243,8 @@ export const VAutocomplete = genericComponent<new <
 
         const originalSelectionIndex = selectionIndex.value
 
-        if (selection.value) select(selection.value)
+        const selectedItem = model.value[selectionIndex.value]
+        if (selectedItem) select(selectedItem)
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
@@ -270,7 +256,7 @@ export const VAutocomplete = genericComponent<new <
           ? selectionIndex.value - 1
           : length - 1
 
-        if (selections.value[prev]) {
+        if (model.value[prev]) {
           selectionIndex.value = prev
         } else {
           selectionIndex.value = -1
@@ -283,7 +269,7 @@ export const VAutocomplete = genericComponent<new <
 
         const next = selectionIndex.value + 1
 
-        if (selections.value[next]) {
+        if (model.value[next]) {
           selectionIndex.value = next
         } else {
           selectionIndex.value = -1
@@ -329,7 +315,7 @@ export const VAutocomplete = genericComponent<new <
 
     function select (item: ListItem) {
       if (props.multiple) {
-        const index = selected.value.findIndex(selection => props.valueComparator(selection, item.value))
+        const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
 
         if (index === -1) {
           model.value = [...model.value, item]
@@ -357,7 +343,7 @@ export const VAutocomplete = genericComponent<new <
 
       if (val) {
         isSelecting.value = true
-        search.value = props.multiple ? '' : String(selections.value.at(-1)?.props.title ?? '')
+        search.value = props.multiple ? '' : String(model.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)
@@ -366,7 +352,7 @@ export const VAutocomplete = genericComponent<new <
         else if (
           highlightFirst.value &&
           !listHasFocus.value &&
-          !selections.value.some(({ value }) => value === displayItems.value[0].value)
+          !model.value.some(({ value }) => value === displayItems.value[0].value)
         ) {
           select(displayItems.value[0])
         }
@@ -385,9 +371,9 @@ export const VAutocomplete = genericComponent<new <
     })
 
     watch(menu, () => {
-      if (!props.hideSelected && menu.value && selections.value.length) {
+      if (!props.hideSelected && menu.value && model.value.length) {
         const index = displayItems.value.findIndex(
-          item => selections.value.some(s => item.value === s.value)
+          item => model.value.some(s => item.value === s.value)
         )
         IN_BROWSER && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
@@ -456,7 +442,7 @@ export const VAutocomplete = genericComponent<new <
                   { hasList && (
                     <VList
                       ref={ listRef }
-                      selected={ selected.value }
+                      selected={ selectedValues.value }
                       selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                       onMousedown={ (e: MouseEvent) => e.preventDefault() }
                       onKeydown={ onListKeydown }
@@ -520,7 +506,7 @@ export const VAutocomplete = genericComponent<new <
                   )}
                 </VMenu>
 
-                { selections.value.map((item, index) => {
+                { model.value.map((item, index) => {
                   function onChipClose (e: Event) {
                     e.stopPropagation()
                     e.preventDefault()
@@ -577,7 +563,7 @@ export const VAutocomplete = genericComponent<new <
                         slots.selection?.({ item, index }) ?? (
                           <span class="v-autocomplete__selection-text">
                             { item.title }
-                            { props.multiple && (index < selections.value.length - 1) && (
+                            { props.multiple && (index < model.value.length - 1) && (
                               <span class="v-autocomplete__selection-comma">,</span>
                             )}
                           </span>

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -26,7 +26,7 @@ import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
-import { genericComponent, getPropertyFromItem, IN_BROWSER, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, IN_BROWSER, noop, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -191,30 +191,15 @@ export const VCombobox = genericComponent<new <
 
     const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
 
-    const selections = computed(() => {
-      return model.value.map(v => {
-        return items.value.find(item => {
-          const itemRawValue = getPropertyFromItem(item.raw, props.itemValue)
-          const modelRawValue = getPropertyFromItem(v.raw, props.itemValue)
-
-          if (itemRawValue === undefined || modelRawValue === undefined) return false
-
-          return props.returnObject
-            ? props.valueComparator(itemRawValue, modelRawValue)
-            : props.valueComparator(item.value, v.value)
-        }) || v
-      })
-    })
-
     const displayItems = computed(() => {
       if (props.hideSelected) {
-        return filteredItems.value.filter(filteredItem => !selections.value.some(s => s.value === filteredItem.value))
+        return filteredItems.value.filter(filteredItem => !model.value.some(s => s.value === filteredItem.value))
       }
       return filteredItems.value
     })
 
-    const selected = computed(() => selections.value.map(selection => selection.props.value))
-    const selection = computed(() => selections.value[selectionIndex.value])
+    const selectedValues = computed(() => model.value.map(selection => selection.value))
+
     const highlightFirst = computed(() => {
       const selectFirst = props.autoSelectFirst === true ||
         (props.autoSelectFirst === 'exact' && search.value === displayItems.value[0]?.title)
@@ -256,7 +241,7 @@ export const VCombobox = genericComponent<new <
       if (props.readonly || form?.isReadonly.value) return
 
       const selectionStart = vTextFieldRef.value.selectionStart
-      const length = selected.value.length
+      const length = model.value.length
 
       if (
         selectionIndex.value > -1 ||
@@ -297,8 +282,8 @@ export const VCombobox = genericComponent<new <
         }
 
         const originalSelectionIndex = selectionIndex.value
-
-        if (selection.value) select(selection.value)
+        const selectedItem = model.value[selectionIndex.value]
+        if (selectedItem) select(selectedItem)
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
@@ -310,7 +295,7 @@ export const VCombobox = genericComponent<new <
           ? selectionIndex.value - 1
           : length - 1
 
-        if (selections.value[prev]) {
+        if (model.value[prev]) {
           selectionIndex.value = prev
         } else {
           selectionIndex.value = -1
@@ -323,7 +308,7 @@ export const VCombobox = genericComponent<new <
 
         const next = selectionIndex.value + 1
 
-        if (selections.value[next]) {
+        if (model.value[next]) {
           selectionIndex.value = next
         } else {
           selectionIndex.value = -1
@@ -344,7 +329,7 @@ export const VCombobox = genericComponent<new <
     }
     function select (item: ListItem) {
       if (props.multiple) {
-        const index = selected.value.findIndex(selection => props.valueComparator(selection, item.value))
+        const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
 
         if (index === -1) {
           model.value = [...model.value, item]
@@ -393,7 +378,7 @@ export const VCombobox = genericComponent<new <
       if (
         highlightFirst.value &&
         !listHasFocus.value &&
-        !selections.value.some(({ value }) => value === displayItems.value[0].value)
+        !model.value.some(({ value }) => value === displayItems.value[0].value)
       ) {
         select(displayItems.value[0])
       } else if (props.multiple && search.value) {
@@ -403,9 +388,9 @@ export const VCombobox = genericComponent<new <
     })
 
     watch(menu, () => {
-      if (!props.hideSelected && menu.value && selections.value.length) {
+      if (!props.hideSelected && menu.value && model.value.length) {
         const index = displayItems.value.findIndex(
-          item => selections.value.some(s => item.value === s.value)
+          item => model.value.some(s => props.valueComparator(s.value, item.value))
         )
         IN_BROWSER && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
@@ -472,7 +457,7 @@ export const VCombobox = genericComponent<new <
                   { hasList && (
                     <VList
                       ref={ listRef }
-                      selected={ selected.value }
+                      selected={ selectedValues.value }
                       selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                       onMousedown={ (e: MouseEvent) => e.preventDefault() }
                       onKeydown={ onListKeydown }
@@ -536,7 +521,7 @@ export const VCombobox = genericComponent<new <
                   )}
                 </VMenu>
 
-                { selections.value.map((item, index) => {
+                { model.value.map((item, index) => {
                   function onChipClose (e: Event) {
                     e.stopPropagation()
                     e.preventDefault()
@@ -593,7 +578,7 @@ export const VCombobox = genericComponent<new <
                         slots.selection?.({ item, index }) ?? (
                           <span class="v-combobox__selection-text">
                             { item.title }
-                            { props.multiple && (index < selections.value.length - 1) && (
+                            { props.multiple && (index < model.value.length - 1) && (
                               <span class="v-combobox__selection-comma">,</span>
                             )}
                           </span>

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -25,9 +25,7 @@ import { makeTransitionProps } from '@/composables/transition'
 // Utilities
 import { computed, mergeProps, ref, shallowRef, watch } from 'vue'
 import {
-  deepEqual,
   genericComponent,
-  getPropertyFromItem,
   IN_BROWSER,
   matchesSelector,
   omit,
@@ -82,10 +80,6 @@ export const makeSelectProps = propsFactory({
     default: '$vuetify.noDataText',
   },
   openOnClear: Boolean,
-  valueComparator: {
-    type: Function as PropType<typeof deepEqual>,
-    default: deepEqual,
-  },
   itemColor: String,
 
   ...makeItemsProps({ itemChildren: false }),
@@ -158,21 +152,7 @@ export const VSelect = genericComponent<new <
       }
     )
     const form = useForm()
-    const selections = computed(() => {
-      return model.value.map(v => {
-        return items.value.find(item => {
-          const itemRawValue = getPropertyFromItem(item.raw, props.itemValue)
-          const modelRawValue = getPropertyFromItem(v.raw, props.itemValue)
-
-          if (itemRawValue === undefined || modelRawValue === undefined) return false
-
-          return props.returnObject
-            ? props.valueComparator(itemRawValue, modelRawValue)
-            : props.valueComparator(item.value, v.value)
-        }) || v
-      })
-    })
-    const selected = computed(() => selections.value.map(selection => selection.props.value))
+    const selectedValues = computed(() => model.value.map(selection => selection.value))
     const isFocused = shallowRef(false)
     const label = computed(() => menu.value ? props.closeText : props.openText)
 
@@ -181,7 +161,7 @@ export const VSelect = genericComponent<new <
 
     const displayItems = computed(() => {
       if (props.hideSelected) {
-        return items.value.filter(item => !selections.value.some(s => s === item))
+        return items.value.filter(item => !model.value.some(s => s === item))
       }
       return items.value
     })
@@ -249,7 +229,7 @@ export const VSelect = genericComponent<new <
     }
     function select (item: ListItem) {
       if (props.multiple) {
-        const index = selected.value.findIndex(selection => props.valueComparator(selection, item.value))
+        const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
 
         if (index === -1) {
           model.value = [...model.value, item]
@@ -289,9 +269,9 @@ export const VSelect = genericComponent<new <
     }
 
     watch(menu, () => {
-      if (!props.hideSelected && menu.value && selections.value.length) {
+      if (!props.hideSelected && menu.value && model.value.length) {
         const index = displayItems.value.findIndex(
-          item => selections.value.some(s => item.value === s.value)
+          item => model.value.some(s => props.valueComparator(s.value, item.value))
         )
         IN_BROWSER && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
@@ -367,7 +347,7 @@ export const VSelect = genericComponent<new <
                   { hasList && (
                     <VList
                       ref={ listRef }
-                      selected={ selected.value }
+                      selected={ selectedValues.value }
                       selectStrategy={ props.multiple ? 'independent' : 'single-independent' }
                       onMousedown={ (e: MouseEvent) => e.preventDefault() }
                       onKeydown={ onListKeydown }
@@ -424,7 +404,7 @@ export const VSelect = genericComponent<new <
                   )}
                 </VMenu>
 
-                { selections.value.map((item, index) => {
+                { model.value.map((item, index) => {
                   function onChipClose (e: Event) {
                     e.stopPropagation()
                     e.preventDefault()
@@ -471,7 +451,7 @@ export const VSelect = genericComponent<new <
                         slots.selection?.({ item, index }) ?? (
                           <span class="v-select__selection-text">
                             { item.title }
-                            { props.multiple && (index < selections.value.length - 1) && (
+                            { props.multiple && (index < model.value.length - 1) && (
                               <span class="v-select__selection-comma">,</span>
                             )}
                           </span>

--- a/packages/vuetify/src/composables/__tests__/filter.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/filter.spec.ts
@@ -5,6 +5,7 @@ import { transformItem, transformItems } from '../list-items'
 // Utilities
 import { describe, expect, it } from '@jest/globals'
 import { nextTick, ref } from 'vue'
+import { deepEqual } from '@/util'
 
 describe('filter', () => {
   describe('defaultFilter', () => {
@@ -114,6 +115,7 @@ describe('filter', () => {
       itemChildren: 'children',
       itemProps: 'props',
       returnObject: false,
+      valueComparator: deepEqual,
     }
     const items = Array.from({ length: 50 }, (v, k) => ({
       text: `item-${k}`,

--- a/packages/vuetify/src/composables/__tests__/items.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/items.spec.ts
@@ -3,6 +3,7 @@ import { useItems } from '../list-items'
 
 // Utilities
 import { describe, expect, it } from '@jest/globals'
+import { deepEqual } from '@/util'
 
 describe('items', () => {
   const defaults = {
@@ -11,6 +12,7 @@ describe('items', () => {
     itemChildren: 'children',
     itemProps: () => ({}),
     returnObject: false,
+    valueComparator: deepEqual,
   }
 
   it('should do nothing to empty array', () => {

--- a/packages/vuetify/src/composables/list-items.ts
+++ b/packages/vuetify/src/composables/list-items.ts
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { deepEqual, getPropertyFromItem, pick, propsFactory } from '@/util'
 
 // Types
-import type { PropType, Ref } from 'vue'
+import type { PropType } from 'vue'
 import type { InternalItem } from '@/composables/filter'
 import type { SelectItemKey } from '@/util'
 
@@ -24,6 +24,7 @@ export interface ItemProps {
   itemChildren: SelectItemKey
   itemProps: SelectItemKey
   returnObject: boolean
+  valueComparator: typeof deepEqual
 }
 
 // Composables
@@ -49,11 +50,15 @@ export const makeItemsProps = propsFactory({
     default: 'props',
   },
   returnObject: Boolean,
+  valueComparator: {
+    type: Function as PropType<typeof deepEqual>,
+    default: deepEqual,
+  },
 }, 'list-items')
 
 export function transformItem (props: Omit<ItemProps, 'items'>, item: any): ListItem {
   const title = getPropertyFromItem(item, props.itemTitle, item)
-  const value = props.returnObject ? item : getPropertyFromItem(item, props.itemValue, title)
+  const value = getPropertyFromItem(item, props.itemValue, title)
   const children = getPropertyFromItem(item, props.itemChildren)
   const itemProps = props.itemProps === true
     ? typeof item === 'object' && item != null && !Array.isArray(item)
@@ -90,26 +95,29 @@ export function transformItems (props: Omit<ItemProps, 'items'>, items: ItemProp
 
 export function useItems (props: ItemProps) {
   const items = computed(() => transformItems(props, props.items))
+  const hasNullItem = computed(() => items.value.some(item => item.value === null))
 
-  return useTransformItems(items, value => transformItem(props, value))
-}
+  function transformIn (value: any[]): ListItem[] {
+    if (!hasNullItem.value) {
+      // When the model value is null, return an InternalItem
+      // based on null only if null is one of the items
+      value = value.filter(v => v !== null)
+    }
 
-export function useTransformItems <T extends { value: unknown }> (items: Ref<T[]>, transform: (value: unknown) => T) {
-  function transformIn (value: any[]): T[] {
-    return value
-      // When the model value is null, returns an InternalItem based on null
-      // only if null is one of the items
-      .filter(v => v !== null || items.value.some(item => item.value === null))
-      .map(v => {
-        const existingItem = items.value.find(item => deepEqual(v, item.value))
-        // Nullish existingItem means value is a custom input value from combobox
-        // In this case, use transformItem to create an InternalItem based on value
-        return existingItem ?? transform(v)
-      })
+    return value.map(v => {
+      if (props.returnObject && typeof v === 'string') {
+        // String model value means value is a custom input value from combobox
+        // Don't look up existing items if the model value is a string
+        return transformItem(props, v)
+      }
+      return items.value.find(item => props.valueComparator(v, item.value)) || transformItem(props, v)
+    })
   }
 
-  function transformOut (value: T[]) {
-    return value.map(({ value }) => value)
+  function transformOut (value: ListItem[]): any[] {
+    return props.returnObject
+      ? value.map(({ raw }) => raw)
+      : value.map(({ value }) => value)
   }
 
   return { items, transformIn, transformOut }


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #17997
continues from #16210, #16279, #16388, #16512
reverts #16859
kinda un-reverts #16546

Also cleaned up a bit:
- `selections` was redundant, replaced with a single map call in transformIn
- `selected` is only needed to pass to VList, renamed to `selectedValues` for clarity
- `selection` was only used in one place, replaced with a local variable

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->

#17997 comparator is used for primitive model:
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model="model"
        :items="items"
        item-value="id"
        :value-comparator="comparator"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const items = [
    { id: '1', title: 'a' },
    { id: '2', title: 'b' },
    { id: '3', title: 'c' },
  ]

  const model = ref(2)

  const comparator = (a, b) => {
    if (a === b) return true
    const c = (a ?? '').toString()
    const d = (b ?? '').toString()
    return c === d
  }
</script>
```

#16546 Combobox shouldn't highlight matching string values:
```vue
<template>
  <v-app>
    <v-container>
      <pre>{{ selection }}</pre>
      <v-combobox v-model="selection" :items="items" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { computed, ref, watch } from 'vue'

  const selection = ref()

  const items = [
    { title: 'One', value: '1' },
    { title: 'Two', value: '2' },
    { title: 'Three', value: '3' },
  ]
</script>
```

