### PR TITLE
fix(VDataTableServer): was missing VDivider above the footer

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
@@ -4,6 +4,7 @@ import { makeVDataTableFooterProps, VDataTableFooter } from './VDataTableFooter'
 import { VDataTableHeaders } from './VDataTableHeaders'
 import { VDataTableRows } from './VDataTableRows'
 import { VTable } from '@/components/VTable'
+import { VDivider } from '@/components/VDivider'
 
 // Composables
 import { provideExpanded } from './composables/expand'
@@ -189,12 +190,16 @@ export const VDataTableServer = genericComponent<new <T extends readonly any[], 
               </>
             ),
             bottom: () => slots.bottom ? slots.bottom(slotProps.value) : (
-              <VDataTableFooter
-                { ...dataTableFooterProps }
-                v-slots={{
-                  prepend: slots['footer.prepend'],
-                }}
-              />
+              <>
+                <VDivider />
+
+                <VDataTableFooter
+                  { ...dataTableFooterProps }
+                  v-slots={{
+                    prepend: slots['footer.prepend'],
+                  }}
+                />
+              </>
             ),
           }}
         </VTable>

--- a/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
@@ -3,8 +3,8 @@ import { makeDataTableProps } from './VDataTable'
 import { makeVDataTableFooterProps, VDataTableFooter } from './VDataTableFooter'
 import { VDataTableHeaders } from './VDataTableHeaders'
 import { VDataTableRows } from './VDataTableRows'
-import { VTable } from '@/components/VTable'
 import { VDivider } from '@/components/VDivider'
+import { VTable } from '@/components/VTable'
 
 // Composables
 import { provideExpanded } from './composables/expand'


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
VDataTableServer was missing VDivider above the footer. This change now makes VDataTableServer more visually consistent with VDataTable
