### PR TITLE
fix(VDataTable): use theme surface color for group header rows

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/labs/VDataTable/VDataTable.sass
@@ -66,7 +66,8 @@
 
 .v-data-table-group-header-row
   td
-    background: lightgrey
+    background: rgba(var(--v-theme-surface))
+    color: rgba(var(--v-theme-on-surface))
 
     > span
       padding-left: 5px


### PR DESCRIPTION
fixes #18543

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Adjusted the group header row colors to be more web accessible. 

## Markup:
VDataTable.sass
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```sass
.v-data-table-group-header-row
  td
    background: lightgrey
```
to 
```sass
.v-data-table-group-header-row
  td
    background: rgba(var(--v-theme-surface))
    color: rgba(var(--v-theme-on-surface))
```
