### PR TITLE
docs(VOtpInput): add v-model to divider example

### DIFF
--- a/packages/docs/src/examples/v-otp-input/misc-divider.vue
+++ b/packages/docs/src/examples/v-otp-input/misc-divider.vue
@@ -11,6 +11,7 @@
     <div class="text-subtitle-2 font-weight-light mb-3">Please enter the verification code sent to your mobile</div>
 
     <v-otp-input
+      v-model="otp"
       class="mb-8"
       divider="•"
       length="4"


### PR DESCRIPTION
`resolves` #18979

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
I have added the v-model to the divider example as discussed in #18979. This would allow the send new code button to empty the input field (desired behaviour).
