### PR TITLE
fix(VCombobox): hide the v-solt:no-data if search prop is empty 

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -492,7 +492,7 @@ export const VCombobox = genericComponent<new <
                     >
                       { slots['prepend-item']?.() }
 
-                      { !displayItems.value.length && !props.hideNoData && (slots['no-data']?.() ?? (
+                      { !displayItems.value.length &&  search.value?.length >= 1 && !props.hideNoData && (slots['no-data']?.() ?? (
                         <VListItem title={ t(props.noDataText) } />
                       ))}
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -423,10 +423,10 @@ export const VCombobox = genericComponent<new <
     useRender(() => {
       const hasChips = !!(props.chips || slots.chip)
       const hasList = !!(
-        (!props.hideNoData || displayItems.value.length) ||
+        (!props.hideNoData && displayItems.value.length) ||
         slots['prepend-item'] ||
         slots['append-item'] ||
-        slots['no-data']
+       (slots['no-data'] && search.value.length>= 1) 
       )
       const isDirty = model.value.length > 0
       const textFieldProps = VTextField.filterProps(props)


### PR DESCRIPTION


## Description
fixes #18897 
`v-slot:no-data` appears even if there is neither a `displayItem` to select nor a search text entered by the user. 
I refactored the code to hide list's slot in that case. 
if there are no items to select, I made it required for the user to enter at least one character to show the slot.

You can compare the new behavior with the [reproduction ](https://play.vuetifyjs.com/#eNp9Uk1v2zAM/SuEMCAJUDuHrhhmuAF62mlDD8MuTQ+KTSdC9WFIdJoh8H8fLdlx0gH1hdR7JE0+8uUsgq/WT22bHzsUhSgJTasl4WZrAcpjVjlLUln00OhO1REeCbNzO3dKAMAxM65G/bgV0W7FB6IIKH11YD45c0BxUDVm1mW1JMl8I3XAK1pxT4HxaGc8ZgXUWBHWM2iJQ3/KkzKdAdfAA5DcX6VpuYtdPtU1BGfwA206TarVOL1b9EEFQkvZUHuCg5FaZ9VBtSFBozAszaQgDx60o2Ic7BIQ1dNcMxsGuoJviYwU6bSG+fvlwGPgFgMYSfx7u4etKAN5Z/eb8xmSttD35XoEtyKHZ04KUL7t6g0Pgr5cDy6Qg8rj0KoEi+/g7GXs2M36s3Zu2Hn69c0BpbDpVNJNRWA8KkZuMvgZKq9aiqF4ap0nqLGRPDKcU8VBzAKWK3jcwHLEAOJxFPCy+CENq7K4g8Wzd3svzfT80+FoSDV/F693l5XH8+TU/6kkZwG203oE+xU7yX0fVlBMfY2FYHmUejWD3FoTsVyj3dMBNvBwQwPQQYX8i8UT/VbV2zKNFsFYMW9du1yt5ox+cvupp2gZ5q0n+UR/J+7z+/y7GOzX/Jt4/QczwzKt)provided in the issue 

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container fluid>
    <v-combobox
      v-model="model"
      v-model:search="search"
      :hide-no-data="false"
      :items="items"
      hide-selected
      hint="Maximum of 5 tags"
      label="Add some tags"
      multiple
      persistent-hint
      small-chips
    >
      <template v-slot:no-data>
        <v-list-item>
          <v-list-item-title>
            No results matching "<strong>{{ search }}</strong>". Press
            <kbd>enter</kbd> to create a new one
          </v-list-item-title>
        </v-list-item>
      </template>
    </v-combobox>
  </v-container>
</template>

<script setup>
  import { nextTick, ref, watch } from 'vue'

  const items = ['Gaming', 'Programming', 'Vue', 'Vuetify']

  const model = ref(['Vuetify'])
  const search = ref(null)

  watch(model, val => {
    if (val.length > 5) {
      nextTick(() => model.value.pop())
    }
  })
</script>

```
