### PR TITLE
fix(VDataTableServer): correct mismatched prop name for the previous ARIA label

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
@@ -128,7 +128,7 @@ export const VDataTableFooter = genericComponent<{ prepend: never }>()({
             last-aria-label={ props.lastPageLabel }
             length={ pageCount.value }
             next-aria-label={ props.nextPageLabel }
-            prev-aria-label={ props.prevPageLabel }
+            previous-aria-label={ props.prevPageLabel }
             rounded
             show-first-last-page
             total-visible={ props.showCurrentPage ? 1 : 0 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

resolves #18864 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table-server
        :items="[]"
        items-length="0"
        first-page-label="go back to the first page"
        prev-page-label="go back to the previous page"
        next-page-label="go forward to the next page"
        last-page-label="go forward to the last page"
      />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>

```
