### PR TITLE
fix(VNumberInput): avoid native number input weird behaviours

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -155,12 +155,10 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     }
 
     function onKeydown (e: KeyboardEvent) {
-      if ([
-        'Enter',
-        'ArrowLeft',
-        'ArrowRight',
-        'Backspace',
-      ].includes(e.key)) return
+      if (
+        ['Enter', 'ArrowLeft', 'ArrowRight', 'Backspace'].includes(e.key) ||
+        e.ctrlKey
+      ) return
 
       if (['ArrowDown'].includes(e.key)) {
         e.preventDefault()

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -208,6 +208,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
                   key="decrement-defaults"
                   defaults={{
                     VBtn: {
+                      disabled: !canDecrease.value,
                       flat: true,
                       height: defaultHeight,
                       size: 'small',
@@ -241,6 +242,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
                   key="increment-defaults"
                   defaults={{
                     VBtn: {
+                      disabled: !canIncrease.value,
                       flat: true,
                       height: defaultHeight,
                       size: 'small',

--- a/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
@@ -1,0 +1,57 @@
+/// <reference types="../../../../types/cypress" />
+
+// Components
+import { VNumberInput } from '../VNumberInput'
+
+// Utilities
+import { ref } from 'vue'
+
+describe('VNumberInput', () => {
+  describe('native number input quirks', () => {
+    it('should not bypass min', () => {
+      const numberInputValue = ref(1)
+      cy.mount(() =>
+        <VNumberInput min={ 5 } max={ 15 } v-model={ numberInputValue.value } ></VNumberInput>
+      )
+        .get('.v-number-input input').should('have.value', '5')
+        .should(() => expect(numberInputValue.value).to.equal(5))
+    })
+
+    it('should not bypass max', () => {
+      const numberInputValue = ref(20)
+      cy.mount(() =>
+        <VNumberInput min={ 5 } max={ 15 } v-model={ numberInputValue.value } ></VNumberInput>
+      )
+        .get('.v-number-input input').should('have.value', '15')
+        .should(() => expect(numberInputValue.value).to.equal(15))
+    })
+
+    it('should support decimal step', () => {
+      const numberInputValue = ref(0)
+      cy.mount(() =>
+        (
+        <VNumberInput
+          step={ 0.03 }
+          v-model={ numberInputValue.value }
+        ></VNumberInput>
+        )
+      )
+        .get('button[name="increment-btn"]')
+        .click()
+        .get('.v-number-input input').should('have.value', '0.03')
+        .then(() => expect(numberInputValue.value).to.equal(0.03))
+        .get('button[name="increment-btn"]')
+        .click()
+        .get('.v-number-input input').should('have.value', '0.06')
+        .then(() => expect(numberInputValue.value).to.equal(0.06))
+        .get('button[name="decrement-btn"]')
+        .click()
+        .get('.v-number-input input').should('have.value', '0.03')
+        .then(() => expect(numberInputValue.value).to.equal(0.03))
+        .get('button[name="decrement-btn"]')
+        .click()
+        .get('.v-number-input input').should('have.value', '0')
+        .then(() => expect(numberInputValue.value).to.equal(0))
+    })
+  })
+})


### PR DESCRIPTION
fixes #19438
fixes #19558
fixes #19538
fixes #19494

- Remove `type="number"` to avoid all sorts of weird behaviours in native number input. [More details from Why the GOV.UK Design System team changed the input type for numbers](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)
- Always clamp modelValue between "min" and "max"
- Disable the increment and decrement buttons when clicking the next step would exceed the 'max' and 'min' values, respectively
- Up and down keys trigger increment and decrement respectively
- Right and left keys trigger go forward and backward navigation
- Only numbers, +, - and dot are allowed to type in
- Fully support decimal step, using `toFixed()` to cope with JS Floating-Point Precision Issues 

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <h1>{{ model }}</h1>
  <v-number-input
    v-model="model"
    :max="10"
    :min="0"
    :step="0.03"
  />
</template>

<script setup>
import { ref } from 'vue'
const model = ref(0)
</script>


```
