### PR TITLE
fix(VStepper): forward prev and next functions to touch gestures

### DIFF
--- a/packages/vuetify/src/labs/VStepper/VStepperActions.tsx
+++ b/packages/vuetify/src/labs/VStepper/VStepperActions.tsx
@@ -6,6 +6,8 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvi
 import { useLocale } from '@/composables/locale'
 
 // Utilities
+import { inject } from 'vue'
+import { VStepperSymbol } from './VStepperWindow'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -54,6 +56,19 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
 
     function onClickNext () {
       emit('click:next')
+    }
+
+    const group = inject(VStepperSymbol, null)
+
+    // Overwrite prev/next methods in group in case of user defined actions
+    if (group) {
+      group.prev = () => {
+        onClickPrev()
+      }
+
+      group.next = () => {
+        onClickNext()
+      }
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VStepper/VStepperWindow.tsx
+++ b/packages/vuetify/src/labs/VStepper/VStepperWindow.tsx
@@ -54,6 +54,7 @@ export const VStepperWindow = genericComponent()({
       return (
         <VWindow
           { ...windowProps }
+          touch={{ left: () => group?.prev(), right: () => group?.next() }}
           v-model={ model.value }
           class="v-stepper-window"
           v-slots={ slots }


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
This forwards the prev and next functions to the touch gestures, currently it fails to update the header. StepperActions also had to be adjusted to make sure that user provided prev/next functions also work.

I.e.
 ```
<v-stepper-actions
  @click:prev="() => {
    console.log('prev')
    stepper--
  }"
  @click:next="() => {
    console.log('next')
    stepper++
  }"
></v-stepper-actions>
```

fixes #18605

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-stepper v-model="stepper">
        <v-stepper-header>
          <template v-for="n in [0,1]" :key="`${n}-step`">
            <v-stepper-item
              :complete="stepper > n"
              :step="`Step {{ n }}`"
              :value="n"
              editable
            ></v-stepper-item>

            <v-divider
              v-if="n !== 2"
              :key="n"
            ></v-divider>
          </template>
        </v-stepper-header>

        <v-stepper-window>
          <v-stepper-window-item
            v-for="n in 2"
            :key="`${n}-content`"
            :value="n"
          >
            <v-card
              color="grey-lighten-1"
              height="200"
            ></v-card>
          </v-stepper-window-item>
        </v-stepper-window>

        <v-stepper-actions
          @click:prev="() => {
            console.log('prev')
            if (stepper > 0) stepper--
          }"
          @click:next="() => {
            console.log('next')
            if (stepper < 2) stepper++
          }"
          test="2"
        ></v-stepper-actions>
    </v-stepper>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from 'vue';

const stepper = ref(0)
</script>

```
