### PR TITLE
Allow alpha transparency to be included in colors

### DIFF
--- a/.github/actions/download-locales/action.yml
+++ b/.github/actions/download-locales/action.yml
@@ -20,6 +20,16 @@ runs:
         push_translations: false
         export_only_approved: false
         crowdin_branch_name: ${{ inputs.crowdin-branch }}
+    - name: Download ja-JP
+      uses: crowdin/github-action@v1.19.0
+      with:
+        download_language: ja
+        config: crowdin.yml
+        upload_sources: false
+        download_translations: true
+        push_translations: false
+        export_only_approved: false
+        crowdin_branch_name: ${{ inputs.crowdin-branch }}
     - name: Download zh-CN
       uses: crowdin/github-action@v1.19.0
       with:

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -23,7 +23,7 @@
     "@cosmicjs/sdk": "^1.0.11",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
-    "@vuetify/one": "^1.8.1",
+    "@vuetify/one": "^1.9.1",
     "algoliasearch": "^4.23.3",
     "fflate": "^0.8.2",
     "isomorphic-fetch": "^3.0.0",

--- a/packages/docs/src/components/app/CommitBtn.vue
+++ b/packages/docs/src/components/app/CommitBtn.vue
@@ -1,10 +1,10 @@
 <template>
   <v-btn
-    v-if="commits.latest"
     :href="`https://github.com/vuetifyjs/vuetify/commit/${commits.latest?.sha}`"
-    :text="commits.latest?.sha?.slice(0, 7)"
+    :prepend-icon="commits.latest ? 'mdi-source-commit' : undefined"
+    :readonly="!commits.latest"
+    :text="commits.latest?.sha.slice(0, 7)"
     class="text-caption"
-    prepend-icon="mdi-source-commit"
     rel="noopener noreferrer"
     size="small"
     target="_blank"

--- a/packages/docs/src/components/app/CommitBtn.vue
+++ b/packages/docs/src/components/app/CommitBtn.vue
@@ -2,7 +2,7 @@
   <v-btn
     v-if="commits.latest"
     :href="`https://github.com/vuetifyjs/vuetify/commit/${commits.latest?.sha}`"
-    :text="commits.latest?.sha.slice(0, 7)"
+    :text="commits.latest?.sha?.slice(0, 7)"
     class="text-caption"
     prepend-icon="mdi-source-commit"
     rel="noopener noreferrer"

--- a/packages/docs/src/components/app/bar/Bar.vue
+++ b/packages/docs/src/components/app/bar/Bar.vue
@@ -2,6 +2,7 @@
   <VoAppBar
     id="app-bar"
     border="b"
+    class="px-md-3"
     logo="vuetify"
     flat
   >

--- a/packages/docs/src/components/app/settings/LatestCommit.vue
+++ b/packages/docs/src/components/app/settings/LatestCommit.vue
@@ -3,7 +3,7 @@
     v-if="commits.latest"
     :href="`https://github.com/vuetifyjs/vuetify/commit/${commits.latest?.sha}`"
     :label="t('latest-commit')"
-    :title="commits.latest?.sha.slice(0, 7)"
+    :title="commits.latest?.sha?.slice(0, 7)"
     append-icon="mdi-open-in-new"
     min-width="90"
     prepend-icon="mdi-source-commit"

--- a/packages/docs/src/components/app/settings/LatestCommit.vue
+++ b/packages/docs/src/components/app/settings/LatestCommit.vue
@@ -3,7 +3,7 @@
     v-if="commits.latest"
     :href="`https://github.com/vuetifyjs/vuetify/commit/${commits.latest?.sha}`"
     :label="t('latest-commit')"
-    :title="commits.latest?.sha?.slice(0, 7)"
+    :title="commits.latest?.sha.slice(0, 7)"
     append-icon="mdi-open-in-new"
     min-width="90"
     prepend-icon="mdi-source-commit"

--- a/packages/docs/src/i18n/locales.json
+++ b/packages/docs/src/i18n/locales.json
@@ -8,7 +8,7 @@
     "title": "日本語",
     "locale": "ja-JP",
     "alternate": "ja",
-    "enabled": false
+    "enabled": true
   },
   {
     "title": "简体中文",

--- a/packages/docs/src/pages/en/components/all.md
+++ b/packages/docs/src/pages/en/components/all.md
@@ -364,7 +364,7 @@ These components are used to display data and information in a variety of ways.
 
 </ComponentsListItem>
 
-<ComponentsListItem name="Sparkline component" src="sparkline">
+<ComponentsListItem name="Sparkline component" src="sparklines">
 
   The sparkline component creates beautiful and expressive simple graphs for displaying numerical data
 

--- a/packages/docs/src/pages/en/styles/content.md
+++ b/packages/docs/src/pages/en/styles/content.md
@@ -36,7 +36,3 @@ Example of an inline `<code>` element.
 ## Variables
 
 <var>v</var> = <var>u</var> * <var>e</var>
-
-## User input
-
-To install Vuetify, type <kbd>npm install vuetify</kbd> into your console. Once complete, type <kbd>cd `<project name>`</kbd> and run <kbd>npm install</kbd>

--- a/packages/docs/src/plugins/vuetify.ts
+++ b/packages/docs/src/plugins/vuetify.ts
@@ -12,6 +12,7 @@ import { fa } from 'vuetify/iconsets/fa'
 import { md } from 'vuetify/iconsets/md'
 import { mdi } from 'vuetify/iconsets/mdi-svg'
 import * as mdiSvg from './icons'
+import { aliases } from '@vuetify/one'
 
 // Locales
 import { en, sv } from 'vuetify/locale'
@@ -112,11 +113,7 @@ export function installVuetify (app: App) {
           },
         },
       },
-      aliases: {
-        /* eslint-disable max-len */
-        x: ['M2.04875 3.00002L9.77052 13.3248L1.99998 21.7192H3.74882L10.5519 14.3697L16.0486 21.7192H22L13.8437 10.8137L21.0765 3.00002H19.3277L13.0624 9.76874L8.0001 3.00002H2.04875ZM4.62054 4.28821H7.35461L19.4278 20.4308H16.6937L4.62054 4.28821Z'],
-        /* eslint-enable max-len */
-      },
+      aliases,
     },
     theme: {
       themes: {

--- a/packages/docs/src/stores/commits.ts
+++ b/packages/docs/src/stores/commits.ts
@@ -4,7 +4,6 @@ import type { components as octokitComponents } from '@octokit/openapi-types'
 export type Commit = octokitComponents['schemas']['commit']
 
 export type State = {
-  latest: Commit | null
   commits: Commit[]
   isLoading: boolean
 }
@@ -13,7 +12,6 @@ const url = import.meta.env.VITE_API_SERVER_URL
 
 export const useCommitsStore = defineStore('commits', {
   state: (): State => ({
-    latest: null,
     commits: [] as Commit[],
     isLoading: false,
   }),
@@ -23,7 +21,7 @@ export const useCommitsStore = defineStore('commits', {
       this.isLoading = true
 
       try {
-        this.latest = await fetch(`${url}/github/commits`, {
+        this.commits = await fetch(`${url}/github/commits`, {
           method: 'GET',
           credentials: 'include',
         }).then(res => res.json())
@@ -32,6 +30,12 @@ export const useCommitsStore = defineStore('commits', {
       }
 
       this.isLoading = false
+    },
+  },
+
+  getters: {
+    latest (state) {
+      return state.commits[0]
     },
   },
 })

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -154,9 +154,13 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       contentEvents,
       scrimEvents,
     } = useActivator(props, { isActive, isTop: localTop })
-    const potentialShadowDomRoot = computed(() => (activatorEl?.value as Element)?.getRootNode() as Element)
-    const { teleportTarget } = useTeleport(computed(() => props.attach || props.contained ||
-      potentialShadowDomRoot.value instanceof ShadowRoot ? potentialShadowDomRoot.value ?? true : false))
+    const { teleportTarget } = useTeleport(() => {
+      const target = props.attach || props.contained
+      if (target) return target
+      const rootNode = activatorEl?.value?.getRootNode()
+      if (rootNode instanceof ShadowRoot) return rootNode
+      return false
+    })
     const { dimensionStyles } = useDimension(props)
     const isMounted = useHydration()
     const { scopeId } = useScopeId()

--- a/packages/vuetify/src/composables/teleport.ts
+++ b/packages/vuetify/src/composables/teleport.ts
@@ -2,12 +2,9 @@
 import { computed, warn } from 'vue'
 import { IN_BROWSER } from '@/util'
 
-// Types
-import type { Ref } from 'vue'
-
-export function useTeleport (target: Ref<boolean | string | Element>) {
+export function useTeleport (target: () => (boolean | string | ParentNode)) {
   const teleportTarget = computed(() => {
-    const _target = target.value
+    const _target = target()
 
     if (_target === true || !IN_BROWSER) return undefined
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,10 +4108,10 @@
   dependencies:
     upath "^2.0.1"
 
-"@vuetify/one@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@vuetify/one/-/one-1.8.1.tgz#f89aa5bd06624db9e366e45643cc641b9bf311e7"
-  integrity sha512-PnlMvLqm3hT2zHFrNAr6DTVLjpM5q9iEG1t/ECNm0fjnT0QfZBTmnAHALcTwjXhLYv9VnD6a7f6KnPlQD4eSZQ==
+"@vuetify/one@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@vuetify/one/-/one-1.9.1.tgz#408d5d0bd6ce9a3ccd7cdba679ba411d7c6e446b"
+  integrity sha512-vp1+9n4Ehs6XP/DuuUwCpUiOKDTwAdJmYc6eqt/HRw+u7s/0W8SGvrKOhzQeXLeGrfzwpIed6iB78NyfZzM66Q==
 
 "@vueuse/head@^1.3.1":
   version "1.3.1"


### PR DESCRIPTION
## Description
Allow transparency to be included in colors in template. They are currently being truncated. 

e.g. resolves #19961

## Markup:

### Steps to reproduce
   1. Create a custom theme.
   2. Create a color named "test" with a value of "#ff000014".
   3.Change VTextField defaults and set its color prop to "test".

### Expected Behavior
The focused text field should have a transparent red color.

### Actual Behavior
The focused text field has a red color, transparency is ignored.

### Reproduction Link

[https://play.vuetifyjs.com/#...](https://play.vuetifyjs.com/#eNpVjk0PgjAMhv9Kg4dpQvxIPJF49eSRcBEPBIpgxma2YjBk/13Y+Jg9tE379H177wOt8sOnRarL7/6lgyiom7dUBD3kCjPCxO3AQKlkA2xiWSpSgZ1Fcyk0wbSAy//htk8FAFXYYAS2ByiwzFpOsRuyvNUkm1v9rIiFjrC8Xg4APMabDnPJpfJBe416oNjmaON0nlXHMEs/d666PH22CiYxdnStkRf+M6PpYDD6zNqritmlIjChaDm36fEDZl9wwA==)