### PR TITLE
fix(VAutocomplete): update:search to not emit when search has not changed

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -358,7 +358,6 @@ export const VAutocomplete = genericComponent<new <
           select(displayItems.value[0])
         }
         menu.value = false
-        search.value = ''
         selectionIndex.value = -1
       }
     })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes the issue when the `@update:search` is triggered when the search value has not changed. The `focused` watcher changing the value to an empty string which triggers the search watcher. So anytime the field is focused, it is always triggering the search watcher/emit.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card>
    <v-container fluid>
      <v-row>
        <v-col cols="12">
          <v-autocomplete
            v-model="query"
            :items="filteredItems"
            label="Default"
            clearable
            @update:search="updateSearch"
          >
            <template #selection="{ item }"> {{ item.value }} </template>
          </v-autocomplete>
        </v-col>
      </v-row>
    </v-container>
  </v-card>
</template>

<script setup>
import { ref } from 'vue';
const query = ref('');

const items = ref(['foo', 'bar', 'fizz', 'buzz', 'foobar']);
const filteredItems = ref([]);

function updateSearch(val) {
  if (val !== '' && val.length >= 2) {
    filteredItems.value = items.value.filter((item) => item.includes(val));
  }
}
</script>

```
