### PR TITLE
feat(VDataIterator): add filtered items count to slot data

### DIFF
--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.tsx
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.tsx
@@ -156,6 +156,7 @@ export const VDataIterator = genericComponent<new <T> (
       page: page.value,
       itemsPerPage: itemsPerPage.value,
       sortBy: sortBy.value,
+      itemsCount: filteredItems.value?.length,
       pageCount: pageCount.value,
       toggleSort,
       prevPage,

--- a/packages/vuetify/src/components/VDataIterator/VDataIterator.tsx
+++ b/packages/vuetify/src/components/VDataIterator/VDataIterator.tsx
@@ -52,6 +52,7 @@ type VDataIteratorSlotProps<T> = {
   isGroupOpen: ReturnType<typeof provideGroupBy>['isGroupOpen']
   toggleGroup: ReturnType<typeof provideGroupBy>['toggleGroup']
   items: readonly DataIteratorItem<T>[]
+  itemsCount: number
   groupedItems: readonly (DataIteratorItem<T> | Group<DataIteratorItem<T>>)[]
 }
 
@@ -156,7 +157,6 @@ export const VDataIterator = genericComponent<new <T> (
       page: page.value,
       itemsPerPage: itemsPerPage.value,
       sortBy: sortBy.value,
-      itemsCount: filteredItems.value?.length,
       pageCount: pageCount.value,
       toggleSort,
       prevPage,
@@ -172,6 +172,7 @@ export const VDataIterator = genericComponent<new <T> (
       isGroupOpen,
       toggleGroup,
       items: paginatedItemsWithoutGroups.value,
+      itemsCount: filteredItems.value.length,
       groupedItems: paginatedItems.value,
     }))
 


### PR DESCRIPTION
``` vue
<template>
  <v-app theme="dark">
    <v-container max-width="600">
      <v-text-field v-model="search" label="Search" />
      <v-data-iterator v-model:page="page" :items="items" :items-per-page="10" :search="search">
        <template #default="{ items }">
          <v-card
            v-for="(item, i) in items"
            :key="i"
            v-bind="item.raw"
          />
        </template>
        <template #footer="{ pageCount, itemsCount }">
          <v-pagination
            v-model="page"
            :length="pageCount"
            variant="outlined"
          />
          <pre>Total items found: {{ itemsCount }}</pre>
        </template>
      </v-data-iterator>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const search = ref(null)
  const page = ref(1)
  const items = ref(Array.from({ length: 77 }, (_, i) => ({ title: `Item #${i}` })))
</script>
```