### PR TITLE
fix(VCombobox): don't update v-model when it already contains the search text in single selection mode

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -415,7 +415,7 @@ export const VCombobox = genericComponent<new <
         !model.value.some(({ value }) => value === displayItems.value[0].value)
       ) {
         select(displayItems.value[0])
-      } else if (search.value && !model.value.some(({ title }) => title === search.value)) {
+      } else if (search.value && (!model.value.some(({ title }) => title === search.value) || props.multiple)) {
         select(transformItem(props, search.value))
       }
     })

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -303,7 +303,7 @@ export const VCombobox = genericComponent<new <
 
       if (e.key === 'Enter' && search.value) {
         select(transformItem(props, search.value))
-        if (hasSelectionSlot.value) search.value = ''
+        if (hasSelectionSlot.value) _search.value = ''
       }
 
       if (!props.multiple) return
@@ -415,8 +415,22 @@ export const VCombobox = genericComponent<new <
         !model.value.some(({ value }) => value === displayItems.value[0].value)
       ) {
         select(displayItems.value[0])
-      } else if (search.value && (!model.value.some(({ title }) => title === search.value) || props.multiple)) {
-        select(transformItem(props, search.value))
+        return
+      }
+
+      if (search.value) {
+        if (props.multiple) {
+          select(transformItem(props, search.value))
+          return
+        }
+
+        if (!hasSelectionSlot.value) return
+
+        if (model.value.some(({ title }) => title === search.value)) {
+          _search.value = ''
+        } else {
+          select(transformItem(props, search.value))
+        }
       }
     })
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -415,7 +415,7 @@ export const VCombobox = genericComponent<new <
         !model.value.some(({ value }) => value === displayItems.value[0].value)
       ) {
         select(displayItems.value[0])
-      } else if (search.value) {
+      } else if (search.value && !model.value.some(({ title }) => title === search.value)) {
         select(transformItem(props, search.value))
       }
     })

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -193,35 +193,6 @@ describe('VCombobox', () => {
       cy.get('.v-combobox__selection')
         .should('contain', 'item3')
     })
-
-    // https://github.com/vuetifyjs/vuetify/issues/19319
-    it('return-object', () => {
-      const items = [
-        { title: 'Item 1', value: 'item1' },
-        { title: 'Item 2', value: 'item2' },
-        { title: 'Item 3', value: 'item3' },
-        { title: 'Item 4', value: 'item4' },
-      ]
-      const model = ref()
-      const search = ref()
-
-      cy.mount(() => (
-        <VCombobox
-          search={ search.value }
-          v-model={ model.value }
-          items={ items }
-        />
-      ))
-        .get('.v-combobox').click()
-        .get('.v-list-item').eq(0).click({ waitForAnimations: false })
-        .should(() => {
-          expect(model.value).to.deep.equal({ title: 'Item 1', value: 'item1' })
-        })
-        .get('.v-combobox input').blur()
-        .should(() => {
-          expect(model.value).to.deep.equal({ title: 'Item 1', value: 'item1' })
-        })
-    })
   })
 
   describe('search', () => {
@@ -733,6 +704,35 @@ describe('VCombobox', () => {
       .get('.v-combobox input').should('have.value', '')
       .should(() => {
         expect(selectedItem.value).to.equal('Item 1')
+      })
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/19319
+  it('should respect return-object when blurring', () => {
+    const items = [
+      { title: 'Item 1', value: 'item1' },
+      { title: 'Item 2', value: 'item2' },
+      { title: 'Item 3', value: 'item3' },
+      { title: 'Item 4', value: 'item4' },
+    ]
+    const model = ref()
+    const search = ref()
+
+    cy.mount(() => (
+      <VCombobox
+        search={ search.value }
+        v-model={ model.value }
+        items={ items }
+      />
+    ))
+      .get('.v-combobox').click()
+      .get('.v-list-item').eq(0).click({ waitForAnimations: false })
+      .should(() => {
+        expect(model.value).to.deep.equal({ title: 'Item 1', value: 'item1' })
+      })
+      .get('.v-combobox input').blur()
+      .should(() => {
+        expect(model.value).to.deep.equal({ title: 'Item 1', value: 'item1' })
       })
   })
 

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.cy.tsx
@@ -193,6 +193,35 @@ describe('VCombobox', () => {
       cy.get('.v-combobox__selection')
         .should('contain', 'item3')
     })
+
+    // https://github.com/vuetifyjs/vuetify/issues/19319
+    it('return-object', () => {
+      const items = [
+        { title: 'Item 1', value: 'item1' },
+        { title: 'Item 2', value: 'item2' },
+        { title: 'Item 3', value: 'item3' },
+        { title: 'Item 4', value: 'item4' },
+      ]
+      const model = ref()
+      const search = ref()
+
+      cy.mount(() => (
+        <VCombobox
+          search={ search.value }
+          v-model={ model.value }
+          items={ items }
+        />
+      ))
+        .get('.v-combobox').click()
+        .get('.v-list-item').eq(0).click({ waitForAnimations: false })
+        .should(() => {
+          expect(model.value).to.deep.equal({ title: 'Item 1', value: 'item1' })
+        })
+        .get('.v-combobox input').blur()
+        .should(() => {
+          expect(model.value).to.deep.equal({ title: 'Item 1', value: 'item1' })
+        })
+    })
   })
 
   describe('search', () => {


### PR DESCRIPTION
fixes #19319

Subject to more testing

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-combobox
        :items="[{id: 1, desc: 'item1'},{id: 2, desc: 'item2'}]"
        v-model="comboRef"
        item-title="desc"
        item-value="id"
        multiple
      />
      <v-autocomplete
        :items="[{id: 1, desc: 'item1'},{id: 2, desc: 'item2'}]"
        v-model="comboRef"
        item-title="desc"
        item-value="id"
        return-object
      />
      <span> Value: {{ comboRef }} </span>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const comboRef = ref(null)
</script>


```
