### PR TITLE
feat(VBtn): add vbtn styling for md3 blueprint

### DIFF
--- a/packages/vuetify/src/blueprints/md3.ts
+++ b/packages/vuetify/src/blueprints/md3.ts
@@ -17,7 +17,9 @@ export const md3: Blueprint = {
     },
     VBtn: {
       color: 'primary',
+      height: 40,
       rounded: 'xl',
+      style: 'text-transform: none;',
     },
     VBtnGroup: {
       rounded: 'xl',


### PR DESCRIPTION
## Description
The button components in Material 3 are slightly higher and shouldn't contain uppercase text. This PR adds default props for VBtn to the md3 blueprint to obey these specs.

Source: https://m3.material.io/components/buttons/specs

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn variant="text">Button</v-btn>
      <v-btn variant="flat">Button</v-btn>
      <v-btn variant="elevated">Button</v-btn>
      <v-btn variant="tonal">Button</v-btn>
      <v-btn variant="outlined">Button</v-btn>
      <v-btn variant="plain">Button</v-btn>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```