### PR TITLE
feat(VInput): add dimensions support to VInput

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -8,13 +8,14 @@ import { VMessages } from '@/components/VMessages/VMessages'
 // Composables
 import { makeComponentProps } from '@/composables/component'
 import { makeDensityProps, useDensity } from '@/composables/density'
+import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { IconValue } from '@/composables/icons'
 import { useRtl } from '@/composables/locale'
 import { makeValidationProps, useValidation } from '@/composables/validation'
 
 // Utilities
 import { computed } from 'vue'
-import { EventProp, genericComponent, getUid, propsFactory, useRender } from '@/util'
+import { EventProp, genericComponent, getUid, only, propsFactory, useRender } from '@/util'
 
 // Types
 import type { ComputedRef, PropType, Ref } from 'vue'
@@ -62,6 +63,11 @@ export const makeVInputProps = propsFactory({
 
   ...makeComponentProps(),
   ...makeDensityProps(),
+  ...only(makeDimensionProps(), [
+    'maxWidth',
+    'minWidth',
+    'width',
+  ]),
   ...makeValidationProps(),
 }, 'VInput')
 
@@ -92,6 +98,7 @@ export const VInput = genericComponent<new <T>(
 
   setup (props, { attrs, slots, emit }) {
     const { densityClasses } = useDensity(props)
+    const { dimensionStyles } = useDimension(props)
     const { rtlClasses } = useRtl()
     const { InputIcon } = useInputIcon(props)
 
@@ -160,7 +167,10 @@ export const VInput = genericComponent<new <T>(
             validationClasses.value,
             props.class,
           ]}
-          style={ props.style }
+          style={[
+            dimensionStyles.value,
+            props.style,
+          ]}
         >
           { hasPrepend && (
             <div key="prepend" class="v-input__prepend">


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

- Add `maxWidth`, `minWidth` & `width` props to VInput
- Heights are restricted by densities

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-text-field
    :max-width="550"
    :min-width="500"
    :width="600"
    :style="{ width: '700px' }"
  />
  <v-select
    :max-width="550"
    :min-width="500"
    :width="600"
  />
  <v-autocomplete
    :max-width="550"
    :min-width="500"
    :width="600"
  />
  <v-combobox
    :max-width="550"
    :min-width="500"
    :width="600"
  />
  <v-file-input
    :max-width="550"
    :min-width="500"
    :width="600"
  />
  <v-textarea
    :max-width="550"
    :min-width="500"
    :width="600"
  />
</template>

<script>
  export default {
  }
</script>
```
