### PR TITLE
fix(VSpacer): import VGrid styles

### DIFF
--- a/packages/vuetify/src/components/VGrid/VSpacer.ts
+++ b/packages/vuetify/src/components/VGrid/VSpacer.ts
@@ -1,3 +1,6 @@
+// Styles
+import './VGrid.sass'
+
 // Utilities
 import { createSimpleFunctional } from '@/util'
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This Pull Request addresses an issue where VGrid.sass is not imported in the release build when only using the V-spacer component.

Problem Details:
When using the V-spacer component alone, VGrid.sass was not properly imported, causing the styles not to be applied.

Solution:
I have made adjustments to ensure that VGrid.sass is properly imported when the V-spacer component is used.

With this fix, the expected styles will be applied even when using the V-spacer component alone.

resolves #18604
resolves #18121

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
