### PR TITLE
fix(VCalendar): Stop day row content overflowing its parent

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendarInterval.sass
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarInterval.sass
@@ -33,6 +33,7 @@
   border-right: $calendar-line-width solid $calendar-line-color
   
   .v-calendar-day__row-content
+    overflow: hidden
     border-bottom: $calendar-line-width solid $calendar-line-color
 
     &.v-calendar-day__row-content-through

--- a/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.sass
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.sass
@@ -1,4 +1,6 @@
 .v-calendar-internal-event
   overflow: hidden
+  padding: 4px
   text-overflow: ellipsis
   white-space: nowrap
+  // width: 100%

--- a/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.sass
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.sass
@@ -1,0 +1,4 @@
+.v-calendar-internal-event
+  overflow: hidden
+  text-overflow: ellipsis
+  white-space: nowrap

--- a/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.tsx
@@ -58,8 +58,8 @@ export const VCalendarIntervalEvent = genericComponent()({
         <VSheet
           height={ calcHeight().height }
           density="comfortable"
-          style={ `width: 100%; margin-top: ${calcHeight().margin}` }
-          class="v-calendar-internal-event align-center pa-1"
+          style={ `margin-top: ${calcHeight().margin}` }
+          class="v-calendar-internal-event"
           color={ props.event?.color ?? undefined }
           rounded={ props.event?.first && props.event?.last
             ? true

--- a/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarIntervalEvent.tsx
@@ -1,3 +1,6 @@
+// Styles
+import './VCalendarIntervalEvent.sass'
+
 // Components
 import { VSheet } from '@/components/VSheet'
 
@@ -56,7 +59,7 @@ export const VCalendarIntervalEvent = genericComponent()({
           height={ calcHeight().height }
           density="comfortable"
           style={ `width: 100%; margin-top: ${calcHeight().margin}` }
-          class="align-center pa-1"
+          class="v-calendar-internal-event align-center pa-1"
           color={ props.event?.color ?? undefined }
           rounded={ props.event?.first && props.event?.last
             ? true


### PR DESCRIPTION
fixes #18968

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-calendar v-model="msg" view-mode="week" :events="events"></v-calendar>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const events = [
    {
      title:
        'The text is too long and overflow, end date is invalid, event only lasts an hour',
      start: new Date('2024-01-23T03:00:00Z'),
      end: new Date('2024-01-23T4:00:00Z'),
      color: 'blue',
    },
  ]

  const msg = ref([new Date('2024-01-23T14:30:00Z')])
</script>


```
