### PR TITLE
fix(VDatePicker): fix not rendering actions slot

### DIFF
--- a/packages/vuetify/src/labs/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePicker.tsx
@@ -280,6 +280,7 @@ export const VDatePicker = genericComponent<VDatePickerSlots>()({
               </div>
             ),
             actions: () => !props.hideActions ? (
+              slots.actions?.() ??
               <div>
                 <VBtn
                   variant="text"


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Render the actions slot if there is one; otherwise, render the default actions slot.

fixes #18315
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker>
        <template #actions>
          <v-btn>custom action</v-btn>
        </template>
      </v-date-picker>
    </v-container>
  </v-app>
</template>
```
