### PR TITLE
fix(VDateInput): convert model to Date for compatible with VConfirmEdit

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -47,7 +47,14 @@ export const VDateInput = genericComponent()({
     const { t } = useLocale()
     const adapter = useDate()
     const { isFocused, focus, blur } = useFocus(props)
-    const model = useProxiedModel(props, 'modelValue', props.multiple ? [] : null)
+    const model = useProxiedModel(
+      props,
+      'modelValue',
+      props.multiple ? [] : null,
+      val => Array.isArray(val) ? val.map(item => adapter.toJsDate(item)) : val ? adapter.toJsDate(val) : null,
+      val => Array.isArray(val) ? val.map(item => adapter.date(item)) : val ? adapter.date(val) : null
+    )
+
     const menu = shallowRef(false)
 
     const display = computed(() => {
@@ -84,7 +91,7 @@ export const VDateInput = genericComponent()({
 
       const target = e.target as HTMLInputElement
 
-      model.value = adapter.date(target.value)
+      model.value = adapter.toJsDate(target.value)
     }
 
     function onClick (e: MouseEvent) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20146 

these lines in VConfirmEdit make VDateInput breaks when using with differences date adapter https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx#L61
https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx#L76

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input v-model="model" label="Date input" @update:model-value="onUpdateModelValue" />

      <v-date-input v-model="modelMultiple" label="Date Multiple" multiple @update:model-value="onUpdateModelValue" />

      <v-date-input v-model="modelRange" label="Date Range" multiple="range" @update:model-value="onUpdateModelValue" />
    </v-container>
  </v-app>
</template>
<script setup lang="ts">
  import { ref } from 'vue'

  const model = ref()
  const modelMultiple = ref()
  const modelRange = ref()

  const onUpdateModelValue = (val) => {
    console.log('onUpdateModelValue', val)
  }
</script>

```
