### PR TITLE
fix(VDatePicker): wrong month can be displayed in header.

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -132,9 +132,9 @@ export const VDatePicker = genericComponent<new <
     const text = computed(() => {
       let date = adapter.date()
 
-      date = adapter.setYear(date, year.value)
-      date = adapter.setMonth(date, month.value)
       date = adapter.setDate(date, 1)
+      date = adapter.setMonth(date, month.value)
+      date = adapter.setYear(date, year.value)
 
       return adapter.format(date, 'monthAndYear')
     })

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -410,6 +410,7 @@ function addWeeks (date: Date, amount: number) {
 
 function addMonths (date: Date, amount: number) {
   const d = new Date(date)
+  d.setDate(1)
   d.setMonth(d.getMonth() + amount)
   return d
 }


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When using the next/previous control in the `VDatePicker`, the current logic could sometime pick the wrong month if the current date does not exists. For example, if it is `April 30th, 2024` - navigating back to March would work, but going to February would show March again. If the date range is between 1 and 28/29, the picker would work as expected. A similar issues was occuring with `VCalendar` within the `addMonth` function.

This is because:
[Date.prototype.setMonth()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth)
> The current day of month will have an impact on the behavior of this method. Conceptually it will add the number of days given by the current day of the month to the 1st day of the new month specified as the parameter, to return the new date. For example, if the current value is 31st January 2016, calling setMonth with a value of 1 will return 2nd March 2016. This is because in 2016 February had 29 days.

Resolves #19126 

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker />
      <v-calendar />
    </v-container>

  </v-app>
</template>

<script setup lang="ts">
import {VDatePicker}  from '../src/components/VDatePicker/VDatePicker'
import {VCalendar}  from '../src/labs/VCalendar/VCalendar'
</script>
```
