### PR TITLE
fix(VTextField): hide v-input__details for underlined variant

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.sass
+++ b/packages/vuetify/src/components/VInput/VInput.sass
@@ -103,8 +103,6 @@
       -moz-appearance: textfield
 
   &--plain-underlined
-    .v-input__details
-      padding: 0
 
     .v-input__prepend,
     .v-input__append

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -31,6 +31,8 @@
 
   .v-input__details
     padding-inline: $text-field-details-padding-inline
+    @at-root #{selector.append('.v-input--plain-underlined', &)}
+      padding-inline: 0
 
   .v-field--no-label,
   .v-field--active


### PR DESCRIPTION
fixes #18671

Probably it's similar to [comment](https://github.com/vuetifyjs/vuetify/pull/18025#discussion_r1365007826) regarding where is the right place for this logic.

VInput by default doesn't have padding for hint, while VTextField is the one that defines `$text-field-details-padding-inline`. So whether to show/hide hint should be moved to VTextField and keep VInput intact.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-form>
    <v-container>
      <v-row>
        <v-col cols="12" sm="6">
          <v-text-field
            label="Your product or service"
            model-value="Grocery delivery"
            hint="For example, flowers or used cars"
          ></v-text-field>
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field
            label="Your landing page"
            hint="www.example.com/page"
            persistent-hint
          ></v-text-field>
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field
            label="Your product or service"
            model-value="Grocery delivery"
            hint="For example, flowers or used cars"
            variant="solo"
          ></v-text-field>
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field
            label="Your landing page"
            hint="www.example.com/page"
            persistent-hint
            variant="solo"
          ></v-text-field>
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field
            label="Your product or service"
            model-value="Grocery delivery"
            hint="For example, flowers or used cars"
            variant="outlined"
          ></v-text-field>
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field
            label="Your landing page"
            hint="www.example.com/page"
            persistent-hint
            variant="outlined"
          ></v-text-field>
        </v-col>
        <v-col cols="12" sm="6">
          <v-text-field
            label="Your product or service"
            model-value="Grocery delivery"
            hint="For example, flowers or used cars"
            variant="underlined"
          ></v-text-field>
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field
            label="Your landing page"
            hint="www.example.com/page"
            persistent-hint
            variant="underlined"
          ></v-text-field>
        </v-col>
      </v-row>
    </v-container>
  </v-form>
</template>


```
