### PR TITLE
docs(List): fix active navigation item

### DIFF
--- a/packages/docs/src/components/app/list/List.vue
+++ b/packages/docs/src/components/app/list/List.vue
@@ -57,6 +57,8 @@
 </template>
 
 <script setup lang="ts">
+  import { useRoute } from 'vue-router'
+
   // Types
   import type { RouteLocationRaw, RouteRecordRaw } from 'vue-router'
   import type { Prop } from 'vue'
@@ -79,6 +81,8 @@
     emphasized?: boolean
     onClick?: () => void
   }
+
+  const { path: currentRoutePath } = useRoute()
 
   function generateApiItems (locale: string) {
     return (generatedRoutes as RouteRecordRaw[])
@@ -117,6 +121,7 @@
         emphasized: route?.meta?.emphasized ?? false,
         to,
         disabled: !route,
+        active: currentRoutePath === route?.path,
       }
     } else if (item.divider) {
       return {


### PR DESCRIPTION
This PR addresses a bug in the sidebar navigation where the same item is always marked as active, regardless of the navigation. The issue was caused by not correctly updating the active state of the sidebar items based on the current route path.

Resolve issues:
resolves #19244
resolves #20151


## Description
To fix this, I have modified the sidebar navigation to use the active prop of the list item component. The active prop is now set by comparing the current route path against the route path of each sidebar navigation item. This ensures that the correct item is marked as active as the user navigates through different pages.