### PR TITLE
fix(VSnackbar): fix class name for center location

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -10,7 +10,7 @@
     margin-inline-end: calc(#{$snackbar-wrapper-margin} + var(--v-scrollbar-offset))
     padding: var(--v-layout-top) var(--v-layout-right) var(--v-layout-bottom) var(--v-layout-left)
 
-    &:not(.v-snackbar--centered):not(.v-snackbar--top)
+    &:not(.v-snackbar--center):not(.v-snackbar--top)
       align-items: flex-end
 
     &__wrapper


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19870 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="text-center ma-2">
    <v-btn @click="snackbar = true"> Open Snackbar </v-btn>
    <v-snackbar v-model="snackbar" location="bottom center">
      {{ text }}

      <template #actions>
        <v-btn color="pink" variant="text" @click="snackbar = false">
          Close
        </v-btn>
      </template>
    </v-snackbar>
  </div>
</template>

<script>
  export default {
    data: () => ({
      snackbar: false,
      text: `Hello, I'm a snackbar`,
    }),
  }
</script>
```
