### PR TITLE
docs: fix accessibility page VMenu with VList example

### DIFF
--- a/packages/docs/src/examples/accessibility/menu.vue
+++ b/packages/docs/src/examples/accessibility/menu.vue
@@ -7,15 +7,15 @@
 
       <v-list>
         <v-list-item @click="onClick">
-          <v-list-item-title title="Option 1"></v-list-item-title>
+          <v-list-item-title>Option 1</v-list-item-title>
         </v-list-item>
 
         <v-list-item disabled>
-          <v-list-item-title title="Option 2"></v-list-item-title>
+          <v-list-item-title>Option 2</v-list-item-title>
         </v-list-item>
 
         <v-list-item @click="onClick">
-          <v-list-item-title title="Option 3"></v-list-item-title>
+          <v-list-item-title>Option 3</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
1. Go to https://vuetifyjs.com/en/features/accessibility/
2. Scroll down to `Focus management and keyboard interactions` section
3. On the example, click on `Click me` button.
4. Menu is open but text is not displayed

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
N/A
