### PR TITLE
feat(VOverlay): introduce MD3 scrim and shadow color variables and update `overlay-scrim-background`

### DIFF
--- a/packages/vuetify/src/components/VOverlay/_variables.scss
+++ b/packages/vuetify/src/components/VOverlay/_variables.scss
@@ -1,3 +1,3 @@
 // Defaults
 $overlay-opacity: var(--v-overlay-opacity, 0.32) !default;
-$overlay-scrim-background: rgb(var(--v-theme-on-surface)) !default;
+$overlay-scrim-background: rgb(var(--v-theme-scrim)) !default;

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -127,6 +127,8 @@ function genDefaults () {
           info: '#2196F3',
           success: '#4CAF50',
           warning: '#FB8C00',
+          scrim: '#000000',
+          shadow: '#000000',
         },
         variables: {
           'border-color': '#000000',
@@ -164,6 +166,8 @@ function genDefaults () {
           info: '#2196F3',
           success: '#4CAF50',
           warning: '#FB8C00',
+          scrim: '#000000',
+          shadow: '#000000',
         },
         variables: {
           'border-color': '#FFFFFF',


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
resolves #20244

Vuetify currently uses the Material Design 2 color system, which does not include a specific color variable for `overlay-scrim-background` required by components like dialogs. As a result, the following setting is used:
```sass
// components/VOverlay/_variables.scss
$overlay-scrim-background: rgb(var(--v-theme-on-surface)) !default;
```
In dark themes, the `on-surface` color is pure white (`#FFFFFF`), leading to a semi-transparent white overlay. This can be very glaring and does not comply with Material Design guidelines.

Material Design 3 (MD3) provides [dedicated color roles](https://m3.material.io/styles/color/roles) for Scrim and Shadow (`md.sys.color.scrim`, `md.sys.color.shadow`), both defaulting to pure black (`#000000`) in light and dark themes. Utilizing these variables for `$overlay-scrim-background` can enhance visual consistency and user experience, especially in dark themes.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-btn text="toggle theme" @click="toggleTheme" />

      <v-dialog max-width="480">
        <template #activator="{ props: activatorProps }">
          <v-btn v-bind="activatorProps" text="Open Dialog" />
        </template>

        <template #default="{ isActive }">
          <v-card title="Dialog">
            <v-card-text> Lorem ipsum dolor sit amet. </v-card-text>

            <v-card-actions>
              <v-spacer />

              <v-btn text="toggle theme" @click="toggleTheme"/>

              <v-btn
                text="Close Dialog"
                @click="isActive.value = false"
              />
            </v-card-actions>
          </v-card>
        </template>
      </v-dialog>
    </v-container>
  </v-app>
</template>

<script setup>
  import { useTheme } from 'vuetify'

  const theme = useTheme()

  function toggleTheme () {
    theme.global.name.value = theme.global.current.value.dark ? 'light' : 'dark'
  }
</script>
```
[Vuetify Playground](https://play.vuetifyjs.com/#eNqdU8FO4zAQ/ZVR9hCQtuke9rCqCguCIxIcuFEOxpmkFo5t2eMCivrvTOImJFW5cImSmTcz772ZPLVZ8HJ57Vyxi5itsjVh47QgvNwYgPVuIZzrX/sPaQ0JZdAfQn3whQwQvtPFJiNb1xqBttjgJoMrqZV8HeOPh/CSqyf1pRLa1tCI98WbKmnL+L///myycQajBlbwS0hSO0HWM6wF560LKxiDD9037GfFI0l+KlNy3RzOjA707x0auO3pHGiOHZYTX07yKrESUXddWlDhupuAp4hI4UsgRRoZOsyagUbYoqN1CXfWYwPKhdhAabX1EBSBaJAK5jWFTqlN+3R6rQlHU/p8cEKin63kyLUfr/Z0nxttA36ZPPYZPCt2QkeEC6iEDkPLWbtB8ilVQ/K71X2h0tUNp92VzW67i6TTP1r9OkivHEFAiunPUI2znqCFGJIPsIfK2wZy/qVIVR958oQHBEoGsrwBfHaeslU0vR6YGHp2Dm0i2FcVtbYvQheGdz/aNMvI6D0aSsmiFP4V/kOuVb2lHFaQdxFmA3yYrCspYQ3Z/reJWveP508PREgK)