### PR TITLE
fix:(VAutoComplete/VCombobox): show selection slot when input has focus and multiple prop is false

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -78,6 +78,10 @@ export const makeVAutocompleteProps = propsFactory({
     type: [Boolean, String] as PropType<boolean | 'exact'>,
   },
   clearOnSelect: Boolean,
+  showSelectionSlot: {
+    type: Boolean,
+    default: false,
+  },
   search: String,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
@@ -243,7 +247,7 @@ export const VAutocomplete = genericComponent<new <
         listRef.value?.focus('next')
       }
 
-      if (!props.multiple) return
+      if (!props.multiple && !props.showSelectionSlot) return
 
       if (['Backspace', 'Delete'].includes(e.key)) {
         if (selectionIndex.value < 0) {
@@ -257,7 +261,7 @@ export const VAutocomplete = genericComponent<new <
         const originalSelectionIndex = selectionIndex.value
 
         const selectedItem = model.value[selectionIndex.value]
-        if (selectedItem && !selectedItem.props.disabled) select(selectedItem)
+        if (selectedItem && !selectedItem.props.disabled) select(selectedItem, !props.showSelectionSlot)
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
@@ -344,7 +348,9 @@ export const VAutocomplete = genericComponent<new <
 
         isSelecting.value = true
 
-        search.value = add ? item.title : ''
+        if (!props.showSelectionSlot) {
+          search.value = add ? item.title : ''
+        }
 
         menu.value = false
         isPristine.value = true
@@ -358,7 +364,15 @@ export const VAutocomplete = genericComponent<new <
 
       if (val) {
         isSelecting.value = true
-        search.value = props.multiple ? '' : String(model.value.at(-1)?.props.title ?? '')
+
+        if (props.multiple) {
+          search.value = ''
+        } else {
+          if (!props.showSelectionSlot) {
+            search.value = String(model.value.at(-1)?.props.title ?? '')
+          }
+        }
+
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)
@@ -432,12 +446,12 @@ export const VAutocomplete = genericComponent<new <
           onChange={ onChange }
           class={[
             'v-autocomplete',
-            `v-autocomplete--${props.multiple ? 'multiple' : 'single'}`,
             {
               'v-autocomplete--active-menu': menu.value,
               'v-autocomplete--chips': !!props.chips,
               'v-autocomplete--selection-slot': !!slots.selection,
               'v-autocomplete--selecting-index': selectionIndex.value > -1,
+              [`v-autocomplete--${props.multiple ? 'multiple' : 'single'}`]: !props.showSelectionSlot,
             },
             props.class,
           ]}

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -82,6 +82,10 @@ export const makeVComboboxProps = propsFactory({
     type: Boolean,
     default: true,
   },
+  showSelectionSlot: {
+    type: Boolean,
+    default: false,
+  },
   delimiters: Array as PropType<readonly string[]>,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
@@ -209,7 +213,7 @@ export const VCombobox = genericComponent<new <
       emit('update:search', value)
     })
     watch(model, value => {
-      if (!props.multiple) {
+      if (!props.multiple && !props.showSelectionSlot) {
         _search.value = value[0]?.title ?? ''
       }
     })
@@ -295,7 +299,7 @@ export const VCombobox = genericComponent<new <
         listRef.value?.focus('next')
       }
 
-      if (!props.multiple) return
+      if (!props.multiple && !props.showSelectionSlot) return
 
       if (['Backspace', 'Delete'].includes(e.key)) {
         if (selectionIndex.value < 0) {
@@ -372,7 +376,9 @@ export const VCombobox = genericComponent<new <
       } else {
         const add = set !== false
         model.value = add ? [item] : []
-        _search.value = add ? item.title : ''
+        if (!props.showSelectionSlot) {
+          _search.value = add ? item.title : ''
+        }
 
         // watch for search watcher to trigger
         nextTick(() => {
@@ -463,7 +469,7 @@ export const VCombobox = genericComponent<new <
               'v-combobox--chips': !!props.chips,
               'v-combobox--selection-slot': !!slots.selection,
               'v-combobox--selecting-index': selectionIndex.value > -1,
-              [`v-combobox--${props.multiple ? 'multiple' : 'single'}`]: true,
+              [`v-autocomplete--${props.multiple ? 'multiple' : 'single'}`]: !props.showSelectionSlot,
             },
             props.class,
           ]}


### PR DESCRIPTION
**Description**
Because of #17294 on focus, the search value updated to item tile and added to input field. Selection slot has opacity: 0 and input tag has position: absolute, due that input overlap the selection slot and showing search value which cause hiding selection slot style.

**Open Issue**
VAutoComplete/VCombobox doesn't use formatted style from selection slot when multiple prop is false and dropdown open
fixes: #18454, #17573, #17291

**Markup**
```
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        :items="items"
        item-title="name"
        item-value="age"
        label="Show selection"
        :show-selection-slot="true"
      >
        <template #selection="{ item }">
          <VChip>{{ item.raw.name }} - {{ item.raw.age }}</VChip>
        </template>
        <template #item="{ item, props }">
          <v-list-item v-bind="props" title="">
            {{ item.raw.name }} - {{ item.raw.age }}
          </v-list-item>
        </template>
      </v-autocomplete>

      <v-autocomplete
        :items="items"
        item-title="name"
        item-value="age"
        label="Show chip without selection slot"
        chips
        :show-selection-slot="true"
      >
        <template #item="{ item, props }">
          <v-list-item v-bind="props" title="">
            {{ item.raw.name }} - {{ item.raw.age }}
          </v-list-item>
        </template>
      </v-autocomplete>

      <v-combobox
        chips
        label="Combobox"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :show-selection-slot="true"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'
  const items = [
    {
      name: 'first',
      age: 42,
    },
    {
      name: 'second',
      age: 83,
    },
  ]
</script>
```
