### PR TITLE
feat(calendar): prop to switch between dynamic/static number of weeks

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -60,7 +60,9 @@ export const makeVDatePickerProps = propsFactory({
   },
 
   ...makeVDatePickerControlsProps(),
-  ...makeVDatePickerMonthProps(),
+  ...makeVDatePickerMonthProps({
+    weeksInMonth: 'static' as const,
+  }),
   ...omit(makeVDatePickerMonthsProps(), ['modelValue']),
   ...omit(makeVDatePickerYearsProps(), ['modelValue']),
   ...makeVPickerProps({ title: '$vuetify.datePicker.title' }),

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -167,7 +167,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
         <MaybeTransition name={ transition.value }>
           <div
             ref={ daysRef }
-            key={ daysInMonth.value[0].date.toString() }
+            key={ daysInMonth.value[0].date?.toString() }
             class="v-date-picker-month__days"
           >
             { !props.hideWeekdays && adapter.getWeekdays().map(weekDay => (

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -21,6 +21,7 @@ export interface CalendarProps {
   month: number | string | undefined
   weekdays: number[]
   year: number | string | undefined
+  weeksInMonth: 'dynamic' | 'static'
 
   'onUpdate:modelValue': ((value: unknown[]) => void) | undefined
   'onUpdate:month': ((value: number) => void) | undefined
@@ -41,6 +42,10 @@ export const makeCalendarProps = propsFactory({
   weekdays: {
     type: Array<number>,
     default: () => [0, 1, 2, 3, 4, 5, 6],
+  },
+  weeksInMonth: {
+    type: String as PropType<'dynamic' | 'static'>,
+    default: 'dynamic',
   },
 }, 'calendar')
 
@@ -86,15 +91,15 @@ export function useCalendar (props: CalendarProps) {
     v => adapter.getMonth(v)
   )
 
-  const weeksInMonth = computed<Date[][]>((): Date[][] => {
+  const weeksInMonth = computed(() => {
     const weeks = adapter.getWeekArray(month.value)
 
     const days = weeks.flat()
 
     // Make sure there's always 6 weeks in month (6 * 7 days)
-    // But only do it if we're not hiding adjacent months?
+    // if weeksInMonth is 'static'
     const daysInMonth = 6 * 7
-    if (days.length < daysInMonth) {
+    if (props.weeksInMonth === 'static' && days.length < daysInMonth) {
       const lastDay = days[days.length - 1]
 
       let week = []
@@ -108,10 +113,10 @@ export function useCalendar (props: CalendarProps) {
       }
     }
 
-    return weeks as Date[][]
+    return weeks
   })
 
-  function genDays (days: Date[], today: Date) {
+  function genDays (days: unknown[], today: unknown) {
     return days.filter(date => {
       return props.weekdays.includes(adapter.toJsDate(date).getDay())
     }).map((date, index) => {
@@ -149,11 +154,9 @@ export function useCalendar (props: CalendarProps) {
       week.push(adapter.addDays(lastDay, day))
     }
 
-    const days = week as Date[]
+    const today = adapter.date()
 
-    const today = adapter.date() as Date
-
-    return genDays(days, today)
+    return genDays(week, today)
   })
 
   const daysInMonth = computed(() => {


### PR DESCRIPTION


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
 
looking at previous art, most "fullscreen" calendars seem to go with a varying week length of either 5 or 6 depending on how the days in the month are arranged. this includes arguably the two biggest examples (google, microsoft). but there are ones that use a static 6 weeks, pretty much always together with showing adjacent days.

date-pickers also vary, but ones based on material design like MUI do use static 6 weeks so that the dialog does not jump when switching months

with this change, date-picker uses static by default, calendar uses dynamic

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker />

      <v-calendar
        v-model="date"
      ></v-calendar>

      <v-calendar
        v-model="date"
        weeks-in-month="static"
        show-adjacent-months
      ></v-calendar>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'
  export default {
    name: 'Playground',
    setup () {
      const date = ref([new Date()])
      return {
        date,
      }
    },
  }
</script>

```
