### PR TITLE
docs(VDataTable): fix wrong v-data-table-headers links

### DIFF
--- a/packages/api-generator/src/locale/en/VDataTable.json
+++ b/packages/api-generator/src/locale/en/VDataTable.json
@@ -14,7 +14,7 @@
     "fixedHeader": "Fixed header to top of table.",
     "groupBy": "Changes which item property should be used for grouping items. Currently only supports a single grouping in the format: `group` or `['group']`. When using an array, only the first element is considered. Can be used with `.sync` modifier.",
     "groupDesc": "Changes which direction grouping is done. Can be used with `.sync` modifier.",
-    "headerProps": "Pass props to the default header. See [`v-data-table-header` API](/api/v-data-table-header) for more information.",
+    "headerProps": "Pass props to the default header. See [`v-data-table-headers` API](/api/v-data-table-headers) for more information.",
     "headers": "An array of objects that each describe a header column. See the example below for a definition of all properties.",
     "headersLength": "Can be used in combination with `hide-default-header` to specify the number of columns in the table to allow expansion rows and loading bar to function properly.",
     "height": "Set an explicit height of table.",

--- a/packages/docs/src/pages/en/components/data-tables/basics.md
+++ b/packages/docs/src/pages/en/components/data-tables/basics.md
@@ -34,7 +34,8 @@ The standard data table presumes that the entire data set is available locally. 
 | Component | Description |
 | - | - |
 | [v-data-table](/api/v-data-table/) | Primary Component |
-| [v-data-table-footer](/api/v-data-table-footer/) | Functional Component used to display Data-table headers |
+| [v-data-table-headers](/api/v-data-table-headers/) | Functional Component used to display Data-table headers |
+| [v-data-table-footer](/api/v-data-table-footer/) | Functional Component used to display Data-table footers |
 | [v-checkbox-btn](/api/v-checkbox-btn/) | Reusable lightweight [v-checkbox](/components/checkboxes) |
 
 <ApiInline hide-links />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixed wrong`VDataTableHeaders` links in `VDataTable`-related docs .

1. `packages/docs/src/pages/en/components/data-tables/basics.md`
  -> fixed `v-data-table-headers`' description (wrongly subtitled as `v-data-table-footer`)
2. `packages/api-generator/src/locale/en/VDataTable.json`
  -> fixed `v-data-table-headers` link (wrongly noted as 'v-data-table-header' - the last 's' was omitted)