### PR TITLE
feat(VDatePicker): add isBeforeYear check

### DIFF
--- a/packages/vuetify/src/composables/date/DateAdapter.ts
+++ b/packages/vuetify/src/composables/date/DateAdapter.ts
@@ -19,6 +19,7 @@ export interface DateAdapter<T = unknown> {
   isEqual (date: T, comparing: T): boolean
   isSameDay (date: T, comparing: T): boolean
   isSameMonth (date: T, comparing: T): boolean
+  isBeforeYear(date: T, comparing: T): boolean
   isValid (date: any): boolean
   isWithinRange (date: T, range: [T, T]): boolean
 

--- a/packages/vuetify/src/composables/date/DateAdapter.ts
+++ b/packages/vuetify/src/composables/date/DateAdapter.ts
@@ -19,7 +19,7 @@ export interface DateAdapter<T = unknown> {
   isEqual (date: T, comparing: T): boolean
   isSameDay (date: T, comparing: T): boolean
   isSameMonth (date: T, comparing: T): boolean
-  isBeforeYear(date: T, comparing: T): boolean
+  isBeforeYear (date: T, comparing: T): boolean
   isValid (date: any): boolean
   isWithinRange (date: T, range: [T, T]): boolean
 

--- a/packages/vuetify/src/composables/date/DateAdapter.ts
+++ b/packages/vuetify/src/composables/date/DateAdapter.ts
@@ -14,12 +14,15 @@ export interface DateAdapter<T = unknown> {
   startOfYear (date: T): T
   endOfYear (date: T): T
 
-  isBefore (date: T, comparing: T): boolean
   isAfter (date: T, comparing: T): boolean
-  isEqual (date: T, comparing: T): boolean
+  isAfterDay(value: T, comparing: T): boolean
+
   isSameDay (date: T, comparing: T): boolean
   isSameMonth (date: T, comparing: T): boolean
-  isBeforeYear (date: T, comparing: T): boolean
+  isSameYear(value: T, comparing: T): boolean
+
+  isBefore (date: T, comparing: T): boolean
+  isEqual (date: T, comparing: T): boolean
   isValid (date: any): boolean
   isWithinRange (date: T, range: [T, T]): boolean
 
@@ -37,6 +40,8 @@ export interface DateAdapter<T = unknown> {
   getMonth (date: T): number
   setMonth (date: T, month: number): T
   getNextMonth (date: T): T
+  getPreviousMonth(date: T): T
+
   getHours (date: T): number
   setHours (date: T, hours: number): T
   getMinutes (date: T): number

--- a/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
+++ b/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
@@ -54,39 +54,39 @@ describe('vuetify date adapter', () => {
   })
 
   describe('isBeforeYear', () => {
-    let dateUtils: VuetifyDateAdapter;
+    let dateUtils: VuetifyDateAdapter
 
     beforeEach(() => {
-      dateUtils = new VuetifyDateAdapter({ locale: 'en-us' });
-    });
+      dateUtils = new VuetifyDateAdapter({ locale: 'en-us' })
+    })
 
     it('returns false when the first date is in the same year as the second date', () => {
-      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-01-02'))).toBe(false);
-    });
+      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-01-02'))).toBe(false)
+    })
 
     it('returns false when dates are in the same year', () => {
-      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-12-31'))).toBe(false);
-    });
+      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-12-31'))).toBe(false)
+    })
 
     it('returns false when the first date is in a year after the second date', () => {
-      expect(dateUtils.isBeforeYear(new Date('2025-01-01'), new Date('2024-12-31'))).toBe(false);
-    });
+      expect(dateUtils.isBeforeYear(new Date('2025-01-01'), new Date('2024-12-31'))).toBe(false)
+    })
 
     describe('handles invalid dates', () => {
-      const validDate = new Date('2024-12-31');
-      const invalidDate = new Date('invalid-date');
+      const validDate = new Date('2024-12-31')
+      const invalidDate = new Date('invalid-date')
 
       it('returns false for invalid first date', () => {
-        expect(dateUtils.isBeforeYear(invalidDate, validDate)).toBe(false);
-      });
+        expect(dateUtils.isBeforeYear(invalidDate, validDate)).toBe(false)
+      })
 
       it('returns false for invalid second date', () => {
-        expect(dateUtils.isBeforeYear(validDate, invalidDate)).toBe(false);
-      });
+        expect(dateUtils.isBeforeYear(validDate, invalidDate)).toBe(false)
+      })
 
       it('returns false for both dates invalid', () => {
-        expect(dateUtils.isBeforeYear(invalidDate, invalidDate)).toBe(false);
-      });
-    });
-  });
+        expect(dateUtils.isBeforeYear(invalidDate, invalidDate)).toBe(false)
+      })
+    })
+  })
 })

--- a/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
+++ b/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
@@ -53,40 +53,47 @@ describe('vuetify date adapter', () => {
     timezoneMock.unregister()
   })
 
-  describe('isBeforeYear', () => {
-    let dateUtils: VuetifyDateAdapter
+  describe('isAfterDay', () => {
+    const dateUtils = new VuetifyDateAdapter({ locale: 'en-us' })
 
-    beforeEach(() => {
-      dateUtils = new VuetifyDateAdapter({ locale: 'en-us' })
+    it.each([
+      [new Date('2024-01-02'), new Date('2024-01-01'), true],
+      [new Date('2024-02-29'), new Date('2024-02-28'), true],
+      [new Date('2024-01-01'), new Date('2024-01-01'), false],
+      [new Date('2024-01-01'), new Date('2024-01-02'), false],
+    ])('returns %s when comparing %s and %s', (date, comparing, expected) => {
+      expect(dateUtils.isAfterDay(date, comparing)).toBe(expected)
     })
+  })
 
-    it('returns false when the first date is in the same year as the second date', () => {
-      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-01-02'))).toBe(false)
+  describe('getPreviousMonth', () => {
+    const dateUtils = new VuetifyDateAdapter({ locale: 'en-us' })
+
+    it.each([
+      [new Date('2024-03-15'), new Date('2024-02-01'), '2024-03-15 -> 2024-02-01'],
+      [new Date('2024-01-01'), new Date('2023-12-01'), '2024-01-01 -> 2023-12-01'],
+      [new Date('2025-01-31'), new Date('2024-12-01'), '2025-01-31 -> 2024-12-01'],
+      [new Date('2024-02-29'), new Date('2024-01-01'), '2024-02-29 -> 2024-01-01 (Leap Year)'],
+      [new Date('2023-03-01'), new Date('2023-02-01'), '2023-03-01 -> 2023-02-01'],
+    ])('correctly calculates the first day of the previous month: %s', (date, expected) => {
+      const result = dateUtils.getPreviousMonth(date)
+      expect(result.getFullYear()).toBe(expected.getFullYear())
+      expect(result.getMonth()).toBe(expected.getMonth())
+      expect(result.getDate()).toBe(expected.getDate())
     })
+  })
 
-    it('returns false when dates are in the same year', () => {
-      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-12-31'))).toBe(false)
-    })
+  describe('isSameYear', () => {
+    const dateUtils = new VuetifyDateAdapter({ locale: 'en-us' })
 
-    it('returns false when the first date is in a year after the second date', () => {
-      expect(dateUtils.isBeforeYear(new Date('2025-01-01'), new Date('2024-12-31'))).toBe(false)
-    })
-
-    describe('handles invalid dates', () => {
-      const validDate = new Date('2024-12-31')
-      const invalidDate = new Date('invalid-date')
-
-      it('returns false for invalid first date', () => {
-        expect(dateUtils.isBeforeYear(invalidDate, validDate)).toBe(false)
-      })
-
-      it('returns false for invalid second date', () => {
-        expect(dateUtils.isBeforeYear(validDate, invalidDate)).toBe(false)
-      })
-
-      it('returns false for both dates invalid', () => {
-        expect(dateUtils.isBeforeYear(invalidDate, invalidDate)).toBe(false)
-      })
+    it.each([
+      [new Date('2024-01-01'), new Date('2024-12-31'), true],
+      [new Date('2024-06-15'), new Date('2024-11-20'), true],
+      [new Date('2023-01-01'), new Date('2024-01-01'), false],
+      [new Date('2024-12-31'), new Date('2025-01-01'), false],
+      [new Date('2024-07-07'), new Date('2023-07-07'), false],
+    ])('returns %s when comparing %s and %s', (date1, date2, expected) => {
+      expect(dateUtils.isSameYear(date1, date2)).toBe(expected)
     })
   })
 })

--- a/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
+++ b/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
@@ -52,4 +52,41 @@ describe('vuetify date adapter', () => {
 
     timezoneMock.unregister()
   })
+
+  describe('isBeforeYear', () => {
+    let dateUtils: VuetifyDateAdapter;
+
+    beforeEach(() => {
+      dateUtils = new VuetifyDateAdapter({ locale: 'en-us' });
+    });
+
+    it('returns false when the first date is in the same year as the second date', () => {
+      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-01-02'))).toBe(false);
+    });
+
+    it('returns false when dates are in the same year', () => {
+      expect(dateUtils.isBeforeYear(new Date('2024-12-31'), new Date('2024-12-31'))).toBe(false);
+    });
+
+    it('returns false when the first date is in a year after the second date', () => {
+      expect(dateUtils.isBeforeYear(new Date('2025-01-01'), new Date('2024-12-31'))).toBe(false);
+    });
+
+    describe('handles invalid dates', () => {
+      const validDate = new Date('2024-12-31');
+      const invalidDate = new Date('invalid-date');
+
+      it('returns false for invalid first date', () => {
+        expect(dateUtils.isBeforeYear(invalidDate, validDate)).toBe(false);
+      });
+
+      it('returns false for invalid second date', () => {
+        expect(dateUtils.isBeforeYear(validDate, invalidDate)).toBe(false);
+      });
+
+      it('returns false for both dates invalid', () => {
+        expect(dateUtils.isBeforeYear(invalidDate, invalidDate)).toBe(false);
+      });
+    });
+  });
 })

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -427,8 +427,8 @@ function isSameMonth (date: Date, comparing: Date) {
     date.getFullYear() === comparing.getFullYear()
 }
 
-function isBeforeYear (value: Date, comparing: Date): boolean {
-  return value.getFullYear() < comparing.getFullYear();
+function isBeforeYear (date: Date, comparing: Date) {
+  return date.getFullYear() < comparing.getFullYear()
 }
 
 function getDiff (date: Date, comparing: Date | string, unit?: string) {
@@ -563,8 +563,8 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
     return !isAfter(date, comparing) && !isEqual(date, comparing)
   }
 
-  isBeforeYear(date: Date, comparing: Date): boolean {
-    return isBeforeYear(date, comparing);
+  isBeforeYear (date: Date, comparing: Date) {
+    return isBeforeYear(date, comparing)
   }
 
   isSameDay (date: Date, comparing: Date) {

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -379,6 +379,10 @@ function getNextMonth (date: Date) {
   return new Date(date.getFullYear(), date.getMonth() + 1, 1)
 }
 
+function getPreviousMonth (date: Date) {
+  return new Date(date.getFullYear(), date.getMonth() - 1, 1)
+}
+
 function getHours (date: Date) {
   return date.getHours()
 }
@@ -408,6 +412,10 @@ function isAfter (date: Date, comparing: Date) {
   return date.getTime() > comparing.getTime()
 }
 
+function isAfterDay (date: Date, comparing: Date): boolean {
+  return isAfter(startOfDay(date), startOfDay(comparing))
+}
+
 function isBefore (date: Date, comparing: Date) {
   return date.getTime() < comparing.getTime()
 }
@@ -427,8 +435,8 @@ function isSameMonth (date: Date, comparing: Date) {
     date.getFullYear() === comparing.getFullYear()
 }
 
-function isBeforeYear (date: Date, comparing: Date) {
-  return date.getFullYear() < comparing.getFullYear()
+function isSameYear (date: Date, comparing: Date) {
+  return date.getFullYear() === comparing.getFullYear()
 }
 
 function getDiff (date: Date, comparing: Date | string, unit?: string) {
@@ -559,12 +567,12 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
     return isAfter(date, comparing)
   }
 
-  isBefore (date: Date, comparing: Date) {
-    return !isAfter(date, comparing) && !isEqual(date, comparing)
+  isAfterDay (date: Date, comparing: Date) {
+    return isAfterDay(date, comparing)
   }
 
-  isBeforeYear (date: Date, comparing: Date) {
-    return isBeforeYear(date, comparing)
+  isBefore (date: Date, comparing: Date) {
+    return !isAfter(date, comparing) && !isEqual(date, comparing)
   }
 
   isSameDay (date: Date, comparing: Date) {
@@ -573,6 +581,10 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
 
   isSameMonth (date: Date, comparing: Date) {
     return isSameMonth(date, comparing)
+  }
+
+  isSameYear (date: Date, comparing: Date) {
+    return isSameYear(date, comparing)
   }
 
   setMinutes (date: Date, count: number) {
@@ -609,6 +621,10 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
 
   getNextMonth (date: Date) {
     return getNextMonth(date)
+  }
+
+  getPreviousMonth (date: Date) {
+    return getPreviousMonth(date)
   }
 
   getHours (date: Date) {

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -427,6 +427,10 @@ function isSameMonth (date: Date, comparing: Date) {
     date.getFullYear() === comparing.getFullYear()
 }
 
+function isBeforeYear (value: Date, comparing: Date): boolean {
+  return value.getFullYear() < comparing.getFullYear();
+}
+
 function getDiff (date: Date, comparing: Date | string, unit?: string) {
   const d = new Date(date)
   const c = new Date(comparing)
@@ -557,6 +561,10 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
 
   isBefore (date: Date, comparing: Date) {
     return !isAfter(date, comparing) && !isEqual(date, comparing)
+  }
+
+  isBeforeYear(date: Date, comparing: Date): boolean {
+    return isBeforeYear(date, comparing);
   }
 
   isSameDay (date: Date, comparing: Date) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Add missing IUtil interface function: isBeforeYear

## Markup:


<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      {{ adapter.date() }}
    </div>
  </v-app>
</template>

<script setup>
  import { useDate } from '../src/composables/date'

  const adapter = useDate()

  console.log(adapter)
</script>
```
