### PR TITLE
fix(VAutocomplete): fix usage with prependAvatar in VListItem

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -495,12 +495,12 @@ export const VAutocomplete = genericComponent<new <
                                     />
                                   ) : undefined }
 
-                                  { item.props.prependIcon && (
-                                    <VIcon icon={ item.props.prependIcon } />
-                                  )}
-
                                   { item.props.prependAvatar && (
                                     <VAvatar image={ item.props.prependAvatar } />
+                                  )}
+
+                                  { item.props.prependIcon && (
+                                    <VIcon icon={ item.props.prependIcon } />
                                   )}
                                 </>
                               ),

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -2,6 +2,7 @@
 import './VAutocomplete.sass'
 
 // Components
+import { VAvatar } from '@/components/VAvatar'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
@@ -496,6 +497,10 @@ export const VAutocomplete = genericComponent<new <
 
                                   { item.props.prependIcon && (
                                     <VIcon icon={ item.props.prependIcon } />
+                                  )}
+
+                                  { item.props.prependAvatar && (
+                                    <VAvatar image={ item.props.prependAvatar } />
                                   )}
                                 </>
                               ),

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -2,6 +2,7 @@
 import './VCombobox.sass'
 
 // Components
+import { VAvatar } from '@/components/VAvatar'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
@@ -525,6 +526,10 @@ export const VCombobox = genericComponent<new <
 
                                   { item.props.prependIcon && (
                                     <VIcon icon={ item.props.prependIcon } />
+                                  )}
+
+                                  { item.props.prependAvatar && (
+                                    <VAvatar image={ item.props.prependAvatar } />
                                   )}
                                 </>
                               ),

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -524,12 +524,12 @@ export const VCombobox = genericComponent<new <
                                     />
                                   ) : undefined }
 
-                                  { item.props.prependIcon && (
-                                    <VIcon icon={ item.props.prependIcon } />
-                                  )}
-
                                   { item.props.prependAvatar && (
                                     <VAvatar image={ item.props.prependAvatar } />
+                                  )}
+
+                                  { item.props.prependIcon && (
+                                    <VIcon icon={ item.props.prependIcon } />
                                   )}
                                 </>
                               ),

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -411,12 +411,12 @@ export const VSelect = genericComponent<new <
                                       />
                                     ) : undefined }
 
-                                    { item.props.prependIcon && (
-                                      <VIcon icon={ item.props.prependIcon } />
-                                    )}
-
                                     { item.props.prependAvatar && (
                                       <VAvatar image={ item.props.prependAvatar } />
+                                    )}
+
+                                    { item.props.prependIcon && (
+                                      <VIcon icon={ item.props.prependIcon } />
                                     )}
                                   </>
                                 ),

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -3,6 +3,7 @@ import './VSelect.sass'
 
 // Components
 import { VDialogTransition } from '@/components/transitions'
+import { VAvatar } from '@/components/VAvatar'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
@@ -412,6 +413,10 @@ export const VSelect = genericComponent<new <
 
                                     { item.props.prependIcon && (
                                       <VIcon icon={ item.props.prependIcon } />
+                                    )}
+
+                                    { item.props.prependAvatar && (
+                                      <VAvatar image={ item.props.prependAvatar } />
                                     )}
                                   </>
                                 ),


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #18933

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete :items="items" :item-props="itemProps" />
      <v-combobox :items="items" :item-props="itemProps" />
      <v-select :items="items" :item-props="itemProps" />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const items = ref(['Item 1'])

  function itemProps (item: any) {
    return {
      title: item,
      prependAvatar:
        'https://avatars0.githubusercontent.com/u/9064066?v=4&s=460',
    }
  }
</script>
```
