### PR TITLE
docs(getting-started): 'global' to 'globals' in the vitest config

### DIFF
--- a/packages/docs/src/pages/en/getting-started/unit-testing.md
+++ b/packages/docs/src/pages/en/getting-started/unit-testing.md
@@ -33,7 +33,7 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   test: {
-    global: true,
+    globals: true,
     environment: 'jsdom',
     deps: {
       inline: ['vuetify'],


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Fixed the 'global' option to 'globals' in the vitest configuration

## Source:

https://vitest.dev/config/#globals
