### PR TITLE
fix(VTextField): Disable onClear in readonly state

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -8,6 +8,7 @@ import { makeVInputProps, VInput } from '@/components/VInput/VInput'
 
 // Composables
 import { useFocus } from '@/composables/focus'
+import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
@@ -70,6 +71,8 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
   setup (props, { attrs, emit, slots }) {
     const model = useProxiedModel(props, 'modelValue')
     const { isFocused, focus, blur } = useFocus(props)
+    const form = useForm()
+    const readonly = computed(() => props.readonly || form?.isReadonly.value)
     const counterValue = computed(() => {
       return typeof props.counterValue === 'function' ? props.counterValue(model.value)
         : typeof props.counterValue === 'number' ? props.counterValue
@@ -128,6 +131,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
       emit('click:control', e)
     }
     function onClear (e: MouseEvent) {
+      if (readonly.value) return
       e.stopPropagation()
 
       onFocus()


### PR DESCRIPTION
fixes #19252

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-form readonly>
      <v-container>
        <v-select clearable v-model="selectedVal" :items="selectValues" />
        <v-autocomplete clearable v-model="selectedVal" :items="selectValues" />
        <v-combobox clearable v-model="selectedVal" :items="selectValues" />
        <v-text-field clearable v-model="selectedVal" />
      </v-container>
    </v-form>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
  const selectedVal = ref(1)
  const selectValues = ref([{ id: 1, title: '1' }])
</script>


```
