### PR TITLE
docs(contributing): suggest to clear vite's cache when using pnpm link

### DIFF
--- a/packages/docs/src/pages/en/getting-started/contributing.md
+++ b/packages/docs/src/pages/en/getting-started/contributing.md
@@ -96,6 +96,7 @@ You can also test Vuetify in your own project using [`pnpm link`](https://pnpm.i
 - Run `pnpm link --global`
 - Navigate to your project's directory
 - Run `pnpm link --global vuetify`
+- Clear Vite's cache by deleting  `node_modules/.vite` folder
 
 If your project is using vuetify-loader you will have to run `pnpm build:lib` in the vuetify package to see changes, otherwise you can use `pnpm watch` for incremental builds.
 


### PR DESCRIPTION
## Description
This might help some people, as without doing this you get unexpected behaviour
