### PR TITLE
docs(VForm): fix validation mistakes in examples

### DIFF
--- a/packages/docs/src/examples/v-form/misc-exposed.vue
+++ b/packages/docs/src/examples/v-form/misc-exposed.vue
@@ -72,7 +72,7 @@
   const name = ref('')
   const nameRules = ref([
     v => !!v || 'Name is required',
-    v => (v && v.length <= 10) || 'Name must be less than 10 characters',
+    v => (v && v.length <= 10) || 'Name must be 10 characters or less',
   ])
   const select = ref(null)
   const checkbox = ref(false)
@@ -96,7 +96,7 @@
       name: '',
       nameRules: [
         v => !!v || 'Name is required',
-        v => (v && v.length <= 10) || 'Name must be less than 10 characters',
+        v => (v && v.length <= 10) || 'Name must be 10 characters or less',
       ],
       select: null,
       items: [

--- a/packages/docs/src/examples/v-form/misc-vee-validate.vue
+++ b/packages/docs/src/examples/v-form/misc-vee-validate.vue
@@ -60,9 +60,9 @@
         return 'Name needs to be at least 2 characters.'
       },
       phone (value) {
-        if (value?.length > 9 && /[0-9-]+/.test(value)) return true
+        if (/^[0-9-]{7,}$/.test(value)) return true
 
-        return 'Phone number needs to be at least 9 digits.'
+        return 'Phone number needs to be at least 7 digits.'
       },
       email (value) {
         if (/^[a-z.-]+@[a-z.-]+\.[a-z]+$/i.test(value)) return true

--- a/packages/docs/src/examples/v-form/prop-fast-fail.vue
+++ b/packages/docs/src/examples/v-form/prop-fast-fail.vue
@@ -24,7 +24,7 @@
   const firstName = ref('')
   const firstNameRules = [
     value => {
-      if (value?.length > 3) return true
+      if (value?.length >= 3) return true
       return 'First name must be at least 3 characters.'
     },
   ]
@@ -44,7 +44,7 @@
       firstName: '',
       firstNameRules: [
         value => {
-          if (value?.length > 3) return true
+          if (value?.length >= 3) return true
 
           return 'First name must be at least 3 characters.'
         },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
The VForm docs examples include a few example components, which contain some example validation rules to demonstrate their usage.
However a few of these have some mistakes in them, which are not a huge deal, but a bit confusing, when you are encoutering them.
This PR fixes three of these mistakes I found, e.g. where the displayed "count" property or the validation message was not matching the actual validation rule.