### PR TITLE
docs(VTreeView): fix divider in example

### DIFF
--- a/packages/docs/src/examples/v-treeview/misc-selectable-icons.vue
+++ b/packages/docs/src/examples/v-treeview/misc-selectable-icons.vue
@@ -30,7 +30,7 @@
         </v-card-text>
       </v-col>
 
-      <v-divider vertical></v-divider>
+      <v-divider :vertical="$vuetify.display.mdAndUp" class="my-md-3"></v-divider>
 
       <v-col
         cols="12"


### PR DESCRIPTION
## Description

I have stumbled upon a misaligned divider and initially thought it should be rather `border-e`, but opted to make it play with responsive layout of this example.

## Markup

```vue
<v-divider vertical />
replaced with:
<v-divider :vertical="$vuetify.display.mdAndUp" class="my-md-3" />
```

## Notes

Technically we could make it default by including `.v-divider--vertical` in `VGrid.sass`, but since after migration I have `.v-row.my-0` all over my project, I suspect more people might have some margins or paddings that will make this small change introduce unnecessary visual regression... although maybe it is not a strong argument. Feel free to update this PR and include these rules.

```sass
.v-row > .v-divider--vertical
  margin-bottom: settings.$grid-gutter * .5
  margin-top: settings.$grid-gutter * .5
  
// and again for `.v-row--dense`
```