### PR TITLE
fix(VSelect): add option role to VListItem elements

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -382,7 +382,7 @@ export const VSelect = genericComponent<new <
                             index,
                             props: itemProps,
                           }) ?? (
-                            <VListItem { ...itemProps }>
+                            <VListItem { ...itemProps } role="option">
                               {{
                                 prepend: ({ isSelected }) => (
                                   <>


### PR DESCRIPTION
# Description
This change fixes an accessibility issue where the items in a VSelect dropdown can not be navigated between by using the arrow keys when [NVDA](https://www.nvaccess.org/) is running. The VList element has a role of "listbox," and according to the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role), each child element should have a role of "option." After adding this role, the VSelect items can  be navigated between using the arrow keys while NVDA is open.

Note: You need to have NVDA running to test these changes out in the playground.


fixes #17767 
fixes #16881

## Markup:
<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select :items="items" label="Select an Item" />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
    data: () => ({
      items: ['Apple', 'Orange', 'Pineapple']
    })
  }
</script>

```
