### PR TITLE
feat(VAutocomplete): new prop disableSelectOnBackspace

### DIFF
--- a/packages/api-generator/src/locale/en/VAutocomplete.json
+++ b/packages/api-generator/src/locale/en/VAutocomplete.json
@@ -5,7 +5,8 @@
     "itemChildren": "This property currently has **no effect**.",
     "filter": "The filtering algorithm used when searching. [example](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VAutocomplete/VAutocomplete.ts#L40).",
     "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props.",
-    "noFilter": "Do not apply filtering when searching. Useful when data is being filtered server side."
+    "noFilter": "Do not apply filtering when searching. Useful when data is being filtered server side.",
+    "disableSelectOnBackspace": "Do not select last item when backspace key is pressed and search is empty."
   },
   "slots": {
     "item": "Define a custom item appearance. The root element of this slot must be a **v-list-item** with `v-bind=\"props\"` applied. `props` includes everything required for the default select list behaviour - including title, value, click handlers, virtual scrolling, and anything else that has been added with `item-props`."

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -79,6 +79,7 @@ export const makeVAutocompleteProps = propsFactory({
   },
   clearOnSelect: Boolean,
   search: String,
+  disableSelectOnBackspace: Boolean,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps(),
@@ -259,7 +260,7 @@ export const VAutocomplete = genericComponent<new <
           select(model.value[selectionIndex.value], false)
 
           selectionIndex.value = originalSelectionIndex >= length - 1 ? (length - 2) : originalSelectionIndex
-        } else if (e.key === 'Backspace' && !search.value) {
+        } else if (e.key === 'Backspace' && !search.value && !props.disableSelectOnBackspace) {
           selectionIndex.value = length - 1
         }
       }


### PR DESCRIPTION
## Description
In some cases hitting Backspace that will remove selected items from VAutocomplete is unwanted. New prop `disable-select-on-backspace` will prevent to blur from search field and activate the latest selected item from selected listm and additional hitting of Backspace that will remove data. This will prevent for unwanted removing.

resolves #19926

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model="model"
        label="Autocomplete"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        chips
        closable-chips
        hide-selected
        multiple
        disable-select-on-backspace
      ></v-autocomplete>
    </v-container>
  </v-app>
</template>

<script>
import { ref } from 'vue'
export default {
  name: 'Playground',
  setup () {
    const model = ref(['California', 'Colorado'])

    return {
      model,
    }
  },
}
</script>
```