### PR TITLE
fix(VAutocomplete/VCombobox): allow delete in single selection mode

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -246,9 +246,14 @@ export const VAutocomplete = genericComponent<new <
         listRef.value?.focus('next')
       }
 
-      if (!props.multiple) return
-
       if (['Backspace', 'Delete'].includes(e.key)) {
+        function deSelectItem (item: ListItem) {
+          if (item && !item.props.disabled) select(item, false)
+        }
+        if (!props.multiple) {
+          deSelectItem(model.value[0])
+          return
+        }
         if (selectionIndex.value < 0) {
           if (e.key === 'Backspace' && !search.value) {
             selectionIndex.value = length - 1
@@ -258,11 +263,12 @@ export const VAutocomplete = genericComponent<new <
         }
 
         const originalSelectionIndex = selectionIndex.value
-        const selectedItem = model.value[selectionIndex.value]
-        if (selectedItem && !selectedItem.props.disabled) select(selectedItem, false)
+        deSelectItem(model.value[selectionIndex.value])
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
+
+      if (!props.multiple) return
 
       if (e.key === 'ArrowLeft') {
         if (selectionIndex.value < 0 && selectionStart > 0) return

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -247,13 +247,12 @@ export const VAutocomplete = genericComponent<new <
       }
 
       if (['Backspace', 'Delete'].includes(e.key)) {
-        function deSelectItem (item: ListItem) {
-          if (item && !item.props.disabled) select(item, false)
-        }
-        if (!props.multiple) {
-          if (hasSelectionSlot.value) deSelectItem(model.value[0])
-          return
-        }
+        if (
+          !props.multiple &&
+          hasSelectionSlot.value &&
+          model.value.length > 0
+        ) return select(model.value[0], false)
+
         if (selectionIndex.value < 0) {
           if (e.key === 'Backspace' && !search.value) {
             selectionIndex.value = length - 1
@@ -263,7 +262,7 @@ export const VAutocomplete = genericComponent<new <
         }
 
         const originalSelectionIndex = selectionIndex.value
-        deSelectItem(model.value[selectionIndex.value])
+        select(model.value[selectionIndex.value], false)
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
@@ -331,8 +330,8 @@ export const VAutocomplete = genericComponent<new <
     const isSelecting = shallowRef(false)
 
     /** @param set - null means toggle */
-    function select (item: ListItem, set: boolean | null = true) {
-      if (item.props.disabled) return
+    function select (item: ListItem | undefined, set: boolean | null = true) {
+      if (!item || item.props.disabled) return
 
       if (props.multiple) {
         const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -251,7 +251,7 @@ export const VAutocomplete = genericComponent<new <
           if (item && !item.props.disabled) select(item, false)
         }
         if (!props.multiple) {
-          deSelectItem(model.value[0])
+          if (hasSelectionSlot.value) deSelectItem(model.value[0])
           return
         }
         if (selectionIndex.value < 0) {

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -306,23 +306,28 @@ export const VCombobox = genericComponent<new <
         if (hasSelectionSlot.value) _search.value = ''
       }
 
-      if (!props.multiple) return
-
       if (['Backspace', 'Delete'].includes(e.key)) {
+        function deSelectItem (item: ListItem) {
+          if (item && !item.props.disabled) select(item, false)
+        }
+        if (!props.multiple) {
+          deSelectItem(model.value[0])
+          return
+        }
         if (selectionIndex.value < 0) {
           if (e.key === 'Backspace' && !search.value) {
             selectionIndex.value = length - 1
           }
-
           return
         }
 
         const originalSelectionIndex = selectionIndex.value
-        const selectedItem = model.value[selectionIndex.value]
-        if (selectedItem && !selectedItem.props.disabled) select(selectedItem, false)
+        deSelectItem(model.value[selectionIndex.value])
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
+
+      if (!props.multiple) return
 
       if (e.key === 'ArrowLeft') {
         if (selectionIndex.value < 0 && selectionStart > 0) return

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -268,6 +268,7 @@ export const VCombobox = genericComponent<new <
       }
       menu.value = !menu.value
     }
+    // eslint-disable-next-line complexity
     function onKeydown (e: KeyboardEvent) {
       if (isComposingIgnoreKey(e) || props.readonly || form?.isReadonly.value) return
 
@@ -307,13 +308,12 @@ export const VCombobox = genericComponent<new <
       }
 
       if (['Backspace', 'Delete'].includes(e.key)) {
-        function deSelectItem (item: ListItem) {
-          if (item && !item.props.disabled) select(item, false)
-        }
-        if (!props.multiple) {
-          if (hasSelectionSlot.value) deSelectItem(model.value[0])
-          return
-        }
+        if (
+          !props.multiple &&
+          hasSelectionSlot.value &&
+          model.value.length > 0
+        ) return select(model.value[0], false)
+
         if (selectionIndex.value < 0) {
           if (e.key === 'Backspace' && !search.value) {
             selectionIndex.value = length - 1
@@ -322,7 +322,7 @@ export const VCombobox = genericComponent<new <
         }
 
         const originalSelectionIndex = selectionIndex.value
-        deSelectItem(model.value[selectionIndex.value])
+        select(model.value[selectionIndex.value], false)
 
         selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
       }
@@ -364,8 +364,8 @@ export const VCombobox = genericComponent<new <
       }
     }
     /** @param set - null means toggle */
-    function select (item: ListItem, set: boolean | null = true) {
-      if (item.props.disabled) return
+    function select (item: ListItem | undefined, set: boolean | null = true) {
+      if (!item || item.props.disabled) return
 
       if (props.multiple) {
         const index = model.value.findIndex(selection => props.valueComparator(selection.value, item.value))

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -311,7 +311,7 @@ export const VCombobox = genericComponent<new <
           if (item && !item.props.disabled) select(item, false)
         }
         if (!props.multiple) {
-          deSelectItem(model.value[0])
+          if (hasSelectionSlot.value) deSelectItem(model.value[0])
           return
         }
         if (selectionIndex.value < 0) {


### PR DESCRIPTION
fixes #19369

In multiple selection mode, Backspace key selects the last item first then remove on second Backspace event.

In single selection mode, remove selected item directly on first Backspace event.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-autocomplete
    label="Autocomplete"
    chips
    :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
  />
  <v-combobox
    chips
    label="Combobox"
    :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
  />
</template>


```
