### PR TITLE
fix(VAutocomplete): only clear search on blur in multiple mode or using chips/selection shots 

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -377,6 +377,7 @@ export const VAutocomplete = genericComponent<new <
           select(displayItems.value[0])
         }
         menu.value = false
+        props.multiple && (search.value = '')
         selectionIndex.value = -1
       }
     })

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -362,12 +362,14 @@ export const VAutocomplete = genericComponent<new <
       if (val === oldVal) return
 
       if (val) {
+
         isSelecting.value = true
         search.value = (props.multiple || hasSelectionSlot.value) ? '' : String(model.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)
       } else {
+
         if (!props.multiple && search.value == null) model.value = []
         else if (
           highlightFirst.value &&
@@ -377,7 +379,6 @@ export const VAutocomplete = genericComponent<new <
           select(displayItems.value[0])
         }
         menu.value = false
-        search.value = ''
         selectionIndex.value = -1
       }
     })

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -362,14 +362,12 @@ export const VAutocomplete = genericComponent<new <
       if (val === oldVal) return
 
       if (val) {
-
         isSelecting.value = true
         search.value = (props.multiple || hasSelectionSlot.value) ? '' : String(model.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
         nextTick(() => isSelecting.value = false)
       } else {
-
         if (!props.multiple && search.value == null) model.value = []
         else if (
           highlightFirst.value &&

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -377,7 +377,7 @@ export const VAutocomplete = genericComponent<new <
           select(displayItems.value[0])
         }
         menu.value = false
-        props.multiple && (search.value = '')
+        if (props.multiple || hasSelectionSlot.value) search.value = ''
         selectionIndex.value = -1
       }
     })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

resolves #19543

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container class="mx-2">
      <v-row>
        <v-col>
          <v-autocomplete
            v-model="model"
            :items="lista"
            density="compact"
            item-title="n"
            item-value="id"
            label="Label"
            title="Choose one"
            variant="outlined"
            hide-no-data
            @update:search="handleSearch"
          />
        </v-col>
        <v-col>
          <v-btn @click="searchCount = 0">Clean Search Count</v-btn>
        </v-col>
        <v-col>Model: {{ model }} Search Count: {{ searchCount }}</v-col>
      </v-row>
      <v-row>
        <v-col>
          <ol>
            <li>Choose one in list</li>
            <li>Click outside autocomplete</li>
            <li>Search occurs two times</li>
          </ol>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'
  const model = ref(0)
  const searchCount = ref(0)
  const lista = ref([{ n: 'Choose one', id: 0 }, { n: 'test', id: 1 }, { n: 'test2', id: 2 }, { n: 'test3', id: 3 }])

  function handleSearch (value: string) {
    searchCount.value++
    console.log(value)
  }
</script>

```
