### PR TITLE
chore: explicitly register global Vue JSX types for 3.4

### DIFF
--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -1,4 +1,5 @@
 // Types
+import 'vue/jsx'
 import type { Events, VNode } from 'vue'
 import type { TouchStoredHandlers } from './directives/touch'
 


### PR DESCRIPTION
Vue 3.4 no longer implicitly registers global JSX namespace and this is necessary to preserve old behavior.