### PR TITLE
fix(VBreadcrumbsItem): add missing title attribute

### DIFF
--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbsItem.tsx
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbsItem.tsx
@@ -55,6 +55,7 @@ export const VBreadcrumbsItem = genericComponent()({
           { !link.isLink.value ? slots.default?.() ?? props.title : (
             <a
               class="v-breadcrumbs-item--link"
+              title={ props.title }
               href={ link.href.value }
               aria-current={ isActive.value ? 'page' : undefined }
               onClick={ link.navigate }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Add missing title prop to anchor. Fixes #18467 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <VBreadcrumbs :items="items" />
</template>

<script setup>
  import { ref } from 'vue'

  const items = ref([
    {
      title: 'VueJS',
      href: 'https://vuejs.org',
    },
    {
      title: 'Vuetify',
      href: 'https://vuetifyjs.com',
    },
  ])
</script>
```
