### PR TITLE
feat(VDateInput): parse text field value in locale aware way

### DIFF
--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -266,6 +266,65 @@ function getWeekdays (locale: string) {
   })
 }
 
+export function getDateTimeFormatOptions (
+  formatString: string,
+): Intl.DateTimeFormatOptions | null {
+  switch (formatString) {
+    case 'fullDate':
+      return { year: 'numeric', month: 'long', day: 'numeric' }
+    case 'fullDateWithWeekday':
+      return { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+    case 'normalDateWithWeekday':
+      return { weekday: 'short', day: 'numeric', month: 'short' }
+    case 'shortDate':
+      return { month: 'short', day: 'numeric' }
+    case 'year':
+      return { year: 'numeric' }
+    case 'month':
+      return { month: 'long' }
+    case 'monthShort':
+      return { month: 'short' }
+    case 'monthAndYear':
+      return { month: 'long', year: 'numeric' }
+    case 'monthAndDate':
+      return { month: 'long', day: 'numeric' }
+    case 'weekday':
+      return { weekday: 'long' }
+    case 'weekdayShort':
+      return { weekday: 'short' }
+    case 'hours12h':
+      return { hour: 'numeric', hour12: true }
+    case 'hours24h':
+      return { hour: 'numeric', hour12: false }
+    case 'minutes':
+      return { minute: 'numeric' }
+    case 'seconds':
+      return { second: 'numeric' }
+    case 'fullTime':
+      return { hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
+    case 'fullTime12h':
+      return { hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
+    case 'fullTime24h':
+      return { hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
+    case 'fullDateTime':
+      return { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
+    case 'fullDateTime12h':
+      return { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
+    case 'fullDateTime24h':
+      return { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
+    case 'keyboardDate':
+      return { year: 'numeric', month: '2-digit', day: '2-digit' }
+    case 'keyboardDateTime':
+      return { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
+    case 'keyboardDateTime12h':
+      return { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
+    case 'keyboardDateTime24h':
+      return { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
+  }
+
+  return null
+}
+
 function format (
   value: Date,
   formatString: string,
@@ -279,93 +338,17 @@ function format (
     return customFormat(newDate, formatString, locale)
   }
 
-  let options: Intl.DateTimeFormatOptions = {}
-  switch (formatString) {
-    case 'fullDate':
-      options = { year: 'numeric', month: 'long', day: 'numeric' }
-      break
-    case 'fullDateWithWeekday':
-      options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
-      break
-    case 'normalDate':
-      const day = newDate.getDate()
-      const month = new Intl.DateTimeFormat(locale, { month: 'long' }).format(newDate)
-      return `${day} ${month}`
-    case 'normalDateWithWeekday':
-      options = { weekday: 'short', day: 'numeric', month: 'short' }
-      break
-    case 'shortDate':
-      options = { month: 'short', day: 'numeric' }
-      break
-    case 'year':
-      options = { year: 'numeric' }
-      break
-    case 'month':
-      options = { month: 'long' }
-      break
-    case 'monthShort':
-      options = { month: 'short' }
-      break
-    case 'monthAndYear':
-      options = { month: 'long', year: 'numeric' }
-      break
-    case 'monthAndDate':
-      options = { month: 'long', day: 'numeric' }
-      break
-    case 'weekday':
-      options = { weekday: 'long' }
-      break
-    case 'weekdayShort':
-      options = { weekday: 'short' }
-      break
-    case 'dayOfMonth':
-      return new Intl.NumberFormat(locale).format(newDate.getDate())
-    case 'hours12h':
-      options = { hour: 'numeric', hour12: true }
-      break
-    case 'hours24h':
-      options = { hour: 'numeric', hour12: false }
-      break
-    case 'minutes':
-      options = { minute: 'numeric' }
-      break
-    case 'seconds':
-      options = { second: 'numeric' }
-      break
-    case 'fullTime':
-      options = { hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
-      break
-    case 'fullTime12h':
-      options = { hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
-      break
-    case 'fullTime24h':
-      options = { hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
-      break
-    case 'fullDateTime':
-      options = { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
-      break
-    case 'fullDateTime12h':
-      options = { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
-      break
-    case 'fullDateTime24h':
-      options = { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
-      break
-    case 'keyboardDate':
-      options = { year: 'numeric', month: '2-digit', day: '2-digit' }
-      break
-    case 'keyboardDateTime':
-      options = { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
-      break
-    case 'keyboardDateTime12h':
-      options = { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: true }
-      break
-    case 'keyboardDateTime24h':
-      options = { year: 'numeric', month: '2-digit', day: '2-digit', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false }
-      break
-    default:
-      options = customFormat ?? { timeZone: 'UTC', timeZoneName: 'short' }
+  if (formatString === 'normalDate') {
+    const day = newDate.getDate()
+    const month = new Intl.DateTimeFormat(locale, { month: 'long' }).format(newDate)
+    return `${day} ${month}`
   }
 
+  if (formatString === 'dayOfMonth') {
+    return new Intl.NumberFormat(locale).format(newDate.getDate())
+  }
+
+  const options: Intl.DateTimeFormatOptions = getDateTimeFormatOptions(formatString) ?? { timeZone: 'UTC', timeZoneName: 'short' }
   return new Intl.DateTimeFormat(locale, options).format(newDate)
 }
 


### PR DESCRIPTION
resolves #19803
resolved #19951

## Description

Changes to the v-date-input:
* new behavior - when text-field blur event occur, the string value is parsed back into the date object (or array of dates) - previously that was not done, which resulted in situations, where somebody typed invalid date string value into the text-field, but after unfocusing the invalid string value stayed in the text-field, but the internal model value still contains the previous date
* blur/enter events on text-field - the string value in text-field is parsed into the Date object in the locale aware way, which resolves issue #19803
* when `multiple = range`, then blur/enter now correctly handles parsing, which resolves #19951
* when `multiple = true`, then blur/enter do nothing; and the `v-text-field` is automatically set into a readonly mode
  * this is because, the displayed value in the text field is in form `{x} selected`, so it makes no sense to parse that value at all into a date; this way nothing can be typed into the text field, but the end user can still select dates in  the picker  

The `dateFromLocalizedValue` function was implemented that can be reused in other places if needed. It was not implemented in the adapter, as it will break the `date-io` interface, so it is just an internal implementation.

Currently, that function is only supporting parsing the string value from the `keyboardDate` format, but if needed, it can be extended for other use cases (e.g., for future VTimeInput to support similar use case as in VDateInput)

## Markup:

```vue
<template>
  <v-app>
    <v-locale-provider :locale="locales[currentLocaleIdx]">
      <v-container>
        <v-row>
          <v-col cols="12">
            <v-btn @click="toggleLocale">Toggle locale</v-btn>
            <span class="ml-3">Locale: {{ locales[currentLocaleIdx] }}</span>
          </v-col>
        </v-row>
        <v-row>
          <v-col cols="12">
            <v-date-input v-model="date" label="date input" />
          </v-col>
        </v-row>
        <v-row>
          <v-col cols="12">
            <v-date-input v-model="range" label="date range input" multiple="range" />
          </v-col>
        </v-row>
        <v-row>
          <v-col cols="12">
            <v-date-input v-model="multi" label="multiple dates input" multiple />
          </v-col>
        </v-row>
        <v-row>
          <v-col cols="12">
            <v-date-input v-model="date" label="single date input / readonly" readonly />
          </v-col>
        </v-row>
      </v-container>
    </v-locale-provider>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const date = ref(new Date())

  const range = ref([new Date(), new Date()])
  range.value[0].setDate(range.value[0].getDate() - 1)

  const multi = ref([new Date(), new Date(), new Date()])
  multi.value[0].setDate(multi.value[0].getDate() - 2)
  multi.value[1].setDate(multi.value[1].getDate() - 1)

  const locales = ['en', 'pl', 'sv']
  const currentLocaleIdx = ref(0)

  function toggleLocale () {
    let newIdx = currentLocaleIdx.value + 1
    if (newIdx >= locales.length) newIdx = 0

    currentLocaleIdx.value = newIdx
  }
</script>
```
