### PR TITLE
fix(VDataTable): only show loading slot if no items or slot provided

### DIFF
--- a/packages/docs/src/examples/v-data-table/slot-loading.vue
+++ b/packages/docs/src/examples/v-data-table/slot-loading.vue
@@ -11,7 +11,7 @@
 
   <v-data-table :loading="loading" :items="items">
     <template v-slot:loading>
-      <v-skeleton-loader type="table-row@6"></v-skeleton-loader>
+      <v-skeleton-loader type="table-row@10"></v-skeleton-loader>
     </template>
   </v-data-table>
 </template>

--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -110,6 +110,9 @@
     height: auto !important
     padding: 0 !important
 
+.v-data-table-progress__loader
+  position: relative
+
 .v-data-table-rows-loading,
 .v-data-table-rows-no-data
   text-align: center

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -217,6 +217,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
                   active
                   color={ typeof props.loading === 'boolean' ? undefined : props.loading }
                   indeterminate
+                  absolute
                   v-slots={{ default: slots.loader }}
                 />
               </th>

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -214,10 +214,10 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
               <th colspan={ columns.value.length }>
                 <LoaderSlot
                   name="v-data-table-progress"
+                  absolute
                   active
                   color={ typeof props.loading === 'boolean' ? undefined : props.loading }
                   indeterminate
-                  absolute
                   v-slots={{ default: slots.loader }}
                 />
               </th>

--- a/packages/vuetify/src/components/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRows.tsx
@@ -68,7 +68,7 @@ export const VDataTableRows = genericComponent<new <T>(
     const { t } = useLocale()
 
     useRender(() => {
-      if (props.loading) {
+      if (props.loading && (!props.items.length || slots.loading)) {
         return (
           <tr
             class="v-data-table-rows-loading"

--- a/packages/vuetify/src/composables/loader.tsx
+++ b/packages/vuetify/src/composables/loader.tsx
@@ -36,10 +36,10 @@ export function useLoader (
 
 export function LoaderSlot (
   props: {
+    absolute?: boolean
     active: boolean
     name: string
     color?: string
-    absolute?: boolean
   } & ExtractPropTypes<SlotsToProps<{
     default: LoaderSlotProps
   }>>,
@@ -52,11 +52,11 @@ export function LoaderSlot (
         isActive: props.active,
       } as LoaderSlotProps) || (
         <VProgressLinear
+          absolute={ props.absolute }
           active={ props.active }
           color={ props.color }
           height="2"
           indeterminate
-          absolute={ props.absolute }
         />
       )}
     </div>

--- a/packages/vuetify/src/composables/loader.tsx
+++ b/packages/vuetify/src/composables/loader.tsx
@@ -39,6 +39,7 @@ export function LoaderSlot (
     active: boolean
     name: string
     color?: string
+    absolute?: boolean
   } & ExtractPropTypes<SlotsToProps<{
     default: LoaderSlotProps
   }>>,
@@ -55,6 +56,7 @@ export function LoaderSlot (
           color={ props.color }
           height="2"
           indeterminate
+          absolute={ props.absolute }
         />
       )}
     </div>


### PR DESCRIPTION
closes #18445

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

change in behavior to match v2. now loading slot will only be shown if it has been defined, and loading text will only show if there are no items.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="pa-10">
    <v-data-table-server
      v-model:items-per-page="itemsPerPage"
      :headers="headers"
      :items-length="totalItems"
      :items="serverItems"
      :loading="loading"
      :search="search"
      item-value="name"
      @update:options="loadItems"
    />
  </div>
</template>

<script>
  const desserts = [
    {
      name: 'Frozen Yogurt',
      calories: 159,
      fat: 6.0,
      carbs: 24,
      protein: 4.0,
      iron: '1',
    },
    {
      name: 'Jelly bean',
      calories: 375,
      fat: 0.0,
      carbs: 94,
      protein: 0.0,
      iron: '0',
    },
    {
      name: 'KitKat',
      calories: 518,
      fat: 26.0,
      carbs: 65,
      protein: 7,
      iron: '6',
    },
    {
      name: 'Eclair',
      calories: 262,
      fat: 16.0,
      carbs: 23,
      protein: 6.0,
      iron: '7',
    },
    {
      name: 'Gingerbread',
      calories: 356,
      fat: 16.0,
      carbs: 49,
      protein: 3.9,
      iron: '16',
    },
    {
      name: 'Ice cream sandwich',
      calories: 237,
      fat: 9.0,
      carbs: 37,
      protein: 4.3,
      iron: '1',
    },
    {
      name: 'Lollipop',
      calories: 392,
      fat: 0.2,
      carbs: 98,
      protein: 0,
      iron: '2',
    },
    {
      name: 'Cupcake',
      calories: 305,
      fat: 3.7,
      carbs: 67,
      protein: 4.3,
      iron: '8',
    },
    {
      name: 'Honeycomb',
      calories: 408,
      fat: 3.2,
      carbs: 87,
      protein: 6.5,
      iron: '45',
    },
    {
      name: 'Donut',
      calories: 452,
      fat: 25.0,
      carbs: 51,
      protein: 4.9,
      iron: '22',
    },
  ]

  const FakeAPI = {
    async fetch ({ page, itemsPerPage, sortBy }) {
      return new Promise(resolve => {
        setTimeout(() => {
          const start = (page - 1) * itemsPerPage
          const end = start + itemsPerPage
          const items = desserts.slice()

          if (sortBy.length) {
            const sortKey = sortBy[0].key
            const sortOrder = sortBy[0].order
            items.sort((a, b) => {
              const aValue = a[sortKey]
              const bValue = b[sortKey]
              return sortOrder === 'desc' ? bValue - aValue : aValue - bValue
            })
          }

          const paginated = items.slice(start, end)

          resolve({ items: paginated, total: items.length })
        }, 500)
      })
    },
  }

  export default {
    data: () => ({
      itemsPerPage: 5,
      headers: [
        {
          title: 'Dessert (100g serving)',
          align: 'start',
          sortable: false,
          key: 'name',
        },
        { title: 'Calories', key: 'calories', align: 'end' },
        { title: 'Fat (g)', key: 'fat', align: 'end' },
        { title: 'Carbs (g)', key: 'carbs', align: 'end' },
        { title: 'Protein (g)', key: 'protein', align: 'end' },
        { title: 'Iron (%)', key: 'iron', align: 'end' },
      ],
      search: '',
      serverItems: [],
      loading: true,
      totalItems: 0,
    }),
    methods: {
      loadItems ({ page, itemsPerPage, sortBy }) {
        this.loading = true
        FakeAPI.fetch({ page, itemsPerPage, sortBy }).then(({ items, total }) => {
          this.serverItems = items
          this.totalItems = total
          this.loading = false
        })
      },
    },
  }
</script>

```
