### PR TITLE
fix(VDivider): visiblity in container with dynamic height

### DIFF
--- a/packages/vuetify/src/components/VDivider/VDivider.sass
+++ b/packages/vuetify/src/components/VDivider/VDivider.sass
@@ -16,7 +16,7 @@
       align-self: stretch
       border-width: $divider-vertical-border-width
       display: inline-flex
-      height: 100%
+      height: auto
       margin-left: $divider-vertical-margin-left
       max-height: 100%
       max-width: 0px


### PR DESCRIPTION
## Description

Assuming `<v-divider vertical>` makes sense only inside flexbox container, the `height: auto` allows `align-self: stretch` to take effect when container does not have explicit height.

Example in [docs](https://vuetifyjs.com/en/components/dividers/#usage) does not expose the issue, because `d-flex` gets additional explicit height, but in real life, we usually leave height to be dynamic and determined based on the children height.

After the change I did not notice any negative effects, but I may not know about use cases outside flexbox.

fixes #19827