### PR TITLE
fix(VSnackbar): handle pointerleave event after transition ends

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -173,7 +173,7 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
     }
 
     function onAfterLeave () {
-      if (isHovering.value) onPointerleave();
+      if (isHovering.value) onPointerleave()
     }
 
     const locationClasses = computed(() => {

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -172,6 +172,10 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
       }
     }
 
+    function onAfterLeave () {
+      if (isHovering.value) onPointerleave();
+    }
+
     const locationClasses = computed(() => {
       return props.location.split(' ').reduce((acc, loc) => {
         acc[`v-snackbar--${loc}`] = true
@@ -226,6 +230,7 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
           _disableGlobalStack
           onTouchstartPassive={ onTouchstart }
           onTouchend={ onTouchend }
+          onAfterLeave={ onAfterLeave }
           { ...scopeId }
           v-slots={{ activator: slots.activator }}
         >


### PR DESCRIPTION
## Description
fixes #20306

- **Problem:** When hovering over `SnackBar`, `isHovering` is truthy as expected but closing `SnackBar` does not fire `onPointerLeave` => `isHovering` is still truthy after the component is closed.
And due to this condition `!isHovering && <VProgressLinear>` from `VSnackBar.tsx:239`, the `ProgressBar` does not appear when reopening the `SnackBar`.

- **Cause**: I found that this causes by the transition duration/delay from `MaybeTransition` in `VOverlay`. Therefore, I think that hover state should be correctly handled after the transition ends, which is addressed in this PR.

## Markup:
I reuse the example from https://github.com/vuetifyjs/vuetify/issues/20306

```vue
<template>
  <div class="text-center">
    <v-btn color="orange-darken-2" @click="snackbar = true">
      Open Snackbar
    </v-btn>

    <v-snackbar v-model="snackbar" :timeout="timeout" timer>
      {{ text }}

      <template v-slot:actions>
        <v-btn color="blue" variant="text" @click="snackbar = false">
          Close
        </v-btn>
      </template>
    </v-snackbar>
  </div>
</template>

<script>
  export default {
    data: () => ({
      snackbar: false,
      text: 'My timeout is set to 2000.',
      timeout: 2000,
    }),
  }
</script>

```
