### PR TITLE
fix/18679(VDataTable): too many nest headers breaks design

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/headers.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/headers.ts
@@ -179,7 +179,7 @@ function parse (items: InternalDataTableHeader[], maxDepth: number) {
       if (item.children) {
         for (const child of item.children) {
           // This internally sorts items that are on the same priority "row"
-          const sort = priority % 1 + (fraction / Math.pow(10, currentDepth + 1))
+          const sort = priority % 1 + (fraction / Math.pow(10, currentDepth + 2))
           queue.enqueue(child, currentDepth + diff + sort)
         }
       }


### PR DESCRIPTION
fixes #18679

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

fixes https://github.com/vuetifyjs/vuetify/issues/18679


## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table
        :headers="headers"
        :items="items"
        item-key="name"
        items-per-page="5"
      ></v-data-table>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
const headers = [
  { title: "Pyramid", value: "name" },
  { title: "Location", value: "location" },
  { title: "Construction Date", value: "constructionDate" },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "Height (m)", value: "height" },
      { title: "Base (m)", value: "base" },
      { title: "Volume (m³)", value: "volume" },
    ],
  },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "Height (m)", value: "height" },
      { title: "Base (m)", value: "base" },
      { title: "Volume (m³)", value: "volume" },
    ],
  },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "Height (m)", value: "height" },
      { title: "Base (m)", value: "base" },
      { title: "Volume (m³)", value: "volume" },
    ],
  },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "Height (m)", value: "height" },
      { title: "Base (m)", value: "base" },
      { title: "Volume (m³)", value: "volume" },
    ],
  },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "Height (m)", value: "height" },
      { title: "Base (m)", value: "base" },
      { title: "Volume (m³)", value: "volume" },
    ],
  },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "Height (m)", value: "height" },
      { title: "Base (m)", value: "base" },
      { title: "Volume (m³)", value: "volume" },
    ],
  },
  {
    title: "Dimensions",
    align: "center",
    children: [
      { title: "problem Height (m)", value: "height" },
      { title: "problem Base (m)", value: "base" },
      { title: "problem Volume (m³)", value: "volume" },
    ],
  },
];

const items = [
  {
    name: "Great Pyramid of Giza",
    location: "Egypt",
    height: "146.6",
    base: "230.4",
    volume: "2583285",
    constructionDate: "c. 2580–2560 BC",
  },
  {
    name: "Pyramid of Khafre",
    location: "Egypt",
    height: "136.4",
    base: "215.3",
    volume: "1477485",
    constructionDate: "c. 2570 BC",
  },
  {
    name: "Red Pyramid",
    location: "Egypt",
    height: "104",
    base: "220",
    volume: "1602895",
    constructionDate: "c. 2590 BC",
  },
  {
    name: "Bent Pyramid",
    location: "Egypt",
    height: "101.1",
    base: "188.6",
    volume: "1200690",
    constructionDate: "c. 2600 BC",
  },
  {
    name: "Pyramid of the Sun",
    location: "Mexico",
    height: "65",
    base: "225",
    volume: "1237097",
    constructionDate: "c. 200 CE",
  },
];
</script>

```
