### PR TITLE
fix(VDataTable): sort with extracted column values

### DIFF
--- a/packages/vuetify/src/components/VDataTable/__tests__/sort.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/sort.spec.ts
@@ -93,6 +93,21 @@ describe('VDataTable - sorting', () => {
     ).toStrictEqual([{ foo: { bar: { baz: 1 } } }, { foo: { bar: { baz: 2 } } }, { foo: { bar: { baz: 3 } } }])
   })
 
+  it('should sort items with value function in column', () => {
+    const items = transformItems({} as any, [
+      { foo: { bar: { baz: 3 } } },
+      { foo: { bar: { baz: 1 } } },
+      { foo: { bar: { baz: 2 } } },
+    ], [
+      { key: 'foobarbaz', value: v => v.foo.bar.baz, sortable: true },
+    ])
+
+    expect(
+      sortItems(items, [{ key: 'foobarbaz', order: 'asc' }], 'en')
+        .map(i => i.raw)
+    ).toStrictEqual([{ foo: { bar: { baz: 1 } } }, { foo: { bar: { baz: 2 } } }, { foo: { bar: { baz: 3 } } }])
+  })
+
   it('should sort items by multiple columns', () => {
     const items = transformItems({} as any, [
       { string: 'foo', number: 1 },

--- a/packages/vuetify/src/components/VDataTable/__tests__/sort.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/sort.spec.ts
@@ -1,6 +1,6 @@
 // Composables
+import { transformItems } from '../composables/items'
 import { sortItems } from '../composables/sort'
-import { transformItems } from '@/composables/list-items'
 
 // Utilities
 import { describe, expect, it } from '@jest/globals'
@@ -12,6 +12,9 @@ describe('VDataTable - sorting', () => {
       { string: 'bar', number: 2 },
       { string: 'baz', number: 4 },
       { string: 'fizzbuzz', number: 3 },
+    ], [
+      { key: 'string', value: 'string', sortable: true },
+      { key: 'number', value: 'number', sortable: true },
     ])
 
     expect(
@@ -76,7 +79,13 @@ describe('VDataTable - sorting', () => {
   })
 
   it('should sort items with deep structure', () => {
-    const items = transformItems({} as any, [{ foo: { bar: { baz: 3 } } }, { foo: { bar: { baz: 1 } } }, { foo: { bar: { baz: 2 } } }])
+    const items = transformItems({} as any, [
+      { foo: { bar: { baz: 3 } } },
+      { foo: { bar: { baz: 1 } } },
+      { foo: { bar: { baz: 2 } } },
+    ], [
+      { key: 'foo.bar.baz', value: 'foo.bar.baz', sortable: true },
+    ])
 
     expect(
       sortItems(items, [{ key: 'foo.bar.baz', order: 'asc' }], 'en')
@@ -90,6 +99,9 @@ describe('VDataTable - sorting', () => {
       { string: 'bar', number: 3 },
       { string: 'baz', number: 2 },
       { string: 'baz', number: 1 },
+    ], [
+      { key: 'string', value: 'string', sortable: true },
+      { key: 'number', value: 'number', sortable: true },
     ])
 
     expect(
@@ -212,6 +224,9 @@ describe('VDataTable - sorting', () => {
       { string: 'foobar', number: 5 },
       { string: 'barbaz', number: undefined },
       { string: 'foobarbuzz', number: '' },
+    ], [
+      { key: 'string', value: 'string', sortable: true },
+      { key: 'number', value: 'number', sortable: true },
     ])
 
     expect(

--- a/packages/vuetify/src/components/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/sort.ts
@@ -128,8 +128,10 @@ export function sortItems<T, I extends DataTableItem<T>|DataIteratorItem<T>> (
 
       if (sortOrder === false) continue
 
-      let sortA = getObjectValueByPath(a.raw, sortKey)
-      let sortB = getObjectValueByPath(b.raw, sortKey)
+      // @ts-expect-error Property 'columns' does not exist on type 'DataIteratorItem<T>'
+      let sortA = getObjectValueByPath(a.columns ?? a.raw, sortKey)
+      // @ts-expect-error Property 'columns' does not exist on type 'DataIteratorItem<T>'
+      let sortB = getObjectValueByPath(b.columns ?? b.raw, sortKey)
 
       if (sortOrder === 'desc') {
         [sortA, sortB] = [sortB, sortA]

--- a/packages/vuetify/src/components/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/sort.ts
@@ -8,7 +8,8 @@ import { getObjectValueByPath, isEmpty, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
-import type { DataTableCompareFunction, InternalDataTableHeader } from '../types'
+import type { DataTableCompareFunction, DataTableItem, InternalDataTableHeader } from '../types'
+import type { DataIteratorItem } from '@/components/VDataIterator/composables/items'
 
 export const makeDataTableSortProps = propsFactory({
   sortBy: {
@@ -93,9 +94,9 @@ export function useSort () {
   return data
 }
 
-export function useSortedItems <T extends Record<string, any>> (
+export function useSortedItems <T, I extends DataTableItem<T>|DataIteratorItem<T>> (
   props: { customKeySort: Record<string, DataTableCompareFunction> | undefined },
-  items: Ref<T[]>,
+  items: Ref<I[]>,
   sortBy: Ref<readonly SortItem[]>,
   sortFunctions?: Ref<Record<string, DataTableCompareFunction> | undefined>,
 ) {
@@ -112,12 +113,12 @@ export function useSortedItems <T extends Record<string, any>> (
   return { sortedItems }
 }
 
-export function sortItems<T extends Record<string, any>> (
-  items: T[],
+export function sortItems<T, I extends DataTableItem<T>|DataIteratorItem<T>> (
+  items: I[],
   sortByItems: readonly SortItem[],
   locale: string,
   customSorters?: Record<string, DataTableCompareFunction>
-): T[] {
+): I[] {
   const stringCollator = new Intl.Collator(locale, { sensitivity: 'accent', usage: 'sort' })
 
   return [...items].sort((a, b) => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix sorting when using functions as value in column definition by using parsed columns in DataTableItem.
To be compatible with VDataIterator which shares the useSortedItems composable, old `.raw` behavior is preserved if there is no `.columns`.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :items="items" :headers="headers" />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        items: [
          { string: 'foo' },
          { string: 'bar' },
        ],
        headers: [
          { key: 'foobar', title: 'String', value: v => v.string },
        ],
      }
    },
  }
</script>
```
