### PR TITLE
chore: fix build script output paths on windows

### DIFF
--- a/packages/vuetify/build/rollup.config.mjs
+++ b/packages/vuetify/build/rollup.config.mjs
@@ -27,6 +27,10 @@ function fixWindowsPath(path) {
   return path.replace(/^[^:]+:\\/, '\\').replaceAll('\\', '/')
 }
 
+const srcDir = fixWindowsPath(fileURLToPath(new URL('../src', import.meta.url)));
+const libDir = fixWindowsPath(fileURLToPath(new URL('../lib', import.meta.url)));
+const labsDir = fixWindowsPath(fileURLToPath(new URL('../src/labs', import.meta.url)));
+
 export default [
   {
     input: 'src/entry-bundler.ts',
@@ -85,11 +89,9 @@ export default [
           })
 
           // Individual CSS files
-          for (const { id, content } of styleNodes) {
-            const out = path.parse(fixWindowsPath(id).replace(
-              fileURLToPath(new URL('../src', import.meta.url)),
-              fileURLToPath(new URL('../lib', import.meta.url))
-            ))
+          for (const {id, content} of styleNodes) {
+            const relativePath = path.relative(srcDir, fixWindowsPath(id))
+            const out = path.parse(path.join(libDir, relativePath))
             mkdirp(out.dir).then(() => {
               writeFile(path.join(out.dir, out.name + '.css'), content, 'utf8')
             })
@@ -222,12 +224,13 @@ export default [
           })
 
           // Individual CSS files
-          styleNodes = styleNodes.filter(node => node.id.includes('src/labs'))
+          styleNodes = styleNodes.filter(node => {
+              return fixWindowsPath(node.id).startsWith(labsDir)
+            }
+          );
           for (const { id, content } of styleNodes) {
-            const out = path.parse(fixWindowsPath(id).replace(
-              fileURLToPath(new URL('../src', import.meta.url)),
-              fileURLToPath(new URL('../lib', import.meta.url))
-            ))
+            const relativePath = path.relative(srcDir, fixWindowsPath(id))
+            const out = path.parse(path.join(libDir, relativePath))
             mkdirp(out.dir).then(() => {
               writeFile(path.join(out.dir, out.name + '.css'), content, 'utf8')
             })


### PR DESCRIPTION

## Description



If it fixes an open issue, please link to the issue here.
 resolves #https://github.com/vuetifyjs/vuetify/issues/19169

I checked it still works on linux/mac, but double check !






