### PR TITLE
fix(VNumberInput): avoid showing NaN

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
@@ -98,7 +98,7 @@ describe('VNumberInput', () => {
             class="disabled-input-2"
             v-model={ value4.value }
             min={ 0 }
-  max={ 10 }
+            max={ 10 }
             disabled
           />
         </>
@@ -156,6 +156,99 @@ describe('VNumberInput', () => {
         .click()
         .get('.v-number-input input').should('have.value', '0')
         .then(() => expect(numberInputValue.value).to.equal(0))
+    })
+  })
+
+  describe('parsing pasted values', () => {
+    it('should parse valid numbers correctly', () => {
+      const scenarios = [
+        { text: '-0', expected: '0' },
+        { text: '-00123', expected: '-123' },
+        { text: '.250', expected: '0.25' },
+        { text: '000.321', expected: '0.321' },
+        { text: '100.000', expected: '100' },
+      ]
+      scenarios.forEach(({ text, expected }) => {
+        cy.mount(() => <VNumberInput />)
+        cy.window().its('navigator.clipboard').then((clip: Clipboard) => clip.writeText(text))
+        cy.get('.v-number-input input').focus()
+        cy.document().invoke('execCommand', 'paste')
+        cy.get('.v-number-input input').blur().should('have.value', expected)
+      })
+    })
+
+    it('should retrieve digits when pasted value contains some mixed characters', () => {
+      const scenarios = [
+        { text: ' 1,250.32\n', expected: '1250.32' },
+        { text: '1\'024.00 meters', expected: '1024' },
+        { text: '- 1123.', expected: '-1123' },
+      ]
+      scenarios.forEach(({ text, expected }) => {
+        cy.mount(() => <VNumberInput />)
+        cy.window().its('navigator.clipboard').then((clip: Clipboard) => clip.writeText(text))
+        cy.get('.v-number-input input').focus()
+        cy.document().invoke('execCommand', 'paste')
+        cy.get('.v-number-input input').blur().should('have.value', expected)
+      })
+    })
+
+    it('should use as much characters as possible to display value containing only received digits', () => {
+      const scenarios = [
+        { text: '0.000010', expected: '0.00001' },
+        { text: '0.012340', expected: '0.01234' },
+        { text: '099999990.000000010', expected: '99999990.00000001' },
+        { text: '99999999999999999999999999999', expected: '999999999999999' },
+        { text: '0.999999999999999999999999999', expected: '0.999999999999999' },
+        { text: '3.9999999999999995', expected: '3.999999999999999' },
+      ]
+      scenarios.forEach(({ text, expected }) => {
+        cy.mount(() => <VNumberInput />)
+        cy.window().its('navigator.clipboard').then((clip: Clipboard) => clip.writeText(text))
+        cy.get('.v-number-input input').focus()
+        cy.document().invoke('execCommand', 'paste')
+        cy.get('.v-number-input input').blur().should('have.value', expected)
+      })
+    })
+  })
+
+  describe('typing values', () => {
+    it('should ignore invalid and duplicated characters', () => {
+      const scenarios = [
+        { text: '+1\'234.12 meters', expected: '1234.12' },
+        { text: '-12 34 55', expected: '-123455' },
+        { text: '1,123..50', expected: '1123.5' },
+        { text: 'abc--', expected: '' },
+        { text: '00.123.40', expected: '0.1234' },
+      ]
+      scenarios.forEach(({ text, expected }) => {
+        cy.mount(() => <VNumberInput />)
+        cy.get('.v-number-input input').focus().realType(text)
+        cy.get('.v-number-input input').blur().should('have.value', expected)
+      })
+    })
+
+    it('should enforce range by replacing text typed by user', () => {
+      const scenarios = [
+        { text: '9999', expected: '50' },
+        { text: '-99', expected: '-25' },
+      ]
+      scenarios.forEach(({ text, expected }) => {
+        cy.mount(() => <VNumberInput min={ -25 } max={ 50 } />)
+        cy.get('.v-number-input input').focus().realType(text)
+        cy.get('.v-number-input input').blur().should('have.value', expected)
+      })
+    })
+
+    it('should not interrupt typing float numbers', () => {
+      const scenarios = [
+        { text: '0.12{backspace}{backspace}89', expected: '0.89' },
+        { text: '-.{backspace}25.{backspace}0.50{backspace}{backspace}99', expected: '-250.99' },
+      ]
+      scenarios.forEach(({ text, expected }) => {
+        cy.mount(() => <VNumberInput />)
+        cy.get('.v-number-input input').focus().realType(text)
+        cy.get('.v-number-input input').blur().should('have.value', expected)
+      })
     })
   })
 })


### PR DESCRIPTION
## Description
In order to avoid `NaN` we need to decouple "text" model for VTextField and the "exposed" model representing value for VNumberInput's consumer. I don't see it any other way and this approach served me many years in my custom wrapper arount VTextField back in Vuetify 2, so I am pretty sure it's the only way forward.

Each time we sync between these two
- "text" model becomes valid number or an empty string – thanks to `typeof model.value === 'number' && !isNaN(...)`
- "exposed" model becomes valid number – thanks to custom aggressive parsing in `extractNumber(...)`

Note: there are many ways to break this implementation, so we will need a bunch of test cases as a safety net for future changes. I plan on introducing them in the following days.

fixes #19798

## Markup:
```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-card class="mx-auto pa-6 my-4" style="max-width: 1200px">
        <v-row>
          <v-col cols="4">
            <small class="d-block mb-2">(clearable)</small>
            <v-number-input v-model="emptyValue" clearable />
            <code>value: {{ emptyValue }}</code>
          </v-col>
          <v-col cols="4">
            <small class="d-block mb-2">(:step=".25")</small>
            <v-number-input v-model="value1" :step=".25" />
            <code>value: {{ value1 }}</code>
          </v-col>
          <v-col cols="4">
            <small class="d-block mb-2">(:max="20" :min="-20")</small>
            <v-number-input v-model="value2" :max="20" :min="-20" />
            <div class="d-flex align-center justify-space-between">
              <code>value: {{ value2 }}</code>
              <div class="text-right">
                <v-btn @click="value2 = 5.125">Set to 5.125</v-btn>
                <v-btn @click="value2 = NaN">Set to NaN</v-btn>
              </div>
            </div>
          </v-col>
        </v-row>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const emptyValue = ref<number>(null)
  const value1 = ref<number>(15)
  const value2 = ref<number>(-10.25)
</script>
```
