### PR TITLE
fix(VDataTable): sticky header problem with bgColor

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -60,7 +60,7 @@
                 .v-data-table-header__sort-icon
                   opacity: 0.5
 
-.v-data-table-column--fixed
+.v-data-table-column--fixed, .v-data-table__th--sticky
   background: $table-background
   position: sticky !important
   left: 0

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -124,6 +124,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
               'v-data-table__th--sortable': column.sortable,
               'v-data-table__th--sorted': isSorted(column),
               'v-data-table__th--fixed': column.fixed,
+              'v-data-table__th--sticky': props.sticky,
             },
             loaderClasses.value,
           ]}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
Fixes https://github.com/vuetifyjs/vuetify/issues/18984

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
