### PR TITLE
fix(VBtn): card-actions add margin-inline-start only for for direct btns

### DIFF
--- a/packages/docs/src/pages/en/components/cards.md
+++ b/packages/docs/src/pages/en/components/cards.md
@@ -41,7 +41,7 @@ The `v-card` component is a stylish way to wrap different types of content; such
 | [v-card-title](/api/v-card-title/) | Sub-component used to display the Card's title. Wraps the `#title` slot |
 | [v-card-subtitle](/api/v-card-subtitle/) | Sub-component used to display the Card's subtitle. Wraps the `#subtitle` slot. |
 | [v-card-text](/api/v-card-text/) | Sub-component used to display the Card's text. Wraps the `#text` slot. |
-| [v-card-actions](/api/v-card-actions/) | Sub-component that modifies the default styling of [v-btn](/components/buttons/). Wraps the `#actions` slot |
+| [v-card-actions](/api/v-card-actions/) | Sub-component that modifies the default styling of [v-btn](/components/buttons/) that are its direct children. Wraps the `#actions` slot |
 
 <ApiInline hide-links />
 

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -233,9 +233,8 @@
 
   // VCard
   .v-btn
-    ~ .v-btn:not(.v-btn-toggle .v-btn)
-      .v-card-actions &
-        margin-inline-start: $button-card-actions-margin
+    .v-card-actions > &
+      margin-inline-start: $button-card-actions-margin
 
   // VPagination
   .v-btn


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #20239

Breaking change: `v-card-actions` only impacts its immediate child v-btns

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input control-variant="stacked" />
    </v-container>
    <v-card-actions>
      <v-btn text="one" />
      <v-btn text="two" />
    </v-card-actions>
    <v-card-actions>
      <v-number-input control-variant="stacked" />
    </v-card-actions>
  </v-app>
</template>

```
