### PR TITLE
fix(VSelect/VAutocomplete): prevent select function from toggling v-model in single selection mode

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -322,13 +322,12 @@ export const VAutocomplete = genericComponent<new <
 
     const isSelecting = shallowRef(false)
 
-    function select (item: ListItem) {
+    function select (item: ListItem, add = true) {
       if (item.props.disabled) return
 
-      const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
-      const add = index === -1
-
       if (props.multiple) {
+        const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
+        add = index === -1
         if (add) {
           model.value = [...model.value, item]
         } else {
@@ -545,7 +544,7 @@ export const VAutocomplete = genericComponent<new <
                     e.stopPropagation()
                     e.preventDefault()
 
-                    select(item)
+                    select(item, false)
                   }
 
                   const slotProps = {

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -514,7 +514,7 @@ describe('VAutocomplete', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/19261
-  it('should not toggle v-model to null when clicking already selected item in selection mode', () => {
+  it('should not toggle v-model to null when clicking already selected item in single selection mode', () => {
     const selectedItem = ref('abc')
 
     cy.mount(() => (
@@ -528,7 +528,7 @@ describe('VAutocomplete', () => {
 
     cy.get('.v-list-item').should('have.length', 2)
     cy.get('.v-list-item').eq(0).click({ waitForAnimations: false }).should(() => {
-      expect(selectedItem.value).to.deep.equal('abc')
+      expect(selectedItem.value).equal('abc')
     })
   })
 

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.cy.tsx
@@ -494,6 +494,7 @@ describe('VAutocomplete', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/18796
+  // https://github.com/vuetifyjs/vuetify/issues/19235
   it('should allow deleting selection via closable-chips', () => {
     const selectedItem = ref('California')
 
@@ -510,6 +511,25 @@ describe('VAutocomplete', () => {
       .then(_ => {
         expect(selectedItem.value).to.equal(null)
       })
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/19261
+  it('should not toggle v-model to null when clicking already selected item in selection mode', () => {
+    const selectedItem = ref('abc')
+
+    cy.mount(() => (
+      <VAutocomplete
+        v-model={ selectedItem.value }
+        items={['abc', 'def']}
+      />
+    ))
+
+    cy.get('.v-autocomplete').click()
+
+    cy.get('.v-list-item').should('have.length', 2)
+    cy.get('.v-list-item').eq(0).click({ waitForAnimations: false }).should(() => {
+      expect(selectedItem.value).to.deep.equal('abc')
+    })
   })
 
   describe('Showcase', () => {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -42,6 +42,7 @@ import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'
 import type { GenericProps, SelectItemKey } from '@/util'
+import { nextTick } from 'process'
 
 type Primitive = string | number | boolean | symbol
 
@@ -207,6 +208,9 @@ export const VSelect = genericComponent<new <
       if (menuDisabled.value) return
 
       menu.value = !menu.value
+      // nextTick(() => {
+      //   debugger
+      // })
     }
     function onKeydown (e: KeyboardEvent) {
       if (!e.key || props.readonly || form?.isReadonly.value) return
@@ -252,11 +256,10 @@ export const VSelect = genericComponent<new <
         model.value = [item]
       }
     }
-    function select (item: ListItem) {
-      const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
-      const add = index === -1
-
+    function select (item: ListItem, add = true) {
       if (props.multiple) {
+        const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))
+        add = index === -1
         if (add) {
           model.value = [...model.value, item]
         } else {
@@ -454,7 +457,7 @@ export const VSelect = genericComponent<new <
                     e.stopPropagation()
                     e.preventDefault()
 
-                    select(item)
+                    select(item, false)
                   }
 
                   const slotProps = {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -42,7 +42,6 @@ import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'
 import type { GenericProps, SelectItemKey } from '@/util'
-import { nextTick } from 'process'
 
 type Primitive = string | number | boolean | symbol
 
@@ -208,9 +207,6 @@ export const VSelect = genericComponent<new <
       if (menuDisabled.value) return
 
       menu.value = !menu.value
-      // nextTick(() => {
-      //   debugger
-      // })
     }
     function onKeydown (e: KeyboardEvent) {
       if (!e.key || props.readonly || form?.isReadonly.value) return

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -533,7 +533,7 @@ describe('VSelect', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/19235
-  it('should update v-model value when click closable chip', () => {
+  it('should update v-model when click closable chip', () => {
     const selectedItem = ref('abc')
 
     cy.mount(() => (
@@ -553,7 +553,7 @@ describe('VSelect', () => {
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/19261
-  it('should not toggle v-model to null when clicking already selected item in selection mode', () => {
+  it('should not toggle v-model to null when clicking already selected item in single selection mode', () => {
     const selectedItem = ref('abc')
 
     cy.mount(() => (
@@ -567,7 +567,7 @@ describe('VSelect', () => {
 
     cy.get('.v-list-item').should('have.length', 2)
     cy.get('.v-list-item').eq(0).click({ waitForAnimations: false }).should(() => {
-      expect(selectedItem.value).to.deep.equal('abc')
+      expect(selectedItem.value).equal('abc')
     })
   })
 

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.cy.tsx
@@ -532,6 +532,45 @@ describe('VSelect', () => {
       .should('not.have.class', 'v-select--active-menu')
   })
 
+  // https://github.com/vuetifyjs/vuetify/issues/19235
+  it('should update v-model value when click closable chip', () => {
+    const selectedItem = ref('abc')
+
+    cy.mount(() => (
+      <VSelect
+        v-model={ selectedItem.value }
+        chips
+        closable-chips
+        items={['abc', 'def']}
+      />
+    ))
+
+    cy.get('.v-chip__close')
+      .click()
+      .then(_ => {
+        expect(selectedItem.value).equal(null)
+      })
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/19261
+  it('should not toggle v-model to null when clicking already selected item in selection mode', () => {
+    const selectedItem = ref('abc')
+
+    cy.mount(() => (
+      <VSelect
+        v-model={ selectedItem.value }
+        items={['abc', 'def']}
+      />
+    ))
+
+    cy.get('.v-select').click()
+
+    cy.get('.v-list-item').should('have.length', 2)
+    cy.get('.v-list-item').eq(0).click({ waitForAnimations: false }).should(() => {
+      expect(selectedItem.value).to.deep.equal('abc')
+    })
+  })
+
   describe('Showcase', () => {
     generate({ stories })
   })


### PR DESCRIPTION
fixes #19261

Made cy tests to prevent regressions: #19261 #19235 #18796

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <h1>Without Multiple</h1>
      <v-select v-model="msg" :items="['abc','def']" />
      <v-autocomplete v-model="msg" :items="['abc','def']" />
      <v-combobox v-model="msg" :items="['abc','def']" />
      {{msg}}
      <h1>Multiple</h1>
      <v-select multiple v-model="msg" :items="['abc','def']" />
      <v-autocomplete multiple v-model="msg" :items="['abc','def']" />
      <v-combobox multiple v-model="msg" :items="['abc','def']" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('abc')
</script>


```
