### PR TITLE
fix(VPagination): correct visible items for selection in the middle

### DIFF
--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -209,7 +209,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
         const rangeStart = length.value - rangeLength + start.value
         return [start.value, props.ellipsis, ...createRange(rangeLength, rangeStart)]
       } else {
-        const rangeLength = Math.max(1, totalVisible.value - 3)
+        const rangeLength = Math.max(1, totalVisible.value - 2)
         const rangeStart = rangeLength === 1 ? page.value : page.value - Math.ceil(rangeLength / 2) + start.value
         return [start.value, props.ellipsis, ...createRange(rangeLength, rangeStart), props.ellipsis, length.value]
       }

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.cy.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.cy.tsx
@@ -82,6 +82,10 @@ describe('VPagination', () => {
 
     // 5 buttons and 1 ellipsis
     cy.get('.v-pagination__item').should('have.length', 6)
+
+    cy.get('.v-btn').contains('4').click()
+    // 5 buttons and 2 ellipsis
+    cy.get('.v-pagination__item').should('have.length', 7)
   })
 
   it('should limit items when not enough space', () => {


### PR DESCRIPTION
## Description

Shows one more element when selection is in the middle and we display "..." twice.

![image](https://github.com/user-attachments/assets/f9bbb8c8-b6ea-419f-9c2f-120345f281de) 

resolves #18853

## Markup:
```vue
<template>
  <v-app>
    <v-container class="d-flex flex-column justify-center ga-3">
      <v-card>
        <VPagination length="100" total-visible="5" />
      </v-card>
      <v-card>
        <pre class="text-center">Repro for #14396 that guided most recent changes to this logic</pre>
        <v-pagination v-model="page" total-visible="3" length="3" />
        <v-pagination v-model="page" total-visible="3" length="4" />
        <v-pagination v-model="page" total-visible="4" length="3" />
        <v-pagination v-model="page" total-visible="4" length="4" />
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from "vue";
const page = ref(1)
</script>
```
