### PR TITLE
docs(VLazy): add example for list

### DIFF
--- a/packages/docs/src/examples/v-lazy/list.vue
+++ b/packages/docs/src/examples/v-lazy/list.vue
@@ -1,0 +1,63 @@
+<template>
+  <h4 class="ma-2">
+    {{ mountedElements }} out of {{ apiTracks.length }} elements created
+  </h4>
+  <v-list id="container" class="py-0" @scroll="onScroll">
+    <v-lazy v-for="(track, index) in apiTracks" :key="track.name" min-height="50">
+      <v-list-item ref="trackElements">
+        <template v-slot:prepend>
+          <p class="mr-4">{{ index + 1 }}</p>
+        </template>
+        <v-list-item-title>{{ track.name }}</v-list-item-title>
+        {{ track.artist }}
+      </v-list-item>
+    </v-lazy>
+  </v-list>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+  import apiTracks from './tracks.json'
+
+  const mountedElements = ref(9)
+  const trackElements = ref([])
+
+  const onScroll = () => {
+    mountedElements.value = trackElements.value.length
+  }
+</script>
+
+<script>
+  import apiTracks from './tracks.json'
+
+  export default {
+    data () {
+      return {
+        mountedElements: 9,
+        apiTracks,
+      }
+    },
+    methods: {
+      onScroll () {
+        this.mountedElements = this.$refs.trackElements.length
+      },
+    },
+  }
+</script>
+
+<style scoped>
+#container {
+  border-width: 3px;
+  border-radius: 15px;
+  height: 400px;
+  margin: 5px;
+}
+
+.v-list-item {
+  border-width: thin;
+}
+
+.v-list-item-title {
+  font-weight: 600;
+}
+</style>

--- a/packages/docs/src/examples/v-lazy/tracks.json
+++ b/packages/docs/src/examples/v-lazy/tracks.json
@@ -1,0 +1,114 @@
+[
+    {
+        "name": "Bohemian Rhapsody",
+        "artist": "Queen"
+    },
+    {
+        "name": "Heat Waves",
+        "artist": "Glass Animals"
+    },
+    {
+        "name": "Sweater Weather",
+        "artist": "The Neighbourhood"
+    },
+    {
+        "name": "Don't Start Now",
+        "artist": "Dua Lipa"
+    },
+    {
+        "name": "God's Plan",
+        "artist": "Drake"
+    },
+    {
+        "name": "Loveyou",
+        "artist": "j^p^n"
+    },
+    {
+        "name": "Circles",
+        "artist": "Post Malone"
+    },
+    {
+        "name": "Riptide",
+        "artist": "Vance Joy"
+    },
+    {
+        "name": "bad guy",
+        "artist": "Billie Eilish"
+    },
+    {
+        "name": "But Anyways",
+        "artist": "The Hourglass Effect"
+    },
+    {
+        "name": "Stressed Out",
+        "artist": "Twenty One Pilots"
+    },
+    {
+        "name": "Wake Me Up",
+        "artist": "Avicii"
+    },
+    {
+        "name": "Hypnotize",
+        "artist": "The Notorious B.I.G."
+    },
+    {
+        "name": "Yellow",
+        "artist": "Coldplay"
+    },
+    {
+        "name": "Counting Stars",
+        "artist": "OneRepublic"
+    },
+    {
+        "name": "Mr. Brightside",
+        "artist": "The Killers"
+    },
+    {
+        "name": "Zeldas Lullaby",
+        "artist": "A L E X"
+    },
+    {
+        "name": "Shape of You",
+        "artist": "Ed Sheeran"
+    },
+    {
+        "name": "505",
+        "artist": "Artic Monkeys"
+    },
+    {
+        "name": "One More Time",
+        "artist": "Marc Rebillet"
+    },
+    {
+        "name": "Jungle",
+        "artist": "Fred again.."
+    },
+    {
+        "name": "Blinding Lights",
+        "artist": "The Weeknd"
+    },
+    {
+        "name": "Dance Monkey",
+        "artist": "Tones And I"
+    },
+    {
+        "name": "Chill Day",
+        "artist": "LAKEY INSPIRED"
+    },
+    {
+        "name": "Warm",
+        "artist": "Joey Pecoraro"
+    },
+    {
+        "name": "Believer",
+        "artist": "Imagine Dragons"
+    },
+    {
+        "name": "Faded",
+        "artist": "Allan Walker"
+    },
+    {
+        "name": "As it was",
+        "artist": "Harry Styles"
+    }
+]

--- a/packages/docs/src/pages/en/components/lazy.md
+++ b/packages/docs/src/pages/en/components/lazy.md
@@ -24,7 +24,7 @@ The `v-lazy` component is used to dynamically load components based upon an elem
 
 The `v-lazy` component by default will not render its contents until it has been intersected. Scroll down and watch the element render as you go past it.
 
-<usage name="v-lazy" />
+<example file="v-lazy/usage" />
 
 <entry />
 
@@ -35,3 +35,11 @@ The `v-lazy` component by default will not render its contents until it has been
 | [v-lazy](/api/v-lazy/) | Primary Component |
 
 <api-inline hide-links />
+
+## Examples
+
+### Lists
+
+The `v-lazy` component can be used to render lists of items. This is useful for long lists that may cause the page to become unresponsive while rendering.
+
+<example file="v-lazy/list" />


### PR DESCRIPTION
I tried to add a new dynamic list example using v-lazy. The styling is not really nice right now.

I updated the **_usage_** to avoid displaying a big chunk of code by default in the page (like ot was done for https://vuetifyjs.com/en/components/tables/#usage) 


Tests : 
https://play.vuetifyjs.com/#eNqFVntP40YQ/yqjtBKgEpPjUelSODWBHI9LOAq0lBJO2tiTeI/1rrVeJ/iifPfO2rHzsK37y955z28euy/zRqTdg04YOtMYG+3GqcEgFMzgp6EEOPWPwRUsis6GjYA1D4eNlAwwn0OgYmnQ6wkMUJoIFgtQsQE1tkwW8kfN3LfIESgnxrdczCVdjeTASx0c+MeZp2lT8MgA98iVq6RhXKIeNgr3YdJs0fHPyNVKCCIo+ZD+FjFZE+xHkh0Aps2x0iS3a2wg+8Clh+979FkFN2zkwu03TEg2FXUkC3DFCrhs+sgnviGBE4ohYyydFpE3OSEHGse5mRyYIr5UOIeXwouEMu1QY4jSWxMhoXAFum4ekwFCNA0ffoMPBOXpQbhu82CjZuWomoYbgdbIKr/USllmZaCQZtrYwiwWRcLrejn2lkbgZ7VcCtBhIzY6UvV4aCBCE2cp8CBU2sDcIgcLGGsVwA614s4as6jXku0cpJFFzvdIyVSQGoZC3O7IM2t09+PeSmKjMEv+y+uaQN5UxNvdg7NPMM/y2zLtTJmIkYQ2DGbUZcdbPYLs9CBLeT399cR/nhu+p4IejlksCKksII8ZRhEuT0CZmFjL1bkUchs+7q+YhduCtizvYkkI0PjKI63CYg7NulcA4/PIKQOfkn8leCNnE6IVOOvesm8ZLpMIhMhVIWYT8kuxGfIYRkp7qJsz7hm/DUfh+x8bdM08HlMWH04KTjbLbThutQpawPSEyzbkUikYzvpgV7qjLGW1fDZOudaYom7Oln5/b7VyHcrWZkipNfbTPbxWe9rFL1ZsDsNGtpDa9NdVPgacSbj3WRgpLxk29omczWgm8leMKGlTZphuql/R4oUnNkXaStt6l3blQEfygAliV+o/zOzm1vBEH9+u520jjz7CrU10pGLtK+XVGLqg5jbwYEgXbtWsbOgiZtDnIavRv1TeTgR3glGmJVXN3kisUq+vppiouKz0/Vv4rQ61c65dUQXZnaKVMWBCyTp/99TL3KPDtuo/TLoIN4oKWKk4Yh5M4orydrkQHKHHqdf8GuUu3cMdmcxYUhG0LdEVVWeS1rs3HqNLnOpyG41RhB58jUmkZGhGE53AV4lwx+kuq2uaJyoHDBD+Dss2OlPucl7XrUkoleE/KuBL+0wZpbmKI+g6186lU2PlGYWo6rBzJTy6meoKcG53GpeTtEkrYKS07zGMR4K7NRYG2oGutkMfVbaAzeELVROt+UoL/6HwWAT9WAg2quiFDvShB//WVY9WBNr32HNVw/c8ePARtZ2gSvWT1kmFR/p3YaAkvZfqorYNMVAa4ZFb0raJAdMu3OPIZl7XeDexnIgK3c+ampFN6AZw6srdFfRSsnXrp8hXw/6E+CZrd1M6mlmOFeo07HZNenBd1zk+pQYXtrO2lfudL71nuL59uLu+713UzosOyqo3ChO4Q1dpplVd7kirYVq1l68DRhccAu3GCT10avQ/M4+e5eWiU/tJujbEW/oir9LsRMANzFgF3ldM64SmiC661O9QvtJ9t9hvHDlHzjFdfPZ7eNh4/R+alfx/