### PR TITLE
fix: Added the missing `update: indeterminate` translation string to `VSwitch.json`

### DIFF
--- a/packages/api-generator/src/locale/en/VSwitch.json
+++ b/packages/api-generator/src/locale/en/VSwitch.json
@@ -8,6 +8,7 @@
   },
   "events": {
     "change": "Emitted when the input is changed by user interaction.",
+    "update:indeterminate": "Event that is emitted when the component's indeterminate state changes.",
     "click": "Emitted when input is clicked. **Note:** the **change** event should be used instead of **click** when monitoring state change."
   }
 }


### PR DESCRIPTION
## Description
This PR fixes a missing translation issue on the [VSwitch API Docs](https://vuetifyjs.com/en/api/v-switch/#events) page

This is the current docs:

![image](https://github.com/vuetifyjs/vuetify/assets/29278616/a60c754b-f062-478f-99ce-b8ed088b8e68)

And this is the docs after this fix has been implemented:

<img width="686" alt="image" src="https://github.com/vuetifyjs/vuetify/assets/29278616/ca215a1e-cb4d-4f30-ab98-ff07b9cffbc0">

