### PR TITLE
fix(VDatePicker): mark current date when it's disabled

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -190,7 +190,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
                         ripple: false,
                         text: item.localized,
                         variant: item.isDisabled
-                          ? 'text'
+                          ? item.isToday ? 'outlined' : 'text'
                           : item.isToday && !item.isSelected ? 'outlined' : 'flat',
                         onClick: () => onClick(item.date),
                       },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19218

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker
        v-model="date"
        :month="pickerMonth"
        :year="pickerYear"
        :min="minDate"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const minDate = '2024-02-20'
  const date = ref(null)
  const pickerMonth = !date.value ? new Date(minDate).getMonth() : undefined
  const pickerYear = !date.value ? new Date(minDate).getFullYear() : undefined
</script>
```
