### PR TITLE
docs(VTextField): Hint possible for solo variant

### DIFF
--- a/packages/docs/src/pages/en/components/text-fields.md
+++ b/packages/docs/src/pages/en/components/text-fields.md
@@ -196,7 +196,7 @@ When **hide-details** is set to `auto` messages will be rendered only if there's
 
 #### Hint
 
-The **hint** property on text fields adds the provided string beneath the text field. Using **persistent-hint** keeps the hint visible when the text field is not focused. Hint prop is _**not**_ supported in solo mode.
+The **hint** property on text fields adds the provided string beneath the text field. Using **persistent-hint** keeps the hint visible when the text field is not focused.
 
 <example file="v-text-field/prop-hint" />
 


### PR DESCRIPTION
Maybe I'm getting this wrong, but right below the text stating hints would not be possible for solo fields is an example with a variant=solo field including a hint.

![documentation](https://github.com/vuetifyjs/vuetify/assets/67763683/0e450d84-3d0c-4266-91b5-be6217cbb89f)
