### PR TITLE
fix(VDatePicker): avoid updating month and year when model array is e…

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -230,6 +230,7 @@ export const VDatePicker = genericComponent<new <
     }
 
     watch(model, (val, oldVal) => {
+      if (val.length === 0) return
       const before = adapter.date(wrapInArray(oldVal)[oldVal.length - 1])
       const after = adapter.date(wrapInArray(val)[val.length - 1])
       const newMonth = adapter.getMonth(after)


### PR DESCRIPTION

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #20015
Prevents this situation:

```vue
const after = adapter.date(undefined) 
```
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:

<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker
        v-model="arr"
        hide-header
        multiple
        elevation="2"
        min="2024-05-01"
        max="2024-05-31"
        next-icon=""
        prev-icon=""
        color="primary"
        :year="2024"
        :month="4"
      >
      </v-date-picker>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const arr = ref([])
</script>
```
