### PR TITLE
fix(VDatePicker): don't add empty weeks to weeks array

### DIFF
--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -193,7 +193,9 @@ function getWeekArray (date: Date, locale: string) {
     currentWeek.push(adjacentDay)
   }
 
-  weeks.push(currentWeek)
+  if (currentWeek.length > 0) {
+    weeks.push(currentWeek)
+  }
 
   return weeks
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When the month ends on whichever is the last weekday of the current locale, an empty week array is added to the weeks array, which causes issues [further down the line if the week array is empty](https://github.com/KarlNilsson/vuetify/blob/aa0ca951070fd41d3451351c93fc462ba0717bc2/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx#L155)

resolves #18521 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <h2>Changing months to August 2024 didn't work before</h2>
      <v-date-picker show-week :model-value="date"> </v-date-picker>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const date = ref([new Date('2024-07-01')])
</script>

```
