### PR TITLE
fix(VRadio): remove duplicate classes, styles

### DIFF
--- a/packages/vuetify/src/components/VRadio/VRadio.tsx
+++ b/packages/vuetify/src/components/VRadio/VRadio.tsx
@@ -25,9 +25,7 @@ export const VRadio = genericComponent<VSelectionControlSlots>()({
         { ...props }
         class={[
           'v-radio',
-          props.class,
         ]}
-        style={ props.style }
         type="radio"
         v-slots={ slots }
       />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20005 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-radio :class="['first', 'radio']" :style="{backgroundColor: 'red'}" :value="1" label="First" />
      <v-radio :class="['second', 'radio']" :value="2" label="Second" />
      <v-radio :value="3" class="third" label="Third" />
    </v-container>
  </v-app>
</template>
```
