### PR TITLE
feat(VAutoComplete): add clearSearchOnSelection prop

### DIFF
--- a/packages/api-generator/src/locale/en/VAutocomplete.json
+++ b/packages/api-generator/src/locale/en/VAutocomplete.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "autoSelectFirst": "When searching, will always highlight the first option and select it on blur. `exact` will only highlight and select exact matches.",
+    "clearSearchOnSelection": "Clears search value after selecting an item.",
     "filter": "The filtering algorithm used when searching. [example](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts#L40).",
     "noFilter": "Do not apply filtering when searching. Useful when data is being filtered server side."
   },

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -76,6 +76,7 @@ export const makeVAutocompleteProps = propsFactory({
     type: [Boolean, String] as PropType<boolean | 'exact'>,
   },
   search: String,
+  clearSearchOnSelection: Boolean,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps(),
@@ -319,6 +320,9 @@ export const VAutocomplete = genericComponent<new <
 
         if (index === -1) {
           model.value = [...model.value, item]
+          if (props.clearSearchOnSelection) {
+            search.value = ''
+          }
         } else {
           const value = [...model.value]
           value.splice(index, 1)

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -493,6 +493,31 @@ describe('VAutocomplete', () => {
       })
   })
 
+  it('should clear search query after selecting an item', () => {
+    const selectedItems = ref(undefined)
+
+    cy
+      .mount(() => (
+        <VAutocomplete
+          v-model={ selectedItems.value }
+          items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']}
+          multiple
+          clearSearchOnSelection
+        />
+      ))
+      .get('.v-autocomplete')
+      .click()
+      .get('.v-list-item')
+      .should('have.length', 6)
+      .get('.v-autocomplete input')
+      .type('Cal')
+      .should('have.length', 1)
+      .get('.v-list-item').eq(0)
+      .click({ waitForAnimations: false })
+      .get('.v-list-item')
+      .should('have.length', 6)
+  })
+
   describe('Showcase', () => {
     generate({ stories })
   })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Add clearSearchOnSelection prop to VAutoComplete component.
Typed search query cleared after selecting an item when this prop is true.

resolves #18428 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-autocomplete
    label="Autocomplete"
    :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
    clearSearchOnSelection
  />
</template>
```
