### PR TITLE
fix(VAppBar): fix inability to scroll to the bottom

### DIFF
--- a/packages/vuetify/src/components/VAppBar/__tests__/VAppBar.spec.cy.tsx
+++ b/packages/vuetify/src/components/VAppBar/__tests__/VAppBar.spec.cy.tsx
@@ -84,6 +84,28 @@ describe('VAppBar', () => {
         .get('.v-app-bar').should('not.be.visible')
     })
 
+    it('should hide correctly when scroll to the bottom', () => {
+      cy.mount(({ scrollBehavior }: any) => (
+        <VLayout>
+          <VAppBar scrollBehavior={ scrollBehavior } />
+
+          <VMain style="min-height: 300px">
+            {
+              Array.from({ length: 7 }, () => (
+                <div class="pa-16 ma-2 w-50 bg-green text-center">
+                  box
+                </div>
+              ))
+            }
+          </VMain>
+        </VLayout>
+      ))
+        .setProps({ scrollBehavior: 'hide' })
+        .get('.v-app-bar').should('be.visible')
+        .window().scrollTo('bottom')
+        .get('.v-app-bar').should('not.be.visible')
+    })
+
     it('collapses', () => {
       cy.mount(({ scrollBehavior }: any) => (
         <VLayout>

--- a/packages/vuetify/src/composables/scroll.ts
+++ b/packages/vuetify/src/composables/scroll.ts
@@ -44,6 +44,7 @@ export function useScroll (
 ) {
   const { canScroll } = args
   let previousScroll = 0
+  let previousScrollHeight = 0
   const target = ref<Element | Window | null>(null)
   const currentScroll = shallowRef(0)
   const savedScroll = shallowRef(0)
@@ -70,6 +71,12 @@ export function useScroll (
 
     previousScroll = currentScroll.value
     currentScroll.value = ('window' in targetEl) ? targetEl.pageYOffset : targetEl.scrollTop
+
+    const currentScrollHeight = targetEl instanceof Window ? document.documentElement.scrollHeight : targetEl.scrollHeight
+    if (previousScrollHeight !== currentScrollHeight) {
+      previousScrollHeight = currentScrollHeight
+      return
+    }
 
     isScrollingUp.value = currentScroll.value < previousScroll
     currentThreshold.value = Math.abs(currentScroll.value - scrollThreshold.value)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #19090 

After altering scrollHeight, determining scroll direction becomes invalid.
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-layout ref="app" class="rounded rounded-md">
    <v-app-bar color="grey-lighten-2" name="app-bar" scroll-behavior="hide" />
    <v-navigation-drawer
      color="grey-darken-2"
      name="drawer"
      expand-on-hover
      permanent
      rail
    />

    <v-main
      class="d-flex flex-column align-center justify-center"
      style="min-height: 300px"
    >
      <div v-for="n in 17" :key="n" class="pa-16 ma-2 w-50 bg-green text-center">
        box {{ n }}
      </div>
    </v-main>

    <v-footer class="justify-center" color="grey" name="footer" app>
      FOOTER
    </v-footer>
  </v-layout>
</template>
```
