### PR TITLE
fix(VNumberInput): fix behavior with float step

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -108,7 +108,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         inputRef.value?.stepDown()
       }
 
-      if (inputRef.value) model.value = parseInt(inputRef.value.value, 10)
+      if (inputRef.value) model.value = parseFloat(inputRef.value.value)
     }
 
     function onClickUp () {


### PR DESCRIPTION
## Description
This change fixes #19494 by parsing the input value as a float for the model update.
It is needed to allow using the VNumberInput with float values and float steps.
It also fixes the behavior of the input when blurring / focussing. (the model-value beig set to the parseInt result)

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input step="0.1" />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>

```
