### PR TITLE
fix(VTreeview): prevent redundant treeview re-render during open

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -97,6 +97,7 @@ export const makeVListProps = propsFactory({
 
   'onClick:open': EventProp<[{ id: unknown, value: boolean, path: unknown[] }]>(),
   'onClick:select': EventProp<[{ id: unknown, value: boolean, path: unknown[] }]>(),
+  'onUpdate:opened': EventProp<[]>(),
   ...makeNestedProps({
     selectStrategy: 'single-leaf' as const,
     openStrategy: 'list' as const,

--- a/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
@@ -12,6 +12,7 @@ import { computed, provide, ref, toRef, watch } from 'vue'
 import { genericComponent, getCurrentInstance, omit, propsFactory, useRender } from '@/util'
 
 // Types
+import type { ExtractPublicPropTypes } from 'vue'
 import { VTreeviewSymbol } from './shared'
 import type { VListChildrenSlots } from '@/components/VList/VListChildren'
 import type { ListItem } from '@/composables/list-items'
@@ -147,7 +148,7 @@ export const VTreeview = genericComponent<new <T>(
     })
 
     useRender(() => {
-      const listProps = VList.filterProps(vm.vnode.props!)
+      const listProps = VList.filterProps(vm.vnode.props! as ExtractPublicPropTypes<typeof makeVTreeviewProps>)
 
       const treeviewChildrenProps = VTreeviewChildren.filterProps(props)
 

--- a/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
@@ -146,7 +146,14 @@ export const VTreeview = genericComponent<new <T>(
     })
 
     useRender(() => {
-      const listProps = VList.filterProps(props)
+      const { opened: _, ...listPropsRaw } = VList.filterProps(props)
+      const listProps = props.opened == null
+        ? listPropsRaw
+        : {
+          ...listPropsRaw,
+          opened: props.opened,
+        }
+
       const treeviewChildrenProps = VTreeviewChildren.filterProps(props)
 
       return (
@@ -158,7 +165,6 @@ export const VTreeview = genericComponent<new <T>(
             props.class,
           ]}
           style={ props.style }
-          v-model:opened={ opened.value }
           v-model:activated={ activated.value }
           v-model:selected={ selected.value }
         >

--- a/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
@@ -9,7 +9,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, provide, ref, toRef, watch } from 'vue'
-import { genericComponent, omit, propsFactory, useRender } from '@/util'
+import { genericComponent, getCurrentInstance, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import { VTreeviewSymbol } from './shared'
@@ -59,6 +59,7 @@ export const VTreeview = genericComponent<new <T>(
   },
 
   setup (props, { slots }) {
+    const vm = getCurrentInstance('VTreeview')
     const { items } = useListItems(props)
     const activeColor = toRef(props, 'activeColor')
     const baseColor = toRef(props, 'baseColor')
@@ -146,13 +147,7 @@ export const VTreeview = genericComponent<new <T>(
     })
 
     useRender(() => {
-      const { opened: _, ...listPropsRaw } = VList.filterProps(props)
-      const listProps = props.opened == null
-        ? listPropsRaw
-        : {
-          ...listPropsRaw,
-          opened: props.opened,
-        }
+      const listProps = VList.filterProps(vm.vnode.props!)
 
       const treeviewChildrenProps = VTreeviewChildren.filterProps(props)
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

fixes #19919

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

- Open action **SHOULD NOT** trigger any re-rendering
- VTreeview has redundant re-rendering from `v-model:opened` change
- This fix should prevent some of redundant renderings and enhance performance noticeably
- After this PR, the remaining redundant rendering should be resolved in the upstream library babel-plugin-jsx

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-treeview 
    :items="items"
    @update:opened="openedUpdate"
    ></v-treeview>
</template>

<script>
  export default {
    computed: {
      items: () => {
        const GetChildren = id => {
          const nodes = []
          for (let i = 0; i < 100; i++) {
            nodes.push({
              id: `${id}-${i}`,
              title: `Example child item ${i}`,
            })
          }
          return nodes
        }
        const nodes = []
        for (let i = 0; i < 100; i++) {
          nodes.push({
            id: i,
            title: `Example item ${i}`,
            children: GetChildren(i),
          })
        }
        return nodes
      },
    },
    methods: {
openedUpdate: function(e) {
  console.log('openedUpdate', e)
}
    },
    data: () => ({}),
  }
</script>

```
