### PR TITLE
fix(VAutocomplete/VCombobox): remove tab key listener

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -238,7 +238,7 @@ export const VAutocomplete = genericComponent<new <
         menu.value = false
       }
 
-      if (highlightFirst.value && ['Enter', 'Tab'].includes(e.key)) {
+      if (highlightFirst.value && e.key === 'Enter') {
         select(displayItems.value[0])
       }
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -290,8 +290,8 @@ export const VCombobox = genericComponent<new <
         menu.value = false
       }
 
-      if (['Enter', 'Escape', 'Tab'].includes(e.key)) {
-        if (highlightFirst.value && ['Enter', 'Tab'].includes(e.key)) {
+      if (['Enter', 'Escape'].includes(e.key)) {
+        if (highlightFirst.value && e.key === 'Enter') {
           select(filteredItems.value[0])
         }
 


### PR DESCRIPTION
For autocomplete/comobobox, "Tab" key is equivalent to "blur", so remove tab key listener and let `isFocused === false` watcher handle "auto-select-first"

fixes #19840

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-combobox
        chips
        label="Combobox"
        :items="['California1', 'California2', 'California3', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        multiple
        hide-selected
        auto-select-first
      />
      <v-autocomplete
        chips
        label="Autocomplete"
        :items="['California1', 'California2', 'California3', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        multiple
        hide-selected
        auto-select-first
      />
    </v-container>
  </v-app>
  <!-- 
  1. Type Cal
  2. Hit tab
  3. Notice California1 and California2 are populated to input field.
  4. Behavior does not occur if you type Cal, arrow down to California2 and tab.

  Appears to have broken in 3.3.11 release. Was working in 3.3.10
        -->
</template>


```
