### PR TITLE
fix(VAutocomplete): search str doesn't remove after selection

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -325,6 +325,8 @@ export const VAutocomplete = genericComponent<new <
           value.splice(index, 1)
           model.value = value
         }
+
+        search.value = ''
       } else {
         model.value = [item]
 


### PR DESCRIPTION
## Description
Search text doesn't clear after selection in multi-select Vautocomplete.

resolves #18481 

## Markup:
```vue
<template>
  <v-autocomplete
    ref="receiverElement"
    v-model="receivers"
    :custom-filter="userFilter"
    :item-title="personName"
    :items="possibleReceivers"
    :loading="possibleReceivers.length === 0"
    chips
    multiple
    closable-chips
    label="Who"
    required
    return-object
    class="ma-4 pa-3"
    @update:search="searchInput=''"
  >
    <template #item="{ props, item }">
      <v-list-item
        :subtitle="item?.raw?.email"
        title="first_name"
        v-bind="props"
      >
        <template #title> {{ personName(item.raw) }} </template>
      </v-list-item>
    </template>
  </v-autocomplete>
</template>
```
