### PR TITLE
fix(VOverlay): App mounted in shadow dom

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -140,7 +140,6 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         if (!(v && props.disabled)) model.value = v
       },
     })
-    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained))
     const { themeClasses } = provideTheme(props)
     const { rtlClasses, isRtl } = useRtl()
     const { hasContent, onAfterLeave: _onAfterLeave } = useLazy(props, isActive)
@@ -155,6 +154,8 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       contentEvents,
       scrimEvents,
     } = useActivator(props, { isActive, isTop: localTop })
+    const potentialShadowDomRoot = (activatorEl?.value as Element)?.getRootNode() as Element;
+    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained || potentialShadowDomRoot instanceof ShadowRoot ? potentialShadowDomRoot : false))
     const { dimensionStyles } = useDimension(props)
     const isMounted = useHydration()
     const { scopeId } = useScopeId()

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -154,8 +154,9 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       contentEvents,
       scrimEvents,
     } = useActivator(props, { isActive, isTop: localTop })
-    const potentialShadowDomRoot = computed( () => (activatorEl?.value as Element)?.getRootNode() as Element);
-    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained || potentialShadowDomRoot.value instanceof ShadowRoot ? potentialShadowDomRoot.value : false))
+    const potentialShadowDomRoot = computed( () => (activatorEl?.value as Element)?.getRootNode() as Element)
+    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained 
+      || potentialShadowDomRoot.value instanceof ShadowRoot ? potentialShadowDomRoot.value : false))
     const { dimensionStyles } = useDimension(props)
     const isMounted = useHydration()
     const { scopeId } = useScopeId()

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -154,8 +154,8 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       contentEvents,
       scrimEvents,
     } = useActivator(props, { isActive, isTop: localTop })
-    const potentialShadowDomRoot = (activatorEl?.value as Element)?.getRootNode() as Element;
-    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained || potentialShadowDomRoot instanceof ShadowRoot ? potentialShadowDomRoot : false))
+    const potentialShadowDomRoot = computed( () => (activatorEl?.value as Element)?.getRootNode() as Element);
+    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained || potentialShadowDomRoot.value instanceof ShadowRoot ? potentialShadowDomRoot.value : false))
     const { dimensionStyles } = useDimension(props)
     const isMounted = useHydration()
     const { scopeId } = useScopeId()

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -154,9 +154,9 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       contentEvents,
       scrimEvents,
     } = useActivator(props, { isActive, isTop: localTop })
-    const potentialShadowDomRoot = computed( () => (activatorEl?.value as Element)?.getRootNode() as Element)
-    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained 
-      || potentialShadowDomRoot.value instanceof ShadowRoot ? potentialShadowDomRoot.value : false))
+    const potentialShadowDomRoot = computed(() => (activatorEl?.value as Element)?.getRootNode() as Element)
+    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained ||
+      potentialShadowDomRoot.value instanceof ShadowRoot ? potentialShadowDomRoot.value : false))
     const { dimensionStyles } = useDimension(props)
     const isMounted = useHydration()
     const { scopeId } = useScopeId()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
This checks if the target of VOverlay is an shadow dom element and attaches it to that one. This fixes issues when mounting app on shadow dom. This fixes #19943

## Markup:
Playground is not provided because this is setup in a different way, it can be examined by the repro here:
https://github.com/joelmandell/shadow_dom

Without applying this PR, v-overlay-container will be attached outside the shadow dom and not working correctly.