### PR TITLE
fix(VField/VInput): centerAffix doesn't work for underlined/plain

### DIFF
--- a/packages/api-generator/src/locale/en/VField.json
+++ b/packages/api-generator/src/locale/en/VField.json
@@ -2,7 +2,7 @@
   "props": {
     "appendInnerIcon": "Creates a [v-icon](/api/v-icon/) component in the **append-inner** slot.",
     "baseColor": "Sets the color of the input when it is not focused.",
-    "centerAffix": "Vertically align **appendInner**, **prependInner**, **clearIcon** and **label** in the center.",
+    "centerAffix": "Automatically apply **[singleLine](/api/v-field/#props-single-line)** under the hood, and vertically align **appendInner**, **prependInner**, **clearIcon**, **label** and **input field** in the center.",
     "clearIcon": "The icon used when the **clearable** prop is set to true.",
     "dirty": "Manually apply the dirty state styling.",
     "disabled": "Removes the ability to click or target the input.",

--- a/packages/api-generator/src/locale/en/VInput.json
+++ b/packages/api-generator/src/locale/en/VInput.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "backgroundColor": "Changes the background-color of the input.",
-    "centerAffix": "Vertically align **appendInner**, **prependInner**, **clearIcon** and **label** in the center.",
+    "centerAffix": "Vertically align **append** and **prepend** in the center.",
     "direction": "Changes the direction of the input.",
     "hideDetails": "Hides hint and validation errors. When set to `auto` messages will be rendered only if there's a message (hint, error message, counter value etc) to display.",
     "hideSpinButtons": "Hides spin buttons on the input when type is set to `number`.",

--- a/packages/api-generator/src/locale/en/VTextField.json
+++ b/packages/api-generator/src/locale/en/VTextField.json
@@ -2,6 +2,7 @@
   "props": {
     "autofocus": "Enables autofocus.",
     "clearIcon": "Applied when using **clearable** and the input is dirty.",
+    "centerAffix": "Automatically apply **[singleLine](/api/v-field/#props-single-line)** under the hood, and vertically align **appendInner**, **prependInner**, **clearIcon**, **label**, **append**, **prepend** and **input field** in the center.",
     "counterValue": "Function returns the counter display text.",
     "flat": "Removes elevation (shadow) added to element when using the **solo** or **solo-inverted** props.",
     "persistentPlaceholder": "Forces placeholder to always be visible.",

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -138,6 +138,10 @@
 
     $root: &
 
+    @at-root #{selector.nest('.v-field.v-field--center-affix.v-field--variant-underlined, .v-field.v-field--center-affix.v-field--variant-plain', &)}
+      padding-top: unset
+      padding-bottom: unset
+
     @at-root
       @include tools.density('v-input', $input-density) using ($modifier)
         @at-root #{selector.nest(&, $root)}
@@ -185,15 +189,11 @@
   .v-field__clearable,
   .v-field__prepend-inner
     display: flex
-    align-items: flex-start
-    padding-top: var(--v-input-padding-top, $field-control-padding-top)
+    align-items: center
+    padding-top: 0
 
-    .v-field--center-affix &
-      align-items: center
-      padding-top: 0
-
-  .v-field.v-field--variant-underlined,
-  .v-field.v-field--variant-plain
+  .v-field:not(.v-field--center-affix).v-field--variant-underlined,
+  .v-field:not(.v-field--center-affix).v-field--variant-plain
     .v-field__append-inner,
     .v-field__clearable,
     .v-field__prepend-inner

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -62,10 +62,7 @@ export const makeVFieldProps = propsFactory({
     default: '$clear',
   },
   active: Boolean,
-  centerAffix: {
-    type: Boolean,
-    default: undefined,
-  },
+  centerAffix: Boolean,
   color: String,
   baseColor: String,
   dirty: Boolean,
@@ -136,8 +133,9 @@ export const VField = genericComponent<new <T>(
     const { roundedClasses } = useRounded(props)
     const { rtlClasses } = useRtl()
 
+    const isSingleLine = computed(() => props.singleLine || props.centerAffix)
     const isActive = computed(() => props.dirty || props.active)
-    const hasLabel = computed(() => !props.singleLine && !!(props.label || slots.label))
+    const hasLabel = computed(() => !isSingleLine.value && !!(props.label || slots.label))
 
     const uid = getUid()
     const id = computed(() => props.id || `input-${uid}`)
@@ -242,7 +240,7 @@ export const VField = genericComponent<new <T>(
             {
               'v-field--active': isActive.value,
               'v-field--appended': hasAppend,
-              'v-field--center-affix': props.centerAffix ?? !isPlainOrUnderlined.value,
+              'v-field--center-affix': props.centerAffix,
               'v-field--disabled': props.disabled,
               'v-field--dirty': props.dirty,
               'v-field--error': props.error,
@@ -251,7 +249,7 @@ export const VField = genericComponent<new <T>(
               'v-field--persistent-clear': props.persistentClear,
               'v-field--prepended': hasPrepend,
               'v-field--reverse': props.reverse,
-              'v-field--single-line': props.singleLine,
+              'v-field--single-line': isSingleLine.value,
               'v-field--no-label': !label(),
               [`v-field--variant-${props.variant}`]: true,
             },

--- a/packages/vuetify/src/components/VInput/VInput.sass
+++ b/packages/vuetify/src/components/VInput/VInput.sass
@@ -77,12 +77,8 @@
   .v-input__prepend,
   .v-input__append
     display: flex
-    align-items: flex-start
-    padding-top: var(--v-input-padding-top)
-
-    .v-input--center-affix &
-      align-items: center
-      padding-top: 0
+    align-items: center
+    padding-top: 0
 
   .v-input__prepend
     grid-area: prepend
@@ -103,7 +99,7 @@
       input[type=number]
         -moz-appearance: textfield
 
-    &--plain-underlined
+    &--plain-underlined:not(&--center-affix)
 
       .v-input__prepend,
       .v-input__append

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -40,10 +40,7 @@ export interface VInputSlot {
 export const makeVInputProps = propsFactory({
   id: String,
   appendIcon: IconValue,
-  centerAffix: {
-    type: Boolean,
-    default: true,
-  },
+  centerAffix: Boolean,
   prependIcon: IconValue,
   hideDetails: [Boolean, String] as PropType<boolean | 'auto'>,
   hideSpinButtons: Boolean,

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -176,7 +176,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
           style={ props.style }
           { ...rootAttrs }
           { ...inputProps }
-          centerAffix={ !isPlainOrUnderlined.value }
+          centerAffix={ props.centerAffix }
           focused={ isFocused.value }
         >
           {{
@@ -202,6 +202,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                 dirty={ isDirty.value || props.dirty }
                 disabled={ isDisabled.value }
                 focused={ isFocused.value }
+                centerAffix={ props.centerAffix }
                 error={ isValid.value === false }
               >
                 {{

--- a/packages/vuetify/src/components/VTextarea/VTextarea.sass
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.sass
@@ -30,6 +30,15 @@
         min-height: 0 !important
         pointer-events: none
 
+
+    .v-field:not(.v-field--center-affix)
+      .v-field__append-inner,
+      .v-field__clearable,
+      .v-field__prepend-inner
+        display: flex
+        align-items: flex-start
+        padding-top: var(--v-input-padding-top, $field-control-padding-top)
+
     &--no-resize
       .v-field__input
         resize: none
@@ -38,6 +47,14 @@
     .v-field--active
       textarea
         opacity: 1
+
+
+    &:not(.v-input--center-affix)
+      .v-input__prepend,
+      .v-input__append
+        display: flex
+        align-items: flex-start
+        padding-top: var(--v-input-padding-top)
 
     textarea
       opacity: 0

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -18,7 +18,7 @@ import Intersect from '@/directives/intersect'
 
 // Utilities
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
-import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
+import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -48,8 +48,8 @@ export const makeVTextareaProps = propsFactory({
   suffix: String,
   modelModifiers: Object as PropType<Record<string, boolean>>,
 
-  ...makeVInputProps(),
-  ...makeVFieldProps(),
+  ...omit(makeVInputProps(), ['centerAffix']),
+  ...omit(makeVFieldProps(), ['centerAffix']),
 }, 'VTextarea')
 
 type VTextareaSlots = Omit<VInputSlots & VFieldSlots, 'default'> & {

--- a/packages/vuetify/src/components/VTextarea/_variables.scss
+++ b/packages/vuetify/src/components/VTextarea/_variables.scss
@@ -1,3 +1,4 @@
+@forward '../VField/variables';
 @use '../../styles/settings';
 
 // VTextarea


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

BREAKING CHANGE: remove `center-affix` from v-textarea, it doesn't make sense anyway

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<!-- eslint-disable vue/attributes-order -->
<template>
  <v-container class="pa-md-12 bg-grey">
    <v-row>
      <v-col cols="4">
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="solo"
          label="solo"
          variant="solo"
          center-affix
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="outlined"
          label="outlined"
          variant="outlined"
          center-affix
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="filled"
          label="filled"
          variant="filled"
          center-affix
        />
        <v-text-field
          bg-color="white"
          clearable
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="underlined"
          label="underlined"
          variant="underlined"
          center-affix
        />
      </v-col>
      <v-col cols="4">
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="solo"
          label="solo"
          variant="solo"
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="outlined"
          label="outlined"
          variant="outlined"
        />
        <v-text-field
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="filled"
          label="filled"
          variant="filled"
        />
        <v-text-field
          bg-color="white"
          clearable
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          placeholder="underlined"
          label="underlined"
          variant="underlined"
        />
      </v-col>
    </v-row>
    <v-row>
      <v-col cols="12">
        <v-textarea
          auto-grow
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          rows="1"
        />
        <v-textarea
          auto-grow
          bg-color="white"
          prepend-icon="$vuetify"
          prepend-inner-icon="$vuetify"
          rows="1"
          variant="underlined"
        />
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'
</script>
```
