### PR TITLE
fix(VCalendar): hide adjacent events when not using show-adjacent-months

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendarMonthDay.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarMonthDay.tsx
@@ -54,24 +54,27 @@ export const VCalendarMonthDay = genericComponent< VCalendarMonthDaySlots >()({
               )}
             </div>
           )}
-          <div key="content" class="v-calendar-weekly__day-content">
-            { slots.content?.() ?? (
-              <div>
-                <div class="v-calendar-weekly__day-alldayevents-container">
-                  { props.events?.filter(event => event.allDay).map(event => (
-                    <VCalendarEvent day={ props.day } event={ event } allDay />
-                  ))}
-                </div>
-                <div class="v-calendar-weekly__day-events-container">
-                  { props.events?.filter(event => !event.allDay).map(event => (
-                    <VCalendarEvent day={ props.day } event={ event } />
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
 
-          { slots.default?.() }
+          { !props.day?.isHidden && (
+            <div key="content" class="v-calendar-weekly__day-content">
+              { slots.content?.() ?? (
+                <div>
+                  <div class="v-calendar-weekly__day-alldayevents-container">
+                    { props.events?.filter(event => event.allDay).map(event => (
+                      <VCalendarEvent day={ props.day } event={ event } allDay />
+                    ))}
+                  </div>
+                  <div class="v-calendar-weekly__day-events-container">
+                    { props.events?.filter(event => !event.allDay).map(event => (
+                      <VCalendarEvent day={ props.day } event={ event } />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          { !props.day?.isHidden && slots.default?.() }
         </div>
       )
     })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
we should not show events on adjacent days unless show-adjacent-months is used

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-calendar
        v-model="date"
        :events="events"
      />
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'
  export default {
    name: 'Playground',
    setup () {
      const date = ref([new Date(2024, 3, 1)])
      return {
        date,
        events: [
          {
            start: new Date(2024, 3, 1),
            end: new Date(2024, 3, 1),
            title: 'foo',
          },
          {
            start: new Date(2024, 4, 1),
            end: new Date(2024, 4, 1),
            title: 'bar',
          },
        ],
      }
    },
  }
</script>

```
