### PR TITLE
fix(nested): Prevent infinite loops when resolving path

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -162,7 +162,7 @@ export const VList = genericComponent<new <
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
     const { roundedClasses } = useRounded(props)
-    const { children, open, parents, select } = useNested(props)
+    const { children, open, parents, select, getPath } = useNested(props)
     const lineClasses = computed(() => props.lines ? `v-list--${props.lines}-line` : undefined)
     const activeColor = toRef(props, 'activeColor')
     const baseColor = toRef(props, 'baseColor')
@@ -288,6 +288,7 @@ export const VList = genericComponent<new <
       focus,
       children,
       parents,
+      getPath,
     }
   },
 })

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -127,6 +127,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
       root,
       parent,
       openOnSelect,
+      id: uid,
     } = useNestedItem(id, false)
     const list = useList()
     const isActive = computed(() =>
@@ -368,6 +369,8 @@ export const VListItem = genericComponent<VListItemSlots>()({
       isSelected,
       list,
       select,
+      root,
+      id: uid,
     }
   },
 })

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -18,6 +18,7 @@ import {
   leafSingleSelectStrategy,
 } from './selectStrategies'
 import { getCurrentInstance, getUid, propsFactory } from '@/util'
+import { preventLoops } from '@/util/nested'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -182,6 +183,7 @@ export const useNested = (props: NestedProps) => {
     let parent: unknown = id
 
     while (parent != null) {
+      preventLoops(path, parent)
       path.unshift(parent)
       parent = parents.value.get(parent)
     }

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -17,8 +17,7 @@ import {
   leafSelectStrategy,
   leafSingleSelectStrategy,
 } from './selectStrategies'
-import { getCurrentInstance, getUid, propsFactory } from '@/util'
-import { preventLoops } from '@/util/nested'
+import { consoleError, getCurrentInstance, getUid, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -77,6 +76,7 @@ type NestedProvide = {
     activate: (id: unknown, value: boolean, event?: Event) => void
     select: (id: unknown, value: boolean, event?: Event) => void
     openOnSelect: (id: unknown, value: boolean, event?: Event) => void
+    getPath: (id: unknown) => unknown[]
   }
 }
 
@@ -99,6 +99,7 @@ export const emptyNested: NestedProvide = {
     activated: ref(new Set()),
     selected: ref(new Map()),
     selectedValues: ref([]),
+    getPath: () => [],
   },
 }
 
@@ -183,7 +184,6 @@ export const useNested = (props: NestedProps) => {
     let parent: unknown = id
 
     while (parent != null) {
-      preventLoops(path, parent)
       path.unshift(parent)
       parent = parents.value.get(parent)
     }
@@ -192,6 +192,8 @@ export const useNested = (props: NestedProps) => {
   }
 
   const vm = getCurrentInstance('nested')
+
+  const nodeIds = new Set<unknown>()
 
   const nested: NestedProvide = {
     id: shallowRef(),
@@ -211,6 +213,15 @@ export const useNested = (props: NestedProps) => {
         return arr
       }),
       register: (id, parentId, isGroup) => {
+        if (nodeIds.has(id)) {
+          const path = getPath(id).join(' -> ')
+          const newPath = getPath(parentId).concat(id).join(' -> ')
+          consoleError(`Multiple nodes with the same ID\n\t${path}\n\t${newPath}`)
+          return
+        } else {
+          nodeIds.add(id)
+        }
+
         parentId && id !== parentId && parents.value.set(id, parentId)
 
         isGroup && children.value.set(id, [])
@@ -222,6 +233,7 @@ export const useNested = (props: NestedProps) => {
       unregister: id => {
         if (isUnmounted) return
 
+        nodeIds.delete(id)
         children.value.delete(id)
         const parent = parents.value.get(id)
         if (parent) {
@@ -291,6 +303,7 @@ export const useNested = (props: NestedProps) => {
       },
       children,
       parents,
+      getPath,
     },
   }
 

--- a/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
@@ -10,6 +10,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 // Utilities
 import { computed, provide, ref, toRaw, toRef } from 'vue'
 import { genericComponent, omit, propsFactory, useRender } from '@/util'
+import { preventLoops } from '@/util/nested'
 
 // Types
 import { VTreeviewSymbol } from './shared'
@@ -98,6 +99,7 @@ export const VTreeview = genericComponent<new <T>(
       const path: unknown[] = []
       let parent: unknown = id
       while (parent != null) {
+        preventLoops(path, parent)
         path.unshift(parent)
         parent = vListRef.value?.parents.get(parent)
       }

--- a/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
@@ -10,7 +10,6 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 // Utilities
 import { computed, provide, ref, toRaw, toRef } from 'vue'
 import { genericComponent, omit, propsFactory, useRender } from '@/util'
-import { preventLoops } from '@/util/nested'
 
 // Types
 import { VTreeviewSymbol } from './shared'
@@ -87,24 +86,13 @@ export const VTreeview = genericComponent<new <T>(
     const search = toRef(props, 'search')
     const { filteredItems } = useFilter(props, flatItems, search)
     const visibleIds = computed(() => {
-      if (!search.value) {
-        return null
-      }
+      if (!search.value) return null
+      const getPath = vListRef.value?.getPath
+      if (!getPath) return null
       return new Set(filteredItems.value.flatMap(item => {
         return [...getPath(item.props.value), ...getChildren(item.props.value)]
       }))
     })
-
-    function getPath (id: unknown) {
-      const path: unknown[] = []
-      let parent: unknown = id
-      while (parent != null) {
-        preventLoops(path, parent)
-        path.unshift(parent)
-        parent = vListRef.value?.parents.get(parent)
-      }
-      return path
-    }
 
     function getChildren (id: unknown) {
       const arr: unknown[] = []

--- a/packages/vuetify/src/labs/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeviewItem.tsx
@@ -9,7 +9,6 @@ import { VProgressCircular } from '@/components/VProgressCircular'
 
 // Composables
 import { IconValue } from '@/composables/icons'
-import { useNestedItem } from '@/composables/nested/nested'
 import { useLink } from '@/composables/router'
 
 // Utilities
@@ -35,20 +34,11 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
 
   setup (props, { attrs, slots, emit }) {
     const link = useLink(props, attrs)
-    const rawId = computed(() => props.value === undefined ? link.href.value : props.value)
     const vListItemRef = ref<VListItem>()
 
-    const {
-      activate,
-      isActivated,
-      isGroupActivator,
-      root,
-      id,
-    } = useNestedItem(rawId, false)
-
     const isActivatableGroupActivator = computed(() =>
-      (root.activatable.value) &&
-      isGroupActivator
+      (vListItemRef.value?.root.activatable.value) &&
+      vListItemRef.value?.isGroupActivator
     )
 
     const isClickable = computed(() =>
@@ -60,15 +50,11 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
     function activateItem (e: MouseEvent | KeyboardEvent) {
       if (
         !isClickable.value ||
-        (!isActivatableGroupActivator.value && isGroupActivator)
+        (!isActivatableGroupActivator.value && vListItemRef.value?.isGroupActivator)
       ) return
 
-      if (root.activatable.value) {
-        if (isActivatableGroupActivator.value) {
-          activate(!isActivated.value, e)
-        } else {
-          vListItemRef.value?.activate(!vListItemRef.value?.isActivated, e)
-        }
+      if (vListItemRef.value?.root.activatable.value) {
+        vListItemRef.value?.activate(!vListItemRef.value?.isActivated, e)
       }
     }
 
@@ -80,13 +66,14 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
 
       return (
         <VListItem
+          ref={ vListItemRef }
           { ...listItemProps }
-          active={ isActivated.value }
+          active={ vListItemRef.value?.isActivated }
           class={[
             'v-treeview-item',
             {
               'v-treeview-item--activatable-group-activator': isActivatableGroupActivator.value,
-              'v-treeview-item--filtered': visibleIds.value && !visibleIds.value.has(id.value),
+              'v-treeview-item--filtered': visibleIds.value && !visibleIds.value.has(vListItemRef.value?.id),
             },
             props.class,
           ]}

--- a/packages/vuetify/src/util/nested.ts
+++ b/packages/vuetify/src/util/nested.ts
@@ -1,9 +1,0 @@
-export function preventLoops<T> (path: T[] | Set<T> | Map<T, any>, itemToPush: T) {
-  if (
-    (Array.isArray(path) && path.includes(itemToPush)) ||
-    (path instanceof Set && path.has(itemToPush)) ||
-    (path instanceof Map && path.has(itemToPush))
-  ) {
-    throw new Error('[Vuetify] Could not resolve nested path because of duplicated identifiers')
-  }
-}

--- a/packages/vuetify/src/util/nested.ts
+++ b/packages/vuetify/src/util/nested.ts
@@ -1,0 +1,9 @@
+export function preventLoops<T> (path: T[] | Set<T> | Map<T, any>, itemToPush: T) {
+  if (
+    (Array.isArray(path) && path.includes(itemToPush)) ||
+    (path instanceof Set && path.has(itemToPush)) ||
+    (path instanceof Map && path.has(itemToPush))
+  ) {
+    throw new Error('[Vuetify] Could not resolve nested path because of duplicated identifiers')
+  }
+}


### PR DESCRIPTION
## Description

While loops used by components with nesting need some safety check to prevent freezing end-users tab. Performance overhead of the checks is close to none, while it makes a big difference in the field.

Error does not necessarily need to be developers fault. Data from the API may contain duplicates or it may be a result of some drag & copy functionality built on top of Vuetify's components.

I was advised to log a warning, but I just don't think it is better than throwing error
- warning inside while loop does not help – tabs usually freeze DevTools as well and devs might work with simplified data, leaving potential for errors in the field
- warning after validating `path`/`parents` collection – unnecessary performance overhead if we can have cheaper solutions
- warning + breaking from the loop – risky... potentially misleading end-users if they click things fast and don't pay attention, and won't get logged in monitoring (like Sentry or Bugsnag)

mitigates #20389

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <h4>Tree view</h4>
      <v-treeview :items="items" item-value="title" open-on-click />
      <v-divider class="my-6" />
      <h4>List</h4>
      <v-list v-model:opened="opened" v-model:selected="selected" select-strategy="classic">
        <v-list-group value="src-group">
          <template #activator="{ props }">
            <v-list-item v-bind="props" title="src">
              <template #prepend="{ isSelected }">
                <v-list-item-action start>
                  <v-checkbox-btn :model-value="isSelected" />
                </v-list-item-action>
              </template>
            </v-list-item>
          </template>
          <v-list-group value="renderer-group">
            <template #activator="{ props }">
              <v-list-item v-bind="props" title="renderer">
                <template #prepend="{ isSelected }">
                  <v-list-item-action start>
                    <v-checkbox-btn :model-value="isSelected" />
                  </v-list-item-action>
                </template>
              </v-list-item>
            </template>
            <v-list-group value="src-group">
              <template #activator="{ props }">
                <v-list-item v-bind="props">
                  <template #title>src ––– <span class="text-red">toggle selection here on one level below</span></template>
                  <template #prepend="{ isSelected }">
                    <v-list-item-action start>
                      <v-checkbox-btn :model-value="isSelected" />
                    </v-list-item-action>
                  </template>
                </v-list-item>
              </template>
              <v-list-group value="assets-group">
                <template #activator="{ props }">
                  <v-list-item v-bind="props">
                    <template #title>assets ––– <span class="text-red">expand me or the parent</span></template>
                    <template #prepend="{ isSelected }">
                      <v-list-item-action start>
                        <v-checkbox-btn :model-value="isSelected" />
                      </v-list-item-action>
                    </template>
                  </v-list-item>
                </template>
                <v-list-item title="styles.sass" value="4 - Leaf">
                  <template #prepend="{ isSelected }">
                    <v-list-item-action start>
                      <v-checkbox-btn :model-value="isSelected" />
                    </v-list-item-action>
                  </template>
                </v-list-item>
              </v-list-group>
            </v-list-group>
          </v-list-group>
        </v-list-group>
      </v-list>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const opened = ref(['src-group', 'renderer-group', 'assets-group'])
  const selected = ref([])

  const items = ref([
    {
      title: 'src',
      children: [
        {
          title: 'renderer',
          children: [
            {
              title: 'src',
              children: [
                {
                  title: 'assets',
                  children: [
                    { title: 'styles.sass', isFileNode: true },
                  ],
                },
              ],
            },
          ],
        },
      ],
    },
  ])
</script>
```
