### PR TITLE
fix(VCalendar): remove default sorting of weekdays

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -122,7 +122,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
               >
                 { !props.hideWeekNumber ? <div key="weekNumber0" class="v-calendar-weekly__head-weeknumber"></div> : '' }
                 {
-                  props.weekdays.sort((a, b) => a - b).map(weekday => (
+                  props.weekdays.map(weekday => (
                     <div class={ `v-calendar-weekly__head-weekday${!props.hideWeekNumber ? '-with-weeknumber' : ''}` }>
                       { dayNames[weekday] }
                     </div>


### PR DESCRIPTION
Ensuring that a custom ordered weekdays will display properly and not be sorted.
See https://vuetifyjs.com/en/components/calendars/#usage

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Ensuring that a custom ordered weekdays will display properly and not be sorted.

## Markup:
See https://vuetifyjs.com/en/components/calendars/#usage

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div>
    <v-sheet
        tile
        height="54"
        class="d-flex"
    >
      <v-select
          v-model="type"
          :items="types"
          dense
          variant="outlined"
          hide-details
          class="ma-2"
          label="View Mode"
      ></v-select>
      <v-select
          v-model="weekday"
          :items="weekdays"
          dense
          variant="outlined"
          hide-details
          label="weekdays"
          class="ma-2"
      ></v-select>
    </v-sheet>
    <v-sheet>
      <v-calendar
          ref="calendar"
          v-model="value"
          :weekdays="weekday"
          :view-mode="type"
          :interval-start="0"
          :events="events"
          title="test"
      ></v-calendar>
    </v-sheet>
  </div>
</template>
<script>
import {useDate} from 'vuetify'

export default {
  data: () => ({
    type: 'month',
    types: ['month', 'week', 'day'],
    weekday: [1, 2, 3, 4, 5, 6, 0],
    weekdays: [
      { title: 'Sun - Sat', value: [0, 1, 2, 3, 4, 5, 6] },
      {title: 'Mon - Sun', value: [1, 2, 3, 4, 5, 6, 0]},
      { title: 'Mon - Fri', value: [1, 2, 3, 4, 5] },
      { title: 'Mon, Wed, Fri', value: [1, 3, 5] },
    ],
    value: [new Date()],
    events: [],
    colors: ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey darken-1'],
    titles: ['Martha', 'Oliver', 'Edgars'],
  }),
  mounted() {
    const adapter = useDate()
    this.getEvents({
      start: adapter.startOfDay(adapter.startOfMonth(new Date())),
      end: adapter.endOfDay(adapter.endOfMonth(new Date()))
    })
  },
  methods: {
    getEvents({start, end}) {
      const events = []

      const min = start
      const max = end
      const days = (max.getTime() - min.getTime()) / 86400000
      const eventCount = this.rnd(days, days + 20)

      for (let i = 0; i < eventCount; i++) {
        const allDay = this.rnd(0, 3) === 0
        const firstTimestamp = this.rnd(min.getTime(), max.getTime())
        const first = new Date(firstTimestamp - (firstTimestamp % 900000))
        const secondTimestamp = this.rnd(2, allDay ? 288 : 8) * 900000
        const second = new Date(first.getTime() + secondTimestamp)

        events.push({
          title: this.titles[this.rnd(0, this.titles.length - 1)],
          start: first,
          end: second,
          color: this.colors[this.rnd(0, this.colors.length - 1)],
          allDay: !allDay,
        })
      }

      this.events = events
    },
    getEventColor(event) {
      return event.color
    },
    rnd(a, b) {
      return Math.floor((b - a + 1) * Math.random()) + a
    },
  },
}
</script>

```
