### PR TITLE
docs: fix `undefined` wireframe github link

### DIFF
--- a/packages/docs/src/layouts/wireframe.vue
+++ b/packages/docs/src/layouts/wireframe.vue
@@ -13,6 +13,6 @@
 
 <script setup>
   const route = useRoute()
-  const { page } = route.meta
-  const href = `https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/examples/wireframes/${page}.vue`
+  const paths = route.path.split('/').filter(p => p.length > 0)
+  const href = `https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/examples/wireframes/${paths.at(-1)}.vue`
 </script>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

`undefined` page in wireframe layout, there is no `page` in route meta: https://discord.com/channels/340160225338195969/1186158657155649536/1281716238078181447

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
