### PR TITLE
docs(VSparkline): fix radius usage in example

### DIFF
--- a/packages/docs/src/examples/v-sparkline/prop-fill.vue
+++ b/packages/docs/src/examples/v-sparkline/prop-fill.vue
@@ -3,10 +3,10 @@
     <v-sparkline
       :fill="fill"
       :gradient="selectedGradient"
-      :line-width="width"
+      :line-width="lineWidth"
       :model-value="value"
       :padding="padding"
-      :smooth="radius || false"
+      :smooth="smooth"
       auto-draw
     ></v-sparkline>
 
@@ -25,7 +25,9 @@
             v-model="selectedGradient"
             mandatory
           >
-            <v-row>
+            <v-row
+              class="pt-6 pl-6"
+            >
               <v-item
                 v-for="(gradient, i) in gradients"
                 :key="i"
@@ -50,54 +52,67 @@
           </v-item-group>
         </v-row>
       </v-col>
+    </v-row>
 
+    <v-row
+      class="mt-5"
+    >
       <v-col
-        cols="12"
-        md="6"
+        cols="2"
+      >
+        Filled
+      </v-col>
+      <v-col
+        cols="3"
+      >
+        <v-switch
+          v-model="fill"
+          class="switch"
+        ></v-switch>
+      </v-col>
+      <v-col
+        cols="3"
+      >
+        Line width
+      </v-col>
+      <v-col
+        cols="3"
       >
         <v-slider
-          v-model="width"
-          label="Width"
+          v-model="lineWidth"
           max="10"
           min="0.1"
           step="0.1"
           thumb-label
         ></v-slider>
       </v-col>
+    </v-row>
 
-      <v-col cols="6">
-        <v-row
-          align="center"
-          class="fill-height"
-        >
-          <v-switch
-            v-model="fill"
-            label="Filled"
-          ></v-switch>
-        </v-row>
-      </v-col>
-
+    <v-row>
       <v-col
-        cols="12"
-        md="6"
+        cols="2"
       >
-        <v-slider
-          v-model="radius"
-          label="Radius"
-          max="25"
-          min="0"
-          thumb-label
-        ></v-slider>
+        Smooth
       </v-col>
-
       <v-col
-        cols="12"
-        md="6"
-        offset-md="6"
+        cols="3"
+      >
+        <v-switch
+          v-model="smooth"
+          class="switch"
+        ></v-switch>
+      </v-col>
+      <v-col
+        cols="3"
+      >
+        Padding
+      </v-col>
+      <v-col
+        cols="3"
       >
         <v-slider
           v-model="padding"
-          label="Padding"
+          cols="3"
           max="25"
           min="0"
           thumb-label
@@ -121,9 +136,9 @@
   const fill = ref(true)
   const selectedGradient = ref(gradients[4])
   const padding = ref(8)
-  const radius = ref(10)
+  const smooth = ref(true)
   const value = ref([0, 2, 5, 9, 5, 10, 3, 5, 0, 0, 1, 8, 2, 9, 0])
-  const width = ref(2)
+  const lineWidth = ref(2)
 </script>
 
 <script>
@@ -142,9 +157,16 @@
       selectedGradient: gradients[4],
       gradients,
       padding: 8,
-      radius: 10,
+      smooth: true,
       value: [0, 2, 5, 9, 5, 10, 3, 5, 0, 0, 1, 8, 2, 9, 0],
-      width: 2,
+      lineWidth: 2,
     }),
   }
 </script>
+
+<style scoped>
+.switch {
+  position: relative;
+  top: -12px;
+}
+</style>


### PR DESCRIPTION
`radius` property on VSparkline has been updated to [`smooth` in Vuetify 3](https://vuetifyjs.com/en/api/v-sparkline/#props-smooth).

This old migrated example was a bit unexplicit about it so I tried to refactor it.

[Preview here](https://play.vuetifyjs.com/#eNrVVs1u4zYQfpWBtoBtwHJk2cnuqo7bokB66aFADz3YAZaRKJkIJQoUbScw/O4dkvqhZSVF0L1skETkfMMZcuabITcnr5LxzW9lOTvsqRd5K0XzkhNF19sCYHXwY1EowgoqIeV7lhixAaqSyGeOiJUARCnj/H7r6c/Wa6WZJAmjhUKkopzGiiZ/1CJHSxvyjyxRO9TTk3/02FHIRUK5fyB8T1HDfB20JEnCigyReuRgVS6EMWsHHUL2SviJJEcrWK9unFPhQdujJuzAEiqNQjN2YCmOdVjqiHHAvwo9zsOtB3mCo7ut1+o0i4BwlhUIxhgLKlE15qTS63QI/R1l2Q5j5KwzKxmmyM+k2Jdw8E1YBkMLOSkSooR8vTDQOm98lcq/g5L7lzu88NYXAzpOhcTF4ya7U2ATYAU086oLc/cTPdNXXMSGMAw9F5okJyCxYgc6BSWyjFM4D5pqmNA4vFa6Oo3NDpHJNaBpol65NngaQgGeSPysg14kUXvIGadFpnawhvnwIoBf4JtmE5GYMbtoHCQ0m8JPp0Zwnnx7a3XnahM8Tt/YmJDIxwhGYfkCleAsGb2r+bvgAtVtkHF/o09hGI7Q1ei4w2SPhtYOpgBaCuXUR6IPaVgOo8oiGFZoSv4t/NeYs/gZFSwZhpRMWeq0XtMXAc3ffgGg2K1ZV9UWlluqPWXjTPCmD7ao2w26wCj/1imry+aAIVvDA1Y6TXpW+5oL99hr3XuPTMU7p/xtz239Whztm5ZmJ7UBG633XK3hL9tD/3tXly2tQu5hG3Oi2m1woKXrn5y86DbZS37OdFcMZvNLcaVoOSRXu33+5HPyRLkbJn10s6MP5e69ZP1tLpAPh6WfrOYe+l7p+hNjawvp/2dsiHFuHq+u1y6LIVJ9IIvfOVcNUr9KULK6cd4sOK1iyUoFFVV1IbO8FFLBCSRN4QypFDmM8LmDrU7DaKtS3cUF97CxTje2NTaNF6fL8GmRLh2JpNhtYSQkKTKqR6+Uc3F0NMq9LLmBDkxwqlxzQRDfpanGPj0ED/b7ELga6ecwWH42SJomYRCY4TylhJJa77E7g+4CuH085ljJPZ10SP95UGu1h94sHx3tOsm10hfXjq2AQR/mRq6hTTCFcAq3U/hq/s9xvjAjHODvfApfjAbCgeu67RO1oRCx1Y1NaZ1efU9DFYuS2o4/qwusvrhLUTHFRBHheiQFXnI/W0CJMgJ/jtekEZyNYW3MpY2x+OMzQn/oi6F9QlOy50h/awKfhCSC8QTu1zBu3zqaORHohLZvhz5lureIZkur1gpbSc2eCDPc2jK06TkwfIngY1RpV7dEiRCzwvPEDGxim2x656m3mC1n86+eHtzO7rzHfwH7s57I) (preview differs from example in the docs so the output might not match perfectly the result obtain in the doc)