### PR TITLE
fix(VSelectionControlGroup): fix readonly radio group in vform

### DIFF
--- a/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
+++ b/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
@@ -45,7 +45,10 @@ export const makeSelectionControlGroupProps = propsFactory({
     default: null,
   },
   name: String,
-  readonly: Boolean,
+  readonly: {
+    type: Boolean as PropType<boolean | null>,
+    default: null,
+  },
   modelValue: null,
   type: String,
   valueComparator: {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #18424 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-form>
        <v-radio-group readonly>
          <template #label>
            I'm a radio group inside a readonly form
          </template>

          <v-radio label="Radio 1" value="1"></v-radio>
          <v-radio label="Radio 2" value="2"></v-radio>
        </v-radio-group>
      </v-form>
    </v-container>
  </v-app>
</template>

<script setup></script>
```
