### PR TITLE
feat(VOtpInput): add number password type to component

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -47,6 +47,7 @@ export const makeVOtpInputProps = propsFactory({
     type: String as PropType<'text' | 'password' | 'number'>,
     default: 'number',
   },
+  numeric: Boolean,
 
   ...makeDimensionProps(),
   ...makeFocusProps(),
@@ -101,6 +102,12 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
       // The maxlength attribute doesn't work for the number type input, so the text type is used.
       // The following logic simulates the behavior of a number input.
       if (props.type === 'number' && /[^0-9]/g.test(current.value.value)) {
+        current.value.value = ''
+        return
+      }
+      // If there is type numeric, then this will make sure that the entered value is a digit.
+      // Helpful to restrict values when using with some predefined type like password.
+      if (props.numeric && /[^0-9]/g.test(current.value.value)) {
         current.value.value = ''
         return
       }


### PR DESCRIPTION
resolves #18964

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
As mentioned in the issue, I have added an attribute called numeric which can be used with type password. Once numeric is set to true, VOtpInput would not accept non-numeric values. 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
eslint-disable vue/script-indent
<template>
  <v-app>
    <v-container>
      <!-- -->
      <v-otp-input v-model="otp" type="password" numeric/>
      {{ otp }}
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue';

  import { VOtpInput } from '../src/components/VOtpInput/index.ts'
  export default {
    name: 'Playground',
    components: {
      VOtpInput,
    },
    setup () {
      const otp = ref('')
      return {
        otp,
        //
      }
    },
  }
</script>

```
