### PR TITLE
feat(VMenu): make activation by arrow keys optional

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -45,7 +45,7 @@ export const makeVMenuProps = propsFactory({
     scrim: false,
     scrollStrategy: 'reposition' as const,
     transition: { component: VDialogTransition as Component },
-    disableArrowKeysActivation: false
+    disableArrowKeysActivation: false,
   }), ['absolute']),
 }, 'VMenu')
 

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -35,6 +35,7 @@ export const makeVMenuProps = propsFactory({
   // TODO
   // disableKeys: Boolean,
   id: String,
+  disableArrowKeysActivation: Boolean,
 
   ...omit(makeVOverlayProps({
     closeDelay: 250,
@@ -44,6 +45,7 @@ export const makeVMenuProps = propsFactory({
     scrim: false,
     scrollStrategy: 'reposition' as const,
     transition: { component: VDialogTransition as Component },
+    disableArrowKeysActivation: false
   }), ['absolute']),
 }, 'VMenu')
 
@@ -161,7 +163,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
           e.preventDefault()
           focusChild(el, 'prev')
         }
-      } else if (['ArrowDown', 'ArrowUp'].includes(e.key)) {
+      } else if (['ArrowDown', 'ArrowUp'].includes(e.key) && !props.disableArrowKeysActivation) {
         isActive.value = true
         e.preventDefault()
         setTimeout(() => setTimeout(() => onActivatorKeydown(e)))


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
To keep arrow key functionality in v-list, it is required that v-menu doesn't activate on arrow-key. To not break anything this is made optional as par the standard WCAG 2.

## Markup:
On v-menu now exists a property disableArrowKeysActivation.

```vue
<template>
  <v-list>
    <v-list-item v-for="i in 5">
      <v-menu :disableArrowKeysActivation="true">
        <template v-slot:activator="{ props }">
          <v-btn v-bind="props">Click me {{ i }}</v-btn>
        </template>
        <v-list v-focus>
          <v-list-item v-for="j in 5" @click="log">
            {{ j }}
          </v-list-item>
        </v-list>
      </v-menu>
    </v-list-item>
  </v-list>
</template>

<script setup>
function log() {
  console.log("hello world");
}

const vFocus = {
  mounted: (el) => {
    setTimeout(() => el.focus(), 50);
  }
}
</script>

```
