### PR TITLE
chore: fix commit template with commit.cleanup=scissors

### DIFF
--- a/.github/.git_commit_msg.txt
+++ b/.github/.git_commit_msg.txt
@@ -1,4 +1,5 @@
 
+# ------------------------ >8 ------------------------
 # |<----   Using a Maximum Of 50 Characters   ---->| Hard limit to 72 -->|
 # <type>: <subject>
 #


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When configured with `commit.cleanup=scissors`, git uses `# ------------------------ >8 ------------------------` as seperator between commit message and comments, instead of treating lines starting with `#` as comments.
This fixes the template with `commit.cleanup=scissors` setup.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
N/A
