### PR TITLE
fix(Tooltip): set width attr,text too length,but text not wrap

### DIFF
--- a/packages/vuetify/src/components/VTooltip/VTooltip.sass
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.sass
@@ -15,7 +15,8 @@
     opacity: 1
     pointer-events: none
     transition-property: opacity, transform
-
+    word-wrap: break-word
+    
     &[class*="enter-active"]
       transition-timing-function: settings.$decelerated-easing
       transition-duration: $tooltip-transition-enter-duration

--- a/packages/vuetify/src/components/VTooltip/VTooltip.sass
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.sass
@@ -15,8 +15,8 @@
     opacity: 1
     pointer-events: none
     transition-property: opacity, transform
-    word-wrap: break-word
-    
+    overflow-wrap: $tooltip-overflow-wrap
+
     &[class*="enter-active"]
       transition-timing-function: settings.$decelerated-easing
       transition-duration: $tooltip-transition-enter-duration

--- a/packages/vuetify/src/components/VTooltip/_variables.scss
+++ b/packages/vuetify/src/components/VTooltip/_variables.scss
@@ -9,3 +9,4 @@ $tooltip-line-height: 1.6 !default;
 $tooltip-transition-enter-duration: 150ms !default;
 $tooltip-transition-leave-duration: 75ms !default;
 $tooltip-padding: 5px 16px !default;
+$tooltip-overflow-wrap: break-word !default;


### PR DESCRIPTION
Tooltip set width，text too length, but text not wrap

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
![image](https://github.com/vuetifyjs/vuetify/assets/37261842/541bc355-32b2-44fb-b437-41655fd9afc0)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
