### PR TITLE
fix(date): startOfWeek/endOfWeek does not respect locale

### DIFF
--- a/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
+++ b/packages/vuetify/src/composables/date/adapters/__tests__/vuetify.spec.ts
@@ -52,4 +52,44 @@ describe('vuetify date adapter', () => {
 
     timezoneMock.unregister()
   })
+
+  it('returns correct start of week', () => {
+    let instance = new VuetifyDateAdapter({ locale: 'en-US' })
+
+    let date = instance.startOfWeek(new Date(2024, 3, 10, 12, 0, 0))
+
+    expect(date?.getFullYear()).toBe(2024)
+    expect(date?.getMonth()).toBe(3)
+    expect(date?.getDate()).toBe(7)
+    expect(date?.getDay()).toBe(0)
+
+    instance = new VuetifyDateAdapter({ locale: 'sv-SE' })
+
+    date = instance.startOfWeek(new Date(2024, 3, 10, 12, 0, 0))
+
+    expect(date?.getFullYear()).toBe(2024)
+    expect(date?.getMonth()).toBe(3)
+    expect(date?.getDate()).toBe(8)
+    expect(date?.getDay()).toBe(1)
+  })
+
+  it('returns correct end of week', () => {
+    let instance = new VuetifyDateAdapter({ locale: 'en-US' })
+
+    let date = instance.endOfWeek(new Date(2024, 3, 10, 12, 0, 0))
+
+    expect(date?.getFullYear()).toBe(2024)
+    expect(date?.getMonth()).toBe(3)
+    expect(date?.getDate()).toBe(13)
+    expect(date?.getDay()).toBe(6)
+
+    instance = new VuetifyDateAdapter({ locale: 'sv-SE' })
+
+    date = instance.endOfWeek(new Date(2024, 3, 10, 12, 0, 0))
+
+    expect(date?.getFullYear()).toBe(2024)
+    expect(date?.getMonth()).toBe(3)
+    expect(date?.getDate()).toBe(14)
+    expect(date?.getDay()).toBe(0)
+  })
 })

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -200,17 +200,18 @@ function getWeekArray (date: Date, locale: string) {
   return weeks
 }
 
-function startOfWeek (date: Date) {
+function startOfWeek (date: Date, locale: string) {
   const d = new Date(date)
-  while (d.getDay() !== 0) {
+  while (d.getDay() !== (firstDay[locale.slice(-2).toUpperCase()] ?? 0)) {
     d.setDate(d.getDate() - 1)
   }
   return d
 }
 
-function endOfWeek (date: Date) {
+function endOfWeek (date: Date, locale: string) {
   const d = new Date(date)
-  while (d.getDay() !== 6) {
+  const lastDay = ((firstDay[locale.slice(-2).toUpperCase()] ?? 0) + 6) % 7
+  while (d.getDay() !== lastDay) {
     d.setDate(d.getDate() + 1)
   }
   return d
@@ -546,11 +547,11 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
   }
 
   startOfWeek (date: Date): Date {
-    return startOfWeek(date)
+    return startOfWeek(date, this.locale)
   }
 
   endOfWeek (date: Date): Date {
-    return endOfWeek(date)
+    return endOfWeek(date, this.locale)
   }
 
   startOfMonth (date: Date) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
v-calendar in week mode did not show the correct day order on other locales

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-calendar view-mode="week" />
    </v-main>
  </v-app>
</template>
```
