### PR TITLE
fix(VBtnToggle): plain variant button opacity when selected

### DIFF
--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
@@ -7,5 +7,4 @@
       @include tools.active-states('> .v-btn__overlay', $btn-toggle-selected-opacity)
 
       &.v-btn--variant-plain
-        > .v-btn__overlay
-          display: block
+        opacity: 1

--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
@@ -5,3 +5,7 @@
   .v-btn-toggle
     > .v-btn.v-btn--active:not(.v-btn--disabled)
       @include tools.active-states('> .v-btn__overlay', $btn-toggle-selected-opacity)
+
+      &.v-btn--variant-plain
+        > .v-btn__overlay
+          display: block


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20142 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-row>
      <v-col class="py-2" cols="12" sm="6">
        <p>Mandatory</p>
        <v-btn-toggle v-model="toggle_one">
          <v-btn value="eins">
            <v-icon>mdi-format-align-left</v-icon>
          </v-btn>

          <v-btn value="zwei">
            <v-icon>mdi-format-align-center</v-icon>
          </v-btn>

          <v-btn value="drei">
            <v-icon>mdi-format-align-right</v-icon>
          </v-btn>

          <v-btn value="vier">
            <v-icon>mdi-format-align-justify</v-icon>
          </v-btn>
        </v-btn-toggle>
      </v-col>

      <v-col class="py-2" cols="12" sm="6">
        <p>Mandatory</p>
        <v-btn-toggle v-model="toggle_one" variant="plain">
          <v-btn value="eins">
            <v-icon>mdi-format-align-left</v-icon>
          </v-btn>

          <v-btn value="zwei">
            <v-icon>mdi-format-align-center</v-icon>
          </v-btn>

          <v-btn value="drei">
            <v-icon>mdi-format-align-right</v-icon>
          </v-btn>

          <v-btn value="vier">
            <v-icon>mdi-format-align-justify</v-icon>
          </v-btn>
        </v-btn-toggle>
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'

  const toggle_one = ref('vier')
</script>
```
