### PR TITLE
feat(VSlideGroup): Expose hasNext and hasPrev in v-slide-group

### DIFF
--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -451,6 +451,8 @@ export const VSlideGroup = genericComponent<new <T>(
       scrollTo,
       scrollOffset,
       focus,
+      hasPrev,
+      hasNext,
     }
   },
 })


### PR DESCRIPTION
fixes #20049

## Description

I am seeking to implement custom navigation buttons in the v-slide-group component and control their disabled state based on hasNext and hasPrev computed flags. The v-slide-group component already utilizes these flags internally, but they are not exposed, making it impossible to access them via ref. I used it like that in Vuetify 2, so that would also improve compatibility with previous version.

## Markup

```javascript
<template>
  <v-app>
    <v-container>
      <v-btn :disabled="prevDisabled" @click="prev">Prev</v-btn>
      <v-btn :disabled="nextDisabled" @click="next">Next</v-btn>
      <v-slide-group ref="slideGroup">
        <v-slide-group-item v-for="n in 20" :key="n">
          <v-card height="200" width="200">{{ n }}</v-card>
        </v-slide-group-item>
      </v-slide-group>
    </v-container>
  </v-app>
</template>

<script>
  import { computed, ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const slideGroup = ref(null)

      const prev = () => slideGroup.value.scrollTo('prev')
      const next = () => slideGroup.value.scrollTo('next')

      const prevDisabled = computed(() => !slideGroup.value?.hasPrev)
      const nextDisabled = computed(() => !slideGroup.value?.hasNext)

      return {
        slideGroup,
        prev,
        next,
        prevDisabled,
        nextDisabled,
      }
    },
  }
</script>

```
