### PR TITLE
docs: add reactions to releases

### DIFF
--- a/packages/docs/src/components/doc/Releases.vue
+++ b/packages/docs/src/components/doc/Releases.vue
@@ -59,7 +59,6 @@
         v-if="model?.author"
         class="d-flex justify-space-between"
       >
-      
         <v-list-item v-if="publishedOn" lines="two">
           <v-list-item-title class="d-flex flex-column justify-center">
             <div class="d-flex align-center">
@@ -75,7 +74,7 @@
                 </template>
               </i18n-t>
             </div>
-            
+
             <div v-if="model?.reactions?.total_count" class="mt-2">
               <v-chip
                 v-if="isAuthenticated"
@@ -100,7 +99,7 @@
                   </v-sheet>
                 </v-menu>
               </v-chip>
-              
+
               <template v-for="(value, key) in reactions" :key="key">
                 <template v-if="model?.reactions?.[key]">
                   <v-chip
@@ -284,7 +283,7 @@
     timeout = setTimeout(() => store.find(val), 500)
   }
 
-  async function react(value: string) {
+  async function react (value: string) {
     await authStore.setReaction(value, model?.value?.id)
     await store.find(search.value)
   }

--- a/packages/docs/src/store/auth.ts
+++ b/packages/docs/src/store/auth.ts
@@ -100,10 +100,37 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  let isReacting = false
+  async function setReaction (reaction: string, release: number | undefined) {
+    if (isReacting || !url || !reaction || !release || !auth?.user.value) return
+
+    const token = await auth.getAccessTokenSilently({ detailedResponse: true })
+    console.log(token)
+    isReacting = true
+
+    try {
+      await fetch(`${url}/api/user/reaction?release=${release}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token.id_token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          reaction,
+        }),
+      })
+    } catch (e) {
+      //
+    } finally {
+      isReacting = false
+    }
+  }
+
   return {
     admin,
     getUser,
     isSubscriber,
+    setReaction,
     sponsor,
     verifyUserSponsorship,
   }


### PR DESCRIPTION
## Description
Adds reactions to GH linked users on releases

## Markup:
Requires API endpoint /user/reactions with query param `release` (github release_id) and body object `{ reaction: string }`

examples `user/reactions.ts`

```ts
export const router = new Router<unknown>()

router.post('/user/reaction', verifyJwt, async ctx => {
  const post = ctx.request.body as { reaction: string }
  const release = ctx.query.release
  
  const token = ctx.state.token

  const management = new ManagementClient({
    domain: process.env.AUTH0_DOMAIN!,
    clientId: process.env.AUTH0_CLIENT_ID!,
    clientSecret: process.env.AUTH0_CLIENT_SECRET!,
  })

  const response = await management.users.get({ id: token.sub })

  const access = response.data.identities.find(identity => identity.provider === 'github')

  if (!access) return ctx.throw(403)

  const octokit = new Octokit({
    auth: access.access_token,
  })
  
  let result
  try {
    result = await octokit.request('POST /repos/{owner}/{repo}/releases/{release_id}/reactions', {
      owner: 'vuetifyjs',
      repo: 'vuetify',
      release_id: release as any,
      content: post.reaction as any,
      headers: {
        'X-GitHub-Api-Version': '2022-11-28'
      }
    })
  } catch (error: any) {
    if (error.status !== 404) throw error
    result = false
    return
  }

  ctx.body = { result }
})
```

