### PR TITLE
fix(Docs): Quick remedy to contrast issues for dark themes

### DIFF
--- a/packages/docs/src/components/api/ApiTable.vue
+++ b/packages/docs/src/components/api/ApiTable.vue
@@ -22,7 +22,7 @@
             name="row"
             v-bind="{
               props: {
-                class: 'bg-surface-bright'
+                style: 'background: rgba(0,0,0,.1)'
               },
               item,
             }"


### PR DESCRIPTION
## Description

When I open docs in Dark theme (which can be the default System theme) contrast of "name", "type" and "default" varies between `1` and `2.9` making crucial elements of component API table almost unreadable. It get's worse on other dark themes especially the one named "High Contrast" where gold text on nearly white background gets contrast score of `1.12`.

I wish I could add a `bg-opacity-10` like in TailwindCSS, but we don't have such capabilities in Vuetify. This `rgba(0,0,0,.1)` is my current override (pasted to Amino browser extension), but it sucks that other developers need to experience this.. hence this quick PR.

Note: Maybe [themes](https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/plugins/vuetify.ts#L121) should be adjusted to have better `surface-bright` color, but I don't know the overall impact of it and there are only 3 out of 7 themes available for docs, so... well... I'm confused a bit on how it works.

### Before

![image](https://github.com/J-Sek/vuetify/assets/20162853/00aa8e87-092b-4f49-8db4-d6ac43d121fc)

![image](https://github.com/J-Sek/vuetify/assets/20162853/f2a78c76-e3a6-44f2-a8f9-9a9683f78f22)

![image](https://github.com/J-Sek/vuetify/assets/20162853/bb666d6c-57dc-45d3-8c5b-661d559a66bd)

![image](https://github.com/J-Sek/vuetify/assets/20162853/335b62e9-9819-4083-aa06-894b6635489d)

### After

![image](https://github.com/J-Sek/vuetify/assets/20162853/c4e91b5f-6fe7-4f6c-a02b-6c2049a956b5)

![image](https://github.com/J-Sek/vuetify/assets/20162853/bfe7246c-6f39-4542-847f-1dac22d65179)

![image](https://github.com/J-Sek/vuetify/assets/20162853/f826f5a7-3f3d-495d-81aa-b62e23a4f2e0)

![image](https://github.com/J-Sek/vuetify/assets/20162853/04486a8d-90b6-425f-bfde-b49ec9aa4184)