### PR TITLE
docs(VSkeletonLoader): make loader appear by default

### DIFF
--- a/packages/docs/src/examples/v-skeleton-loader/usage.vue
+++ b/packages/docs/src/examples/v-skeleton-loader/usage.vue
@@ -16,7 +16,7 @@
     <template v-slot:configuration>
       <v-select
         v-model="type"
-        :items="items"
+        :items="types"
         clearable
         label="Type"
       ></v-select>
@@ -49,8 +49,8 @@
   const elevation = ref()
   const color = ref()
   const colors = ['primary', 'secondary', 'success', 'info', 'warning', 'error']
-  const items = ['card', 'paragraph', 'list-item-avatar', 'article', 'card-avatar']
-  const type = ref()
+  const type = ref('card')
+  const types = ['card', 'paragraph', 'list-item-avatar', 'article', 'card-avatar']
 
   const props = computed(() => {
     return {


### PR DESCRIPTION
Currently the loader is not visible either in black mode or light mode 
![image](https://github.com/vuetifyjs/vuetify/assets/46346622/ed180b10-215f-4454-9103-6032fa38dc4e)
![image](https://github.com/vuetifyjs/vuetify/assets/46346622/51599aee-9012-481f-9a23-5ea5f228052f)

So a default type to card is good to have.

![image](https://github.com/vuetifyjs/vuetify/assets/46346622/e5cffae7-c93e-45ae-8583-f00e17f262ae)
