### PR TITLE
fix(VDataTable): select all checkbox showing when not enabled on mobile

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -89,6 +89,8 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
     const { columns, headers } = useHeaders()
     const { loaderClasses } = useLoader(props)
 
+    console.log('showSelectAll', showSelectAll)
+
     function getFixedStyles (column: InternalDataTableHeader, y: number): CSSProperties | undefined {
       if (!props.sticky && !column.fixed) return undefined
 
@@ -227,6 +229,12 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
       })
 
       const appendIcon = computed(() => {
+        const showSelectColumn = columns.value.find(column => column.key === 'data-table-select')
+
+        if (typeof showSelectColumn === 'undefined') {
+          return
+        }
+
         return allSelected.value ? '$checkboxOn' : someSelected.value ? '$checkboxIndeterminate' : '$checkboxOff'
       })
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -231,7 +231,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
       const appendIcon = computed(() => {
         const showSelectColumn = columns.value.find(column => column.key === 'data-table-select')
 
-        if (typeof showSelectColumn === 'undefined') {
+        if (showSelectColumn == null) {
           return
         }
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -229,9 +229,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
       const appendIcon = computed(() => {
         const showSelectColumn = columns.value.find(column => column.key === 'data-table-select')
 
-        if (showSelectColumn == null) {
-          return
-        }
+        if (showSelectColumn == null) return
 
         return allSelected.value ? '$checkboxOn' : someSelected.value ? '$checkboxIndeterminate' : '$checkboxOff'
       })

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -89,8 +89,6 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
     const { columns, headers } = useHeaders()
     const { loaderClasses } = useLoader(props)
 
-    console.log('showSelectAll', showSelectAll)
-
     function getFixedStyles (column: InternalDataTableHeader, y: number): CSSProperties | undefined {
       if (!props.sticky && !column.fixed) return undefined
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes the issue where the select all checkbox is showing up next to the sortby select on mobile when `data-table-select` is not present in the `columns`

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```typescript
const appendIcon = computed(() => {
  const showSelectColumn = columns.value.find(column => column.key === 'data-table-select')

  if (showSelectColumn == null) {
    return
  }

  return allSelected.value ? '$checkboxOn' : someSelected.value ? '$checkboxIndeterminate' : '$checkboxOff'
})
```
