### PR TITLE
feat(VOverlay): add clickOutsideIgnore prop to v-overlay

### DIFF
--- a/packages/api-generator/src/locale/en/VOverlay.json
+++ b/packages/api-generator/src/locale/en/VOverlay.json
@@ -2,6 +2,7 @@
   "props": {
     "absolute": "Applies **position: absolute** to the content element.",
     "attach": "Specifies which DOM element the overlay content should teleport to. Can be a direct element reference, querySelector string, or `true` to disable teleporting. Uses `body` by default.",
+    "clickOutsideIgnore": "Prevents the overlay from closing when clicking outside of it. click:outside event will not be emitted. Useful when clothing a notification that is not a part of overlay content.",
     "closeOnBack": "Closes the overlay content when the browser's back button is pressed or `$router.back()` is called, cancelling the original navigation. `persistent` overlays will cancel navigation and animate as if they were clicked outside instead of closing.",
     "contained": "Limits the size of the component and scrim to its offset parent. Implies `absolute` and `attach`. (Note: The parent element must have position: relative.).",
     "noClickAnimation": "Disables the bounce effect when clicking outside of the content element when using the persistent prop.",

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -90,6 +90,7 @@ export const makeVOverlayProps = propsFactory({
   noClickAnimation: Boolean,
   modelValue: Boolean,
   persistent: Boolean,
+  clickOutsideIgnore: [Function, String],
   scrim: {
     type: [Boolean, String],
     default: true,
@@ -293,7 +294,12 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                 <div
                   ref={ contentEl }
                   v-show={ isActive.value }
-                  v-click-outside={{ handler: onClickOutside, closeConditional, include: () => [activatorEl.value] }}
+                  v-click-outside={{
+                    handler: onClickOutside,
+                    closeConditional,
+                    include: () => [activatorEl.value],
+                    ignore: props.clickOutsideIgnore,
+                  }}
                   class={[
                     'v-overlay__content',
                     props.contentClass,


### PR DESCRIPTION
# Ignoring click outside event

Add prop to prevent closing on clicking outside when we need it. When clicking on notification, for example.

## Description
We have an overlay/dialog with action, that could show us a toast notification, that should be closed. The notification is not part of the overlay content and the dialog is closing when we click on it.

As a solution, we could specify persistent prop. In this case, we lose the possibility to close an overlay on ESC or by clicking outside the overlay content.

So, here is a clickOutsideIgnore prop, that allows us to provide a function or selector for ignoring clicking on specific elements.

Playground.vue code
```vue
<script lang="ts" setup>
  const ignoreFn = (e: MouseEvent): boolean => {
    if (!(e.target instanceof HTMLElement)) return false
    return e.target.textContent?.trim() === 'GOOD'
  }
</script>

<template>
  <v-app>
    <v-container>
      <VDialog :click-outside-ignore="'.el-q'">
        <template #activator="{ props }">
          <v-btn v-bind="props">Open Dialog (Selector)</v-btn>
        </template>

        <VCard>
          Content
        </VCard>
      </VDialog>

      <VDialog :click-outside-ignore="ignoreFn">
        <template #activator="{ props }">
          <v-btn v-bind="props">Open Dialog (Function)</v-btn>
        </template>

        <VCard>
          Content
        </VCard>
      </VDialog>

      <VDialog>
        <template #activator="{ props }">
          <v-btn v-bind="props">Open Dialog (Base)</v-btn>
        </template>

        <VCard>
          Content
        </VCard>
      </VDialog>

      <div class="el-q">
        <div class="nested">
          GOOD
        </div>
      </div>
    </v-container>
  </v-app>
</template>

<style lang="scss" scoped>
  .el-q {
    color: red;
    position: fixed;
    left: 0;
    top: 0;
    z-index: 4000;
    background: #fff;
    padding: 20px;
  }
</style>
```
