### PR TITLE
docs(v-toolbar): fix example with image prop

### DIFF
--- a/packages/docs/src/examples/v-toolbar/prop-floating-with-search.vue
+++ b/packages/docs/src/examples/v-toolbar/prop-floating-with-search.vue
@@ -2,7 +2,7 @@
   <v-card
     class="pa-4"
     height="300px"
-    img="https://cdn.vuetifyjs.com/images/toolbar/map.jpg"
+    image="https://cdn.vuetifyjs.com/images/toolbar/map.jpg"
     flat
   >
     <v-toolbar


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This just uses the normal 'image' prop, instead of 'img', that doesn't work in Vuetify 3

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
