### PR TITLE
fix(VDataTable): show correct items count after expanding group

### DIFF
--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
@@ -377,7 +377,7 @@ describe('VDataTable', () => {
             groupBy={[{ key: 'group', order: 'desc' }]}
           >
             {{
-              'body.append': ({ items }) => <div id='body-append'>{ items.length }</div>,
+              'body.append': ({ items }) => <div id="body-append">{ items.length }</div>,
             }}
           </VDataTable>
         </Application>

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.cy.tsx
@@ -366,6 +366,27 @@ describe('VDataTable', () => {
       cy.get('.v-data-table').find('h2').should('exist')
       cy.get('.v-data-table').find('h3').should('exist')
     })
+
+    it('should have body slot and slot prop should show correct item count after group is expanded', () => {
+      cy.mount(() => (
+        <Application>
+          <VDataTable
+            items={ DESSERT_ITEMS }
+            headers={ DESSERT_HEADERS }
+            itemsPerPage={ -1 }
+            groupBy={[{ key: 'group', order: 'desc' }]}
+          >
+            {{
+              'body.append': ({ items }) => <div id='body-append'>{ items.length }</div>,
+            }}
+          </VDataTable>
+        </Application>
+      ))
+
+      cy.get('.v-data-table').find('div#body-append').should('have.text', DESSERT_ITEMS.length)
+      cy.get(':nth-child(1) > .v-data-table__td > .v-btn').click()
+      cy.get('.v-data-table').find('div#body-append').should('have.text', DESSERT_ITEMS.length)
+    })
   })
 
   describe('sort', () => {

--- a/packages/vuetify/src/components/VDataTable/composables/group.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/group.ts
@@ -90,7 +90,7 @@ export function provideGroupBy (options: {
         }
       }
 
-      return arr
+      return [...new Set(arr)]
     }
     return dive({ type: 'group', items, id: 'dummy', key: 'dummy', value: 'dummy', depth: 0 })
   }


### PR DESCRIPTION
## Description
fixes #20313 

* Problem: `items` slot prop contains duplicated items when a group is expanded

* Cause: `items` slot prop in the parent component is `paginatedItemsWithoutGroups`. This items are first flattened from its group in `useGroupedItems` (`VDataTable.jsx:163`) and then extracted to rows in `extractRows` (`VDataTable.jsx:169`). The extraction again flattens the items from its group which causes the duplication

* Solution: make `extractRows` operation returns unique items

## Markup:
I reused reproduction provided by https://github.com/vuetifyjs/vuetify/issues/20313

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    :group-by="groupBy"
    :headers="headers"
    :items="desserts"
    item-value="name"
    items-per-page="-1"
  >
    <template #body.append="{ items }"> {{ items.length }} </template>
  </v-data-table>
</template>

<script>
  export default {
    data() {
      return {
        groupBy: [
          {
            key: 'gluten',
            order: 'asc',
          },
        ],
        headers: [
          {
            title: 'Dessert (100g serving)',
            align: 'start',
            sortable: false,
            key: 'name',
          },
          { title: 'Calories', key: 'calories' },
          { title: 'Fat (g)', key: 'fat' },
          { title: 'Carbs (g)', key: 'carbs' },
          { title: 'Protein (g)', key: 'protein' },
          { title: 'Iron (%)', key: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 159,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
            gluten: false,
          },
          {
            name: 'Ice cream sandwich',
            calories: 237,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
            gluten: false,
          },
          {
            name: 'Eclair',
            calories: 262,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
            gluten: true,
          },
          {
            name: 'Cupcake',
            calories: 305,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
            gluten: true,
          },
          {
            name: 'Gingerbread',
            calories: 356,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
            gluten: true,
          },
          {
            name: 'Jelly bean',
            calories: 375,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
            gluten: false,
          },
          {
            name: 'Lollipop',
            calories: 392,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
            gluten: false,
          },
          {
            name: 'Honeycomb',
            calories: 408,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
            gluten: true,
          },
          {
            name: 'Donut',
            calories: 452,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
            gluten: true,
          },
          {
            name: 'KitKat',
            calories: 518,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
            gluten: true,
          },
        ],
      }
    },
  }
</script>

```
