### PR TITLE
fix(VDatePicker): change title width in landscape mode

### DIFF
--- a/packages/vuetify/src/components/VPicker/_variables.scss
+++ b/packages/vuetify/src/components/VPicker/_variables.scss
@@ -4,5 +4,5 @@ $picker-border-radius: $border-radius-root !default;
 $picker-title-padding: 16px !default;
 $picker-inactive-btn-opacity: .6 !default;
 $picker-active-btn-opacity: 1 !default;
-$picker-landscape-title-width: 170px !default;
+$picker-landscape-title-width: 200px !default;
 $picker-font-size: 1rem !default;


### PR DESCRIPTION
September, October, and November were not displayed correctly when the month picker is in landscape mode

fixes #9783

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-date-picker v-model="picker" landscape type="month" />
  </v-container>
</template>

<script>
export default {
  data() {
    return {
      picker: new Date().toISOString().substr(0, 7)
    };
  }
};
</script>
```
