### PR TITLE
fix(VCombobox): default ReturnObject props to false 

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -94,7 +94,7 @@ type ItemType<T> = T extends readonly (infer U)[] ? U : never
 export const VCombobox = genericComponent<new <
   T extends readonly any[],
   Item = ItemType<T>,
-  ReturnObject extends boolean = true,
+  ReturnObject extends boolean = false,
   Multiple extends boolean = false,
   V extends Value<Item, ReturnObject, Multiple> = Value<Item, ReturnObject, Multiple>
 >(


### PR DESCRIPTION
## Description
ReturnObject props default to false for VAutocomplete and VSelect but not for VCombobox who essentially behave similar to previous two for this functionality.
So this default behaviour seems inconsistant.  
If intended, i'll be glad to have an explanation why.  
thanks for taking the time of reading this PR and have a nice day.
