### PR TITLE
docs: fix v-icon component link

### DIFF
--- a/packages/docs/src/pages/en/components/avatars.md
+++ b/packages/docs/src/pages/en/components/avatars.md
@@ -41,7 +41,7 @@ Avatars in their simplest form display content within a circular container.
 
 The recommended placement of elements inside of `v-avatar` is:
 
-* Place a [v-img](/components/images/) or [v-icon](/components/images/) component within the default *slot*
+* Place a [v-img](/components/images/) or [v-icon](/components/icons/) component within the default *slot*
 * Place textual content within the default *slot*
 
 ![Avatar Anatomy](https://cdn.vuetifyjs.com/docs/images/components-temp/v-avatar/v-avatar-anatomy.png)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixed the incorrect link to the v-icon component in the documentation. The v-icon component is located in the `/components/icons/`directory, so the link destination has been changed from `/components/images/` to `/components/icons/`. With this fix, the documentation now provides the correct link to the v-icon component.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
