### PR TITLE
fix(VDataTable): support groupBy when sorting is disabled

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -21,7 +21,7 @@ import { provideDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 
 // Utilities
-import { computed, toRef } from 'vue'
+import { computed, toRef, toRefs } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -130,6 +130,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     const { groupBy } = createGroupBy(props)
     const { sortBy, multiSort, mustSort } = createSort(props)
     const { page, itemsPerPage } = createPagination(props)
+    const { disableSort } = toRefs(props)
 
     const {
       columns,
@@ -152,13 +153,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     })
 
     const { toggleSort } = provideSort({ sortBy, multiSort, mustSort, page })
-    const {
-      sortByWithGroups,
-      opened,
-      extractRows,
-      isGroupOpen,
-      toggleGroup,
-    } = provideGroupBy({ groupBy, sortBy, disableSort: toRef(props, 'disableSort') })
+    const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy, disableSort })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
       transform: item => item.columns,

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -152,7 +152,13 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     })
 
     const { toggleSort } = provideSort({ sortBy, multiSort, mustSort, page })
-    const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy })
+    const {
+      sortByWithGroups,
+      opened,
+      extractRows,
+      isGroupOpen,
+      toggleGroup,
+    } = provideGroupBy({ groupBy, sortBy, disableSort: toRef(props, 'disableSort') })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
       transform: item => item.columns,

--- a/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
@@ -18,7 +18,7 @@ import { createSort, provideSort } from './composables/sort'
 import { provideDefaults } from '@/composables/defaults'
 
 // Utilities
-import { computed, provide, toRef } from 'vue'
+import { computed, provide, toRef, toRefs } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -69,6 +69,7 @@ export const VDataTableServer = genericComponent<new <T extends readonly any[], 
     const { groupBy } = createGroupBy(props)
     const { sortBy, multiSort, mustSort } = createSort(props)
     const { page, itemsPerPage } = createPagination(props)
+    const { disableSort } = toRefs(props)
     const itemsLength = computed(() => parseInt(props.itemsLength, 10))
 
     const { columns, headers } = createHeaders(props, {
@@ -81,7 +82,7 @@ export const VDataTableServer = genericComponent<new <T extends readonly any[], 
 
     const { toggleSort } = provideSort({ sortBy, multiSort, mustSort, page })
 
-    const { opened, isGroupOpen, toggleGroup, extractRows } = provideGroupBy({ groupBy, sortBy, disableSort: toRef(props, 'disableSort') })
+    const { opened, isGroupOpen, toggleGroup, extractRows } = provideGroupBy({ groupBy, sortBy, disableSort })
 
     const { pageCount, setItemsPerPage } = providePagination({ page, itemsPerPage, itemsLength })
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
@@ -81,7 +81,7 @@ export const VDataTableServer = genericComponent<new <T extends readonly any[], 
 
     const { toggleSort } = provideSort({ sortBy, multiSort, mustSort, page })
 
-    const { opened, isGroupOpen, toggleGroup, extractRows } = provideGroupBy({ groupBy, sortBy })
+    const { opened, isGroupOpen, toggleGroup, extractRows } = provideGroupBy({ groupBy, sortBy, disableSort: toRef(props, 'disableSort') })
 
     const { pageCount, setItemsPerPage } = providePagination({ page, itemsPerPage, itemsLength })
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -19,7 +19,7 @@ import { makeFilterProps, useFilter } from '@/composables/filter'
 import { makeVirtualProps, useVirtual } from '@/composables/virtual'
 
 // Utilities
-import { computed, shallowRef, toRef } from 'vue'
+import { computed, shallowRef, toRef, toRefs } from 'vue'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -85,6 +85,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
   setup (props, { attrs, slots }) {
     const { groupBy } = createGroupBy(props)
     const { sortBy, multiSort, mustSort } = createSort(props)
+    const { disableSort } = toRefs(props)
 
     const {
       columns,
@@ -106,13 +107,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
     })
 
     const { toggleSort } = provideSort({ sortBy, multiSort, mustSort })
-    const {
-      sortByWithGroups,
-      opened,
-      extractRows,
-      isGroupOpen,
-      toggleGroup,
-    } = provideGroupBy({ groupBy, sortBy, disableSort: toRef(props, 'disableSort') })
+    const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy, disableSort })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
       transform: item => item.columns,

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -106,7 +106,13 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
     })
 
     const { toggleSort } = provideSort({ sortBy, multiSort, mustSort })
-    const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy })
+    const {
+      sortByWithGroups,
+      opened,
+      extractRows,
+      isGroupOpen,
+      toggleGroup,
+    } = provideGroupBy({ groupBy, sortBy, disableSort: toRef(props, 'disableSort') })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
       transform: item => item.columns,

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
@@ -7,9 +7,6 @@ import { Application } from '../../../../cypress/templates'
 // Utilities
 import { ref } from 'vue'
 
-// Types
-import type { SortItem } from '../composables/sort'
-
 const DESSERT_HEADERS = [
   { title: 'Dessert (100g serving)', key: 'name' },
   { title: 'Calories', key: 'calories' },
@@ -373,28 +370,17 @@ describe('VDataTable', () => {
 
   describe('sort', () => {
     it('should sort by sortBy', () => {
-      const sortBy = ref<SortItem[]>([])
       cy.mount(() => (
         <Application>
           <VDataTable
           items={ DESSERT_ITEMS }
           headers={ DESSERT_HEADERS }
           itemsPerPage={ 10 }
-          sortBy={ sortBy.value }
+          sortBy={[{ key: 'fat', order: 'asc' }]}
           />
         </Application>
-      )).get('thead .v-data-table__td').eq(2).should('not.have.class', 'v-data-table__th--sorted')
-        .get('tbody td:nth-child(3)').then(rows => {
-          const actualFat = Array.from(rows).map(row => {
-            return Number(row.textContent)
-          })
-          const expectedFat = DESSERT_ITEMS.map(d => d.fat)
-          expect(actualFat).to.deep.equal(expectedFat)
-        })
-        .then(() => {
-          sortBy.value = [{ key: 'fat', order: 'asc' }]
-        })
-        .get('thead .v-data-table__td').eq(2).should('have.class', 'v-data-table__th--sorted')
+      ))
+      cy.get('thead .v-data-table__td').eq(2).should('have.class', 'v-data-table__th--sorted')
         .get('tbody td:nth-child(3)').then(rows => {
           const actualFat = Array.from(rows).map(row => {
             return Number(row.textContent)
@@ -402,9 +388,7 @@ describe('VDataTable', () => {
           const expectedFat = DESSERT_ITEMS.map(d => d.fat).sort((a, b) => a - b)
           expect(actualFat).to.deep.equal(expectedFat)
         })
-        .then(() => {
-          sortBy.value = [{ key: 'fat', order: 'desc' }]
-        })
+      cy.get('thead .v-data-table__td').eq(2).click()
         .get('thead .v-data-table__td').eq(2).should('have.class', 'v-data-table__th--sorted')
         .get('tbody td:nth-child(3)').then(rows => {
           const actualFat = Array.from(rows).map(row => {

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
@@ -7,6 +7,9 @@ import { Application } from '../../../../cypress/templates'
 // Utilities
 import { ref } from 'vue'
 
+// Types
+import type { SortItem } from '../composables/sort'
+
 const DESSERT_HEADERS = [
   { title: 'Dessert (100g serving)', key: 'name' },
   { title: 'Calories', key: 'calories' },
@@ -14,6 +17,7 @@ const DESSERT_HEADERS = [
   { title: 'Carbs (g)', key: 'carbs' },
   { title: 'Protein (g)', key: 'protein' },
   { title: 'Iron (%)', key: 'iron' },
+  { title: 'Group', key: 'group' },
 ]
 
 const DESSERT_ITEMS = [
@@ -24,6 +28,7 @@ const DESSERT_ITEMS = [
     carbs: 24,
     protein: 4.0,
     iron: '1%',
+    group: 1,
   },
   {
     name: 'Ice cream sandwich',
@@ -32,6 +37,7 @@ const DESSERT_ITEMS = [
     carbs: 37,
     protein: 4.3,
     iron: '1%',
+    group: 3,
   },
   {
     name: 'Eclair',
@@ -40,6 +46,7 @@ const DESSERT_ITEMS = [
     carbs: 23,
     protein: 6.0,
     iron: '7%',
+    group: 2,
   },
   {
     name: 'Cupcake',
@@ -48,6 +55,7 @@ const DESSERT_ITEMS = [
     carbs: 67,
     protein: 4.3,
     iron: '8%',
+    group: 2,
   },
   {
     name: 'Gingerbread',
@@ -56,6 +64,7 @@ const DESSERT_ITEMS = [
     carbs: 49,
     protein: 3.9,
     iron: '16%',
+    group: 3,
   },
   {
     name: 'Jelly bean',
@@ -64,6 +73,7 @@ const DESSERT_ITEMS = [
     carbs: 94,
     protein: 0.0,
     iron: '0%',
+    group: 1,
   },
   {
     name: 'Lollipop',
@@ -72,6 +82,7 @@ const DESSERT_ITEMS = [
     carbs: 98,
     protein: 0,
     iron: '2%',
+    group: 2,
   },
   {
     name: 'Honeycomb',
@@ -80,6 +91,7 @@ const DESSERT_ITEMS = [
     carbs: 87,
     protein: 6.5,
     iron: '45%',
+    group: 3,
   },
   {
     name: 'Donut',
@@ -88,6 +100,7 @@ const DESSERT_ITEMS = [
     carbs: 51,
     protein: 4.9,
     iron: '22%',
+    group: 3,
   },
   {
     name: 'KitKat',
@@ -96,6 +109,7 @@ const DESSERT_ITEMS = [
     carbs: 65,
     protein: 7,
     iron: '6%',
+    group: 1,
   },
 ]
 
@@ -354,6 +368,107 @@ describe('VDataTable', () => {
       cy.get('.v-data-table').find('h1').should('exist')
       cy.get('.v-data-table').find('h2').should('exist')
       cy.get('.v-data-table').find('h3').should('exist')
+    })
+  })
+
+  describe('sort', () => {
+    it('should sort by sortBy', () => {
+      const sortBy = ref<SortItem[]>([])
+      cy.mount(() => (
+        <Application>
+          <VDataTable
+          items={ DESSERT_ITEMS }
+          headers={ DESSERT_HEADERS }
+          itemsPerPage={ 10 }
+          sortBy={ sortBy.value }
+          />
+        </Application>
+      )).get('thead .v-data-table__td').eq(2).should('not.have.class', 'v-data-table__th--sorted')
+        .get('tbody td:nth-child(3)').then(rows => {
+          const actualFat = Array.from(rows).map(row => {
+            return Number(row.textContent)
+          })
+          const expectedFat = DESSERT_ITEMS.map(d => d.fat)
+          expect(actualFat).to.deep.equal(expectedFat)
+        })
+        .then(() => {
+          sortBy.value = [{ key: 'fat', order: 'asc' }]
+        })
+        .get('thead .v-data-table__td').eq(2).should('have.class', 'v-data-table__th--sorted')
+        .get('tbody td:nth-child(3)').then(rows => {
+          const actualFat = Array.from(rows).map(row => {
+            return Number(row.textContent)
+          })
+          const expectedFat = DESSERT_ITEMS.map(d => d.fat).sort((a, b) => a - b)
+          expect(actualFat).to.deep.equal(expectedFat)
+        })
+        .then(() => {
+          sortBy.value = [{ key: 'fat', order: 'desc' }]
+        })
+        .get('thead .v-data-table__td').eq(2).should('have.class', 'v-data-table__th--sorted')
+        .get('tbody td:nth-child(3)').then(rows => {
+          const actualFat = Array.from(rows).map(row => {
+            return Number(row.textContent)
+          })
+          const expectedFat = DESSERT_ITEMS.map(d => d.fat).sort((a, b) => b - a)
+          expect(actualFat).to.deep.equal(expectedFat)
+        })
+    })
+
+    it('should sort by groupBy and sortBy', () => {
+      cy.mount(() => (
+        <Application>
+          <VDataTable
+          items={ DESSERT_ITEMS }
+          headers={ DESSERT_HEADERS }
+          itemsPerPage={ 10 }
+          groupBy={[{ key: 'group', order: 'desc' }]}
+          sortBy={[{ key: 'calories', order: 'desc' }]}
+          />
+        </Application>
+      )).get('tr.v-data-table-group-header-row .v-data-table__td button + span').then(rows => {
+        const actualGroup = Array.from(rows).map(row => {
+          return Number(row.textContent)
+        })
+        const expectedGroup = [...new Set(DESSERT_ITEMS.map(d => d.group))].sort((a, b) => b - a)
+        expect(actualGroup).to.deep.equal(expectedGroup)
+      }).get('.v-data-table-group-header-row button').eq(0).click()
+        .get('.v-data-table__tr td:nth-child(3)').then(rows => {
+          const actualCalories = Array.from(rows).map(row => {
+            return Number(row.textContent)
+          })
+          const expectedCalories = DESSERT_ITEMS.filter(d => d.group === 3).map(d => d.calories).sort((a, b) => b - a)
+          expect(actualCalories).to.deep.equal(expectedCalories)
+        })
+    })
+
+    // https://github.com/vuetifyjs/vuetify/issues/20046
+    it('should sort by groupBy while sort is disabled', () => {
+      cy.mount(() => (
+        <Application>
+          <VDataTable
+          items={ DESSERT_ITEMS }
+          headers={ DESSERT_HEADERS }
+          itemsPerPage={ 10 }
+          groupBy={[{ key: 'group', order: 'desc' }]}
+          sortBy={[{ key: 'calories', order: 'desc' }]}
+          disableSort
+          />
+        </Application>
+      )).get('tr.v-data-table-group-header-row .v-data-table__td button + span').then(rows => {
+        const actualGroup = Array.from(rows).map(row => {
+          return Number(row.textContent)
+        })
+        const expectedGroup = [...new Set(DESSERT_ITEMS.map(d => d.group))].sort((a, b) => b - a)
+        expect(actualGroup).to.deep.equal(expectedGroup)
+      }).get('.v-data-table-group-header-row button').eq(0).click()
+        .get('.v-data-table__tr td:nth-child(3)').then(rows => {
+          const actualCalories = Array.from(rows).map(row => {
+            return Number(row.textContent)
+          })
+          const expectedCalories = DESSERT_ITEMS.filter(d => d.group === 3).map(d => d.calories)
+          expect(actualCalories).to.deep.equal(expectedCalories)
+        })
     })
   })
 })

--- a/packages/vuetify/src/components/VDataTable/composables/group.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/group.ts
@@ -52,9 +52,9 @@ export function createGroupBy (props: GroupProps) {
 }
 
 export function provideGroupBy (options: {
-  disableSort: Ref<boolean>
   groupBy: Ref<readonly SortItem[]>
   sortBy: Ref<readonly SortItem[]>
+  disableSort?: Ref<boolean>
 }) {
   const { disableSort, groupBy, sortBy } = options
   const opened = ref(new Set<string>())
@@ -63,7 +63,7 @@ export function provideGroupBy (options: {
     return groupBy.value.map<SortItem>(val => ({
       ...val,
       order: val.order ?? false,
-    })).concat(disableSort.value ? [] : sortBy.value)
+    })).concat(disableSort?.value ? [] : sortBy.value)
   })
 
   function isGroupOpen (group: Group) {

--- a/packages/vuetify/src/components/VDataTable/composables/group.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/group.ts
@@ -51,15 +51,19 @@ export function createGroupBy (props: GroupProps) {
   return { groupBy }
 }
 
-export function provideGroupBy (options: { groupBy: Ref<readonly SortItem[]>, sortBy: Ref<readonly SortItem[]> }) {
-  const { groupBy, sortBy } = options
+export function provideGroupBy (options: {
+  disableSort: Ref<boolean>
+  groupBy: Ref<readonly SortItem[]>
+  sortBy: Ref<readonly SortItem[]>
+}) {
+  const { disableSort, groupBy, sortBy } = options
   const opened = ref(new Set<string>())
 
   const sortByWithGroups = computed(() => {
     return groupBy.value.map<SortItem>(val => ({
       ...val,
       order: val.order ?? false,
-    })).concat(sortBy.value)
+    })).concat(disableSort.value ? [] : sortBy.value)
   })
 
   function isGroupOpen (group: Group) {

--- a/packages/vuetify/src/components/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/sort.ts
@@ -98,7 +98,6 @@ export function useSort () {
 export function useSortedItems<T extends InternalItem> (
   props: {
     customKeySort: Record<string, DataTableCompareFunction> | undefined
-    disableSort?: Boolean
   },
   items: Ref<T[]>,
   sortBy: Ref<readonly SortItem[]>,
@@ -110,7 +109,7 @@ export function useSortedItems<T extends InternalItem> (
 ) {
   const locale = useLocale()
   const sortedItems = computed(() => {
-    if (!sortBy.value.length || props.disableSort) return items.value
+    if (!sortBy.value.length) return items.value
 
     return sortItems(items.value, sortBy.value, locale.current.value, {
       transform: options?.transform,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20046 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    :group-by="groupBy"
    :headers="headers"
    :items="desserts"
    item-value="name"
    disable-sort
  />
</template>

<script>
  export default {
    data () {
      return {
        groupBy: [
          {
            key: 'group',
            order: 'desc',
          },
        ],
        headers: [
          { title: 'Dessert (100g serving)', key: 'name' },
          { title: 'Calories', key: 'calories' },
          { title: 'Fat (g)', key: 'fat' },
          { title: 'Carbs (g)', key: 'carbs' },
          { title: 'Protein (g)', key: 'protein' },
          { title: 'Iron (%)', key: 'iron' },
          { title: 'Group', key: 'group' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
            gluten: false,
            group: 1,
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
            gluten: false,
            group: 1,
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
            gluten: true,
            group: 2,
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
            gluten: true,
            group: 2,
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
            gluten: true,
            group: 2,
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
            gluten: false,
            group: 2,
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
            gluten: false,
            group: 3,
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
            gluten: true,
            group: 3,
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
            gluten: true,
            group: 4,
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
            gluten: true,
            group: 4,
          },
        ],
      }
    },
  }
</script>
```
