### PR TITLE
fix(VCalendar): display events starting or ending outside intervals

### DIFF
--- a/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
+++ b/packages/vuetify/src/components/VCalendar/mixins/calendar-with-events.ts
@@ -267,7 +267,9 @@ export default CalendarBase.extend({
       })
     },
     genTimedEvent ({ event, left, width }: CalendarEventVisual, day: CalendarDayBodySlotScope): VNode | false {
-      if (day.timeDelta(event.end) < 0 || day.timeDelta(event.start) >= 1 || isEventHiddenOn(event, day)) {
+      if ((day.date === event.end.date && day.timeDelta(event.end) < 0) ||
+        (day.date === event.start.date && day.timeDelta(event.start) >= 1) ||
+        isEventHiddenOn(event, day)) {
         return false
       }
 


### PR DESCRIPTION
fixes #18483 

## Description
These changes allow events that start or end outside of the calendar interval to be displayed within the visible area of the calendar.
E.g. a calendar that has a defined interval from 6am to 10pm and 1 event starting on 2019-01-06 23:00 and ending at 2019-01-08 23:00. Previously the event was not visible at all even though it should have been visible on two days (07th and the 8th).
See #18483 for details.
The problem was a missing date check when checking the timeDelta of the event and the current day.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-calendar
      :now="today"
      :value="today"
      :events="events"
      type="week"

      :first-interval="24"
      :interval-count="64"
      interval-minutes="15"
      interval-height="40"
    ></v-calendar>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      today: '2019-01-08',
      events: [
        {
          name: 'Workshop 1',
          start: '2019-01-06 23:00',
          end: '2019-01-08 23:00',
        },
        {
          name: 'Workshop 2',
          start: '2019-01-09 10:00',
          end: '2019-01-09 23:00',
        },
      ],
    }),
  }
</script>
```
