### PR TITLE
fix(VCheckboxBtn): reset checked state when readonly is true

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/__tests__/VCheckboxBtn.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCheckbox/__tests__/VCheckboxBtn.spec.cy.tsx
@@ -51,7 +51,7 @@ describe('VCheckboxBtn', () => {
   it('should not update input checked state when it is readonly', () => {
     const model = ref(false)
     cy.mount(() => (
-      <VCheckboxBtn v-model={ model.value } readonly={ true } />
+      <VCheckboxBtn v-model={ model.value } readonly />
     ))
 
     cy.get('.v-checkbox-btn').click(20, 20)

--- a/packages/vuetify/src/components/VCheckbox/__tests__/VCheckboxBtn.spec.cy.tsx
+++ b/packages/vuetify/src/components/VCheckbox/__tests__/VCheckboxBtn.spec.cy.tsx
@@ -47,4 +47,17 @@ describe('VCheckboxBtn', () => {
 
     cy.get('input').should('have.attr', 'aria-checked', 'mixed')
   })
+
+  it('should not update input checked state when it is readonly', () => {
+    const model = ref(false)
+    cy.mount(() => (
+      <VCheckboxBtn v-model={ model.value } readonly={ true } />
+    ))
+
+    cy.get('.v-checkbox-btn').click(20, 20)
+
+    cy.get('input').should('not.be.checked').then(() => {
+      expect(model.value).to.be.false
+    })
+  })
 })

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -209,10 +209,10 @@ export const VSelectionControl = genericComponent<new <T>(
           // model value is not updated when input is not interactive
           // but the internal checked state of the input is still updated,
           // so here it's value is restored
-          input.value.checked = model.value;
+          input.value.checked = model.value
         }
 
-        return;
+        return
       }
 
       if (props.readonly && group) {

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -204,7 +204,16 @@ export const VSelectionControl = genericComponent<new <T>(
     }
 
     function onInput (e: Event) {
-      if (!isInteractive.value) return
+      if (!isInteractive.value) {
+        if (input.value) {
+          // model value is not updated when input is not interactive
+          // but the internal checked state of the input is still updated,
+          // so here it's value is restored
+          input.value.checked = model.value;
+        }
+
+        return;
+      }
 
       if (props.readonly && group) {
         nextTick(() => group.forceUpdate())


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #19137

How to reproduce the bug is described in the referenced issue, but shortly, the `input` internal checked state was out of sync with modelValue when the `readonly` flag is `true`.

That caused the bug, when the checkbox becomes interactive again, and sometimes it would not update the model value on the first click on the checkbox.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-checkbox-btn
        label="Checkbox #1:"
        v-model="checkboxState"
        :readonly="shouldLockCheckboxUpdates"
      />

      <v-checkbox-btn
        v-model="shouldLockCheckboxUpdates"
        label="Checkbox #2:"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from 'vue'

const checkboxState = ref(false);
const shouldLockCheckboxUpdates = ref(false);
</script>

```
