### PR TITLE
docs(TreeShaking): Example code constant button should be same as used in template

### DIFF
--- a/packages/docs/src/pages/en/features/treeshaking.md
+++ b/packages/docs/src/pages/en/features/treeshaking.md
@@ -179,7 +179,7 @@ Dynamic components using `<component>` can be registered locally:
   import { VChip } from 'vuetify/components/VChip'
   import { shallowRef } from 'vue'
 
-  const btn = shallowRef(false)
+  const button = shallowRef(false)
 </script>
 ```
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
It confuses users that somehow vue or vuetify is looking at a boolean called btn and making it into full form button based on some naming convention.
