### PR TITLE
docs:(introduction.md): update reference component

### DIFF
--- a/packages/docs/src/pages/en/labs/introduction.md
+++ b/packages/docs/src/pages/en/labs/introduction.md
@@ -30,15 +30,15 @@ Components available through Labs are considered **NOT** production ready and on
 
 ## Usage
 
-Using a Labs component is as simple as importing from `vuetify/labs`. The following example shows how to import and bootstrap `v-data-table` in your component:
+Using a Labs component is as simple as importing from `vuetify/labs`. The following example shows how to import and bootstrap `v-picker` in your component:
 
 ```html
 <template>
-  <v-data-table />
+  <v-picker />
 </template>
 
 <script setup>
-  import { VDataTable } from 'vuetify/labs/VDataTable'
+  import { VPicker } from 'vuetify/labs/VPicker'
 </script>
 ```
 
@@ -46,16 +46,16 @@ Alternatively you can make the component available globally by importing it in y
 
 ```js { resource="src/plugins/vuetify.js" }
 import { createVuetify } from 'vuetify'
-import { VDataTable } from 'vuetify/labs/VDataTable'
+import { VPicker } from 'vuetify/labs/VPicker'
 
 export default createVuetify({
   components: {
-    VDataTable,
+    VPicker,
   },
 })
 ```
 
-When Vuetify instantiates it will register `VDataTable` as a usable component within templates.
+When Vuetify instantiates it will register `VPicker` as a usable component within templates.
 
 If you wish to install all available Vuetify components use the following code snippet:
 


### PR DESCRIPTION
VDatatable doesn't need to be imported separately in 3.4.3, in fact it gives an error when trying to import it from labs (File not found)

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
