### PR TITLE
fix(VSelectionControl): set width to max-content

### DIFF
--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -17,7 +17,7 @@
     white-space: normal
     word-break: break-word
     height: 100%
-    width: 100%
+    width: max-content
 
   &--disabled
     opacity: var(--v-disabled-opacity)

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -6,6 +6,7 @@
 .v-switch
   .v-label
     padding-inline-start: $switch-label-margin-inline-start
+    width: (max-content !important)
 
   .v-switch__thumb
     background-color: $switch-thumb-background

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -6,7 +6,6 @@
 .v-switch
   .v-label
     padding-inline-start: $switch-label-margin-inline-start
-    width: (max-content !important)
 
   .v-switch__thumb
     background-color: $switch-thumb-background


### PR DESCRIPTION


## Description
fixes #18225 
**the problem:** VSwitch is clickable as a block element (it takes 100% of the screen width) as shown in the issue [reproduciton](https://play.vuetifyjs.com/#eNqNkUFuwjAQRa9iWV2ARGxVtJsoRfQMLDESIR6K29ix7ElohXL3OjZpESxglczY89//4/WJvlvLuhZoTgsEbesSYSEMIUWX+aPC6jAUhHSZbiTUb4LGr6CpfVASMglYqtqnjjIeMP3mdbmLI9tVVMrJ0ylOM2xW6JT5mEz7bZJaFHwEBnzBL7yE0ldOWYy+4Ns2DomEfdnWSE4JJUssJ9OxIsQBts7814REcE7QtTAbu3366WMjFAX/A9EZrZX58uzTNyYsJyoJWnkvaE7WaVDQA6L1OeeVNOFmIKjOMQPIjdU8rBXV/mc5Z3P2/Mql8jj2srAaz6LaILURpg9EpYdsmS7tFTYdRPQ5kqBBaajveFiGa9y1BpUOD9XoaOYlebloM/A627nm6MEFEUHPO4qYwfADqLtxA+NGmwdgBy5zYCQ4cI9Guhq7jHV1dBPt/Ng97Wc0joXNJ8908wuQiwTp)
**The solution:** 
changed `VSwitch`'s label width from 100% to `max-content` 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-switch
    v-model="model"
    hide-details
    inset
    :label="`Switch: ${model.toString()}`"
  ></v-switch>
</template>

<script>
  export default {
    data() {
      return {
        model: true,
      }
    },
  }
</script>

```
