### PR TITLE
fix(VCombobox): fix v-combobox deleting both values when a duplicate is entered

### DIFF
--- a/packages/docs/src/pages/en/components/date-pickers.md
+++ b/packages/docs/src/pages/en/components/date-pickers.md
@@ -124,7 +124,7 @@ By default days from previous and next months are not visible. They can be displ
 
 #### Colors
 
-Date picker colors can be set using the **color** and **header-color** props. If **header-color** prop is not provided header will use the **color** prop value.
+Date picker colors can be set using the **color** props.
 
 <example file="v-date-picker/prop-colors" />
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -341,7 +341,7 @@ export const VCombobox = genericComponent<new <
         vTextFieldRef.value?.focus()
       }
     }
-    function select(item: ListItem, enterKey: Boolean = false) {
+    function select (item: ListItem, enterKey: Boolean = false) {
       if (props.multiple) {
         const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -277,7 +277,6 @@ export const VCombobox = genericComponent<new <
         if (highlightFirst.value && ['Enter', 'Tab'].includes(e.key)) {
           select(filteredItems.value[0])
         }
-
         isPristine.value = true
       }
 
@@ -332,7 +331,7 @@ export const VCombobox = genericComponent<new <
       }
 
       if (e.key === 'Enter' && search.value) {
-        select(transformItem(props, search.value))
+        select(transformItem(props, search.value), true)
         search.value = ''
       }
     }
@@ -342,7 +341,7 @@ export const VCombobox = genericComponent<new <
         vTextFieldRef.value?.focus()
       }
     }
-    function select (item: ListItem) {
+    function select(item: ListItem, enterKey: Boolean = false) {
       if (props.multiple) {
         const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
 
@@ -350,7 +349,9 @@ export const VCombobox = genericComponent<new <
           model.value = [...model.value, item]
         } else {
           const value = [...model.value]
-          value.splice(index, 1)
+          if (!enterKey) {
+            value.splice(index, 1)
+          }
           model.value = value
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Add a boolean to the "select" method to prevent the deletion of items when called by enter key. Fixes bug where duplicate value entered in v-combobox component would delete both.

fixes #16100 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-combobox
        v-model="values"
        :items="items"
        multiple
        chips
        variant="outlined"
        lable="Enter your value"
        closable-chips
      />
    </v-container>
  </v-app>
</template>

<script>
import { ref } from "vue";
export default {
  name: "Playground",
  setup() {
    const items = [
      "California",
      "Colorado",
      "Florida",
      "Georgia",
      "Texas",
      "Wyoming",
    ];
    const values = ref(["Colorado"]);
    return {
      items,
      values,
    };
  },
};
</script>

```
