### PR TITLE
fix(VTimePicker): it won't trigger update Value when user only update hour 

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
@@ -264,7 +264,6 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
           break
       }
 
-      const emitChange = selecting.value === (props.useSeconds ? SelectingTimes.Second : SelectingTimes.Minute)
 
       if (selecting.value === SelectingTimes.Hour) {
         selecting.value = SelectingTimes.Minute
@@ -284,7 +283,7 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
       lazyInputMinute.value = inputMinute.value
       props.useSeconds && (lazyInputSecond.value = inputSecond.value)
 
-      emitChange && emitValue()
+      emitValue()
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
@@ -264,7 +264,6 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
           break
       }
 
-
       if (selecting.value === SelectingTimes.Hour) {
         selecting.value = SelectingTimes.Minute
       } else if (props.useSeconds && selecting.value === SelectingTimes.Minute) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
There's an obvious bug in Labs/VTimePicker. When the user first selects the hour and minute, it works fine.
However, when the user changes the hour and keeps the minute the same, it does not emit the `update:modelValue` function.
It only emits `update:hour`.

For example, if you first select "11:50 am" and then try to change it to "12:50 am", you will see that the `v-model` doesn't change to 12. Because the `update:modelValue` does not emit.

I remove the `emitChange` part.  Because it is for "update after user change the second". But at that moment, the following `lazyInputHour` would already changed. 
