### PR TITLE
fix(VField): rounded with long label border-radius

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -399,7 +399,7 @@
       &__notch
         flex: none
         position: relative
-        max-width: calc(100% - $field-control-affixed-padding)
+        max-width: calc(100% - var(--v-input-control-height))
 
         &::before,
         &::after


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes  [#20305](https://github.com/vuetifyjs/vuetify/issues/20305)

- Problem: The end of the text field won't be rounded, and the text field will be bigger than the max-width set.
- Cause: `.v-field__outline__notch` sets a width larger than the specified max-width value.
- Solution: `.v-field__outline__notch` sets max-width according to the element's height.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
I reused reproduction provided by  [#20305](https://github.com/vuetifyjs/vuetify/issues/20305)
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        label="ravuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuusuuus"
        rounded
        variant="outlined"
      />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
