### PR TITLE
fix(teleport): correctly select overlay container in shadow DOM

### DIFF
--- a/packages/vuetify/src/composables/teleport.ts
+++ b/packages/vuetify/src/composables/teleport.ts
@@ -18,7 +18,8 @@ export function useTeleport (target: () => (boolean | string | ParentNode)) {
       return undefined
     }
 
-    let container = targetElement.querySelector(':scope > .v-overlay-container')
+    const rootSelector = targetElement instanceof ShadowRoot ? ':host' : ':scope'
+    let container = targetElement.querySelector(`${rootSelector} > .v-overlay-container`)
 
     if (!container) {
       container = document.createElement('div')


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

When VOverlay is mounted in the Shadow DOM, it passes correctly the shadowRoot element to the teleport composable. Then the teleport composable checks for an existing v-overlay-container using `:scope > .v-overlay-container` selector.

However, as confirmed by css [specs](https://github.com/w3c/csswg-drafts/issues/7261) discussion, :scope selector doesn't select anything when used on a ShadowRoot element, so an existing overlay container is never found and it is created and appended again.

The solution is to use `:host > .v-overlay-container` selector when the element is an instance of ShadowRoot.

fixes #20276

## Markup:

```vue
<template>
  <v-menu v-bind="$attrs" location="right">
    <template #activator="{ props }">
      <v-btn v-bind="props" class="ma-5">Normal Menu</v-btn>
    </template>
    <v-list>
      <v-menu location="right">
        <template #activator="{ props }">
          <v-list-item v-bind="props" title="Submenu" />
        </template>
        <v-list>
          <v-list-item title="Submenu item" />
          <v-list-item title="Submenu item" />
        </v-list>
      </v-menu>
    </v-list>
  </v-menu>

  <div ref="shadow" />
</template>

<script>
  import { createApp, h } from 'vue'
  import vuetify from './vuetify'
  import { VBtn, VList, VListItem, VMenu } from 'vuetify/src/components'

  export default {
    name: 'Playground',
    setup () {
      return {

      }
    },
    mounted () {
      const shadowRoot = this.$refs.shadow.attachShadow({ mode: 'open' })
      const shadowApp = document.createElement('div')
      shadowApp.id = 'shadow-app'
      shadowRoot.appendChild(shadowApp)
      document.querySelectorAll('style').forEach(styleElement => {
        shadowRoot.appendChild(styleElement.cloneNode(true))
      })

      createApp({
        render: () => h(VMenu, { location: 'right' }, {
          activator: ({ props }) => h(VBtn, { ...props, class: 'ma-5' }, 'Shadow Menu'),
          default: () => [
            h(VList, {}, () => [
              h(VMenu, { location: 'right' }, {
                activator: ({ props }) => h(VListItem, { ...props, title: 'Submenu' }),
                default: () => [
                  h(VList, {}, () => [
                    h(VListItem, { title: 'Submenu item' }),
                    h(VListItem, { title: 'Submenu item' }),
                  ]),
                ],
              }),
            ]),
          ],
        }),
      })
        .use(vuetify)
        .mount(shadowApp)
    },
  }
</script>

```
