### PR TITLE
fix(click-outside): correctly remove shadow DOM event listeners

### DIFF
--- a/packages/vuetify/src/directives/click-outside/__tests__/click-outside-shadow-dom.spec.ts
+++ b/packages/vuetify/src/directives/click-outside/__tests__/click-outside-shadow-dom.spec.ts
@@ -63,7 +63,7 @@ describe('click-outside.js within the Shadow DOM', () => {
     const { outsideClickHandler, shadowEl, binding } = bootstrap()
     expect(window.document.addEventListener).toHaveBeenCalledWith('click', outsideClickHandler, true)
 
-    ClickOutside.unmounted(shadowEl, binding)
+    ClickOutside.beforeUnmount(shadowEl, binding)
     expect(window.document.removeEventListener).toHaveBeenCalledWith('click', outsideClickHandler, true)
   })
 
@@ -71,7 +71,7 @@ describe('click-outside.js within the Shadow DOM', () => {
     const { shadowClickHandler, shadowRoot, shadowEl, binding } = bootstrap()
     expect(shadowRoot.addEventListener).toHaveBeenCalledWith('click', shadowClickHandler, true)
 
-    ClickOutside.unmounted(shadowEl, binding)
+    ClickOutside.beforeUnmount(shadowEl, binding)
     expect(shadowRoot.removeEventListener).toHaveBeenCalledWith('click', shadowClickHandler, true)
   })
 

--- a/packages/vuetify/src/directives/click-outside/__tests__/click-outside.spec.ts
+++ b/packages/vuetify/src/directives/click-outside/__tests__/click-outside.spec.ts
@@ -44,7 +44,7 @@ describe('v-click-outside', () => {
     const { clickHandler, el, binding } = bootstrap()
     expect(window.document.addEventListener).toHaveBeenCalledWith('click', clickHandler, true)
 
-    ClickOutside.unmounted(el, binding)
+    ClickOutside.beforeUnmount(el, binding)
     expect(window.document.removeEventListener).toHaveBeenCalledWith('click', clickHandler, true)
   })
 

--- a/packages/vuetify/src/directives/click-outside/index.ts
+++ b/packages/vuetify/src/directives/click-outside/index.ts
@@ -102,7 +102,7 @@ export const ClickOutside = {
     }
   },
 
-  unmounted (el: HTMLElement, binding: ClickOutsideDirectiveBinding) {
+  beforeUnmount (el: HTMLElement, binding: ClickOutsideDirectiveBinding) {
     if (!el._clickOutside) return
 
     handleShadow(el, (app: HTMLElement) => {


### PR DESCRIPTION
## Description

ClickOutside directive uses global `onmousedown` and `click` events in the parent shadowRoot of the element when the element is inside the Shadow DOM.

When unmounted, the directive tries to remove those event handlers, but since the element is already unmounted, it can't find the parent shadowRoot, so the events are never removed.

This causes VOverlay content clicks to behave incorrectly, closing menus and submenus when they should stay open.

Using beforeUnmount instead of unmounted to remove event handlers in ClickOutside directive solves the issue.

fixes #19616

## Markup:
```vue
<template>
  <v-menu v-bind="$attrs" location="right">
    <template #activator="{ props }">
      <v-btn v-bind="props" class="ma-5">Normal Menu</v-btn>
    </template>
    <v-list>
      <v-menu location="right">
        <template #activator="{ props }">
          <v-list-item v-bind="props" title="Submenu" />
        </template>
        <v-list>
          <v-list-item title="Submenu item" />
          <v-list-item title="Submenu item" />
        </v-list>
      </v-menu>
    </v-list>
  </v-menu>

  <div ref="shadow" />
</template>

<script>
  import { createApp, h } from 'vue'
  import vuetify from './vuetify'
  import { VBtn, VList, VListItem, VMenu } from 'vuetify/src/components'

  export default {
    name: 'Playground',
    setup () {
      return {

      }
    },
    mounted () {
      const shadowRoot = this.$refs.shadow.attachShadow({ mode: 'open' })
      const shadowApp = document.createElement('div')
      shadowApp.id = 'shadow-app'
      shadowRoot.appendChild(shadowApp)
      document.querySelectorAll('style').forEach(styleElement => {
        shadowRoot.appendChild(styleElement.cloneNode(true))
      })

      createApp({
        render: () => h(VMenu, { location: 'right' }, {
          activator: ({ props }) => h(VBtn, { ...props, class: 'ma-5' }, 'Shadow Menu'),
          default: () => [
            h(VList, {}, () => [
              h(VMenu, { location: 'right' }, {
                activator: ({ props }) => h(VListItem, { ...props, title: 'Submenu' }),
                default: () => [
                  h(VList, {}, () => [
                    h(VListItem, { title: 'Submenu item' }),
                    h(VListItem, { title: 'Submenu item' }),
                  ]),
                ],
              }),
            ]),
          ],
        }),
      })
        .use(vuetify)
        .mount(shadowApp)
    },
  }
</script>
```
