### PR TITLE
refactor composable file(Loader.tsx): Add optional chaining for slots

### DIFF
--- a/packages/vuetify/src/composables/loader.tsx
+++ b/packages/vuetify/src/composables/loader.tsx
@@ -47,7 +47,7 @@ export function LoaderSlot (
 ) {
   return (
     <div class={ `${props.name}__loader` }>
-      { slots.default?.({
+      { slots?.default?.({
         color: props.color,
         isActive: props.active,
       } as LoaderSlotProps) || (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This solves the error `cannot read properties of undefined (reading 'default')` when compiling vue in compat mode with webpack.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
