### PR TITLE
feat(VDatePicker): add header-color props

### DIFF
--- a/packages/api-generator/src/locale/en/VDatePicker.json
+++ b/packages/api-generator/src/locale/en/VDatePicker.json
@@ -11,6 +11,7 @@
     "flat": "Removes  elevation.",
     "format": "Takes a date object and returns it in a specified format.",
     "header": "Text shown when no **display-date** is set.",
+    "headerColor": "Defines the header color. If not specified it will use the color defined by color prop or the default picker color.",
     "headerDateFormat": "Allows you to customize the format of the month string that appears in the header of the calendar. Called with date (ISO 8601 **date** string) arguments.",
     "inputMode": "Toggles between showing dates or inputs.",
     "locale": "Sets the locale. Accepts a string with a BCP 47 language tag.",

--- a/packages/docs/src/examples/v-date-picker/prop-colors.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-colors.vue
@@ -4,6 +4,11 @@
       <v-date-picker
         color="primary"
       ></v-date-picker>
+
+      <v-date-picker
+        color="primary"
+        header-color="secondary"
+      ></v-date-picker>
     </v-row>
   </v-container>
 </template>

--- a/packages/docs/src/pages/en/components/date-pickers.md
+++ b/packages/docs/src/pages/en/components/date-pickers.md
@@ -84,8 +84,7 @@ By default days from previous and next months are not visible. They can be displ
 
 #### Colors
 
-Date picker colors can be set using the **color** props.
-
+Date picker colors can be set using the **color** and ***header-color*** props. If ***header-color*** prop is not provided header will use the **color** prop value.
 <ExamplesExample file="v-date-picker/prop-colors" />
 
 #### Allowed dates

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -58,6 +58,7 @@ export const makeVDatePickerProps = propsFactory({
     type: String,
     default: '$vuetify.datePicker.header',
   },
+  headerColor: String,
 
   ...makeVDatePickerControlsProps(),
   ...makeVDatePickerMonthProps({
@@ -249,9 +250,9 @@ export const VDatePicker = genericComponent<new <
     })
 
     useRender(() => {
-      const pickerProps = VPicker.filterProps(props)
+      const pickerProps = omit(VPicker.filterProps(props), ['color'])
       const datePickerControlsProps = VDatePickerControls.filterProps(props)
-      const datePickerHeaderProps = VDatePickerHeader.filterProps(props)
+      const datePickerHeaderProps = omit(VDatePickerHeader.filterProps(props), ['color'])
       const datePickerMonthProps = VDatePickerMonth.filterProps(props)
       const datePickerMonthsProps = omit(VDatePickerMonths.filterProps(props), ['modelValue'])
       const datePickerYearsProps = omit(VDatePickerYears.filterProps(props), ['modelValue'])
@@ -260,10 +261,12 @@ export const VDatePicker = genericComponent<new <
         header: header.value,
         transition: headerTransition.value,
       }
+      const headerColor = props.headerColor || props.color
 
       return (
         <VPicker
           { ...pickerProps }
+          color={ headerColor }
           class={[
             'v-date-picker',
             `v-date-picker--${viewMode.value}`,
@@ -292,6 +295,7 @@ export const VDatePicker = genericComponent<new <
                 key="header"
                 { ...datePickerHeaderProps }
                 { ...headerProps }
+                color={ headerColor }
                 onClick={ viewMode.value !== 'month' ? onClickDate : undefined }
                 v-slots={{
                   ...slots,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
resolves #18310 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app theme="light">
    <v-container>
      <v-row justify="space-around">
        <v-date-picker
          color="primary"
        ></v-date-picker>

        <v-date-picker
          color="primary"
          header-color="secondary"
        ></v-date-picker>
      </v-row>
    </v-container>
  </v-app>
</template>
```
