### PR TITLE
fix mobile header title font weight

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -2,6 +2,7 @@
 @use '../../styles/tools'
 @use '../../components/VTable/variables' as *
 @use './variables' as *
+@use '../VTable/variables' as VTable
 
 @include tools.layer('components')
   .v-data-table
@@ -147,7 +148,7 @@
         border-bottom: 0 !important
 
   .v-data-table__td-title
-    font-weight: bold
+    font-weight: VTable.$table-header-font-weight
     text-align: left
 
   .v-data-table__td-value


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
