### PR TITLE
fix(VChipGroup): supports color props

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -174,7 +174,7 @@ export const VChip = genericComponent<VChipSlots>()({
       const hasFilter = !!(slots.filter || props.filter) && group
       const hasPrependMedia = !!(props.prependIcon || props.prependAvatar)
       const hasPrepend = !!(hasPrependMedia || slots.prepend)
-      const hasColor = !group || group.isSelected.value
+      const hasColor = !group || !group.isSelected.value
 
       return isActive.value && (
         <Tag

--- a/packages/vuetify/src/components/VChipGroup/__tests__/VChipGroup.spec.cy.tsx
+++ b/packages/vuetify/src/components/VChipGroup/__tests__/VChipGroup.spec.cy.tsx
@@ -1,0 +1,19 @@
+/// <reference types="../../../../types/cypress" />
+
+// Components
+import { VChipGroup } from '..'
+import { VChip } from '@/components/VChip'
+
+describe('VChipGroup', () => {
+  it('should supports color props', () => {
+    cy.mount(() => (
+      <VChipGroup color="red" selected-class="text-primary">
+        <VChip>Chip</VChip>
+      </VChipGroup>
+    )).get('.v-chip')
+      .should('have.class', 'text-red')
+      .get('.v-chip')
+      .click()
+      .should('have.class', 'text-primary')
+  })
+})


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #19678 
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row justify="center">
    <v-col cols="12" sm="7" md="6" lg="5">
      <v-sheet elevation="10" rounded="xl">
        <div class="pa-4">
          <!--These chips should be red -->
          <v-chip-group color="red" selected-class="text-primary" column>
            <v-chip v-for="tag in 3" :key="tag">
              chip {{ tag }}
            </v-chip>
          </v-chip-group>

          <!--Works without chip-group -->
          <v-chip color="red"> hellooo </v-chip>
        </div>
      </v-sheet>
    </v-col>
  </v-row>
</template>
```
