### PR TITLE
docs(VListItem): Add descriptions for lines, nav, and slim properties

### DIFF
--- a/packages/api-generator/src/locale/en/VListItem.json
+++ b/packages/api-generator/src/locale/en/VListItem.json
@@ -4,6 +4,9 @@
     "color": "Applies specified color to the control when in an **active** state or **input-value** is **true** - supports utility colors (for example `success` or `purple`) or css color (`#033` or `rgba(255, 0, 0, 0.5)`). Find a list of built-in classes on the [colors page](/styles/colors#material-colors),",
     "contained": "Changes the component style by changing how color is applied to the background.",
     "title": "Generates a `v-list-item-title` component with the supplied value. Note that this overrides the native [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) attribute, that must be set with `v-bind:title.attr` instead.",
-    "value": "The value used for selection."
+    "value": "The value used for selection.",
+    "lines": "The line declaration specifies the minimum height of the item and can also be controlled from v-list with the same prop.",
+    "nav": "Reduces the width v-list-item takes up as well as adding a border radius.",
+    "slim": "Reduces horizontal spacing for badges, icons, tooltips, and avatars to create a more compact visual representation."
   }
 }


### PR DESCRIPTION
## Description
Added descriptions for the properties `lines`, `nav`, and `slim` to the `VListItem.json` documentation. These properties were missing and this addition aims to provide clarity and completeness to the documentation.

## Markup:
Not applicable for this documentation change. 
