### PR TITLE
feat(VDataTable): add headerProps/rowProps/cellProps

### DIFF
--- a/packages/vuetify/src/labs/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableColumn.tsx
@@ -16,7 +16,7 @@ export const VDataTableColumn = defineFunctionalComponent({
   noPadding: Boolean,
   tag: String,
   width: [Number, String],
-}, (props, { slots, attrs }) => {
+}, (props, { slots }) => {
   const Tag = props.tag ?? 'td'
   return (
     <Tag
@@ -34,7 +34,6 @@ export const VDataTableColumn = defineFunctionalComponent({
         width: convertToUnit(props.width),
         left: convertToUnit(props.fixedOffset || null),
       }}
-      { ...attrs }
     >
       { slots.default?.() }
     </Tag>

--- a/packages/vuetify/src/labs/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableHeaders.tsx
@@ -137,6 +137,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           onClick={ column.sortable ? () => toggleSort(column) : undefined }
           lastFixed={ column.lastFixed }
           noPadding={ noPadding }
+          { ...column.headerProps }
         >
           {{
             default: () => {
@@ -200,11 +201,11 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           { slots.headers
             ? slots.headers(slotProps.value)
             : headers.value.map((row, y) => (
-            <tr>
-              { row.map((column, x) => (
-                <VDataTableHeaderCell column={ column } x={ x } y={ y } />
-              ))}
-            </tr>
+              <tr>
+                { row.map((column, x) => (
+                  <VDataTableHeaderCell column={ column } x={ x } y={ y } />
+                ))}
+              </tr>
             ))}
 
           { props.loading && (

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRow.tsx
@@ -81,8 +81,6 @@ export const VDataTableRow = genericComponent<VDataTableRowSlots>()({
             })
             : column.cellProps
 
-          console.log(cellProps, columnCellProps)
-
           return (
             <VDataTableColumn
               align={ column.align }

--- a/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/labs/VDataTable/VDataTableRows.tsx
@@ -16,7 +16,7 @@ import { genericComponent, getPrefixedEventHandlers, propsFactory, useRender } f
 // Types
 import type { PropType } from 'vue'
 import type { Group } from './composables/group'
-import type { DataTableItem, GroupHeaderSlot, ItemSlot } from './types'
+import type { CellProps, DataTableItem, GroupHeaderSlot, ItemSlot, RowProps } from './types'
 import type { VDataTableGroupHeaderRowSlots } from './VDataTableGroupHeaderRow'
 import type { VDataTableRowSlots } from './VDataTableRow'
 
@@ -44,6 +44,8 @@ export const makeVDataTableRowsProps = propsFactory({
     default: '$vuetify.noDataText',
   },
   rowHeight: Number,
+  rowProps: [Object, Function] as PropType<RowProps>,
+  cellProps: [Object, Function] as PropType<CellProps>,
 }, 'VDataTableRows')
 
 export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
@@ -134,8 +136,16 @@ export const VDataTableRows = genericComponent<VDataTableRowsSlots>()({
                   } : undefined,
                   index,
                   item,
+                  cellProps: props.cellProps,
                 },
-                getPrefixedEventHandlers(attrs, ':row', () => slotProps)
+                getPrefixedEventHandlers(attrs, ':row', () => slotProps),
+                typeof props.rowProps === 'function'
+                  ? props.rowProps({
+                    item: slotProps.item,
+                    index: slotProps.index,
+                    internalItem: slotProps.internalItem,
+                  })
+                  : props.rowProps,
               ),
             }
 

--- a/packages/vuetify/src/labs/VDataTable/composables/items.ts
+++ b/packages/vuetify/src/labs/VDataTable/composables/items.ts
@@ -4,7 +4,7 @@ import { getPropertyFromItem, propsFactory } from '@/util'
 
 // Types
 import type { PropType, Ref } from 'vue'
-import type { DataTableItem, InternalDataTableHeader } from '../types'
+import type { CellProps, DataTableItem, InternalDataTableHeader, RowProps } from '../types'
 import type { SelectItemKey } from '@/util'
 
 export interface DataTableItemProps {
@@ -28,6 +28,8 @@ export const makeDataTableItemsProps = propsFactory({
     type: [String, Array, Function] as PropType<SelectItemKey>,
     default: null,
   },
+  rowProps: [Object, Function] as PropType<RowProps>,
+  cellProps: [Object, Function] as PropType<CellProps>,
   returnObject: Boolean,
 }, 'DataTable-items')
 

--- a/packages/vuetify/src/labs/VDataTable/types.ts
+++ b/packages/vuetify/src/labs/VDataTable/types.ts
@@ -19,6 +19,9 @@ export type DataTableHeader = {
   minWidth?: string
   maxWidth?: string
 
+  headerProps?: Record<string, any>
+  cellProps?: HeaderCellProps
+
   sortable?: boolean
   sort?: DataTableCompareFunction
 
@@ -74,3 +77,15 @@ export type ItemKeySlot<T = any> = ItemSlotBase<T> & {
   value: any
   column: InternalDataTableHeader
 }
+
+export type RowProps =
+  | Record<string, any>
+  | ((data: Pick<ItemKeySlot, 'index' | 'item' | 'internalItem'>) => Record<string, any>)
+
+export type CellProps =
+  | Record<string, any>
+  | ((data: Pick<ItemKeySlot, 'index' | 'item' | 'internalItem' | 'value' | 'column'>) => Record<string, any>)
+
+export type HeaderCellProps =
+  | Record<string, any>
+  | ((data: Pick<ItemKeySlot, 'index' | 'item' | 'internalItem' | 'value'>) => Record<string, any>)


### PR DESCRIPTION
closes #16648
closes #16991

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :headers="headers" :items="items" :cell-props="getCellProps" />
    </v-container>
  </v-app>
</template>

<script setup>
  function getCellProps (data) {
    if (data.value > 25) {
      return { class: 'text-error' }
    }
    if (data.value < 10) {
      return { class: 'text-success' }
    }
  }

  const headers = [
    { key: 'name', title: 'Name' },
    {
      key: 'calories',
      title: 'Calories',
      headerProps: { class: 'text-h4' },
    },
    {
      key: 'fat',
      title: 'Fat',
      cellProps: ({ value }) => ({
        class: value > 10 ? 'text-warning' : 'text-purple', // classes don't override, so specificity matters
      }),
    },
    { key: 'carbs', title: 'Carbs' },
    { key: 'protein', title: 'Protein' },
    { key: 'iron', title: 'Iron' },
  ]
  const items = [
    {
      name: 'Frozen Yogurt',
      calories: 159,
      fat: 6.0,
      carbs: 24,
      protein: 4.0,
      iron: '1',
    },
    {
      name: 'Ice cream sandwich',
      calories: 237,
      fat: 9.0,
      carbs: 37,
      protein: 4.3,
      iron: '1',
    },
    {
      name: 'Eclair',
      calories: 262,
      fat: 16.0,
      carbs: 23,
      protein: 6.0,
      iron: '7',
    },
    {
      name: 'Cupcake',
      calories: 305,
      fat: 3.7,
      carbs: 67,
      protein: 4.3,
      iron: '8',
    },
    {
      name: 'Gingerbread',
      calories: 356,
      fat: 16.0,
      carbs: 49,
      protein: 3.9,
      iron: '16',
    },
    {
      name: 'Jelly bean',
      calories: 375,
      fat: 0.0,
      carbs: 94,
      protein: 0.0,
      iron: '0',
    },
    {
      name: 'Lollipop',
      calories: 392,
      fat: 0.2,
      carbs: 98,
      protein: 0,
      iron: '2',
    },
    {
      name: 'Honeycomb',
      calories: 408,
      fat: 3.2,
      carbs: 87,
      protein: 6.5,
      iron: '45',
    },
    {
      name: 'Donut',
      calories: 452,
      fat: 25.0,
      carbs: 51,
      protein: 4.9,
      iron: '22',
    },
    {
      name: 'KitKat',
      calories: 518,
      fat: 26.0,
      carbs: 65,
      protein: 7,
      iron: '6',
    },
  ]
</script>
```
