### PR TITLE
docs(VStepper): correctly use disabled prop in example

### DIFF
--- a/packages/docs/src/examples/v-stepper/misc-dynamic.vue
+++ b/packages/docs/src/examples/v-stepper/misc-dynamic.vue
@@ -42,7 +42,7 @@
         </v-stepper-window>
 
         <v-stepper-actions
-          :disable="disable"
+          :disabled="disabled"
           @click:prev="prev"
           @click:next="next"
         ></v-stepper-actions>
@@ -57,7 +57,7 @@
   const e1 = ref(1)
   const steps = ref(2)
 
-  const disable = computed(() => {
+  const disabled = computed(() => {
     return e1.value === 1 ? 'prev' : e1.value === steps.value ? 'next' : undefined
   })
 </script>
@@ -72,7 +72,7 @@
     },
 
     computed: {
-      disable () {
+      disabled () {
         return this.e1 === 1 ? 'prev' : this.e1 === this.steps ? 'next' : undefined
       },
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
The correct props is `disabled` instead of `disable` (see [documentation](https://vuetifyjs.com/en/api/v-stepper-actions/#props-disabled))

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
