### PR TITLE
fix(useDisplay): more intuitive use of `mobile-breakpoint`

### DIFF
--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -231,14 +231,17 @@ export function useDisplay (
   if (!display) throw new Error('Could not find Vuetify display injection')
 
   const mobile = computed(() => {
-    if (props.mobile != null) return props.mobile
-    if (!props.mobileBreakpoint) return display.mobile.value
-
-    const breakpointValue = typeof props.mobileBreakpoint === 'number'
-      ? props.mobileBreakpoint
-      : display.thresholds.value[props.mobileBreakpoint]
-
-    return display.width.value < breakpointValue
+    if (props.mobile) {
+      return true
+    } else if (typeof props.mobileBreakpoint === 'number') {
+      return display.width.value < props.mobileBreakpoint
+    } else if (props.mobileBreakpoint) {
+      return display.width.value < display.thresholds.value[props.mobileBreakpoint]
+    } else if (props.mobile == null) {
+      return display.mobile.value
+    } else {
+      return false
+    }
   })
 
   const displayClasses = computed(() => {

--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -237,7 +237,7 @@ export function useDisplay (
       return display.width.value < props.mobileBreakpoint
     } else if (props.mobileBreakpoint) {
       return display.width.value < display.thresholds.value[props.mobileBreakpoint]
-    } else if (props.mobile == null) {
+    } else if (props.mobile === null) {
       return display.mobile.value
     } else {
       return false


### PR DESCRIPTION
resolves #19883 

## Description
The `mobile-breakpoint` prop requires `:mobile='null'` to work, otherwise it is ignored. It is not intuitive and developers ask about it on Discord or assume it does not work, because components' API docs don't mention this requirement.

> The reason Docs do not use description from api-generator » ... » [display.json](https://github.com/vuetifyjs/vuetify/blob/master/packages/api-generator/src/locale/en/display.json) is that most components already have their own description for `mobile` prop.

I wish we could let user work with `mobile-breakpoint` and don't bother about the other prop. The logic could then be:
1. If `mobile === true`, then force mobile view
2. If `mobile-breakpoint` is set, accept it's value to resolve mobile state
3. All defaults (not using these props) means no responsiveness (as suggested by [comment](https://github.com/vuetifyjs/vuetify/issues/19726#issuecomment-2092005717) under #19726)
4. `mobile='null'` makes the component rely on default mobile breakpoint

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <pre class="mt-8">
      $vuetify.display.width: {{ $vuetify.display.width }}px
      mobile-breakpoint="md" instructs labels to hide below the 960px (md breakpoint)
      </pre>
      <v-stepper mobile-breakpoint="md">
        <v-stepper-header>
          <template v-for="(item, i) in items" :key="i">
            <v-divider v-if="i" />
            <v-stepper-item v-bind="item" />
          </template>
        </v-stepper-header>
      </v-stepper>

      <pre class="mt-8">
      $vuetify.display.width: {{ $vuetify.display.width }}px
      :mobile-breakpoint="800" instructs labels to hide below the 800px
      </pre>
      <v-stepper :mobile-breakpoint="800">
        <v-stepper-header>
          <template v-for="(item, i) in items" :key="i">
            <v-divider v-if="i" />
            <v-stepper-item v-bind="item" />
          </template>
        </v-stepper-header>
      </v-stepper>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  const items = Array.from({ length: 4 }).map((_, i) => ({
    title: `Step ${i + 1}`,
    subtitle: `Step ${i + 1} subtitle`,
    value: i + 1,
  }))
</script>
```
