### PR TITLE
Fix 19798 tweaks

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -69,14 +69,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
   },
 
   setup (props, { slots }) {
-    const _model = useProxiedModel(props, 'modelValue')
-
-    const model = computed({
-      get: () => _model.value,
-      set (val) {
-        if (typeof val !== 'string') _model.value = val
-      },
-    })
+    const model = useProxiedModel(props, 'modelValue')
 
     const vTextFieldRef = ref<VTextField | undefined>()
 
@@ -304,7 +297,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       return (
         <VTextField
           ref={ vTextFieldRef }
-          v-model={ model.value }
+          modelValue={ model.value }
           onBeforeinput={ onBeforeinput }
           onChange={ clampModel }
           onKeydown={ onKeydown }

--- a/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
@@ -25,6 +25,41 @@ describe('VNumberInput', () => {
     })
   })
 
+  it.only('should resolve to numeric value after blur', () => {
+    const scenarios = [
+      { typing: '-', expected: '' },
+      { typing: '.', expected: '' },
+      { typing: '-.', expected: '' },
+      { typing: '-.50', expected: '-0.5' },
+      { typing: '5.{leftarrow}{backspace}', expected: '' },
+    ]
+    scenarios.forEach(({ typing, expected }) => {
+      cy.mount(() => <VNumberInput />)
+        .get('.v-number-input input').focus().realType(typing)
+        .get('.v-number-input input').blur().should('have.value', expected)
+    })
+  })
+
+  it('should resolve to numeric value after blur (advanced)', () => {
+    cy.mount(() => <VNumberInput />)
+      .get('.v-number-input input').focus().realType('-0.21')
+      .get('.v-number-input input').blur().focus().realType('{home}{rightarrow}{del}') // removes "0", leaving "-.21"
+      .get('.v-number-input input').blur().should('have.value', '-0.21')
+  })
+
+  it('should accept up/down actions after typing a value', () => {
+    const scenarios = [
+      { typing: '500{uparrow}', expected: '501' },
+      { typing: '11{downarrow}', expected: '10' },
+      { typing: '7{uparrow}{uparrow}', expected: '9' },
+    ]
+    scenarios.forEach(({ typing, expected }) => {
+      cy.mount(() => <VNumberInput />)
+        .get('.v-number-input input').focus().realType(typing)
+        .get('.v-number-input input').should('have.value', expected)
+    })
+  })
+
   it('should reset v-model to null when click:clear is triggered', () => {
     const model = ref(5)
 


### PR DESCRIPTION
PR consists of 2 independent parts:
- refactoring to make it clear **none** of the `update:model-value` emits from VTextField are accepted (because all of them provide type `string`, they were already filtered out by the `_model` wrapper)
- test cases (mostly failing) to guide further implementation tweaks
  - scenarios for mixed usage of typing (adding/removing digits) and incrementing value (up/down arrows)
  - additional scenarios to ensure consistent state after blur

There is one more advanced scenario that works around auto-cleanup on blur (initial typing for `-0.21` is actually optional)
1. focus input with **existing value** and change text without changing effective number
   - e.g. `-.21`, `-0000.21`, `-0.2100`
2. after blur the text stays the same
   - it might not be a critical bug, but it is inconsistent with behavior when we type a new value, developers might be bothered by their QA team about this

---
Supports #20211 