### PR TITLE
fix(VTextField): new-password of autocomplete doesn't behave correctly on chrome

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -108,10 +108,6 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
       props.active
     ))
     function onFocus () {
-      if (inputRef.value !== document.activeElement) {
-        inputRef.value?.focus()
-      }
-
       if (!isFocused.value) focus()
     }
     function onControlMousedown (e: MouseEvent) {


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19559

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-responsive
        class="mx-auto"
        width="344"
      >
        <v-form>
          <v-label>Vuetify field</v-label>
          <v-text-field
            autocomplete="new-password"
            label="Password"
            name="password"
            type="password"
          />
          <v-text-field
            autocomplete="new-password"
            label="Confirm Password"
            name="confirm password"
            type="password"
          />
        </v-form>
        <!-- <form class="pure-form">
          <fieldset>
            <legend>Confirm password with HTML5</legend>

            <input id="password" placeholder="Password" type="password" required>
            <input id="confirm_password" placeholder="Confirm Password" type="password" required>

            <button class="mx-1" type="submit">Confirm</button>
          </fieldset>
        </form> -->
      </v-responsive>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
