### PR TITLE
fix(VDataTable): don't check select-all when table has no rows

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/composables/select.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/select.ts
@@ -153,7 +153,7 @@ export function provideSelection (
       allItems: allSelectable.value,
       currentPage: currentPageSelectable.value,
     })
-    return isSelected(items)
+    return items.length && isSelected(items)
   })
 
   const data = {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix the issue by checking if items has length.

fixes #18268 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table
        v-model="selected"
        v-model:items-per-page="itemsPerPage"
        :headers="headers"
        :items="data"
        select-strategy="all"
        :show-select="true"
      ></v-data-table>
    </v-container>
  </v-app>
</template>

<script lang="ts">
  import { ref } from 'vue'

  export default {
    name: 'BrokenSelectAllStrategy',
    data() {
      const itemsPerPage: number = 10;
      const headers = [
        {
          title: 'Foo',
          key: 'foo',
        },
        {
          title: 'Bar',
          key: 'bar',
        },
      ];
      const data = [];
      const selected = [];

      return {
        itemsPerPage,
        headers,
        data,
        selected,
      };
    }
  }
</script>

```
