### PR TITLE
docs(VChip): Fixed a mistake in the features section

### DIFF
--- a/packages/docs/src/pages/en/components/chips.md
+++ b/packages/docs/src/pages/en/components/chips.md
@@ -10,10 +10,10 @@ related:
   - /components/selects
 features:
   figma: true
-  github: /components/VBtn/
+  github: /components/VChip/
   label: 'C: VChip'
   report: true
-  spec: https://m2.material.io/components/buttons
+  spec: https://m2.material.io/components/chips
 ---
 
 # Chips


### PR DESCRIPTION
I changed the Github and spec columns in the "features" section from "v-btn" to "v-chip".

## Description
There was an mistake in the "features" section of the v-chip.
The links for Github and the design specs were incorrectly set as buttons instead of chips.
This has been fixed.

