### PR TITLE
fix(VDatePicker): fix range selection crossing DST

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -79,15 +79,11 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
           rangeStop.value = _value
         }
 
-        const diff = adapter.getDiff(rangeStop.value, rangeStart.value, 'days')
-        const datesInRange = [rangeStart.value]
+        const datesInRange = []
 
-        for (let i = 1; i < diff; i++) {
-          const nextDate = adapter.addDays(rangeStart.value, i)
-          datesInRange.push(nextDate)
+        for (let d = rangeStart.value; d <= rangeStop.value; d = adapter.addDays(d, 1)) {
+          datesInRange.push(d)
         }
-
-        datesInRange.push(rangeStop.value)
 
         model.value = datesInRange
       } else {

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
@@ -21,4 +21,22 @@ describe('VDatePicker', () => {
         expect(model.value).to.have.length(11)
       })
   })
+
+  it('selects a range of dates crossing DST boundary', () => {
+    const model = ref<unknown[]>([])
+    cy.mount(() => (
+      <Application>
+        <VDatePicker v-model={ model.value } multiple="range" />
+      </Application>
+    ))
+
+    cy.get('.v-date-picker-controls__month-btn').click()
+    cy.get('.v-date-picker-months__content').contains('Mar').click()
+    cy.get('.v-date-picker-month__day').contains(30).click()
+    cy.get('.v-date-picker-controls__month > button + button').click()
+    cy.get('.v-date-picker-month__day').contains(12).click()
+      .then(() => {
+        expect(model.value).to.have.length(14)
+      })
+  })
 })


### PR DESCRIPTION
## Description

fixes #19313

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      {{ data }}
      <v-date-picker v-model="data" multiple="range"></v-date-picker>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      return {
        data: ref(null)
      }
    },
  }   
</script>
```
