### PR TITLE
fix(VOtpInput): Display numeric keyboard when type is number

### DIFF
--- a/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/labs/VOtpInput/VOtpInput.tsx
@@ -250,7 +250,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                           class={[
                             'v-otp-input__field',
                           ]}
-                          inputmode="text"
+                          inputmode={ props.type === 'number' ? 'numeric' : 'text' }
                           min={ props.type === 'number' ? 0 : undefined }
                           maxlength="1"
                           placeholder={ props.placeholder }


### PR DESCRIPTION
fix #18000

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
</script>


```
