### PR TITLE
fix(VListItem): subtitle wrong font

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -180,7 +180,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
     useRender(() => {
       const Tag = isLink.value ? 'a' : props.tag
       const hasTitle = (slots.title || props.title)
-      const hasSubtitle = (slots.subtitle || props.subtitle)
+      const hasSubtitle = (slots.subtitle || props.subtitle !== undefined)
       const hasAppendMedia = !!(props.appendAvatar || props.appendIcon)
       const hasAppend = !!(hasAppendMedia || slots.append)
       const hasPrependMedia = !!(props.prependAvatar || props.prependIcon)


### PR DESCRIPTION
fixes #18719

## Description
Changed prop condition ```(props.subtitle)``` to ```(props.subtitle !== undefined)```, as subtitle can be a number (```subtitle: [String, Number, Boolean]```), and for this reason, if subtitle was ```0``` (not a string), there was a bug.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
Code from the issue, now working fine:

```vue
<template>
  <v-app>
    <v-container>
      <v-list>
        <v-list-item title="Subtitle is zero" :subtitle="0"></v-list-item>
        <v-list-item title="Subtitle is one" :subtitle="1"></v-list-item>
      </v-list>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>

```
