### PR TITLE
fix(VFileInput): emit null after VForm reset()

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -98,7 +98,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       'modelValue',
       props.modelValue,
       val => wrapInArray(val),
-      val => (props.multiple || Array.isArray(props.modelValue)) ? val : (val[0] ?? null),
+      val => (!props.multiple && Array.isArray(val)) ? val[0] : val,
     )
     const { isFocused, focus, blur } = useFocus(props)
     const base = computed(() => typeof props.showSize !== 'boolean' ? props.showSize : undefined)


### PR DESCRIPTION
fixes #20101

reproduce example
```
<template>
  <v-app>
    <v-container>
      <v-form ref="form">
        <v-file-input v-model="files" />
      </v-form>
      <v-btn @click="resetForm">reset form</v-btn>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const files = ref()
  const form = ref()

  const resetForm = () => form.value.reset()
</script>
```