### PR TITLE
fix(VDatePicker): use Safari-compatible format for dates

### DIFF
--- a/packages/vuetify/src/labs/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
@@ -15,7 +15,7 @@ describe('VDatePicker', () => {
         <VDatePicker v-model={ model.value } hideActions />
       </Application>
     ))
-      .get('div[data-v-date="2023-1-2"]')
+      .get('div[data-v-date="2023/1/2"]')
       .click()
       .vue()
       .then(wrapper => {
@@ -32,7 +32,7 @@ describe('VDatePicker', () => {
         <VDatePicker v-model={ model.value } />
       </Application>
     ))
-      .get('div[data-v-date="2023-1-2"]')
+      .get('div[data-v-date="2023/1/2"]')
       .click()
       .vue()
       .then(wrapper => {

--- a/packages/vuetify/src/labs/date/date.ts
+++ b/packages/vuetify/src/labs/date/date.ts
@@ -115,7 +115,7 @@ export function useDate () {
 
 export function toIso (adapter: DateAdapter<any>, value: any) {
   const date = adapter.toJsDate(value)
-  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+  return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`
 }
 
 function getMondayOfFirstWeekOfYear (year: number) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Datepickers don't work on Safari because YYYY-M-D is not recognized as a valid format for the Date constructor parameter. Using YYYY/M/D resolves the issue as that format is reported to work across all major browsers.

resolves #17822

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker
        v-model="dateValue"
        multiple
        show-adjacent-months
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const dateValue = ref(null)
</script>
```
