### PR TITLE
fix(VDatePicker): fixed missing adapter abstractions

### DIFF
--- a/packages/vuetify/dev/vuetify/locale.js
+++ b/packages/vuetify/dev/vuetify/locale.js
@@ -1,10 +1,12 @@
-import { ar, en, ja, sv } from 'vuetify/src/locale'
+import { ar, en, fa, ja, sv } from 'vuetify/src/locale'
 
 export default {
+  locale: 'fa',
   messages: {
     en,
     ar,
     sv,
     ja,
+    fa,
   },
 }

--- a/packages/vuetify/dev/vuetify/locale.js
+++ b/packages/vuetify/dev/vuetify/locale.js
@@ -1,12 +1,10 @@
-import { ar, en, fa, ja, sv } from 'vuetify/src/locale'
+import { ar, en, ja, sv } from 'vuetify/src/locale'
 
 export default {
-  locale: 'fa',
   messages: {
     en,
     ar,
     sv,
     ja,
-    fa,
   },
 }

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -119,25 +119,22 @@ export const VDatePicker = genericComponent<new <
 
     const isReversing = shallowRef(false)
     const header = computed(() => {
-      return props.multiple && model.value.length > 1
-        ? t('$vuetify.datePicker.itemsSelected', model.value.length)
-        : model.value[0] && adapter.isValid(model.value[0])
-          ? adapter.format(
-            adapter.date(model.value[0]),
-            'normalDateWithWeekday')
-          : t(props.header)
+      if (props.multiple && model.value.length > 1) {
+        return t('$vuetify.datePicker.itemsSelected', model.value.length)
+      }
+
+      return (model.value[0] && adapter.isValid(model.value[0]))
+        ? adapter.format(adapter.date(model.value[0]), 'normalDateWithWeekday')
+        : t(props.header)
     })
     const text = computed(() => {
-      let _date = adapter.date()
+      let date = adapter.date()
 
-      _date = adapter.setYear(_date, year.value)
-      _date = adapter.setMonth(_date, month.value)
-      _date = adapter.setDate(_date, 1)
+      date = adapter.setYear(date, year.value)
+      date = adapter.setMonth(date, month.value)
+      date = adapter.setDate(date, 1)
 
-      return adapter.format(
-        _date,
-        'monthAndYear',
-      )
+      return adapter.format(date, 'monthAndYear')
     })
     // const headerIcon = computed(() => props.inputMode === 'calendar' ? props.keyboardIcon : props.calendarIcon)
     const headerTransition = computed(() => `date-picker-header${isReversing.value ? '-reverse' : ''}-transition`)

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -122,12 +122,20 @@ export const VDatePicker = genericComponent<new <
       return props.multiple && model.value.length > 1
         ? t('$vuetify.datePicker.itemsSelected', model.value.length)
         : model.value[0] && adapter.isValid(model.value[0])
-          ? adapter.format(model.value[0], 'normalDateWithWeekday')
+          ? adapter.format(
+            adapter.date(model.value[0]),
+            'normalDateWithWeekday')
           : t(props.header)
     })
     const text = computed(() => {
+      let _date = adapter.date()
+
+      _date = adapter.setYear(_date, year.value)
+      _date = adapter.setMonth(_date, month.value)
+      _date = adapter.setDate(_date, 1)
+
       return adapter.format(
-        adapter.date(new Date(year.value, month.value, 1)),
+        _date,
         'monthAndYear',
       )
     })

--- a/packages/vuetify/src/composables/date/DateAdapter.ts
+++ b/packages/vuetify/src/composables/date/DateAdapter.ts
@@ -35,6 +35,8 @@ export interface DateAdapter<T = unknown> {
   getWeekdays (): string[]
   getMonth (date: T): number
   setMonth (date: T, month: number): T
+  getDate (date: T): number
+  setDate (date: T, day: number): T
   getNextMonth (date: T): T
   getHours (date: T): number
   setHours (date: T, hours: number): T

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -375,6 +375,10 @@ function getMonth (date: Date) {
   return date.getMonth()
 }
 
+function getDate (date: Date) {
+  return date.getDate()
+}
+
 function getNextMonth (date: Date) {
   return new Date(date.getFullYear(), date.getMonth() + 1, 1)
 }
@@ -469,6 +473,12 @@ function setMinutes (date: Date, count: number) {
 function setMonth (date: Date, count: number) {
   const d = new Date(date)
   d.setMonth(count)
+  return d
+}
+
+function setDate (date: Date, day: number) {
+  const d = new Date(date)
+  d.setDate(day)
   return d
 }
 
@@ -595,6 +605,10 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
     return setMonth(date, count)
   }
 
+  setDate (date: Date, day: number): Date {
+    return setDate(date, day)
+  }
+
   setYear (date: Date, year: number) {
     return setYear(date, year)
   }
@@ -613,6 +627,10 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
 
   getMonth (date: Date) {
     return getMonth(date)
+  }
+
+  getDate (date: Date) {
+    return getDate(date)
   }
 
   getNextMonth (date: Date) {


### PR DESCRIPTION
Fixed code to use adapter abstraction in text and header computed values

## Description
changed text and header computed values to use adapter abstraction while computing first day of month and header value.
resoves #18942


## Markup:
packages/vuetify/dev/vuetify/locale.js
```js
import { ar, en, fa, ja, sv } from 'vuetify/src/locale'

export default {
  locale: 'fa',
  messages: {
    en,
    ar,
    sv,
    ja,
    fa,
  },
}
```
packages/vuetify/dev/Playground.vue:
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker
        v-model="date"
        show-adjacent-months
      />
      <!-- -->
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    data: () => ({
      date: new Date(),
    }),
  }
</script>

```
