### PR TITLE
fix(VTab): VBtn height inside VTab with non-default density #18970

### DIFF
--- a/packages/docs/src/components/app/bar/Bar.vue
+++ b/packages/docs/src/components/app/bar/Bar.vue
@@ -84,6 +84,8 @@
   const app = useAppStore()
   const user = useUserStore()
   const { smAndUp, mdAndUp, lgAndUp, mdAndDown } = useDisplay()
+  // TODO: maybe remove below
+  // eslint-disable-next-line no-unused-vars
   const route = useRoute()
   const theme = useTheme()
 

--- a/packages/docs/src/components/app/bar/Bar.vue
+++ b/packages/docs/src/components/app/bar/Bar.vue
@@ -84,8 +84,6 @@
   const app = useAppStore()
   const user = useUserStore()
   const { smAndUp, mdAndUp, lgAndUp, mdAndDown } = useDisplay()
-  // TODO: maybe remove below
-  // eslint-disable-next-line no-unused-vars
   const route = useRoute()
   const theme = useTheme()
 

--- a/packages/vuetify/src/components/VTabs/VTab.sass
+++ b/packages/vuetify/src/components/VTabs/VTab.sass
@@ -3,7 +3,7 @@
 .v-tab
   // override v-btn size specificity
   &.v-tab
-    --v-btn-height: var(--v-tabs-height)
+    height: var(--v-tabs-height)
     border-radius: $tab-border-radius
     min-width: $tab-min-width
 

--- a/packages/vuetify/src/components/VTabs/VTab.sass
+++ b/packages/vuetify/src/components/VTabs/VTab.sass
@@ -2,7 +2,7 @@
 
 .v-tab
   // override v-btn size specificity
-  &.v-tab
+  &.v-tab.v-btn
     height: var(--v-tabs-height)
     border-radius: $tab-border-radius
     min-width: $tab-min-width


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes #18970

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-tabs bg-color="primary">
        <v-tab value="one">Item One</v-tab>
        <v-tab value="two">Item Two</v-tab>
        <v-tab value="three">Item Three</v-tab>
      </v-tabs>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from "vue";

const msg = ref("Hello World!");
</script>
```
also change this in `vuetify.js`:
```js
export default createVuetify({
  directives,
  ssr: !!process.env.VITE_SSR,
  date,
  defaults,
  icons,
  locale,
  theme: { defaultTheme: 'light' },
  defaults: {
    VTab: {
      density: 'comfortable', // << added this
    },
  },
})
```