### PR TITLE
fix(VTimePicker): Fix emits on change

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
@@ -254,10 +254,10 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
         case 'hour':
           emit('update:hour', value)
           break
-        case 'minutes':
+        case 'minute':
           emit('update:minute', value)
           break
-        case 'seconds':
+        case 'second':
           emit('update:second', value)
           break
         default:


### PR DESCRIPTION
```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-row>
          <v-col>
            <v-menu>
              <template #activator="{ props }">
                <v-text-field v-bind="props" v-model="thisDate" readonly />
              </template>
              <v-time-picker v-model="thisDate" format="24hr" @update:hour="hour = true" @update:minute="minute = true" @update:second="second = true" />
            </v-menu>
          </v-col>
          {{ hour }}
          {{ minute }}
          {{ second }}
        </v-row>
      </v-container>
    </v-main>
  </v-app>
</template>
<script setup>
  import { ref } from 'vue'

  const thisDate = ref(new Date())

  const minute = ref(false)
  const hour = ref(false)
  const second = ref(false)
</script>
```
