### PR TITLE
fix(VAutocomplete/VCombobox): input always absolute position when not using selection slot/chips

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -76,7 +76,7 @@
       caret-color: transparent
 
   &--single:not(.v-autocomplete--selection-slot)
-    &.v-text-field .v-field--focused input
+    &.v-text-field input
       flex: 1 1
       position: absolute
       left: 0

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -76,7 +76,7 @@
       caret-color: transparent
 
   &--single:not(.v-combobox--selection-slot)
-    &.v-text-field .v-field--focused input
+    &.v-text-field input
       flex: 1 1
       position: absolute
       left: 0


### PR DESCRIPTION
fixes #19279

### Cause
Input width changed when become focused, which impacts caret position. It's a default behaviour either in Vue or Js: [demo](https://play.vuejs.org/#eNqdVMlu2zAQ/ZWBgEIJ4FgOmpOqBF2QAinQBW1vVQ+KTDlMKJLgotgw/O99JC1baNMcoouoeTNv3izUNnun9XzwLCuzyraGa0eWOa+vasl7rYyjLRnW0Y46o3rK4ZrXslXSOmJrx+TyRmrv6DJ4nXSNsOx0xHu72tvzHMbOy9ZxJWFBipNT2taS8Exo5kMjPENQJAowOA7GHJlruZsw8RD0UbXe0sj3FJsz/l8yoeSKHNzprxOyIEdVpHagEfhwrNeicQxfRJUX8Y2T4FeflbeM1MAMuTtG1jXGcdBovEl1SeMsYJJawdsH6oLgGbWNYY60sjzVYunRIH9VgPS/9KjtJcytMoa17sBdFfsaqiUfENxYe1lnGJtruGSmzkYFU1hjlHwN7Fs8VAXA0S9qoeGsV0sm4ItW1xm9jYLweRwUrOVI+CvvNxHJZ7TN0+TycjrC3W/4F3vJY7rq1juHuoYz3oFl4h5Sxk7AvN8yyI2nqkhRYKiKyTgr6zYiHOaH6tMiLbmFz6akTrD1m2B55Et3V9LFYqGTYexwiZUGHR8YzNid+b6sRBTiSzpPSBKbgGN4c2uV8C6EH9KcLxavEh1Wca8xm2XOQmfHV/N7qyRubWQKo+s1F8x81YERXS7H61VnjRDq8VO0hZswG+3tHWsfnrDfWwy5xAFztswMrM4OGLZ7xdDnAF//+IJyJiCG7wW8nwG/s1gpNCa3914uIXviF9XexH8PrtFPex06Zseixqu8i/51hv/Rh2dKP8p9Pb+IcehotvsD0gSyfw==)

### Solution
Because of #19294, input is now always aligned next to selection slot/chips, which gracefully resolves #18796.

So now input can be always safely positioned absolute when not using selection slot/chips, which means input width doesn't change, so caret position will be accurate

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card>
    <v-container fluid>
      <v-row>
        <v-col cols="12">
          <v-combobox v-model="value" :items="items"></v-combobox>
          <v-autocomplete v-model="value" :items="items"></v-autocomplete>
          Issue: <a href="https://github.com/vuetifyjs/vuetify/issues/18796">#18796</a>
          <v-autocomplete
            chips
            v-model="state"
            closable-chips
            label="Autocomplete"
            :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
          ></v-autocomplete>
          <v-combobox
            chips
            closable-chips
            v-model="state"
            label="Combobox"
            :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
          />
          <v-select
            chips
            closable-chips
            v-model="state"
            label="Select"
            :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
          />
        </v-col>
      </v-row>
    </v-container>
  </v-card>
</template>

<script>
  export default {
    data: () => ({
      items: ['foo foo foo foo foo foo foo foo', 'bar', 'fizz', 'buzz'],
      value: 'foo foo foo foo foo foo foo foo',
      state: 'California',
    }),
  }
</script>


```
