### PR TITLE
fix(VDataTable): fixed header when height is not set

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -84,8 +84,12 @@
   .v-data-table-column--last-fixed
     border-right: 1px solid rgba(var(--v-border-color), var(--v-border-opacity))
 
-  .v-data-table.v-table--fixed-header > .v-table__wrapper > table > thead > tr > th.v-data-table-column--fixed
-    z-index: 2
+  .v-data-table.v-table--fixed-header
+    &:not(.v-table--fixed-height) > .v-table__wrapper
+      overflow: visible
+    
+    > .v-table__wrapper > table > thead > tr > th.v-data-table-column--fixed
+      z-index: 2
 
   .v-data-table-group-header-row
     td

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
@@ -238,6 +238,23 @@ describe('VDataTable', () => {
       .get('thead .v-selection-control').should('exist')
   })
 
+  it('should fixed header while scrolling when the height is not fixed', () => {
+    cy.mount(() => (
+      <Application>
+        <VDataTable
+        fixedHeader
+        items={[...DESSERT_ITEMS, ...DESSERT_ITEMS]}
+        headers={ DESSERT_HEADERS }
+        itemsPerPage={ 100 }
+        />
+      </Application>
+    ))
+    cy.scrollTo('bottom')
+      .get('thead').then(header => {
+        expect(header[0].getBoundingClientRect().top).to.be.eq(0)
+      })
+  })
+
   describe('slots', () => {
     it('should have top slot', () => {
       cy.mount(() => (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20201 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-data-table
      :headers="headers"
      :items="plants"
      density="compact"
      item-key="name"
      fixed-header
    />
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      headers: [
        { title: 'Plant', align: 'start', sortable: false, key: 'name' },
        { title: 'Light', align: 'end', key: 'light' },
        { title: 'Height', align: 'end', key: 'height' },
        { title: 'Pet Friendly', align: 'end', key: 'petFriendly' },
        { title: 'Price ($)', align: 'end', key: 'price' },
      ],
      plants: [
        {
          name: 'Fern',
          light: 'Low',
          height: '20cm',
          petFriendly: 'Yes',
          price: 20,
        },
        {
          name: 'Snake Plant',
          light: 'Low',
          height: '50cm',
          petFriendly: 'No',
          price: 35,
        },
        {
          name: 'Monstera',
          light: 'Medium',
          height: '60cm',
          petFriendly: 'No',
          price: 50,
        },
        {
          name: 'Pothos',
          light: 'Low to medium',
          height: '40cm',
          petFriendly: 'Yes',
          price: 25,
        },
        {
          name: 'ZZ Plant',
          light: 'Low to medium',
          height: '90cm',
          petFriendly: 'Yes',
          price: 30,
        },
        {
          name: 'Spider Plant',
          light: 'Bright, indirect',
          height: '30cm',
          petFriendly: 'Yes',
          price: 15,
        },
        {
          name: 'Air Plant',
          light: 'Bright, indirect',
          height: '15cm',
          petFriendly: 'Yes',
          price: 10,
        },
        {
          name: 'Peperomia',
          light: 'Bright, indirect',
          height: '25cm',
          petFriendly: 'Yes',
          price: 20,
        },
        {
          name: 'Aloe Vera',
          light: 'Bright, direct',
          height: '30cm',
          petFriendly: 'Yes',
          price: 15,
        },
        {
          name: 'Jade Plant',
          light: 'Bright, direct',
          height: '40cm',
          petFriendly: 'Yes',
          price: 25,
        },
        {
          name: 'Air Plant',
          light: 'Bright, indirect',
          height: '15cm',
          petFriendly: 'Yes',
          price: 10,
        },
        {
          name: 'Peperomia',
          light: 'Bright, indirect',
          height: '25cm',
          petFriendly: 'Yes',
          price: 20,
        },
        {
          name: 'Aloe Vera',
          light: 'Bright, direct',
          height: '30cm',
          petFriendly: 'Yes',
          price: 15,
        },
        {
          name: 'Jade Plant',
          light: 'Bright, direct',
          height: '40cm',
          petFriendly: 'Yes',
          price: 25,
        },
        {
          name: 'Air Plant',
          light: 'Bright, indirect',
          height: '15cm',
          petFriendly: 'Yes',
          price: 10,
        },
        {
          name: 'Peperomia',
          light: 'Bright, indirect',
          height: '25cm',
          petFriendly: 'Yes',
          price: 20,
        },
        {
          name: 'Aloe Vera',
          light: 'Bright, direct',
          height: '30cm',
          petFriendly: 'Yes',
          price: 15,
        },
        {
          name: 'Jade Plant',
          light: 'Bright, direct',
          height: '40cm',
          petFriendly: 'Yes',
          price: 25,
        },
        {
          name: 'Air Plant',
          light: 'Bright, indirect',
          height: '15cm',
          petFriendly: 'Yes',
          price: 10,
        },
        {
          name: 'Peperomia',
          light: 'Bright, indirect',
          height: '25cm',
          petFriendly: 'Yes',
          price: 20,
        },
        {
          name: 'Aloe Vera',
          light: 'Bright, direct',
          height: '30cm',
          petFriendly: 'Yes',
          price: 15,
        },
        {
          name: 'Jade Plant',
          light: 'Bright, direct',
          height: '40cm',
          petFriendly: 'Yes',
          price: 25,
        },
        {
          name: 'Air Plant',
          light: 'Bright, indirect',
          height: '15cm',
          petFriendly: 'Yes',
          price: 10,
        },
        {
          name: 'Peperomia',
          light: 'Bright, indirect',
          height: '25cm',
          petFriendly: 'Yes',
          price: 20,
        },
        {
          name: 'Aloe Vera',
          light: 'Bright, direct',
          height: '30cm',
          petFriendly: 'Yes',
          price: 15,
        },
        {
          name: 'Jade Plant',
          light: 'Bright, direct',
          height: '40cm',
          petFriendly: 'Yes',
          price: 25,
        },
      ],
    }),
  }
</script>

```
