### PR TITLE
docs(theme): fixes wrong type import statements in code examples

### DIFF
--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -95,7 +95,7 @@ When using Typescript you may use the `ThemeDefinition` type to get type hints f
 
 ```ts { resource="src/plugins/vuetify.ts" }
 import { createApp } from 'vue'
-import { createVuetify, ThemeDefinition } from 'vuetify'
+import { createVuetify, type ThemeDefinition } from 'vuetify'
 
 const myCustomLightTheme: ThemeDefinition = {
   dark: false,

--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -48,7 +48,7 @@ This makes it possible for Vuetify to implement Material Design concepts such as
 
 ```js { resource="src/plugins/vuetify.js" }
 import { createApp } from 'vue'
-import { createVuetify, ThemeDefinition } from 'vuetify'
+import { createVuetify } from 'vuetify'
 
 const myCustomLightTheme = {
   dark: false,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
The [Theme section](https://vuetifyjs.com/en/features/theme/) of the docs has two code examples that show wrong import statements of a type definition.

One is in the [TypeScript example](https://vuetifyjs.com/en/features/theme/#typescript) where the `type` keyword is missing.

The other one is in the [JavaScript example](https://vuetifyjs.com/en/features/theme/#javascript) where it shouldn't even be.

This PR fixes both.
