### PR TITLE
docs(VTimePicker): fix example using display information

### DIFF
--- a/packages/docs/src/examples/v-time-picker/prop-ampm-in-title.vue
+++ b/packages/docs/src/examples/v-time-picker/prop-ampm-in-title.vue
@@ -10,7 +10,7 @@
     ></v-time-picker>
     <v-time-picker
       v-model="picker"
-      :landscape="$vuetify.breakpoint.smAndUp"
+      :landscape="$vuetify.display.smAndUp"
       ampm-in-title
     ></v-time-picker>
   </v-row>

--- a/packages/docs/src/examples/v-time-picker/prop-disabled.vue
+++ b/packages/docs/src/examples/v-time-picker/prop-disabled.vue
@@ -9,7 +9,7 @@
     ></v-time-picker>
     <v-time-picker
       v-model="picker"
-      :landscape="$vuetify.breakpoint.smAndUp"
+      :landscape="$vuetify.display.smAndUp"
       disabled
     ></v-time-picker>
   </v-row>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
1. Go to https://vuetifyjs.com/en/components/time-pickers/#disabled
2. The example isn't shown up
=> The reason is the example code using `$vuetify.breakpoint` which is deprecated: https://vuetifyjs.com/en/getting-started/upgrade-guide/#layout

*Note: Although after this fixed, the example is shown up, but `disabled` props doesn't work correctly. It might need to fix in another PR
