### PR TITLE
fix(VListChildren): pass return-object to nested VListChildren

### DIFF
--- a/packages/vuetify/src/components/VList/VListChildren.tsx
+++ b/packages/vuetify/src/components/VList/VListChildren.tsx
@@ -85,7 +85,11 @@ export const VListChildren = genericComponent<new <T extends InternalListItem>(
                 )
             },
             default: () => (
-              <VListChildren items={ children } v-slots={ slots } />
+              <VListChildren
+                items={ children }
+                returnObject={ props.returnObject }
+                v-slots={ slots }
+              />
             ),
           }}
         </VListGroup>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script setup>
  import { ref } from 'vue';


  const selections = ref([])

  function onOpen() {
    console.log(arguments)
  }

const items = [
  {
   title: 'Option 1',
   subtitle: 'This is option 1',
   value: 1,
  },
  {
    title: 'Option 2',
    subtitle: 'This is option 2',
    value: 2,
    children: [
      {
        title: 'Option 1',
        subtitle: 'This is option 1',
        value: 1,
      },
    ]
  },
]
</script>

<template>
  <v-card class="mx-auto" max-width="400">
    <v-toolbar color="purple">
      <v-btn icon="mdi-menu"></v-btn>

      <v-toolbar-title>Settings</v-toolbar-title>

      <v-spacer></v-spacer>

      <v-btn icon="mdi-magnify"></v-btn>
    </v-toolbar>

    <v-divider></v-divider>

    <v-list
      selectable
      v-model:selected="selections"
      @click:open="onOpen"
      :items="items"
      lines="three"
      select-strategy="classic"
      return-object
    />

    <pre>{{ selections }}</pre>
  </v-card>
</template>


```
