### PR TITLE
feat(VDialog): add content support

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -44,7 +44,7 @@
             padding: $dialog-card-text-padding
 
           > .v-card-actions
-            justify-content: flex-end
+            justify-content: $dialog-card-actions-justify
 
   .v-dialog--fullscreen
     --v-scrollbar-offset: 0px
@@ -84,6 +84,3 @@
         > .v-card-text
           backface-visibility: hidden
           overflow-y: auto
-
-  .v-dialog__close
-    margin: $dialog-close-margin

--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -43,6 +43,9 @@
             line-height: inherit
             padding: $dialog-card-text-padding
 
+          > .v-card-actions
+            justify-content: flex-end
+
   .v-dialog--fullscreen
     --v-scrollbar-offset: 0px
 
@@ -81,3 +84,6 @@
         > .v-card-text
           backface-visibility: hidden
           overflow-y: auto
+
+  .v-dialog__close
+    margin: $dialog-close-margin

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -26,18 +26,13 @@ export type DialogSlots = OverlaySlots & {
   item: { isActive: Ref<boolean> }
   prepend: { isActive: Ref<boolean> }
   title: { isActive: Ref<boolean> }
+  text: { isActive: Ref<boolean> }
   subtitle: { isActive: Ref<boolean> }
   append: { isActive: Ref<boolean> }
   actions: { isActive: Ref<boolean> }
-  close: { isActive: Ref<boolean>, props: Record<string, any> }
 }
 
 export const makeVDialogProps = propsFactory({
-  closable: Boolean,
-  closeIcon: {
-    type: String,
-    default: '$close',
-  },
   fullscreen: Boolean,
   retainFocus: {
     type: Boolean,
@@ -132,15 +127,12 @@ export const VDialog = genericComponent<DialogSlots>()({
       const cardProps = VCard.filterProps(props)
 
       const hasTitle = !!(slots.title || props.title != null)
+      const hasText = !!(slots.text || props.text != null)
       const hasSubtitle = !!(slots.subtitle || props.subtitle != null)
       const hasHeader = hasTitle || hasSubtitle
-      const hasAppend = !!(slots.append || props.appendAvatar || props.appendIcon || props.closable)
+      const hasAppend = !!(slots.append || props.appendAvatar || props.appendIcon)
       const hasPrepend = !!(slots.prepend || props.prependAvatar || props.prependIcon)
-      const hasCardItem = hasHeader || hasPrepend || hasAppend
-
-      function onClickClose () {
-        isActive.value = false
-      }
+      const hasCardItem = hasHeader || hasPrepend || hasAppend || hasText
 
       return (
         <VOverlay
@@ -177,42 +169,9 @@ export const VDialog = genericComponent<DialogSlots>()({
                       default: slots.item ? () => slots.item?.(...args) : undefined,
                       prepend: slots.prepend ? () => slots.prepend?.(...args) : undefined,
                       title: slots.title ? () => slots.title?.(...args) : undefined,
+                      text: slots.text ? () => slots.text?.(...args) : undefined,
                       subtitle: slots.subtitle ? () => slots.subtitle?.(...args) : undefined,
-                      append: hasAppend ? () => (
-                        <>
-                          { slots.append?.(...args) }
-
-                          <div class="v-dialog__close">
-                            { !slots.close ? (
-                              <VBtn
-                                icon={ props.closeIcon }
-                                onClick={ onClickClose }
-                                variant="text"
-                                density="comfortable"
-                                size="small"
-                              ></VBtn>
-                            ) : (
-                              <VDefaultsProvider
-                                defaults={{
-                                  VBtn: {
-                                    icon: props.closeIcon,
-                                    variant: 'text',
-                                    density: 'comfortable',
-                                    size: 'small',
-                                  },
-                                }}
-                              >
-                                {{
-                                  default: () => slots.close?.({
-                                    ...args[0],
-                                    props: { onClick: onClickClose },
-                                  }),
-                                }}
-                              </VDefaultsProvider>
-                            )}
-                          </div>
-                        </>
-                      ) : undefined,
+                      append: slots.append ? () => slots.append?.(...args) : undefined,
                       actions: slots.actions ? () => (
                         <VDefaultsProvider
                           defaults={{

--- a/packages/vuetify/src/components/VDialog/_variables.scss
+++ b/packages/vuetify/src/components/VDialog/_variables.scss
@@ -7,7 +7,8 @@ $dialog-elevation: 24 !default;
 $dialog-border-radius: settings.$border-radius-root !default;
 $dialog-margin: 24px !default;
 
-$dialog-card-header-padding: 14px 24px 0 !default;
-$dialog-card-header-text-padding-top: 10px !default;
-$dialog-card-text-padding: 16px 24px 10px !default;
+$dialog-card-header-padding: 16px 24px !default;
+$dialog-card-header-text-padding-top: 0 !default;
+$dialog-card-text-padding: 16px 24px 24px !default;
+$dialog-close-margin: -12px -12px 0 0 !default;
 $dialog-card-text-letter-spacing: tools.map-deep-get(settings.$typography, 'body-1', 'letter-spacing') !default;

--- a/packages/vuetify/src/components/VDialog/_variables.scss
+++ b/packages/vuetify/src/components/VDialog/_variables.scss
@@ -7,8 +7,8 @@ $dialog-elevation: 24 !default;
 $dialog-border-radius: settings.$border-radius-root !default;
 $dialog-margin: 24px !default;
 
+$dialog-card-actions-justify: flex-end !default;
 $dialog-card-header-padding: 16px 24px !default;
 $dialog-card-header-text-padding-top: 0 !default;
 $dialog-card-text-padding: 16px 24px 24px !default;
-$dialog-close-margin: -12px -12px 0 0 !default;
 $dialog-card-text-letter-spacing: tools.map-deep-get(settings.$typography, 'body-1', 'letter-spacing') !default;


### PR DESCRIPTION
## Motivation and Context

- Add content support through VCard

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-main>
      <v-btn>
        Click me

        <v-dialog
          v-model="dialog"
          activator="parent"
          color="primary"
          max-width="300"
          text="This will reset your device to its default factory stettings."
          title="Reset settings?"
          closable
        >
          <template #actions="{ isActive }">
            <v-btn @click="isActive.value = false">Cancel</v-btn>

            <v-btn @click="isActive.value = false">Accept</v-btn>
          </template>
        </v-dialog>
      </v-btn>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const color = ref(0)
  const timeout = ref(5000)
  const dialog = ref(false)
</script>

```
</details>