### PR TITLE
fix(VSwitch): label when using direction vertical

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -97,11 +97,6 @@ export const makeVSelectProps = propsFactory({
     role: 'combobox',
   }), ['validationValue', 'dirty', 'appendInnerIcon']),
   ...makeTransitionProps({ transition: { component: VDialogTransition as Component } }),
-  direction: {
-    type: String as PropType<'horizontal' | 'vertical'>,
-    default: 'horizontal',
-    validator: (v: any) => ['vertical', 'horizontal'].includes(v),
-  },
 }, 'VSelect')
 
 type ItemType<T> = T extends readonly (infer U)[] ? U : never
@@ -361,7 +356,7 @@ export const VSelect = genericComponent<new <
               [`v-select--${props.multiple ? 'multiple' : 'single'}`]: true,
               'v-select--selected': model.value.length,
               'v-select--selection-slot': !!slots.selection,
-              [`v-input--${props.direction.valueOf}`]: true,
+              [`v-input--${props.direction}`]: true,
             },
             props.class,
           ]}

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -97,6 +97,11 @@ export const makeVSelectProps = propsFactory({
     role: 'combobox',
   }), ['validationValue', 'dirty', 'appendInnerIcon']),
   ...makeTransitionProps({ transition: { component: VDialogTransition as Component } }),
+  direction: {
+    type: String as PropType<'horizontal' | 'vertical'>,
+    default: 'horizontal',
+    validator: (v: any) => ['vertical', 'horizontal'].includes(v),
+  },
 }, 'VSelect')
 
 type ItemType<T> = T extends readonly (infer U)[] ? U : never
@@ -356,6 +361,7 @@ export const VSelect = genericComponent<new <
               [`v-select--${props.multiple ? 'multiple' : 'single'}`]: true,
               'v-select--selected': model.value.length,
               'v-select--selection-slot': !!slots.selection,
+              [`v-input--${props.direction.valueOf}`]: true,
             },
             props.class,
           ]}

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -356,7 +356,6 @@ export const VSelect = genericComponent<new <
               [`v-select--${props.multiple ? 'multiple' : 'single'}`]: true,
               'v-select--selected': model.value.length,
               'v-select--selection-slot': !!slots.selection,
-              [`v-input--${props.direction}`]: true,
             },
             props.class,
           ]}

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -120,8 +120,10 @@
   &.v-switch--inset
     .v-selection-control__wrapper
       width: auto
+
   &.v-input--vertical
     .v-label
       min-width: max-content
+
     .v-selection-control__wrapper
-      transform: rotate(-90deg)
+      transform: $switch-thumb-vertical-transform

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -120,3 +120,8 @@
   &.v-switch--inset
     .v-selection-control__wrapper
       width: auto
+  &.v-input--vertical
+    .v-label
+      min-width: max-content
+    .v-selection-control__wrapper
+      transform: rotate(-90deg)

--- a/packages/vuetify/src/components/VSwitch/_variables.scss
+++ b/packages/vuetify/src/components/VSwitch/_variables.scss
@@ -27,6 +27,7 @@ $switch-thumb-width: 20px !default;
 $switch-thumb-offset: 2px !default;
 $switch-thumb-radius: 50% !default;
 $switch-thumb-transition: .15s .05s transform settings.$decelerated-easing, .2s color settings.$standard-easing, .2s background-color settings.$standard-easing !default;
+$switch-thumb-vertical-transform: rotate(-90deg) !default;
 
 $switch-track-background: rgb(var(--v-theme-surface-variant)) !default;
 $switch-track-radius: 9999px !default;


### PR DESCRIPTION
Feature to fix #18952

Added direction prop on ```VSelect``` and added styling to ```VSwitch```

```vue
<template>
  <v-app>
    <v-container>
      <v-switch
        v-model="model"
        direction="vertical"
        label="Vertical"
      ></v-switch>
      <v-switch
        v-model="model"
        direction="horizontal"
        label="Horizontal"
      ></v-switch>
      <v-switch v-model="model" label="Default"></v-switch>
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
  data: () => ({
    model: false,
  }),
};
</script>
```