### PR TITLE
fix(VNumberInput): attributes fall through to root

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -303,6 +303,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             props.class,
           ]}
           { ...textFieldProps }
+          { ...attrs }
           style={ props.style }
           inputmode="decimal"
         >

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -56,8 +56,6 @@ const makeVNumberInputProps = propsFactory({
 export const VNumberInput = genericComponent<VNumberInputSlots>()({
   name: 'VNumberInput',
 
-  inheritAttrs: false,
-
   props: {
     ...makeVNumberInputProps(),
   },
@@ -303,7 +301,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             props.class,
           ]}
           { ...textFieldProps }
-          { ...attrs }
           style={ props.style }
           inputmode="decimal"
         >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

fix https://github.com/vuetifyjs/vuetify/issues/19953

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

I fixed it because attr was not used.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
  <v-app>
    <v-container>
      <v-text-field
        aria-autocomplete="none"
        autocomplete="off"
        label="Label"
        aru
      ></v-text-field>
      <v-number-input
        :hideInput="false"
        :inset="false"
        :reverse="false"
        aria-autocomplete="none"
        autocomplete="off"
        controlVariant="default"
        label=""
      ></v-number-input>
    </v-container>
  </v-app>
```
