### PR TITLE
fix(VSelect/VAutocomplete/VCombobox): use selected items as counter value

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -400,7 +400,7 @@ export const VAutocomplete = genericComponent<new <
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
-          counterValue={ () => model.value.length }
+          counterValue={ model.value.length }
           dirty={ isDirty }
           onInput={ onInput }
           onChange={ onChange }

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -400,6 +400,7 @@ export const VAutocomplete = genericComponent<new <
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
+          counterValue={ () => model.value.length }
           dirty={ isDirty }
           onInput={ onInput }
           onChange={ onChange }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -417,7 +417,7 @@ export const VCombobox = genericComponent<new <
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
-          counterValue={ () => model.value.length }
+          counterValue={ props.multiple ? model.value.length : search.value.length }
           dirty={ isDirty }
           class={[
             'v-combobox',

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -417,6 +417,7 @@ export const VCombobox = genericComponent<new <
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
+          counterValue={ () => model.value.length }
           dirty={ isDirty }
           class={[
             'v-combobox',

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -304,6 +304,7 @@ export const VSelect = genericComponent<new <
           onUpdate:modelValue={ onModelUpdate }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
+          counterValue={ () => model.value.length }
           dirty={ isDirty }
           class={[
             'v-select',

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -304,7 +304,7 @@ export const VSelect = genericComponent<new <
           onUpdate:modelValue={ onModelUpdate }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
-          counterValue={ () => model.value.length }
+          counterValue={ model.value.length }
           dirty={ isDirty }
           class={[
             'v-select',

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -29,7 +29,7 @@ const activeTypes = ['color', 'file', 'time', 'date', 'datetime-local', 'week', 
 export const makeVTextFieldProps = propsFactory({
   autofocus: Boolean,
   counter: [Boolean, Number, String] as PropType<true | number | string>,
-  counterValue: Function as PropType<(value: any) => number>,
+  counterValue: [Number, Function] as PropType<number | ((value: any) => number)>,
   prefix: String,
   placeholder: String,
   persistentPlaceholder: Boolean,
@@ -71,8 +71,8 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
     const model = useProxiedModel(props, 'modelValue')
     const { isFocused, focus, blur } = useFocus(props)
     const counterValue = computed(() => {
-      return typeof props.counterValue === 'function'
-        ? props.counterValue(model.value)
+      return typeof props.counterValue === 'function' ? props.counterValue(model.value)
+        : typeof props.counterValue === 'number' ? props.counterValue
         : (model.value ?? '').toString().length
     })
     const max = computed(() => {


### PR DESCRIPTION
fixes #17812

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-text-field
    v-model="value"
    label="Chips"
    multiple
    counter="5"
  />
  <v-select
    v-model="value"
    :items="items"
    chips
    label="VSelect"
    multiple
    counter="5"
    persistent-counter
  />
  <v-autocomplete
    v-model="value"
    :items="items"
    chips
    label="VAutocomplete"
    multiple
    counter="5"
    persistent-counter
  />
  <v-combobox
    v-model="value"
    :items="items"
    chips
    label="VCombobox"
    multiple
    counter="5"
    persistent-counter
  />
</template>

<script>
  export default {
    data: () => ({
      items: ['foo', 'bar', 'fizz', 'buzz'],
      value: ['foo', 'bar', 'fizz', 'buzz'],
    }),
  }
</script>
```
