### PR TITLE
docs(VBtn): add description for `slim` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VBtn.json
+++ b/packages/api-generator/src/locale/en/VBtn.json
@@ -5,6 +5,6 @@
     "icon": "Apply a specific icon using the [v-icon](/components/icons/) component. The button will become _round_.",
     "plain": "Removes the default background change applied when hovering over the button.",
     "stacked": "Displays the button as a flex-column.",
-    "slim": "Reduces padding to 0 8px"
+    "slim": "Reduces padding to 0 8px."
   }
 }

--- a/packages/api-generator/src/locale/en/VBtn.json
+++ b/packages/api-generator/src/locale/en/VBtn.json
@@ -4,6 +4,7 @@
     "flat": "Removes the button box shadow. This is different than using the 'flat' variant.",
     "icon": "Apply a specific icon using the [v-icon](/components/icons/) component. The button will become _round_.",
     "plain": "Removes the default background change applied when hovering over the button.",
-    "stacked": "Displays the button as a flex-column."
+    "stacked": "Displays the button as a flex-column.",
+    "slim": "Reduces padding to 0 8px"
   }
 }


### PR DESCRIPTION
Adds missing documentation for the slim prop, detailing its use in reducing the vertical padding to render thinner buttons.

related: #17562

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<v-btn slim>Slim button</v-btn>
```
