### PR TITLE
fix(VSlider): add aria-label to v-slider-thumb

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -168,7 +168,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
                   onFocus={ focus }
                   onBlur={ blur }
                   ripple={ props.ripple }
-                  name = { props.name}
+                  name={ props.name }
                 >
                   {{ 'thumb-label': slots['thumb-label'] }}
                 </VSliderThumb>

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -168,6 +168,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
                   onFocus={ focus }
                   onBlur={ blur }
                   ripple={ props.ripple }
+                  name = { props.name}
                 >
                   {{ 'thumb-label': slots['thumb-label'] }}
                 </VSliderThumb>

--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -48,6 +48,10 @@ export const makeVSliderThumbProps = propsFactory({
     type: [Boolean, Object] as PropType<RippleDirectiveBinding['value']>,
     default: true,
   },
+  name:{
+    type: String,
+    default: 'Slider'
+  },
 
   ...makeComponentProps(),
 }, 'VSliderThumb')
@@ -152,6 +156,7 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
           ]}
           role="slider"
           tabindex={ disabled.value ? -1 : 0 }
+          aria-label={ props.name }
           aria-valuemin={ props.min }
           aria-valuemax={ props.max }
           aria-valuenow={ props.modelValue }

--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -48,10 +48,7 @@ export const makeVSliderThumbProps = propsFactory({
     type: [Boolean, Object] as PropType<RippleDirectiveBinding['value']>,
     default: true,
   },
-  name:{
-    type: String,
-    default: 'Slider'
-  },
+  name: String,
 
   ...makeComponentProps(),
 }, 'VSliderThumb')


### PR DESCRIPTION
Accessability problem with v-slider component.
![image](https://github.com/vuetifyjs/vuetify/assets/33714934/a6b62f83-1866-47ec-91f9-d8046e195fda)


The code pass `name` prop to slider thumb component and uses name as an aria-label value. If name prop isn't passed it just uses `Slider` as a default aria-label value.

