### PR TITLE
fix(VMenu): don't close when press enter

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -135,6 +135,9 @@ export const VMenu = genericComponent<OverlaySlots>()({
           isActive.value = false
           overlay.value?.activatorEl?.focus()
         }
+      }else if(e.key === 'Enter' && props.closeOnContentClick){
+        isActive.value = false;
+        parent?.closeParents();
       }
     }
 

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -135,9 +135,9 @@ export const VMenu = genericComponent<OverlaySlots>()({
           isActive.value = false
           overlay.value?.activatorEl?.focus()
         }
-      }else if(e.key === 'Enter' && props.closeOnContentClick){
-        isActive.value = false;
-        parent?.closeParents();
+      } else if (['Enter', ' '].includes(e.key) && props.closeOnContentClick) {
+        isActive.value = false
+        parent?.closeParents()
       }
     }
 


### PR DESCRIPTION
fixes #19361

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This PR addresses issue #19361 by the VMenu closing when the Enter key is pressed. Previously, when navigate through the arrow keys and pressing Enter wouldn't close the menu, causing inconvenience for users. This change ensures that the menu closes when Enter is pressed, improving the user experience. Issue can be found [here](https://github.com/vuetifyjs/vuetify/issues/19361)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-menu>
      <template #activator="{ props }">
        <v-btn v-bind="props">Open Menu</v-btn>
      </template>
      <v-list>
        <v-list-item @click="{}">1</v-list-item>
        <v-list-item @click="{}">2</v-list-item>
      </v-list>
    </v-menu>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
