### PR TITLE
fix(VDatePicker): issue on emited update:month and update:year fixed

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -25,7 +25,6 @@ import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/
 import type { PropType } from 'vue'
 import type { VPickerSlots } from '@/labs/VPicker/VPicker'
 import type { GenericProps } from '@/util'
-
 // Types
 export type VDatePickerSlots = Omit<VPickerSlots, 'header'> & {
   header: {
@@ -179,11 +178,7 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
       } else {
         year.value++
         month.value = 0
-
-        emit('update:year', year.value)
       }
-
-      emit('update:month', month.value)
     }
 
     function onClickPrev () {
@@ -192,11 +187,7 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
       } else {
         year.value--
         month.value = 11
-
-        emit('update:year', year.value)
       }
-
-      emit('update:month', month.value)
     }
 
     function onClickMonth () {
@@ -209,10 +200,14 @@ export const VDatePicker = genericComponent<new <T, Multiple extends boolean = f
 
     watch(month, () => {
       if (viewMode.value === 'months') onClickMonth()
+
+      emit('update:month', month.value)
     })
 
     watch(year, () => {
       if (viewMode.value === 'year') onClickYear()
+
+      emit('update:year', year.value)
     })
 
     watch(model, (val, oldVal) => {

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -25,6 +25,7 @@ import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/
 import type { PropType } from 'vue'
 import type { VPickerSlots } from '@/labs/VPicker/VPicker'
 import type { GenericProps } from '@/util'
+
 // Types
 export type VDatePickerSlots = Omit<VPickerSlots, 'header'> & {
   header: {


### PR DESCRIPTION
fixes: #18747 

## Description
I have moved the emit calls for `update:month` and `update:year` into the watch scope. This ensures that these events are only triggered when the corresponding values change, preventing unnecessary updates and improving overall performance.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

<script setup>
const updateMonth = month => {
  console.log('>> month', month)
}
const updateYear = year => {
  console.log('>> year', year)
}
const updateModel = model => {
  console.log('>> model', model)
}
</script>
<template>
  <v-app>
    <v-container>
      <v-date-picker
        @update:month="updateMonth"
        @update:year="updateYear"
        @update:model-value="updateModel"
      ></v-date-picker>
    </v-container>
  </v-app>
</template>


```
