### PR TITLE
fix(VCalendar): not usable without v-model

### DIFF
--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -143,7 +143,7 @@ export function useCalendar (props: CalendarProps) {
   }
 
   const daysInWeek = computed(() => {
-    const lastDay = adapter.startOfWeek(model.value)
+    const lastDay = adapter.startOfWeek(displayValue.value)
     const week = []
     for (let day = 0; day <= 6; day++) {
       week.push(adapter.addDays(lastDay, day))

--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -41,31 +41,31 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
   setup (props, { emit, slots }) {
     const adapter = useDate()
 
-    const { daysInMonth, daysInWeek, genDays, model, weekNumbers } = useCalendar(props as any)
+    const { daysInMonth, daysInWeek, genDays, model, displayValue, weekNumbers } = useCalendar(props as any)
 
     const dayNames = adapter.getWeekdays()
 
     function onClickNext () {
       if (props.viewMode === 'month') {
-        model.value = [adapter.addMonths(model.value[0], 1)]
+        model.value = [adapter.addMonths(displayValue.value, 1)]
       }
       if (props.viewMode === 'week') {
-        model.value = [adapter.addDays(model.value[0], 7)]
+        model.value = [adapter.addDays(displayValue.value, 7)]
       }
       if (props.viewMode === 'day') {
-        model.value = [adapter.addDays(model.value[0], 1)]
+        model.value = [adapter.addDays(displayValue.value, 1)]
       }
     }
 
     function onClickPrev () {
       if (props.viewMode === 'month') {
-        model.value = [adapter.addMonths(model.value[0], -1)]
+        model.value = [adapter.addMonths(displayValue.value, -1)]
       }
       if (props.viewMode === 'week') {
-        model.value = [adapter.addDays(model.value[0], -7)]
+        model.value = [adapter.addDays(displayValue.value, -7)]
       }
       if (props.viewMode === 'day') {
-        model.value = [adapter.addDays(model.value[0], -1)]
+        model.value = [adapter.addDays(displayValue.value, -1)]
       }
     }
 
@@ -74,7 +74,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
     }
 
     const title = computed(() => {
-      return adapter.format(model.value[0], 'monthAndYear')
+      return adapter.format(displayValue.value, 'monthAndYear')
     })
 
     useRender(() => {
@@ -173,11 +173,12 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
             { props.viewMode === 'day' && (
               <VCalendarDay
                 { ...calendarDayProps }
-                day={ genDays([model.value[0] as Date], adapter.date() as Date)[0] }
+                day={ genDays([displayValue.value as Date], adapter.date() as Date)[0] }
+                dayIndex={ 0 }
                 events={
                   props.events?.filter(e =>
-                    adapter.isSameDay(e.start, genDays([model.value[0] as Date], adapter.date() as Date)[0].date) ||
-                    adapter.isSameDay(e.end, genDays([model.value[0] as Date], adapter.date() as Date)[0].date)
+                    adapter.isSameDay(e.start, genDays([displayValue.value as Date], adapter.date() as Date)[0].date) ||
+                    adapter.isSameDay(e.end, genDays([displayValue.value as Date], adapter.date() as Date)[0].date)
                   )
                 }
               ></VCalendarDay>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
v-calendar was not usable without supplying a v-model

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-calendar />
    </v-main>
  </v-app>
</template>
```
