### PR TITLE
docs(checkboxes.md): update v-simple-checkbox description.

### DIFF
--- a/packages/docs/src/pages/en/components/checkboxes.md
+++ b/packages/docs/src/pages/en/components/checkboxes.md
@@ -31,7 +31,7 @@ A `v-checkbox` in its simplest form provides a toggle between 2 values.
 
 ::: tip
 
-A simpler version, `v-simple-checkbox` is used primarily as a lightweight alternative in data-table components to select rows or display inline boolean data.
+A simpler version, [`v-checkbox-btn`](/components/data-tables/basics/#simple-checkbox) is used primarily as a lightweight alternative in data-table components to select rows or display inline boolean data.
 
 :::
 


### PR DESCRIPTION
In the v-checkbox documentation, a tip is mentioning v-simple-checkbox. This seems to be a leftover from vuetify 2. Now we have v-checkbox-btn instead. I corrected that and also added a link to more information about v-checkbox-btn.
