### PR TITLE
fix(VOtpInput): limit length when type=number

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -98,11 +98,16 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     const current = computed(() => inputRef.value[focusIndex.value])
 
     function onInput () {
+      // maxlength doesn't work for number type,
+      // so the input type always uses 'text' but simulates the 'number' type behavior here.
+      if (props.type === 'number' && /[^0-9]/g.test(current.value.value)) {
+        current.value.value = ''
+        return
+      }
       const array = model.value.slice()
       const value = current.value.value
 
-      // Use the last character in the updated value
-      array[focusIndex.value] = value?.[1] ?? value
+      array[focusIndex.value] = value
 
       let target: any = null
 
@@ -254,7 +259,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                           min={ props.type === 'number' ? 0 : undefined }
                           maxlength="1"
                           placeholder={ props.placeholder }
-                          type={ props.type }
+                          type={ props.type === 'number' ? 'text' : props.type }
                           value={ model.value[i] }
                           onInput={ onInput }
                           onFocus={ e => onFocus(e, i) }

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -98,8 +98,8 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     const current = computed(() => inputRef.value[focusIndex.value])
 
     function onInput () {
-      // maxlength doesn't work for number type,
-      // so the input type always uses 'text' but simulates the 'number' type behavior here.
+      // The maxlength attribute doesn't work for the number type input, so the text type is used.
+      // The following logic simulates the behavior of a number input.
       if (props.type === 'number' && /[^0-9]/g.test(current.value.value)) {
         current.value.value = ''
         return


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input />
    </v-container>
  </v-app>
</template>

```
