### PR TITLE
fix(VListItem): Removed hover effect if list item is not clickable

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -46,10 +46,10 @@
       > .v-badge .v-icon,
       > .v-icon
         opacity: #{$list-item-icon-active-opacity}
-    &:not(&--hover)
+
+    &:not(.v-list-item--link)
       .v-list-item__overlay
-        // specificity has to be higher to override theme !important
-        opacity: calc(#{map.get(settings.$states, 'activated')} * var(--v-theme-overlay-multiplier)) !important
+        opacity: calc(#{map.get(settings.$states, 'activated')} * var(--v-theme-overlay-multiplier))
 
   &--rounded
     @include tools.rounded($list-item-rounded-border-radius)

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -46,6 +46,10 @@
       > .v-badge .v-icon,
       > .v-icon
         opacity: #{$list-item-icon-active-opacity}
+    &:not(&--hover)
+      .v-list-item__overlay
+        // specificity has to be higher to override theme !important
+        opacity: calc(#{map.get(settings.$states, 'activated')} * var(--v-theme-overlay-multiplier)) !important
 
   &--rounded
     @include tools.rounded($list-item-rounded-border-radius)

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -215,7 +215,6 @@ export const VListItem = genericComponent<VListItemSlots>()({
             'v-list-item',
             {
               'v-list-item--active': isActive.value,
-              'v-list-item--active--hover': isClickable.value,
               'v-list-item--disabled': props.disabled,
               'v-list-item--link': isClickable.value,
               'v-list-item--nav': props.nav,

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -215,6 +215,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
             'v-list-item',
             {
               'v-list-item--active': isActive.value,
+              'v-list-item--active--hover': isClickable.value,
               'v-list-item--disabled': props.disabled,
               'v-list-item--link': isClickable.value,
               'v-list-item--nav': props.nav,


### PR DESCRIPTION
Fixes #19005

Removed the hover effect if list item isn't set to clickable if link or href isn't set

```vue
<template>
  <v-app>
    <v-container>
      <v-list>
        <v-list-item>Item 1</v-list-item>
        <v-list-item active>Item 2</v-list-item>
        <v-list-item link="#" active>Item 3</v-list-item>
        <v-list-item link="#">Item 4</v-list-item>
        <v-list-item>Item 5</v-list-item>
      </v-list>
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
};
</script>

```