### PR TITLE
fix(VList): respect return-object in list items

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -236,7 +236,11 @@ export const VList = genericComponent<new <T>(
           onFocus={ onFocus }
           onKeydown={ onKeydown }
         >
-          <VListChildren returnObject={ props.returnObject } items={ items.value } v-slots={ slots }></VListChildren>
+          <VListChildren
+            items={ items.value }
+            returnObject={ props.returnObject }
+            v-slots={ slots }
+          />
         </props.tag>
       )
     })

--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -236,7 +236,7 @@ export const VList = genericComponent<new <T>(
           onFocus={ onFocus }
           onKeydown={ onKeydown }
         >
-          <VListChildren items={ items.value } v-slots={ slots }></VListChildren>
+          <VListChildren returnObject={ props.returnObject } items={ items.value } v-slots={ slots }></VListChildren>
         </props.tag>
       )
     })

--- a/packages/vuetify/src/components/VList/VListChildren.tsx
+++ b/packages/vuetify/src/components/VList/VListChildren.tsx
@@ -26,11 +26,13 @@ export type VListChildrenSlots<T> = {
 
 export const makeVListChildrenProps = propsFactory({
   items: Array as PropType<readonly InternalListItem[]>,
+  returnObject: Boolean,
 }, 'VListChildren')
 
 export const VListChildren = genericComponent<new <T extends InternalListItem>(
   props: {
     items?: readonly T[]
+    returnObject?: boolean
   },
   slots: VListChildrenSlots<T>
 ) => GenericProps<typeof props, typeof slots>>()({
@@ -71,7 +73,14 @@ export const VListChildren = genericComponent<new <T extends InternalListItem>(
           {{
             activator: ({ props: activatorProps }) => slots.header
               ? slots.header({ props: { ...itemProps, ...activatorProps } })
-              : <VListItem { ...itemProps } { ...activatorProps } v-slots={ slotsWithItem } />,
+              : (
+                <VListItem
+                  title={ itemProps.title }
+                  value={ props.returnObject ? item : itemProps.value }
+                  { ...activatorProps }
+                  v-slots={ slotsWithItem }
+                />
+              ),
             default: () => (
               <VListChildren items={ children } v-slots={ slots } />
             ),
@@ -80,7 +89,8 @@ export const VListChildren = genericComponent<new <T extends InternalListItem>(
       ) : (
         slots.item ? slots.item({ props: itemProps }) : (
           <VListItem
-            { ...itemProps }
+            title={ itemProps.title }
+            value={ props.returnObject ? item : itemProps.value }
             v-slots={ slotsWithItem }
           />
         )


### PR DESCRIPTION
fixes #18304

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <VMenu location="right">
        <template #activator="{ props: menuProps }">
          <VBtn v-bind="mergeProps(menuProps)">Test</VBtn>
        </template>
        <VList
          :return-object="true"
          :items="viewList"
          v-model:selected="currentView"
          item-value="id"
          item-title="title"
        />
      </VMenu>
      {{ currentView }}
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, mergeProps } from 'vue'

  const currentView = ref([])
  const viewList = ref([
    { id: '1', title: 'Events' },
    { id: '2', title: 'Labour' },
    { id: '3', title: 'Equipment' },
  ])

</script>


```
