### PR TITLE
fix: no types for `vuetify/framework` sub-package

### DIFF
--- a/packages/vuetify/build/rollup.config.mjs
+++ b/packages/vuetify/build/rollup.config.mjs
@@ -32,7 +32,7 @@ export default [
     input: 'src/entry-bundler.ts',
     output: [
       {
-        file: 'dist/vuetify.esm.js',
+        file: 'dist/vuetify.mjs',
         format: 'es',
         sourcemap: true,
         banner,
@@ -189,7 +189,7 @@ export default [
         banner,
       },
       {
-        file: 'dist/vuetify-labs.esm.js',
+        file: 'dist/vuetify-labs.mjs',
         format: 'es',
         sourcemap: true,
         banner,

--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -62,7 +62,10 @@
       "default": "./lib/styles/main.css"
     },
     "./styles/*": "./lib/styles/*",
-    "./framework": "./lib/framework.mjs",
+    "./framework": {
+      "types": "./lib/index.d.mts",
+      "default": "./lib/framework.mjs"
+    },
     "./blueprints": "./lib/blueprints/index.mjs",
     "./blueprints/*": "./lib/blueprints/*.mjs",
     "./components": "./lib/components/index.mjs",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

This PR also moves `.esm.js` to `.mjs` files that can be interpreted as CJS when they are ESM:
- `dist/vuetify.esm.js` => `dist/vuetify.mjs`
- `dist/vuetify-labs.esm.js` => `dist/vuetify-labs.mjs`

Current framework subpackage (https://arethetypeswrong.github.io/?p=vuetify%403.5.13):

![imagen](https://github.com/vuetifyjs/vuetify/assets/6311119/6ee04987-930f-46cb-9090-c006313ff11b)

With this PR:

![imagen](https://github.com/vuetifyjs/vuetify/assets/6311119/ebb675ba-f0a5-4c4f-87c5-ad16f03e5f56)

About the `esm.js` files you can check the warning here (or running `npx publint` in your local, install publint globally):  https://publint.dev/vuetify@3.5.13

