### PR TITLE
docs(VChip): fix action event examples.

### DIFF
--- a/packages/docs/src/examples/v-chip/event-action-chips.vue
+++ b/packages/docs/src/examples/v-chip/event-action-chips.vue
@@ -35,16 +35,19 @@
 
     <v-card-text class="d-flex justify-space-between">
       <v-chip
+        @click="lights"
         prepend-icon="mdi-brightness-5"
       >
         Turn on lights
       </v-chip>
       <v-chip
+        @click="alarm"
         prepend-icon="mdi-alarm-check"
       >
         Set alarm
       </v-chip>
       <v-chip
+        @click="blinds"
         icon="mdi-blinds"
       >
         Close blinds
@@ -52,3 +55,19 @@
     </v-card-text>
   </v-card>
 </template>
+
+<script>
+export default {
+  methods: {
+    alarm () {
+      alert('Turning on alarm...')
+    },
+    blinds () {
+      alert('Toggling blinds...')
+    },
+    lights () {
+      alert('Toggling lights...')
+    },
+  },
+}
+</script>

--- a/packages/docs/src/examples/v-chip/event-action-chips.vue
+++ b/packages/docs/src/examples/v-chip/event-action-chips.vue
@@ -35,20 +35,20 @@
 
     <v-card-text class="d-flex justify-space-between">
       <v-chip
-        @click="lights"
         prepend-icon="mdi-brightness-5"
+        @click="lights"
       >
         Turn on lights
       </v-chip>
       <v-chip
-        @click="alarm"
         prepend-icon="mdi-alarm-check"
+        @click="alarm"
       >
         Set alarm
       </v-chip>
       <v-chip
-        @click="blinds"
         icon="mdi-blinds"
+        @click="blinds"
       >
         Close blinds
       </v-chip>
@@ -57,17 +57,17 @@
 </template>
 
 <script>
-export default {
-  methods: {
-    alarm () {
-      alert('Turning on alarm...')
+  export default {
+    methods: {
+      alarm () {
+        alert('Turning on alarm...')
+      },
+      blinds () {
+        alert('Toggling blinds...')
+      },
+      lights () {
+        alert('Toggling lights...')
+      },
     },
-    blinds () {
-      alert('Toggling blinds...')
-    },
-    lights () {
-      alert('Toggling lights...')
-    },
-  },
-}
+  }
 </script>


### PR DESCRIPTION
## Description

This PR fixes an issue created in this commit where the example is no longer clickable: https://github.com/vuetifyjs/vuetify/commit/c99f1af11d7cd731e8976ff3107f542a75f34f45#diff-c8bd9378bdae034fb0c54438765e9d59a153f0d443c97e4f48545c8b8252f45b
