### PR TITLE
feat(VField): support border prop

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -325,12 +325,6 @@
     right: 0
     width: 100%
     
-    @include tools.border($field-border-prop...)
-
-    &.v-field__outline--border
-      --v-field-border-width: 0
-      --v-field-border-opacity: 0
-
 
     @media (hover: hover)
       .v-field:hover &
@@ -385,10 +379,13 @@
         border-top-width: var(--v-field-border-width)
         border-bottom-width: var(--v-field-border-width)
         border-inline-start-width: var(--v-field-border-width)
+        border-inline-end-width: 0 !important
         border-start-start-radius: inherit
         border-start-end-radius: 0
         border-end-end-radius: 0
         border-end-start-radius: inherit
+        &--border
+          @include tools.border($field-border-prop...)
 
         @at-root
           #{selector.append('.v-field--rounded', &)},
@@ -408,6 +405,14 @@
         flex: none
         position: relative
         max-width: calc(100% - $field-control-affixed-padding)
+        border-inline-end-width: 0 !important
+        border-inline-start-width: 0 !important
+        &--border
+          @include tools.border($field-border-prop...)
+
+        &--border 
+          opacity: var(--v-field-border-opacity)
+          transition: opacity $field-subtle-transition-timing
 
         &::before,
         &::after
@@ -416,14 +421,15 @@
 
           @include tools.absolute(true)
 
-        &::before
+        &:not(.v-field__outline__notch--border)::before
           border-width: var(--v-field-border-width) 0 0
 
-        &::after
+        &:not(.v-field__outline__notch--border)::after
           bottom: 0
           border-width: 0 0 var(--v-field-border-width)
 
         @at-root #{selector.append('.v-field--active', &)}
+          border-top-width: 0 !important
           &::before
             opacity: 0
 
@@ -431,11 +437,15 @@
         flex: 1
         border-top-width: var(--v-field-border-width)
         border-bottom-width: var(--v-field-border-width)
+        border-inline-start-width: 0 !important
         border-inline-end-width: var(--v-field-border-width)
         border-start-start-radius: 0
         border-start-end-radius: inherit
         border-end-end-radius: inherit
         border-end-start-radius: 0
+
+        &--border
+          @include tools.border($field-border-prop...)
 
         @at-root #{selector.append('.v-field--reverse', &)}
           border-start-start-radius: inherit

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -324,6 +324,13 @@
     position: absolute
     right: 0
     width: 100%
+    
+    @include tools.border($field-border-prop...)
+
+    &.v-field__outline--border
+      --v-field-border-width: 0
+      --v-field-border-opacity: 0
+
 
     @media (hover: hover)
       .v-field:hover &
@@ -336,7 +343,7 @@
     .v-input.v-input--error &
       --v-field-border-opacity: 1
 
-    .v-field--variant-outlined.v-field--focused &
+    .v-field--variant-outlined.v-field--focused &:not(.v-field__outline--border)
       --v-field-border-width: #{$field-focused-border-width}
 
     .v-field--variant-filled &,

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -324,10 +324,12 @@
     position: absolute
     right: 0
     width: 100%
-    
 
+    &--border
+      --v-field-border-opacity: none
+    
     @media (hover: hover)
-      .v-field:hover &
+      .v-field:hover &:not(.v-field__outline--border)
         --v-field-border-opacity: var(--v-high-emphasis-opacity)
 
     .v-field--error:not(.v-field--disabled) &
@@ -407,13 +409,11 @@
         max-width: calc(100% - $field-control-affixed-padding)
         border-inline-end-width: 0 !important
         border-inline-start-width: 0 !important
-        &--border
-          @include tools.border($field-border-prop...)
-
         &--border 
+          @include tools.border($field-border-prop...)
           opacity: var(--v-field-border-opacity)
           transition: opacity $field-subtle-transition-timing
-
+        
         &::before,
         &::after
           opacity: var(--v-field-border-opacity)

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -379,6 +379,9 @@ export const VField = genericComponent<new <T>(
           <div
             class={[
               'v-field__outline',
+              {
+                'v-field__outline--border': props.border,
+              },
               textColorClasses.value,
             ]}
             style={ textColorStyles.value }
@@ -387,11 +390,8 @@ export const VField = genericComponent<new <T>(
               <>
                 <div
                   class={[
-                    'v-field__outline__start',
-                    {
-                      'v-field__outline__start--border': props.border,
-                    },
                     outlineStartBorderClasses.value,
+                    'v-field__outline__start',
                   ]}
                 />
 

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -39,7 +39,7 @@ import type { PropType, Ref } from 'vue'
 import type { LoaderSlotProps } from '@/composables/loader'
 import type { GenericProps } from '@/util'
 
-const allowedVariants = ['underlined', 'outlined', 'filled', 'solo', 'solo-inverted', 'solo-filled', 'plain', 'border'] as const
+const allowedVariants = ['underlined', 'outlined', 'filled', 'solo', 'solo-inverted', 'solo-filled', 'plain'] as const
 type Variant = typeof allowedVariants[number]
 
 export interface DefaultInputSlot {
@@ -133,7 +133,9 @@ export const VField = genericComponent<new <T>(
 
   setup (props, { attrs, emit, slots }) {
     const { themeClasses } = provideTheme(props)
-    const { borderClasses } = useBorder(props, 'v-field__outline')
+    const { borderClasses: outlineStartBorderClasses } = useBorder(props, 'v-field__outline__start')
+    const { borderClasses: outlineNotchBorderClasses } = useBorder(props, 'v-field__outline__notch')
+    const { borderClasses: outlineEndBorderClasses } = useBorder(props, 'v-field__outline__end')
     const { loaderClasses } = useLoader(props)
     const { focusClasses, isFocused, focus, blur } = useFocus(props)
     const { InputIcon } = useInputIcon(props)
@@ -377,24 +379,42 @@ export const VField = genericComponent<new <T>(
           <div
             class={[
               'v-field__outline',
-              borderClasses.value,
               textColorClasses.value,
             ]}
             style={ textColorStyles.value }
           >
             { isOutlined && (
               <>
-                <div class="v-field__outline__start" />
+                <div
+                  class={[
+                    'v-field__outline__start',
+                    {
+                      'v-field__outline__start--border': props.border,
+                    },
+                    outlineStartBorderClasses.value,
+                  ]}
+                />
 
                 { hasLabel.value && (
-                  <div class="v-field__outline__notch">
+                  <div class={[
+                    'v-field__outline__notch',
+                    {
+                      'v-field__outline__notch--border': props.border,
+                    },
+                    outlineNotchBorderClasses.value,
+                  ]}
+                  >
                     <VFieldLabel ref={ floatingLabelRef } floating for={ id.value }>
                       { label() }
                     </VFieldLabel>
                   </div>
                 )}
 
-                <div class="v-field__outline__end" />
+                <div class={[
+                  'v-field__outline__end',
+                  outlineEndBorderClasses.value,
+                ]}
+                />
               </>
             )}
 

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -8,6 +8,7 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { useInputIcon } from '@/components/VInput/InputIcon'
 
 // Composables
+import { makeBorderProps, useBorder } from '@/composables/border'
 import { useBackgroundColor, useTextColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
 import { makeFocusProps, useFocus } from '@/composables/focus'
@@ -38,7 +39,7 @@ import type { PropType, Ref } from 'vue'
 import type { LoaderSlotProps } from '@/composables/loader'
 import type { GenericProps } from '@/util'
 
-const allowedVariants = ['underlined', 'outlined', 'filled', 'solo', 'solo-inverted', 'solo-filled', 'plain'] as const
+const allowedVariants = ['underlined', 'outlined', 'filled', 'solo', 'solo-inverted', 'solo-filled', 'plain', 'border'] as const
 type Variant = typeof allowedVariants[number]
 
 export interface DefaultInputSlot {
@@ -90,6 +91,7 @@ export const makeVFieldProps = propsFactory({
   'onClick:appendInner': EventProp<[MouseEvent]>(),
   'onClick:prependInner': EventProp<[MouseEvent]>(),
 
+  ...makeBorderProps(),
   ...makeComponentProps(),
   ...makeLoaderProps(),
   ...makeRoundedProps(),
@@ -119,6 +121,7 @@ export const VField = genericComponent<new <T>(
   props: {
     id: String,
 
+    ...makeBorderProps(),
     ...makeFocusProps(),
     ...makeVFieldProps(),
   },
@@ -130,12 +133,14 @@ export const VField = genericComponent<new <T>(
 
   setup (props, { attrs, emit, slots }) {
     const { themeClasses } = provideTheme(props)
+    const { borderClasses } = useBorder(props, 'v-field__outline')
     const { loaderClasses } = useLoader(props)
     const { focusClasses, isFocused, focus, blur } = useFocus(props)
     const { InputIcon } = useInputIcon(props)
     const { roundedClasses } = useRounded(props)
     const { rtlClasses } = useRtl()
 
+    const variant = computed(() => props.border ? 'outlined' : props.variant)
     const isActive = computed(() => props.dirty || props.active)
     const hasLabel = computed(() => !props.singleLine && !!(props.label || slots.label))
 
@@ -146,7 +151,7 @@ export const VField = genericComponent<new <T>(
     const labelRef = ref<VFieldLabel>()
     const floatingLabelRef = ref<VFieldLabel>()
     const controlRef = ref<HTMLElement>()
-    const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
+    const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(variant.value))
 
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(toRef(props, 'bgColor'))
     const { textColorClasses, textColorStyles } = useTextColor(computed(() => {
@@ -221,7 +226,7 @@ export const VField = genericComponent<new <T>(
     }
 
     useRender(() => {
-      const isOutlined = props.variant === 'outlined'
+      const isOutlined = variant.value === 'outlined' || props.border
       const hasPrepend = !!(slots['prepend-inner'] || props.prependInnerIcon)
       const hasClear = !!(props.clearable || slots.clear)
       const hasAppend = !!(slots['append-inner'] || props.appendInnerIcon || hasClear)
@@ -253,7 +258,7 @@ export const VField = genericComponent<new <T>(
               'v-field--reverse': props.reverse,
               'v-field--single-line': props.singleLine,
               'v-field--no-label': !label(),
-              [`v-field--variant-${props.variant}`]: true,
+              [`v-field--variant-${variant.value}`]: true,
             },
             themeClasses.value,
             backgroundColorClasses.value,
@@ -290,7 +295,7 @@ export const VField = genericComponent<new <T>(
           )}
 
           <div class="v-field__field" data-no-activator="">
-            {['filled', 'solo', 'solo-inverted', 'solo-filled'].includes(props.variant) && hasLabel.value && (
+            {['filled', 'solo', 'solo-inverted', 'solo-filled'].includes(variant.value) && hasLabel.value && (
               <VFieldLabel
                 key="floating-label"
                 ref={ floatingLabelRef }
@@ -372,6 +377,7 @@ export const VField = genericComponent<new <T>(
           <div
             class={[
               'v-field__outline',
+              borderClasses.value,
               textColorClasses.value,
             ]}
             style={ textColorStyles.value }

--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -49,6 +49,20 @@ $field-input-row-gap: 8px !default;
 // LABEL
 $field-label-floating-scale: .75 !default;
 
+// BORDER
+$field-border-prop-color: settings.$border-color-root !default;
+$field-border-prop-radius: settings.$border-radius-root !default;
+$field-border-prop-style: settings.$border-style-root !default;
+$field-border-prop-thin-width: thin !default;
+$field-border-prop-width: 0 !default;
+
+$field-border-prop: (
+  $field-border-prop-color,
+  $field-border-prop-style,
+  $field-border-prop-width,
+  $field-border-prop-thin-width
+) !default;
+
 // OUTLINE
 $field-outline-opacity: .38 !default;
 $field-border-width: 1px !default;

--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -54,7 +54,7 @@ $field-border-prop-color: settings.$border-color-root !default;
 $field-border-prop-radius: settings.$border-radius-root !default;
 $field-border-prop-style: settings.$border-style-root !default;
 $field-border-prop-thin-width: thin !default;
-$field-border-prop-width: 0 !default;
+$field-border-prop-width: thin !default;
 
 $field-border-prop: (
   $field-border-prop-color,

--- a/packages/vuetify/src/components/VField/_variables.scss
+++ b/packages/vuetify/src/components/VField/_variables.scss
@@ -51,10 +51,9 @@ $field-label-floating-scale: .75 !default;
 
 // BORDER
 $field-border-prop-color: settings.$border-color-root !default;
-$field-border-prop-radius: settings.$border-radius-root !default;
 $field-border-prop-style: settings.$border-style-root !default;
+$field-border-prop-width: 1px !default;
 $field-border-prop-thin-width: thin !default;
-$field-border-prop-width: thin !default;
 
 $field-border-prop: (
   $field-border-prop-color,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->




## Description

When border prop applied, VField actually uses outlined variant under the hood but override outline styles with border styles

![May-16-2024 14-19-32](https://github.com/vuetifyjs/vuetify/assets/5698884/4f6505dd-016d-4f39-afd1-51ec57944390)
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        border="md"
        placeholder="test"
      />
      <v-text-field
        label="Label"
        border="success lg"
      />
      <v-text-field
        label="Label"
        variant="outlined"
      />
    </v-container>
  </v-app>
</template>
<script setup>
</script>



```
