### PR TITLE
fix(VTimePicker): use window events instead of element

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
@@ -200,6 +200,10 @@ export const VTimePickerClock = genericComponent()({
     function onMouseDown (e: MouseEvent | TouchEvent) {
       e.preventDefault()
 
+      window.addEventListener('mousemove', onDragMove)
+      window.addEventListener('touchmove', onDragMove)
+      window.addEventListener('mouseup', onMouseUp)
+      window.addEventListener('touchend', onMouseUp)
       valueOnMouseDown.value = null
       valueOnMouseUp.value = null
       isDragging.value = true
@@ -208,6 +212,10 @@ export const VTimePickerClock = genericComponent()({
 
     function onMouseUp (e: MouseEvent | TouchEvent) {
       e.stopPropagation()
+      window.removeEventListener('mousemove', onDragMove)
+      window.removeEventListener('touchmove', onDragMove)
+      window.removeEventListener('mouseup', onMouseUp)
+      window.removeEventListener('touchend', onMouseUp)
 
       isDragging.value = false
       if (valueOnMouseUp.value !== null && isAllowed(valueOnMouseUp.value)) {
@@ -226,12 +234,7 @@ export const VTimePickerClock = genericComponent()({
             },
           ]}
           onMousedown={ onMouseDown }
-          onMouseup={ onMouseUp }
-          onMouseleave={ (e: MouseEvent) => (isDragging.value && onMouseUp(e)) }
           onTouchstart={ onMouseDown }
-          onTouchend={ onMouseUp }
-          onMousemove={ onDragMove }
-          onTouchmove={ onDragMove }
           onWheel={ (e: WheelEvent) => (props.scrollable && wheel(e)) }
           ref={ clockRef }
         >


### PR DESCRIPTION
Change the event handlers to use window events instead of limiting to picker container.

```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-row>
          {{ thisDate }}
          <v-col>
            <v-switch v-model="format24" color="primary" false-value="ampm" label="24hr" true-value="24hr" />
          </v-col>
          <v-col>
            <v-switch v-model="seconds" color="primary" label="Seconds" />
          </v-col>
        </v-row>
        <v-row>
          <v-col cols="12">
            <v-time-picker v-model="thisDate" :format="format24" :use-seconds="seconds" scrollable />
          </v-col>
        </v-row>
      </v-container>
    </v-main>
  </v-app>
</template>
<script setup>
  import { ref } from 'vue'

  const thisDate = ref(new Date())

  const format24 = ref('24hr')
  const seconds = ref(false)
</script>
```