### PR TITLE
fix(group): use index as value if not provided

### DIFF
--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -2,7 +2,7 @@
 import { useProxiedModel } from './proxiedModel'
 
 // Utilities
-import { computed, inject, isRef, onBeforeUnmount, onMounted, provide, reactive, toRef, watch } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, provide, reactive, toRef, unref, watch } from 'vue'
 import { consoleWarn, deepEqual, findChildrenWithProvide, getCurrentInstance, getUid, propsFactory, wrapInArray } from '@/util'
 
 // Types
@@ -179,10 +179,7 @@ export function useGroup (
     const children = findChildrenWithProvide(key, groupVm?.vnode)
     const index = children.indexOf(vm)
 
-    if (!unwrapped.value || (
-      isRef(unwrapped.value) &&
-      unwrapped.value.value == null
-    )) {
+    if (unref(unwrapped.value) == null) {
       unwrapped.value = index
     }
 

--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -2,7 +2,7 @@
 import { useProxiedModel } from './proxiedModel'
 
 // Utilities
-import { computed, inject, onBeforeUnmount, onMounted, provide, reactive, toRef, watch } from 'vue'
+import { computed, inject, isRef, onBeforeUnmount, onMounted, provide, reactive, toRef, watch } from 'vue'
 import { consoleWarn, deepEqual, findChildrenWithProvide, getCurrentInstance, getUid, propsFactory, wrapInArray } from '@/util'
 
 // Types
@@ -178,6 +178,13 @@ export function useGroup (
     const key = Symbol.for(`${injectKey.description}:id`)
     const children = findChildrenWithProvide(key, groupVm?.vnode)
     const index = children.indexOf(vm)
+
+    if (!unwrapped.value || (
+      isRef(unwrapped.value) &&
+      unwrapped.value.value == null
+    )) {
+      unwrapped.value = index
+    }
 
     if (index > -1) {
       items.splice(index, 0, unwrapped)


### PR DESCRIPTION
## Motivation and Context

closes #19107

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-container>
      <pre>{{ JSON.stringify(step, null, 2) }}</pre>
      <v-stepper v-model="step">
        <v-stepper-header>
          <v-stepper-item title="step 1" />
          <v-stepper-item title="step 2" />
        </v-stepper-header>

        <v-stepper-window>
          <v-stepper-window-item> step 1 </v-stepper-window-item>
          <v-stepper-window-item> step 2 </v-stepper-window-item>
        </v-stepper-window>
      </v-stepper>
    </v-container>
  </v-app>
</template>
<script setup>
  import { ref } from 'vue'
  const step = ref(1)
</script>

```
</details>