### PR TITLE
fix(VBottomSheet): merge the bottom sheet classes with dialog classes

### DIFF
--- a/packages/vuetify/src/labs/VBottomSheet/VBottomSheet.tsx
+++ b/packages/vuetify/src/labs/VBottomSheet/VBottomSheet.tsx
@@ -46,11 +46,12 @@ export const VBottomSheet = genericComponent<OverlaySlots>()({
           v-model={ isActive.value }
           class={[
             'v-bottom-sheet',
-            props.class,
             {
               'v-bottom-sheet--inset': props.inset,
             },
+            props.class,
           ]}
+          style={ props.style }
           v-slots={ slots }
         />
       )

--- a/packages/vuetify/src/labs/VBottomSheet/VBottomSheet.tsx
+++ b/packages/vuetify/src/labs/VBottomSheet/VBottomSheet.tsx
@@ -46,6 +46,7 @@ export const VBottomSheet = genericComponent<OverlaySlots>()({
           v-model={ isActive.value }
           class={[
             'v-bottom-sheet',
+            props.class,
             {
               'v-bottom-sheet--inset': props.inset,
             },


### PR DESCRIPTION
> VBottomSheet
> 
> ## Description
> ## Markup:
> I want to insert classes at the root of the dialog from the bottom sheet.
> 
> ```
> <v-bottom-sheet v-model="showDialog" class="classExample">
>     Content
> </v-bottom-sheet>
> ```
> 
> This class inserted it isn't merge with dialog classes.