### PR TITLE
fix(VOtpInput): exclude loader slot in VField slots

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.sass
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.sass
@@ -54,3 +54,6 @@
   height: 100%
   justify-content: center
   width: 100%
+
+  .v-progress-linear
+    position: absolute

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -287,7 +287,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
             <VOverlay
               contained
               content-class="v-otp-input__loader"
-              modelValue={ !!props.loading }
+              model-value={ !!props.loading }
               persistent
             >
               { slots.loader?.() ?? (

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -212,6 +212,8 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     useRender(() => {
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
 
+      const { loader: _, ...vFieldSlots } = slots
+
       return (
         <div
           class={[
@@ -244,7 +246,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                   key={ i }
                 >
                   {{
-                    ...slots,
+                    ...vFieldSlots,
                     default: () => {
                       return (
                         <input
@@ -285,7 +287,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
             <VOverlay
               contained
               content-class="v-otp-input__loader"
-              model-value={ !!props.loading }
+              modelValue={ !!props.loading }
               persistent
             >
               { slots.loader?.() ?? (

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -212,8 +212,6 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     useRender(() => {
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
 
-      const { loader: _, ...vFieldSlots } = slots
-
       return (
         <div
           class={[
@@ -246,7 +244,8 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                   key={ i }
                 >
                   {{
-                    ...vFieldSlots,
+                    ...slots,
+                    loader: undefined,
                     default: () => {
                       return (
                         <input


### PR DESCRIPTION
fixes #18809

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input :loading="true">
        <template v-slot:loader>
          <v-progress-circular indeterminate ></v-progress-circular>
        </template>
      </v-otp-input>
      <v-otp-input :loading="true">
        <template v-slot:loader>
          <v-progress-linear :location="'bottom'" indeterminate></v-progress-linear>
        </template>
      </v-otp-input>
    </v-container>
  </v-app>
</template>




```
