### PR TITLE
fix(memory): defaultThemeOptions moved inline theme.ts

### DIFF
--- a/packages/vuetify/_settings.scss
+++ b/packages/vuetify/_settings.scss
@@ -1,3 +1,0 @@
-@forward './lib/styles/settings';
-@forward './dist/component-variables';
-@forward './dist/component-variables-labs';

--- a/packages/vuetify/_styles.scss
+++ b/packages/vuetify/_styles.scss
@@ -1,1 +1,0 @@
-@forward './lib/styles/main';

--- a/packages/vuetify/_tools.scss
+++ b/packages/vuetify/_tools.scss
@@ -1,1 +1,0 @@
-@forward './lib/styles/tools';

--- a/packages/vuetify/src/components/VApp/VApp.tsx
+++ b/packages/vuetify/src/components/VApp/VApp.tsx
@@ -33,7 +33,7 @@ export const VApp = genericComponent()({
           'v-application',
           theme.themeClasses.value,
           layoutClasses.value,
-          rtlClasses.value,
+          rtlClasses,
           props.class,
         ]}
         style={[

--- a/packages/vuetify/src/components/VColorPicker/VColorPicker.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPicker.tsx
@@ -135,7 +135,7 @@ export const VColorPicker = defineComponent({
           theme={ props.theme }
           class={[
             'v-color-picker',
-            rtlClasses.value,
+            rtlClasses,
             props.class,
           ]}
           style={[

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -250,7 +250,7 @@ export const VField = genericComponent<new <T>(
             focusClasses.value,
             loaderClasses.value,
             roundedClasses.value,
-            rtlClasses.value,
+            rtlClasses,
             props.class,
           ]}
           style={[

--- a/packages/vuetify/src/components/VGrid/VContainer.tsx
+++ b/packages/vuetify/src/components/VGrid/VContainer.tsx
@@ -32,7 +32,7 @@ export const VContainer = genericComponent()({
         class={[
           'v-container',
           { 'v-container--fluid': props.fluid },
-          rtlClasses.value,
+          rtlClasses,
           props.class,
         ]}
         style={ props.style }

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -156,7 +156,7 @@ export const VInput = genericComponent<new <T>(
               'v-input--hide-spin-buttons': props.hideSpinButtons,
             },
             densityClasses.value,
-            rtlClasses.value,
+            rtlClasses,
             validationClasses.value,
             props.class,
           ]}

--- a/packages/vuetify/src/components/VLocaleProvider/VLocaleProvider.tsx
+++ b/packages/vuetify/src/components/VLocaleProvider/VLocaleProvider.tsx
@@ -32,7 +32,7 @@ export const VLocaleProvider = genericComponent()({
       <div
         class={[
           'v-locale-provider',
-          rtlClasses.value,
+          rtlClasses,
           props.class,
         ]}
         style={ props.style }

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -120,7 +120,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
         : Number(props.rail ? props.railWidth : props.width)
     })
     const location = computed(() => {
-      return toPhysical(props.location, isRtl.value) as 'left' | 'right' | 'bottom'
+      return toPhysical(props.location, isRtl) as 'left' | 'right' | 'bottom'
     })
     const isTemporary = computed(() => !props.permanent && (mobile.value || props.temporary))
     const isSticky = computed(() =>

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -266,7 +266,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                   'v-overlay--contained': props.contained,
                 },
                 themeClasses.value,
-                rtlClasses.value,
+                rtlClasses,
                 props.class,
               ]}
               style={[

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -23,14 +23,14 @@ import {
 import { Box, getOverflow, getTargetBox } from '@/util/box'
 
 // Types
-import type { PropType, Ref } from 'vue'
+import type { ComputedRef, PropType, Ref, WritableComputedRef } from 'vue'
 import type { Anchor } from '@/util'
 
 export interface LocationStrategyData {
   contentEl: Ref<HTMLElement | undefined>
   target: Ref<HTMLElement | [x: number, y: number] | undefined>
   isActive: Ref<boolean>
-  isRtl: Ref<boolean>
+  isRtl: boolean
 }
 
 type LocationStrategyFn = (
@@ -74,7 +74,12 @@ export const makeLocationStrategyProps = propsFactory({
 
 export function useLocationStrategies (
   props: StrategyProps,
-  data: LocationStrategyData
+  data: {
+    contentEl: Ref<HTMLElement | undefined>
+    isActive: WritableComputedRef<any>
+    isRtl: boolean
+    target: ComputedRef<[x: number, y: number] | undefined | HTMLElement>
+  }
 ) {
   const contentStyles = ref({})
   const updateLocation = ref<(e: Event) => void>()
@@ -162,16 +167,16 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     Object.assign(contentStyles.value, {
       position: 'fixed',
       top: 0,
-      [data.isRtl.value ? 'right' : 'left']: 0,
+      [data.isRtl ? 'right' : 'left']: 0,
     })
   }
 
   const { preferredAnchor, preferredOrigin } = destructComputed(() => {
-    const parsedAnchor = parseAnchor(props.location, data.isRtl.value)
+    const parsedAnchor = parseAnchor(props.location, data.isRtl)
     const parsedOrigin =
       props.origin === 'overlap' ? parsedAnchor
       : props.origin === 'auto' ? flipSide(parsedAnchor)
-      : parseAnchor(props.origin, data.isRtl.value)
+      : parseAnchor(props.origin, data.isRtl)
 
     // Some combinations of props may produce an invalid origin
     if (parsedAnchor.side === parsedOrigin.side && parsedAnchor.align === flipAlign(parsedOrigin).align) {
@@ -236,7 +241,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     if (!data.target.value || !data.contentEl.value) return
 
     const targetBox = getTargetBox(data.target.value)
-    const contentBox = getIntrinsicSize(data.contentEl.value, data.isRtl.value)
+    const contentBox = getIntrinsicSize(data.contentEl.value, data.isRtl)
     const scrollParents = getScrollParents(data.contentEl.value)
     const viewportMargin = 12
 
@@ -400,8 +405,8 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       transformOrigin: `${placement.origin.side} ${placement.origin.align}`,
       // transform: `translate(${pixelRound(x)}px, ${pixelRound(y)}px)`,
       top: convertToUnit(pixelRound(y)),
-      left: data.isRtl.value ? undefined : convertToUnit(pixelRound(x)),
-      right: data.isRtl.value ? convertToUnit(pixelRound(-x)) : undefined,
+      left: data.isRtl ? undefined : convertToUnit(pixelRound(x)),
+      right: data.isRtl ? convertToUnit(pixelRound(-x)) : undefined,
       minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value),
       maxWidth: convertToUnit(pixelCeil(clamp(available.x, minWidth.value === Infinity ? 0 : minWidth.value, maxWidth.value))),
       maxHeight: convertToUnit(pixelCeil(clamp(available.y, minHeight.value === Infinity ? 0 : minHeight.value, maxHeight.value))),

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -279,28 +279,28 @@ export const VPagination = genericComponent<VPaginationSlots>()({
 
       return {
         first: props.showFirstLastPage ? {
-          icon: isRtl.value ? props.lastIcon : props.firstIcon,
+          icon: isRtl ? props.lastIcon : props.firstIcon,
           onClick: (e: Event) => setValue(e, start.value, 'first'),
           disabled: prevDisabled,
           ariaLabel: t(props.firstAriaLabel),
           ariaDisabled: prevDisabled,
         } : undefined,
         prev: {
-          icon: isRtl.value ? props.nextIcon : props.prevIcon,
+          icon: isRtl ? props.nextIcon : props.prevIcon,
           onClick: (e: Event) => setValue(e, page.value - 1, 'prev'),
           disabled: prevDisabled,
           ariaLabel: t(props.previousAriaLabel),
           ariaDisabled: prevDisabled,
         },
         next: {
-          icon: isRtl.value ? props.prevIcon : props.nextIcon,
+          icon: isRtl ? props.prevIcon : props.nextIcon,
           onClick: (e: Event) => setValue(e, page.value + 1, 'next'),
           disabled: nextDisabled,
           ariaLabel: t(props.nextAriaLabel),
           ariaDisabled: nextDisabled,
         },
         last: props.showFirstLastPage ? {
-          icon: isRtl.value ? props.firstIcon : props.lastIcon,
+          icon: isRtl ? props.firstIcon : props.lastIcon,
           onClick: (e: Event) => setValue(e, start.value + length.value - 1, 'last'),
           disabled: nextDisabled,
           ariaLabel: t(props.lastAriaLabel),

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
@@ -83,7 +83,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
     const height = computed(() => parseInt(props.height, 10))
     const normalizedBuffer = computed(() => parseFloat(props.bufferValue) / max.value * 100)
     const normalizedValue = computed(() => parseFloat(progress.value) / max.value * 100)
-    const isReversed = computed(() => isRtl.value !== props.reverse)
+    const isReversed = computed(() => isRtl !== props.reverse)
     const transition = computed(() => props.indeterminate ? 'fade-transition' : 'slide-x-transition')
     const opacity = computed(() => {
       return props.bgOpacity == null
@@ -115,7 +115,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
           },
           roundedClasses.value,
           themeClasses.value,
-          rtlClasses.value,
+          rtlClasses,
           props.class,
         ]}
         style={[

--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
@@ -139,7 +139,7 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
               'v-slider--pressed': mousePressed.value,
               'v-slider--disabled': props.disabled,
             },
-            rtlClasses.value,
+            rtlClasses,
             props.class,
           ]}
           style={ props.style }

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -141,7 +141,7 @@ export const VSlideGroup = genericComponent<new <T>(
                 selectedElement,
                 containerSize: containerSize.value,
                 contentSize: contentSize.value,
-                isRtl: isRtl.value,
+                isRtl,
                 isHorizontal: isHorizontal.value,
               })
             } else if (isOverflowing.value) {
@@ -149,7 +149,7 @@ export const VSlideGroup = genericComponent<new <T>(
                 selectedElement,
                 containerSize: containerSize.value,
                 contentSize: contentSize.value,
-                isRtl: isRtl.value,
+                isRtl,
                 currentScrollOffset: scrollOffset.value,
                 isHorizontal: isHorizontal.value,
               })
@@ -166,7 +166,7 @@ export const VSlideGroup = genericComponent<new <T>(
 
     function onTouchstart (e: TouchEvent) {
       const sizeProperty = isHorizontal.value ? 'clientX' : 'clientY'
-      const sign = isRtl.value && isHorizontal.value ? -1 : 1
+      const sign = isRtl && isHorizontal.value ? -1 : 1
       startOffset = sign * scrollOffset.value
       startTouch = e.touches[0][sizeProperty]
       disableTransition.value = true
@@ -176,7 +176,7 @@ export const VSlideGroup = genericComponent<new <T>(
       if (!isOverflowing.value) return
 
       const sizeProperty = isHorizontal.value ? 'clientX' : 'clientY'
-      const sign = isRtl.value && isHorizontal.value ? -1 : 1
+      const sign = isRtl && isHorizontal.value ? -1 : 1
       scrollOffset.value = sign * (startOffset + startTouch - e.touches[0][sizeProperty])
     }
 
@@ -213,7 +213,7 @@ export const VSlideGroup = genericComponent<new <T>(
               selectedElement: item as HTMLElement,
               containerSize: containerSize.value,
               contentSize: contentSize.value,
-              isRtl: isRtl.value,
+              isRtl,
               currentScrollOffset: scrollOffset.value,
               isHorizontal: isHorizontal.value,
             })
@@ -239,9 +239,9 @@ export const VSlideGroup = genericComponent<new <T>(
 
       if (isHorizontal.value) {
         if (e.key === 'ArrowRight') {
-          focus(isRtl.value ? 'prev' : 'next')
+          focus(isRtl ? 'prev' : 'next')
         } else if (e.key === 'ArrowLeft') {
-          focus(isRtl.value ? 'next' : 'prev')
+          focus(isRtl ? 'next' : 'prev')
         }
       } else {
         if (e.key === 'ArrowDown') {
@@ -296,7 +296,7 @@ export const VSlideGroup = genericComponent<new <T>(
         scrollAmount = bias(-scrollOffset.value)
       }
 
-      const sign = isRtl.value && isHorizontal.value ? -1 : 1
+      const sign = isRtl && isHorizontal.value ? -1 : 1
       return {
         transform: `translate${isHorizontal.value ? 'X' : 'Y'}(${sign * scrollAmount}px)`,
         transition: disableTransition.value ? 'none' : '',
@@ -375,7 +375,7 @@ export const VSlideGroup = genericComponent<new <T>(
           >
             { slots.prev?.(slotProps.value) ?? (
               <VFadeTransition>
-                <VIcon icon={ isRtl.value ? props.nextIcon : props.prevIcon }></VIcon>
+                <VIcon icon={ isRtl ? props.nextIcon : props.prevIcon }></VIcon>
               </VFadeTransition>
             )}
           </div>
@@ -413,7 +413,7 @@ export const VSlideGroup = genericComponent<new <T>(
           >
             { slots.next?.(slotProps.value) ?? (
               <VFadeTransition>
-                <VIcon icon={ isRtl.value ? props.prevIcon : props.nextIcon }></VIcon>
+                <VIcon icon={ isRtl ? props.prevIcon : props.nextIcon }></VIcon>
               </VFadeTransition>
             )}
           </div>

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -107,7 +107,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
               'v-slider--pressed': mousePressed.value,
               'v-slider--disabled': props.disabled,
             },
-            rtlClasses.value,
+            rtlClasses,
             props.class,
           ]}
           style={ props.style }

--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -103,8 +103,8 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
       const steps = (props.max - props.min) / _step
       if ([left, right, down, up].includes(e.key)) {
         const increase = vertical.value
-          ? [isRtl.value ? left : right, isReversed.value ? down : up]
-          : indexFromEnd.value !== isRtl.value ? [left, up] : [right, up]
+          ? [isRtl ? left : right, isReversed.value ? down : up]
+          : indexFromEnd.value !== isRtl ? [left, up] : [right, up]
         const direction = increase.includes(e.key) ? 1 : -1
         const multiplier = e.shiftKey ? 2 : (e.ctrlKey ? 1 : 0)
 
@@ -140,7 +140,7 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
               'v-slider-thumb--pressed': props.focused && mousePressed.value,
             },
             props.class,
-            rtlClasses.value,
+            rtlClasses,
           ]}
           style={[
             {

--- a/packages/vuetify/src/components/VSlider/slider.ts
+++ b/packages/vuetify/src/components/VSlider/slider.ts
@@ -220,7 +220,7 @@ export const useSlider = ({
     // It is possible for left to be NaN, force to number
     let clickPos = Math.min(Math.max((clickOffset - trackStart - startOffset.value) / trackLength, 0), 1) || 0
 
-    if (vertical ? indexFromEnd.value : indexFromEnd.value !== isRtl.value) clickPos = 1 - clickPos
+    if (vertical ? indexFromEnd.value : indexFromEnd.value !== isRtl) clickPos = 1 - clickPos
 
     return roundValue(min.value + clickPos * (max.value - min.value))
   }

--- a/packages/vuetify/src/components/VTimeline/VTimeline.tsx
+++ b/packages/vuetify/src/components/VTimeline/VTimeline.tsx
@@ -115,7 +115,7 @@ export const VTimeline = genericComponent()({
           themeClasses.value,
           densityClasses.value,
           sideClasses.value,
-          rtlClasses.value,
+          rtlClasses,
           props.class,
         ]}
         style={[

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -128,7 +128,7 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
             elevationClasses.value,
             roundedClasses.value,
             themeClasses.value,
-            rtlClasses.value,
+            rtlClasses,
             props.class,
           ]}
           style={[

--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -118,7 +118,7 @@ export const VWindow = genericComponent<new <T>(
     const group = useGroup(props, VWindowGroupSymbol)
 
     const rootRef = ref()
-    const isRtlReverse = computed(() => isRtl.value ? !props.reverse : props.reverse)
+    const isRtlReverse = computed(() => isRtl ? !props.reverse : props.reverse)
     const isReversed = shallowRef(false)
     const transition = computed(() => {
       const axis = props.direction === 'vertical' ? 'y' : 'x'
@@ -172,7 +172,7 @@ export const VWindow = genericComponent<new <T>(
       const arrows = []
 
       const prevProps = {
-        icon: isRtl.value ? props.nextIcon : props.prevIcon,
+        icon: isRtl ? props.nextIcon : props.prevIcon,
         class: `v-window__${isRtlReverse.value ? 'right' : 'left'}`,
         onClick: group.prev,
         ariaLabel: t('$vuetify.carousel.prev'),
@@ -186,7 +186,7 @@ export const VWindow = genericComponent<new <T>(
       )
 
       const nextProps = {
-        icon: isRtl.value ? props.prevIcon : props.nextIcon,
+        icon: isRtl ? props.prevIcon : props.nextIcon,
         class: `v-window__${isRtlReverse.value ? 'left' : 'right'}`,
         onClick: group.next,
         ariaLabel: t('$vuetify.carousel.next'),

--- a/packages/vuetify/src/composables/locale.ts
+++ b/packages/vuetify/src/composables/locale.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { computed, inject, provide, ref } from 'vue'
+import { inject, provide } from 'vue'
 import { defaultRtl } from '@/locale'
 import { createVuetifyAdapter } from '@/locale/adapters/vuetify'
 
@@ -74,31 +74,34 @@ export interface RtlProps {
 }
 
 export interface RtlInstance {
-  isRtl: Ref<boolean>
-  rtl: Ref<Record<string, boolean>>
-  rtlClasses: Ref<string>
+  isRtl: boolean
+  rtl: Record<string, boolean>
+  rtlClasses: string
 }
 
 export const RtlSymbol: InjectionKey<RtlInstance> = Symbol.for('vuetify:rtl')
 
 export function createRtl (i18n: LocaleInstance, options?: RtlOptions): RtlInstance {
-  const rtl = ref<Record<string, boolean>>(options?.rtl ?? defaultRtl)
-  const isRtl = computed(() => rtl.value[i18n.current.value] ?? false)
+  const rtl = options?.rtl ?? defaultRtl
+  // @ts-expect-error
+  const isRtl = rtl[i18n.current.value] ?? false
+  const rtlClasses = isRtl ? 'v-locale--is-rtl' : 'v-locale--is-ltr'
 
   return {
     isRtl,
     rtl,
-    rtlClasses: computed(() => `v-locale--is-${isRtl.value ? 'rtl' : 'ltr'}`),
+    rtlClasses,
   }
 }
 
 export function provideRtl (locale: LocaleInstance, rtl: RtlInstance['rtl'], props: RtlProps): RtlInstance {
-  const isRtl = computed(() => props.rtl ?? rtl.value[locale.current.value] ?? false)
+  const isRtl = props.rtl ?? rtl[locale.current.value] ?? false
+  const rtlClasses = isRtl ? 'v-locale--is-rtl' : 'v-locale--is-ltr'
 
   return {
     isRtl,
     rtl,
-    rtlClasses: computed(() => `v-locale--is-${isRtl.value ? 'rtl' : 'ltr'}`),
+    rtlClasses,
   }
 }
 

--- a/packages/vuetify/src/composables/location.ts
+++ b/packages/vuetify/src/composables/location.ts
@@ -35,7 +35,7 @@ export function useLocation (props: LocationProps, opposite = false, offset?: (s
       props.location.split(' ').length > 1
         ? props.location
         : `${props.location} center` as Anchor,
-      isRtl.value
+      isRtl
     )
 
     function getOffset (side: string) {

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -105,104 +105,86 @@ export const makeThemeProps = propsFactory({
   theme: String,
 }, 'theme')
 
-const defaultThemeOptions: Exclude<ThemeOptions, false> = {
-  defaultTheme: 'light',
-  variations: { colors: [], lighten: 0, darken: 0 },
-  themes: {
-    light: {
-      dark: false,
-      colors: {
-        background: '#FFFFFF',
-        surface: '#FFFFFF',
-        'surface-bright': '#FFFFFF',
-        'surface-variant': '#424242',
-        'on-surface-variant': '#EEEEEE',
-        primary: '#1867C0',
-        'primary-darken-1': '#1F5592',
-        secondary: '#48A9A6',
-        'secondary-darken-1': '#018786',
-        error: '#B00020',
-        info: '#2196F3',
-        success: '#4CAF50',
-        warning: '#FB8C00',
-      },
-      variables: {
-        'border-color': '#000000',
-        'border-opacity': 0.12,
-        'high-emphasis-opacity': 0.87,
-        'medium-emphasis-opacity': 0.60,
-        'disabled-opacity': 0.38,
-        'idle-opacity': 0.04,
-        'hover-opacity': 0.04,
-        'focus-opacity': 0.12,
-        'selected-opacity': 0.08,
-        'activated-opacity': 0.12,
-        'pressed-opacity': 0.12,
-        'dragged-opacity': 0.08,
-        'theme-kbd': '#212529',
-        'theme-on-kbd': '#FFFFFF',
-        'theme-code': '#F5F5F5',
-        'theme-on-code': '#000000',
-      },
-    },
-    dark: {
-      dark: true,
-      colors: {
-        background: '#121212',
-        surface: '#212121',
-        'surface-bright': '#ccbfd6',
-        'surface-variant': '#a3a3a3',
-        'on-surface-variant': '#424242',
-        primary: '#2196F3',
-        'primary-darken-1': '#277CC1',
-        secondary: '#54B6B2',
-        'secondary-darken-1': '#48A9A6',
-        error: '#CF6679',
-        info: '#2196F3',
-        success: '#4CAF50',
-        warning: '#FB8C00',
-      },
-      variables: {
-        'border-color': '#FFFFFF',
-        'border-opacity': 0.12,
-        'high-emphasis-opacity': 1,
-        'medium-emphasis-opacity': 0.70,
-        'disabled-opacity': 0.50,
-        'idle-opacity': 0.10,
-        'hover-opacity': 0.04,
-        'focus-opacity': 0.12,
-        'selected-opacity': 0.08,
-        'activated-opacity': 0.12,
-        'pressed-opacity': 0.16,
-        'dragged-opacity': 0.08,
-        'theme-kbd': '#212529',
-        'theme-on-kbd': '#FFFFFF',
-        'theme-code': '#343434',
-        'theme-on-code': '#CCCCCC',
-      },
-    },
-  },
-}
-
-function parseThemeOptions (options: ThemeOptions = defaultThemeOptions): InternalThemeOptions {
-  if (!options) return { ...defaultThemeOptions, isDisabled: true } as InternalThemeOptions
-
-  const themes: Record<string, InternalThemeDefinition> = {}
-  for (const [key, theme] of Object.entries(options.themes ?? {})) {
-    const defaultTheme = theme.dark || key === 'dark'
-      ? defaultThemeOptions.themes?.dark
-      : defaultThemeOptions.themes?.light
-    themes[key] = mergeDeep(defaultTheme, theme) as InternalThemeDefinition
-  }
-
-  return mergeDeep(
-    defaultThemeOptions,
-    { ...options, themes },
-  ) as InternalThemeOptions
-}
-
 // Composables
 export function createTheme (options?: ThemeOptions): ThemeInstance & { install: (app: App) => void } {
+  const defaultThemeOptions: Exclude<ThemeOptions, false> = {
+    defaultTheme: 'light',
+    variations: { colors: [], lighten: 0, darken: 0 },
+    themes: {
+      light: {
+        dark: false,
+        colors: {
+          background: '#FFFFFF',
+          surface: '#FFFFFF',
+          'surface-bright': '#FFFFFF',
+          'surface-variant': '#424242',
+          'on-surface-variant': '#EEEEEE',
+          primary: '#1867C0',
+          'primary-darken-1': '#1F5592',
+          secondary: '#48A9A6',
+          'secondary-darken-1': '#018786',
+          error: '#B00020',
+          info: '#2196F3',
+          success: '#4CAF50',
+          warning: '#FB8C00',
+        },
+        variables: {
+          'border-color': '#000000',
+          'border-opacity': 0.12,
+          'high-emphasis-opacity': 0.87,
+          'medium-emphasis-opacity': 0.60,
+          'disabled-opacity': 0.38,
+          'idle-opacity': 0.04,
+          'hover-opacity': 0.04,
+          'focus-opacity': 0.12,
+          'selected-opacity': 0.08,
+          'activated-opacity': 0.12,
+          'pressed-opacity': 0.12,
+          'dragged-opacity': 0.08,
+          'theme-kbd': '#212529',
+          'theme-on-kbd': '#FFFFFF',
+          'theme-code': '#F5F5F5',
+          'theme-on-code': '#000000',
+        },
+      },
+      dark: {
+        dark: true,
+        colors: {
+          background: '#121212',
+          surface: '#212121',
+          'surface-bright': '#ccbfd6',
+          'surface-variant': '#a3a3a3',
+          'on-surface-variant': '#424242',
+          primary: '#2196F3',
+          'primary-darken-1': '#277CC1',
+          secondary: '#54B6B2',
+          'secondary-darken-1': '#48A9A6',
+          error: '#CF6679',
+          info: '#2196F3',
+          success: '#4CAF50',
+          warning: '#FB8C00',
+        },
+        variables: {
+          'border-color': '#FFFFFF',
+          'border-opacity': 0.12,
+          'high-emphasis-opacity': 1,
+          'medium-emphasis-opacity': 0.70,
+          'disabled-opacity': 0.50,
+          'idle-opacity': 0.10,
+          'hover-opacity': 0.04,
+          'focus-opacity': 0.12,
+          'selected-opacity': 0.08,
+          'activated-opacity': 0.12,
+          'pressed-opacity': 0.16,
+          'dragged-opacity': 0.08,
+          'theme-kbd': '#212529',
+          'theme-on-kbd': '#FFFFFF',
+          'theme-code': '#343434',
+          'theme-on-code': '#CCCCCC',
+        },
+      },
+    },
+  }
   const parsedOptions = parseThemeOptions(options)
   const name = ref(parsedOptions.defaultTheme)
   const themes = ref(parsedOptions.themes)
@@ -341,6 +323,23 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
   }
 
   const themeClasses = computed(() => parsedOptions.isDisabled ? undefined : `v-theme--${name.value}`)
+
+  function parseThemeOptions (options: ThemeOptions = defaultThemeOptions): InternalThemeOptions {
+    if (!options) return { ...defaultThemeOptions, isDisabled: true } as InternalThemeOptions
+
+    const themes: Record<string, InternalThemeDefinition> = {}
+    for (const [key, theme] of Object.entries(options.themes ?? {})) {
+      const defaultTheme = theme.dark || key === 'dark'
+        ? defaultThemeOptions.themes?.dark
+        : defaultThemeOptions.themes?.light
+      themes[key] = mergeDeep(defaultTheme, theme) as InternalThemeDefinition
+    }
+
+    return mergeDeep(
+      defaultThemeOptions,
+      { ...options, themes },
+    ) as InternalThemeOptions
+  }
 
   return {
     install,


### PR DESCRIPTION
## Description
When using vuetify in Nuxt SSR, with high traffic there are memory leaks on certain objects. I was able to isolate those to the theme composable and fix them. Resolves 18393

## Markup:
This repository can be used to reproduce: https://github.com/memic84/vuetify-memory-leak-reproduction

First you should link your local vuetify code with yarn link and yarn link "vuetify"

and then you can run Nuxt.

```
yarn && yarn build && node --inspect .output/server/index.mjs
```

To test the fix, link the PR code to the vuetify reproduction code.
