### PR TITLE
docs(VDataTable): adjust item key slot for v-data-table to make eslint happy

### DIFF
--- a/packages/docs/src/examples/v-data-table/slot-item-key.vue
+++ b/packages/docs/src/examples/v-data-table/slot-item-key.vue
@@ -3,7 +3,7 @@
     :headers="headers"
     :items="vegetables"
   >
-    <template v-slot:item.calories="{ value }">
+    <template v-slot:[`item.calories`]="{ value }">
       <v-chip :color="getColor(value)">
         {{ value }}
       </v-chip>


### PR DESCRIPTION
## Description

Editing documentation for item-key-slot for dynamic datatables.
Eslint will show an error. Editing the syntax to dynamic arguments: https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments will solve the issue without having to modify eslint like described here: https://stackoverflow.com/questions/61344980/v-slot-directive-doesnt-support-any-modifier

## Markup:

Use the code from the documentation: https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/examples/v-data-table/slot-item-key.vue
