### PR TITLE
fix(V-Menu): only closing menu in closeParents if persistent is not set

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -77,7 +77,8 @@ export const VMenu = genericComponent<OverlaySlots>()({
       closeParents (e) {
         setTimeout(() => {
           if (!openChildren.value &&
-            (e == null || (e && !isClickInsideElement(e, overlay.value!.contentEl!)))
+            (e == null || (e && !isClickInsideElement(e, overlay.value!.contentEl!))) &&
+            !props.persistent
           ) {
             isActive.value = false
             parent?.closeParents()

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -77,8 +77,8 @@ export const VMenu = genericComponent<OverlaySlots>()({
       closeParents (e) {
         setTimeout(() => {
           if (!openChildren.value &&
-            (e == null || (e && !isClickInsideElement(e, overlay.value!.contentEl!))) &&
-            !props.persistent
+            !props.persistent &&
+            (e == null || (e && !isClickInsideElement(e, overlay.value!.contentEl!)))
           ) {
             isActive.value = false
             parent?.closeParents()


### PR DESCRIPTION
## Description
When using nested v-menus, if the parent has persistent set to true, it should remain open on an outside click even when the child menu is closed with an outside click.
When using a v-menu to get input from the user we set the parent menu to be persistent and expect it to remain open until the user cancels/saves. 

* Added check to `closeParents` function to take into account if the menu is persistent or not. 

This is related to #19239, which kept the parent menu open if the child menu was closed by clicking on the parent menu content. This extends this check to account for the parent being persistent, thus keeping the menu open even on outside clicks and resolves #19780.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

<template>
  <v-app>
    <v-container>
      <v-btn id="rootButton">
        Open Menu 1
      </v-btn>
      <v-menu
        v-model="menu1"
        :close-on-content-click="false"
        activator="#rootButton"
        height="300px"
        location="top"
        width="260px"
        persistent
      >
        <v-card>
          <v-card-title>
            Menu 1
          </v-card-title>
          <v-card-item>
            <v-row>
              <v-col cols="12">
                <v-text-field v-model="menu1Text" label="Some text" />
              </v-col>
              <v-col cols="12">
                <v-menu
                  v-model="menu2"
                  :close-on-content-click="false"
                >
                  <template #activator="{ props }">
                    <div v-bind="props" z-index="2000">
                      <v-text-field
                        :model-value="date"
                      />
                    </div>
                  </template>
                  <v-date-picker
                    v-model="date"
                    theme="legacy"
                    @update:model-value="menu2 = false"
                  />
                </v-menu>
              </v-col>
            </v-row>
          </v-card-item>
          <v-card-actions>
            <v-spacer />

            <v-btn
              variant="text"
              @click="menu1 = false"
            >
              Cancel
            </v-btn>
            <v-btn
              color="primary"
              variant="text"
              @click="menu1 = false"
            >
              Save
            </v-btn>
          </v-card-actions>
        </v-card>
      </v-menu>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { Ref, ref } from 'vue'

  const menu1: Ref<boolean> = ref(false)
  const menu2: Ref<boolean> = ref(false)
  const menu1Text: Ref<string> = ref('')
  const date: Ref<Date> = ref(new Date())
</script>

```
