### PR TITLE
fix(VTabs): render tabs correctly using items

### DIFF
--- a/packages/api-generator/src/locale/en/VTabs.json
+++ b/packages/api-generator/src/locale/en/VTabs.json
@@ -13,7 +13,7 @@
     "height": "Sets the height of the tabs bar.",
     "hideSlider": "Hide's the generated `v-tabs-slider`.",
     "iconsAndText": "Will stack icon and text vertically.",
-    "items": "The items to display in the component. This can be an array of strings or objects with a property `title`.",
+    "items": "The items to display in the component. This can be an array of strings or objects with a property `text`.",
     "light": "Applies the light theme variant to the component.",
     "mobileBreakpoint": "Sets the designated mobile breakpoint for the component.",
     "optional": "Does not require an active item. Useful when using `v-tab` as a `router-link`.",

--- a/packages/vuetify/src/components/VTabs/VTabs.tsx
+++ b/packages/vuetify/src/components/VTabs/VTabs.tsx
@@ -144,7 +144,7 @@ export const VTabs = genericComponent<VTabsSlots>()({
                   key={ item.text }
                   value={ item.value }
                   v-slots={{
-                    default: () => slots[`tab.${item.value}`]?.({ item }),
+                    default: slots[`tab.${item.value}`] ? () => slots[`tab.${item.value}`]?.({ item }) : undefined,
                   }}
                 />
               )

--- a/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.cy.tsx
+++ b/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.cy.tsx
@@ -145,4 +145,17 @@ describe('VTabs', () => {
         expect(model.value).to.equal('B')
       })
   })
+
+  it('should render tabs using items', () => {
+    const items = [
+      { text: 'A', value: 1 },
+      { text: 'B', value: 2 },
+      { text: 'C', value: 3 },
+    ]
+    cy.mount(() => (
+      <VTabs items={ items } />
+    )).get('.v-tab').eq(0).should('have.text', 'A')
+      .get('.v-tab').eq(1).should('have.text', 'B')
+      .get('.v-tab').eq(2).should('have.text', 'C')
+  })
 })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #19855 
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-tabs v-model="value">
        <v-tab :value="1">A</v-tab>
        <v-tab :value="2">B</v-tab>
        <v-tab :value="3">C</v-tab>
      </v-tabs>

      <v-divider class="my-8" />

      <v-tabs v-model="value" :items="items" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref(2)
  const items = [
    { text: 'A', value: 1 },
    { text: 'B', value: 2 },
    { text: 'C', value: 3 },
  ]
</script>
```
