### PR TITLE
fix(VAutocomplete): unexpected value deletion [Fixes #18408 ] 

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts
@@ -355,7 +355,7 @@ export default VSelect.extend({
       // If typing and menu is not currently active
       if (target.value) this.activateMenu()
 
-      if (!this.multiple && value === '') this.deleteCurrentItem()
+      if (!this.multiple && !this.hasChips && value === '') this.deleteCurrentItem()
 
       this.internalSearch = value
       this.badInput = target.validity && target.validity.badInput

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete3.spec.ts
@@ -253,4 +253,40 @@ describe('VAutocomplete.ts', () => {
 
     expect(wrapper.vm.internalValue).toBeNull()
   })
+
+  it('should not remove selected item when text-field is cleared but chips prop is set', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo', 'bar'],
+        value: 'foo',
+        chips: true,
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.element.value = ''
+    input.trigger('input')
+
+    expect(wrapper.vm.internalValue).not.toBeNull()
+    expect(wrapper.vm.internalValue).toBe('foo')
+  })
+
+  it('should not remove selected item when text-field is cleared but small-chips prop is set', () => {
+    const wrapper = mountFunction({
+      propsData: {
+        items: ['foo', 'bar'],
+        value: 'foo',
+        smallChips: true,
+      },
+    })
+
+    const input = wrapper.find('input')
+
+    input.element.value = ''
+    input.trigger('input')
+
+    expect(wrapper.vm.internalValue).not.toBeNull()
+    expect(wrapper.vm.internalValue).toBe('foo')
+  })
 })


### PR DESCRIPTION
## Description
Non-multiple v-autocomplete component with chips or small-chips prop is prevented from clearing its value when last key from the searchkey has been deleted. Caused by a fix for a similar issue whose behavior is not supposed to apply to autocompletes using chips. [ Fixes #18408 ] 

## How Has This Been Tested?
Unit testing and pulled from workaround in local project where this already works as intended.

## Types of changes
* [x]   Bug fix (non-breaking change which fixes an issue)
* [ ]   New feature (non-breaking change which adds functionality)
* [ ]   Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]   Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
* [x]   The PR title is no longer than 64 characters.
* [x]   The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and backwards compatible changes and `next` for non-backwards compatible changes).
* [x]   My code follows the code style of this project.
* [ ]   I've added relevant changes to the documentation (applies to new features and breaking changes in core library)

## Codepen
https://codepen.io/notSmoothie/pen/RwEqwXG

Steps to reproduce:

1. Start writing text into a non-multiple V-Autocomplete with value selected
2. Try to delete text

