### PR TITLE
fix(VAutocomplete/VCombobox): add buffer space after selection to hold input

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -23,7 +23,7 @@
 
     &:not(.v-field--focused)
       input
-        min-width: 0
+        display: none
 
   .v-field--dirty
     .v-autocomplete__selection

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -50,7 +50,7 @@
     height: calc($input-font-size * $input-line-height)
     letter-spacing: inherit
     line-height: inherit
-    max-width: calc(100% - $autocomplete-selection-gap * 2)
+    max-width: calc(100% - $autocomplete-selection-gap - 2px)
 
   &__selection
     &:first-child

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -23,7 +23,7 @@
 
     &:not(.v-field--focused)
       input
-        display: none
+        min-width: 0
 
   .v-field--dirty
     .v-autocomplete__selection
@@ -50,7 +50,7 @@
     height: calc($input-font-size * $input-line-height)
     letter-spacing: inherit
     line-height: inherit
-    max-width: calc(100% - $autocomplete-selection-gap)
+    max-width: calc(100% - $autocomplete-selection-gap * 2)
 
   &__selection
     &:first-child

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -50,7 +50,7 @@
     height: calc($input-font-size * $input-line-height)
     letter-spacing: inherit
     line-height: inherit
-    max-width: calc(100% - $autocomplete-selection-gap - 2px)
+    max-width: calc(100% - $autocomplete-selection-gap - $autocomplete-input-buffer)
 
   &__selection
     &:first-child

--- a/packages/vuetify/src/components/VAutocomplete/_variables.scss
+++ b/packages/vuetify/src/components/VAutocomplete/_variables.scss
@@ -5,6 +5,7 @@
 $autocomplete-content-border-radius: 4px !default;
 $autocomplete-content-elevation: 4 !default;
 $autocomplete-focused-input: 64px !default;
+$autocomplete-input-buffer: 2px !default;
 $autocomplete-line-height: 1.75 !default;
 $autocomplete-selection-gap: 2px !default;
 $autocomplete-transition: .2s settings.$standard-easing !default;

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -23,11 +23,11 @@
 
     &:not(.v-field--focused)
       input
-        display: none
+        min-width: 0
 
   .v-field--dirty
     .v-combobox__selection
-      margin-inline-end: 2px
+      margin-inline-end: $combobox-selection-gap
 
   .v-combobox__selection-text
     overflow: hidden
@@ -50,7 +50,7 @@
     height: calc($input-font-size * $input-line-height)
     letter-spacing: inherit
     line-height: inherit
-    max-width: 90%
+    max-width: calc(100% - $combobox-selection-gap * 2)
 
   &__selection
     &:first-child

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -23,7 +23,7 @@
 
     &:not(.v-field--focused)
       input
-        min-width: 0
+        display: none
 
   .v-field--dirty
     .v-combobox__selection

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -50,7 +50,7 @@
     height: calc($input-font-size * $input-line-height)
     letter-spacing: inherit
     line-height: inherit
-    max-width: calc(100% - $combobox-selection-gap - 2px)
+    max-width: calc(100% - $combobox-selection-gap - $combobox-input-buffer)
 
   &__selection
     &:first-child

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -50,7 +50,7 @@
     height: calc($input-font-size * $input-line-height)
     letter-spacing: inherit
     line-height: inherit
-    max-width: calc(100% - $combobox-selection-gap * 2)
+    max-width: calc(100% - $combobox-selection-gap - 2px)
 
   &__selection
     &:first-child

--- a/packages/vuetify/src/components/VCombobox/_variables.scss
+++ b/packages/vuetify/src/components/VCombobox/_variables.scss
@@ -6,6 +6,7 @@ $combobox-content-border-radius: 4px !default;
 $combobox-content-elevation: 4 !default;
 $combobox-focused-input: 64px !default;
 $combobox-line-height: 1.75 !default;
+$combobox-selection-gap: 2px !default;
 $combobox-transition: .2s settings.$standard-easing !default;
 $combobox-chips-control-min-height: null !default;
 $combobox-chips-margin-top: null !default;

--- a/packages/vuetify/src/components/VCombobox/_variables.scss
+++ b/packages/vuetify/src/components/VCombobox/_variables.scss
@@ -5,6 +5,7 @@
 $combobox-content-border-radius: 4px !default;
 $combobox-content-elevation: 4 !default;
 $combobox-focused-input: 64px !default;
+$combobox-input-buffer: 2px !default;
 $combobox-line-height: 1.75 !default;
 $combobox-selection-gap: 2px !default;
 $combobox-transition: .2s settings.$standard-easing !default;


### PR DESCRIPTION
fixes #18894

Cause: `selection` + `inline-margin-end` occupies the whole flex container, so there is no pixel left to hold input in the same row

Solution: introduce a fixed 2px buffer placeholder to hold input and prevent it flow to next line




<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <div style="width: 200px">
        <v-autocomplete
          :items="['Hello i am a very very very very veeeeeery long text']"
          density="compact"
          variant="outlined"
          hide-details
          clearable
        />
      </div>
      <v-autocomplete
        v-model="value"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-autocomplete
        style="width: 150px"
        v-model="value"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-autocomplete
        style="width: 100px"
        v-model="value"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <h5>Combobox</h5> 
      <v-combobox
        v-model="value"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-combobox
        style="width: 150px"
        v-model="value"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
      <v-combobox
        style="width: 100px"
        v-model="value"
        multiple
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const value = ref(['California'])
</script>


```
