### PR TITLE
refactor(VTreeview): avoid re-render by opened & respect openAll

### DIFF
--- a/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
@@ -1,0 +1,172 @@
+/// <reference types="../../../../types/cypress" />
+
+// Components
+import { VTreeview } from '../VTreeview'
+
+// Utilities
+import { ref } from 'vue'
+
+describe('VTreeview', () => {
+  const items = ref([
+    {
+      id: 1,
+      title: 'Videos :',
+      children: [
+        {
+          id: 2,
+          title: 'Tutorials :',
+          children: [
+            { id: 3, title: 'Basic layouts : mp4' },
+            { id: 4, title: 'Advanced techniques : mp4' },
+            { id: 5, title: 'All about app : dir' },
+          ],
+        },
+        { id: 6, title: 'Intro : mov' },
+        { id: 7, title: 'Conference introduction : avi' },
+      ],
+    },
+  ])
+  describe('select', () => {
+    it('single-leaf strategy', () => {
+      const selected = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:selected={ selected.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            selectable
+            select-strategy="single-leaf"
+          />
+        </>
+      ))
+
+      cy.get('.v-checkbox-btn').should('have.length', 5)
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
+        .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .then(_ => {
+          expect(selected.value).to.deep.equal([4])
+        })
+        .get('.v-checkbox-btn').eq(3).click(20, 20)
+        .then(_ => {
+          expect(selected.value).to.deep.equal([6])
+        })
+    })
+    it('leaf strategy', () => {
+      const selected = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:selected={ selected.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            selectable
+            select-strategy="leaf"
+          />
+        </>
+      ))
+
+      cy.get('.v-checkbox-btn').should('have.length', 5)
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
+        .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([3, 4].sort())
+        })
+        .get('.v-checkbox-btn').eq(3).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([3, 4, 6].sort())
+        })
+    })
+    it('independent strategy', () => {
+      const selected = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:selected={ selected.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            selectable
+            select-strategy="independent"
+          />
+        </>
+      ))
+
+      cy.get('.v-checkbox-btn').should('have.length', 7)
+        .get('.v-checkbox-btn').eq(2).click(20, 20)
+        .get('.v-checkbox-btn').eq(3).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([3, 4].sort())
+        })
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
+        .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([1, 2, 3, 4].sort())
+        })
+    })
+    it('single-independent strategy', () => {
+      const selected = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:selected={ selected.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            selectable
+            select-strategy="single-independent"
+          />
+        </>
+      ))
+
+      cy.get('.v-checkbox-btn').should('have.length', 7)
+        .get('.v-checkbox-btn').eq(2).click(20, 20)
+        .get('.v-checkbox-btn').eq(3).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([4].sort())
+        })
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
+        .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([2].sort())
+        })
+    })
+    it('classic strategy', () => {
+      const selected = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:selected={ selected.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            selectable
+            select-strategy="classic"
+          />
+        </>
+      ))
+
+      cy.get('.v-checkbox-btn').eq(2).click(20, 20)
+        .get('.v-checkbox-btn').eq(3).click(20, 20)
+        .get('.v-checkbox-btn').eq(4).click(20, 20)
+        .then(_ => {
+          expect(selected.value).to.deep.equal([3, 4, 5])
+        })
+        .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .then(_ => {
+          expect(selected.value).to.deep.equal([])
+        })
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
+        .then(_ => {
+          expect(selected.value.sort()).to.deep.equal([3, 4, 5, 6, 7].sort())
+        })
+    })
+  })
+})

--- a/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
@@ -203,7 +203,7 @@ describe('VTreeview', () => {
           expect(selected.value.sort()).to.deep.equal([3, 4, 6].sort())
         })
     })
-    it('independent strategy', () => {
+    it.only('independent strategy', () => {
       const selected = ref([])
       cy.mount(() => (
         <>
@@ -225,8 +225,8 @@ describe('VTreeview', () => {
         .then(_ => {
           expect(selected.value.sort()).to.deep.equal([3, 4].sort())
         })
-        .get('.v-checkbox-btn').eq(0).click(20, 20)
         .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
         .then(_ => {
           expect(selected.value.sort()).to.deep.equal([1, 2, 3, 4].sort())
         })
@@ -253,10 +253,10 @@ describe('VTreeview', () => {
         .then(_ => {
           expect(selected.value.sort()).to.deep.equal([4].sort())
         })
-        .get('.v-checkbox-btn').eq(0).click(20, 20)
         .get('.v-checkbox-btn').eq(1).click(20, 20)
+        .get('.v-checkbox-btn').eq(0).click(20, 20)
         .then(_ => {
-          expect(selected.value.sort()).to.deep.equal([2].sort())
+          expect(selected.value.sort()).to.deep.equal([1].sort())
         })
     })
     it('classic strategy', () => {

--- a/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
@@ -291,4 +291,19 @@ describe('VTreeview', () => {
         })
     })
   })
+  it('should have all items visible when open-all is applied', () => {
+    cy.mount(() => (
+      <>
+        <VTreeview
+          open-all
+          items={ items.value }
+          item-title="title"
+          item-value="id"
+        />
+      </>
+    ))
+      .get('.v-treeview-item')
+      .filter(':visible')
+      .should('have.length', 7)
+  })
 })

--- a/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VTreeview/__tests__/VTreeview.spec.cy.tsx
@@ -26,6 +26,128 @@ describe('VTreeview', () => {
       ],
     },
   ])
+  describe('activate', () => {
+    it('single-leaf strategy', () => {
+      const activated = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:activated={ activated.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            activatable
+            active-strategy="single-leaf"
+          />
+        </>
+      ))
+
+      cy.get('.v-treeview-item').should('have.length', 7)
+        .get('.v-treeview-item').eq(0).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([])
+        })
+        .get('.v-treeview-item').eq(2).click()
+        .get('.v-treeview-item').eq(3).click()
+        .get('.v-treeview-item').eq(4).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([5])
+        })
+    })
+    it('leaf strategy', () => {
+      const activated = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:activated={ activated.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            activatable
+            active-strategy="leaf"
+          />
+        </>
+      ))
+
+      cy.get('.v-treeview-item').should('have.length', 7)
+        .get('.v-treeview-item').eq(0).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([])
+        })
+        .get('.v-treeview-item').eq(2).click()
+        .get('.v-treeview-item').eq(3).click()
+        .get('.v-treeview-item').eq(4).click()
+        .then(_ => {
+          expect(activated.value.sort()).to.deep.equal([3, 4, 5].sort())
+        })
+    })
+    it('independent strategy', () => {
+      const activated = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:activated={ activated.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            activatable
+            active-strategy="independent"
+          />
+        </>
+      ))
+
+      cy.get('.v-treeview-item').should('have.length', 7)
+        .get('.v-treeview-item').eq(0).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([1])
+        })
+        .get('.v-treeview-item').eq(1).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([1, 2])
+        })
+        .get('.v-treeview-item').eq(2).click()
+        .get('.v-treeview-item').eq(3).click()
+        .get('.v-treeview-item').eq(4).click()
+        .then(_ => {
+          expect(activated.value.sort()).to.deep.equal([1, 2, 3, 4, 5].sort())
+        })
+    })
+    it('single-independent strategy', () => {
+      const activated = ref([])
+      cy.mount(() => (
+        <>
+          <VTreeview
+            v-model:activated={ activated.value }
+            open-all
+            items={ items.value }
+            item-title="title"
+            item-value="id"
+            activatable
+            active-strategy="single-independent"
+          />
+        </>
+      ))
+
+      cy.get('.v-treeview-item').should('have.length', 7)
+        .get('.v-treeview-item').eq(0).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([1])
+        })
+        .get('.v-treeview-item').eq(1).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([2])
+        })
+        .get('.v-treeview-item').eq(2).click()
+        .get('.v-treeview-item').eq(3).click()
+        .get('.v-treeview-item').eq(4).click()
+        .then(_ => {
+          expect(activated.value).to.deep.equal([5])
+        })
+    })
+  })
   describe('select', () => {
     it('single-leaf strategy', () => {
       const selected = ref([])


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

Keep the fix for #19919
Add cy tests & fixes #20024
fixes #19997

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-treeview
    :items="items"
  />
</template>

<script>
  export default {
    computed: {
      items: () => {
        const GetChildren = id => {
          const nodes = []
          for (let i = 0; i < 100; i++) {
            nodes.push({
              id: `${id}-${i}`,
              title: `Example child item ${i}`,
            })
          }
          return nodes
        }
        const nodes = []
        for (let i = 0; i < 2; i++) {
          nodes.push({
            id: i,
            title: `Example item ${i}`,
            children: GetChildren(i),
          })
        }
        return nodes
      },
    },
    methods: {
openedUpdate: function(e) {
  this.opened = e;
  console.log('openedUpdate', e)
}
    },
    data: () => ({
      opened: [],
    }),
  }
</script>


```
