### PR TITLE
fix:(VSelect/VAutocomplete): Clearable icon not keyboard accessible

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -220,6 +220,12 @@
   .v-field--error:not(.v-field--disabled) &
     > .v-icon
       color: rgb(var(--v-theme-error))
+  &:focus
+    opacity: 1
+    outline: none
+
+    .v-icon
+      opacity: 1
 
 .v-field__clearable
   cursor: pointer

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -20,6 +20,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { computed, ref, toRef, watch } from 'vue'
 import {
   animate,
+  callEvent,
   convertToUnit,
   EventProp,
   genericComponent,
@@ -313,10 +314,18 @@ export const VField = genericComponent<new <T>(
             <VExpandXTransition key="clear">
               <div
                 class="v-field__clearable"
+                tabindex="0"
                 v-show={ props.dirty }
                 onMousedown={ (e: MouseEvent) => {
                   e.preventDefault()
                   e.stopPropagation()
+                }}
+                onKeydown={ (e: KeyboardEvent) => {
+                  if (e.key !== 'Enter') return
+
+                  e.preventDefault()
+                  e.stopPropagation()
+                  callEvent(props['onClick:clear'], new MouseEvent('click'))
                 }}
               >
                 { slots.clear


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Resolves https://github.com/vuetifyjs/vuetify/issues/18482

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select
        clearable
        label="Select"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      ></v-select>
      <v-autocomplete
        clearable
        label="Select"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      ></v-autocomplete>
    </v-container>
  </v-app>
</template>

```
