### PR TITLE
fix(locale): fix german locale translations for date and time -picker

### DIFF
--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -2,7 +2,7 @@ export default {
   badge: 'Abzeichen',
   open: 'Öffnen',
   close: 'Schließen',
-  dismiss: 'Dismiss',
+  dismiss: 'Verwerfen',
   confirmEdit: {
     ok: 'OK',
     cancel: 'Abbrechen',
@@ -36,7 +36,7 @@ export default {
     divider: 'bis',
   },
   datePicker: {
-    itemsSelected: '{0} selected',
+    itemsSelected: '{0} ausgewählt',
     range: {
       title: 'Daten auswählen',
       header: 'Daten eingeben',
@@ -57,7 +57,7 @@ export default {
   },
   calendar: {
     moreEvents: '{0} mehr',
-    today: 'Today',
+    today: 'Heute',
   },
   input: {
     clear: '{0} leeren',
@@ -72,7 +72,7 @@ export default {
   timePicker: {
     am: 'AM',
     pm: 'PM',
-    title: 'Select Time',
+    title: 'Uhrzeit auswählen',
   },
   pagination: {
     ariaLabel: {


### PR DESCRIPTION
This PR completes the german translation for vuetify. I have found that issue by using the date and time -picker. 