### PR TITLE
docs(v-app-bar): corrected the code snippet in usage example

### DIFF
--- a/packages/docs/src/examples/v-app-bar/usage.vue
+++ b/packages/docs/src/examples/v-app-bar/usage.vue
@@ -71,6 +71,9 @@
   })
 
   const code = computed(() => {
-    return `<${name}${propsToString(props.value)}>${slots.value}</${name}>`
+    return `<${name}${propsToString(props.value)}>
+    <v-app-bar-nav-icon></v-app-bar-nav-icon>
+    <v-app-bar-title>Application Bar</v-app-bar-title>
+    ${slots.value}</${name}>`
   })
 </script>


### PR DESCRIPTION
## Description
fixes #18922

As it is mentioned in the issue, the code snippet of the usage of `v-app-bar` ([link](https://vuetifyjs.com/en/components/app-bars/#usage)) isn't detailed enough to represent the provided example.
I missed the title and the icon which I had added
