### PR TITLE
feat(VStepper): pass item props from item objects

### DIFF
--- a/packages/vuetify/src/components/VStepper/VStepper.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepper.tsx
@@ -16,7 +16,7 @@ import { makeGroupProps, useGroup } from '@/composables/group'
 
 // Utilities
 import { computed, toRefs } from 'vue'
-import { genericComponent, getPropertyFromItem, only, propsFactory, useRender } from '@/util'
+import { genericComponent, getPropertyFromItem, isObject, only, pick, propsFactory, useRender } from '@/util'
 
 // Types
 import type { InjectionKey, PropType } from 'vue'
@@ -90,11 +90,14 @@ export const VStepper = genericComponent<VStepperSlots>()({
     const { items: _items, next, prev, selected } = useGroup(props, VStepperSymbol)
     const { color, editable, prevText, nextText } = toRefs(props)
 
+    const itemComponentPropNames = Object.keys(VStepperItem.props)
     const items = computed(() => props.items.map((item, index) => {
       const title = getPropertyFromItem(item, props.itemTitle, item)
       const value = getPropertyFromItem(item, props.itemValue, index + 1)
+      const inheritedProps = isObject(item) ? pick(item, itemComponentPropNames) : null
 
       return {
+        ...inheritedProps,
         title,
         value,
         raw: item,

--- a/packages/vuetify/src/components/VStepper/__tests__/VStepper.spec.ts
+++ b/packages/vuetify/src/components/VStepper/__tests__/VStepper.spec.ts
@@ -1,0 +1,77 @@
+// Components
+
+import { VStepper } from '../VStepper'
+import { VStepperItem } from '../VStepperItem'
+
+// Utilities
+import { describe, expect, it } from '@jest/globals'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from '@/framework'
+
+describe('VStepper.ts', () => {
+  const vuetify = createVuetify()
+  const mountFunction = (options: Record<string, any> = {}) => {
+    const { global, ...opts } = options
+    return mount(VStepper, {
+      ...opts,
+      global: {
+        plugins: [vuetify],
+        ...global,
+      },
+    })
+  }
+
+  it('should use string if item is string', () => {
+    const itemString = 'leItem'
+    const wrapper = mountFunction({
+      props: {
+        items: [itemString],
+      },
+    })
+    const itemWrapper = wrapper.getComponent(VStepperItem)
+
+    expect(itemWrapper.vm.title).toEqual(itemString)
+    expect(itemWrapper.vm.value).toBe(1)
+  })
+
+  it('should pass item values to item component', () => {
+    const itemProps = {
+      color: 'leColor',
+      title: 'overridden by itemTitle prop',
+      subtitle: 'leSubtitle',
+      complete: true,
+      editable: true,
+      editIcon: 'leEditIcon',
+      error: true,
+      errorIcon: 'leErrorIcon',
+      icon: 'leIcon',
+      ripple: false,
+      rules: [Boolean],
+      value: 'overridden by itemValue prop',
+      disabled: true,
+      selectedClass: 'leSelectedClass',
+    }
+    const itemTitle = 'myTitle'
+    const itemValue = 'myValue'
+    const renamedProps = {
+      [itemTitle]: 'leTitle',
+      [itemValue]: 'leValue',
+    }
+    const wrapper = mountFunction({
+      props: {
+        itemTitle,
+        itemValue,
+        items: [{
+          ...itemProps,
+          ...renamedProps,
+        }],
+      },
+    })
+    const itemWrapper = wrapper.getComponent(VStepperItem)
+    const expectedProps = { ...itemProps, title: renamedProps[itemTitle], value: renamedProps[itemValue] }
+    const excludedAttributes = Object.fromEntries(Object.keys(renamedProps).map(key => [key.toLowerCase(), expect.anything()]))
+
+    expect(itemWrapper.vm).toMatchObject(expectedProps)
+    expect(itemWrapper.attributes()).not.toMatchObject(excludedAttributes)
+  })
+})


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19036 (see for problem description)

Implementation is straight-forward: If items are objects, their properties are filtered by prop names of VStepperItem and added to the internal item.

Tests are added to ensure string items still work and props are taken over as expected.
 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-card color="primary">
      <v-card-title>Stepper with items in slot</v-card-title>

      <v-stepper :model-value="items[2].value">
        <v-stepper-header>
          <v-stepper-item v-for="item in items" v-bind="item"></v-stepper-item>
        </v-stepper-header>
        <v-stepper-window />
      </v-stepper>
    </v-card>
    <v-card color="primary" class="mt-4">
      <v-card-title>Stepper with :item prop</v-card-title>

      <v-stepper :model-value="items[2].value" :items="items"
        ><template #actions
      /></v-stepper>
    </v-card>
  </v-container>
</template>
<script setup lang="ts">
    import { ref } from 'vue'
    import type { VStepperItem } from 'vuetify/components';

    const items = ref([
      {
        value: 'a',
        title: 'Completed with color',
        complete: true,
        color: 'secondary',
      },{
        value: 'b',
        title: 'Erroneous',
        rules: [() => false],
      },{
        value: 'c',
        title: 'Disabled current step',
        disabled: true
      },{
        value: 'd',
        title: 'Subtitle & custom icon',
        subtitle: 'subtitle',
        icon: 'mdi-car',
      },
    ])
</script>
```
## Notes:
- VList works similarly, but the [`item-props`](https://vuetifyjs.com/en/api/v-list/#props-item-props) prop has to be used to enable takeover whole or in parts. This makes sense for lists, which are often generated using existing data, like a list of purchases. I am not sure if it makes sense for a stepper, which is generally not created from unrelated data objects. But I can easily add it if requested.
- I would like to rename the `items` variable to `internalItems`, since the word `item` is somewhat overused in the component, but I am not sure if this is the place to do it (is it?).

This is my first contribution, please let me know what I am doing wrong!
Thank you for Vuetify! I enjoy it a lot.