### PR TITLE
docs: fix typo in styles and utility classes description

### DIFF
--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -104,7 +104,7 @@ app.use(vuetify)
 
 - `.hidden-{breakpoint}-only` has been renamed to `.hidden-{breakpoint}`
 - `.text-xs-{alignment}` has been renamed to `.text-{alignment}` to reflect the fact that it applies to all breakpoints.
-- Typography classes are have been renamed for consistency and are all prefixed with `text-`, for example `.display-4` is now `.text-h1`
+- Typography classes have been renamed for consistency and are all prefixed with `text-`, for example `.display-4` is now `.text-h1`
 - Transition easing classes have been removed.
 
 :::info


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix typo in https://vuetifyjs.com/en/getting-started/upgrade-guide/#styles-and-utility-classes
Currently:

Typography classes are have been renamed for consistency and are all prefixed with text-, for example .display-4 is now .text-h1

Expected:

Typography classes have been renamed for consistency and are all prefixed with text-, for example .display-4 is now .text-h1
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
None