### PR TITLE
feat(VVirtualScroll): support fractional scroll index

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -132,7 +132,12 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
 
   function calculateOffset (index: number) {
     index = clamp(index, 0, items.value.length - 1)
-    return offsets[index] || 0
+    const whole = Math.floor(index)
+    const fraction = index % 1
+    const next = whole + 1
+    const wholeOffset = offsets[whole] || 0
+    const nextOffset = offsets[next] || wholeOffset
+    return wholeOffset + (nextOffset - wholeOffset) * fraction
   }
 
   function calculateIndex (scrollTop: number) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

`scrollToIndex` does not scroll to fractional values. Fractional values would allow scrolling to a point _between_ two elements.

For example, `scrollToIndex(1.5)` should scroll halfway between indices 1 and 2.

`scrollToIndex` also does not support scroll options, which makes it difficult to programmatically use `smooth` vs `instant` scrolling.

This change should be backwards compatible with existing consumers of this API:
  * fractional values did not work at all prior to this change, and would fail.
  * the second options argument did not exist.


Playground
```vue

<template>
    <v-app>
        <v-container>
            <v-btn @click="scroll">scroll</v-btn>

            <v-virtual-scroll ref="scroller" :height="300"
                :items="['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30']">
                <template v-slot:default="{ item }"> Item {{ item }} </template>
            </v-virtual-scroll>
        </v-container>
    </v-app>
</template>
<script setup lang="ts">
import { ref } from "vue";

const scroller = ref<any>();
function scroll() {
    console.log('scrolling');
    scroller.value!.scrollToIndex(5.5);
}
</script>
```