### PR TITLE
fix(VInput/VMessages): move aria attributes to details

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -209,9 +209,13 @@ export const VInput = genericComponent<new <T>(
           )}
 
           { hasDetails && (
-            <div class="v-input__details">
+            <div
+              id={ messagesId.value }
+              class="v-input__details"
+              role="alert"
+              aria-live="polite"
+            >
               <VMessages
-                id={ messagesId.value }
                 active={ hasMessages }
                 messages={ messages.value }
                 v-slots={{ message: slots.message }}

--- a/packages/vuetify/src/components/VMessages/VMessages.tsx
+++ b/packages/vuetify/src/components/VMessages/VMessages.tsx
@@ -64,8 +64,6 @@ export const VMessages = genericComponent<VMessagesSlots>()({
           textColorStyles.value,
           props.style,
         ]}
-        role="alert"
-        aria-live="polite"
       >
         { props.active && (
           messages.value.map((message, i) => (


### PR DESCRIPTION
## Description

This PR moves `id`, `role="alert"` and `aria-live="polite"` attributes from `VMessages` to `VInput` details content.
This improve ARIA support for additional details that are not messages, such as counter or other custom details slot.

## Markup:

```vue
<template>
<v-app>
  <v-container>
    <v-textarea label="Body" maxlength="255" counter />
  </v-container>
</v-app>
</template>
```
