### PR TITLE
docs(buttons.md): changed role to type on button a11y description.

### DIFF
--- a/packages/docs/src/pages/en/components/buttons.md
+++ b/packages/docs/src/pages/en/components/buttons.md
@@ -387,7 +387,7 @@ The `v-btn` component is an extension of the native `button` element and support
 
 ### ARIA Attributes
 
-By default, the `v-btn` component includes relevant [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) attributes to enhance accessibility. The component is automatically assigned the `role="button"` attribute, which indicates its purpose as a button to assistive technologies.
+By default, the `v-btn` component includes relevant [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) attributes to enhance accessibility. The component is automatically assigned the `type="button"` attribute, which indicates its purpose as a button to assistive technologies.
 
 ### Keyboard Navigation
 


### PR DESCRIPTION
The role attribute is mentioned in the docs but was never set in all the implementations I tried. I worked with the m3 theme, so this might be the reason. I changed it to type since you do set a type on every button to type=button. 
