### PR TITLE
fix(VAutocomplete): Use v-model to modify search.value instead of using onInput

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -279,10 +279,6 @@ export const VAutocomplete = genericComponent<new <
       }
     }
 
-    function onInput (e: InputEvent) {
-      search.value = (e.target as HTMLInputElement).value
-    }
-
     function onChange (e: Event) {
       if (matchesSelector(vTextFieldRef.value, ':autofill') || matchesSelector(vTextFieldRef.value, ':-webkit-autofill')) {
         const item = items.value.find(item => item.title === (e.target as HTMLInputElement).value)
@@ -397,13 +393,12 @@ export const VAutocomplete = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
-          modelValue={ search.value }
+          v-model={ search.value }
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
           counterValue={ model.value.length }
           dirty={ isDirty }
-          onInput={ onInput }
           onChange={ onChange }
           class={[
             'v-autocomplete',


### PR DESCRIPTION
fixes #18494

Root cause:
When input value becomes '', `model.value = []` is called in `onUpdateModelValue`, which triggers render function but `search.value` hasn't been updated, so its previous value is drilled into VTextField via `modelValue` and shows old value.

Therefore, use `v-model` resolves it

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete 
        placeholder='Select Item'
        v-model="selectedPerson"
        :items="people"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const people = ['John Smith', 'John Doe']

  const selectedPerson = ref(null)

  // Issue 1
  // 1. Click into the auto-complete
  // 2. Select "John Smith" (Observe that "John Smith" is added to the autocomplete selected list)
  // 3. Start using the back-space to delete. (Observe that to delete "J" the back-space needs to be pressed twice)
  // Expected behavior: "J" should have been deleted with only one back-space press

  // Issue 2
  // 1. Click into the auto-complete
  // 2. Select "John Smith" (Observe that "John Smith" is added to the autocomplete selected list)
  // 3. Select "John Smith" with your mouse or ctrl+A
  // 4. Press the back-space to delete (Observe that the option is not deleted)
  // 5. Repeat steps 3 and 4.  (Observe that the option is deleted)
  // Expected behavior: The selected option should be deleted at the first try
</script>


```
