### PR TITLE
feat(VDataTable): add slot for group header columns

### DIFF
--- a/packages/api-generator/src/locale/en/VDataTable.json
+++ b/packages/api-generator/src/locale/en/VDataTable.json
@@ -37,7 +37,9 @@
     "virtualRows": "Virtualizes the rendering of rows. Be aware that you can not use the `body`, `body.prepend` or `body.append` slots with this prop."
   },
   "slots": {
+    "[`column.${string}`]": "Slot for custom rendering of a column header.",
     "[`item.${string}`]": "Slot for custom rendering of a row cell.",
+    "[`group.${string}`]": "Slot for custom rendering of a group header cell.",
     "body": "Slot to replace the default table `<tbody>`.",
     "body.append": "Appends elements to the end of the default table `<tbody>`.",
     "body.prepend": "Prepends elements to the start of the default table `<tbody>`.",

--- a/packages/api-generator/src/locale/en/VDataTableServer.json
+++ b/packages/api-generator/src/locale/en/VDataTableServer.json
@@ -3,8 +3,9 @@
     "itemsLength": "Number of all items."
   },
   "slots": {
-    "[`column.${string}`]": "Slot for custom rendering of a column.",
+    "[`column.${string}`]": "Slot for custom rendering of a column header.",
     "[`item.${string}`]": "Slot for custom rendering of a row cell.",
+    "[`group.${string}`]": "Slot for custom rendering of a group header cell.",
     "body": "Slot to replace the default rendering of the `<tbody>` element.",
     "bottom": "Slot to add content below the table.",
     "colgroup": "Slot to replace the default rendering of the `<colgroup>` element.",

--- a/packages/api-generator/src/locale/en/VDataTableVirtual.json
+++ b/packages/api-generator/src/locale/en/VDataTableVirtual.json
@@ -1,7 +1,8 @@
 {
   "slots": {
-    "[`column.${string}`]": "Slot for custom rendering of a column.",
+    "[`column.${string}`]": "Slot for custom rendering of a column header.",
     "[`item.${string}`]": "Slot for custom rendering of a row cell.",
+    "[`group.${string}`]": "Slot for custom rendering of a group header cell.",
     "body": "Slot to replace the default rendering of the `<tbody>` element.",
     "bottom": "Slot to add content below the table.",
     "colgroup": "Slot to replace the default rendering of the `<colgroup>` element.",

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -89,7 +89,7 @@ export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
         <>
           { props.items.map((item, index) => {
             if (item.type === 'group') {
-              return slots['group-header'] ? slots['group-header']({
+              const slotProps = {
                 index,
                 item,
                 columns: columns.value,
@@ -99,9 +99,12 @@ export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
                 toggleSelect,
                 toggleGroup,
                 isGroupOpen,
-              } as GroupHeaderSlot) : (
+              } satisfies GroupHeaderSlot
+
+              return slots['group-header']?.(slotProps) ?? (
                 <VDataTableGroupHeaderRow
                   key={ `group-header_${item.id}` }
+                  index={ index }
                   item={ item }
                   v-slots={ slots }
                 />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This resolves #18278 by adding ``[`group.${string}`]`` slots to `VDataTable`. 

Added a set of slots ``[`group.${string}`]`` to v-data-table much like ``[`item.${string}`]``, which will allow people to override what is rendered for the corresponding column in a group header. The slot will be forwarded the `item` prop from VDataTableGroupHeaderRow allowing users to take advantage of group depth, key, and all the other things which `data-table-group` and `group-header` slots have access to.

## Playground:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-chip-group v-model="groupBy" multiple filter>
        <v-chip :value="{ key: 'city', order: 'asc' }">
          City
        </v-chip>
        <v-chip :value="{ key: 'sport', order: 'asc' }">
          Sport
        </v-chip>
      </v-chip-group>
      <v-data-table
        :group-by="groupBy"
        :headers="headers"
        :items="sports"
        :items-per-page="20"
      >
        <template #[`group.active`]="{ item }">
          {{ getItemsRecursive(item).reduce((a, v) => v.raw.active + a, 0) }}
        </template>
        <template #[`group.inactive`]="{ item }">
          {{ getItemsRecursive(item).reduce((a, v) => v.raw.inactive + a, 0) }}
        </template>
      </v-data-table>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { Group } from '@/labs/VDataTable/composables/group'
  import { SortItem } from '@/labs/VDataTable/composables/sort'
  import { DataTableHeader } from '@/labs/VDataTable/types'
  import { ref } from 'vue'

  const groupBy = ref<readonly SortItem[]>([{ key: 'sport', order: 'asc' }, { key: 'city', order: 'asc' }])

  type Team = {
    name: string
    city: string
    sport: string,
    active: number
    inactive: number
  }

  const getItemsRecursive = (group:Group) => {
    let items = group.items
    while (items[0].items) {
      items = items.flatMap((v:Group) => v.items)
    }
    return items
  }
  const headers: DataTableHeader[] = [
    {
      title: 'Name',
      align: 'start',
      key: 'name',
    },
    {
      title: 'City',
      align: 'start',
      key: 'city',
    },
    {
      title: 'Sport',
      align: 'start',
      key: 'sport',
    },
    { title: 'Active Players', key: 'active', align: 'end' },
    { title: 'Inactive Players', key: 'inactive', align: 'end' },
  ]
  const sports: Team[] = [
    {
      name: 'Celtics',
      city: 'Boston',
      sport: 'Basketball',
      active: 10,
      inactive: 5,
    },
    {
      name: 'Lakers',
      city: 'Los Angeles',
      sport: 'Basketball',
      active: 15,
      inactive: 3,
    },
    {
      name: '49ers',
      city: 'San Francisco',
      sport: 'Football',
      active: 12,
      inactive: 4,
    },
    {
      name: 'Giants',
      city: 'San Francisco',
      sport: 'Baseball',
      active: 16,
      inactive: 2,
    },
    {
      name: 'Warriors',
      city: 'San Francisco',
      sport: 'Basketball',
      active: 14,
      inactive: 4,
    },
    {
      name: 'Sharks',
      city: 'San Jose',
      sport: 'Hockey',
      active: 17,
      inactive: 3,
    },
    {
      name: 'Raiders',
      city: 'Las Vegas',
      sport: 'Football',
      active: 11,
      inactive: 5,
    },
    {
      name: 'Golden Knights',
      city: 'Las Vegas',
      sport: 'Hockey',
      active: 19,
      inactive: 1,
    },
    {
      name: 'Heat',
      city: 'Miami',
      sport: 'Basketball',
      active: 16,
      inactive: 2,
    },
    {
      name: 'Marlins',
      city: 'Miami',
      sport: 'Baseball',
      active: 14,
      inactive: 4,
    },
    {
      name: 'Dolphins',
      city: 'Miami',
      sport: 'Football',
      active: 12,
      inactive: 4,
    },
    {
      name: 'Lightning',
      city: 'Tampa Bay',
      sport: 'Hockey',
      active: 18,
      inactive: 2,
    },
    {
      name: 'Rays',
      city: 'Tampa Bay',
      sport: 'Baseball',
      active: 15,
      inactive: 3,
    },
    {
      name: 'Buccaneers',
      city: 'Tampa Bay',
      sport: 'Football',
      active: 14,
      inactive: 2,
    },
    {
      name: 'Timberwolves',
      city: 'Minnesota',
      sport: 'Basketball',
      active: 11,
      inactive: 5,
    },
    {
      name: 'Twins',
      city: 'Minnesota',
      sport: 'Baseball',
      active: 17,
      inactive: 1,
    },
    {
      name: 'Bruins',
      city: 'Boston',
      sport: 'Hockey',
      active: 20,
      inactive: 4,
    },
    {
      name: 'Red Sox',
      city: 'Boston',
      sport: 'Baseball',
      active: 15,
      inactive: 3,
    },
    {
      name: 'Yankees',
      city: 'New York',
      sport: 'Baseball',
      active: 17,
      inactive: 5,
    },
    {
      name: 'Mets',
      city: 'New York',
      sport: 'Baseball',
      active: 13,
      inactive: 2,
    },
    {
      name: 'Dodgers',
      city: 'Los Angeles',
      sport: 'Baseball',
      active: 18,
      inactive: 1,
    },
    {
      name: 'Angels',
      city: 'Los Angeles',
      sport: 'Baseball',
      active: 14,
      inactive: 4,
    },
  ]
</script>
```
EDIT: Update the playground section to use better example
