### PR TITLE
fix(VList): set explicit overflow-wrap to break-word

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -182,6 +182,7 @@
   padding: $list-item-subtitle-padding
   text-overflow: ellipsis
   overflow-wrap: $list-item-subtitle-overflow-wrap
+  word-break: $list-item-subtitle-word-break
 
   .v-list-item--one-line &
     -webkit-line-clamp: 1

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -181,7 +181,7 @@
   overflow: hidden
   padding: $list-item-subtitle-padding
   text-overflow: ellipsis
-  word-break: $list-item-subtitle-word-break
+  overflow-wrap: $list-item-subtitle-overflow-wrap
 
   .v-list-item--one-line &
     -webkit-line-clamp: 1

--- a/packages/vuetify/src/components/VList/_variables.scss
+++ b/packages/vuetify/src/components/VList/_variables.scss
@@ -100,7 +100,7 @@ $list-item-subtitle-letter-spacing: tools.map-deep-get(settings.$typography, 'bo
 $list-item-subtitle-line-height: 1rem !default;
 $list-item-subtitle-padding: 0 !default;
 $list-item-subtitle-text-transform: none !default;
-$list-item-subtitle-word-break: break-all !default;
+$list-item-subtitle-overflow-wrap: break-word !default;
 
 $list-item-title-font-size: tools.map-deep-get(settings.$typography, 'body-1', 'size') !default;
 $list-item-title-font-weight: tools.map-deep-get(settings.$typography, 'body-1', 'weight') !default;

--- a/packages/vuetify/src/components/VList/_variables.scss
+++ b/packages/vuetify/src/components/VList/_variables.scss
@@ -101,6 +101,7 @@ $list-item-subtitle-line-height: 1rem !default;
 $list-item-subtitle-padding: 0 !default;
 $list-item-subtitle-text-transform: none !default;
 $list-item-subtitle-overflow-wrap: break-word !default;
+$list-item-subtitle-word-break: initial !default;
 
 $list-item-title-font-size: tools.map-deep-get(settings.$typography, 'body-1', 'size') !default;
 $list-item-title-font-weight: tools.map-deep-get(settings.$typography, 'body-1', 'weight') !default;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19233
reverts 74be064

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
<img width="657" alt="Before" src="https://github.com/vuetifyjs/vuetify/assets/1302542/6d4c6ff1-e0e8-47fe-9936-b21c942efb90">
<img width="653" alt="After" src="https://github.com/vuetifyjs/vuetify/assets/1302542/dfd473e8-820b-4db5-9aef-80f31b1d80c8">
