### PR TITLE
fix(VDatePickerMonth): set rangeStart/rangeStop from model

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -75,15 +75,15 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
         rangeStart.value = _value
         model.value = [rangeStart.value]
       } else if (!rangeStop.value) {
-        if (adapter.isSameDay(value, rangeStart.value)) {
+        if (adapter.isSameDay(_value, rangeStart.value)) {
           rangeStart.value = undefined
           model.value = []
           return
-        } else if (adapter.isBefore(value, rangeStart.value)) {
-          rangeStop.value = rangeStart.value
+        } else if (adapter.isBefore(_value, rangeStart.value)) {
+          rangeStop.value = adapter.endOfDay(rangeStart.value)
           rangeStart.value = _value
         } else {
-          rangeStop.value = _value
+          rangeStop.value = adapter.endOfDay(_value)
         }
 
         const diff = adapter.getDiff(rangeStop.value, rangeStart.value, 'days')

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -55,6 +55,13 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
     const rangeStart = shallowRef()
     const rangeStop = shallowRef()
 
+    if (props.multiple === 'range' && model.value.length > 0) {
+      rangeStart.value = model.value[0]
+      if (model.value.length > 1) {
+        rangeStop.value = model.value[model.value.length - 1]
+      }
+    }
+
     const atMax = computed(() => {
       const max = ['number', 'string'].includes(typeof props.multiple) ? Number(props.multiple) : Infinity
 

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
@@ -21,4 +21,23 @@ describe('VDatePicker', () => {
         expect(model.value).to.have.length(11)
       })
   })
+
+  it('selects a range of dates across month boundary', () => {
+    const model = ref<unknown[]>([])
+    cy.mount(() => (
+      <Application>
+        <VDatePicker v-model={ model.value } multiple="range" />
+      </Application>
+    ))
+
+    cy.get('.v-date-picker-controls__month-btn').click()
+    cy.get('.v-date-picker-months__content').contains('Jan').click()
+    cy.get('.v-date-picker-month__day').contains(7).click()
+    cy.get('.v-date-picker-controls__month-btn').click()
+    cy.get('.v-date-picker-months__content').contains('Feb').click()
+    cy.get('.v-date-picker-month__day').contains(7).click()
+      .then(() => {
+        expect(model.value).to.have.length(32)
+      })
+  })
 })

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -479,7 +479,7 @@ function setYear (date: Date, year: number) {
 }
 
 function startOfDay (date: Date) {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0)
 }
 
 function endOfDay (date: Date) {


### PR DESCRIPTION
## Description

fixes #19366

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      {{ data }}
      <v-date-picker v-model="data" multiple="range"></v-date-picker>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      return {
        data: ref(null)
      }
    },
  }   
</script>
```
