### PR TITLE
fix(VBreadcrumbs): fix types for slots

### DIFF
--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.tsx
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbs.tsx
@@ -25,10 +25,12 @@ import type { PropType } from 'vue'
 import type { LinkProps } from '@/composables/router'
 import type { GenericProps } from '@/util'
 
-export type BreadcrumbItem = string | (Partial<LinkProps> & {
+export type InternalBreadcrumbItem = Partial<LinkProps> & {
   title: string
   disabled?: boolean
-})
+}
+
+export type BreadcrumbItem = string | InternalBreadcrumbItem
 
 export const makeVBreadcrumbsProps = propsFactory({
   activeClass: String,
@@ -58,9 +60,9 @@ export const VBreadcrumbs = genericComponent<new <T extends BreadcrumbItem>(
   },
   slots: {
     prepend: never
-    title: { item: T, index: number }
+    title: { item: InternalBreadcrumbItem, index: number }
     divider: { item: T, index: number }
-    item: { item: T, index: number }
+    item: { item: InternalBreadcrumbItem, index: number }
     default: never
   }
 ) => GenericProps<typeof props, typeof slots>>()({


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19339

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <!-- proof that `title` exists on `item` -->
      <v-breadcrumbs :items="['foo', 'bar']">
        <template #item="{ item }">{{ item }}</template>
      </v-breadcrumbs>

      <!-- renders as expected but causes ts error -->
      <v-breadcrumbs :items="['foo', 'bar']">
        <template #item="{ item }">{{ item.title }}</template>
      </v-breadcrumbs>

      <!-- explicitly creating the item object fixes the error -->
      <v-breadcrumbs :items="['foo', 'bar'].map((entry) => { return { title: entry } })">
        <template #item="{ item }">{{ item.title }}</template>
      </v-breadcrumbs>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>
```
