### PR TITLE
Feat(VSparkline): multi-line support

### DIFF
--- a/packages/vuetify/src/labs/VSparkline/VMultiTrend.tsx
+++ b/packages/vuetify/src/labs/VSparkline/VMultiTrend.tsx
@@ -1,11 +1,14 @@
+// Composables
+import { makeThemeProps, provideTheme } from '@/composables/theme'
+
 // Utilities
 import { computed, nextTick, ref, watch } from 'vue'
 import { makeLineProps } from './util/line'
 import { genPath as _genPath } from './util/path'
-import { genericComponent, getPropertyFromItem, getUid, propsFactory, useRender } from '@/util'
+import { genericComponent, getPropertyFromItem, getUid, isCssColor, propsFactory, useRender } from '@/util'
 
 // Types
-export type VTrendlineSlots = {
+export type VMultiTrendSlots = {
   default: void
   label: { index: number, value: string }
 }
@@ -30,24 +33,25 @@ export interface Point {
   value: number
 }
 
-export const makeVTrendlineProps = propsFactory({
+export const makeVMultiTrendProps = propsFactory({
   fill: Boolean,
-
   ...makeLineProps(),
-}, 'VTrendline')
+  ...makeThemeProps(),
+}, 'VMultiTrend')
 
-export const VTrendline = genericComponent<VTrendlineSlots>()({
-  name: 'VTrendline',
+export const VMultiTrend = genericComponent<VMultiTrendSlots>()({
+  name: 'VMultiTrend',
 
-  props: makeVTrendlineProps(),
+  props: makeVMultiTrendProps(),
 
   setup (props, { slots }) {
+    const theme = provideTheme(props)
     const uid = getUid()
-    const id = computed(() => props.id || `trendline-${uid}`)
+    const id = computed(() => props.id || `multitrend-${uid}`)
     const autoDrawDuration = computed(() => Number(props.autoDrawDuration) || (props.fill ? 500 : 2000))
 
     const lastLength = ref(0)
-    const path = ref<SVGPathElement | null>(null)
+    const paths = ref<SVGPathElement[] | []>([])
 
     function genPoints (
       values: number[],
@@ -60,9 +64,6 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
 
       const gridX = (maxX - minX) / (totalValues - 1)
       const gridY = (maxY - minY) / ((maxValue - minValue) || 1)
-      if (values.length === 1) {
-        values.push(values[0])
-      }
 
       return values.map((value, index) => {
         return {
@@ -94,14 +95,28 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
         maxY: parseInt(props.height, 10) - padding,
       }
     })
-    const items = computed(() => props.modelValue.map(item => getPropertyFromItem(item, props.itemValue, item)))
+    const items = computed(() => {
+      let lines = []
+      if (!Array.isArray(props.modelValue?.[0])) {
+        lines = [props.modelValue.map(item => getPropertyFromItem(item, props.itemValue, item))]
+      } else {
+        lines = props.modelValue.map(item => (item as SparklineItem[]).map(nested => getPropertyFromItem(nested, props.itemValue, nested)))
+      }
+      // Need to make lines the same length
+      const longestLine = lines.reduce((longest, line) => line.length > longest ? line.length : longest, 0)
+      lines = lines.map(line => line.length === longestLine
+        ? line
+        : [...line, ...Array.from({ length: longestLine - line.length }, (v, i) => line.at(-1))]
+      )
+      return lines
+    })
     const parsedLabels = computed(() => {
       const labels = []
-      const points = genPoints(items.value, boundary.value)
+      const points = items.value.map(item => genPoints(item, boundary.value))
       const len = points.length
 
       for (let i = 0; labels.length < len; i++) {
-        const item = points[i]
+        const item = points[0][i]
         let value = props.labels[i]
 
         if (!value) {
@@ -122,38 +137,40 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
     watch(() => props.modelValue, async () => {
       await nextTick()
 
-      if (!props.autoDraw || !path.value) return
+      if (!props.autoDraw || !paths.value || !paths.value.length) return
+      for (const path of paths.value) {
+        const pathRef = path
+        const length = pathRef.getTotalLength()
 
-      const pathRef = path.value
-      const length = pathRef.getTotalLength()
+        if (!props.fill) {
+          // Initial setup to "hide" the line by using the stroke dash array
+          pathRef.style.strokeDasharray = `${length}`
+          pathRef.style.strokeDashoffset = `${length}`
 
-      if (!props.fill) {
-        // Initial setup to "hide" the line by using the stroke dash array
-        pathRef.style.strokeDasharray = `${length}`
-        pathRef.style.strokeDashoffset = `${length}`
+          // Force reflow to ensure the transition starts from this state
+          pathRef.getBoundingClientRect()
 
-        // Force reflow to ensure the transition starts from this state
-        pathRef.getBoundingClientRect()
-
-        // Animate the stroke dash offset to "draw" the line
-        pathRef.style.transition = `stroke-dashoffset ${autoDrawDuration.value}ms ${props.autoDrawEasing}`
-        pathRef.style.strokeDashoffset = '0'
-      } else {
-        // Your existing logic for filled paths remains the same
-        pathRef.style.transformOrigin = 'bottom center'
-        pathRef.style.transition = 'none'
-        pathRef.style.transform = `scaleY(0)`
-        pathRef.getBoundingClientRect()
-        pathRef.style.transition = `transform ${autoDrawDuration.value}ms ${props.autoDrawEasing}`
-        pathRef.style.transform = `scaleY(1)`
+          // Animate the stroke dash offset to "draw" the line
+          pathRef.style.transition = `stroke-dashoffset ${autoDrawDuration.value}ms ${props.autoDrawEasing}`
+          pathRef.style.strokeDashoffset = '0'
+        } else {
+          pathRef.style.fill = 'black'
+          // Your existing logic for filled paths remains the same
+          pathRef.style.transformOrigin = 'bottom center'
+          pathRef.style.transition = 'none'
+          pathRef.style.transform = `scaleY(0)`
+          pathRef.getBoundingClientRect()
+          pathRef.style.transition = `transform ${autoDrawDuration.value}ms ${props.autoDrawEasing}`
+          pathRef.style.transform = `scaleY(1)`
+        }
       }
 
       lastLength.value = length
     }, { immediate: true })
 
-    function genPath (fill: boolean) {
+    function genPath (index: number, fill: boolean) {
       return _genPath(
-        genPoints(items.value, boundary.value),
+        genPoints(items.value[index], boundary.value),
         props.smooth ? 8 : Number(props.smooth),
         fill,
         parseInt(props.height, 10)
@@ -207,19 +224,30 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
               }
             </g>
           )}
-
-          <path
-            ref={ path }
-            d={ genPath(props.fill) }
-            fill={ props.fill ? `url(#${id.value})` : 'none' }
-            stroke={ props.fill ? 'none' : `url(#${id.value})` }
-          />
+          {
+            items.value.map((item, i) => (
+              <path
+                ref={ paths }
+                d={ genPath(i, props.fill) }
+                fill={ props.fill ? `url(#${id.value}-line${i})` : 'none' }
+                stroke={ props.fill ? 'none' : Array.isArray(props.color)
+                  ? props.color[i]
+                    ? isCssColor(props.color[i])
+                      ? props.color[i]
+                      : theme.current.value.colors[props.color[i]]
+                    : isCssColor(props.color.at(-1))
+                      ? props.color.at(-1)
+                      : theme.current.value.colors[props.color.at(-1)]
+                  : isCssColor(props.color) ? props.color : theme.current.value.colors[props.color] }
+              />
+            ))
+          }
 
           { props.fill && (
             <path
-              d={ genPath(false) }
+              d={ genPath(0, false) }
               fill="none"
-              stroke={ props.color ?? props.gradient?.[0] }
+              stroke={ (Array.isArray(props.color) ? props.color[0] : props.color) ?? props.gradient?.[0] }
             />
           )}
         </svg>
@@ -228,4 +256,4 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
   },
 })
 
-export type VTrendline = InstanceType<typeof VTrendline>
+export type VMultiTrend = InstanceType<typeof VMultiTrend>

--- a/packages/vuetify/src/labs/VSparkline/VSparkline.tsx
+++ b/packages/vuetify/src/labs/VSparkline/VSparkline.tsx
@@ -1,5 +1,6 @@
 // Components
 import { makeVBarlineProps, VBarline } from './VBarline'
+import { makeVMultiTrendProps, VMultiTrend } from './VMultiTrend'
 import { makeVTrendlineProps, VTrendline } from './VTrendline'
 
 // Composables
@@ -16,11 +17,12 @@ import type { PropType } from 'vue'
 
 export const makeVSparklineProps = propsFactory({
   type: {
-    type: String as PropType<'trend' | 'bar'>,
+    type: String as PropType<'trend' | 'bar' | 'multi'>,
     default: 'trend',
   },
 
   ...makeVBarlineProps(),
+  ...makeVMultiTrendProps(),
   ...makeVTrendlineProps(),
 }, 'VSparkline')
 
@@ -35,7 +37,11 @@ export const VSparkline = genericComponent<VSparklineSlots>()({
   props: makeVSparklineProps(),
 
   setup (props, { slots }) {
-    const { textColorClasses, textColorStyles } = useTextColor(toRef(props, 'color'))
+    const { textColorClasses, textColorStyles } = useTextColor(
+      Array.isArray(props.color)
+        ? toRef(props, 'color[0]')
+        : toRef(props, 'color')
+    )
     const hasLabels = computed(() => {
       return Boolean(
         props.showLabels ||
@@ -52,8 +58,12 @@ export const VSparkline = genericComponent<VSparklineSlots>()({
     })
 
     useRender(() => {
-      const Tag = props.type === 'trend' ? VTrendline : VBarline
-      const lineProps = props.type === 'trend' ? VTrendline.filterProps(props) : VBarline.filterProps(props)
+      const Tag = props.type === 'trend' ? VTrendline : props.type === 'bar' ? VBarline : VMultiTrend
+      const lineProps = props.type === 'trend'
+        ? VTrendline.filterProps(props)
+        : props.type === 'bar'
+          ? VBarline.filterProps(props)
+          : VMultiTrend.filterProps(props)
 
       return (
         <Tag

--- a/packages/vuetify/src/labs/VSparkline/VTrendline.tsx
+++ b/packages/vuetify/src/labs/VSparkline/VTrendline.tsx
@@ -60,7 +60,9 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
 
       const gridX = (maxX - minX) / (totalValues - 1)
       const gridY = (maxY - minY) / ((maxValue - minValue) || 1)
-
+      if (values.length === 1) {
+        values.push(values[0])
+      }
       return values.map((value, index) => {
         return {
           x: minX + index * gridX,
@@ -124,7 +126,7 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
       await nextTick()
 
       if (!props.autoDraw || !paths.value || !paths.value.length) return
-      console.log(paths.value)
+      let pathIndex = 0
       for (const path of paths.value) {
         const pathRef = path
         const length = pathRef.getTotalLength()
@@ -141,6 +143,7 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
           pathRef.style.transition = `stroke-dashoffset ${autoDrawDuration.value}ms ${props.autoDrawEasing}`
           pathRef.style.strokeDashoffset = '0'
         } else {
+          pathRef.style.fill = 'black'
           // Your existing logic for filled paths remains the same
           pathRef.style.transformOrigin = 'bottom center'
           pathRef.style.transition = 'none'
@@ -149,6 +152,7 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
           pathRef.style.transition = `transform ${autoDrawDuration.value}ms ${props.autoDrawEasing}`
           pathRef.style.transform = `scaleY(1)`
         }
+        pathIndex++
       }
 
       lastLength.value = length
@@ -216,7 +220,9 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
                 ref={ paths }
                 d={ genPath(i, props.fill) }
                 fill={ props.fill ? `url(#${id.value})` : 'none' }
-                stroke={ props.fill ? 'none' : `url(#${id.value})` }
+                stroke={ props.fill ? 'none' : Array.isArray(props.color)
+                  ? props.color[i] ? props.color[i] : props.color.at(-1)
+                  : props.color }
               />
             ))
           }
@@ -225,7 +231,7 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
             <path
               d={ genPath(0, false) }
               fill="none"
-              stroke={ props.color ?? props.gradient?.[0] }
+              stroke={ (Array.isArray(props.color) ? props.color[0] : props.color) ?? props.gradient?.[0] }
             />
           )}
         </svg>

--- a/packages/vuetify/src/labs/VSparkline/VTrendline.tsx
+++ b/packages/vuetify/src/labs/VSparkline/VTrendline.tsx
@@ -1,8 +1,11 @@
+// Composables
+import { makeThemeProps, provideTheme } from '@/composables/theme'
+
 // Utilities
 import { computed, nextTick, ref, watch } from 'vue'
 import { makeLineProps } from './util/line'
 import { genPath as _genPath } from './util/path'
-import { genericComponent, getPropertyFromItem, getUid, propsFactory, useRender } from '@/util'
+import { genericComponent, getPropertyFromItem, getUid, isCssColor, propsFactory, useRender } from '@/util'
 
 // Types
 export type VTrendlineSlots = {
@@ -32,8 +35,8 @@ export interface Point {
 
 export const makeVTrendlineProps = propsFactory({
   fill: Boolean,
-
   ...makeLineProps(),
+  ...makeThemeProps(),
 }, 'VTrendline')
 
 export const VTrendline = genericComponent<VTrendlineSlots>()({
@@ -42,6 +45,7 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
   props: makeVTrendlineProps(),
 
   setup (props, { slots }) {
+    const theme = provideTheme(props)
     const uid = getUid()
     const id = computed(() => props.id || `trendline-${uid}`)
     const autoDrawDuration = computed(() => Number(props.autoDrawDuration) || (props.fill ? 500 : 2000))
@@ -221,8 +225,14 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
                 d={ genPath(i, props.fill) }
                 fill={ props.fill ? `url(#${id.value})` : 'none' }
                 stroke={ props.fill ? 'none' : Array.isArray(props.color)
-                  ? props.color[i] ? props.color[i] : props.color.at(-1)
-                  : props.color }
+                  ? props.color[i]
+                    ? isCssColor(props.color[i])
+                      ? props.color[i]
+                      : theme.current.value.colors[props.color[i]]
+                    : isCssColor(props.color.at(-1))
+                      ? props.color.at(-1)
+                      : theme.current.value.colors[props.color.at(-1)]
+                  : isCssColor(props.color) ? props.color : theme.current.value.colors[props.color] }
               />
             ))
           }

--- a/packages/vuetify/src/labs/VSparkline/util/line.ts
+++ b/packages/vuetify/src/labs/VSparkline/util/line.ts
@@ -45,7 +45,7 @@ export const makeLineProps = propsFactory({
     default: 'value',
   },
   modelValue: {
-    type: Array as PropType<SparklineItem[]>,
+    type: Array as PropType<SparklineItem[] | Array<SparklineItem[]>>,
     default: () => ([]),
   },
   min: [String, Number],

--- a/packages/vuetify/src/labs/VSparkline/util/line.ts
+++ b/packages/vuetify/src/labs/VSparkline/util/line.ts
@@ -13,7 +13,7 @@ export const makeLineProps = propsFactory({
     type: String,
     default: 'ease',
   },
-  color: String,
+  color: [Array<String>, String],
   gradient: {
     type: Array as PropType<string[]>,
     default: () => ([]),


### PR DESCRIPTION
```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-row>
          <v-col>
            <v-sparkline
              :color="['primary', 'secondary', '#e1e']"
              :model-value="value"
              height="100"
              padding="24"
              stroke-linecap="round"
              smooth
            >
              <template #label="item">
                ${{ item.value }}
              </template>
            </v-sparkline>
          </v-col>
        </v-row>
      </v-container>
    </v-main>
  </v-app>
</template>
<script setup>
  import { ref } from 'vue'

  const value = ref([
    [
      423,
      446,
      675,
      510,
      590,
      610,
      760,
    ],
    [
      409,
      446,
      575,
      490,
      420,
      470,
      520,
    ],
    [
      400,
    ],
  ])
</script>

```