### PR TITLE
chore: fix missing labs components css on Windows

### DIFF
--- a/packages/vuetify/build/rollup.config.mjs
+++ b/packages/vuetify/build/rollup.config.mjs
@@ -220,10 +220,7 @@ export default [
           })
 
           // Individual CSS files
-          styleNodes = styleNodes.filter(node => {
-              return node.id.startsWith(labsDir)
-            }
-          );
+          styleNodes = styleNodes.filter(node => path.normalize(node.id).startsWith(labsDir));
           for (const { id, content } of styleNodes) {
             const relativePath = path.relative(srcDir, id)
             const out = path.parse(path.join(libDir, relativePath))


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
`node.id` from sass not normalized, styles nodes in `labs` bundler empty when filtering: this PR checks paths via upath normalize

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

NA
