### PR TITLE
fix(VExpansionPanel): fix v-expansion-panel readonly prop

### DIFF
--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.tsx
@@ -76,6 +76,9 @@ export const VExpansionPanel = genericComponent<VExpansionPanelSlots>()({
       VExpansionPanelText: {
         eager: toRef(props, 'eager'),
       },
+      VExpansionPanelTitle: {
+        readonly: toRef(props, 'readonly'),
+      },
     })
 
     useRender(() => {

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanels.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanels.tsx
@@ -56,8 +56,6 @@ export const VExpansionPanels = genericComponent()({
     provideDefaults({
       VExpansionPanel: {
         color: toRef(props, 'color'),
-      },
-      VExpansionPanelTitle: {
         readonly: toRef(props, 'readonly'),
       },
     })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix the issue by providing default readonly for VExpansionPanelTitle using VExapnsionPanel readonly prop.

fixes #18346 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-expansion-panels multiple>
      <v-expansion-panel :disabled="true">
        <v-expansion-panel-title
          >I'm a disabled panel, everything is ok</v-expansion-panel-title
        >
        <v-expansion-panel-text> Some content </v-expansion-panel-text>
      </v-expansion-panel>

      <v-expansion-panel :readonly="true">
        <v-expansion-panel-title
          >I'm a readonly panel, but you can still open me
          :(</v-expansion-panel-title
        >
        <v-expansion-panel-text> Some content </v-expansion-panel-text>
      </v-expansion-panel>
    </v-expansion-panels>
  </v-app>
</template>

<script setup></script>

```
