### PR TITLE
docs(Overlay): add information about contained that the desirable container should be relative to be taken as container

### DIFF
--- a/packages/docs/src/pages/en/components/overlays.md
+++ b/packages/docs/src/pages/en/components/overlays.md
@@ -133,7 +133,12 @@ No scroll strategy is used.
 
 #### Contained
 
-A **contained** overlay is positioned absolutely and contained inside its parent element. (Note: The parent element must have position: relative.)",
+A **contained** overlay is positioned absolutely and contained inside its parent element.
+
+::: info
+  Note: The parent element must have position: relative.
+:::
+
 
 <ExamplesExample file="v-overlay/prop-contained" />
 

--- a/packages/docs/src/pages/en/components/overlays.md
+++ b/packages/docs/src/pages/en/components/overlays.md
@@ -133,7 +133,7 @@ No scroll strategy is used.
 
 #### Contained
 
-A **contained** overlay is positioned absolutely and contained inside its parent element.
+A **contained** overlay is positioned absolutely and contained inside its parent element. (Note: The parent element must have position: relative.)",
 
 <ExamplesExample file="v-overlay/prop-contained" />
 

--- a/packages/docs/src/pages/en/components/overlays.md
+++ b/packages/docs/src/pages/en/components/overlays.md
@@ -139,7 +139,6 @@ A **contained** overlay is positioned absolutely and contained inside its parent
   Note: The parent element must have position: relative.
 :::
 
-
 <ExamplesExample file="v-overlay/prop-contained" />
 
 ### Misc


### PR DESCRIPTION
## Description

I got difficulties to have the overlay only over my parent, then I read on https://github.com/vuetifyjs/vuetify/issues/16086 that the parent should have the parent.

The API mentions but not the example, this could be helpful to have as it's not clear for the issuer of https://github.com/vuetifyjs/vuetify/issues/17071.

fixes #17071