### PR TITLE
fix(Dialog): add afterLeave event

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -47,7 +47,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
     afterLeave: () => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { emit, slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
     const { scopeId } = useScopeId()
 
@@ -95,6 +95,10 @@ export const VDialog = genericComponent<OverlaySlots>()({
       }
     }
 
+    function onAfterLeave () {
+      emit('afterLeave')
+    }
+
     watch(isActive, async val => {
       if (!val) {
         await nextTick()
@@ -131,6 +135,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
           contentProps={ contentProps }
           role="dialog"
           onAfterEnter={ onAfterEnter }
+          onAfterLeave={ onAfterLeave }
           { ...scopeId }
         >
           {{

--- a/packages/vuetify/src/components/VDialog/__test__/VDialog.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDialog/__test__/VDialog.spec.cy.tsx
@@ -1,0 +1,39 @@
+/// <reference types="../../../../types/cypress" />
+
+// Components
+import { VDialog } from '..'
+
+// Utilities
+import { ref } from 'vue'
+
+// Tests
+describe('VDialog', () => {
+  it('should render correctly', () => {
+    const model = ref(false)
+    cy.mount(() => (
+      <VDialog v-model={ model.value } data-test="dialog">
+        <div data-test="content">Content</div>
+      </VDialog>
+    )).get('[data-test="dialog"]').should('not.exist')
+      .then(() => { model.value = true })
+      .get('[data-test="dialog"]').should('be.visible')
+      .get('[data-test="content"]').should('be.visible')
+      .get('body').click()
+      .then(() => {
+        expect(model.value).to.be.false
+      })
+      .get('[data-test="dialog"]').should('not.exist')
+      .get('[data-test="content"]').should('not.exist')
+  })
+
+  it('should emit afterLeave', () => {
+    const model = ref(true)
+    const onAfterLeave = cy.spy().as('afterLeave')
+    cy.mount(() => (
+      <VDialog v-model={ model.value } onAfterLeave={ onAfterLeave }>
+        <div data-test="content">Content</div>
+      </VDialog>
+    )).get('body').click()
+      .get('@afterLeave').should('have.been.calledOnce')
+  })
+})


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #19660 
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-dialog v-model="showDialog" width="600" @after-leave="onAfterLeave()">
        <div class="content">Content</div>
      </v-dialog>
      <v-btn @click="reset">Reset</v-btn>
      <div>{{ hidden ? "hidden" : "visible" }}</div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const showDialog = ref(true)
  const hidden = ref(false)

  function reset () {
    showDialog.value = true
    hidden.value = false
  }

  function onAfterLeave () {
    hidden.value = true
  }
</script>
<style scoped>
.content {
  width: 200px;
  height: 200px;
  background-color: #fff;
}
</style>
```
