### PR TITLE
feat: added support for scoped slots for Vuetify components

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.ts
+++ b/packages/vuetify/src/components/VBtn/VBtn.ts
@@ -18,6 +18,7 @@ import Sizeable from '../../mixins/sizeable'
 // Utilities
 import mixins, { ExtractVue } from '../../util/mixins'
 import { breaking } from '../../util/console'
+import { getSlot } from '../../util/helpers'
 
 // Types
 import { VNode } from 'vue'
@@ -167,7 +168,7 @@ export default baseMixins.extend<options>().extend({
     genContent (): VNode {
       return this.$createElement('span', {
         staticClass: 'v-btn__content',
-      }, this.$slots.default)
+      }, getSlot(this))
     },
     genLoader (): VNode {
       return this.$createElement('span', {

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.ts
@@ -385,7 +385,7 @@ export default baseMixins.extend({
     genContent () {
       return this.$createElement('div', {
         staticClass: 'v-navigation-drawer__content',
-      }, this.$slots.default)
+      }, getSlot(this))
     },
     genBorder () {
       return this.$createElement('div', {


### PR DESCRIPTION
## Description
I have added the ability to use both `$slots.default` and `$scopedSlots.default` to the VNavigationDrawer component. With my modification, the following code works without any issues, and both cases can be used. Without my changes, the code wouldn't display the text 'default slot!'.

This is my first pull request to Vuetify, but I hope it meets your requirements. Please review and accept.

```vue
<script>
  import {VNavigationDrawer} from "../lib";

  export default {
    render(createElement) {
      return createElement(VNavigationDrawer, {
        scopedSlots: {
          append: () => createElement('span', 'append slot!'),
          default: () => createElement('span', 'default slot!'),
          prepend: () => createElement('span', 'prepend slot!')
        }
      })
    }
  }
</script>
```

The changes in this branch are part of a broader effort to improve the overall structure and maintainability of the code. 