### PR TITLE
fix: ignore disable props in v-select/v-autocomplete/v-combobox

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -515,6 +515,7 @@ export const VAutocomplete = genericComponent<new <
                   }
 
                   const slotProps = {
+                    disabled: item.props.disabled,
                     'onClick:close': onChipClose,
                     onMousedown (e: MouseEvent) {
                       e.preventDefault()
@@ -522,7 +523,6 @@ export const VAutocomplete = genericComponent<new <
                     },
                     modelValue: true,
                     'onUpdate:modelValue': undefined,
-                    ...item.props,
                   }
 
                   return (

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -515,7 +515,6 @@ export const VAutocomplete = genericComponent<new <
                   }
 
                   const slotProps = {
-                    disabled: item.props.disabled,
                     'onClick:close': onChipClose,
                     onMousedown (e: MouseEvent) {
                       e.preventDefault()
@@ -544,6 +543,7 @@ export const VAutocomplete = genericComponent<new <
                             closable={ props.closableChips }
                             size="small"
                             text={ item.title }
+                            disabled={ item.props.disabled }
                             { ...slotProps }
                           />
                         ) : (

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -522,6 +522,7 @@ export const VAutocomplete = genericComponent<new <
                     },
                     modelValue: true,
                     'onUpdate:modelValue': undefined,
+                    ...item.props,
                   }
 
                   return (

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -530,7 +530,6 @@ export const VCombobox = genericComponent<new <
                   }
 
                   const slotProps = {
-                    disabled: item.props.disabled,
                     'onClick:close': onChipClose,
                     onMousedown (e: MouseEvent) {
                       e.preventDefault()
@@ -559,6 +558,7 @@ export const VCombobox = genericComponent<new <
                             closable={ props.closableChips }
                             size="small"
                             text={ item.title }
+                            disabled={ item.props.disabled }
                             { ...slotProps }
                           />
                         ) : (

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -537,6 +537,7 @@ export const VCombobox = genericComponent<new <
                     },
                     modelValue: true,
                     'onUpdate:modelValue': undefined,
+                    ...item.props,
                   }
 
                   return (

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -530,6 +530,7 @@ export const VCombobox = genericComponent<new <
                   }
 
                   const slotProps = {
+                    disabled: item.props.disabled,
                     'onClick:close': onChipClose,
                     onMousedown (e: MouseEvent) {
                       e.preventDefault()
@@ -537,7 +538,6 @@ export const VCombobox = genericComponent<new <
                     },
                     modelValue: true,
                     'onUpdate:modelValue': undefined,
-                    ...item.props,
                   }
 
                   return (

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -413,6 +413,7 @@ export const VSelect = genericComponent<new <
                   }
 
                   const slotProps = {
+                    disabled: item.props.disabled,
                     'onClick:close': onChipClose,
                     onMousedown (e: MouseEvent) {
                       e.preventDefault()
@@ -420,7 +421,6 @@ export const VSelect = genericComponent<new <
                     },
                     modelValue: true,
                     'onUpdate:modelValue': undefined,
-                    ...item.props,
                   }
 
                   return (

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -413,7 +413,6 @@ export const VSelect = genericComponent<new <
                   }
 
                   const slotProps = {
-                    disabled: item.props.disabled,
                     'onClick:close': onChipClose,
                     onMousedown (e: MouseEvent) {
                       e.preventDefault()
@@ -432,6 +431,7 @@ export const VSelect = genericComponent<new <
                             closable={ props.closableChips }
                             size="small"
                             text={ item.title }
+                            disabled={ item.props.disabled }
                             { ...slotProps }
                           />
                         ) : (

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -420,6 +420,7 @@ export const VSelect = genericComponent<new <
                     },
                     modelValue: true,
                     'onUpdate:modelValue': undefined,
+                    ...item.props,
                   }
 
                   return (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix ignoring disabled prop in VSelect, VAutocomplete & VCombobox components by passing items props to VChip.

fixes #18293 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card>
    <v-container fluid>
      <v-row>
        <v-col cols="12">
          <v-select
            v-model="vSelectValues"
            :items="vSelectItems"
            label="VSelect"
            multiple
            chips
            closable-chips
            return-object
          ></v-select>
        </v-col>
      </v-row>
      <v-row>
        <v-col cols="12">
          <v-autocomplete
            v-model="vAutocompleteValues"
            :items="vAutocompleteItems"
            label="VAutocomplete"
            multiple
            chips
            closable-chips
            return-object
          ></v-autocomplete>
        </v-col>
      </v-row>
      <v-row>
        <v-col cols="12">
          <v-combobox
            v-model="vComboboxValues"
            :items="vComboboxItems"
            label="VCombobox"
            multiple
            chips
            closable-chips
            return-object
          ></v-combobox>
        </v-col>
      </v-row>
    </v-container>
  </v-card>
</template>

<script>
  export default {
    data: () => ({
      vSelectItems: [
        { title: 'Item 1', value: 'item1', props: { disabled: true } },
        { title: 'Item 2', value: 'item 2' },
        { title: 'Item 3', value: 'item 3' },
      ],
      vSelectValues: [
        { title: 'Item 1', value: 'item1', props: { disabled: true } },
      ],
      vAutocompleteItems: [
        { title: 'Item 1', value: 'item1', props: { disabled: true } },
        { title: 'Item 2', value: 'item 2' },
        { title: 'Item 3', value: 'item 3' },
      ],
      vAutocompleteValues: [
        { title: 'Item 1', value: 'item1', props: { disabled: true } },
      ],
      vComboboxItems: [
        { title: 'Item 1', value: 'item1', props: { disabled: true } },
        { title: 'Item 2', value: 'item 2' },
        { title: 'Item 3', value: 'item 3' },
      ],
      vComboboxValues: [
        { title: 'Item 1', value: 'item1', props: { disabled: true } },
      ],
    }),
  }
</script>

```
