### PR TITLE
fix(VSelectionContolGroup): add correct ripple prop type

### DIFF
--- a/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
+++ b/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
@@ -16,6 +16,7 @@ import { deepEqual, genericComponent, getUid, propsFactory, useRender } from '@/
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
 import type { GenericProps } from '@/util'
+import type { RippleDirectiveBinding } from '@/directives/ripple'
 
 export interface VSelectionGroupContext {
   modelValue: Ref<any>
@@ -38,7 +39,7 @@ export const makeSelectionControlGroupProps = propsFactory({
   falseIcon: IconValue,
   trueIcon: IconValue,
   ripple: {
-    type: Boolean,
+    type: [Boolean, Object] as PropType<RippleDirectiveBinding['value']>,
     default: true,
   },
   multiple: {

--- a/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
+++ b/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
@@ -15,8 +15,8 @@ import { deepEqual, genericComponent, getUid, propsFactory, useRender } from '@/
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
-import type { GenericProps } from '@/util'
 import type { RippleDirectiveBinding } from '@/directives/ripple'
+import type { GenericProps } from '@/util'
 
 export interface VSelectionGroupContext {
   modelValue: Ref<any>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #19462

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

packages/vuetify/dev/Playground.vue
```vue
<template>
  <v-app>
    <v-container>
      <v-switch />
      <v-checkbox />
      <v-radio-group />
      <v-radio />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
  }
</script>
```

packages/vuetify/dev/vuetify/defaults.js
```js
export default {
  global: {
    ripple: { class: "text-error" },
  },
};
```