### PR TITLE
fix(VField): use xl border-radius for rounded prop

### DIFF
--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -4,7 +4,7 @@
 
 // INPUT
 $field-border-radius: settings.$border-radius-root !default;
-$field-rounded-border-radius: map-get(settings.$rounded, 'pill') !default;
+$field-rounded-border-radius: map-get(settings.$rounded, 'xl') !default;
 $field-color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity)) !default;
 $field-disabled-color: rgba(var(--v-theme-on-surface), var(--v-disabled-opacity)) !default;
 $field-error-color: rgb(var(--v-theme-error)) !default;


### PR DESCRIPTION
fixes #19151

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="ma-5">
    <v-combobox
      label="Fruits"
      variant="outlined"
      rounded
      multiple
      chips
      v-model="fruits"
    ></v-combobox>
    <v-combobox
      label="Fruits"
      variant="outlined"
      rounded
      chips
    ></v-combobox>
  </div>
</template>
<script setup>
  const fruits = [
    'Apple',
    'Apricot',
    'Avocado',
    'Banana',
    'Blackberry',
    'Blackcurrant',
    'Blueberry',
    'Boysenberry',
    'Breadfruit',
    'Cantaloupe',
    'Carambola',
    'Cherimoya',
    'Cherry',
    'Clementine',
    'Coconut',
    'Cranberry',
    'Date',
    'Dragonfruit',
    'Durian',
    'Elderberry',
    'Feijoa',
    'Fig',
    'Goji berry',
    'Gooseberry',
    'Grape',
    'Grapefruit',
    'Guava',
    'Honeydew',
    'Huckleberry',
    'Jabuticaba',
    'Jackfruit',
    'Jambul',
    'Jujube',
    'Juniper berry',
    'Kiwi',
    'Kumquat',
    'Lemon',
    'Lime',
    'Longan',
    'Lychee',
    'Mandarin',
    'Mango',
    'Mangosteen',
    'Marionberry',
    'Melon',
    'Miracle fruit',
    'Mulberry',
    'Nectarine',
    'Orange',
    'Papaya',
    'Passionfruit',
    'Peach',
    'Pear',
    'Persimmon',
    'Pineapple',
    'Pitaya',
    'Plantain',
    'Plum',
    'Pomegranate',
    'Pomelo',
    'Prickly pear',
    'Quince',
    'Rambutan',
    'Raspberry',
    'Red currant',
    'Salak',
    'Sapodilla',
    'Sapote',
    'Soursop',
    'Star apple',
    'Star fruit',
    'Strawberry',
    'Surinam cherry',
    'Tamarillo',
    'Tamarind',
    'Tangerine',
    'Tomato',
    'Ugli fruit',
    'Watermelon',
    'White currant',
    'White sapote',
    'Yuzu',
    'Zucchini',
    'Acerola',
    'Ackee',
    'African cucumber',
    'Amla',
    'Bilberry',
    'Camu Camu',
    'Cape gooseberry',
    'Cherries',
    'Cloudberry',
    'Cornelian cherry',
    'Damson',
    'Eggfruit',
    'Elderberry',
    'Feijoa',
    'Guinep',
    'Honeycrisp apple',
    'Ice cream bean',
    'Ilama',
    'Imbe',
    'Jaboticaba',
    'Kaffir lime',
    'Kiwano',
    'Kiwiberry',
    'Loquat',
    'Lucuma',
    'Mamey sapote',
    'Mangaba',
    'Maypop',
    'Medlar',
    'Mirabelle plum',
    'Monstera deliciosa fruit',
    'Mountain soursop',
    'Nance',
    'Nashi pear',
    'Noni',
    'Olive',
    'Pawpaw',
    'Pepino',
    'Physalis',
    'Pineberry',
    'Pink grapefruit',
    'Pitanga',
    'Pluot',
    'Pomato',
    'Purple mangosteen',
    'Raspberry',
    'Red banana',
    'Rose apple',
    'Salmonberry',
    'Santol',
    'Sea buckthorn',
    'Serviceberry',
    'Snake fruit',
    'Soncoya',
    'Strawberry guava',
    'Sugar apple',
    'Sweet lime',
    'Tangelo',
    'Tejocote',
    'Texas persimmon',
    'Thimbleberry',
    'Velvet apple',
    'Wax apple',
    'Wax jambu',
    'White mulberry',
    'Wild grape',
    'Yumberry',
  ]
</script>


```
