### PR TITLE
fix(VOtpInput): cast length prop to number

### DIFF
--- a/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
@@ -190,7 +190,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     }, { scoped: true })
 
     watch(model, val => {
-      if (val.length === props.length) emit('finish', val.join(''))
+      if (val.length === Number(props.length)) emit('finish', val.join(''))
     }, { deep: true })
 
     watch(focusIndex, val => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix the issue by casting prop length type to number.

fixes #18327
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-otp-input
    v-model="passCode"
    length="4"
    :loading="loading"
    @finish="onFinish"
  ></v-otp-input>
</template>

<script setup>
  import { ref } from 'vue'
  const passCode = ref('')
  const loading = ref(false)

  function onFinish() {
    loading.value = true
    setTimeout(() => {
      loading.value = false
    }, 2000)
  }
</script>

<style scoped lang="scss"></style>

```
