### PR TITLE
docs(VAvatar): fix cropped icons

### DIFF
--- a/packages/docs/src/examples/v-avatar/slot-default.vue
+++ b/packages/docs/src/examples/v-avatar/slot-default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row class="my-0" justify="space-around">
+  <div class="d-flex align-center justify-space-around">
     <v-avatar color="info">
       <v-icon icon="mdi-account-circle"></v-icon>
     </v-avatar>
@@ -14,5 +14,5 @@
     <v-avatar color="red">
       <span class="text-h5">CJ</span>
     </v-avatar>
-  </v-row>
+  </div>
 </template>

--- a/packages/docs/src/examples/v-avatar/slot-default.vue
+++ b/packages/docs/src/examples/v-avatar/slot-default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row justify="space-around">
+  <v-row class="my-0" justify="space-around">
     <v-avatar color="info">
       <v-icon icon="mdi-account-circle"></v-icon>
     </v-avatar>


### PR DESCRIPTION
By default a `margin: -12px;` is applied in the whole documentation for v-row but in this case, it is messing up the UI.