### PR TITLE
fix(VDialog): remove `aria-expanded` from activator

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -111,7 +111,6 @@ export const VDialog = genericComponent<OverlaySlots>()({
       const overlayProps = VOverlay.filterProps(props)
       const activatorProps = mergeProps({
         'aria-haspopup': 'dialog',
-        'aria-expanded': String(isActive.value),
       }, props.activatorProps)
       const contentProps = mergeProps({
         tabindex: -1,


### PR DESCRIPTION
## Description

Remove useless `aria-expanded` attribute on dialog activators to follow [WAI-ARIA recommandations](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/).

When focusing a dialog activator, dialog will never already be expanded, so this information is useless and will pollute screen readers users.

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
<v-app>
  <v-container>
    <v-dialog>
      <template #activator={ props }>
        <v-btn v-bind="props">Open</v-btn>
      </template> 
    </v-dialog>
  </v-container>
</v-app>
</template>
```
