### PR TITLE
docs(VList): add description for `slim` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VList.json
+++ b/packages/api-generator/src/locale/en/VList.json
@@ -5,6 +5,7 @@
     "lines": "Designates a **minimum-height** for all children `v-list-item` components. This prop uses [line-clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp) and is not supported in all browsers.",
     "link": "Applies `v-list-item` hover styles. Useful when using the item is an _activator_.",
     "nav": "An alternative styling that reduces `v-list-item` width and rounds the corners. Typically used with **[v-navigation-drawer](/components/navigation-drawers)**.",
-    "subheader": "Removes the top padding from `v-list-subheader` components. When used as a **String**, renders a subheader for you."
+    "subheader": "Removes the top padding from `v-list-subheader` components. When used as a **String**, renders a subheader for you.",
+    "slim": "Reduces horizontal spacing for badges, icons, tooltips, and avatars within slim list items to create a more compact visual representation."
   }
 }


### PR DESCRIPTION
Clarifies the reduction of horizontal spacing to 8 pixels for badges, icons, tooltips, and avatars within slim list items, from a previous 32 pixels, ensuring a tighter, more compact visual structure.

related: #17562

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Live demo: [playground](https://play.vuetifyjs.com/#eNrtU8tu2zAQ/JUFL7YBU/KjQAvBCdB7T0VvUQ4baZNsQ0oEuVIcGP73kpIfMvoDOeTGmd0dLmfAh4MKvsp/Opf1HalC7YSsMyh0XzYAu15X6GuoDIZwVyq719hJWyqwuNfvXMtrZLerVamG/mHCcJATumDNUffMAfT6ufVxcp7oJfACuIF0DqW6dhVv9BGb+Ibr0XSU2CQ4KVStGSSdZ4v+Y1oK3ZOwmDT1q/VkgV3oLNRpAgILoCWJAk2gSkg6D1iz48AVNy9AhmWq5jw5amqNPQqmG19FXCjy3GNTt7YL5DNLOTrOXevFI0vI31tLTf4j++terloXk25t0sOy0SOhvZxemqVzNHmX/9d4tXpaO8dx4iK8yQeC4XPPV0ifJ6QRpD8XwS6ffMYIQ+XZjV20T2tDTc/YGYHDKFTHxxYwX8DdPcxPHIyRFfBwgLRfAbPfhEb/YUuzmGp0NFK2Zl2ZtnqbwfFxOU4eF8PhmBa5XK2OS7XNvmUr/USC2VqN8Lu2GCSaullttnq90eutevwHKVJf2g==)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<v-list slim>
    ...
</v-list>
```