### PR TITLE
fix(VMenu): allow enter keypress to work in textareas

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -126,6 +126,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
       if (props.disabled) return
 
       if (e.key === 'Tab' || (e.key === 'Enter' && !props.closeOnContentClick)) {
+        if (e.key === 'Enter' && e.target instanceof HTMLTextAreaElement) return
         if (e.key === 'Enter') e.preventDefault()
 
         const nextElement = getNextElement(


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

Previously, when a `<v-menu />` with `:close-on-content-click="false"` contained a textarea, an enter press inside the textarea would do nothing and not produce a new line. Now, it will allow a new line to be typed into the textarea when pressing enter.

This last worked in Vuetify v3.5.14 and was broken starting in v3.5.15. The fix for #19519 in 85ba4a800 caused this issue.

fixes #19767

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-menu v-model="show" :close-on-content-click="false">
        <template #activator="{ props }">
          <v-btn color="primary" dark v-bind="props"> Open menu </v-btn>
        </template>

        <v-card class="pa-4">
          <v-textarea v-model="foo" />
        </v-card>
      </v-menu>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const foo = ref('Type and press enter here')
  const show = ref(true)
</script>

```

Before this fix, and pre-v3.5.15, enter cannot be typed in:

![Screenshot-Vuetify Dev Playground-2024-05-07-11-26-57](https://github.com/vuetifyjs/vuetify/assets/3038600/63b9043a-d1c3-4b17-8bfa-6eeb436e4f47)

After this fix, the behavior matches the Vuetify <= v3.5.14 behavior and enter can be typed into the textarea:

![Screenshot-Vuetify Dev Playground-2024-05-07-11-26-29](https://github.com/vuetifyjs/vuetify/assets/3038600/e7c7da07-6bf4-4877-bb6f-50a3f4e7d29d)

