### PR TITLE
fix(VField): ensure label is reversed when reverse prop is used

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -387,6 +387,14 @@
         #{selector.append('[class^="rounded-"]', &)},
         #{selector.append('[class*=" rounded-"]', &)}
           flex-basis: calc(var(--v-input-control-height) / 2 + 2px)
+      
+      @at-root #{selector.append('.v-field--reverse', &)}
+        border-start-start-radius: 0
+        border-start-end-radius: inherit
+        border-end-end-radius: inherit 
+        border-end-start-radius: 0
+        border-inline-end-width: var(--v-field-border-width)
+        border-inline-start-width: 0
 
     &__notch
       flex: none
@@ -420,6 +428,14 @@
       border-start-end-radius: inherit
       border-end-end-radius: inherit
       border-end-start-radius: 0
+
+      @at-root #{selector.append('.v-field--reverse', &)}
+        border-start-start-radius: inherit
+        border-start-end-radius: 0
+        border-end-end-radius: 0
+        border-end-start-radius: inherit 
+        border-inline-end-width: 0
+        border-inline-start-width: var(--v-field-border-width)
 
 /* endregion */
 /* region LOADER */
@@ -493,7 +509,9 @@
 /* endregion */
 /* region MODIFIERS */
 .v-field--reverse
-  .v-field__field, .v-field__input
+  .v-field__field,
+  .v-field__input,
+  .v-field__outline
     flex-direction: row-reverse
 
   .v-field__input, input


### PR DESCRIPTION
Fixes the issue that labels are not reversed when reverse prop is used.

It happens to "underlined" & "outlined" variants as their labels are inside "v-field__outline"

<img width="753" alt="Screenshot 2024-02-13 at 7 01 07 pm" src="https://github.com/vuetifyjs/vuetify/assets/5698884/197601f3-91c2-4b00-9e5d-bb3778c01c68">
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        label="File input"
        reverse
        variant="underlined"
        model-value="test"
      />
      <v-text-field
        label="File input"
        reverse
        variant="outlined"
        model-value="test"
      />
      <v-text-field
        label="File input"
        reverse
        variant="filled"
        model-value="test"
      />
      <v-text-field
        label="Solo"
        reverse
        variant="solo"
        model-value="test"
      />
    </v-container>
  </v-app>
</template>



```
