### PR TITLE
fix(VCalendar): remove background for week view mode

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.sass
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.sass
@@ -9,8 +9,6 @@
     flex-direction: column
     // https://github.com/vuetifyjs/vuetify/issues/8319
     min-height: 0
-    // Themed
-    background-color: #fff
 
   .v-calendar__container
     border-top: $calendar-line-width solid $calendar-line-color

--- a/packages/vuetify/src/labs/VCalendar/VCalendar.sass
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.sass
@@ -2,6 +2,9 @@
 @use './variables' as *
 
 @include tools.layer('components')
+  .v-calendar
+    @include tools.theme($calendar-theme...)
+
   .v-calendar-weekly
     width: 100%
     height: 100%

--- a/packages/vuetify/src/labs/VCalendar/_variables.scss
+++ b/packages/vuetify/src/labs/VCalendar/_variables.scss
@@ -1,3 +1,6 @@
+$calendar-color: rgba(var(--v-theme-on-background), var(--v-high-emphasis-opacity)) !default;
+$calendar-background: rgb(var(--v-theme-background)) !default;
+
 $calendar-line-width: thin !default;
 $calendar-line-color: #e0e0e0 !default;
 
@@ -45,3 +48,8 @@ $calendar-event-border-width: 1px !default;
 $calendar-event-font-size: 12px !default;
 $calendar-event-line-height: 20px !default;
 $calendar-event-right-empty: 10px !default;
+
+$calendar-theme: (
+  $calendar-background,
+  $calendar-color
+) !default;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #18988
regression https://github.com/vuetifyjs/vuetify/commit/4820347463f5ea139bea08a712dd4573c3f492b4

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-calendar v-model="msg" view-mode="week" :events="events"></v-calendar>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const events = [
    {
      title: 'First',
      start: new Date('2024-01-22T02:00:00Z'),
      end: new Date('2024-01-22T04:30:00Z'),
      color: 'blue',
    },
    {
      title: 'Second',
      start: new Date('2024-01-23T05:30:00Z'),
      end: new Date('2024-01-23T08:30:00Z'),
      color: 'red',
    },
    {
      title: 'Third',
      start: new Date('2024-01-23T08:30:00Z'),
      end: new Date('2024-01-23T09:30:00Z'),
      color: 'green',
    },
    {
      title: 'Fourth',
      start: new Date('2024-01-24T02:01:00Z'),
      end: new Date('2024-01-24T04:01:00Z'),
      color: 'green',
    },
  ]

  const msg = ref([new Date('2024-01-23T14:30:00Z')])
</script>
```
