### PR TITLE
docs(VDialog): add missing slot props

### DIFF
--- a/packages/api-generator/src/maps/v-dialog.js
+++ b/packages/api-generator/src/maps/v-dialog.js
@@ -8,6 +8,7 @@ module.exports = {
       {
         name: 'activator',
         props: {
+          attrs: '{ role: string, aria-haspopup: boolean, aria-expanded: string }',
           on: '{ [eventName]: eventHandler }',
           value: 'boolean',
         },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

I used web-types of Vuetify 2 to generate global component types for Volar intellisense and type check. Then I found `attrs` is missing in `activator` slot in docs of VDialog, resulting into type error:

![image](https://github.com/vuetifyjs/vuetify/assets/40021217/bd0863c3-36fc-4b5f-93f4-e8b45569325f)

