### PR TITLE
fix(VIcon): don't set aria-hidden on the svg tag when it's set to false

### DIFF
--- a/packages/vuetify/src/components/VIcon/VIcon.ts
+++ b/packages/vuetify/src/components/VIcon/VIcon.ts
@@ -159,7 +159,7 @@ const VIcon = mixins(
           xmlns: 'http://www.w3.org/2000/svg',
           viewBox: '0 0 24 24',
           role: 'img',
-          'aria-hidden': true,
+          'aria-hidden': this.$attrs['aria-hidden'] !== 'false',
         },
       }
 


### PR DESCRIPTION
fixes #20382

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

fixes #20382

Make the Vicon component compliant with this part of the documentation: https://v2.vuetifyjs.com/en/components/icons/#semantic-font-icons

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-btn>
        <span class="mr-2">
          show
        </span>
        <v-icon
          aria-hidden="false"
          aria-description="Account"
        >{{ mdiAccount }}</v-icon>
      </v-btn>
  </v-container>
</template>

<script>
  import { mdiAccount } from '@mdi/js'

  export default {
    data: () => ({
      mdiAccount,
    }),
  }
</script>

```

```typescript
export default new Vuetify({
  lang: {
    locales,
  },
  icons: {
    iconfont: 'mdi',
    // iconfont: 'faSvg',
  },
})
```
