### PR TITLE
docs: replace deprecated config for vitest@0.34.0

### DIFF
--- a/packages/docs/src/pages/en/getting-started/unit-testing.md
+++ b/packages/docs/src/pages/en/getting-started/unit-testing.md
@@ -35,8 +35,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    deps: {
-      inline: ['vuetify'],
+    server: {
+      deps: {
+        inline: ['vuetify'],
+      },
     },
   },
 })


### PR DESCRIPTION
This PR fixes https://github.com/vuetifyjs/vuetify/issues/18396

## Description
The vitest config has changed with `vitest@0.34.0`.
`test.deps` has been deprecated and is supposed to be replaced with `test.server.deps`.
Check out these release notes: https://github.com/vitest-dev/vitest/releases/tag/v0.34.0

We now have to pass in the `deps` with `server.deps`, otherwise there is a deprecation warning printed.