### PR TITLE
docs: fix typos

### DIFF
--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -61,7 +61,7 @@ The recommended placement of elements inside of `v-alert` is:
 
 ## Guide
 
-The `v-alert` component is a callout element designed to attack the attention of a user. Unlike [v-banner](/components/banners/), the `v-alert` component is intended to be used and re-used throughout your application. An alert's color is derived from its **type** property which corresponds to your application's contextual [theme colors](/features/theme/#custom-theme-colors) and [iconfont aliases](/features/icon-fonts/#creating-a-custom-icon-set).
+The `v-alert` component is a callout element designed to attract the attention of a user. Unlike [v-banner](/components/banners/), the `v-alert` component is intended to be used and re-used throughout your application. An alert's color is derived from its **type** property which corresponds to your application's contextual [theme colors](/features/theme/#custom-theme-colors) and [iconfont aliases](/features/icon-fonts/#creating-a-custom-icon-set).
 
 ### Props
 

--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -61,7 +61,7 @@ The recommended placement of elements inside of `v-alert` is:
 
 ## Guide
 
-The `v-alert` component is a callout element designed to attact the attention of a user. Unlike [v-banner](/components/banners/), the `v-alert` component is intended to be used and re-used throughout your application. An alert's color is derived from its **type** property which corresponds to your application's contextual [theme colors](/features/theme/#custom-theme-colors) and [iconfont aliases](/features/icon-fonts/#creating-a-custom-icon-set).
+The `v-alert` component is a callout element designed to attack the attention of a user. Unlike [v-banner](/components/banners/), the `v-alert` component is intended to be used and re-used throughout your application. An alert's color is derived from its **type** property which corresponds to your application's contextual [theme colors](/features/theme/#custom-theme-colors) and [iconfont aliases](/features/icon-fonts/#creating-a-custom-icon-set).
 
 ### Props
 

--- a/packages/docs/src/pages/en/components/buttons.md
+++ b/packages/docs/src/pages/en/components/buttons.md
@@ -185,7 +185,7 @@ In addition to [Button groups](/components/button-groups/), the `v-btn` componen
 
 <example file="v-btn/misc-group-survey" hide-invert />
 
-### Tax form comfirmation
+### Tax form confirmation
 
 This example utilizes the [v-text-field](/components/text-fields/) component to collect data from the user and the **loading** prop of `v-btn` when submitting the form.
 

--- a/packages/docs/src/pages/en/directives/mutate.md
+++ b/packages/docs/src/pages/en/directives/mutate.md
@@ -2,7 +2,7 @@
 meta:
   nav: Mutation observer
   title: Mutation observer directive
-  description: The mutation observer directive utilizes the Mutation observer API. It allows you to invoke a callback when targetted elements are updated.
+  description: The mutation observer directive utilizes the Mutation observer API. It allows you to invoke a callback when targeted elements are updated.
   keywords: mutate, vuetify mutate directive, mutation observer directive, mutation observer
 related:
   - /components/sheets/

--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -259,7 +259,7 @@ In your template, assign the return value of `defineProps` to a variable and pas
 </script>
 ```
 
-Notice that we have to explicltly use the `props` object in the template. This is because Vue automatically unwraps the values in `defineProps`.
+Notice that we have to explicitly use the `props` object in the template. This is because Vue automatically unwraps the values in `defineProps`.
 
 ```diff
 -<div>I am {{ foo }}</div>


### PR DESCRIPTION
Fix small typos in the documentation  📝 