### PR TITLE
fix(VTabs): issue with :items parsing in v-tabs component

### DIFF
--- a/packages/vuetify/src/components/VTabs/VTab.tsx
+++ b/packages/vuetify/src/components/VTabs/VTab.tsx
@@ -122,7 +122,7 @@ export const VTab = genericComponent()({
           maxWidth={ props.fixed ? 300 : undefined }
           onGroup:selected={ updateSlider }
         >
-          { slots.default?.() ?? props.text }
+          { slots.default?.() ?? props.text ?? props.title }
 
           { !props.hideSlider && (
             <div


### PR DESCRIPTION
The v-tab `:items` prop parsing fails to correctly shape the `TabItem` object for use in the tabs themselves, leaving the tab titles blank. This fixes that by falling back on `props.title` if `props.text` is not present.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

The v-tabs component has an `items` prop which is meant to simplify the tab value/text options, but it does not work correctly because it uses `title` when the tab component itself looks for `text`. This simply adds `title` as an additional fallback which makes `items` work in the expected fashion.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
    <v-tabs
      :items="['1', '2', '3']"
      v-model="tab"
      bg-color="primary"
    >
    </v-tabs>
```
