### PR TITLE
fix(VSpeedDial): Use `content-class`

### DIFF
--- a/packages/vuetify/src/components/VSpeedDial/VSpeedDial.tsx
+++ b/packages/vuetify/src/components/VSpeedDial/VSpeedDial.tsx
@@ -67,6 +67,7 @@ export const VSpeedDial = genericComponent<OverlaySlots>()({
           contentClass={[
             'v-speed-dial__content',
             locationClasses.value,
+            props.contentClass,
           ]}
           location={ location.value }
           ref={ menuRef }


### PR DESCRIPTION
## Description

`content-class` is mentioned by [VSpeedDial API docs](https://vuetifyjs.com/en/api/v-speed-dial/#props-content-class) and should be applied down to the VMenu.

resolves #20051

## Markup:
```vue
<template>
  <v-card class="pa-6">
    <v-fab size="large" icon>
      <v-icon>mdi-comment</v-icon>
      <v-speed-dial
        v-model="fabOpen"
        :content-class="['bg-grey-lighten-3','rounded-pill','elevation-2','pa-2']"
        activator="parent"
        location="right center"
      >
        <v-btn key="1" color="success" icon="$success" />
        <v-btn key="2" color="info" icon="$info" />
        <v-btn key="3" color="warning" icon="$warning" />
        <v-btn key="4" color="error" icon="$error" />
      </v-speed-dial>
    </v-fab>
  </v-card>
</template>

<script setup>
  import { ref } from 'vue'
  const fabOpen = ref(true)
</script>
```
