### PR TITLE
fix(VMenu): check if element still exists before closing parent

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -78,7 +78,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
         setTimeout(() => {
           if (!openChildren.value &&
             !props.persistent &&
-            (e == null || (e && !isClickInsideElement(e, overlay.value!.contentEl!)))
+            (e == null || (e && overlay.value && overlay.value.contentEl && !isClickInsideElement(e, overlay.value.contentEl)))
           ) {
             isActive.value = false
             parent?.closeParents()

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -78,7 +78,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
         setTimeout(() => {
           if (!openChildren.value &&
             !props.persistent &&
-            (e == null || (e && overlay.value && overlay.value.contentEl && !isClickInsideElement(e, overlay.value.contentEl)))
+            (e == null || (overlay.value?.contentEl && !isClickInsideElement(e, overlay.value.contentEl)))
           ) {
             isActive.value = false
             parent?.closeParents()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20248 

Instead of using the `!` operator, I just added some null checks before using the `overlay.value.contentEl`.
I don't think it should cause any issue since the issue occurs when the view is completely destroyed (through the router in the reported case), so there is no cleanup to do anyways

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
I used the same reproduction repo I provided in the issue to validate the changes:
https://github.com/Arinono/vuetify-vmenu-bug
```vue
<v-menu v-if="open" :close-on-content-click="false">
    <template #activator="{ props }">
      <v-btn v-bind="props">Open</v-btn>
    </template>
    <v-sheet class="pa-4">
      <div class="d-flex">
        <v-menu>
          <template #activator="{ props }">
            <v-btn style="display: block" v-bind="props">Sub menu</v-btn>
          </template>
          <v-sheet class="pa-4"> Click back in the input</v-sheet>
        </v-menu>
        <v-text-field style="width: 400px"></v-text-field>
      </div>
    </v-sheet>
  </v-menu>

  <router-link to="other-route" style="margin-left: 48px"> leave </router-link>
```

and used [this section of the docs](https://vuetifyjs.com/en/getting-started/contributing/#vuetify) to test it