### PR TITLE
fix(VChip): prevent text selection for link chips

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.sass
+++ b/packages/vuetify/src/components/VChip/VChip.sass
@@ -32,6 +32,7 @@
   &--link
     cursor: pointer
 
+  &--link,
   &--filter
     user-select: none
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Dragging the cursor slightly while clicking a `VChip` with the `link` prop (or otherwise clickable with `@click` I think) would cause the text to become selected. This PR prevents text selection.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-chip link>Try selecting me</v-chip>
    </v-main>
  </v-app>
</template>
```
