### PR TITLE
fix(VChip): Prevent default onClose

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -141,6 +141,7 @@ export const VChip = genericComponent<VChipSlots>()({
     const closeProps = computed(() => ({
       'aria-label': t(props.closeLabel),
       onClick (e: MouseEvent) {
+        e.preventDefault()
         e.stopPropagation()
 
         isActive.value = false


### PR DESCRIPTION
Fixes #19461

Chip still navigates to href link even if close icon is clicked

```vue
<template>
  <v-app>
    <v-container>
      <v-chip href="https://vuetifyjs.com" closable> chip A </v-chip>
      <v-chip to="https://vuetifyjs.com" closable> chip B </v-chip>
      <v-chip href="https://vuetifyjs.com" closable> chip C </v-chip>
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
};
</script>

```