### PR TITLE
fix(VDatePicker): select same date as start/end in date range picker

### DIFF
--- a/packages/api-generator/src/locale/en/VDatePickerMonth.json
+++ b/packages/api-generator/src/locale/en/VDatePickerMonth.json
@@ -2,6 +2,7 @@
   "props": {
     "hideWeekdays": "Hide the days of the week letters.",
     "transition": "The transition used when changing months into the future",
-    "reverseTransition": "The transition used when changing months into the past"
+    "reverseTransition": "The transition used when changing months into the past",
+    "allowOneDayRange": "Allow selecting the same day as start and end of the range"
   }
 }

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -40,6 +40,10 @@ export const makeVDatePickerMonthProps = propsFactory({
     type: String,
     default: 'picker-reverse-transition',
   },
+  allowOneDayRange: {
+    type: Boolean,
+    default: false,
+  },
 
   ...makeCalendarProps(),
 }, 'VDatePickerMonth')
@@ -98,7 +102,17 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
         rangeStart.value = _value
         model.value = [rangeStart.value]
       } else if (!rangeStop.value) {
-        if (adapter.isBefore(_value, rangeStart.value)) {
+        if (adapter.isSameDay(_value, rangeStart.value)) {
+          if (props.allowOneDayRange) {
+            rangeStop.value = adapter.endOfDay(_value)
+            model.value = [rangeStart.value]
+            return
+          } else {
+            rangeStart.value = undefined
+            model.value = []
+            return
+          }
+        } else if (adapter.isBefore(_value, rangeStart.value)) {
           rangeStop.value = adapter.endOfDay(rangeStart.value)
           rangeStart.value = _value
         } else {

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -98,11 +98,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
         rangeStart.value = _value
         model.value = [rangeStart.value]
       } else if (!rangeStop.value) {
-        if (adapter.isSameDay(_value, rangeStart.value)) {
-          rangeStart.value = undefined
-          model.value = []
-          return
-        } else if (adapter.isBefore(_value, rangeStart.value)) {
+        if (adapter.isBefore(_value, rangeStart.value)) {
           rangeStop.value = adapter.endOfDay(rangeStart.value)
           rangeStart.value = _value
         } else {

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
@@ -22,6 +22,22 @@ describe('VDatePicker', () => {
       })
   })
 
+  it('selects the same day as a range', () => {
+    const model = ref<unknown[]>([])
+    cy.mount(() => (
+      <Application>
+        <VDatePicker v-model={ model.value } multiple="range" />
+      </Application>
+    ))
+
+    cy.get('.v-date-picker-month__day').contains(10).click()
+    cy.get('.v-date-picker-month__day').contains(10).click()
+      .then(() => {
+        expect(model.value).to.have.length(2)
+        expect(model.value[0]).to.equal(model.value[1])
+      })
+  })
+
   it('selects a range of dates across month boundary', () => {
     const model = ref<unknown[]>([])
     cy.mount(() => (

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
@@ -22,18 +22,18 @@ describe('VDatePicker', () => {
       })
   })
 
-  it('selects the same day as a range', () => {
+  it('selects the same day as start and end of the range when allowOneDayRange is enabled', () => {
     const model = ref<unknown[]>([])
     cy.mount(() => (
       <Application>
-        <VDatePicker v-model={ model.value } multiple="range" />
+        <VDatePicker v-model={ model.value } multiple="range" allow-one-day-range />
       </Application>
     ))
 
     cy.get('.v-date-picker-month__day').contains(10).click()
     cy.get('.v-date-picker-month__day').contains(10).click()
       .then(() => {
-        expect(model.value).to.have.length(2)
+        expect(model.value).to.have.length(1)
       })
   })
 

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.cy.tsx
@@ -34,7 +34,6 @@ describe('VDatePicker', () => {
     cy.get('.v-date-picker-month__day').contains(10).click()
       .then(() => {
         expect(model.value).to.have.length(2)
-        expect(model.value[0]).to.equal(model.value[1])
       })
   })
 


### PR DESCRIPTION
fixes 19989

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #19989

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker v-model="dates" multiple="range" />
      Selected dates: {{ dates }}
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const dates = ref([new Date('2024-06-11'), new Date('2024-06-11')])
</script>

```
