### PR TITLE
fix(VDialog): passthrough custom attributes

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.ts
+++ b/packages/vuetify/src/components/VDialog/VDialog.ts
@@ -6,6 +6,7 @@ import { VThemeProvider } from '../VThemeProvider'
 
 // Mixins
 import Activatable from '../../mixins/activatable'
+import BindsAttrs from '../../mixins/binds-attrs'
 import Dependent from '../../mixins/dependent'
 import Detachable from '../../mixins/detachable'
 import Overlayable from '../../mixins/overlayable'
@@ -27,6 +28,7 @@ import {
 import { VNode, VNodeData } from 'vue'
 
 const baseMixins = mixins(
+  BindsAttrs,
   Dependent,
   Detachable,
   Overlayable,
@@ -40,6 +42,8 @@ export default baseMixins.extend({
   name: 'v-dialog',
 
   directives: { ClickOutside },
+
+  inheritAttrs: false,
 
   props: {
     dark: Boolean,
@@ -254,6 +258,7 @@ export default baseMixins.extend({
               role: 'dialog',
               'aria-modal': this.hideOverlay ? undefined : 'true',
               ...this.getScopeIdAttrs(),
+              ...this.attrs$,
             },
             on: { keydown: this.onKeydown },
             style: { zIndex: this.activeZIndex },

--- a/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.ts
+++ b/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.ts
@@ -130,6 +130,17 @@ describe('VDialog.ts', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('should render component with custom attributes and match snapshot', () => {
+    const wrapper = mountFunction({
+      attrs: {
+        'aria-labelledby': 'dialog-title',
+        'aria-describedby': 'dialog-description',
+      },
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should open dialog on activator click', async () => {
     const input = jest.fn()
     const wrapper = mountFunction({

--- a/packages/vuetify/src/components/VDialog/__tests__/__snapshots__/VDialog.spec.ts.snap
+++ b/packages/vuetify/src/components/VDialog/__tests__/__snapshots__/VDialog.spec.ts.snap
@@ -45,6 +45,11 @@ exports[`VDialog.ts should render component and match snapshot 1`] = `
 </div>
 `;
 
+exports[`VDialog.ts should render component with custom attributes and match snapshot 1`] = `
+<div class="v-dialog__container">
+</div>
+`;
+
 exports[`VDialog.ts should render component with custom origin and match snapshot 1`] = `
 <div class="v-dialog__container">
 </div>


### PR DESCRIPTION
## Description
Bind `$attrs` to the `v-dialog__content` element in `VDialog`, with has the `role="dialog"` attribute.

Fixes #14755

## Motivation and Context
This allows the user to apply ARIA attributes to the `VDialog` to ensure accessibility.

## How Has This Been Tested?
Tested via the playground

## Markup:

<details>

```vue
<template>
  <v-container>
    <v-dialog
      v-model="dialog"
      width="500"
      aria-labelledby="dialog1Title"
      aria-describedby="dialog1Desc"
    >
      <template v-slot:activator="{ on, attrs }">
        <v-btn
          color="red lighten-2"
          dark
          v-bind="attrs"
          v-on="on"
        >
          Click Me
        </v-btn>
      </template>

      <v-card>
        <v-card-title
          id="dialog1Title"
          class="text-h5 grey lighten-2"
        >
          Privacy Policy
        </v-card-title>

        <v-card-text id="dialog1Desc">
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
        </v-card-text>

        <v-divider></v-divider>

        <v-card-actions>
          <v-spacer></v-spacer>
          <v-btn
            color="primary"
            text
            @click="dialog = false"
          >
            I accept
          </v-btn>
        </v-card-actions>
      </v-card>
    </v-dialog>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      dialog: false,
    }),
  }
</script>
```
</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
- [x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
