### PR TITLE
fix(VTextarea): up/down/home/end keys inside VList

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -207,7 +207,7 @@ export const VList = genericComponent<new <
     function onKeydown (e: KeyboardEvent) {
       const target = e.target as HTMLElement
 
-      if (!contentRef.value || target.tagName === 'INPUT') return
+      if (!contentRef.value || ['INPUT', 'TEXTAREA'].includes(target.tagName)) return
 
       if (e.key === 'ArrowDown') {
         focus('next')


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes #19092

Up/down/home/end keys were not working in a VTextarea that is inside a VList

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-form>
    <v-list>
      <v-list-item>
        <v-textarea
          name="input-1"
          variant="filled"
          auto-grow
          rows="1"
          :model-value="text"
        />
      </v-list-item>
    </v-list>
  </v-form>
</template>

<script setup>
  const text = `The Woodman set to work at once,
and so sharp was his
axe that the tree was soon
chopped nearly through.`
</script>

```
