### PR TITLE
feat(VDataTable): Add option to hide an entire column

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -52,6 +52,9 @@
                 & .v-data-table-header__content
                   display: contents
 
+              &.v-data-table-column--hidden
+                display: none
+
             > th
               align-items: center
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
@@ -18,6 +18,7 @@ export const VDataTableColumn = defineFunctionalComponent({
   width: [Number, String],
   maxWidth: [Number, String],
   nowrap: Boolean,
+  hidden: Boolean,
 }, (props, { slots }) => {
   const Tag = props.tag ?? 'td'
   return (
@@ -29,6 +30,7 @@ export const VDataTableColumn = defineFunctionalComponent({
           'v-data-table-column--last-fixed': props.lastFixed,
           'v-data-table-column--no-padding': props.noPadding,
           'v-data-table-column--nowrap': props.nowrap,
+          'v-data-table-column--hidden': props.hidden,
         },
         `v-data-table-column--align-${props.align}`,
       ]}

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -160,6 +160,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           onClick={ column.sortable ? () => toggleSort(column) : undefined }
           fixed={ column.fixed }
           nowrap={ column.nowrap }
+          hidden={ column.hidden }
           lastFixed={ column.lastFixed }
           noPadding={ noPadding }
           { ...headerProps }

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -130,6 +130,7 @@ export const VDataTableRow = genericComponent<new <T>(
               maxWidth={ !mobile.value ? column.maxWidth : undefined }
               noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
               nowrap={ column.nowrap }
+              hidden={ column.hidden }
               width={ !mobile.value ? column.width : undefined }
               { ...cellProps }
               { ...columnCellProps }

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -19,6 +19,7 @@ export type DataTableHeader<T = Record<string, any>> = {
   minWidth?: string
   maxWidth?: string
   nowrap?: boolean
+  hidden?: boolean
 
   headerProps?: Record<string, any>
   cellProps?: HeaderCellProps


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
This PR adds the option to hide entire columns by specifying `hidden: true`.

Would allow to workaround issues like https://github.com/vuetifyjs/vuetify/issues/17863 by adding `{ key: "data-table-group", hidden: true },`

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table
        :headers="headers"
        :items="desserts"
        item-value="name"
      />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data () {
      return {
        headers: [
          { title: 'Dessert (100g serving)', key: 'name' },
          { title: 'Calories', key: 'calories', hidden: true },
          { title: 'Fat (g)', key: 'fat' },
          { title: 'Carbs (g)', key: 'carbs' },
          { title: 'Protein (g)', key: 'protein' },
          { title: 'Iron (%)', key: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
            gluten: false,
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
            gluten: false,
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
            gluten: true,
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
            gluten: true,
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
            gluten: true,
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
            gluten: false,
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
            gluten: false,
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
            gluten: true,
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
            gluten: true,
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
            gluten: true,
          },
        ],
      }
    },
  }
</script>

```
