### PR TITLE
fix(VDataTable): improve headers value function typing

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -24,9 +24,9 @@ import { computed, toRef } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
-import type { UnwrapRef } from 'vue'
+import type { DeepReadonly, UnwrapRef } from 'vue'
 import type { Group } from './composables/group'
-import type { CellProps, DataTableItem, InternalDataTableHeader, RowProps } from './types'
+import type { CellProps, DataTableHeader, DataTableItem, InternalDataTableHeader, RowProps } from './types'
 import type { VDataTableHeadersSlots } from './VDataTableHeaders'
 import type { VDataTableRowsSlots } from './VDataTableRows'
 import type { GenericProps, SelectItemKey } from '@/util'
@@ -101,6 +101,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     rowProps?: RowProps<ItemType<T>>
     cellProps?: CellProps<ItemType<T>>
     itemSelectable?: SelectItemKey<ItemType<T>>
+    headers?: DeepReadonly<DataTableHeader<ItemType<T>>[]>
     modelValue?: V
     'onUpdate:modelValue'?: (value: V) => void
   },

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -7,9 +7,9 @@ import type { SelectItemKey } from '@/util'
 
 export type DataTableCompareFunction<T = any> = (a: T, b: T) => number
 
-export type DataTableHeader = {
+export type DataTableHeader<T = Record<string, any>> = {
   key?: 'data-table-group' | 'data-table-select' | 'data-table-expand' | (string & {})
-  value?: SelectItemKey
+  value?: SelectItemKey<T>
   title?: string
 
   fixed?: boolean
@@ -26,7 +26,7 @@ export type DataTableHeader = {
   sort?: DataTableCompareFunction
   filter?: FilterFunction
 
-  children?: DataTableHeader[]
+  children?: DataTableHeader<T>[]
 }
 
 export type InternalDataTableHeader = Omit<DataTableHeader, 'key' | 'value' | 'children'> & {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Improve typing on value functions with generics.

With markup below, before:
```
    Types of property 'value' are incompatible.
      Type '(v: Data) => string' is not assignable to type 'SelectItemKey'.
        Type '(v: Data) => string' is not assignable to type '(item: Record<string, any>, fallback?: any) => any'.
          Types of parameters 'v' and 'item' are incompatible.
            Property 'string' is missing in type 'Record<string, any>' but required in type 'Data'.

4       <v-data-table :items="items" :headers="headers" />
```
after: passes typecheck.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table :items="items" :headers="headers" />
    </v-container>
  </v-app>
</template>

<script lang="ts">
  interface Data {
    string: string
  }

  export default {
    name: 'Playground',
    setup () {
      return {
        items: [
          { string: 'foo' },
          { string: 'bar' },
        ] as Data[],
        headers: [
          { key: 'foobar', title: 'String', value: (v: Data) => v.string },
        ],
      }
    },
  }
</script>

```
