### PR TITLE
fix(VDataTable): avoid changing page if oldOptions is not defined

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/options.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/options.ts
@@ -34,7 +34,7 @@ export function useOptions ({
     if (deepEqual(oldOptions, options.value)) return
 
     // Reset page when searching
-    if (oldOptions?.search !== options.value.search) {
+    if (typeof oldOptions?.search !== 'undefined' && oldOptions?.search !== options.value.search) {
       page.value = 1
     }
 

--- a/packages/vuetify/src/components/VDataTable/composables/options.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/options.ts
@@ -34,7 +34,7 @@ export function useOptions ({
     if (deepEqual(oldOptions, options.value)) return
 
     // Reset page when searching
-    if (typeof oldOptions?.search !== 'undefined' && oldOptions?.search !== options.value.search) {
+    if (oldOptions && oldOptions.search !== options.value.search) {
       page.value = 1
     }
 


### PR DESCRIPTION
fixes #17966

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes initial checking of old search value to include a check for undefined. Without it the condition was always true.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-text-field
    v-model="search"
    label="Search"
  />
  <v-data-table
    :headers="headers"
    :items="desserts"
    :items-per-page="5"
    :page="2"
    :search="search"
  />
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const search = ref('')

  const headers = ref([
    {
      title: 'Dessert (100g serving)',
      align: 'start',
      sortable: false,
      key: 'name',
    },
    { title: 'Calories', key: 'calories' },
    { title: 'Fat (g)', key: 'fat' },
    { title: '', key: 'data-table-expand' },
  ] as const)
  const desserts = ref([
    {
      name: 'Frozen Yogurt',
      calories: 159,
      fat: 6,
    },
    {
      name: 'KitKat',
      calories: 518,
      fat: 26,
    },
    {
      name: 'Ice cream sandwich with some really long name',
      calories: 237,
      fat: 9,
    },
    {
      name: 'Eclair',
      calories: 262,
      fat: 16,
    },
    {
      name: 'Cupcake',
      calories: 305,
      fat: 3.7,
    },
    {
      name: 'Gingerbread',
      calories: 356,
      fat: 16,
    },
    {
      name: 'Jelly bean',
      calories: 375,
      fat: 0,
    },
    {
      name: 'Honeycomb',
      calories: 408,
      fat: 3.2,
    },
    {
      name: 'Donut',
      calories: 452,
      fat: 25,
    },
    {
      name: 'KitKat',
      calories: 518,
      fat: 26,
    },
  ])
</script>

```
