### PR TITLE
fix(VVirtualScrollItem): pass dynamic template ref function for itemRef

### DIFF
--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScrollItem.tsx
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScrollItem.tsx
@@ -45,7 +45,7 @@ export const VVirtualScrollItem = genericComponent<new <Renderless extends boole
 
     useRender(() => props.renderless ? (
       <>
-        { slots.default?.({ itemRef: resizeRef }) }
+        { slots.default?.({ itemRef: el => resizeRef.value = el }) }
       </>
     ) : (
       <div


### PR DESCRIPTION
Temporarily use `"vue": "^3.4.25"` to replicate the issue

fixes #19713

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-select
    :items="items"
    item-title="name"
    label="User"
    v-for="item in selectArr"
  >
    <template v-slot:item="{ props, item }">
      <v-list-item
        v-bind="props"
        :subtitle="item.raw.department"
      />
    </template>
  </v-select>
  <button @click="selectArr.push(1)">Add Select</button>
</template>

<script>
  export default {
    data: () => ({
      selectArr: [1, 1],
      items: [
        {
          name: 'John',
          department: 'Marketing',
        },
        {
          name: 'Jane',
          department: 'Engineering',
        },
        {
          name: 'Joe',
          department: 'Sales',
        },
        {
          name: 'Janet',
          department: 'Engineering',
        },
        {
          name: 'Jake',
          department: 'Marketing',
        },
        {
          name: 'Jack',
          department: 'Sales',
        },
      ],
    }),
  }
</script>


```
