### PR TITLE
fix(VDatePicker): add header color prop and provide it

### DIFF
--- a/packages/api-generator/src/locale/en/VDatePicker.json
+++ b/packages/api-generator/src/locale/en/VDatePicker.json
@@ -13,6 +13,7 @@
     "flat": "Removes  elevation.",
     "format": "Takes a date object and returns it in a specified format.",
     "header": "Text shown when no **display-date** is set.",
+    "headerColor": "Sets color of date picker header",
     "headerDateFormat": "Allows you to customize the format of the month string that appears in the header of the calendar. Called with date (ISO 8601 **date** string) arguments.",
     "hideActions": "Hide the picker actions.",
     "inputMode": "Toggles between showing dates or inputs.",

--- a/packages/vuetify/src/labs/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/labs/VDatePicker/VDatePicker.tsx
@@ -29,6 +29,7 @@ export type VDatePickerSlots = Omit<VPickerSlots, 'header'> & {
   header: {
     header: string
     appendIcon: string
+    headerColor?: string
     'onClick:append': () => void
   }
 }
@@ -63,6 +64,7 @@ export const makeVDatePickerProps = propsFactory({
     default: '$vuetify.datePicker.header',
   },
   hideActions: Boolean,
+  headerColor: String,
 
   ...makeDateProps(),
   ...makeVDatePickerControlsProps(),
@@ -98,6 +100,7 @@ export const VDatePicker = genericComponent<VDatePickerSlots>()({
         : adapter.format(displayDate.value, 'shortDate')
     })
     const header = computed(() => model.value.length ? adapter.format(model.value[0], 'normalDateWithWeekday') : t(props.header))
+    const headerColor = computed(() => props.headerColor ? props.headerColor : props.color)
     const headerIcon = computed(() => inputMode.value === 'calendar' ? props.keyboardIcon : props.calendarIcon)
     const headerTransition = computed(() => `date-picker-header${isReversing.value ? '-reverse' : ''}-transition`)
     const minDate = computed(() => props.min && adapter.isValid(props.min) ? adapter.date(props.min) : null)
@@ -198,19 +201,25 @@ export const VDatePicker = genericComponent<VDatePickerSlots>()({
     const headerSlotProps = computed(() => ({
       header: header.value,
       appendIcon: headerIcon.value,
+      color: headerColor.value,
       transition: headerTransition.value,
       'onClick:append': onClickAppend,
     }))
 
+    const pickerProps = computed(() => {
+      const [filteredProps] = VPicker.filterProps(props)
+
+      return { ...filteredProps, color: headerColor.value }
+    })
+
     useRender(() => {
-      const [pickerProps] = VPicker.filterProps(props)
       const [datePickerControlsProps] = VDatePickerControls.filterProps(props)
       const [datePickerMonthProps] = VDatePickerMonth.filterProps(props)
       const [datePickerYearsProps] = VDatePickerYears.filterProps(props)
 
       return (
         <VPicker
-          { ...pickerProps }
+          { ...pickerProps.value }
           class={[
             'v-date-picker',
             `v-date-picker--${viewMode.value}`,


### PR DESCRIPTION
## Description
Was done:
 * Added a new props headerColor
 * Provided a new prop  to VDatePickerHeader and VPicker as a color prop
 * Added prop description to api generator VDatePicker.json file
Related issue: #17631

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker header-color="purple darken-6" />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
      }
    },
  }
</script>


```
