### PR TITLE
fix(VProgressLinear): Remove will-change to prevent weird visual behaviour

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
@@ -57,7 +57,6 @@
     right: auto
     top: 0
     width: auto
-    will-change: left, right
 
   .long
     animation-name: indeterminate-ltr


### PR DESCRIPTION
fixes #19410

`will-change` should be used as a last resort to resolve existing performance problem, it's doing strange pre-animation effect in Windows here.


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-checkbox label="Show Loading" v-model="loading" />
      <v-text-field
        v-model="msg"
        color="blue"
        :loading="loading"
        variant="outlined"
      />
      <div class="h3 mb-2">Temporay Solution</div>
      <v-text-field
        v-model="msg"
        color="blue"
        :loading="loading"
        variant="outlined"
      >
        <template #loader>
          <v-progress-linear
            v-show="loading"
            height="2"
            color="blue"
            indeterminate
          />
        </template>
      </v-text-field>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const loading = ref(false)
  const msg = ref('Check to show loading')
</script>


```
