### PR TITLE
fix(VDataTable): fix accessibility issues

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -123,6 +123,7 @@ export const VDataTableRow = genericComponent<new <T>(
                         icon={ isExpanded(item) ? '$collapse' : '$expand' }
                         size="small"
                         variant="text"
+                        aria-label={ isExpanded(item) ? 'Collapse item' : 'Expand item' }
                         onClick={ withModifiers(() => toggleExpand(item), ['stop']) }
                       />
                     )

--- a/packages/vuetify/src/components/VDataTable/composables/headers.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/headers.ts
@@ -246,7 +246,7 @@ export function createHeaders (
     }
 
     if (options?.showExpand?.value && !keys.has('data-table-expand')) {
-      items.push({ key: 'data-table-expand' })
+      items.push({ key: 'data-table-expand', title: 'Actions' })
     }
 
     const internalHeaders = convertToInternalHeaders(items)


### PR DESCRIPTION


## Description
When using expandable data table, there are two accessibility issues:

1. Expand/collapse button is not readable by screen readers as it does not have text or label explaining what it does
2. According to accessibility rules, the table headers should not be empty, as screen readers can't know what they are about

This PR fixes both issues, granting better accessibility to end users.

## Markup:
```
<template>
  <v-app>
    <main>
      <h1>Example</h1>
      <v-data-table v-model:expanded="expanded" :headers="dessertHeaders" :items="desserts" item-value="name"
        show-expand>
        <template v-slot:top>
          <v-toolbar flat>
            <v-toolbar-title>Expandable Table</v-toolbar-title>
          </v-toolbar>
        </template>
        <template v-slot:expanded-row="{ columns, item }">
          <tr>
            <td :colspan="columns.length">
              More info about {{ item.name }}
            </td>
          </tr>
        </template>
      </v-data-table>
    </main>
  </v-app>
</template>

<script>
export default {
  name: 'Playground',
  setup() {
    return {
      //
    }
  },
  data() {
    return {
      expanded: [],
      dessertHeaders: [
        {
          title: 'Dessert (100g serving)',
          align: 'start',
          sortable: false,
          key: 'name',
        },
        { title: 'Calories', key: 'calories' },
        { title: 'Fat (g)', key: 'fat' },
        { title: 'Carbs (g)', key: 'carbs' },
        { title: 'Protein (g)', key: 'protein' },
        { title: 'Iron (%)', key: 'iron' },
        { title: 'Actions', key: 'data-table-expand' },
      ],
      desserts: [
        {
          name: 'Frozen Yogurt',
          calories: 159,
          fat: 6.0,
          carbs: 24,
          protein: 4.0,
          iron: 1,
        },
        {
          name: 'Ice cream sandwich',
          calories: 237,
          fat: 9.0,
          carbs: 37,
          protein: 4.3,
          iron: 1,
        },
        {
          name: 'Eclair',
          calories: 262,
          fat: 16.0,
          carbs: 23,
          protein: 6.0,
          iron: 7,
        },
        {
          name: 'Cupcake',
          calories: 305,
          fat: 3.7,
          carbs: 67,
          protein: 4.3,
          iron: 8,
        },
        {
          name: 'Gingerbread',
          calories: 356,
          fat: 16.0,
          carbs: 49,
          protein: 3.9,
          iron: 16,
        },
        {
          name: 'Jelly bean',
          calories: 375,
          fat: 0.0,
          carbs: 94,
          protein: 0.0,
          iron: 0,
        },
        {
          name: 'Lollipop',
          calories: 392,
          fat: 0.2,
          carbs: 98,
          protein: 0,
          iron: 2,
        },
        {
          name: 'Honeycomb',
          calories: 408,
          fat: 3.2,
          carbs: 87,
          protein: 6.5,
          iron: 45,
        },
        {
          name: 'Donut',
          calories: 452,
          fat: 25.0,
          carbs: 51,
          protein: 4.9,
          iron: 22,
        },
        {
          name: 'KitKat',
          calories: 518,
          fat: 26.0,
          carbs: 65,
          protein: 7,
          iron: 6,
        },
      ],
    }
  },
}
</script>
```
