### PR TITLE
fix(VOtpInput): allows naturelly focus last input

### DIFF
--- a/packages/vuetify/src/labs/VOtpInput/__tests__/VOtpInput.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VOtpInput/__tests__/VOtpInput.spec.cy.tsx
@@ -7,7 +7,7 @@ import { VOtpInput } from '../VOtpInput'
 import { keyValues } from '@/util'
 
 describe('VOtpInput', () => {
-  it('enters value and moves to next input and focus the last input at end', () => {
+  it('enters value and moves to next input and focuses the last input at end', () => {
     cy.mount(() => (<VOtpInput />))
       .get('.v-otp-input input').eq(0)
       .type('1')

--- a/packages/vuetify/src/labs/VOtpInput/__tests__/VOtpInput.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VOtpInput/__tests__/VOtpInput.spec.cy.tsx
@@ -7,7 +7,7 @@ import { VOtpInput } from '../VOtpInput'
 import { keyValues } from '@/util'
 
 describe('VOtpInput', () => {
-  it('enters value and moves to next input and blurs at end', () => {
+  it('enters value and moves to next input and focus the last input at end', () => {
     cy.mount(() => (<VOtpInput />))
       .get('.v-otp-input input').eq(0)
       .type('1')
@@ -26,7 +26,7 @@ describe('VOtpInput', () => {
       .get('.v-otp-input input').eq(5)
       .should('be.focused')
       .type('6')
-      .should('not.be.focused')
+      .should('be.focused')
   })
 
   it('enters value and moves to next input when focused index is not next', () => {


### PR DESCRIPTION
fixes #18016
fixes #18548

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-form>
        {{ otp }}
        <v-otp-input v-model="otp" type="number"> </v-otp-input>
        <v-btn type="submit" @click="submitFn">Submit</v-btn>
      </v-form>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  let otp = ref('')
  function submitFn(e) {
    console.log('submited form!')
    e.preventDefault()
  }
</script>


```
