### PR TITLE
fix(locale): Fix a typo in fr locale, for dataFooter.itemsPerPageText

### DIFF
--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -19,7 +19,7 @@ export default {
     sortBy: 'Trier par',
   },
   dataFooter: {
-    itemsPerPageText: 'Élements par page :',
+    itemsPerPageText: 'Éléments par page :',
     itemsPerPageAll: 'Tous',
     nextPage: 'Page suivante',
     prevPage: 'Page précédente',


### PR DESCRIPTION
## Description
There was a typo in the fr locale, for ``dataFooter.itemsPerPageText``. Changed "Élements" to "Éléments"

## Markup:
````
export default {
  // Other keys
  dataFooter: {
    itemsPerPageText: 'Éléments par page :',
    // Other keys
  },
}
````

