### PR TITLE
fix(VMenu): do not call closeParents() when clickoutside is inside parent

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -15,7 +15,17 @@ import { useScopeId } from '@/composables/scopeId'
 // Utilities
 import { computed, inject, mergeProps, nextTick, provide, ref, shallowRef, watch } from 'vue'
 import { VMenuSymbol } from './shared'
-import { focusableChildren, focusChild, genericComponent, getNextElement, getUid, omit, propsFactory, useRender } from '@/util'
+import {
+  focusableChildren,
+  focusChild,
+  genericComponent,
+  getNextElement,
+  getUid,
+  isClickInsideElement,
+  omit,
+  propsFactory,
+  useRender,
+} from '@/util'
 
 // Types
 import type { Component } from 'vue'
@@ -106,8 +116,10 @@ export const VMenu = genericComponent<OverlaySlots>()({
       }
     })
 
-    function onClickOutside () {
-      parent?.closeParents()
+    function onClickOutside (e: MouseEvent) {
+      if (e && !isClickInsideElement(e, overlay.value!.contentEl!)) {
+        parent?.closeParents()
+      }
     }
 
     function onKeydown (e: KeyboardEvent) {

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -708,3 +708,16 @@ export function defer (timeout: number, cb: () => void) {
 
   return () => window.clearTimeout(timeoutId)
 }
+
+export function isClickInsideElement (event: MouseEvent, targetDiv: HTMLElement) {
+  const mouseX = event.clientX
+  const mouseY = event.clientY
+
+  const divRect = targetDiv.getBoundingClientRect()
+  const divLeft = divRect.left
+  const divTop = divRect.top
+  const divRight = divRect.right
+  const divBottom = divRect.bottom
+
+  return mouseX >= divLeft && mouseX <= divRight && mouseY >= divTop && mouseY <= divBottom
+}


### PR DESCRIPTION
fixes #17004 
fixes #19138

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-menu :close-on-content-click="false">
        <template #activator="{ props }">
          <v-btn v-bind="props">Open</v-btn>
        </template>
        <v-sheet class="pa-4">
          <div class="d-flex">
            <v-menu>
              <template #activator="{ props }">
                <v-btn style="display: block" v-bind="props">Sub menu</v-btn>
              </template>
              <v-sheet class="pa-4"> Click back in the input</v-sheet>
            </v-menu>
            <v-text-field style="width: 400px"></v-text-field>
          </div>
        </v-sheet>
      </v-menu>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>


```
