### PR TITLE
types: vue types utilities

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -79,7 +79,7 @@ export const VCarousel = genericComponent<new <T>(
   setup (props, { slots }) {
     const model = useProxiedModel(props, 'modelValue')
     const { t } = useLocale()
-    const windowRef = ref<typeof VWindow>()
+    const windowRef = ref<InstanceType<typeof VWindow>>()
 
     let slideTimeout = -1
     watch(model, restartTimeout)

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -222,7 +222,7 @@ type DefineComponentWithSlots<Slots extends RawSlots> = <
     Options
   >
 ) => DefineComponentFromOptions<
-  (undefined extends Props ? {} : Props) & SlotsToProps<Slots>,
+  ExtractPropTypes<(undefined extends Props ? {} : Props)> & SlotsToProps<Slots>,
   RawBindings,
   D,
   C,

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -176,7 +176,7 @@ type DefineComponentWithGenericProps<T extends (new (props: Record<string, any>,
     Options
   >
 ) => DefineComponentFromOptions<
-  undefined extends Props ? {} : Props,
+  LooseOptional<ExtractPropTypes<(undefined extends Props ? {} : Omit<Props, keyof InstanceType<T>['$props']>)>>,
   RawBindings,
   D,
   C,
@@ -222,7 +222,7 @@ type DefineComponentWithSlots<Slots extends RawSlots> = <
     Options
   >
 ) => DefineComponentFromOptions<
-  ExtractPropTypes<(undefined extends Props ? {} : Props)> & SlotsToProps<Slots>,
+  LooseOptional<ExtractPropTypes<(undefined extends Props ? {} : Props)>> & SlotsToProps<Slots>,
   RawBindings,
   D,
   C,

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -30,83 +30,38 @@ import type {
   VNodeChild,
 } from 'vue'
 
-// // No props
-// export function defineComponent<
-//   Props = {},
-//   RawBindings = {},
-//   D = {},
-//   C extends ComputedOptions = {},
-//   M extends MethodOptions = {},
-//   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-//   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-//   E extends EmitsOptions = {},
-//   EE extends string = string,
-//   I extends {} = {},
-//   II extends string = string,
-//   S extends SlotsType = {},
-// >(
-//   options: ComponentOptionsWithoutProps<
-//     Props,
-//     RawBindings,
-//     D,
-//     C,
-//     M,
-//     Mixin,
-//     Extends,
-//     E,
-//     EE,
-//     I,
-//     II,
-//     S
-//   >
-// ): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
-
-// // Object Props
-// export function defineComponent<
-//   PropsOptions extends Readonly<ComponentPropsOptions>,
-//   RawBindings,
-//   D,
-//   C extends ComputedOptions = {},
-//   M extends MethodOptions = {},
-//   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-//   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-//   E extends EmitsOptions = {},
-//   EE extends string = string,
-//   I extends {} = {},
-//   II extends string = string,
-//   S extends SlotsType = {},
-// >(
-//   options: ComponentOptionsWithObjectProps<
-//     PropsOptions,
-//     RawBindings,
-//     D,
-//     C,
-//     M,
-//     Mixin,
-//     Extends,
-//     E,
-//     EE,
-//     I,
-//     II,
-//     S
-//   >
-// ): DefineComponent<PropsOptions, RawBindings, D, C, M0, Mixin, Extends, E, EE> & FilterPropsOptions<PropsOptions>
-
 export function defineComponent<
-Props = undefined,
-RawBindings = {},
-D = {},
-C extends ComputedOptions = {},
-M extends MethodOptions = {},
-Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-E extends EmitsOptions = {},
-EE extends string = string,
-I extends ComponentInjectOptions = {},
-II extends string = string,
-S extends SlotsType = {},
-Options extends Record<PropertyKey, any> = {}>(options: DefineComponentOptions<
-  Props,
+  Props = undefined,
+  RawBindings = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = {},
+  EE extends string = string,
+  I extends ComponentInjectOptions = {},
+  II extends string = string,
+  S extends SlotsType = {},
+  Options extends Record<PropertyKey, any> = {}
+>(
+  options: DefineComponentOptions<
+    Props,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    I,
+    II,
+    S,
+    Options
+  >
+): DefineComponentFromOptions<
+  undefined extends Props ? {} : Props,
   RawBindings,
   D,
   C,
@@ -119,20 +74,6 @@ Options extends Record<PropertyKey, any> = {}>(options: DefineComponentOptions<
   II,
   S,
   Options
->): DefineComponentFromOptions<
-undefined extends Props ? {} : Props,
-RawBindings,
-D,
-C,
-M,
-Mixin,
-Extends,
-E,
-EE,
-I,
-II,
-S,
-Options
 > & (Props extends Readonly<ComponentPropsOptions> ? FilterPropsOptions<Props> : {})
 
 // Implementation
@@ -203,23 +144,39 @@ export type GenericProps<Props, Slots extends Record<string, unknown>> = {
 
 type DefineComponentWithGenericProps<T extends (new (props: Record<string, any>, slots: RawSlots) => {
   $props?: Record<string, any>
-})>
-= <
-Props = undefined,
-RawBindings = {},
-D = {},
-C extends ComputedOptions = {},
-M extends MethodOptions = {},
-Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-E extends EmitsOptions = {},
-EE extends string = string,
-I extends ComponentInjectOptions = {},
-II extends string = string,
+})> = <
+  Props = undefined,
+  RawBindings = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = {},
+  EE extends string = string,
+  I extends ComponentInjectOptions = {},
+  II extends string = string,
   Slots extends RawSlots = ConstructorParameters<T>[1],
   S extends SlotsType = SlotsType<Partial<MakeSlots<Slots>>>,
-Options extends Record<PropertyKey, any> = {}>(options: DefineComponentOptions<
-  Props,
+  Options extends Record<PropertyKey, any> = {}
+>(
+  options: DefineComponentOptions<
+    Props,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    I,
+    II,
+    S,
+    Options
+  >
+) => DefineComponentFromOptions<
+  undefined extends Props ? {} : Props,
   RawBindings,
   D,
   C,
@@ -232,39 +189,40 @@ Options extends Record<PropertyKey, any> = {}>(options: DefineComponentOptions<
   II,
   S,
   Options
->) => DefineComponentFromOptions<
-undefined extends Props ? {} : Props,
-RawBindings,
-D,
-C,
-M,
-Mixin,
-Extends,
-E,
-EE,
-I,
-II,
-S,
-Options
 > & T & (Props extends Readonly<ComponentPropsOptions> ? FilterPropsOptions<Props> : {})
 
 type DefineComponentWithSlots<Slots extends RawSlots> = <
-Props = undefined,
-RawBindings = {},
-D = {},
-C extends ComputedOptions = {},
-M extends MethodOptions = {},
-Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-E extends EmitsOptions = {},
-EE extends string = string,
-I extends ComponentInjectOptions = {},
-II extends string = string,
-S extends SlotsType = SlotsType<Partial<MakeSlots<Slots>>>,
-Options extends Record<PropertyKey, any> = {}
+  Props = undefined,
+  RawBindings = {},
+  D = {},
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  E extends EmitsOptions = {},
+  EE extends string = string,
+  I extends ComponentInjectOptions = {},
+  II extends string = string,
+  S extends SlotsType = SlotsType<Partial<MakeSlots<Slots>>>,
+  Options extends Record<PropertyKey, any> = {}
 >(
   options: DefineComponentOptions<
-  Props,
+    Props,
+    RawBindings,
+    D,
+    C,
+    M,
+    Mixin,
+    Extends,
+    E,
+    EE,
+    I,
+    II,
+    S,
+    Options
+  >
+) => DefineComponentFromOptions<
+  undefined extends Props ? {} : Props,
   RawBindings,
   D,
   C,
@@ -277,21 +235,6 @@ Options extends Record<PropertyKey, any> = {}
   II,
   S,
   Options
->
-) => DefineComponentFromOptions<
-undefined extends Props ? {} : Props,
-RawBindings,
-D,
-C,
-M,
-Mixin,
-Extends,
-E,
-EE,
-I,
-II,
-S,
-Options
 > & (Props extends Readonly<ComponentPropsOptions> ? FilterPropsOptions<Props> : {})
 
 // No argument - simple default slot

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -222,7 +222,7 @@ type DefineComponentWithSlots<Slots extends RawSlots> = <
     Options
   >
 ) => DefineComponentFromOptions<
-  undefined extends Props ? {} : Props,
+  (undefined extends Props ? {} : Props) & SlotsToProps<Slots>,
   RawBindings,
   D,
   C,

--- a/packages/vuetify/src/util/defineComponent.tsx
+++ b/packages/vuetify/src/util/defineComponent.tsx
@@ -11,93 +11,132 @@ import { propsFactory } from '@/util/propsFactory'
 
 // Types
 import type {
-  AllowedComponentProps,
-  ComponentCustomProps,
   ComponentInjectOptions,
   ComponentObjectPropsOptions,
   ComponentOptions,
   ComponentOptionsMixin,
-  ComponentOptionsWithObjectProps,
-  ComponentOptionsWithoutProps,
   ComponentPropsOptions,
   ComputedOptions,
-  DefineComponent,
+  DefineComponentFromOptions,
+  DefineComponentOptions,
   EmitsOptions,
   ExtractDefaultPropTypes,
   ExtractPropTypes,
   FunctionalComponent,
+  LooseOptional,
   MethodOptions,
-  ObjectEmitsOptions,
   SlotsType,
   VNode,
   VNodeChild,
-  VNodeProps,
 } from 'vue'
 
-// No props
-export function defineComponent<
-  Props = {},
-  RawBindings = {},
-  D = {},
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = {},
-  EE extends string = string,
-  I extends {} = {},
-  II extends string = string,
-  S extends SlotsType = {},
->(
-  options: ComponentOptionsWithoutProps<
-    Props,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    E,
-    EE,
-    I,
-    II,
-    S
-  >
-): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
+// // No props
+// export function defineComponent<
+//   Props = {},
+//   RawBindings = {},
+//   D = {},
+//   C extends ComputedOptions = {},
+//   M extends MethodOptions = {},
+//   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+//   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+//   E extends EmitsOptions = {},
+//   EE extends string = string,
+//   I extends {} = {},
+//   II extends string = string,
+//   S extends SlotsType = {},
+// >(
+//   options: ComponentOptionsWithoutProps<
+//     Props,
+//     RawBindings,
+//     D,
+//     C,
+//     M,
+//     Mixin,
+//     Extends,
+//     E,
+//     EE,
+//     I,
+//     II,
+//     S
+//   >
+// ): DefineComponent<Props, RawBindings, D, C, M, Mixin, Extends, E, EE>
 
-// Object Props
+// // Object Props
+// export function defineComponent<
+//   PropsOptions extends Readonly<ComponentPropsOptions>,
+//   RawBindings,
+//   D,
+//   C extends ComputedOptions = {},
+//   M extends MethodOptions = {},
+//   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+//   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+//   E extends EmitsOptions = {},
+//   EE extends string = string,
+//   I extends {} = {},
+//   II extends string = string,
+//   S extends SlotsType = {},
+// >(
+//   options: ComponentOptionsWithObjectProps<
+//     PropsOptions,
+//     RawBindings,
+//     D,
+//     C,
+//     M,
+//     Mixin,
+//     Extends,
+//     E,
+//     EE,
+//     I,
+//     II,
+//     S
+//   >
+// ): DefineComponent<PropsOptions, RawBindings, D, C, M0, Mixin, Extends, E, EE> & FilterPropsOptions<PropsOptions>
+
 export function defineComponent<
-  PropsOptions extends Readonly<ComponentPropsOptions>,
+Props = undefined,
+RawBindings = {},
+D = {},
+C extends ComputedOptions = {},
+M extends MethodOptions = {},
+Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+E extends EmitsOptions = {},
+EE extends string = string,
+I extends ComponentInjectOptions = {},
+II extends string = string,
+S extends SlotsType = {},
+Options extends Record<PropertyKey, any> = {}>(options: DefineComponentOptions<
+  Props,
   RawBindings,
   D,
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = {},
-  EE extends string = string,
-  I extends {} = {},
-  II extends string = string,
-  S extends SlotsType = {},
->(
-  options: ComponentOptionsWithObjectProps<
-    PropsOptions,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    E,
-    EE,
-    I,
-    II,
-    S
-  >
-): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE> & FilterPropsOptions<PropsOptions>
+  C,
+  M,
+  Mixin,
+  Extends,
+  E,
+  EE,
+  I,
+  II,
+  S,
+  Options
+>): DefineComponentFromOptions<
+undefined extends Props ? {} : Props,
+RawBindings,
+D,
+C,
+M,
+Mixin,
+Extends,
+E,
+EE,
+I,
+II,
+S,
+Options
+> & (Props extends Readonly<ComponentPropsOptions> ? FilterPropsOptions<Props> : {})
 
 // Implementation
-export function defineComponent (options: ComponentOptions) {
+export function defineComponent (options: ComponentOptions & { props?: ComponentObjectPropsOptions}) {
   options._setup = options._setup ?? options.setup
 
   if (!options.name) {
@@ -133,8 +172,6 @@ export function defineComponent (options: ComponentOptions) {
   return options
 }
 
-type ToListeners<T extends string | number | symbol> = { [K in T]: K extends `on${infer U}` ? Uncapitalize<U> : K }[T]
-
 export type SlotsToProps<
   U extends RawSlots,
   T = MakeInternalSlots<U>
@@ -166,66 +203,23 @@ export type GenericProps<Props, Slots extends Record<string, unknown>> = {
 
 type DefineComponentWithGenericProps<T extends (new (props: Record<string, any>, slots: RawSlots) => {
   $props?: Record<string, any>
-})> = <
-  PropsOptions extends Readonly<ComponentObjectPropsOptions>,
-  RawBindings,
-  D,
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = Record<string, any>,
-  EE extends string = string,
-  I extends ComponentInjectOptions = {},
-  II extends string = string,
-  // Slots extends RawSlots = ConstructorParameters<T> extends [any, infer SS extends RawSlots | undefined] ? Exclude<SS, undefined> : {},
+})>
+= <
+Props = undefined,
+RawBindings = {},
+D = {},
+C extends ComputedOptions = {},
+M extends MethodOptions = {},
+Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+E extends EmitsOptions = {},
+EE extends string = string,
+I extends ComponentInjectOptions = {},
+II extends string = string,
   Slots extends RawSlots = ConstructorParameters<T>[1],
   S extends SlotsType = SlotsType<Partial<MakeSlots<Slots>>>,
-  III = InstanceType<T>,
-  P = III extends Record<'$props', any>
-    ? Omit<PropsOptions, keyof III['$props']>
-    : PropsOptions,
-  EEE extends EmitsOptions = E extends any[]
-    ? E
-    : III extends Record<'$props', any>
-      ? Omit<E, ToListeners<keyof III['$props']>>
-      : E,
-  Base = DefineComponent<
-    P,
-    RawBindings,
-    D,
-    C,
-    M,
-    Mixin,
-    Extends,
-    EEE,
-    EE,
-    PublicProps,
-    ExtractPropTypes<P> & ({} extends E ? {} : EmitsToProps<EEE>),
-    ExtractDefaultPropTypes<P>,
-    S
-  >
->(
-  options: ComponentOptionsWithObjectProps<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE, I, II, S>
-) => Base & T & FilterPropsOptions<PropsOptions>
-
-type DefineComponentWithSlots<Slots extends RawSlots> = <
-  PropsOptions extends Readonly<ComponentPropsOptions>,
-  RawBindings,
-  D,
-  C extends ComputedOptions = {},
-  M extends MethodOptions = {},
-  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
-  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-  E extends EmitsOptions = Record<string, any>,
-  EE extends string = string,
-  I extends ComponentInjectOptions = {},
-  II extends string = string,
-  S extends SlotsType = SlotsType<Partial<MakeSlots<Slots>>>,
->(
-  options: ComponentOptionsWithObjectProps<PropsOptions, RawBindings, D, C, M, Mixin, Extends, E, EE, I, II, S>
-) => DefineComponent<
-  ExtractPropTypes<PropsOptions> & SlotsToProps<Slots>,
+Options extends Record<PropertyKey, any> = {}>(options: DefineComponentOptions<
+  Props,
   RawBindings,
   D,
   C,
@@ -234,11 +228,71 @@ type DefineComponentWithSlots<Slots extends RawSlots> = <
   Extends,
   E,
   EE,
-  PublicProps,
-  ExtractPropTypes<PropsOptions> & SlotsToProps<Slots> & ({} extends E ? {} : EmitsToProps<E>),
-  ExtractDefaultPropTypes<PropsOptions>,
-  S
-> & FilterPropsOptions<PropsOptions>
+  I,
+  II,
+  S,
+  Options
+>) => DefineComponentFromOptions<
+undefined extends Props ? {} : Props,
+RawBindings,
+D,
+C,
+M,
+Mixin,
+Extends,
+E,
+EE,
+I,
+II,
+S,
+Options
+> & T & (Props extends Readonly<ComponentPropsOptions> ? FilterPropsOptions<Props> : {})
+
+type DefineComponentWithSlots<Slots extends RawSlots> = <
+Props = undefined,
+RawBindings = {},
+D = {},
+C extends ComputedOptions = {},
+M extends MethodOptions = {},
+Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+E extends EmitsOptions = {},
+EE extends string = string,
+I extends ComponentInjectOptions = {},
+II extends string = string,
+S extends SlotsType = SlotsType<Partial<MakeSlots<Slots>>>,
+Options extends Record<PropertyKey, any> = {}
+>(
+  options: DefineComponentOptions<
+  Props,
+  RawBindings,
+  D,
+  C,
+  M,
+  Mixin,
+  Extends,
+  E,
+  EE,
+  I,
+  II,
+  S,
+  Options
+>
+) => DefineComponentFromOptions<
+undefined extends Props ? {} : Props,
+RawBindings,
+D,
+C,
+M,
+Mixin,
+Extends,
+E,
+EE,
+I,
+II,
+S,
+Options
+> & (Props extends Readonly<ComponentPropsOptions> ? FilterPropsOptions<Props> : {})
 
 // No argument - simple default slot
 export function genericComponent (exposeDefaults?: boolean): DefineComponentWithSlots<{ default: never }>
@@ -263,34 +317,10 @@ export function defineFunctionalComponent<
   PropsOptions = ComponentObjectPropsOptions,
   Defaults = ExtractDefaultPropTypes<PropsOptions>,
   Props = Readonly<ExtractPropTypes<PropsOptions>>,
-> (props: PropsOptions, render: T): FunctionalComponent<Partial<Defaults> & Omit<Props, keyof Defaults>> {
+> (props: PropsOptions, render: T): FunctionalComponent<Partial<Defaults> & Omit<LooseOptional<Props>, keyof Defaults>> {
   render.props = props as any
   return render as any
 }
-
-type EmitsToProps<T extends EmitsOptions> = T extends string[]
-  ? {
-    [K in string & `on${Capitalize<T[number]>}`]?: (...args: any[]) => any
-  }
-  : T extends ObjectEmitsOptions
-    ? {
-      [K in string &
-        `on${Capitalize<string & keyof T>}`]?: K extends `on${infer C}`
-        ? T[Uncapitalize<C>] extends null
-          ? (...args: any[]) => any
-          : (
-            ...args: T[Uncapitalize<C>] extends (...args: infer P) => any
-              ? P
-              : never
-          ) => any
-        : never
-    }
-    : {}
-
-type PublicProps =
-  & VNodeProps
-  & AllowedComponentProps
-  & ComponentCustomProps
 
 // Adds a filterProps method to the component options
 export interface FilterPropsOptions<PropsOptions extends Readonly<ComponentPropsOptions>, Props = ExtractPropTypes<PropsOptions>> {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Support for newer vue utility types https://github.com/vuejs/core/pull/9556, there was an overall work done to `defineComponent` , it requires Typescript `5.3.*` and `slots` are not currently failing to resolve the type.

