### PR TITLE
fix(VAutocomplete): unexpected value deletion

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -1,191 +1,184 @@
 // Styles
-import "./VAutocomplete.sass";
+import './VAutocomplete.sass'
 
 // Extensions
-import VSelect, {
-  defaultMenuProps as VSelectMenuProps
-} from "../VSelect/VSelect";
-import VTextField from "../VTextField/VTextField";
+import VSelect, { defaultMenuProps as VSelectMenuProps } from '../VSelect/VSelect'
+import VTextField from '../VTextField/VTextField'
 
 // Utilities
-import mergeData from "../../util/mergeData";
+import mergeData from '../../util/mergeData'
 import {
   getObjectValueByPath,
   getPropertyFromItem,
-  keyCodes
-} from "../../util/helpers";
+  keyCodes,
+} from '../../util/helpers'
 
 // Types
-import { PropType, VNode } from "vue";
-import { PropValidator } from "vue/types/options";
+import { PropType, VNode } from 'vue'
+import { PropValidator } from 'vue/types/options'
 
 const defaultMenuProps = {
   ...VSelectMenuProps,
   offsetY: true,
   offsetOverflow: true,
-  transition: false
-};
+  transition: false,
+}
 
 /* @vue/component */
 export default VSelect.extend({
-  name: "v-autocomplete",
+  name: 'v-autocomplete',
 
   props: {
     autoSelectFirst: {
       type: Boolean,
-      default: false
+      default: false,
     },
     filter: {
       type: Function,
       default: (item: any, queryText: string, itemText: string) => {
-        return (
-          itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) >
-          -1
-        );
-      }
-    } as PropValidator<
-      (item: any, queryText: string, itemText: string) => boolean
-    >,
+        return itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
+      },
+    } as PropValidator<(item: any, queryText: string, itemText: string) => boolean>,
     hideNoData: Boolean,
     menuProps: {
       type: VSelect.options.props.menuProps.type,
-      default: () => defaultMenuProps
+      default: () => defaultMenuProps,
     },
     noFilter: Boolean,
     searchInput: {
-      type: String as PropType<string | null>
+      type: String as PropType<string | null>,
+    },
+  },
+
+  data () {
+    return {
+      lazySearch: this.searchInput,
     }
   },
 
-  data() {
-    return {
-      lazySearch: this.searchInput
-    };
-  },
-
   computed: {
-    classes(): object {
+    classes (): object {
       return {
         ...VSelect.options.computed.classes.call(this),
-        "v-autocomplete": true,
-        "v-autocomplete--is-selecting-index": this.selectedIndex > -1
-      };
+        'v-autocomplete': true,
+        'v-autocomplete--is-selecting-index': this.selectedIndex > -1,
+      }
     },
-    computedItems(): object[] {
-      return this.filteredItems;
+    computedItems (): object[] {
+      return this.filteredItems
     },
-    selectedValues(): object[] {
-      return this.selectedItems.map(item => this.getValue(item));
+    selectedValues (): object[] {
+      return this.selectedItems.map(item => this.getValue(item))
     },
-    hasDisplayedItems(): boolean {
+    hasDisplayedItems (): boolean {
       return this.hideSelected
         ? this.filteredItems.some(item => !this.hasItem(item))
-        : this.filteredItems.length > 0;
+        : this.filteredItems.length > 0
     },
-    currentRange(): number {
-      if (this.selectedItem == null) return 0;
+    currentRange (): number {
+      if (this.selectedItem == null) return 0
 
-      return String(this.getText(this.selectedItem)).length;
+      return String(this.getText(this.selectedItem)).length
     },
-    filteredItems(): object[] {
-      if (!this.isSearching || this.noFilter || this.internalSearch == null)
-        return this.allItems;
+    filteredItems (): object[] {
+      if (!this.isSearching || this.noFilter || this.internalSearch == null) return this.allItems
 
       return this.allItems.filter(item => {
-        const value = getPropertyFromItem(item, this.itemText);
-        const text = value != null ? String(value) : "";
+        const value = getPropertyFromItem(item, this.itemText)
+        const text = value != null ? String(value) : ''
 
-        return this.filter(item, String(this.internalSearch), text);
-      });
+        return this.filter(item, String(this.internalSearch), text)
+      })
     },
     internalSearch: {
-      get(): string | null {
-        return this.lazySearch;
+      get (): string | null {
+        return this.lazySearch
       },
-      set(val: any) {
-        // TODO: this should be `string | null` but it breaks lots of other types
+      set (val: any) { // TODO: this should be `string | null` but it breaks lots of other types
         // emit update event only when the new
         // search value is different from previous
         if (this.lazySearch !== val) {
-          this.lazySearch = val;
-          this.$emit("update:search-input", val);
+          this.lazySearch = val
+          this.$emit('update:search-input', val)
         }
-      }
+      },
     },
-    isAnyValueAllowed(): boolean {
-      return false;
+    isAnyValueAllowed (): boolean {
+      return false
     },
-    isDirty(): boolean {
-      return this.searchIsDirty || this.selectedItems.length > 0;
+    isDirty (): boolean {
+      return this.searchIsDirty || this.selectedItems.length > 0
     },
-    isSearching(): boolean {
+    isSearching (): boolean {
       return (
-        (this.multiple && this.searchIsDirty) ||
-        (this.searchIsDirty &&
-          this.internalSearch !== this.getText(this.selectedItem))
-      );
+        this.multiple &&
+        this.searchIsDirty
+      ) || (
+        this.searchIsDirty &&
+        this.internalSearch !== this.getText(this.selectedItem)
+      )
     },
-    menuCanShow(): boolean {
-      if (!this.isFocused) return false;
+    menuCanShow (): boolean {
+      if (!this.isFocused) return false
 
-      return this.hasDisplayedItems || !this.hideNoData;
+      return this.hasDisplayedItems || !this.hideNoData
     },
-    $_menuProps(): object {
+    $_menuProps (): object {
       const props = VSelect.options.computed.$_menuProps.call(this);
-      (props as any).contentClass = `v-autocomplete__content ${(props as any)
-        .contentClass || ""}`.trim();
+      (props as any).contentClass = `v-autocomplete__content ${(props as any).contentClass || ''}`.trim()
       return {
         ...defaultMenuProps,
-        ...props
-      };
+        ...props,
+      }
     },
-    searchIsDirty(): boolean {
-      return this.internalSearch != null && this.internalSearch !== "";
+    searchIsDirty (): boolean {
+      return this.internalSearch != null &&
+        this.internalSearch !== ''
     },
-    selectedItem(): any {
-      if (this.multiple) return null;
+    selectedItem (): any {
+      if (this.multiple) return null
 
       return this.selectedItems.find(i => {
-        return this.valueComparator(
-          this.getValue(i),
-          this.getValue(this.internalValue)
-        );
-      });
+        return this.valueComparator(this.getValue(i), this.getValue(this.internalValue))
+      })
     },
-    listData() {
-      const data = VSelect.options.computed.listData.call(this) as any;
+    listData () {
+      const data = VSelect.options.computed.listData.call(this) as any
 
       data.props = {
         ...data.props,
         items: this.virtualizedItems,
-        noFilter:
-          this.noFilter || !this.isSearching || !this.filteredItems.length,
-        searchInput: this.internalSearch
-      };
+        noFilter: (
+          this.noFilter ||
+          !this.isSearching ||
+          !this.filteredItems.length
+        ),
+        searchInput: this.internalSearch,
+      }
 
-      return data;
-    }
+      return data
+    },
   },
 
   watch: {
-    filteredItems: "onFilteredItemsChanged",
-    internalValue: "setSearch",
-    isFocused(val) {
+    filteredItems: 'onFilteredItemsChanged',
+    internalValue: 'setSearch',
+    isFocused (val) {
       if (val) {
-        document.addEventListener("copy", this.onCopy);
-        this.$refs.input && this.$refs.input.select();
+        document.addEventListener('copy', this.onCopy)
+        this.$refs.input && this.$refs.input.select()
       } else {
-        document.removeEventListener("copy", this.onCopy);
-        this.blur();
-        this.updateSelf();
+        document.removeEventListener('copy', this.onCopy)
+        this.blur()
+        this.updateSelf()
       }
     },
-    isMenuActive(val) {
-      if (val || !this.hasSlot) return;
+    isMenuActive (val) {
+      if (val || !this.hasSlot) return
 
-      this.lazySearch = null;
+      this.lazySearch = null
     },
-    items(val, oldVal) {
+    items (val, oldVal) {
       // If we are focused, the menu
       // is not active, hide no data is enabled,
       // and items change
@@ -197,229 +190,242 @@ export default VSelect.extend({
         this.isFocused &&
         !this.isMenuActive &&
         val.length
-      )
-        this.activateMenu();
+      ) this.activateMenu()
     },
-    searchInput(val: string) {
-      this.lazySearch = val;
+    searchInput (val: string) {
+      this.lazySearch = val
     },
-    internalSearch: "onInternalSearchChanged",
-    itemText: "updateSelf"
+    internalSearch: 'onInternalSearchChanged',
+    itemText: 'updateSelf',
   },
 
-  created() {
-    this.setSearch();
+  created () {
+    this.setSearch()
   },
 
-  destroyed() {
-    document.removeEventListener("copy", this.onCopy);
+  destroyed () {
+    document.removeEventListener('copy', this.onCopy)
   },
 
   methods: {
-    onFilteredItemsChanged(val: never[], oldVal: never[]) {
+    onFilteredItemsChanged (val: never[], oldVal: never[]) {
       // TODO: How is the watcher triggered
       // for duplicate items? no idea
-      if (val === oldVal) return;
+      if (val === oldVal) return
 
       if (!this.autoSelectFirst) {
-        const preSelectedItem = oldVal[this.$refs.menu.listIndex];
+        const preSelectedItem = oldVal[this.$refs.menu.listIndex]
 
         if (preSelectedItem) {
-          this.setMenuIndex(val.findIndex(i => i === preSelectedItem));
+          this.setMenuIndex(val.findIndex(i => i === preSelectedItem))
         } else {
-          this.setMenuIndex(-1);
+          this.setMenuIndex(-1)
         }
-        this.$emit("update:list-index", this.$refs.menu.listIndex);
+        this.$emit('update:list-index', this.$refs.menu.listIndex)
       }
 
       this.$nextTick(() => {
-        if (!this.internalSearch || (val.length !== 1 && !this.autoSelectFirst))
-          return;
+        if (
+          !this.internalSearch ||
+          (val.length !== 1 &&
+            !this.autoSelectFirst)
+        ) return
 
-        this.$refs.menu.getTiles();
+        this.$refs.menu.getTiles()
 
         if (this.autoSelectFirst && val.length) {
-          this.setMenuIndex(0);
-          this.$emit("update:list-index", this.$refs.menu.listIndex);
+          this.setMenuIndex(0)
+          this.$emit('update:list-index', this.$refs.menu.listIndex)
         }
-      });
+      })
     },
-    onInternalSearchChanged() {
-      this.updateMenuDimensions();
+    onInternalSearchChanged () {
+      this.updateMenuDimensions()
     },
-    updateMenuDimensions() {
+    updateMenuDimensions () {
       // Type from menuable is not making it through
-      this.isMenuActive &&
-        this.$refs.menu &&
-        this.$refs.menu.updateDimensions();
+      this.isMenuActive && this.$refs.menu && this.$refs.menu.updateDimensions()
     },
-    changeSelectedIndex(keyCode: number) {
+    changeSelectedIndex (keyCode: number) {
       // Do not allow changing of selectedIndex
       // when search is dirty
-      if (this.searchIsDirty) return;
+      if (this.searchIsDirty) return
 
       if (this.multiple && keyCode === keyCodes.left) {
         if (this.selectedIndex === -1) {
-          this.selectedIndex = this.selectedItems.length - 1;
+          this.selectedIndex = this.selectedItems.length - 1
         } else {
-          this.selectedIndex--;
+          this.selectedIndex--
         }
       } else if (this.multiple && keyCode === keyCodes.right) {
         if (this.selectedIndex >= this.selectedItems.length - 1) {
-          this.selectedIndex = -1;
+          this.selectedIndex = -1
         } else {
-          this.selectedIndex++;
+          this.selectedIndex++
         }
-      } else if (
-        keyCode === keyCodes.backspace ||
-        keyCode === keyCodes.delete
-      ) {
-        this.deleteCurrentItem();
+      } else if (keyCode === keyCodes.backspace || keyCode === keyCodes.delete) {
+        this.deleteCurrentItem()
       }
     },
-    deleteCurrentItem() {
-      const curIndex = this.selectedIndex;
-      const curItem = this.selectedItems[curIndex];
+    deleteCurrentItem () {
+      const curIndex = this.selectedIndex
+      const curItem = this.selectedItems[curIndex]
 
       // Do nothing if input or item is disabled
-      if (!this.isInteractive || this.getDisabled(curItem)) return;
+      if (
+        !this.isInteractive ||
+        this.getDisabled(curItem)
+      ) return
 
-      const lastIndex = this.selectedItems.length - 1;
+      const lastIndex = this.selectedItems.length - 1
 
       // Select the last item if
       // there is no selection
-      if (this.selectedIndex === -1 && lastIndex !== 0) {
-        this.selectedIndex = lastIndex;
+      if (
+        this.selectedIndex === -1 &&
+        lastIndex !== 0
+      ) {
+        this.selectedIndex = lastIndex
 
-        return;
+        return
       }
 
-      const length = this.selectedItems.length;
-      const nextIndex = curIndex !== length - 1 ? curIndex : curIndex - 1;
-      const nextItem = this.selectedItems[nextIndex];
+      const length = this.selectedItems.length
+      const nextIndex = curIndex !== length - 1
+        ? curIndex
+        : curIndex - 1
+      const nextItem = this.selectedItems[nextIndex]
 
       if (!nextItem) {
-        this.setValue(this.multiple ? [] : null);
+        this.setValue(this.multiple ? [] : null)
       } else {
-        this.selectItem(curItem);
+        this.selectItem(curItem)
       }
 
-      this.selectedIndex = nextIndex;
+      this.selectedIndex = nextIndex
     },
-    clearableCallback() {
-      this.internalSearch = null;
+    clearableCallback () {
+      this.internalSearch = null
 
-      VSelect.options.methods.clearableCallback.call(this);
+      VSelect.options.methods.clearableCallback.call(this)
     },
-    genInput() {
-      const input = VTextField.options.methods.genInput.call(this);
+    genInput () {
+      const input = VTextField.options.methods.genInput.call(this)
 
       input.data = mergeData(input.data!, {
         attrs: {
-          "aria-activedescendant": getObjectValueByPath(
-            this.$refs.menu,
-            "activeTile.id"
-          ),
-          autocomplete: getObjectValueByPath(
-            input.data!,
-            "attrs.autocomplete",
-            "off"
-          )
+          'aria-activedescendant': getObjectValueByPath(this.$refs.menu, 'activeTile.id'),
+          autocomplete: getObjectValueByPath(input.data!, 'attrs.autocomplete', 'off'),
         },
-        domProps: { value: this.internalSearch }
-      });
+        domProps: { value: this.internalSearch },
+      })
 
-      return input;
+      return input
     },
-    genInputSlot() {
-      const slot = VSelect.options.methods.genInputSlot.call(this);
+    genInputSlot () {
+      const slot = VSelect.options.methods.genInputSlot.call(this)
 
-      slot.data!.attrs!.role = "combobox";
+      slot.data!.attrs!.role = 'combobox'
 
-      return slot;
+      return slot
     },
-    genSelections(): VNode | never[] {
+    genSelections (): VNode | never[] {
       return this.hasSlot || this.multiple
         ? VSelect.options.methods.genSelections.call(this)
-        : [];
+        : []
     },
-    onClick(e: MouseEvent) {
-      if (!this.isInteractive) return;
+    onClick (e: MouseEvent) {
+      if (!this.isInteractive) return
 
-      this.selectedIndex > -1 ? (this.selectedIndex = -1) : this.onFocus();
+      this.selectedIndex > -1
+        ? (this.selectedIndex = -1)
+        : this.onFocus()
 
-      if (!this.isAppendInner(e.target)) this.activateMenu();
+      if (!this.isAppendInner(e.target)) this.activateMenu()
     },
-    onInput(e: Event) {
-      if (this.selectedIndex > -1 || !e.target) return;
+    onInput (e: Event) {
+      if (
+        this.selectedIndex > -1 ||
+        !e.target
+      ) return
 
-      const target = e.target as HTMLInputElement;
-      const value = target.value;
+      const target = e.target as HTMLInputElement
+      const value = target.value
 
       // If typing and menu is not currently active
-      if (target.value) this.activateMenu();
+      if (target.value) this.activateMenu()
 
       // delete value if non-multiple and non-chip and searchinput is empty
-      if (!this.multiple && !this.hasChips && value === "")
-        this.deleteCurrentItem();
+      if (!this.multiple && this.hasChips && value === '') this.deleteCurrentItem()
 
-      this.internalSearch = value;
-      this.badInput = target.validity && target.validity.badInput;
+      this.internalSearch = value
+      this.badInput = target.validity && target.validity.badInput
     },
-    onKeyDown(e: KeyboardEvent) {
-      const keyCode = e.keyCode;
+    onKeyDown (e: KeyboardEvent) {
+      const keyCode = e.keyCode
 
-      if (e.ctrlKey || ![keyCodes.home, keyCodes.end].includes(keyCode)) {
-        VSelect.options.methods.onKeyDown.call(this, e);
+      if (
+        e.ctrlKey ||
+        ![keyCodes.home, keyCodes.end].includes(keyCode)
+      ) {
+        VSelect.options.methods.onKeyDown.call(this, e)
       }
 
       // The ordering is important here
       // allows new value to be updated
       // and then moves the index to the
       // proper location
-      this.changeSelectedIndex(keyCode);
+      this.changeSelectedIndex(keyCode)
     },
-    onSpaceDown(e: KeyboardEvent) {
-      /* noop */
+    onSpaceDown (e: KeyboardEvent) { /* noop */ },
+    onTabDown (e: KeyboardEvent) {
+      VSelect.options.methods.onTabDown.call(this, e)
+      this.updateSelf()
     },
-    onTabDown(e: KeyboardEvent) {
-      VSelect.options.methods.onTabDown.call(this, e);
-      this.updateSelf();
-    },
-    onUpDown(e: Event) {
+    onUpDown (e: Event) {
       // Prevent screen from scrolling
-      e.preventDefault();
+      e.preventDefault()
 
       // For autocomplete / combobox, cycling
       // interfers with native up/down behavior
       // instead activate the menu
-      this.activateMenu();
+      this.activateMenu()
     },
-    selectItem(item: object) {
-      VSelect.options.methods.selectItem.call(this, item);
-      this.setSearch();
+    selectItem (item: object) {
+      VSelect.options.methods.selectItem.call(this, item)
+      this.setSearch()
     },
-    setSelectedItems() {
-      VSelect.options.methods.setSelectedItems.call(this);
+    setSelectedItems () {
+      VSelect.options.methods.setSelectedItems.call(this)
 
       // #4273 Don't replace if searching
       // #4403 Don't replace if focused
-      if (!this.isFocused) this.setSearch();
+      if (!this.isFocused) this.setSearch()
     },
-    setSearch() {
+    setSearch () {
       // Wait for nextTick so selectedItem
       // has had time to update
       this.$nextTick(() => {
-        if (!this.multiple || !this.internalSearch || !this.isMenuActive) {
-          this.internalSearch =
-            !this.selectedItems.length || this.multiple || this.hasSlot
-              ? null
-              : this.getText(this.selectedItem);
+        if (
+          !this.multiple ||
+          !this.internalSearch ||
+          !this.isMenuActive
+        ) {
+          this.internalSearch = (
+            !this.selectedItems.length ||
+            this.multiple ||
+            this.hasSlot
+          )
+            ? null
+            : this.getText(this.selectedItem)
         }
-      });
+      })
     },
-    updateSelf() {
-      if (!this.searchIsDirty && !this.internalValue) return;
+    updateSelf () {
+      if (
+        !this.searchIsDirty &&
+        !this.internalValue
+      ) return
 
       if (
         !this.multiple &&
@@ -428,23 +434,20 @@ export default VSelect.extend({
           this.getValue(this.internalValue)
         )
       ) {
-        this.setSearch();
+        this.setSearch()
       }
     },
-    hasItem(item: any): boolean {
-      return this.selectedValues.indexOf(this.getValue(item)) > -1;
+    hasItem (item: any): boolean {
+      return this.selectedValues.indexOf(this.getValue(item)) > -1
     },
-    onCopy(event: ClipboardEvent) {
-      if (this.selectedIndex === -1) return;
+    onCopy (event: ClipboardEvent) {
+      if (this.selectedIndex === -1) return
 
-      const currentItem = this.selectedItems[this.selectedIndex];
-      const currentItemText = this.getText(currentItem);
-      event.clipboardData?.setData("text/plain", currentItemText);
-      event.clipboardData?.setData(
-        "text/vnd.vuetify.autocomplete.item+plain",
-        currentItemText
-      );
-      event.preventDefault();
-    }
-  }
-});
+      const currentItem = this.selectedItems[this.selectedIndex]
+      const currentItemText = this.getText(currentItem)
+      event.clipboardData?.setData('text/plain', currentItemText)
+      event.clipboardData?.setData('text/vnd.vuetify.autocomplete.item+plain', currentItemText)
+      event.preventDefault()
+    },
+  },
+})

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -1,184 +1,191 @@
 // Styles
-import './VAutocomplete.sass'
+import "./VAutocomplete.sass";
 
 // Extensions
-import VSelect, { defaultMenuProps as VSelectMenuProps } from '../VSelect/VSelect'
-import VTextField from '../VTextField/VTextField'
+import VSelect, {
+  defaultMenuProps as VSelectMenuProps
+} from "../VSelect/VSelect";
+import VTextField from "../VTextField/VTextField";
 
 // Utilities
-import mergeData from '../../util/mergeData'
+import mergeData from "../../util/mergeData";
 import {
   getObjectValueByPath,
   getPropertyFromItem,
-  keyCodes,
-} from '../../util/helpers'
+  keyCodes
+} from "../../util/helpers";
 
 // Types
-import { PropType, VNode } from 'vue'
-import { PropValidator } from 'vue/types/options'
+import { PropType, VNode } from "vue";
+import { PropValidator } from "vue/types/options";
 
 const defaultMenuProps = {
   ...VSelectMenuProps,
   offsetY: true,
   offsetOverflow: true,
-  transition: false,
-}
+  transition: false
+};
 
 /* @vue/component */
 export default VSelect.extend({
-  name: 'v-autocomplete',
+  name: "v-autocomplete",
 
   props: {
     autoSelectFirst: {
       type: Boolean,
-      default: false,
+      default: false
     },
     filter: {
       type: Function,
       default: (item: any, queryText: string, itemText: string) => {
-        return itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
-      },
-    } as PropValidator<(item: any, queryText: string, itemText: string) => boolean>,
+        return (
+          itemText.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) >
+          -1
+        );
+      }
+    } as PropValidator<
+      (item: any, queryText: string, itemText: string) => boolean
+    >,
     hideNoData: Boolean,
     menuProps: {
       type: VSelect.options.props.menuProps.type,
-      default: () => defaultMenuProps,
+      default: () => defaultMenuProps
     },
     noFilter: Boolean,
     searchInput: {
-      type: String as PropType<string | null>,
-    },
-  },
-
-  data () {
-    return {
-      lazySearch: this.searchInput,
+      type: String as PropType<string | null>
     }
   },
 
+  data() {
+    return {
+      lazySearch: this.searchInput
+    };
+  },
+
   computed: {
-    classes (): object {
+    classes(): object {
       return {
         ...VSelect.options.computed.classes.call(this),
-        'v-autocomplete': true,
-        'v-autocomplete--is-selecting-index': this.selectedIndex > -1,
-      }
+        "v-autocomplete": true,
+        "v-autocomplete--is-selecting-index": this.selectedIndex > -1
+      };
     },
-    computedItems (): object[] {
-      return this.filteredItems
+    computedItems(): object[] {
+      return this.filteredItems;
     },
-    selectedValues (): object[] {
-      return this.selectedItems.map(item => this.getValue(item))
+    selectedValues(): object[] {
+      return this.selectedItems.map(item => this.getValue(item));
     },
-    hasDisplayedItems (): boolean {
+    hasDisplayedItems(): boolean {
       return this.hideSelected
         ? this.filteredItems.some(item => !this.hasItem(item))
-        : this.filteredItems.length > 0
+        : this.filteredItems.length > 0;
     },
-    currentRange (): number {
-      if (this.selectedItem == null) return 0
+    currentRange(): number {
+      if (this.selectedItem == null) return 0;
 
-      return String(this.getText(this.selectedItem)).length
+      return String(this.getText(this.selectedItem)).length;
     },
-    filteredItems (): object[] {
-      if (!this.isSearching || this.noFilter || this.internalSearch == null) return this.allItems
+    filteredItems(): object[] {
+      if (!this.isSearching || this.noFilter || this.internalSearch == null)
+        return this.allItems;
 
       return this.allItems.filter(item => {
-        const value = getPropertyFromItem(item, this.itemText)
-        const text = value != null ? String(value) : ''
+        const value = getPropertyFromItem(item, this.itemText);
+        const text = value != null ? String(value) : "";
 
-        return this.filter(item, String(this.internalSearch), text)
-      })
+        return this.filter(item, String(this.internalSearch), text);
+      });
     },
     internalSearch: {
-      get (): string | null {
-        return this.lazySearch
+      get(): string | null {
+        return this.lazySearch;
       },
-      set (val: any) { // TODO: this should be `string | null` but it breaks lots of other types
+      set(val: any) {
+        // TODO: this should be `string | null` but it breaks lots of other types
         // emit update event only when the new
         // search value is different from previous
         if (this.lazySearch !== val) {
-          this.lazySearch = val
-          this.$emit('update:search-input', val)
+          this.lazySearch = val;
+          this.$emit("update:search-input", val);
         }
-      },
-    },
-    isAnyValueAllowed (): boolean {
-      return false
-    },
-    isDirty (): boolean {
-      return this.searchIsDirty || this.selectedItems.length > 0
-    },
-    isSearching (): boolean {
-      return (
-        this.multiple &&
-        this.searchIsDirty
-      ) || (
-        this.searchIsDirty &&
-        this.internalSearch !== this.getText(this.selectedItem)
-      )
-    },
-    menuCanShow (): boolean {
-      if (!this.isFocused) return false
-
-      return this.hasDisplayedItems || !this.hideNoData
-    },
-    $_menuProps (): object {
-      const props = VSelect.options.computed.$_menuProps.call(this);
-      (props as any).contentClass = `v-autocomplete__content ${(props as any).contentClass || ''}`.trim()
-      return {
-        ...defaultMenuProps,
-        ...props,
       }
     },
-    searchIsDirty (): boolean {
-      return this.internalSearch != null &&
-        this.internalSearch !== ''
+    isAnyValueAllowed(): boolean {
+      return false;
     },
-    selectedItem (): any {
-      if (this.multiple) return null
+    isDirty(): boolean {
+      return this.searchIsDirty || this.selectedItems.length > 0;
+    },
+    isSearching(): boolean {
+      return (
+        (this.multiple && this.searchIsDirty) ||
+        (this.searchIsDirty &&
+          this.internalSearch !== this.getText(this.selectedItem))
+      );
+    },
+    menuCanShow(): boolean {
+      if (!this.isFocused) return false;
+
+      return this.hasDisplayedItems || !this.hideNoData;
+    },
+    $_menuProps(): object {
+      const props = VSelect.options.computed.$_menuProps.call(this);
+      (props as any).contentClass = `v-autocomplete__content ${(props as any)
+        .contentClass || ""}`.trim();
+      return {
+        ...defaultMenuProps,
+        ...props
+      };
+    },
+    searchIsDirty(): boolean {
+      return this.internalSearch != null && this.internalSearch !== "";
+    },
+    selectedItem(): any {
+      if (this.multiple) return null;
 
       return this.selectedItems.find(i => {
-        return this.valueComparator(this.getValue(i), this.getValue(this.internalValue))
-      })
+        return this.valueComparator(
+          this.getValue(i),
+          this.getValue(this.internalValue)
+        );
+      });
     },
-    listData () {
-      const data = VSelect.options.computed.listData.call(this) as any
+    listData() {
+      const data = VSelect.options.computed.listData.call(this) as any;
 
       data.props = {
         ...data.props,
         items: this.virtualizedItems,
-        noFilter: (
-          this.noFilter ||
-          !this.isSearching ||
-          !this.filteredItems.length
-        ),
-        searchInput: this.internalSearch,
-      }
+        noFilter:
+          this.noFilter || !this.isSearching || !this.filteredItems.length,
+        searchInput: this.internalSearch
+      };
 
-      return data
-    },
+      return data;
+    }
   },
 
   watch: {
-    filteredItems: 'onFilteredItemsChanged',
-    internalValue: 'setSearch',
-    isFocused (val) {
+    filteredItems: "onFilteredItemsChanged",
+    internalValue: "setSearch",
+    isFocused(val) {
       if (val) {
-        document.addEventListener('copy', this.onCopy)
-        this.$refs.input && this.$refs.input.select()
+        document.addEventListener("copy", this.onCopy);
+        this.$refs.input && this.$refs.input.select();
       } else {
-        document.removeEventListener('copy', this.onCopy)
-        this.blur()
-        this.updateSelf()
+        document.removeEventListener("copy", this.onCopy);
+        this.blur();
+        this.updateSelf();
       }
     },
-    isMenuActive (val) {
-      if (val || !this.hasSlot) return
+    isMenuActive(val) {
+      if (val || !this.hasSlot) return;
 
-      this.lazySearch = null
+      this.lazySearch = null;
     },
-    items (val, oldVal) {
+    items(val, oldVal) {
       // If we are focused, the menu
       // is not active, hide no data is enabled,
       // and items change
@@ -190,241 +197,229 @@ export default VSelect.extend({
         this.isFocused &&
         !this.isMenuActive &&
         val.length
-      ) this.activateMenu()
+      )
+        this.activateMenu();
     },
-    searchInput (val: string) {
-      this.lazySearch = val
+    searchInput(val: string) {
+      this.lazySearch = val;
     },
-    internalSearch: 'onInternalSearchChanged',
-    itemText: 'updateSelf',
+    internalSearch: "onInternalSearchChanged",
+    itemText: "updateSelf"
   },
 
-  created () {
-    this.setSearch()
+  created() {
+    this.setSearch();
   },
 
-  destroyed () {
-    document.removeEventListener('copy', this.onCopy)
+  destroyed() {
+    document.removeEventListener("copy", this.onCopy);
   },
 
   methods: {
-    onFilteredItemsChanged (val: never[], oldVal: never[]) {
+    onFilteredItemsChanged(val: never[], oldVal: never[]) {
       // TODO: How is the watcher triggered
       // for duplicate items? no idea
-      if (val === oldVal) return
+      if (val === oldVal) return;
 
       if (!this.autoSelectFirst) {
-        const preSelectedItem = oldVal[this.$refs.menu.listIndex]
+        const preSelectedItem = oldVal[this.$refs.menu.listIndex];
 
         if (preSelectedItem) {
-          this.setMenuIndex(val.findIndex(i => i === preSelectedItem))
+          this.setMenuIndex(val.findIndex(i => i === preSelectedItem));
         } else {
-          this.setMenuIndex(-1)
+          this.setMenuIndex(-1);
         }
-        this.$emit('update:list-index', this.$refs.menu.listIndex)
+        this.$emit("update:list-index", this.$refs.menu.listIndex);
       }
 
       this.$nextTick(() => {
-        if (
-          !this.internalSearch ||
-          (val.length !== 1 &&
-            !this.autoSelectFirst)
-        ) return
+        if (!this.internalSearch || (val.length !== 1 && !this.autoSelectFirst))
+          return;
 
-        this.$refs.menu.getTiles()
+        this.$refs.menu.getTiles();
 
         if (this.autoSelectFirst && val.length) {
-          this.setMenuIndex(0)
-          this.$emit('update:list-index', this.$refs.menu.listIndex)
+          this.setMenuIndex(0);
+          this.$emit("update:list-index", this.$refs.menu.listIndex);
         }
-      })
+      });
     },
-    onInternalSearchChanged () {
-      this.updateMenuDimensions()
+    onInternalSearchChanged() {
+      this.updateMenuDimensions();
     },
-    updateMenuDimensions () {
+    updateMenuDimensions() {
       // Type from menuable is not making it through
-      this.isMenuActive && this.$refs.menu && this.$refs.menu.updateDimensions()
+      this.isMenuActive &&
+        this.$refs.menu &&
+        this.$refs.menu.updateDimensions();
     },
-    changeSelectedIndex (keyCode: number) {
+    changeSelectedIndex(keyCode: number) {
       // Do not allow changing of selectedIndex
       // when search is dirty
-      if (this.searchIsDirty) return
+      if (this.searchIsDirty) return;
 
       if (this.multiple && keyCode === keyCodes.left) {
         if (this.selectedIndex === -1) {
-          this.selectedIndex = this.selectedItems.length - 1
+          this.selectedIndex = this.selectedItems.length - 1;
         } else {
-          this.selectedIndex--
+          this.selectedIndex--;
         }
       } else if (this.multiple && keyCode === keyCodes.right) {
         if (this.selectedIndex >= this.selectedItems.length - 1) {
-          this.selectedIndex = -1
+          this.selectedIndex = -1;
         } else {
-          this.selectedIndex++
+          this.selectedIndex++;
         }
-      } else if (keyCode === keyCodes.backspace || keyCode === keyCodes.delete) {
-        this.deleteCurrentItem()
+      } else if (
+        keyCode === keyCodes.backspace ||
+        keyCode === keyCodes.delete
+      ) {
+        this.deleteCurrentItem();
       }
     },
-    deleteCurrentItem () {
-      const curIndex = this.selectedIndex
-      const curItem = this.selectedItems[curIndex]
+    deleteCurrentItem() {
+      const curIndex = this.selectedIndex;
+      const curItem = this.selectedItems[curIndex];
 
       // Do nothing if input or item is disabled
-      if (
-        !this.isInteractive ||
-        this.getDisabled(curItem)
-      ) return
+      if (!this.isInteractive || this.getDisabled(curItem)) return;
 
-      const lastIndex = this.selectedItems.length - 1
+      const lastIndex = this.selectedItems.length - 1;
 
       // Select the last item if
       // there is no selection
-      if (
-        this.selectedIndex === -1 &&
-        lastIndex !== 0
-      ) {
-        this.selectedIndex = lastIndex
+      if (this.selectedIndex === -1 && lastIndex !== 0) {
+        this.selectedIndex = lastIndex;
 
-        return
+        return;
       }
 
-      const length = this.selectedItems.length
-      const nextIndex = curIndex !== length - 1
-        ? curIndex
-        : curIndex - 1
-      const nextItem = this.selectedItems[nextIndex]
+      const length = this.selectedItems.length;
+      const nextIndex = curIndex !== length - 1 ? curIndex : curIndex - 1;
+      const nextItem = this.selectedItems[nextIndex];
 
       if (!nextItem) {
-        this.setValue(this.multiple ? [] : null)
+        this.setValue(this.multiple ? [] : null);
       } else {
-        this.selectItem(curItem)
+        this.selectItem(curItem);
       }
 
-      this.selectedIndex = nextIndex
+      this.selectedIndex = nextIndex;
     },
-    clearableCallback () {
-      this.internalSearch = null
+    clearableCallback() {
+      this.internalSearch = null;
 
-      VSelect.options.methods.clearableCallback.call(this)
+      VSelect.options.methods.clearableCallback.call(this);
     },
-    genInput () {
-      const input = VTextField.options.methods.genInput.call(this)
+    genInput() {
+      const input = VTextField.options.methods.genInput.call(this);
 
       input.data = mergeData(input.data!, {
         attrs: {
-          'aria-activedescendant': getObjectValueByPath(this.$refs.menu, 'activeTile.id'),
-          autocomplete: getObjectValueByPath(input.data!, 'attrs.autocomplete', 'off'),
+          "aria-activedescendant": getObjectValueByPath(
+            this.$refs.menu,
+            "activeTile.id"
+          ),
+          autocomplete: getObjectValueByPath(
+            input.data!,
+            "attrs.autocomplete",
+            "off"
+          )
         },
-        domProps: { value: this.internalSearch },
-      })
+        domProps: { value: this.internalSearch }
+      });
 
-      return input
+      return input;
     },
-    genInputSlot () {
-      const slot = VSelect.options.methods.genInputSlot.call(this)
+    genInputSlot() {
+      const slot = VSelect.options.methods.genInputSlot.call(this);
 
-      slot.data!.attrs!.role = 'combobox'
+      slot.data!.attrs!.role = "combobox";
 
-      return slot
+      return slot;
     },
-    genSelections (): VNode | never[] {
+    genSelections(): VNode | never[] {
       return this.hasSlot || this.multiple
         ? VSelect.options.methods.genSelections.call(this)
-        : []
+        : [];
     },
-    onClick (e: MouseEvent) {
-      if (!this.isInteractive) return
+    onClick(e: MouseEvent) {
+      if (!this.isInteractive) return;
 
-      this.selectedIndex > -1
-        ? (this.selectedIndex = -1)
-        : this.onFocus()
+      this.selectedIndex > -1 ? (this.selectedIndex = -1) : this.onFocus();
 
-      if (!this.isAppendInner(e.target)) this.activateMenu()
+      if (!this.isAppendInner(e.target)) this.activateMenu();
     },
-    onInput (e: Event) {
-      if (
-        this.selectedIndex > -1 ||
-        !e.target
-      ) return
+    onInput(e: Event) {
+      if (this.selectedIndex > -1 || !e.target) return;
 
-      const target = e.target as HTMLInputElement
-      const value = target.value
+      const target = e.target as HTMLInputElement;
+      const value = target.value;
 
       // If typing and menu is not currently active
-      if (target.value) this.activateMenu()
+      if (target.value) this.activateMenu();
 
-      if (!this.multiple && value === '') this.deleteCurrentItem()
+      // delete value if non-multiple and non-chip and searchinput is empty
+      if (!this.multiple && !this.hasChips && value === "")
+        this.deleteCurrentItem();
 
-      this.internalSearch = value
-      this.badInput = target.validity && target.validity.badInput
+      this.internalSearch = value;
+      this.badInput = target.validity && target.validity.badInput;
     },
-    onKeyDown (e: KeyboardEvent) {
-      const keyCode = e.keyCode
+    onKeyDown(e: KeyboardEvent) {
+      const keyCode = e.keyCode;
 
-      if (
-        e.ctrlKey ||
-        ![keyCodes.home, keyCodes.end].includes(keyCode)
-      ) {
-        VSelect.options.methods.onKeyDown.call(this, e)
+      if (e.ctrlKey || ![keyCodes.home, keyCodes.end].includes(keyCode)) {
+        VSelect.options.methods.onKeyDown.call(this, e);
       }
 
       // The ordering is important here
       // allows new value to be updated
       // and then moves the index to the
       // proper location
-      this.changeSelectedIndex(keyCode)
+      this.changeSelectedIndex(keyCode);
     },
-    onSpaceDown (e: KeyboardEvent) { /* noop */ },
-    onTabDown (e: KeyboardEvent) {
-      VSelect.options.methods.onTabDown.call(this, e)
-      this.updateSelf()
+    onSpaceDown(e: KeyboardEvent) {
+      /* noop */
     },
-    onUpDown (e: Event) {
+    onTabDown(e: KeyboardEvent) {
+      VSelect.options.methods.onTabDown.call(this, e);
+      this.updateSelf();
+    },
+    onUpDown(e: Event) {
       // Prevent screen from scrolling
-      e.preventDefault()
+      e.preventDefault();
 
       // For autocomplete / combobox, cycling
       // interfers with native up/down behavior
       // instead activate the menu
-      this.activateMenu()
+      this.activateMenu();
     },
-    selectItem (item: object) {
-      VSelect.options.methods.selectItem.call(this, item)
-      this.setSearch()
+    selectItem(item: object) {
+      VSelect.options.methods.selectItem.call(this, item);
+      this.setSearch();
     },
-    setSelectedItems () {
-      VSelect.options.methods.setSelectedItems.call(this)
+    setSelectedItems() {
+      VSelect.options.methods.setSelectedItems.call(this);
 
       // #4273 Don't replace if searching
       // #4403 Don't replace if focused
-      if (!this.isFocused) this.setSearch()
+      if (!this.isFocused) this.setSearch();
     },
-    setSearch () {
+    setSearch() {
       // Wait for nextTick so selectedItem
       // has had time to update
       this.$nextTick(() => {
-        if (
-          !this.multiple ||
-          !this.internalSearch ||
-          !this.isMenuActive
-        ) {
-          this.internalSearch = (
-            !this.selectedItems.length ||
-            this.multiple ||
-            this.hasSlot
-          )
-            ? null
-            : this.getText(this.selectedItem)
+        if (!this.multiple || !this.internalSearch || !this.isMenuActive) {
+          this.internalSearch =
+            !this.selectedItems.length || this.multiple || this.hasSlot
+              ? null
+              : this.getText(this.selectedItem);
         }
-      })
+      });
     },
-    updateSelf () {
-      if (
-        !this.searchIsDirty &&
-        !this.internalValue
-      ) return
+    updateSelf() {
+      if (!this.searchIsDirty && !this.internalValue) return;
 
       if (
         !this.multiple &&
@@ -433,20 +428,23 @@ export default VSelect.extend({
           this.getValue(this.internalValue)
         )
       ) {
-        this.setSearch()
+        this.setSearch();
       }
     },
-    hasItem (item: any): boolean {
-      return this.selectedValues.indexOf(this.getValue(item)) > -1
+    hasItem(item: any): boolean {
+      return this.selectedValues.indexOf(this.getValue(item)) > -1;
     },
-    onCopy (event: ClipboardEvent) {
-      if (this.selectedIndex === -1) return
+    onCopy(event: ClipboardEvent) {
+      if (this.selectedIndex === -1) return;
 
-      const currentItem = this.selectedItems[this.selectedIndex]
-      const currentItemText = this.getText(currentItem)
-      event.clipboardData?.setData('text/plain', currentItemText)
-      event.clipboardData?.setData('text/vnd.vuetify.autocomplete.item+plain', currentItemText)
-      event.preventDefault()
-    },
-  },
-})
+      const currentItem = this.selectedItems[this.selectedIndex];
+      const currentItemText = this.getText(currentItem);
+      event.clipboardData?.setData("text/plain", currentItemText);
+      event.clipboardData?.setData(
+        "text/vnd.vuetify.autocomplete.item+plain",
+        currentItemText
+      );
+      event.preventDefault();
+    }
+  }
+});

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -253,4 +253,40 @@ describe('VAutocomplete.ts', () => {
 
     expect(wrapper.vm.internalValue).toBeNull()
   })
+
+  it('should not remove selected item when text-field is cleared but chips prop is set', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo', 'bar'],
+        value: 'foo',
+        chips:true
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.element.value = ''
+    input.trigger('input')
+
+    expect(wrapper.vm.internalValue).not.toBeNull()
+    expect(wrapper.vm.internalValue).toBe("foo")
+  })
+
+  it('should not remove selected item when text-field is cleared but small-chips prop is set', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo', 'bar'],
+        value: 'foo',
+        smallChips:true
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.element.value = ''
+    input.trigger('input')
+
+    expect(wrapper.vm.internalValue).not.toBeNull()
+    expect(wrapper.vm.internalValue).toBe("foo")
+  })
 })


### PR DESCRIPTION
## Description
Non-multiple v-autocomplete component with chips or small-chips prop is prevented from clearing its value when last key from the searchkey has been deleted. Caused by a fix for a similar issue whose behavior is not supposed to apply to autocompletes using chips. [Fixes #18408]

## How Has This Been Tested?
Unit testing and pulled from workaround in local project where this already works as intended.

## Types of changes
* [x]   Bug fix (non-breaking change which fixes an issue)
* [ ]   New feature (non-breaking change which adds functionality)
* [ ]   Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]   Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
* [x]   The PR title is no longer than 64 characters.
* [x]   The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
* [x]   My code follows the code style of this project.
* [ ]   I've added relevant changes to the documentation (applies to new features and breaking changes in core library)

## Codepen
https://codepen.io/notSmoothie/pen/RwEqwXG

Steps to reproduce:

1. Start writing text into a non-multiple V-Autocomplete with value selected
2. Try to delete text

