### PR TITLE
docs: Fix yarn install command for the nuxt 3 installation guide

### DIFF
--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -120,7 +120,7 @@ and then install the required Vuefity modules as dependencies:
 ::: tabs
 
 ```bash [yarn]
-yarn add --dev vuetify vite-plugin-vuetify
+yarn add -D vuetify vite-plugin-vuetify
 yarn add @mdi/font
 ```
 

--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -120,7 +120,7 @@ and then install the required Vuefity modules as dependencies:
 ::: tabs
 
 ```bash [yarn]
-yarn add dev vuetify vite-plugin-vuetify
+yarn add --dev vuetify vite-plugin-vuetify
 yarn add @mdi/font
 ```
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This fixes the command that is shown for installing Vuetify with Nuxt 3. Before, the command would also try to install the [`dev`](https://www.npmjs.com/package/dev) Package, which looks like an oversight to me.
