### PR TITLE
fix(VListItem): Duplicate Titles

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -196,8 +196,10 @@ export const VListItem = genericComponent<VListItemSlots>()({
 
     useRender(() => {
       const Tag = isLink.value ? 'a' : props.tag
-      const hasTitle = (slots.title || props.title != null)
-      const hasSubtitle = (slots.subtitle || props.subtitle != null)
+      const hasTitle = (!slots.default?.(slotProps.value).find(x => x.type?.name === 'VListItemTitle') &&
+      (slots.title || props.title != null))
+      const hasSubtitle = (!slots.default?.(slotProps.value).find(x => x.type?.name === 'VListItemSubtitle') &&
+      (slots.subtitle || props.subtitle != null))
       const hasAppendMedia = !!(props.appendAvatar || props.appendIcon)
       const hasAppend = !!(hasAppendMedia || slots.append)
       const hasPrependMedia = !!(props.prependAvatar || props.prependIcon)

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -196,9 +196,9 @@ export const VListItem = genericComponent<VListItemSlots>()({
 
     useRender(() => {
       const Tag = isLink.value ? 'a' : props.tag
-      const hasTitle = (!slots.default?.(slotProps.value).find(x => x.type?.name === 'VListItemTitle') &&
+      const hasTitle = (!slots.default?.(slotProps.value).find(x => (x as any).type?.name === 'VListItemTitle') &&
       (slots.title || props.title != null))
-      const hasSubtitle = (!slots.default?.(slotProps.value).find(x => x.type?.name === 'VListItemSubtitle') &&
+      const hasSubtitle = (!slots.default?.(slotProps.value).find(x => (x as any).type?.name === 'VListItemSubtitle') &&
       (slots.subtitle || props.subtitle != null))
       const hasAppendMedia = !!(props.appendAvatar || props.appendIcon)
       const hasAppend = !!(hasAppendMedia || slots.append)


### PR DESCRIPTION
Fixes #19396

List Item not taking slots into account when checking if it has a title

```vue
<template>
  <v-app>
    <v-container>
      <v-select v-model="model" :items="items"></v-select>
    </v-container>
    <v-container>
      <v-select v-model="model" :items="items">
        <template #item="{ props, item }">
          <v-list-item v-bind="props" :title="item.title"></v-list-item>
        </template>
      </v-select>
    </v-container>
    <v-container>
      <v-select v-model="model" :items="items">
        <template #item="{ props, item }">
          <v-list-item v-bind="props">
            <v-list-item-title>--- {{ item.title }} ---</v-list-item-title>
            <v-list-item-subtitle>{{ item.value }}</v-list-item-subtitle>
          </v-list-item>
        </template>
      </v-select>
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
  setup() {
    return {
      //
    };
  },
  data: () => ({
    items: ["Foo", "Bar", "Fizz", "Buzz"],
    model: "Foo",
  }),
};
</script>

```
