### PR TITLE
docs: Correct VDatatable component's Introduction.md

### DIFF
--- a/packages/docs/src/pages/en/components/data-tables/introduction.md
+++ b/packages/docs/src/pages/en/components/data-tables/introduction.md
@@ -37,7 +37,7 @@ Before diving into the guides and examples, let's take a moment to understand th
 | [v-data-table](/api/v-data-table/)                 | Primary Component                                           |
 | [v-data-table-server](/api/v-data-table-server/)   | Specialized Data-table for displaying results from a server |
 | [v-data-table-virtual](/api/v-data-table-virtual/) | Data-table with built in row virtualization                 |
-| [v-data-table-footer](/api/v-data-table-footer/)   | Functional Component used to display Data-table headers     |
+| [v-data-table-footer](/api/v-data-table-footer/)   | Functional Component used to display Data-table footer     |
 | [v-checkbox-btn](/api/v-checkbox-btn/)             | Reusable lightweight [v-checkbox](/components/checkboxes)   |
 
 <ApiInline hide-links />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Changed the **v-data-table-footer** description in its documentation

It came from this :
<code>[v-data-table-footer](/api/v-data-table-footer/)   | Functional Component used to display Data-table headers     |</code>

To this :
<code>[v-data-table-footer](/api/v-data-table-footer/)   | Functional Component used to display Data-table footer     |</code>

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
I didn't need to open my IDE

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
-
```
