### PR TITLE
fix(locale): typo in CZ translations

### DIFF
--- a/packages/vuetify/src/locale/cs.ts
+++ b/packages/vuetify/src/locale/cs.ts
@@ -1,6 +1,6 @@
 export default {
   badge: 'Odznak',
-  open: 'Otevřit',
+  open: 'Otevřiť',
   close: 'Zavřít',
   confirmEdit: {
     ok: 'OK',


### PR DESCRIPTION
## Description
Fixes a typo in CZ translations.
