### PR TITLE
fix(VFileInput): make child elements clickable

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.sass
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.sass
@@ -31,7 +31,6 @@
       position: absolute
       top: 0
       width: 100%
-      z-index: 1
 
     .v-input__details
       padding-inline: $file-input-details-padding-inline

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -215,6 +215,14 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                 disabled={ isDisabled.value }
                 focused={ isFocused.value }
                 error={ isValid.value === false }
+                onDragover={ (e: MouseEvent) => { e.preventDefault() } }
+                onDrop={ (e: DragEvent) => {
+                  e.preventDefault()
+
+                  if (!e.dataTransfer) return
+
+                  model.value = [...e.dataTransfer.files ?? []]
+                }}
               >
                 {{
                   ...slots,


### PR DESCRIPTION
## Description
- fixes https://github.com/vuetifyjs/vuetify/issues/18638

- `VChip` inside `VInputField` is not clickable due to `VInputField`'s `z-index: 1`, which was introduced in https://github.com/vuetifyjs/vuetify/pull/16058 to handle drag and drop
- This PR removes the `z-index` and handles drag and drop manually

## Markup:
- Reused and tested markup provided by https://github.com/vuetifyjs/vuetify/issues/18638

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-file-input v-model="files" :readonly="readonly">
        <template #selection="{ fileNames }">
          <div v-for="fileName in fileNames">
            <v-chip @click="click" closable link>{{fileName}}</v-chip>
            <v-chip @click="click2" closable link>{{fileName}}</v-chip>
          </div>
        </template>
      </v-file-input>

      <v-switch v-model="readonly" label="v-file-input Readonly"></v-switch>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const files = ref([new File([], 'testfile')])

  const readonly = ref(false)

  function click() {
    alert('click')
  }
  function click2(event) {
    event.stopPropagation()
    alert('click')
  }
</script>
```
[Playground](https://play.vuetifyjs.com/#eNqVUkFOwzAQ/MrKHJJKNEHAAaGA4MIRIa5tDybdgFXHtmw3FYryd9Z20zYgJDjZHs+Md2e96JmzdfloTNFtkd2yymNrJPd4v1QAVTfnxsRtPNRaeS4U2j0UwUZInAtlth66eavXKO+WLIBuyeDWIl9rJT8JG7dLdpCTwfggnDmUWHuhFXF7CA7PvEUHw0RAkrXo6KlG2/1DgQZCHSXfBKn2D2HgoZai3pAsrlRfLbXjbxJBCrW57/vRYhiqMmn+5HT5f6uqpDZOgygn0SfoNF2CT1J3O+Hrj5PEj+mC5G8Rmszm9Zh+8E36cbShwMlsA5JGP6mLjq62wnhw6LepIdEabT30YLGBARqrW8joN2Xhklydj4NxcBcY+ULhDp4IyBerc8g8Oh+us9lqlhpMkrGdvarh0uGe0GxV/CaUOEWfz6BPXXCJ1udZRDPiAv2cH/TLHDtU/iCKp8J5bV6sNvydB2oe1b84VmWKgJpnwzm7Kq6KGxbW6+KCrb4AB54TAA==)