### PR TITLE
fix(VDatePicker): disabled prop on datepicker non functioning

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -144,7 +144,7 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
       return props.max && adapter.isValid(date) ? date : null
     })
     const disabled = computed(() => {
-      const targets = []
+      let targets = []
 
       if (viewMode.value !== 'month') {
         targets.push(...['prev', 'next'])
@@ -165,6 +165,10 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
 
           adapter.isAfter(date, maxDate.value) && targets.push('next')
         }
+      }
+
+      if (props.disabled) {
+        targets = ['prev', 'next', 'mode', 'text']
       }
 
       return targets
@@ -279,6 +283,7 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
                       v-model={ month.value }
                       min={ minDate.value }
                       max={ maxDate.value }
+                      disabled={ props.disabled }
                     />
                   ) : viewMode.value === 'year' ? (
                     <VDatePickerYears
@@ -287,6 +292,7 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
                       v-model={ year.value }
                       min={ minDate.value }
                       max={ maxDate.value }
+                      disabled={ props.disabled }
                     />
                   ) : (
                     <VDatePickerMonth
@@ -297,6 +303,7 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
                       v-model:year={ year.value }
                       min={ minDate.value }
                       max={ maxDate.value }
+                      disabled={ props.disabled }
                     />
                   )}
                 </VFadeTransition>

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
@@ -16,6 +16,9 @@
 
 .v-date-picker-month__weekday
   font-size: .875rem
+  
+  &--disabled
+    opacity: 0.26
 
 .v-date-picker-month__days
   display: grid
@@ -37,6 +40,7 @@
 
   &--week
     font-size: var(--v-btn-size)
+
 
 .v-date-picker-month__day--adjacent
   opacity: 0.5

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -38,6 +38,7 @@ export const makeVDatePickerMonthProps = propsFactory({
   showAdjacentMonths: Boolean,
   showWeek: Boolean,
   year: [Number, String],
+  disabled: Boolean,
 }, 'VDatePickerMonth')
 
 export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
@@ -159,6 +160,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
     function isDisabled (value: unknown) {
       const date = adapter.date(value)
 
+      if (props.disabled) return true
       if (props.min && adapter.isAfter(props.min, date)) return true
       if (props.max && adapter.isAfter(date, props.max)) return true
 
@@ -216,6 +218,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
               class={[
                 'v-date-picker-month__day',
                 'v-date-picker-month__weekday',
+                { 'v-date-picker-month__weekday--disabled': props.disabled },
               ]}
             >{ weekDay }</div>
           ))}

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonths.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonths.tsx
@@ -30,6 +30,7 @@ export const makeVDatePickerMonthsProps = propsFactory({
   color: String,
   height: [String, Number],
   modelValue: Number,
+  disabled: Boolean,
 }, 'VDatePickerMonths')
 
 export const VDatePickerMonths = genericComponent<VDatePickerMonthsSlots>()({
@@ -79,6 +80,7 @@ export const VDatePickerMonths = genericComponent<VDatePickerMonthsSlots>()({
               text: month.text,
               variant: model.value === month.value ? 'flat' : 'text',
               onClick: () => onClick(i),
+              disabled: props.disabled,
             } as const
 
             function onClick (i: number) {

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerYears.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerYears.tsx
@@ -40,6 +40,7 @@ export const makeVDatePickerYearsProps = propsFactory({
   min: null as any as PropType<unknown>,
   max: null as any as PropType<unknown>,
   modelValue: Number,
+  disabled: Boolean,
 }, 'VDatePickerYears')
 
 export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
@@ -110,6 +111,7 @@ export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
               text: year.text,
               variant: model.value === year.value ? 'flat' : 'text',
               onClick: () => model.value = year.value,
+              disabled: props.disabled,
             } as const
 
             return slots.year?.({


### PR DESCRIPTION
## Description
On passing "Disabled" prop v-date-picker still allows date selection. This PR fixes that.

resolved #18650 

## Markup:

```vue
<template>
  <v-container>
    <v-row justify="space-around">
      <v-date-picker disabled />
      <v-date-picker disabled view-mode="months" />
      <v-date-picker disabled view-mode="year" />
    </v-row>
  </v-container>
</template>
```

## Fix Preview
<img width="1358" alt="Screenshot 2023-11-11 at 1 58 42 PM" src="https://github.com/vuetifyjs/vuetify/assets/47316464/4da4bbeb-f826-4cc8-8574-46b311aa5331">
