### PR TITLE
fix(VTreeview): Load children when expanded

### DIFF
--- a/packages/vuetify/src/labs/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeviewChildren.tsx
@@ -132,7 +132,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
                 ...itemProps,
                 ...activatorProps,
                 value: itemProps?.value,
-                onToggleExpand: activatorProps.onClick as any,
+                onToggleExpand: [() => checkChildren(item), activatorProps.onClick] as any,
                 onClick: isClickOnOpen.value ? [() => checkChildren(item), activatorProps.onClick] as any : undefined,
               }
 


### PR DESCRIPTION
## Description

resolves #20360

## Markup

```vue
<template>
  <v-container>
    <p>Click exactly the icon to verify</p>
    <v-treeview
      v-model:activated="active"
      v-model:opened="open"
      :items="items"
      :load-children="fetchUsers"
      density="compact"
      item-title="name"
      item-value="id"
      activatable
      open-on-click
    />
  </v-container>
</template>

<script setup>
  import { computed, ref } from 'vue'

  const active = ref([])
  const open = ref([])
  const users = ref([])

  const items = computed(() => {
    return [
      {
        name: 'Users',
        children: users.value,
      },
    ]
  })

  async function fetchUsers(item) {
    await new Promise(r => setTimeout(r, 1500))
    return fetch('https://jsonplaceholder.typicode.com/users')
      .then(res => res.json())
      .then(json => item.children.push(...json))
      .catch(err => console.warn(err))
  }
</script>
```
