### PR TITLE
fix(VField/VInput): centerAffix doesn't work for underlined/plain

### DIFF
--- a/packages/api-generator/src/locale/en/VField.json
+++ b/packages/api-generator/src/locale/en/VField.json
@@ -2,7 +2,7 @@
   "props": {
     "appendInnerIcon": "Creates a [v-icon](/api/v-icon/) component in the **append-inner** slot.",
     "baseColor": "Sets the color of the input when it is not focused.",
-    "centerAffix": "Vertically align **appendInner**, **prependInner**, **clearIcon** and **label** in the center.",
+    "centerAffix": "Automatically apply **[singleLine](/api/v-field/#props-single-line)** under the hood, and vertically align **appendInner**, **prependInner**, **clearIcon**, **label** and **input field** in the center.",
     "clearIcon": "The icon used when the **clearable** prop is set to true.",
     "dirty": "Manually apply the dirty state styling.",
     "disabled": "Removes the ability to click or target the input.",

--- a/packages/api-generator/src/locale/en/VInput.json
+++ b/packages/api-generator/src/locale/en/VInput.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "backgroundColor": "Changes the background-color of the input.",
-    "centerAffix": "Vertically align **appendInner**, **prependInner**, **clearIcon** and **label** in the center.",
+    "centerAffix": "Vertically align **append** and **prepend** in the center.",
     "direction": "Changes the direction of the input.",
     "hideDetails": "Hides hint and validation errors. When set to `auto` messages will be rendered only if there's a message (hint, error message, counter value etc) to display.",
     "hideSpinButtons": "Hides spin buttons on the input when type is set to `number`.",

--- a/packages/api-generator/src/locale/en/VTextField.json
+++ b/packages/api-generator/src/locale/en/VTextField.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "autofocus": "Enables autofocus.",
-    "centerAffix": "Vertically align **append**, **appendInner**, **prepend**, **prependInner**, **clearIcon** and **label** in the center.",
     "clearIcon": "Applied when using **clearable** and the input is dirty.",
     "counterValue": "Function returns the counter display text.",
     "flat": "Removes elevation (shadow) added to element when using the **solo** or **solo-inverted** props.",

--- a/packages/api-generator/src/locale/en/VTextField.json
+++ b/packages/api-generator/src/locale/en/VTextField.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "autofocus": "Enables autofocus.",
+    "centerAffix": "Vertically align **append**, **appendInner**, **prepend**, **prependInner**, **clearIcon** and **label** in the center.",
     "clearIcon": "Applied when using **clearable** and the input is dirty.",
     "counterValue": "Function returns the counter display text.",
     "flat": "Removes elevation (shadow) added to element when using the **solo** or **solo-inverted** props.",

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -197,12 +197,13 @@
 
   .v-field.v-field--variant-underlined,
   .v-field.v-field--variant-plain
-    .v-field__append-inner,
-    .v-field__clearable,
-    .v-field__prepend-inner
-      align-items: flex-start
-      padding-top: $field-input-padding-top
-      padding-bottom: $field-input-padding-bottom
+    &:not(.v-field--center-affix)
+      .v-field__append-inner,
+      .v-field__clearable,
+      .v-field__prepend-inner
+        align-items: flex-start
+        padding-top: $field-input-padding-top
+        padding-bottom: $field-input-padding-bottom
 
   .v-field__prepend-inner,
   .v-field__append-inner

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -141,6 +141,10 @@
 
     $root: &
 
+    @at-root #{selector.nest('.v-field.v-field--center-affix.v-field--variant-underlined, .v-field.v-field--center-affix.v-field--variant-plain', &)}
+      padding-top: unset
+      padding-bottom: unset
+    
     @at-root
       @include tools.density('v-input', $input-density) using ($modifier)
         @at-root #{selector.nest(&, $root)}
@@ -195,15 +199,14 @@
       align-items: center
       padding-top: 0
 
-  .v-field.v-field--variant-underlined,
-  .v-field.v-field--variant-plain
-    &:not(.v-field--center-affix)
-      .v-field__append-inner,
-      .v-field__clearable,
-      .v-field__prepend-inner
-        align-items: flex-start
-        padding-top: $field-input-padding-top
-        padding-bottom: $field-input-padding-bottom
+  .v-field:not(.v-field--center-affix).v-field--variant-underlined,
+  .v-field:not(.v-field--center-affix).v-field--variant-plain
+    .v-field__append-inner,
+    .v-field__clearable,
+    .v-field__prepend-inner
+      align-items: flex-start
+      padding-top: $field-input-padding-top
+      padding-bottom: $field-input-padding-bottom
 
   .v-field__prepend-inner,
   .v-field__append-inner

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -64,7 +64,7 @@ export const makeVFieldProps = propsFactory({
   active: Boolean,
   centerAffix: {
     type: Boolean,
-    default: undefined,
+    default: false,
   },
   color: String,
   baseColor: String,

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -136,8 +136,9 @@ export const VField = genericComponent<new <T>(
     const { roundedClasses } = useRounded(props)
     const { rtlClasses } = useRtl()
 
+    const isSingleLine = computed(() => props.singleLine || props.centerAffix)
     const isActive = computed(() => props.dirty || props.active)
-    const hasLabel = computed(() => !props.singleLine && !!(props.label || slots.label))
+    const hasLabel = computed(() => !isSingleLine.value && !!(props.label || slots.label))
 
     const uid = getUid()
     const id = computed(() => props.id || `input-${uid}`)
@@ -242,7 +243,7 @@ export const VField = genericComponent<new <T>(
             {
               'v-field--active': isActive.value,
               'v-field--appended': hasAppend,
-              'v-field--center-affix': props.centerAffix ?? !isPlainOrUnderlined.value,
+              'v-field--center-affix': props.centerAffix,
               'v-field--disabled': props.disabled,
               'v-field--dirty': props.dirty,
               'v-field--error': props.error,
@@ -251,7 +252,7 @@ export const VField = genericComponent<new <T>(
               'v-field--persistent-clear': props.persistentClear,
               'v-field--prepended': hasPrepend,
               'v-field--reverse': props.reverse,
-              'v-field--single-line': props.singleLine,
+              'v-field--single-line': isSingleLine.value,
               'v-field--no-label': !label(),
               [`v-field--variant-${props.variant}`]: true,
             },

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -62,10 +62,7 @@ export const makeVFieldProps = propsFactory({
     default: '$clear',
   },
   active: Boolean,
-  centerAffix: {
-    type: Boolean,
-    default: false,
-  },
+  centerAffix: Boolean,
   color: String,
   baseColor: String,
   dirty: Boolean,

--- a/packages/vuetify/src/components/VInput/VInput.sass
+++ b/packages/vuetify/src/components/VInput/VInput.sass
@@ -104,13 +104,13 @@
         -moz-appearance: textfield
 
     &--plain-underlined
+      &:not(.v-input--center-affix)
+        .v-input__prepend,
+        .v-input__append
+          $this: &
+          align-items: flex-start
 
-      .v-input__prepend,
-      .v-input__append
-        $this: &
-        align-items: flex-start
-
-        @at-root
-          @include tools.density('v-input', $input-density) using ($modifier)
-            @at-root #{selector.append(&, $this)}
-              padding-top: calc(var(--v-input-padding-top) + #{math.max(0px, 4px + $modifier * .25)})
+          @at-root
+            @include tools.density('v-input', $input-density) using ($modifier)
+              @at-root #{selector.append(&, $this)}
+                padding-top: calc(var(--v-input-padding-top) + #{math.max(0px, 4px + $modifier * .25)})

--- a/packages/vuetify/src/components/VInput/VInput.sass
+++ b/packages/vuetify/src/components/VInput/VInput.sass
@@ -103,14 +103,14 @@
       input[type=number]
         -moz-appearance: textfield
 
-    &--plain-underlined
-      &:not(.v-input--center-affix)
-        .v-input__prepend,
-        .v-input__append
-          $this: &
-          align-items: flex-start
+    &--plain-underlined:not(&--center-affix)
 
-          @at-root
-            @include tools.density('v-input', $input-density) using ($modifier)
-              @at-root #{selector.append(&, $this)}
-                padding-top: calc(var(--v-input-padding-top) + #{math.max(0px, 4px + $modifier * .25)})
+      .v-input__prepend,
+      .v-input__append
+        $this: &
+        align-items: flex-start
+
+        @at-root
+          @include tools.density('v-input', $input-density) using ($modifier)
+            @at-root #{selector.append(&, $this)}
+              padding-top: calc(var(--v-input-padding-top) + #{math.max(0px, 4px + $modifier * .25)})

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -40,10 +40,7 @@ export interface VInputSlot {
 export const makeVInputProps = propsFactory({
   id: String,
   appendIcon: IconValue,
-  centerAffix: {
-    type: Boolean,
-    default: false,
-  },
+  centerAffix: Boolean,
   prependIcon: IconValue,
   hideDetails: [Boolean, String] as PropType<boolean | 'auto'>,
   hideSpinButtons: Boolean,

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -42,7 +42,7 @@ export const makeVInputProps = propsFactory({
   appendIcon: IconValue,
   centerAffix: {
     type: Boolean,
-    default: true,
+    default: false,
   },
   prependIcon: IconValue,
   hideDetails: [Boolean, String] as PropType<boolean | 'auto'>,

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -42,7 +42,7 @@ export const makeVInputProps = propsFactory({
   appendIcon: IconValue,
   centerAffix: {
     type: Boolean,
-    default: false,
+    default: true,
   },
   prependIcon: IconValue,
   hideDetails: [Boolean, String] as PropType<boolean | 'auto'>,

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -176,7 +176,6 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
           style={ props.style }
           { ...rootAttrs }
           { ...inputProps }
-          centerAffix={ props.centerAffix }
           focused={ isFocused.value }
         >
           {{

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -176,7 +176,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
           style={ props.style }
           { ...rootAttrs }
           { ...inputProps }
-          centerAffix={ !isPlainOrUnderlined.value }
+          centerAffix={ props.centerAffix }
           focused={ isFocused.value }
         >
           {{
@@ -202,6 +202,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                 dirty={ isDirty.value || props.dirty }
                 disabled={ isDisabled.value }
                 focused={ isFocused.value }
+                centerAffix={ props.centerAffix }
                 error={ isValid.value === false }
               >
                 {{

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -228,7 +228,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
           style={ props.style }
           { ...rootAttrs }
           { ...inputProps }
-          centerAffix={ rows.value === 1 && !isPlainOrUnderlined.value }
+          centerAffix={ props.centerAffix ?? (rows.value === 1 && !isPlainOrUnderlined.value) }
           focused={ isFocused.value }
         >
           {{
@@ -253,7 +253,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                 { ...fieldProps }
                 id={ id.value }
                 active={ isActive.value || isDirty.value }
-                centerAffix={ rows.value === 1 && !isPlainOrUnderlined.value }
+                centerAffix={ props.centerAffix ?? (rows.value === 1 && !isPlainOrUnderlined.value) }
                 dirty={ isDirty.value || props.dirty }
                 disabled={ isDisabled.value }
                 focused={ isFocused.value }

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -152,6 +152,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
     const sizerRef = ref<HTMLTextAreaElement>()
     const rows = ref(+props.rows)
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
+    const isCenterAffix = computed(() => props.centerAffix ?? (rows.value === 1 && !isPlainOrUnderlined.value))
     watchEffect(() => {
       if (!props.autoGrow) rows.value = +props.rows
     })
@@ -228,7 +229,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
           style={ props.style }
           { ...rootAttrs }
           { ...inputProps }
-          centerAffix={ props.centerAffix ?? (rows.value === 1 && !isPlainOrUnderlined.value) }
+          centerAffix={ isCenterAffix.value }
           focused={ isFocused.value }
         >
           {{
@@ -253,7 +254,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                 { ...fieldProps }
                 id={ id.value }
                 active={ isActive.value || isDirty.value }
-                centerAffix={ props.centerAffix ?? (rows.value === 1 && !isPlainOrUnderlined.value) }
+                centerAffix={ isCenterAffix.value }
                 dirty={ isDirty.value || props.dirty }
                 disabled={ isDisabled.value }
                 focused={ isFocused.value }

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -18,7 +18,7 @@ import Intersect from '@/directives/intersect'
 
 // Utilities
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
-import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
+import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -48,8 +48,8 @@ export const makeVTextareaProps = propsFactory({
   suffix: String,
   modelModifiers: Object as PropType<Record<string, boolean>>,
 
-  ...makeVInputProps(),
-  ...makeVFieldProps(),
+  ...omit(makeVInputProps(), ['centerAffix']),
+  ...omit(makeVFieldProps(), ['centerAffix']),
 }, 'VTextarea')
 
 type VTextareaSlots = Omit<VInputSlots & VFieldSlots, 'default'> & {
@@ -152,7 +152,6 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
     const sizerRef = ref<HTMLTextAreaElement>()
     const rows = ref(+props.rows)
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
-    const isCenterAffix = computed(() => props.centerAffix ?? (rows.value === 1 && !isPlainOrUnderlined.value))
     watchEffect(() => {
       if (!props.autoGrow) rows.value = +props.rows
     })
@@ -229,7 +228,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
           style={ props.style }
           { ...rootAttrs }
           { ...inputProps }
-          centerAffix={ isCenterAffix.value }
+          centerAffix={ false }
           focused={ isFocused.value }
         >
           {{
@@ -254,7 +253,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                 { ...fieldProps }
                 id={ id.value }
                 active={ isActive.value || isDirty.value }
-                centerAffix={ isCenterAffix.value }
+                centerAffix={ false }
                 dirty={ isDirty.value || props.dirty }
                 disabled={ isDisabled.value }
                 focused={ isFocused.value }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
Automatically apply singleLine under the hood, and vertically align **appendInner**, **prependInner**, **clearIcon**, **label** and **input field** in the center.

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container class="pa-md-12 bg-grey">
    <v-row>
      <v-col cols="4">
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="solo"
          label="solo"
          variant="solo"
          center-affix
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="outlined"
          label="outlined"
          variant="outlined"
          center-affix
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="filled"
          label="filled"
          variant="filled"
          center-affix
        />
        <v-text-field
          bg-color="white"
          clearable
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="underlined"
          label="underlined"
          variant="underlined"
          center-affix
        />
      </v-col>
      <v-col cols="4">
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="solo"
          label="solo"
          variant="solo"
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="outlined"
          label="outlined"
          variant="outlined"
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="filled"
          label="filled"
          variant="filled"
        />
        <v-text-field
          bg-color="white"
          clearable
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="underlined"
          label="underlined"
          variant="underlined"
        />
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'
</script>




```
