### PR TITLE
feat(router): add `NuxtLink` support for `useLink`

### DIFF
--- a/packages/vuetify/src/composables/router.tsx
+++ b/packages/vuetify/src/composables/router.tsx
@@ -50,7 +50,13 @@ export interface UseLink extends Omit<Partial<ReturnType<typeof _useLink>>, 'hre
 }
 
 export function useLink (props: LinkProps & LinkListeners, attrs: SetupContext['attrs']): UseLink {
-  const RouterLink = resolveDynamicComponent('RouterLink') as typeof _RouterLink | string
+  // NuxtLink component name can be changed in nuxt config file, but we cannot access to that name
+  // NuxtLink is not registered globally, and so we cannot use resolveDynamicComponent, the user
+  // must register it globally (vuetify-nuxt-module will add an option to enable global registration)
+  let RouterLink = resolveDynamicComponent('NuxtLink') as typeof _RouterLink | string
+  if (typeof RouterLink === 'string' || !('useLink' in RouterLink)) {
+    RouterLink = resolveDynamicComponent('RouterLink') as typeof _RouterLink | string
+  }
 
   const isLink = computed(() => !!(props.href || props.to))
   const isClickable = computed(() => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

This PR allows use `useLink` with `NuxtLink`, this Nuxt PR should be merged https://github.com/nuxt/nuxt/pull/26522

This will work only when:
- NuxtLink is registed globally: Nuxt will resolve it on demand, it is not registered globally, check https://github.com/nuxt/nuxt/issues/13659
- NuxtLink is register with that name: Nuxt allows us to change the name

To register NuxtLink globally we can use a plugin:
```ts
import { NuxtLink } from '#components'

export default defineNuxtPlugin((nuxtApp) => {
  nuxtApp.vueApp.component('NuxtLink', NuxtLink)
})
```

`vuetify-nuxt-module` will provide an option to register NuxtLink globally: will allow also to use other name (will register both).

resolves #17490


