### PR TITLE
fix(VSelectionControl): set width to fit-content

### DIFF
--- a/packages/docs/src/components/PageFeatures.vue
+++ b/packages/docs/src/components/PageFeatures.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-8">
     <page-feature-chip
-      v-if="meta.features.figma"
+      v-if="meta?.features?.figma"
       :text="t('figma-design')"
       prepend-icon="mdi-image"
       href="https://figma.vuetifyjs.com/"
@@ -14,7 +14,7 @@
     </page-feature-chip>
 
     <page-feature-chip
-      v-if="meta.features.report"
+      v-if="meta?.features?.report"
       :text="t('report-an-issue')"
       prepend-icon="mdi-bug-outline"
       target="_blank"
@@ -27,7 +27,7 @@
     </page-feature-chip>
 
     <page-feature-chip
-      v-if="meta.features.github"
+      v-if="meta?.features?.github"
       :text="t('view-in-github')"
       prepend-icon="mdi-github"
       :href="`https://github.com/vuetifyjs/vuetify/tree/${branch}/packages/vuetify/src${meta.features.github}`"
@@ -40,7 +40,7 @@
     </page-feature-chip>
 
     <page-feature-chip
-      v-if="meta.features.spec"
+      v-if="meta?.features?.spec"
       :text="t('design-spec')"
       prepend-icon="mdi-material-design"
       :href="meta.features.spec"

--- a/packages/docs/src/pages/en/components/data-iterators.md
+++ b/packages/docs/src/pages/en/components/data-iterators.md
@@ -8,18 +8,24 @@ related:
   - /components/data-tables/basics/
   - /components/simple-tables/
   - /components/toolbars/
+features:
+  github: /components/VDataIterator/
+  label: 'C: VDataIterator'
+  report: true
 ---
 
 # Data iterators
 
 The `v-data-iterator` component is used for displaying arbitrary data, and shares a majority of its functionality with the `v-data-table` component. Features include sorting, searching, pagination, and selection.
 
-![Data iterator Entry](https://cdn.vuetifyjs.com/docs/images/components/v-data-iterator/v-data-iterator-entry.png){ placeholder=true }
+<!-- ![Data iterator Entry](https://cdn.vuetifyjs.com/docs/images/components/v-data-iterator/v-data-iterator-entry.png){ placeholder=true } -->
 
-----
+<page-features />
 
 ::: warning
+
 This feature requires [v3.3.0 (Icarus)](/getting-started/release-notes/?version=v3.3.0)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/components/data-tables/basics.md
+++ b/packages/docs/src/pages/en/components/data-tables/basics.md
@@ -8,16 +8,23 @@ related:
   - /components/paginations/
   - /components/tables/
   - /components/lists/
+features:
+  github: /components/VDataTable/
+  label: 'C: VDataTable'
+  report: true
+  spec: https://m2.material.io/components/data-tables
 ---
 
 # Data tables
 
 The `v-data-table` component is used for displaying tabular data. Features include sorting, searching, pagination, grouping, and row selection.
 
-----
+<page-features />
 
 ::: warning
+
 This feature requires [v3.1.0 (Valkyrie)](/getting-started/release-notes/?version=v3.1.0)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/components/date-pickers.md
+++ b/packages/docs/src/pages/en/components/date-pickers.md
@@ -7,6 +7,11 @@ related:
   - /components/buttons/
   - /features/dates/
   - /components/text-fields/
+features:
+  github: /components/VDatePicker/
+  label: 'C: VDatePicker'
+  report: true
+  spec: https://material.io/components/date-pickers
 ---
 
 # Date pickers
@@ -15,10 +20,12 @@ related:
 
 <!-- ![Date picker Entry](https://cdn.vuetifyjs.com/docs/images/components/v-date-picker/v-date-picker-entry.png) -->
 
----
+<page-features />
 
 ::: warning
+
 This feature requires [v3.3.4](/getting-started/release-notes/?version=v3.3.4)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/components/infinite-scroller.md
+++ b/packages/docs/src/pages/en/components/infinite-scroller.md
@@ -8,16 +8,28 @@ related:
   - /components/lists/
   - /components/data-tables/basics/
   - /components/data-iterators/
+features:
+  github: /components/VInfiniteScroll/
+  label: 'C: VInfiniteScroll'
+  report: true
 ---
 
 # Infinite scroller
 
 The `v-infinite-scroll` component displays a potentially infinite list, by loading more items of the list when scrolling. It supports either vertical or horizontal scrolling.
 
-----
+<page-features />
+
+::: success
+
+This component is feature complete and is pending release in [v3.4.0 (Blackguard)](/introduction/roadmap/#v3-4-blackguard)
+
+:::
 
 ::: warning
+
 This feature requires [v3.2.0 (Orion)](/getting-started/release-notes/?version=v3.2.0)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/components/otp-input.md
+++ b/packages/docs/src/pages/en/components/otp-input.md
@@ -8,6 +8,10 @@ related:
   - /components/inputs/
   - /components/text-fields/
   - /components/forms/
+features:
+  label: 'C: VOtpInput'
+  github: /labs/VOtpInput/
+  report: true
 ---
 
 # OTP Input
@@ -16,10 +20,12 @@ The OTP input is used for MFA procedure of authenticating users by a one-time pa
 
 ![Otp input Entry](https://cdn.vuetifyjs.com/docs/images/components/v-otp-input/v-otp-input-entry.png){ height=300 }
 
-----
+<page-features />
 
 ::: warning
+
 This feature requires [v3.3.11](/getting-started/release-notes/?version=v3.3.11)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/components/skeleton-loaders.md
+++ b/packages/docs/src/pages/en/components/skeleton-loaders.md
@@ -8,6 +8,10 @@ related:
   - /components/cards/
   - /components/progress-circular/
   - /components/buttons/
+features:
+  label: 'C: VSkeletonLoader'
+  github: /labs/VSkeletonLoader/
+  report: true
 ---
 
 # Skeleton loaders
@@ -16,10 +20,12 @@ Skeleton loaders provide a simple way to display loading placeholders in your ap
 
 ![Skeleton loader Entry](https://cdn.vuetifyjs.com/docs/images/components-temp/v-skeleton-loader/v-skeleton-loader-entry.png)
 
-----
+<page-features />
 
 ::: warning
+
 This feature requires [v3.2.0 (Orion)](/getting-started/release-notes/?version=v3.2.0)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/components/steppers.md
+++ b/packages/docs/src/pages/en/components/steppers.md
@@ -9,6 +9,12 @@ related:
   - /components/tabs/
   - /components/item-groups/
   - /components/windows/
+features:
+  figma: true
+  github: /components/VStepper/
+  label: 'C: VStepper'
+  report: true
+  spec: https://m1.material.io/components/steppers.html
 ---
 
 # Steppers
@@ -17,10 +23,12 @@ The `v-stepper` component displays progress through numbered steps.
 
 <!-- ![Pending graphic](https://cdn.vuetifyjs.com/docs/images/components/v-stepper/v-stepper-entry.png){ height=300 } -->
 
----
+<page-features />
 
 ::: warning
+
 This feature requires [v3.3.11](/getting-started/release-notes/?version=v3.3.11)
+
 :::
 
 ## Usage

--- a/packages/docs/src/pages/en/features/dates.md
+++ b/packages/docs/src/pages/en/features/dates.md
@@ -8,18 +8,24 @@ related:
 - /features/blueprints/
 - /features/global-configuration/
 - /features/treeshaking/
+features:
+  github: /labs/date/
+  label: 'E: date'
+  report: true
 ---
 
 # Dates
 
 Easily hook up date libraries that are used for components that require date functionality.
 
+<page-features />
+
 <entry />
 
-----
-
 ::: warning
+
 This feature requires [v3.2.0 (Orion)](/getting-started/release-notes/?version=v3.2.0)
+
 :::
 
 ## Usage

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -17,7 +17,8 @@
     white-space: normal
     word-break: break-word
     height: 100%
-    width: max-content
+    width: fit-content
+    max-width : 100%
 
   &--disabled
     opacity: var(--v-disabled-opacity)


### PR DESCRIPTION

## Description
fixes #18252 
the max-content width on the VSelectionControl component is causing it to overflow the parent element like it is demonstrated on the issue's [reproduction](https://play.vuetifyjs.com/#eNqlU8GO0zAQ/RXjS0FqkoVFHEoXLaCVgAMgQOKw2YMbTxtnE9vyOG1XVf+dsZ2W0AW00l6i8czkvXnP4+sdR1cVb63N1z3wGZ976GwrPLwpNWPzdSasjWE8VEZ7oTQ4hv6uhYuSb5T09Yy9ODuz29clH1pTcw3V7cJs2TrrjISWujtclZy1YhFPdSPrRqCs+0YJrJteyb5WlAnfEMZIqr5GQZ8QGIoaI41CYVRTSxSSAIvDhMVoxCSAMknBvBgpoyNWTlnPEHyfBKrOGufZjjlYsj1bOtOxCZkyCe2MES56RgLYReh4OvkAbWvYT+Na+WTyLBAkSALjU57Qsk7YvEGjydldQCmHApZ8xmIm5IglnMkR7y3OiqKSmn4jz9Ta5Rp8oW1XXFJb4XrtVQeZNN3leX6evyykQj9O54BdtnBmg+AIpOTTEY1Xy7sHUA2dkeH5q0Qx5DK6PQwc97ALIlyDyxxoCQ7cQyWd/DaWdVK6Jy2w70u9J8NbpW/xxOsKo8/XhyEfpzmiBaibxOiRdmKpVqekprOqBffFekU788dFC1qZzaeY866Ho3vxqfwl3+A2ufjVQfRi5LgXbgU+la++f4YtxcciPbi+HZbqH8VvgKbtw4yp7V2vJY096ovTfoz7qvTqB15tPWg8iAqDRv9jf9yA9/+R/ntcMvh4b/spj9dNdibf+c0v8ySJlQ==)


## Markup:

```vue
<template>
  <v-app>
    <v-container style="width: 200px;">
      <v-checkbox v-model="msg" label="hjdhjasdhujiashjuiduhijasuhijduhiasuhidiuhsaiuhdiuhosaijodoisaoijhdsad" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>

```
