### PR TITLE
fix(VTimePicker): fix types for emit events

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
@@ -56,11 +56,11 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
   props: makeVTimePickerProps(),
 
   emits: {
-    'update:hour': (val: number) => val,
-    'update:minute': (val: number) => val,
-    'update:period': (val: Period) => val,
-    'update:second': (val: number) => val,
-    'update:modelValue': (val: string) => val,
+    'update:hour': (val: number) => true,
+    'update:minute': (val: number) => true,
+    'update:period': (val: Period) => true,
+    'update:second': (val: number) => true,
+    'update:modelValue': (val: string) => true,
   },
 
   setup (props, { emit, slots }) {

--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
@@ -56,8 +56,8 @@ export const VTimePickerClock = genericComponent()({
   props: makeVTimePickerClockProps(),
 
   emits: {
-    change: (val: number) => val,
-    input: (val: number) => val,
+    change: (val: number) => true,
+    input: (val: number) => true,
   },
 
   setup (props, { emit }) {

--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
@@ -36,8 +36,8 @@ export const VTimePickerControls = genericComponent()({
   props: makeVTimePickerControlsProps(),
 
   emits: {
-    'update:period': (data: Period) => data,
-    'update:selecting': (data: 1 | 2 | 3) => data,
+    'update:period': (data: Period) => true,
+    'update:selecting': (data: 1 | 2 | 3) => true,
   },
 
   setup (props, { emit, slots }) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20085 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-time-picker
        v-model="time"
        format="24hr"
        max="22:15"
        min="9:30"
        scrollable
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const time = ref()
</script>
```
