### PR TITLE
fix(VDatePickerMonth): range bug with programmatic startdate

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -93,6 +93,9 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
 
       if (model.value.length === 0) {
         rangeStart.value = undefined
+      } else if (model.value.length === 1) {
+        rangeStart.value = model.value[0]
+        rangeStop.value = undefined
       }
       if (!rangeStart.value) {
         rangeStart.value = _value


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Fix: When a startDate is set programmatically after Date Picker is rendered, rangeStart value should also be updated. So that when we click a date for the end date, the rangeStart won't get reset into what we click as endDate. 

Resolves #20168

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-btn @click="handleSetDeliveryDateToEarliestPossible">
        Set {{ earliestPossibleDeliveryDate.toLocaleDateString('de-DE') }} as
        initial start date
      </v-btn>
      <v-date-picker
        v-model="selectedDateRange"
        color="secondary"
        multiple="range"
        width="100%"
        hide-header
        show-adjacent-months
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue';
  const selectedDateRange = ref([])
  const earliestPossibleDeliveryDate = ref(new Date()) // can be any date, here it's today for simplicity
  function handleSetDeliveryDateToEarliestPossible () {
    selectedDateRange.value = [earliestPossibleDeliveryDate.value]
  }
</script>

```
