### PR TITLE
fix(VDatePicker): Fix month text format when using adapter

### DIFF
--- a/packages/vuetify/src/labs/VConfirmEdit/__test__/VConfirmEdit.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VConfirmEdit/__test__/VConfirmEdit.spec.cy.tsx
@@ -24,7 +24,8 @@ describe('VConfirmEdit', () => {
       .get('p')
       .should('have.text', 'bar')
   })
-  it.only(`doesn't mutate the original value`, () => {
+
+  it(`doesn't mutate the original value`, () => {
     const externalModel = ref(['foo'])
 
     cy.mount(
@@ -51,6 +52,7 @@ describe('VConfirmEdit', () => {
         expect(externalModel.value).to.deep.equal(['foo', 'bar'])
       })
   })
+
   it('hides actions if used from the slot', () => {
     cy.mount(
       <VConfirmEdit></VConfirmEdit>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When using the Luxon adapter we found that for single digit months we were getting and "Invalid DateTime" on the month text. It turned out to be an issue with the date format passed to the format function in the text computed. Luxon is expecting an ISO-8601 formatted string and was rejecting the month without a leading zero. 

This change formats the month into a 2 digit format for proper date parsing. 

fixes #19196 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
  }
</script>

<style lang="scss">

</style>
```
