### PR TITLE
fix(VDataTable): change mobile default to false

### DIFF
--- a/packages/api-generator/src/locale/en/display.json
+++ b/packages/api-generator/src/locale/en/display.json
@@ -1,6 +1,6 @@
 {
   "props": {
-    "mobile": "Explicitly designate as a mobile display configuration.",
-    "mobileBreakpoint": "Overrides the display configuration default."
+    "mobile": "Determines the display mode of the component. If true, the component will be displayed in mobile mode. If false, the component will be displayed in desktop mode. If null, will be based on the current mobile-breakpoint",
+    "mobileBreakpoint": "Overrides the display configuration default screen size that the component should be considered in mobile."
   }
 }

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -217,7 +217,7 @@ export function createDisplay (options?: DisplayOptions, ssr?: SSROptions): Disp
 export const makeDisplayProps = propsFactory({
   mobile: {
     type: Boolean,
-    default: null,
+    default: false,
   },
   mobileBreakpoint: [Number, String] as PropType<number | DisplayBreakpoint>,
 }, 'display')

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -216,7 +216,7 @@ export function createDisplay (options?: DisplayOptions, ssr?: SSROptions): Disp
 
 export const makeDisplayProps = propsFactory({
   mobile: {
-    type: Boolean,
+    type: Boolean as PropType<boolean | null>,
     default: false,
   },
   mobileBreakpoint: [Number, String] as PropType<number | DisplayBreakpoint>,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Changes the `VDataTable` mobile prop to a default of `false`
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Partially fixes https://github.com/vuetifyjs/vuetify/issues/19726

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
