### PR TITLE
fix(VTextfield): Have consistent IME behaviour as in Vue

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -138,7 +138,9 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
         callEvent(props['onClick:clear'], e)
       })
     }
-    function onInput (e: Event) {
+    function onInput (e: InputEvent) {
+      if (e.isComposing) return
+
       const el = e.target as HTMLInputElement
       model.value = el.value
       if (
@@ -151,6 +153,10 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
           el.selectionEnd = caretPosition[1]
         })
       }
+    }
+
+    function onCompositionend (e: CompositionEvent) {
+      model.value = e.data
     }
 
     useRender(() => {
@@ -214,6 +220,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                         ref={ inputRef }
                         value={ model.value }
                         onInput={ onInput }
+                        onCompositionend={ onCompositionend }
                         v-intersect={[{
                           handler: onIntersect,
                         }, null, ['once']]}


### PR DESCRIPTION
Attempting to fix #18981

Vuetify `v-text-field` IME behaviour should be the same as [it's in Vue](https://vuejs.org/guide/essentials/forms.html#vmodel-ime-tip)

- `v-model` doesn't update during composition session
- has a new input event that allows users to respond to input changes during composition session

But it's against the purpose in #15907

@KaelWD @johnleider Do you agree with these changes? Or any comments?

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field label="type chinese with IME" v-model="msg" />
      {{ msg }}
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('中文')
</script>


```
