### PR TITLE
fix(VDataTable): render default slot if only comments are between tags

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.tsx
@@ -22,6 +22,7 @@ import { makeFilterProps, useFilter } from '@/composables/filter'
 // Utilities
 import { computed, toRef } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
+import { isVNodesEmpty } from '@/util/helpers'
 
 // Types
 import type { UnwrapRef } from 'vue'
@@ -203,7 +204,7 @@ export const VDataTable = genericComponent<VDataTableSlots>()({
         >
           {{
             top: () => slots.top?.(slotProps.value),
-            default: () => slots.default ? slots.default(slotProps.value) : (
+            default: () => !isVNodesEmpty(slots.default?.(slotProps.value)) ? slots.default?.(slotProps.value) : (
               <>
                 { slots.colgroup?.(slotProps.value) }
                 <thead>

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { camelize, capitalize, computed, Fragment, reactive, toRefs, watchEffect } from 'vue'
+import { camelize, capitalize, computed, Fragment, reactive, toRefs, watchEffect, Comment } from 'vue'
 import { IN_BROWSER } from '@/util/globals'
 
 // Types
@@ -699,4 +699,8 @@ export function matchesSelector (el: Element | undefined, selector: string): boo
   } catch (err) {
     return null
   }
+}
+
+export function isVNodesEmpty(vnodes: VNode[] | undefined): boolean {
+  return !vnodes || wrapInArray(vnodes).every((vnode) => vnode.type === Comment)
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix the issue by writing a new helper function called isVNodesEmpty.
This function returns true if there is no VNode or all VNodes type is comment.

fixes #18308 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
      <v-data-table
        :headers="[{ title: 'foo', key: 'foo' }]"
        :items="[{ foo: 'bar' }, { foo: 'baz' }]"
      >
        <div>
          this should affect the rendering
        </div>
      </v-data-table>
      <v-data-table
        :headers="[{ title: 'foo', key: 'foo' }]"
        :items="[{ foo: 'bar' }, { foo: 'baz' }]"
      >
        <!-- this should not affect the rendering -->
        this should affect the rendering
      </v-data-table>
      <v-data-table
        :headers="[{ title: 'foo', key: 'foo' }]"
        :items="[{ foo: 'bar' }, { foo: 'baz' }]"
      >
        <!-- this should not affect the rendering -->
      </v-data-table>
      <v-data-table
        :headers="[{ title: 'foo', key: 'foo' }]"
        :items="[{ foo: 'bar' }, { foo: 'baz' }]"
      >
      </v-data-table>
  </v-app>
</template>
```
