### PR TITLE
fix: augment GlobalComponents in multiple vue modules

### DIFF
--- a/packages/vuetify/src/shims.d.ts
+++ b/packages/vuetify/src/shims.d.ts
@@ -16,9 +16,12 @@ declare global {
     }
   }
 }
-
+interface _GlobalComponents {
+  // @generate-components
+}
 declare module 'vue' {
   export type JSXComponent<Props = any> = { new (): ComponentPublicInstance<Props> } | FunctionalComponent<Props>
+  export interface GlobalComponents extends _GlobalComponents {}
 }
 
 declare module '@vue/runtime-dom' {
@@ -28,6 +31,7 @@ declare module '@vue/runtime-dom' {
   export interface SVGAttributes {
     $children?: VNodeChild
   }
+  export interface GlobalComponents extends _GlobalComponents {}
 }
 
 declare module '@vue/runtime-core' {
@@ -43,8 +47,5 @@ declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     $vuetify: Vuetify
   }
-
-  export interface GlobalComponents {
-    // @generate-components
-  }
+  export interface GlobalComponents extends _GlobalComponents {}
 }


### PR DESCRIPTION

## Description
Starting with the VScode Volar extension `v2.0.20`, Vuetify components when using auto imports will show as `Unknown` by IntelliSense. 
![Screenshot 2024-07-11 at 8 41 43 AM](https://github.com/vuetifyjs/vuetify/assets/5513740/9a21dadb-2732-43b4-8f4a-62a4b0afc459)

This module augmentation has been done in many projects so far, i.e: https://github.com/nuxt/nuxt/pull/26541

The idea is to augment modules `vue`, `@vue/runtime-dom` and `@vue/runtime-core`
After augmenting all the proper modules, IntelliSense starts to work again.
![Screenshot 2024-07-11 at 8 43 17 AM](https://github.com/vuetifyjs/vuetify/assets/5513740/bc42f4a6-b3a0-46db-be6a-94863488ffc4)


