### PR TITLE
docs(components/all): remove duplicated Bottom Sheet Component

### DIFF
--- a/packages/docs/src/pages/en/components/all.md
+++ b/packages/docs/src/pages/en/components/all.md
@@ -96,12 +96,6 @@ Containment components wrap other components and provide additional functionalit
 
 </components-list-item>
 
-<components-list-item name="Bottom Sheet component" src="bottom-sheets">
-
-  The bottom sheet component is a modified dialog that slides from the bottom of the screen
-
-</components-list-item>
-
 <components-list-item name="Sheet component" src="sheets">
 
   The sheet component is a simple piece of paper that can be used to style and customize a block of content


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Inside all components showcase, there was a duplicated Bottom Sheet component. Just removed the last one as both of them redirects to the bottom sheet page.

![vuetify duplicated content](https://github.com/vuetifyjs/vuetify/assets/11396307/a85342bc-d308-496c-9d6b-59c4b025c5ab)

