### PR TITLE
fix(VBtn): prevent keyboard tab from triggering the loading button

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -199,6 +199,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
             props.style,
           ]}
           disabled={ isDisabled.value || undefined }
+          tabindex={ props.loading ? '-1' : undefined }
           href={ link.href.value }
           v-ripple={[
             !isDisabled.value && props.ripple,

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -198,9 +198,10 @@ export const VBtn = genericComponent<VBtnSlots>()({
             sizeStyles.value,
             props.style,
           ]}
+          aria-busy={ props.loading ? true : undefined }
           disabled={ isDisabled.value || undefined }
-          tabindex={ props.loading ? '-1' : undefined }
           href={ link.href.value }
+          tabindex={ props.loading ? -1 : undefined }
           v-ripple={[
             !isDisabled.value && props.ripple,
             null,


### PR DESCRIPTION
## Description
When the loading prop is true, Vbtn still lets the user select the button through the tab and register the enter event.

resolves #18524

## Markup:
```vue
<template>
  <v-card
    class="mx-auto"
    max-width="450"
    title="Strengthen your passwords"
    text="Update your weak or re-used passwords with Password Checkup. It's free and only takes a few minutes. Click the Take Checkup button to get started."
  >
    <template #actions>
      <v-btn height="48"> No Thanks </v-btn>

      <v-btn
        :loading="loading"
        class="flex-grow-1"
        height="48"
        variant="tonal"
        @click="load"
      >
        Take Checkup
      </v-btn>

    </template>
  </v-card>
</template>
```
