### PR TITLE
docs(Theme): theme.global.name/current shouldn't have .value

### DIFF
--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -165,7 +165,7 @@ import { useTheme } from 'vuetify'
 const theme = useTheme()
 
 function toggleTheme () {
-  theme.global.name.value = theme.global.current.value.dark ? 'light' : 'dark'
+  theme.global.name = theme.global.current.dark ? 'light' : 'dark'
 }
 </script>
 ```


### PR DESCRIPTION
## Description
Removed `.value` from `theme.global.name` and `theme.global.current`,
because it broke the function `toggleTheme`.