### PR TITLE
fix(VDataTable): use item.raw and columns in sorting transform

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -130,7 +130,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     const { groupBy } = createGroupBy(props)
     const { sortBy, multiSort, mustSort } = createSort(props)
     const { page, itemsPerPage } = createPagination(props)
-    
+
     const {
       columns,
       headers,

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -130,7 +130,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     const { groupBy } = createGroupBy(props)
     const { sortBy, multiSort, mustSort } = createSort(props)
     const { page, itemsPerPage } = createPagination(props)
-
+    
     const {
       columns,
       headers,
@@ -155,7 +155,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
-      transform: item => item.raw,
+      transform: item => ({ ...item.raw, ...item.columns }),
       sortFunctions,
       sortRawFunctions,
     })

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -147,7 +147,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
 
     const search = toRef(props, 'search')
     const { filteredItems } = useFilter(props, items, search, {
-      transform: item => item.raw,
+      transform: item => item.columns,
       customKeyFilter: filterFunctions,
     })
 

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -147,7 +147,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
 
     const search = toRef(props, 'search')
     const { filteredItems } = useFilter(props, items, search, {
-      transform: item => item.columns,
+      transform: item => item.raw,
       customKeyFilter: filterFunctions,
     })
 
@@ -155,7 +155,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
-      transform: item => item.columns,
+      transform: item => item.raw,
       sortFunctions,
       sortRawFunctions,
     })

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -109,7 +109,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
     const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
-      transform: item => item.raw,
+      transform: item => ({ ...item.raw, ...item.columns }),
       sortFunctions,
       sortRawFunctions,
     })

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -109,7 +109,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
     const { sortByWithGroups, opened, extractRows, isGroupOpen, toggleGroup } = provideGroupBy({ groupBy, sortBy })
 
     const { sortedItems } = useSortedItems(props, filteredItems, sortByWithGroups, {
-      transform: item => item.columns,
+      transform: item => item.raw,
       sortFunctions,
       sortRawFunctions,
     })

--- a/packages/vuetify/src/components/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/sort.ts
@@ -4,7 +4,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, inject, provide, toRef } from 'vue'
-import { isEmpty, propsFactory } from '@/util'
+import { getObjectValueByPath, isEmpty, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -149,8 +149,9 @@ export function sortItems<T extends InternalItem> (
 
       if (sortOrder === false) continue
 
-      let sortA = a[1][sortKey]
-      let sortB = b[1][sortKey]
+      let sortA = getObjectValueByPath(a[1], sortKey)
+      let sortB = getObjectValueByPath(b[1], sortKey)
+
       let sortARaw = a[0].raw
       let sortBRaw = b[0].raw
 

--- a/packages/vuetify/src/components/VDataTable/composables/sort.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/sort.ts
@@ -151,7 +151,6 @@ export function sortItems<T extends InternalItem> (
 
       let sortA = getObjectValueByPath(a[1], sortKey)
       let sortB = getObjectValueByPath(b[1], sortKey)
-
       let sortARaw = a[0].raw
       let sortBRaw = b[0].raw
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #20045 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    :group-by="groupBy"
    :headers="headers"
    :items="desserts"
    item-value="name"
  >
  </v-data-table>
</template>

<script>
  export default {
    data() {
      return {
        groupBy: [
          {
            key: 'group.deep', // work with deep key now
            order: 'desc',
          },
        ],
        headers: [
          { title: 'Dessert (100g serving)', key: 'name' },
          { title: 'Calories', key: 'calories' },
          { title: 'Fat (g)', key: 'fat' },
          { title: 'Carbs (g)', key: 'carbs' },
          { title: 'Protein (g)', key: 'protein' },
          { title: 'Iron (%)', key: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
            gluten: false,
            group: {
             deep: 1,
            }
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
            gluten: false,
            group: {
             deep: 1,
            }
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
            gluten: true,
            group: {
             deep: 2,
            }
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
            gluten: true,
            group: {
             deep: 2,
            }
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
            gluten: true,
            group: {
             deep: 2,
            }
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
            gluten: false,
            group: {
             deep: 2,
            }
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
            gluten: false,
            group: {
             deep: 3,
            }
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
            gluten: true,
            group: {
             deep: 3,
            }
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
            gluten: true,
            group: {
             deep: 4,
            }
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
            gluten: true,
            group: {
             deep: 4,
            }
          },
        ],
      }
    },
  }
</script>
```
