### PR TITLE
fix(typography): use relative line heights

### DIFF
--- a/packages/vuetify/src/styles/settings/_variables.scss
+++ b/packages/vuetify/src/styles/settings/_variables.scss
@@ -180,7 +180,7 @@ $typography: map-deep-merge(
     'h1': (
       'size': 6rem,
       'weight': 300,
-      'line-height': 6rem,
+      'line-height': 1,
       'letter-spacing': -.015625em,
       'font-family': $heading-font-family,
       'text-transform': none
@@ -188,7 +188,7 @@ $typography: map-deep-merge(
     'h2': (
       'size': 3.75rem,
       'weight': 300,
-      'line-height': 3.75rem,
+      'line-height': 1,
       'letter-spacing': -.0083333333em,
       'font-family': $heading-font-family,
       'text-transform': none
@@ -196,7 +196,7 @@ $typography: map-deep-merge(
     'h3': (
       'size': 3rem,
       'weight': 400,
-      'line-height': 3.125rem,
+      'line-height': 1.05,
       'letter-spacing': normal,
       'font-family': $heading-font-family,
       'text-transform': none
@@ -204,7 +204,7 @@ $typography: map-deep-merge(
     'h4': (
       'size': 2.125rem,
       'weight': 400,
-      'line-height': 2.5rem,
+      'line-height': 1.175,
       'letter-spacing': .0073529412em,
       'font-family': $heading-font-family,
       'text-transform': none
@@ -212,7 +212,7 @@ $typography: map-deep-merge(
     'h5': (
       'size': 1.5rem,
       'weight': 400,
-      'line-height': 2rem,
+      'line-height': 1.333,
       'letter-spacing': normal,
       'font-family': $heading-font-family,
       'text-transform': none
@@ -220,7 +220,7 @@ $typography: map-deep-merge(
     'h6': (
       'size': 1.25rem,
       'weight': 500,
-      'line-height': 2rem,
+      'line-height': 1.6,
       'letter-spacing': .0125em,
       'font-family': $heading-font-family,
       'text-transform': none
@@ -228,7 +228,7 @@ $typography: map-deep-merge(
     'subtitle-1': (
       'size': 1rem,
       'weight': normal,
-      'line-height': 1.75rem,
+      'line-height': 1.75,
       'letter-spacing': .009375em,
       'font-family': $body-font-family,
       'text-transform': none
@@ -236,7 +236,7 @@ $typography: map-deep-merge(
     'subtitle-2': (
       'size': .875rem,
       'weight': 500,
-      'line-height': 1.375rem,
+      'line-height': 1.6,
       'letter-spacing': .0071428571em,
       'font-family': $body-font-family,
       'text-transform': none
@@ -244,7 +244,7 @@ $typography: map-deep-merge(
     'body-1': (
       'size': 1rem,
       'weight': 400,
-      'line-height': 1.5rem,
+      'line-height': 1.5,
       'letter-spacing': .03125em,
       'font-family': $body-font-family,
       'text-transform': none
@@ -252,7 +252,7 @@ $typography: map-deep-merge(
     'body-2': (
       'size': .875rem,
       'weight': 400,
-      'line-height': 1.25rem,
+      'line-height': 1.425,
       'letter-spacing': .0178571429em,
       'font-family': $body-font-family,
       'text-transform': none
@@ -260,7 +260,7 @@ $typography: map-deep-merge(
     'button': (
       'size': .875rem,
       'weight': 500,
-      'line-height': 2.25rem,
+      'line-height': 2.6,
       'letter-spacing': .0892857143em,
       'font-family': $body-font-family,
       'text-transform': uppercase
@@ -268,7 +268,7 @@ $typography: map-deep-merge(
     'caption': (
       'size': .75rem,
       'weight': 400,
-      'line-height': 1.25rem,
+      'line-height': 1.667,
       'letter-spacing': .0333333333em,
       'font-family': $body-font-family,
       'text-transform': none
@@ -276,7 +276,7 @@ $typography: map-deep-merge(
     'overline': (
       'size': .75rem,
       'weight': 500,
-      'line-height': 2rem,
+      'line-height': 2.667,
       'letter-spacing': .1666666667em,
       'font-family': $body-font-family,
       'text-transform': uppercase


### PR DESCRIPTION
Been like this since dbddc073d9ee4eca71a06aba8c4d8c70d84f6ef0

There's some more places in components with rem but I cbf, feel free to change them too I guess.
