### PR TITLE
fix(VOtpInput): Manually deal with input number type ignores maxlength

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -97,27 +97,43 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     const inputRef = ref<HTMLInputElement[]>([])
     const current = computed(() => inputRef.value[focusIndex.value])
 
-    function onInput () {
+    function onInput (e: Event) {
       const array = model.value.slice()
-      const value = current.value.value
 
-      // Use the last character in the updated value
-      array[focusIndex.value] = value?.[1] ?? value
+      array[focusIndex.value] = (e as InputEvent).data!
+      model.value = array
 
+      moveFocus()
+    }
+
+    function moveFocus () {
       let target: any = null
 
       if (focusIndex.value > model.value.length) {
-        target = model.value.length + 1
+        target = model.value.length
       } else if (focusIndex.value + 1 !== length.value) {
         target = 'next'
       }
-
-      model.value = array
 
       if (target) focusChild(contentRef.value!, target)
     }
 
     function onKeydown (e: KeyboardEvent) {
+      // input tag with type number ignores maxlength attribute,
+      // manually prevents user type more than one digits
+      if (
+        props.type === 'number' &&
+        !isNaN(Number(e.key)) &&
+        current.value.value.length === 1 // input already has one digit
+      ) {
+        if (model.value[focusIndex.value] === e.key) {
+          e.preventDefault() // prevent trigger onInput
+          moveFocus()
+        }
+        current.value.value = e.key
+        return
+      }
+
       const array = model.value.slice()
       const index = focusIndex.value
       let target: 'next' | 'prev' | 'first' | 'last' | number | null = null


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input></v-otp-input>
    </v-container>
  </v-app>
</template>

```
