### PR TITLE
feat(VCalendar): add day click events

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -36,6 +36,9 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
   emits: {
     next: null,
     prev: null,
+    'click:monthDay': (value: Date) => true,
+    'click:weekDay': (value: Date) => true,
+    'click:day': (value: Date) => true,
     'update:modelValue': null,
   },
 
@@ -72,6 +75,18 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
 
     function onClickToday () {
       model.value = [new Date()]
+    }
+
+    function onMonthDayClick (date: Date) {
+      emit('click:monthDay', date)
+    }
+
+    function onWeekDayClick (date: Date) {
+      emit('click:weekDay', date)
+    }
+
+    function onDayClick (date: Date) {
+      emit('click:day', date)
     }
 
     const title = computed(() => {
@@ -156,6 +171,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                           v-slots={{
                             event: slots.event,
                           }}
+                          onMonthDayClick={ onMonthDayClick }
                         ></VCalendarMonthDay>
                       )),
                     ]
@@ -170,6 +186,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                   day={ day }
                   dayIndex={ i }
                   events={ props.events?.filter(e => adapter.isSameDay(e.start, day.date) || adapter.isSameDay(e.end, day.date)) }
+                  onDayClick={ onWeekDayClick }
                 ></VCalendarDay>
               ))
             )}
@@ -185,6 +202,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                     adapter.isSameDay(e.end, genDays([displayValue.value as Date], adapter.date() as Date)[0].date)
                   )
                 }
+                onDayClick={ onDayClick }
               ></VCalendarDay>
             )}
           </div>

--- a/packages/vuetify/src/labs/VCalendar/VCalendarDay.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarDay.tsx
@@ -27,12 +27,20 @@ export const VCalendarDay = genericComponent()({
 
   props: makeVCalendarDayProps(),
 
-  setup (props) {
+  emits: {
+    dayClick: (value: Date) => true,
+  },
+
+  setup (props, { emit }) {
     const adapter = useDate()
     const intervals = computed(() => [
       ...Array.from({ length: props.intervals }, (v, i) => i)
         .filter((int, index) => (props.intervalDuration * (index + props.intervalStart)) < 1440),
     ])
+
+    function onDayClick () {
+      emit('dayClick', props.day?.date)
+    }
 
     useRender(() => {
       const calendarIntervalProps = VCalendarInterval.filterProps(props)
@@ -51,6 +59,7 @@ export const VCalendarDay = genericComponent()({
                   icon
                   text={ adapter.format(props.day.date, 'dayOfMonth') }
                   variant="text"
+                  onClick={ onDayClick }
                 />
               </div>
             </div>

--- a/packages/vuetify/src/labs/VCalendar/VCalendarMonthDay.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarMonthDay.tsx
@@ -30,6 +30,10 @@ export const VCalendarMonthDay = genericComponent<VCalendarMonthDaySlots>()({
   props: makeVCalendarMonthDayProps(),
 
   setup (props, { emit, slots }) {
+    function onDayClick () {
+      emit('monthDayClick', props.day?.date)
+    }
+
     useRender(() => {
       const hasTitle = !!(props.title || slots.title?.({ title: props.title }))
 
@@ -49,6 +53,7 @@ export const VCalendarMonthDay = genericComponent<VCalendarMonthDaySlots>()({
                   icon
                   size="x-small"
                   variant={ props.day?.isToday ? undefined : 'flat' }
+                  onClick={ onDayClick }
                 >
                   { props.title }
                 </VBtn>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
it would be nice to be able to track clicking on a day in the calendar (to add a new event i.e.)
I added events ```monthDayClick``` for ```VCalendarMonthDay```, ```dayClick``` for ```VCalendarDay``` and several events for ```VCalendar``` itself to handle all these clicks: ```click:monthDay```, ```click:weekDay```, ```click:day```

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-calendar
        view-mode="month"
        @click:day="click('Day', $event)"
        @click:month-day="click('Month', $event)"
        @click:week-day="click('Weekday', $event)"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
function click (type: string, date: Date) {
  alert(`${type}: ${date}`)
}
</script>
```
