### PR TITLE
docs: fix typo in v-list-item active prop description

### DIFF
--- a/packages/api-generator/src/locale/en/VListItem.json
+++ b/packages/api-generator/src/locale/en/VListItem.json
@@ -1,6 +1,6 @@
 {
   "props": {
-    "active": "Controls the **active** state of the item. This is typically used to highlight the component,",
+    "active": "Controls the **active** state of the item. This is typically used to highlight the component.",
     "color": "Applies specified color to the control when in an **active** state or **input-value** is **true** - supports utility colors (for example `success` or `purple`) or css color (for example `success` or `purple`) or css color (`#033` or `rgba(255, 0, 0, 0.5)`). Find a list of built-in classes on the [colors page](/styles/colors#material-colors),",
     "contained": "Changes the component style by changing how color is applied to the background.",
     "title": "Generates a `v-list-item-title` component with the supplied value. Note that this overrides the native [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) attribute, that must be set with `v-bind:title.attr` instead.",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

Fix typo in https://vuetifyjs.com/en/api/v-list-item/#props-active.
Currently:
```
Controls the active state of the item. This is typically used to highlight the component,
```

Expected:
```
Controls the active state of the item. This is typically used to highlight the component.
```

This is my first PR for Vuetify, hoping I follow the contributing correctly. Thank you.🙏

<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
None
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
