### PR TITLE
docs: fix data-table guide links

### DIFF
--- a/packages/docs/src/pages/en/components/data-tables/introduction.md
+++ b/packages/docs/src/pages/en/components/data-tables/introduction.md
@@ -46,8 +46,7 @@ Before diving into the guides and examples, let's take a moment to understand th
 
 Explore data table pages that provide detailed explanations and code samples for various functionalities and use cases.
 
-| Guide                                                     | Description                                                |
-|-----------------------------------------------------------|------------------------------------------------------------|
-| [Basics](/guides/data-tables/basics/)                     | Understand the fundamental building blocks of Data Tables. |
-| [Data and Display](/guides/data-tables/data-and-display/) | Learn how to manipulate and display data effectively.      |
-| [Structure](/guides/data-tables/structure/)               | Dive into the inner workings and structure of Data Tables. |
+| Guide                                                         | Description                                                |
+|---------------------------------------------------------------|------------------------------------------------------------|
+| [Basics](/components/data-tables/basics/)                     | Understand the fundamental building blocks of Data Tables. |
+| [Data and Display](/components/data-tables/data-and-display/) | Learn how to manipulate and display data effectively.      |


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
The table was incorrect and had links that did not work. This PR fixes that
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
