### PR TITLE
fix(VCard): apply elevation on hover

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -65,7 +65,6 @@
       opacity: 0
 
     &:hover
-      
       @include tools.elevation($card-hover-elevation)
 
   &--link

--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -64,8 +64,6 @@
     &:hover::before
       opacity: 0
 
-    @include tools.elevation(0)
-
     &:hover
       
       @include tools.elevation($card-hover-elevation)

--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -66,6 +66,10 @@
 
     @include tools.elevation(0)
 
+    &:hover
+      
+      @include tools.elevation($card-hover-elevation)
+
   &--link
     cursor: pointer
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

**hover** prop on v-card doesn't apply any hover effect.

Other things that not sure if is in

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<v-card hover>
  Im a Card
</v-card>
```
