### PR TITLE
fix(VNumberInput): fix inc/dec slots with split control variant

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -97,6 +97,11 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       return props.hideInput ? 'stacked' : props.controlVariant
     })
 
+    const incrementIcon = computed(() => controlVariant.value === 'split' ? '$plus' : '$collapse')
+    const decrementIcon = computed(() => controlVariant.value === 'split' ? '$minus' : '$expand')
+    const controlNodeSize = computed(() => controlVariant.value === 'split' ? 'default' : 'small')
+    const controlNodeDefaultHeight = computed(() => controlVariant.value === 'stacked' ? 'auto' : '100%')
+
     const incrementSlotProps = computed(() => ({ click: onClickUp }))
 
     const decrementSlotProps = computed(() => ({ click: onClickDown }))
@@ -160,77 +165,80 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     useRender(() => {
       const { modelValue: _, ...textFieldProps } = VTextField.filterProps(props)
 
+      function incrementControlNode () {
+        return !slots.increment ? (
+          <VBtn
+            disabled={ !canIncrease.value }
+            flat
+            key="increment-btn"
+            height={ controlNodeDefaultHeight.value }
+            name="increment-btn"
+            icon={ incrementIcon.value }
+            onClick={ onClickUp }
+            onMousedown={ onControlMousedown }
+            size={ controlNodeSize.value }
+            tabindex="-1"
+          />
+        ) : (
+          <VDefaultsProvider
+            key="increment-defaults"
+            defaults={{
+              VBtn: {
+                disabled: !canIncrease.value,
+                flat: true,
+                height: controlNodeDefaultHeight.value,
+                size: controlNodeSize.value,
+                icon: incrementIcon.value,
+              },
+            }}
+          >
+            { slots.increment(incrementSlotProps.value) }
+          </VDefaultsProvider>
+        )
+      }
+
+      function decrementControlNode () {
+        return !slots.decrement ? (
+          <VBtn
+            disabled={ !canDecrease.value }
+            flat
+            key="decrement-btn"
+            height={ controlNodeDefaultHeight.value }
+            name="decrement-btn"
+            icon={ decrementIcon.value }
+            size={ controlNodeSize.value }
+            tabindex="-1"
+            onClick={ onClickDown }
+            onMousedown={ onControlMousedown }
+          />
+        ) : (
+          <VDefaultsProvider
+            key="decrement-defaults"
+            defaults={{
+              VBtn: {
+                disabled: !canDecrease.value,
+                flat: true,
+                height: controlNodeDefaultHeight.value,
+                size: controlNodeSize.value,
+                icon: decrementIcon.value,
+              },
+            }}
+          >
+            { slots.decrement(decrementSlotProps.value) }
+          </VDefaultsProvider>
+        )
+      }
+
       function controlNode () {
-        const defaultHeight = controlVariant.value === 'stacked' ? 'auto' : '100%'
         return (
           <div class="v-number-input__control">
-            {
-              !slots.decrement ? (
-                <VBtn
-                  disabled={ !canDecrease.value }
-                  flat
-                  key="decrement-btn"
-                  height={ defaultHeight }
-                  name="decrement-btn"
-                  icon="$expand"
-                  size="small"
-                  tabindex="-1"
-                  onClick={ onClickDown }
-                  onMousedown={ onControlMousedown }
-                />
-              ) : (
-                <VDefaultsProvider
-                  key="decrement-defaults"
-                  defaults={{
-                    VBtn: {
-                      disabled: !canDecrease.value,
-                      flat: true,
-                      height: defaultHeight,
-                      size: 'small',
-                      icon: '$expand',
-                    },
-                  }}
-                >
-                  { slots.decrement(decrementSlotProps.value) }
-                </VDefaultsProvider>
-              )
-            }
+            { decrementControlNode() }
 
             <VDivider
               vertical={ controlVariant.value !== 'stacked' }
             />
 
-            {
-              !slots.increment ? (
-                <VBtn
-                  disabled={ !canIncrease.value }
-                  flat
-                  key="increment-btn"
-                  height={ defaultHeight }
-                  name="increment-btn"
-                  icon="$collapse"
-                  onClick={ onClickUp }
-                  onMousedown={ onControlMousedown }
-                  size="small"
-                  tabindex="-1"
-                />
-              ) : (
-                <VDefaultsProvider
-                  key="increment-defaults"
-                  defaults={{
-                    VBtn: {
-                      disabled: !canIncrease.value,
-                      flat: true,
-                      height: defaultHeight,
-                      size: 'small',
-                      icon: '$collapse',
-                    },
-                  }}
-                >
-                  { slots.increment(incrementSlotProps.value) }
-                </VDefaultsProvider>
-              )
-            }
+            { incrementControlNode() }
           </div>
         )
       }
@@ -245,15 +253,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             <div class="v-number-input__control">
               <VDivider vertical />
 
-              <VBtn
-                flat
-                height="100%"
-                icon="$plus"
-                tile
-                tabindex="-1"
-                onClick={ onClickUp }
-                onMousedown={ onControlMousedown }
-              />
+              { incrementControlNode() }
             </div>
           ) : (!props.reverse
             ? <>{ dividerNode() }{ controlNode() }</>
@@ -265,15 +265,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         controlVariant.value === 'split'
           ? (
             <div class="v-number-input__control">
-              <VBtn
-                flat
-                height="100%"
-                icon="$minus"
-                tile
-                tabindex="-1"
-                onClick={ onClickDown }
-                onMousedown={ onControlMousedown }
-              />
+              { decrementControlNode() }
 
               <VDivider vertical />
             </div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20056 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input control-variant="default" />
      <v-number-input control-variant="default">
        <template #increment> inc </template>
        <template #decrement> dec </template>
      </v-number-input>

      <v-number-input control-variant="split" />
      <v-number-input control-variant="split">
        <template #increment> inc </template>
        <template #decrement> dec </template>
      </v-number-input>
      <v-number-input control-variant="stacked" />
      <v-number-input control-variant="stacked">
        <template #increment> inc </template>
        <template #decrement> dec </template>
      </v-number-input>
    </v-container>
  </v-app>
</template>
```
