### PR TITLE
style(VNavigationDrawer): The internal avatar is displayed in the center of the menu collapse

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -61,7 +61,7 @@
   .v-navigation-drawer--rail:not(.v-navigation-drawer--expand-on-hover) &,
   .v-navigation-drawer--rail.v-navigation-drawer--expand-on-hover:not(.v-navigation-drawer--is-hovering) &
     .v-avatar
-      --v-avatar-height: 24px 
+      --v-avatar-height: 24px
 
 .v-list-item__prepend
   align-items: center
@@ -236,7 +236,6 @@
             padding-top: math.div($three-line-padding, 2)
 
       &:not(.v-list-item--nav)
-
         &.v-list-item--one-line
           padding-inline: list.nth($list-item-padding, 2)
 

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -61,7 +61,7 @@
   .v-navigation-drawer--rail:not(.v-navigation-drawer--expand-on-hover) &,
   .v-navigation-drawer--rail.v-navigation-drawer--expand-on-hover:not(.v-navigation-drawer--is-hovering) &
     .v-avatar
-      --v-avatar-height: 24px
+      --v-avatar-height: 24px 
 
 .v-list-item__prepend
   align-items: center
@@ -236,6 +236,7 @@
             padding-top: math.div($three-line-padding, 2)
 
       &:not(.v-list-item--nav)
+
         &.v-list-item--one-line
           padding-inline: list.nth($list-item-padding, 2)
 
@@ -244,6 +245,9 @@
 
         &.v-list-item--three-line
           padding-inline: list.nth($list-item-three-line-padding, 2)
+
+      .v-navigation-drawer &.v-list-item--density-default 
+        padding-inline: list.nth($list-item-padding, 2)
 
   &--nav
     padding-inline: $list-nav-padding

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -245,15 +245,12 @@
         &.v-list-item--three-line
           padding-inline: list.nth($list-item-three-line-padding, 2)
 
-      .v-navigation-drawer &.v-list-item--density-default 
-        padding-inline: list.nth($list-item-padding, 2)
+  .v-list &
+    &--nav
+      padding-inline: $list-nav-padding
 
-  &--nav
-    padding-inline: $list-nav-padding
-
-    .v-list &
-      &:not(:only-child)
-        margin-bottom: $list-item-nav-margin-top
+    &:not(:only-child)
+      margin-bottom: $list-item-nav-margin-top
 
 .v-list-item__underlay
   position: absolute


### PR DESCRIPTION
Related to https://github.com/vuetifyjs/vuetify/issues/18561
But I later discovered that the reduction of the internal avatar might be intentional.
Because you can keep a similar size to the icon below
https://vuetifyjs.com/zh-Hans/components/navigation-drawers/#section-7a84578b53d853166548679c 
The avatar in the menu here in the document will be scaled but not centered when folded
This modification worked for my use case and no other errors occurred after applying it.
Maybe css selectors should be more rigorous. Can you provide some comments?

before 

![v1](https://github.com/vuetifyjs/vuetify/assets/49276902/681c976d-1c7f-4821-82d2-ee2f2e31d0f3)

after

![v2](https://github.com/vuetifyjs/vuetify/assets/49276902/67bb181c-fe44-49de-a812-51d01c31f93a)
