### PR TITLE
feat(VNumberInput): emit events when using controls

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -30,6 +30,7 @@ type VNumberInputSlots = Omit<VTextFieldSlots, 'default'> & {
 }
 
 type ControlVariant = 'default' | 'stacked' | 'split'
+type ControlClickEvent = { type: 'increase' | 'decrease' }
 
 const makeVNumberInputProps = propsFactory({
   controlVariant: {
@@ -67,9 +68,10 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
   emits: {
     'update:modelValue': (val: number) => true,
+    'click:control': (evt: ControlClickEvent) => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { emit, slots }) {
     const _model = useProxiedModel(props, 'modelValue')
 
     const model = computed({
@@ -142,11 +144,13 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     function onClickUp (e: MouseEvent) {
       e.stopPropagation()
       toggleUpDown()
+      emit('click:control', { type: 'increase' })
     }
 
     function onClickDown (e: MouseEvent) {
       e.stopPropagation()
       toggleUpDown(false)
+      emit('click:control', { type: 'decrease' })
     }
 
     function onBeforeinput (e: InputEvent) {


### PR DESCRIPTION
## Description

resolves #20342

## Markup

```vue
<template>
  <v-app>
    <v-container>
      <v-number-input
        v-model="someValue"
        :loading="saving"
        clearable
        @blur="save"
        @click:clear="save"
        @click:control="save"
      />
      <pre class="mt-3">lastSavedValue: {{ lastSavedValue }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const someValue = ref(0)
  const lastSavedValue = ref(0)
  const saving = ref(false)

  // simplified example - it would be debounced and guarded against race conditions in real life
  async function save() {
    const v = someValue.value
    if (v !== lastSavedValue.value) {
      saving.value = true
      await new Promise(r => setTimeout(r, 1000))
      lastSavedValue.value = v
      saving.value = false
    }
  }
</script>
```
