### PR TITLE
docs(VTabs): correct centered to align-tabs center

### DIFF
--- a/packages/docs/src/examples/v-tabs/misc-content.vue
+++ b/packages/docs/src/examples/v-tabs/misc-content.vue
@@ -18,7 +18,7 @@
       <template v-slot:extension>
         <v-tabs
           v-model="model"
-          centered
+          alignTabs="center"
         >
           <v-tab
             v-for="i in 3"

--- a/packages/docs/src/examples/v-tabs/misc-content.vue
+++ b/packages/docs/src/examples/v-tabs/misc-content.vue
@@ -18,7 +18,7 @@
       <template v-slot:extension>
         <v-tabs
           v-model="model"
-          alignTabs="center"
+          align-tabs="center"
         >
           <v-tab
             v-for="i in 3"

--- a/packages/docs/src/examples/v-tabs/misc-dynamic-height.vue
+++ b/packages/docs/src/examples/v-tabs/misc-dynamic-height.vue
@@ -19,7 +19,7 @@
       <template v-slot:extension>
         <v-tabs
           v-model="tabs"
-          alignTabs="center"
+          align-tabs="center"
         >
           <v-tab
             v-for="n in 3"

--- a/packages/docs/src/examples/v-tabs/misc-dynamic-height.vue
+++ b/packages/docs/src/examples/v-tabs/misc-dynamic-height.vue
@@ -19,7 +19,7 @@
       <template v-slot:extension>
         <v-tabs
           v-model="tabs"
-          centered
+          alignTabs="center"
         >
           <v-tab
             v-for="n in 3"

--- a/packages/docs/src/examples/v-tabs/prop-stacked.vue
+++ b/packages/docs/src/examples/v-tabs/prop-stacked.vue
@@ -3,7 +3,7 @@
     <v-tabs
       v-model="tab"
       bg-color="deep-purple-accent-4"
-      centered
+      alignTabs="center"
       stacked
     >
       <v-tab value="tab-1">

--- a/packages/docs/src/examples/v-tabs/prop-stacked.vue
+++ b/packages/docs/src/examples/v-tabs/prop-stacked.vue
@@ -3,7 +3,7 @@
     <v-tabs
       v-model="tab"
       bg-color="deep-purple-accent-4"
-      alignTabs="center"
+      align-tabs="center"
       stacked
     >
       <v-tab value="tab-1">


### PR DESCRIPTION
fix VTabs example in documentation

centered property (v2) => align-tabs="center" (v3)
