### PR TITLE
fix(VBreadcrumbs): set overflow-x to auto

### DIFF
--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.sass
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.sass
@@ -6,6 +6,7 @@
   align-items: center
   line-height: $breadcrumbs-line-height
   padding: $breadcrumbs-padding-y $breadcrumbs-padding-x
+  overflow-x: auto
 
   &--rounded
     @include tools.rounded($breadcrumbs-rounded-border-radius)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Add `overflow-x: auto` so that the component becomes scrollable when it doesn't fit the screen. Fixes #18464 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <VBreadcrumbs :items="items" />
</template>

<script setup>
  import { ref } from 'vue'

  const items = ref([
    {
      title: 'VueJS',
    },
    {
      title: 'Frameworks',
    },
    {
      title: 'Vuetify',
    },
    {
      title: 'Documentation',
    },
    {
      title: 'Directives',
    },
    {
      title: 'Some directive',
    },
    {
      title: 'Usage',
    },
  ])
</script>
```
