### PR TITLE
fix(locale): translate `open` for no.ts

### DIFF
--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -1,6 +1,6 @@
 export default {
   badge: 'Skilt',
-  open: 'Open',
+  open: 'Åpne',
   close: 'Lukk',
   confirmEdit: {
     ok: 'OK',


### PR DESCRIPTION
I'm guessing `open` here is the imperative, as you'd see on a button (and not a description of something being open)


(btw, `no` is a macrolanguage covering `nb` and `nn`; this file contains text in `nb`, but if the rot has spread then perhaps it's a bit late to change it now)