### PR TITLE
docs(installation): Add details about Vitepress configuration

### DIFF
--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -318,6 +318,20 @@ export default {
 }
 ```
 
+And in your `.vitepress/config.mts`
+
+```ts
+export default defineConfig({
+    // rest of the config
+
+    vite: {
+        ssr: {
+            noExternal: [/^vuetify/],
+        },
+    },
+));
+```
+
 ## Existing projects
 
 Follow these steps if for example you are adding Vuetify to an existing project, or simply do not want to use a scaffolding tool.


### PR DESCRIPTION
## Description

When following the installation guide for Vitepress the following error occurs when building.

> Unknown file extension ".css" for ......\node_modules\vuetify\lib\components\VCode\VCode.css

Added the solution found in #15700 to the documentation section.
