### PR TITLE
feat(VDataTable): Feat/emit sorted and filtered items v data table

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -121,6 +121,8 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     'update:groupBy': (value: any) => true,
     'update:expanded': (value: any) => true,
     'update:currentItems': (value: any) => true,
+    'update:sortedItems': (value: any) => true,
+    'update:filteredItems': (value: any) => true,
   },
 
   setup (props, { attrs, slots }) {

--- a/packages/vuetify/src/components/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/sort.ts
@@ -3,8 +3,8 @@ import { useLocale } from '@/composables'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, inject, provide, toRef } from 'vue'
-import { getObjectValueByPath, isEmpty, propsFactory } from '@/util'
+import { computed, inject, provide, toRef, watch } from 'vue'
+import { getCurrentInstance, getObjectValueByPath, isEmpty, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -101,6 +101,7 @@ export function useSortedItems <T extends Record<string, any>> (
   sortFunctions?: Ref<Record<string, DataTableCompareFunction> | undefined>,
   sortRawFunctions?: Ref<Record<string, DataTableCompareFunction> | undefined>,
 ) {
+  const vm = getCurrentInstance('userSortedItems')
   const locale = useLocale()
   const sortedItems = computed(() => {
     if (!sortBy.value.length) return items.value
@@ -109,6 +110,10 @@ export function useSortedItems <T extends Record<string, any>> (
       ...props.customKeySort,
       ...sortFunctions?.value,
     }, sortRawFunctions?.value)
+  })
+
+  watch(sortedItems, val => {
+    vm.emit('update:sortedItems', val)
   })
 
   return { sortedItems }

--- a/packages/vuetify/src/composables/filter.ts
+++ b/packages/vuetify/src/composables/filter.ts
@@ -3,7 +3,7 @@
 
 // Utilities
 import { computed, ref, unref, watchEffect } from 'vue'
-import { getPropertyFromItem, propsFactory, wrapInArray } from '@/util'
+import { getCurrentInstance, getPropertyFromItem, propsFactory, wrapInArray } from '@/util'
 
 // Types
 import type { PropType, Ref } from 'vue'
@@ -139,6 +139,7 @@ export function useFilter <T extends InternalItem> (
     customKeyFilter?: MaybeRef<FilterKeyFunctions | undefined>
   }
 ) {
+  const vm = getCurrentInstance('useFilter');
   const filteredItems: Ref<T[]> = ref([])
   const filteredMatches: Ref<Map<unknown, Record<string, FilterMatch>>> = ref(new Map())
   const transformedItems = computed(() => (
@@ -180,6 +181,8 @@ export function useFilter <T extends InternalItem> (
     })
     filteredItems.value = _filteredItems
     filteredMatches.value = _filteredMatches
+
+    vm.emit("update:filteredItems", filteredItems.value)
   })
 
   function getMatches (item: T) {


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
It exposes events for susbscribing on filtered data when using search-prop and also getting the sorted data when sorting.
Something I need for example to export all visible rows to a pdf and not only the paged result (i.e currentItems).
Seen as requested here as well for example: https://stackoverflow.com/questions/76008941/vuetify-3-data-table-current-items

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```
<template>
  <v-data-table :search="searchKey" :items="items" 
   @update:filteredItems="filteredItems" 
   @update:sortedItems="sortedItems"></v-data-table>
</template>

<script setup>
  import {
   ref
  } from 'vue'

  const searchKey = ref(''),
 
  const filteredItems = (items) => {
      console.log(items);
  }

  const sortedItems = (items) => {
      console.log(items);
  }

  const items = [
    {
      name: 'African Elephant',
      species: 'Loxodonta africana',
      diet: 'Herbivore',
      habitat: 'Savanna, Forests',
    },
    {
      name: 'Fantastic',
      species: 'Fab',
      diet: 'Vegan',
      habitat: 'Vuitton',
    },
    // ... more items
  ]
</script>
```
