### PR TITLE
docs: missing closing bracket in Nuxt installation guide

### DIFF
--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -166,7 +166,7 @@ export default defineNuxtConfig({
       },
     },
   },
-}
+})
 ```
 
 Nuxt allows you to change its Vite config by using its built-in hook `vite:extendConfig`. In its callback function, add the Vuetify plugin to the array of Vite plugins. To resolve relative asset URLs that are passed to Vuetify components such as `VImg` (e.g. `~/assets/img/some.png`) the `transformAssetUrls` function needs to be added in the `vite` entry .


### PR DESCRIPTION
This PR adds the missing closing bracket when installing with Nuxt.
