### PR TITLE
feat(VColorPicker): add hide-eye-dropper prop

### DIFF
--- a/packages/api-generator/src/locale/en/VColorPicker.json
+++ b/packages/api-generator/src/locale/en/VColorPicker.json
@@ -4,6 +4,7 @@
     "dotSize": "Changes the size of the selection dot on the canvas.",
     "flat": "Removes elevation.",
     "hideCanvas": "Hides canvas.",
+    "hideEyeDropper": "Hides EyeDropper.",
     "hideSliders": "Hides sliders.",
     "hideInputs": "Hides inputs.",
     "hideModeSwitch": "Hides mode switch.",

--- a/packages/vuetify/src/components/VColorPicker/VColorPicker.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPicker.tsx
@@ -33,6 +33,7 @@ export const makeVColorPickerProps = propsFactory({
     default: 10,
   },
   hideCanvas: Boolean,
+  hideEyeDropper: Boolean,
   hideSliders: Boolean,
   hideInputs: Boolean,
   mode: {
@@ -167,6 +168,7 @@ export const VColorPicker = defineComponent({
                   color={ currentColor.value }
                   onUpdate:color={ updateColor }
                   hideAlpha={ !mode.value.endsWith('a') }
+                  hideEyeDropper={ props.hideEyeDropper }
                   disabled={ props.disabled }
                 />
               )}

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
@@ -30,7 +30,7 @@ export const makeVColorPickerPreviewProps = propsFactory({
   },
   disabled: Boolean,
   hideAlpha: Boolean,
-
+  hideEyeDropper: Boolean,
   ...makeComponentProps(),
 }, 'VColorPickerPreview')
 
@@ -70,7 +70,7 @@ export const VColorPickerPreview = defineComponent({
         ]}
         style={ props.style }
       >
-        { SUPPORTS_EYE_DROPPER && (
+        { SUPPORTS_EYE_DROPPER && !props.hideEyeDropper && (
           <div class="v-color-picker-preview__eye-dropper" key="eyeDropper">
             <VBtn onClick={ openEyeDropper } icon="$eyeDropper" variant="plain" density="comfortable" />
           </div>

--- a/packages/vuetify/src/components/VColorPicker/__tests__/VColorPicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VColorPicker/__tests__/VColorPicker.spec.cy.tsx
@@ -35,6 +35,14 @@ describe('VColorPicker', () => {
     cy.get('.v-color-picker-swatches').should('exist')
   })
 
+  it('should hide eyedropper', () => {
+    cy.mount(() => (
+      <Application>
+        <VColorPicker hideEyeDropper />
+      </Application>
+    ))
+  })
+
   it('should hide inputs', () => {
     cy.mount(() => (
       <Application>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
resolves #19150 

### Why is this change required?
You currently can't disable the eye-dropper in v-color-picker if its enabled on your browser.
When you do want it hidden you have to write some custom css to force hide it.

### What problem does it solve?
The lack of hiding it using a prop on the component itself.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-color-picker hide-eye-dropper />
    </v-container>
  </v-app>
</template>

<script setup>
</script>

```
