### PR TITLE
feat(VBadge): support `left` for `inline`

### DIFF
--- a/packages/api-generator/src/locale/en/VBadge.json
+++ b/packages/api-generator/src/locale/en/VBadge.json
@@ -6,6 +6,7 @@
     "floating": "Elevates the badge above the slotted content.",
     "inline": "Moves the badge to be inline with the wrapping element. Supports the usage of the **left** prop.",
     "label": "The **aria-label** used for the badge.",
+    "left": "Moves badge to the left. Requires **inline** prop. Use **location** to position the badge in any other scenario.",
     "max": "Sets the maximum number allowed when using the **content** prop with a `number` like value. If the content number exceeds the maximum value, a `+` suffix is added.",
     "offsetX": "Offset the badge on the x-axis.",
     "offsetY": "Offset the badge on the y-axis.",

--- a/packages/docs/src/examples/v-badge/usage.vue
+++ b/packages/docs/src/examples/v-badge/usage.vue
@@ -24,6 +24,10 @@
         min="0"
         step="1"
       ></v-slider>
+
+      <v-expand-transition>
+        <v-checkbox v-model="left" label="Inline Left"></v-checkbox>
+      </v-expand-transition>
     </template>
   </ExamplesUsageExample>
 </template>
@@ -33,6 +37,7 @@
   const model = ref('default')
   const content = ref(0)
   const dot = ref(false)
+  const left = ref(false)
   const options = ['floating', 'inline']
   const props = computed(() => {
     return {
@@ -40,6 +45,7 @@
       dot: dot.value || undefined,
       floating: model.value === 'floating' || undefined,
       inline: model.value === 'inline' || undefined,
+      left: left.value || undefined,
     }
   })
 

--- a/packages/vuetify/src/components/VBadge/VBadge.sass
+++ b/packages/vuetify/src/components/VBadge/VBadge.sass
@@ -53,6 +53,9 @@
       position: relative
       vertical-align: $badge-inline-vertical-align
 
+    .v-badge--inline-left &
+      order: -1
+
     .v-icon
       color: inherit
       font-size: $badge-font-size

--- a/packages/vuetify/src/components/VBadge/VBadge.tsx
+++ b/packages/vuetify/src/components/VBadge/VBadge.tsx
@@ -32,6 +32,7 @@ export const makeVBadgeProps = propsFactory({
   floating: Boolean,
   icon: IconValue,
   inline: Boolean,
+  left: Boolean,
   label: {
     type: String,
     default: '$vuetify.badge',
@@ -102,6 +103,7 @@ export const VBadge = genericComponent<VBadgeSlots>()({
               'v-badge--dot': props.dot,
               'v-badge--floating': props.floating,
               'v-badge--inline': props.inline,
+              'v-badge--inline-left': props.inline && props.left,
             },
             props.class,
           ]}


### PR DESCRIPTION
## Description

Possible paths:
- just restore `inline left` (from v2)
- change it to hybrid boolean/string type (e.g. `inline="left"`, and `inline` defaulting to `right` for backward compatibility)

resolves #19613

## Markup:

```vue
<v-badge inline left color="primary">
  <v-icon icon="$vuetify" size="x-large" />
</v-badge>
```
