### PR TITLE
fix(VDataTable): max-width doesn work properly, new prop to wrap text when use maxWidth

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -42,6 +42,14 @@
             &.v-data-table-column--no-padding
               padding: 0 8px
 
+            &.v-data-table-column--nowrap
+              text-overflow: ellipsis
+              text-wrap: nowrap
+              overflow: hidden
+
+              & .v-data-table-header__content
+                display: contents
+
           > th
             align-items: center
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
@@ -16,6 +16,8 @@ export const VDataTableColumn = defineFunctionalComponent({
   noPadding: Boolean,
   tag: String,
   width: [Number, String],
+  maxWidth: [Number, String],
+  nowrap: Boolean,
 }, (props, { slots }) => {
   const Tag = props.tag ?? 'td'
   return (
@@ -26,12 +28,14 @@ export const VDataTableColumn = defineFunctionalComponent({
           'v-data-table-column--fixed': props.fixed,
           'v-data-table-column--last-fixed': props.lastFixed,
           'v-data-table-column--no-padding': props.noPadding,
+          'v-data-table-column--nowrap': props.nowrap,
         },
         `v-data-table-column--align-${props.align}`,
       ]}
       style={{
         height: convertToUnit(props.height),
         width: convertToUnit(props.width),
+        maxWidth: convertToUnit(props.maxWidth),
         left: convertToUnit(props.fixedOffset || null),
       }}
     >

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -135,12 +135,14 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           style={{
             width: convertToUnit(column.width),
             minWidth: convertToUnit(column.minWidth),
+            maxWidth: convertToUnit(column.maxWidth),
             ...getFixedStyles(column, y),
           }}
           colspan={ column.colspan }
           rowspan={ column.rowspan }
           onClick={ column.sortable ? () => toggleSort(column) : undefined }
           fixed={ column.fixed }
+          nowrap={ column.nowrap }
           lastFixed={ column.lastFixed }
           noPadding={ noPadding }
           { ...headerProps }

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -100,6 +100,8 @@ export const VDataTableRow = genericComponent<new <T>(
               lastFixed={ column.lastFixed }
               noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
               width={ column.width }
+              maxWidth={ column.maxWidth }
+              nowrap={ column.nowrap }
               { ...cellProps }
               { ...columnCellProps }
             >

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -18,6 +18,7 @@ export type DataTableHeader<T = Record<string, any>> = {
   width?: number | string
   minWidth?: string
   maxWidth?: string
+  nowrap?: boolean
 
   headerProps?: Record<string, any>
   cellProps?: HeaderCellProps


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fix for issue: https://github.com/vuetifyjs/vuetify/issues/18862

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
in this playground use props
maxWidth: '60px',
wrap: true,

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table-server
    v-model:items-per-page="itemsPerPage"
    :headers="headers"
    :items-length="totalItems"
    :items="serverItems"
    :loading="loading"
    item-value="name"
    @update:options="loadItems"
  ></v-data-table-server>
</template>

<script>
const desserts = [
  {
    name: 'Frozen Yogurt,Frozen Yogurt,Frozen Yogurt,Frozen Yogurt,Frozen Yogurt,Frozen Yogurt,Frozen Yogurt,',
    calories: 159,
    fat: 6.0,
    carbs: 24,
    protein: 4.0,
    iron: '1',
  },
  {
    name: 'Eclair',
    calories: 262,
    fat: 16.0,
    carbs: 23,
    protein: 6.0,
    iron: '7',
  },
  {
    name: 'Gingerbread',
    calories: 356,
    fat: 16.0,
    carbs: 49,
    protein: 3.9,
    iron: '16',
  },
  {
    name: 'Ice cream sandwich',
    calories: 237,
    fat: 9.0,
    carbs: 37,
    protein: 4.3,
    iron: '1',
  },
  {
    name: 'Lollipop',
    calories: 392,
    fat: 0.2,
    carbs: 98,
    protein: 0,
    iron: '2',
  },
]

const FakeAPI = {
  async fetch({ page, itemsPerPage, sortBy }) {
    return new Promise(resolve => {
      setTimeout(() => {
        const start = (page - 1) * itemsPerPage
        const end = start + itemsPerPage
        const items = desserts.slice()

        if (sortBy.length) {
          const sortKey = sortBy[0].key
          const sortOrder = sortBy[0].order
          items.sort((a, b) => {
            const aValue = a[sortKey]
            const bValue = b[sortKey]
            return sortOrder === 'desc' ? bValue - aValue : aValue - bValue
          })
        }

        const paginated = items.slice(start, end)

        resolve({ items: paginated, total: items.length })
      }, 500)
    })
  },
}

export default {
  data: () => ({
    itemsPerPage: 5,
    headers: [
      {
        title: 'Dessert (100g serving), Dessert (100g serving)',
        align: 'start',
        sortable: false,
        key: 'name',
        maxWidth: '60px',
        wrap: true,
      },
      { title: 'Calories', key: 'calories', align: 'start' },
      { title: 'Fat (g)', key: 'fat', align: 'end' },
      { title: 'Carbs (g)', key: 'carbs', align: 'end' },
      { title: 'Protein (g)', key: 'protein', align: 'end' },
      { title: 'Iron (%)', key: 'iron', align: 'end' },
    ],
    serverItems: [],
    loading: true,
    totalItems: 0,
  }),
  methods: {
    loadItems({ page, itemsPerPage, sortBy }) {
      this.loading = true
      FakeAPI.fetch({ page, itemsPerPage, sortBy }).then(
        ({ items, total }) => {
          this.serverItems = items
          this.totalItems = total
          this.loading = false
        }
      )
    },
  },
}
</script>
```
