### PR TITLE
feat(VNumberInput): ability to hide controls + spacing tweaks

### DIFF
--- a/packages/docs/src/examples/v-number-input/prop-control-variant.vue
+++ b/packages/docs/src/examples/v-number-input/prop-control-variant.vue
@@ -18,6 +18,12 @@
 
         <v-number-input control-variant="split"></v-number-input>
       </v-col>
+
+      <v-col cols="12" md="4" sm="4">
+        <h5>Hidden</h5>
+
+        <v-number-input control-variant="hidden"></v-number-input>
+      </v-col>
     </v-row>
   </v-container>
 </template>

--- a/packages/docs/src/pages/en/components/number-inputs.md
+++ b/packages/docs/src/pages/en/components/number-inputs.md
@@ -75,7 +75,7 @@ The `v-number-input` component has support for most of `v-field`'s props and is 
 
 #### Control-variant
 
-The `control-variant` prop offers an easy way to customize steppers button layout. The following values are valid options: **default**, **stacked** and **split**.
+The `control-variant` prop offers an easy way to customize steppers button layout. The following values are valid options: **default**, **stacked**, **split** and **hidden**.
 
 <ExamplesExample file="v-number-input/prop-control-variant" />
 

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
@@ -15,8 +15,18 @@
         -webkit-appearance: none
 
     .v-field
-      padding-inline-end: 0
-      padding-inline-start: 0
+      &:not(:has(.v-field__prepend-inner > .v-icon))
+        padding-inline-start: 0
+
+      &:not(:has(.v-field__append-inner > .v-icon))
+        padding-inline-end: 0
+
+    .v-field__prepend-inner:has(.v-number-input__control) > .v-icon
+      margin-inline-end: 12px
+
+    .v-field__append-inner:has(.v-number-input__control) > .v-icon
+      margin-inline-start: 12px
+
 
     &--inset
       .v-divider

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -29,7 +29,7 @@ type VNumberInputSlots = Omit<VTextFieldSlots, 'default'> & {
   decrement: ControlSlot
 }
 
-type ControlVariant = 'default' | 'stacked' | 'split'
+type ControlVariant = 'default' | 'stacked' | 'split' | 'hidden'
 
 const makeVNumberInputProps = propsFactory({
   controlVariant: {
@@ -55,7 +55,7 @@ const makeVNumberInputProps = propsFactory({
     default: 1,
   },
 
-  ...omit(makeVTextFieldProps({}), ['appendInnerIcon', 'modelValue', 'prependInnerIcon']),
+  ...omit(makeVTextFieldProps({}), ['modelValue']),
 }, 'VNumberInput')
 
 export const VNumberInput = genericComponent<VNumberInputSlots>()({
@@ -297,7 +297,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
               { incrementControlNode() }
             </div>
-          ) : (props.reverse
+          ) : (props.reverse || controlVariant.value === 'hidden'
             ? undefined
             : <>{ dividerNode() }{ controlNode() }</>)
 
@@ -311,7 +311,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
               <VDivider vertical />
             </div>
-          ) : (props.reverse
+          ) : (props.reverse && controlVariant.value !== 'hidden'
             ? <>{ controlNode() }{ dividerNode() }</>
             : undefined)
 


### PR DESCRIPTION
## Description
- `control-variant="hidden"` allows us replace controls with icon (e.g. for readonly state)
- `append-inner-icon` and `prepend-inner-icon` have been already restored, but need a minor CSS fix for spacing

resolves #19897
fixes #20782

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-card class="mx-auto pa-6 my-4" style="max-width: 600px">
        <h5>v-number-input</h5>
        <div class="d-flex ga-3 align-center">
          <v-switch
            hide-details
            v-model="fieldConfig.reverse"
            label="reverse"
          />
          <v-spacer />
          <v-radio-group hide-details v-model="fieldConfig.controlVariant">
            <div class="d-flex ga-3 align-center">
              <v-radio value="default" label="default" />
              <v-radio value="stacked" label="stacked" />
              <v-radio value="split" label="split" />
            </div>
          </v-radio-group>
        </div>
        <div class="d-flex flex-column ga-2">
          <v-number-input
            v-bind="fieldConfig"
            prepend-inner-icon="mdi-bitcoin"
            class="v-number-input--append-inner-slot v-number-input--append-inner-slot v-number-input--prepend-inner-slot"
            :model-value="120"
            readonly
            hide-details
          />
          <v-number-input
            v-bind="fieldConfig"
            class="v-number-input--append-inner-slot v-number-input--append-inner-slot v-number-input--prepend-inner-slot"
            :model-value="120"
            readonly
            hide-details
            prepend-inner-icon="mdi-bitcoin"
            append-inner-icon="mdi-lock-outline"
          />
          <v-number-input
            v-bind="fieldConfig"
            class="v-number-input--hidden-controls v-number-input--append-inner-slot v-number-input--prepend-inner-slot"
            :model-value="120"
            readonly
            hide-details
            control-variant="hidden"
            prepend-inner-icon="mdi-bitcoin"
            append-inner-icon="mdi-lock-outline"
          />
          <h5>workaround with v-text-field</h5>
          <v-text-field
            v-bind="fieldConfig"
            class="v-number-input--append-inner-slot"
            :model-value="120"
            readonly
            hide-details
            prepend-inner-icon="mdi-bitcoin"
            append-inner-icon="mdi-lock-outline"
          />
        </div>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { reactive } from 'vue';
  const fieldConfig = reactive({
    controlVariant: 'stacked',
    reverse: false,
  })
</script>

<style>
  input {
    outline: 1px dashed red;
    outline-offset: -4px;
  }
</style>
```