### PR TITLE
fix(VAutocomplete): increase selection width by using 100% calc

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -28,7 +28,7 @@
 
   .v-field--dirty
     .v-autocomplete__selection
-      margin-inline-end: $autocomplete-dirty-selection-margin-inline-end
+      margin-inline-end: $autocomplete-selection-gap
 
   .v-autocomplete__selection-text
     overflow: hidden
@@ -50,7 +50,7 @@
     align-items: center
     letter-spacing: inherit
     line-height: inherit
-    max-width: calc(100% - $autocomplete-dirty-selection-margin-inline-end)
+    max-width: calc(100% - $autocomplete-selection-gap)
 
   &__selection
     margin-top: var(--v-input-chips-margin-top)

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -28,7 +28,7 @@
 
   .v-field--dirty
     .v-autocomplete__selection
-      margin-inline-end: 2px
+      margin-inline-end: $autocomplete-dirty-selection-margin-inline-end
 
   .v-autocomplete__selection-text
     overflow: hidden
@@ -50,7 +50,7 @@
     align-items: center
     letter-spacing: inherit
     line-height: inherit
-    max-width: 90%
+    max-width: calc(100% - $autocomplete-dirty-selection-margin-inline-end)
 
   &__selection
     margin-top: var(--v-input-chips-margin-top)

--- a/packages/vuetify/src/components/VAutocomplete/_variables.scss
+++ b/packages/vuetify/src/components/VAutocomplete/_variables.scss
@@ -3,9 +3,9 @@
 // Defaults
 $autocomplete-content-border-radius: 4px !default;
 $autocomplete-content-elevation: 4 !default;
-$autocomplete-selection-gap: 2px !default;
 $autocomplete-focused-input: 64px !default;
 $autocomplete-line-height: 1.75 !default;
+$autocomplete-selection-gap: 2px !default;
 $autocomplete-transition: .2s settings.$standard-easing !default;
 $autocomplete-chips-control-min-height: 64px !default;
 $autocomplete-chips-margin-top: 2px !default;

--- a/packages/vuetify/src/components/VAutocomplete/_variables.scss
+++ b/packages/vuetify/src/components/VAutocomplete/_variables.scss
@@ -3,7 +3,7 @@
 // Defaults
 $autocomplete-content-border-radius: 4px !default;
 $autocomplete-content-elevation: 4 !default;
-$autocomplete-dirty-selection-margin-inline-end: 2px !default;
+$autocomplete-selection-gap: 2px !default;
 $autocomplete-focused-input: 64px !default;
 $autocomplete-line-height: 1.75 !default;
 $autocomplete-transition: .2s settings.$standard-easing !default;

--- a/packages/vuetify/src/components/VAutocomplete/_variables.scss
+++ b/packages/vuetify/src/components/VAutocomplete/_variables.scss
@@ -3,6 +3,7 @@
 // Defaults
 $autocomplete-content-border-radius: 4px !default;
 $autocomplete-content-elevation: 4 !default;
+$autocomplete-dirty-selection-margin-inline-end: 2px !default;
 $autocomplete-focused-input: 64px !default;
 $autocomplete-line-height: 1.75 !default;
 $autocomplete-transition: .2s settings.$standard-easing !default;


### PR DESCRIPTION
fixes #18470

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div style="width: 200px">
    <v-autocomplete
      label="Autocomplete"
      clearable
      :items="['California California California California California California California California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
    />
  </div>
</template>

```
