### PR TITLE
fix(VNavigationDrawer): Content behind v-navigation-drawer scrolls

### DIFF
--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.sass
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.sass
@@ -76,17 +76,6 @@
     object-fit: $navigation-drawer-img-object-fit
     width: $navigation-drawer-img-width
 
-.v-navigation-drawer__scrim
-  position: absolute
-  top: 0
-  left: 0
-  width: 100%
-  height: 100%
-  background: black
-  opacity: $navigation-drawer-scrim-opacity
-  transition: opacity $navigation-drawer-transition-duration $navigation-drawer-transition-timing-function
-  z-index: 1
-
 .v-navigation-drawer__prepend,
 .v-navigation-drawer__append
   flex: none

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -4,6 +4,7 @@ import './VNavigationDrawer.sass'
 // Components
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VImg } from '@/components/VImg'
+import { VOverlay } from '@/components/VOverlay'
 
 // Composables
 import { useSticky } from './sticky'
@@ -26,7 +27,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { useToggleScope } from '@/composables/toggleScope'
 
 // Utilities
-import { computed, nextTick, onBeforeMount, ref, shallowRef, toRef, Transition, watch } from 'vue'
+import { computed, nextTick, onBeforeMount, ref, shallowRef, toRef, watch } from 'vue'
 import { genericComponent, propsFactory, toPhysical, useRender } from '@/util'
 
 // Types
@@ -187,14 +188,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
 
     const { isStuck, stickyStyles } = useSticky({ rootEl, isSticky, layoutItemStyles })
 
-    const scrimColor = useBackgroundColor(computed(() => {
-      return typeof props.scrim === 'string' ? props.scrim : null
-    }))
     const scrimStyles = computed(() => ({
-      ...isDragging.value ? {
-        opacity: dragProgress.value * 0.2,
-        transition: 'none',
-      } : undefined,
       ...layoutItemScrimStyles.value,
     }))
 
@@ -213,7 +207,6 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
 
     useRender(() => {
       const hasImage = (slots.image || props.image)
-
       return (
         <>
           <props.tag
@@ -294,18 +287,20 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
                 { slots.append?.() }
               </div>
             )}
+
           </props.tag>
 
-          <Transition name="fade-transition">
-            { isTemporary.value && (isDragging.value || isActive.value) && !!props.scrim && (
-              <div
-                class={['v-navigation-drawer__scrim', scrimColor.backgroundColorClasses.value]}
-                style={[scrimStyles.value, scrimColor.backgroundColorStyles.value]}
-                onClick={ () => isActive.value = false }
-                { ...scopeId }
-              />
-            )}
-          </Transition>
+          { !!isTemporary.value && !!props.scrim && (
+            <VOverlay
+              v-model={ isActive.value }
+              origin="center center"
+              scrollStrategy="block"
+              locationStrategy="connected"
+              scrim={ props.scrim }
+              style={[scrimStyles.value]}
+              { ...scopeId }
+            />
+          )}
         </>
       )
     })

--- a/packages/vuetify/src/components/VNavigationDrawer/_variables.scss
+++ b/packages/vuetify/src/components/VNavigationDrawer/_variables.scss
@@ -23,7 +23,6 @@ $navigation-drawer-temporary-elevation: 16 !default;
 $navigation-drawer-transition-duration: 0.2s !default;
 $navigation-drawer-transition-property: box-shadow, transform, visibility, width, height, left, right, top, bottom !default;
 $navigation-drawer-transition-timing-function: settings.$standard-easing !default;
-$navigation-drawer-scrim-opacity: .2 !default;
 
 // Lists
 $navigation-drawer-border: (


### PR DESCRIPTION
Replace scrim with v-overlay component, which fixes the scroll issues

fixes #19477

<!-- packages/vuetify/dev/Playground.vue --->
```vue
<template>
  <v-app>
    <v-container>
          <v-navigation-drawer v-model="drawer" location="right" temporary>
            <v-list-item
              prepend-avatar="https://randomuser.me/api/portraits/men/78.jpg"
              title="John Leider"
            ></v-list-item>

            <v-divider></v-divider>

            <v-list density="compact" nav>
              <v-list-item
                prepend-icon="mdi-view-dashboard"
                title="Home"
                value="home"
              ></v-list-item>
              <v-list-item
                prepend-icon="mdi-forum"
                title="About"
                value="about"
              ></v-list-item>
            </v-list>
          </v-navigation-drawer>
          <v-main>
            <div class="d-flex justify-center align-center">
              <v-btn color="primary" @click.stop="drawer = !drawer"> Toggle </v-btn>
            </div>
            Lorem ipsum dolor sit amet, consectetur adipiscing elit. In gravida,
            risus vitae varius porttitor, sapien quam mollis ipsum, ac lacinia nibh
            mi at ex. Pellentesque id neque ligula. In at sem non sem efficitur
            elementum. Curabitur ultrices ac nunc vitae hendrerit. Curabitur velit
            neque, cursus in velit sed, feugiat pharetra magna. Donec eleifend
            tincidunt massa sagittis lobortis. Phasellus ut ipsum blandit, vulputate
            velit ac, vulputate magna. Vivamus hendrerit, tellus at pulvinar
            dignissim, lacus velit dignissim nisl, eget gravida neque nisi convallis
            metus. Phasellus lobortis dictum sapien quis suscipit. Fusce elit
            mauris, dictum at mauris ac, pharetra pretium nulla. In ante erat,
            vulputate at est non, commodo malesuada nulla. Mauris eget lobortis
            eros. Vestibulum pharetra leo at egestas vulputate. Cras eu neque magna.
            Cras non ipsum ultrices, ultricies metus sit amet, semper lacus. Nullam
            scelerisque lacinia nisl a faucibus. Aliquam bibendum neque sit amet est
            auctor, eget euismod tellus vehicula. Aenean varius erat at nulla tempus
            viverra. Duis feugiat consequat est, ac mollis lectus tempus eu.
            Suspendisse pellentesque ipsum ut varius rutrum. Ut sed enim quis orci
            condimentum rutrum eget a nisi. Donec maximus lorem eu lorem lacinia
            accumsan. Praesent vel massa vel metus porta mollis. Nulla sit amet
            turpis pulvinar, feugiat nisl pellentesque, porttitor nunc. Maecenas
            consequat mattis gravida. Curabitur nec laoreet tellus, a mollis purus.
            Phasellus id semper turpis. Donec sit amet hendrerit lectus. Suspendisse
            eu lacus at sapien varius pulvinar in vitae est. Nulla id sem vitae erat
            dapibus varius. Integer mattis vitae est eget cursus. Fusce mattis
            tristique enim, et porta mauris rutrum malesuada. Nullam semper dui ut
            pulvinar tincidunt. Ut et urna fermentum, condimentum leo a, malesuada
            quam. Duis gravida est nec lectus luctus sollicitudin. Praesent ut quam
            auctor, pulvinar tortor ut, ullamcorper risus. Pellentesque elementum
            ante quis lobortis pellentesque. Interdum et malesuada fames ac ante
            ipsum primis in faucibus. Cras iaculis consectetur scelerisque. Duis
            iaculis ultrices ligula, et facilisis ligula placerat sed. Morbi aliquet
            vitae enim sed iaculis. Quisque eget dui a metus sagittis placerat ut
            vel arcu. Phasellus euismod risus lacinia dictum sagittis. Suspendisse
            sapien neque, dictum et risus sed, luctus fringilla est. Orci varius
            natoque penatibus et magnis dis parturient montes, nascetur ridiculus
            mus. Cras euismod mauris nunc. Donec dictum tellus et velit
            sollicitudin, et ultrices eros volutpat. In non sollicitudin erat.
            Suspendisse massa lorem, tincidunt et orci sed, pharetra vehicula urna.
            Donec egestas et turpis in imperdiet. Pellentesque nec tincidunt magna,
            a rutrum urna. Donec sollicitudin commodo eros. Suspendisse malesuada
            diam a risus gravida, ac pretium nunc elementum. Cras consequat eros ac
            justo condimentum, pretium efficitur tellus tincidunt. Pellentesque sit
            amet pellentesque purus, ac ullamcorper ex. Integer at luctus felis.
            Maecenas varius urna vel eros cursus, sed tincidunt ante hendrerit.
            Quisque nec urna in est tempor elementum nec quis odio. Maecenas egestas
            posuere est, luctus vulputate nibh consectetur id. Suspendisse potenti.
            Aliquam erat volutpat. Donec sit amet efficitur arcu, feugiat faucibus
            purus. Sed eu aliquet nibh, vel ultrices nibh. Vivamus accumsan ultrices
            purus, a vehicula sapien convallis vel. Nam diam dui, dapibus at pretium
            nec, consequat sit amet ante. Mauris sit amet felis ut sem sollicitudin
            vulputate. Nulla ut orci accumsan odio malesuada eleifend non id erat.
            Lorem ipsum dolor sit amet, consectetur adipiscing elit. In gravida,
            risus vitae varius porttitor, sapien quam mollis ipsum, ac lacinia nibh
            mi at ex. Pellentesque id neque ligula. In at sem non sem efficitur
            elementum. Curabitur ultrices ac nunc vitae hendrerit. Curabitur velit
            neque, cursus in velit sed, feugiat pharetra magna. Donec eleifend
            tincidunt massa sagittis lobortis. Phasellus ut ipsum blandit, vulputate
            velit ac, vulputate magna. Vivamus hendrerit, tellus at pulvinar
            dignissim, lacus velit dignissim nisl, eget gravida neque nisi convallis
            metus. Phasellus lobortis dictum sapien quis suscipit. Fusce elit
            mauris, dictum at mauris ac, pharetra pretium nulla. In ante erat,
            vulputate at est non, commodo malesuada nulla. Mauris eget lobortis
            eros. Vestibulum pharetra leo at egestas vulputate. Cras eu neque magna.
            Cras non ipsum ultrices, ultricies metus sit amet, semper lacus. Nullam
            scelerisque lacinia nisl a faucibus. Aliquam bibendum neque sit amet est
            auctor, eget euismod tellus vehicula. Aenean varius erat at nulla tempus
            viverra. Duis feugiat consequat est, ac mollis lectus tempus eu.
            Suspendisse pellentesque ipsum ut varius rutrum. Ut sed enim quis orci
            condimentum rutrum eget a nisi. Donec maximus lorem eu lorem lacinia
            accumsan. Praesent vel massa vel metus porta mollis. Nulla sit amet
            turpis pulvinar, feugiat nisl pellentesque, porttitor nunc. Maecenas
            consequat mattis gravida. Curabitur nec laoreet tellus, a mollis purus.
            Phasellus id semper turpis. Donec sit amet hendrerit lectus. Suspendisse
            eu lacus at sapien varius pulvinar in vitae est. Nulla id sem vitae erat
            dapibus varius. Integer mattis vitae est eget cursus. Fusce mattis
            tristique enim, et porta mauris rutrum malesuada. Nullam semper dui ut
            pulvinar tincidunt. Ut et urna fermentum, condimentum leo a, malesuada
            quam. Duis gravida est nec lectus luctus sollicitudin. Praesent ut quam
            auctor, pulvinar tortor ut, ullamcorper risus. Pellentesque elementum
            ante quis lobortis pellentesque. Interdum et malesuada fames ac ante
            ipsum primis in faucibus. Cras iaculis consectetur scelerisque. Duis
            iaculis ultrices ligula, et facilisis ligula placerat sed. Morbi aliquet
            vitae enim sed iaculis. Quisque eget dui a metus sagittis placerat ut
            vel arcu. Phasellus euismod risus lacinia dictum sagittis. Suspendisse
            sapien neque, dictum et risus sed, luctus fringilla est. Orci varius
            natoque penatibus et magnis dis parturient montes, nascetur ridiculus
            mus. Cras euismod mauris nunc. Donec dictum tellus et velit
            sollicitudin, et ultrices eros volutpat. In non sollicitudin erat.
            Suspendisse massa lorem, tincidunt et orci sed, pharetra vehicula urna.
            Donec egestas et turpis in imperdiet. Pellentesque nec tincidunt magna,
            a rutrum urna. Donec sollicitudin commodo eros. Suspendisse malesuada
            diam a risus gravida, ac pretium nunc elementum. Cras consequat eros ac
            justo condimentum, pretium efficitur tellus tincidunt. Pellentesque sit
            amet pellentesque purus, ac ullamcorper ex. Integer at luctus felis.
            Maecenas varius urna vel eros cursus, sed tincidunt ante hendrerit.
            Quisque nec urna in est tempor elementum nec quis odio. Maecenas egestas
            posuere est, luctus vulputate nibh consectetur id. Suspendisse potenti.
            Aliquam erat volutpat. Donec sit amet efficitur arcu, feugiat faucibus
            purus. Sed eu aliquet nibh, vel ultrices nibh. Vivamus accumsan ultrices
            purus, a vehicula sapien convallis vel. Nam diam dui, dapibus at pretium
            nec, consequat sit amet ante. Mauris sit amet felis ut sem sollicitudin
            vulputate. Nulla ut orci accumsan odio malesuada eleifend non id erat.
            Lorem ipsum dolor sit amet, consectetur adipiscing elit. In gravida,
            risus vitae varius porttitor, sapien quam mollis ipsum, ac lacinia nibh
            mi at ex. Pellentesque id neque ligula. In at sem non sem efficitur
            elementum. Curabitur ultrices ac nunc vitae hendrerit. Curabitur velit
            neque, cursus in velit sed, feugiat pharetra magna. Donec eleifend
            tincidunt massa sagittis lobortis. Phasellus ut ipsum blandit, vulputate
            velit ac, vulputate magna. Vivamus hendrerit, tellus at pulvinar
            dignissim, lacus velit dignissim nisl, eget gravida neque nisi convallis
            metus. Phasellus lobortis dictum sapien quis suscipit. Fusce elit
            mauris, dictum at mauris ac, pharetra pretium nulla. In ante erat,
            vulputate at est non, commodo malesuada nulla. Mauris eget lobortis
            eros. Vestibulum pharetra leo at egestas vulputate. Cras eu neque magna.
            Cras non ipsum ultrices, ultricies metus sit amet, semper lacus. Nullam
            scelerisque lacinia nisl a faucibus. Aliquam bibendum neque sit amet est
            auctor, eget euismod tellus vehicula. Aenean varius erat at nulla tempus
            viverra. Duis feugiat consequat est, ac mollis lectus tempus eu.
            Suspendisse pellentesque ipsum ut varius rutrum. Ut sed enim quis orci
            condimentum rutrum eget a nisi. Donec maximus lorem eu lorem lacinia
            accumsan. Praesent vel massa vel metus porta mollis. Nulla sit amet
            turpis pulvinar, feugiat nisl pellentesque, porttitor nunc. Maecenas
            consequat mattis gravida. Curabitur nec laoreet tellus, a mollis purus.
            Phasellus id semper turpis. Donec sit amet hendrerit lectus. Suspendisse
            eu lacus at sapien varius pulvinar in vitae est. Nulla id sem vitae erat
            dapibus varius. Integer mattis vitae est eget cursus. Fusce mattis
            tristique enim, et porta mauris rutrum malesuada. Nullam semper dui ut
            pulvinar tincidunt. Ut et urna fermentum, condimentum leo a, malesuada
            quam. Duis gravida est nec lectus luctus sollicitudin. Praesent ut quam
            auctor, pulvinar tortor ut, ullamcorper risus. Pellentesque elementum
            ante quis lobortis pellentesque. Interdum et malesuada fames ac ante
            ipsum primis in faucibus. Cras iaculis consectetur scelerisque. Duis
            iaculis ultrices ligula, et facilisis ligula placerat sed. Morbi aliquet
            vitae enim sed iaculis. Quisque eget dui a metus sagittis placerat ut
            vel arcu. Phasellus euismod risus lacinia dictum sagittis. Suspendisse
            sapien neque, dictum et risus sed, luctus fringilla est. Orci varius
            natoque penatibus et magnis dis parturient montes, nascetur ridiculus
            mus. Cras euismod mauris nunc. Donec dictum tellus et velit
            sollicitudin, et ultrices eros volutpat. In non sollicitudin erat.
            Suspendisse massa lorem, tincidunt et orci sed, pharetra vehicula urna.
            Donec egestas et turpis in imperdiet. Pellentesque nec tincidunt magna,
            a rutrum urna. Donec sollicitudin commodo eros. Suspendisse malesuada
            diam a risus gravida, ac pretium nunc elementum. Cras consequat eros ac
            justo condimentum, pretium efficitur tellus tincidunt. Pellentesque sit
            amet pellentesque purus, ac ullamcorper ex. Integer at luctus felis.
            Maecenas varius urna vel eros cursus, sed tincidunt ante hendrerit.
            Quisque nec urna in est tempor elementum nec quis odio. Maecenas egestas
            posuere est, luctus vulputate nibh consectetur id. Suspendisse potenti.
            Aliquam erat volutpat. Donec sit amet efficitur arcu, feugiat faucibus
            purus. Sed eu aliquet nibh, vel ultrices nibh. Vivamus accumsan ultrices
            purus, a vehicula sapien convallis vel. Nam diam dui, dapibus at pretium
            nec, consequat sit amet ante. Mauris sit amet felis ut sem sollicitudin
            vulputate. Nulla ut orci accumsan odio malesuada eleifend non id erat.
          </v-main>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
    data() {
      return {
        drawer: null,
      }
    },
  }
</script>
```


![test-1](https://github.com/vuetifyjs/vuetify/assets/8360946/4c6bab00-1bca-4796-95d0-7c744d430fc3)
![test-2](https://github.com/vuetifyjs/vuetify/assets/8360946/920c222d-a5f6-44ad-be13-86921f95dd77)
