### PR TITLE
docs(VVirtualScroll): remove outdated api link

### DIFF
--- a/packages/docs/src/pages/en/components/virtual-scroller.md
+++ b/packages/docs/src/pages/en/components/virtual-scroller.md
@@ -39,7 +39,6 @@ The virtual scroller displays just enough records to fill the viewport and uses 
 | Component | Description |
 | - | - |
 | [v-virtual-scroll](/api/v-virtual-scroll/) | Primary Component |
-| [v-virtual-scroll-item](/api/v-virtual-scroll-item/) | Wraps content and communicates height to parent |
 
 <api-inline hide-links />
 


### PR DESCRIPTION
Removed link to`v- virtual-scroll-item` as it does not appear to exist

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
