### PR TITLE
fix(VTreeview): match loading state with opened node

### DIFF
--- a/packages/vuetify/src/labs/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeviewChildren.tsx
@@ -62,12 +62,12 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
 
     const isClickOnOpen = computed(() => props.openOnClick != null ? props.openOnClick : props.selectable)
 
-    function checkChildren (item: any) {
+    function checkChildren (item: any, itemValue: any) {
       return new Promise<void>(resolve => {
         if (!props.items?.length || !props.loadChildren) return resolve()
 
         if (item?.children?.length === 0) {
-          isLoading.value = item.value
+          isLoading.value = itemValue
           props.loadChildren(item).then(resolve)
 
           return
@@ -86,7 +86,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
     }
 
     return () => slots.default?.() ?? props.items?.map(({ children, props: itemProps, raw: item }) => {
-      const loading = isLoading.value === item.value
+      const loading = isLoading.value === itemProps.value
       const slotsWithItem = {
         prepend: slotProps => (
           <>
@@ -132,8 +132,8 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
                 ...itemProps,
                 ...activatorProps,
                 value: itemProps?.value,
-                onToggleExpand: [() => checkChildren(item), activatorProps.onClick] as any,
-                onClick: isClickOnOpen.value ? [() => checkChildren(item), activatorProps.onClick] as any : undefined,
+                onToggleExpand: [() => checkChildren(item, itemProps.value), activatorProps.onClick] as any,
+                onClick: isClickOnOpen.value ? [() => checkChildren(item, itemProps.value), activatorProps.onClick] as any : undefined,
               }
 
               return (


### PR DESCRIPTION
## Description

fixes #19390

Currently I need to add `value` to the initial `items` to make the loading animation stick to the clicked node. But it should respect `item-value`.

~~Needs to be coordinated with #20364~~ Updated

## Markup:

```vue
<template>
  <v-card class="ma-4">
    <v-toolbar class="bg-indigo text-h5">
      <span class="pl-6">User Directory</span>
      <v-spacer />
      <v-btn @click="reset" prepend-icon="mdi-reload">Reset</v-btn>
    </v-toolbar>

    <div class="pa-4">
      <v-treeview
        :items="items"
        v-model:opened="open"
        :load-children="loadChildren"
        density="compact"
        item-title="name"
        item-value="id"
        open-on-click
        transition
      >
        <template v-slot:prepend="{ item }">
          <v-icon
            v-if="!item.children"
            :icon="item.isAlbum ? 'mdi-image' : 'mdi-account'"
          />
        </template>
      </v-treeview>
    </div>
  </v-card>
</template>

<script>
  const pause = ms => new Promise(resolve => setTimeout(resolve, ms))

  export default {
    data: () => ({
      open: [],
      users: [],
      albums: [],
    }),

    computed: {
      items() {
        return [
          { id: 11, name: 'Users', children: this.users },
          { id: 12, name: 'Albums', children: this.albums },
        ]
      },
    },

    methods: {
      reset() {
        this.users = []
        this.albums = []
        this.open = []
      },
      async loadChildren(item) {
        switch (item.name) {
          case 'Users': await this.fetchUsers(); break;
          case 'Albums': await this.fetchAlbums(); break;
          default: break;
        }
      },
      async fetchUsers(item) {
        await pause(1000)
        return fetch('https://jsonplaceholder.typicode.com/users')
          .then(res => res.json())
          .then(
            newItems =>
              (this.users = newItems
                .slice(0, 5)
                .map(x => ({ id: x.id, name: x.name })))
          )
      },
      async fetchAlbums(item) {
        await pause(1000)
        return fetch('https://jsonplaceholder.typicode.com/albums')
          .then(res => res.json())
          .then(
            newItems =>
              (this.albums = newItems
                .slice(0, 10)
                .map(x => ({ id: x.id, name: x.title, isAlbum: true })))
          )
      },
    },
  }
</script>
```
