### PR TITLE
fix(VBtn): apply center ripple when using the icon prop

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -30,7 +30,7 @@ import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant
 import { Ripple } from '@/directives/ripple'
 
 // Utilities
-import { computed } from 'vue'
+import { computed, withDirectives } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -88,8 +88,6 @@ export const makeVBtnProps = propsFactory({
 
 export const VBtn = genericComponent<VBtnSlots>()({
   name: 'VBtn',
-
-  directives: { Ripple },
 
   props: makeVBtnProps(),
 
@@ -163,7 +161,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
         (!group || link.isActive?.value)
       )
 
-      return (
+      return withDirectives(
         <Tag
           type={ Tag === 'a' ? undefined : 'button' }
           class={[
@@ -203,11 +201,6 @@ export const VBtn = genericComponent<VBtnSlots>()({
           disabled={ isDisabled.value || undefined }
           href={ link.href.value }
           tabindex={ props.loading ? -1 : undefined }
-          v-ripple={[
-            !isDisabled.value && props.ripple,
-            null,
-            props.icon ? ['center'] : null,
-          ]}
           onClick={ onClick }
           value={ valueAttr.value }
         >
@@ -289,7 +282,13 @@ export const VBtn = genericComponent<VBtnSlots>()({
               )}
             </span>
           )}
-        </Tag>
+        </Tag>,
+        [[
+          Ripple,
+          !isDisabled.value && !!props.ripple,
+          '',
+          { center: !!props.icon },
+        ]]
       )
     })
 


### PR DESCRIPTION
fixes #17376

```vue
<template>
  <v-app>
    <div class="ma-4 pa-4">
      <v-btn>asdf</v-btn>
      <v-btn icon="$vuetify" />
    </div>
  </v-app>
</template>
```
