### PR TITLE
perf(VDataTable,VDataIterator)!: add `item-id` and fix check/uncheck all entries performance

### DIFF
--- a/packages/api-generator/src/locale/en/DataTable-items.json
+++ b/packages/api-generator/src/locale/en/DataTable-items.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "itemSelectable": "Property on supplied `items` that indicates whether the item is selectable.",
+    "itemId": "Property on supplied `items` that contains its identifier.",
     "itemValue": "Property on supplied `items` that contains its value.",
     "returnObject": "Changes the selection behavior to return the object directly rather than the value specified with **item-value**."
   }

--- a/packages/api-generator/src/locale/en/VDataIterator.json
+++ b/packages/api-generator/src/locale/en/VDataIterator.json
@@ -11,7 +11,7 @@
     "groupBy": "Changes which item property should be used for grouping items. Currently only supports a single grouping in the format: `group` or `['group']`. When using an array, only the first element is considered. Can be used with `.sync` modifier.",
     "groupDesc": "Changes which direction grouping is done. Can be used with `.sync` modifier.",
     "hideDefaultFooter": "Hides default footer.",
-    "itemKey": "The property on each item that is used as a unique key.",
+    "itemId": "The property on each item that is used as a unique key.",
     "itemsPerPage": "Changes how many items per page should be visible. Can be used with `.sync` modifier. Setting this prop to `-1` will display all items on the page.",
     "loading": "If `true` and no items are provided, then a loading text will be shown.",
     "loadingText": "Text shown when `loading` is true and no items are provided.",

--- a/packages/vuetify/src/components/VDataIterator/composables/items.ts
+++ b/packages/vuetify/src/components/VDataIterator/composables/items.ts
@@ -17,7 +17,6 @@ export interface DataIteratorItemProps {
 }
 
 export interface DataIteratorItem<T = any> extends GroupableItem<T>, SelectableItem {
-  key: any
   value: unknown
 }
 

--- a/packages/vuetify/src/components/VDataIterator/composables/items.ts
+++ b/packages/vuetify/src/components/VDataIterator/composables/items.ts
@@ -62,7 +62,7 @@ export function transformItems (
   props: Omit<DataIteratorItemProps, 'items'>,
   items: DataIteratorItemProps['items']
 ) {
-  const itemId = props.itemId
+  const itemId = props.itemId || 'id'
   const getId = typeof itemId === 'function'
     ? (item: any) => itemId(item)
     : (item: any) => getObjectValueByPath(item, itemId)

--- a/packages/vuetify/src/components/VDataIterator/composables/items.ts
+++ b/packages/vuetify/src/components/VDataIterator/composables/items.ts
@@ -1,21 +1,23 @@
 // Utilities
 import { computed } from 'vue'
-import { getPropertyFromItem, propsFactory } from '@/util'
+import { getObjectValueByPath, getPropertyFromItem, propsFactory } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
 import type { GroupableItem } from '@/components/VDataTable/composables/group'
 import type { SelectableItem } from '@/components/VDataTable/composables/select'
-import type { SelectItemKey } from '@/util'
+import type { SelectItemId, SelectItemKey } from '@/util'
 
 export interface DataIteratorItemProps {
   items: any[]
+  itemId: SelectItemId
   itemValue: SelectItemKey
   itemSelectable: SelectItemKey
   returnObject: boolean
 }
 
 export interface DataIteratorItem<T = any> extends GroupableItem<T>, SelectableItem {
+  key: any
   value: unknown
 }
 
@@ -24,6 +26,10 @@ export const makeDataIteratorItemsProps = propsFactory({
   items: {
     type: Array as PropType<DataIteratorItemProps['items']>,
     default: () => ([]),
+  },
+  itemId: {
+    type: [String, Function] as PropType<SelectItemId>,
+    default: 'id',
   },
   itemValue: {
     type: [String, Array, Function] as PropType<SelectItemKey>,
@@ -38,6 +44,7 @@ export const makeDataIteratorItemsProps = propsFactory({
 
 export function transformItem (
   props: Omit<DataIteratorItemProps, 'items'>,
+  id: number | string,
   item: any
 ): DataIteratorItem {
   const value = props.returnObject ? item : getPropertyFromItem(item, props.itemValue)
@@ -45,6 +52,7 @@ export function transformItem (
 
   return {
     type: 'item',
+    key: id,
     value,
     selectable,
     raw: item,
@@ -55,10 +63,15 @@ export function transformItems (
   props: Omit<DataIteratorItemProps, 'items'>,
   items: DataIteratorItemProps['items']
 ) {
+  const itemId = props.itemId
+  const getId = typeof itemId === 'function'
+    ? (item: any) => itemId(item)
+    : (item: any) => getObjectValueByPath(item, itemId)
+
   const array: DataIteratorItem[] = []
 
   for (const item of items) {
-    array.push(transformItem(props, item))
+    array.push(transformItem(props, getId(item), item))
   }
 
   return array

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -30,7 +30,7 @@ import type { Group } from './composables/group'
 import type { CellProps, DataTableHeader, DataTableItem, InternalDataTableHeader, RowProps } from './types'
 import type { VDataTableHeadersSlots } from './VDataTableHeaders'
 import type { VDataTableRowsSlots } from './VDataTableRows'
-import type { GenericProps, SelectItemKey } from '@/util'
+import type { GenericProps, SelectItemId, SelectItemKey } from '@/util'
 
 export type VDataTableSlotProps<T> = {
   page: number

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -30,7 +30,7 @@ import type { Group } from './composables/group'
 import type { CellProps, DataTableHeader, DataTableItem, InternalDataTableHeader, RowProps } from './types'
 import type { VDataTableHeadersSlots } from './VDataTableHeaders'
 import type { VDataTableRowsSlots } from './VDataTableRows'
-import type { GenericProps, SelectItemId, SelectItemKey } from '@/util'
+import type { GenericProps, SelectItemKey } from '@/util'
 
 export type VDataTableSlotProps<T> = {
   page: number

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.ts
@@ -217,7 +217,7 @@ describe.skip('VDataTable.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         headers: testHeaders,
-        itemKey: 'name',
+        itemId: 'name',
         items: testItems,
         itemsPerPage: 5,
         showExpand: true,
@@ -638,7 +638,7 @@ describe.skip('VDataTable.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         headers: testHeaders,
-        itemKey: 'name',
+        itemId: 'name',
         items: testItems.slice(0, 2),
         value: [testItems[0]],
         showSelect: true,
@@ -749,7 +749,7 @@ describe.skip('VDataTable.ts', () => {
       propsData: {
         headers,
         items,
-        itemKey: 'id',
+        itemId: 'id',
         groupBy: 'name',
       },
     })
@@ -767,7 +767,7 @@ describe.skip('VDataTable.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         headers: testHeaders,
-        itemKey: 'name',
+        itemId: 'name',
         items: testItems.slice(0, 2),
         groupBy: 'name',
       },
@@ -811,7 +811,7 @@ describe.skip('VDataTable.ts', () => {
       propsData: {
         headers,
         items,
-        itemKey: 'id',
+        itemId: 'id',
       },
       listeners: {
         pagination,
@@ -872,7 +872,7 @@ describe.skip('VDataTable.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         headers,
-        itemKey: 'id',
+        itemId: 'id',
         serverItemsLength: 0,
       },
     })
@@ -888,7 +888,7 @@ describe.skip('VDataTable.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         headers: testHeaders,
-        itemKey: 'name',
+        itemId: 'name',
         items: testItems.slice(0, 5),
         sortBy: 'calories',
       },
@@ -1081,7 +1081,7 @@ describe.skip('VDataTable.ts', () => {
     const wrapper = mountFunction({
       propsData: {
         items,
-        itemKey: 'name',
+        itemId: 'name',
         itemsPerPage: 5,
         showSelect: true,
         headers: testHeaders,

--- a/packages/vuetify/src/components/VDataTable/composables/items.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/items.ts
@@ -68,7 +68,7 @@ export function transformItems (
   items: DataTableItemProps['items'],
   columns: InternalDataTableHeader[]
 ): DataTableItem[] {
-  const itemId = props.itemId
+  const itemId = props.itemId || 'id'
   const getId = typeof itemId === 'function'
     ? (item: any) => itemId(item)
     : (item: any) => getObjectValueByPath(item, itemId)

--- a/packages/vuetify/src/components/VDataTable/composables/select.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/select.ts
@@ -3,7 +3,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, inject, provide } from 'vue'
-import { deepEqual, propsFactory, wrapInArray } from '@/util'
+import { deepEqual, getObjectValueByPath, propsFactory, wrapInArray } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -11,6 +11,7 @@ import type { DataTableItemProps } from './items'
 import type { EventProp } from '@/util'
 
 export interface SelectableItem {
+  key: any
   value: any
   selectable: boolean
 }
@@ -18,23 +19,24 @@ export interface SelectableItem {
 export interface DataTableSelectStrategy {
   showSelectAll: boolean
   allSelected: (data: {
+    selectedSize: number
     allItems: SelectableItem[]
     currentPage: SelectableItem[]
   }) => SelectableItem[]
   select: (data: {
     items: SelectableItem[]
     value: boolean
-    selected: Set<unknown>
-  }) => Set<unknown>
+    selected: Map<string | number, unknown>
+  }) => Map<string | number, unknown>
   selectAll: (data: {
     value: boolean
     allItems: SelectableItem[]
     currentPage: SelectableItem[]
-    selected: Set<unknown>
-  }) => Set<unknown>
+    selected: Map<string | number, unknown>
+  }) => Map<string | number, unknown>
 }
 
-type SelectionProps = Pick<DataTableItemProps, 'itemValue'> & {
+type SelectionProps = Pick<DataTableItemProps, 'itemId'> & Pick<DataTableItemProps, 'itemValue'> & {
   modelValue: readonly any[]
   selectStrategy: 'single' | 'page' | 'all'
   valueComparator: typeof deepEqual
@@ -44,8 +46,10 @@ type SelectionProps = Pick<DataTableItemProps, 'itemValue'> & {
 const singleSelectStrategy: DataTableSelectStrategy = {
   showSelectAll: false,
   allSelected: () => [],
-  select: ({ items, value }) => {
-    return new Set(value ? [items[0]?.value] : [])
+  select: ({ items, value, selected }) => {
+    selected.clear()
+    if (value) selected.set(items[0].key, items[0])
+    return selected
   },
   selectAll: ({ selected }) => selected,
 }
@@ -55,8 +59,8 @@ const pageSelectStrategy: DataTableSelectStrategy = {
   allSelected: ({ currentPage }) => currentPage,
   select: ({ items, value, selected }) => {
     for (const item of items) {
-      if (value) selected.add(item.value)
-      else selected.delete(item.value)
+      if (value) selected.set(item.key, item)
+      else selected.delete(item.key)
     }
 
     return selected
@@ -69,8 +73,8 @@ const allSelectStrategy: DataTableSelectStrategy = {
   allSelected: ({ allItems }) => allItems,
   select: ({ items, value, selected }) => {
     for (const item of items) {
-      if (value) selected.add(item.value)
-      else selected.delete(item.value)
+      if (value) selected.set(item.key, item)
+      else selected.delete(item.key)
     }
 
     return selected
@@ -100,9 +104,16 @@ export function provideSelection (
   props: SelectionProps,
   { allItems, currentPage }: { allItems: Ref<SelectableItem[]>, currentPage: Ref<SelectableItem[]> }
 ) {
+  const itemId = props.itemId ?? 'id'
+  const extractId = typeof itemId === 'function'
+    ? (item: any) => itemId(item)
+    : (item: any) => getObjectValueByPath(item, itemId)
+  const findItem = (a: any, b: any) => extractId(a) === extractId(b)
+  const selectedItems = new Map<string | number, SelectableItem>()
+
   const selected = useProxiedModel(props, 'modelValue', props.modelValue, v => {
     return new Set(wrapInArray(v).map(v => {
-      return allItems.value.find(item => props.valueComparator(v, item.value))?.value ?? v
+      return allItems.value.find(item => findItem(v, item.value))?.value ?? v
     }))
   }, v => {
     return [...v.values()]
@@ -112,6 +123,7 @@ export function provideSelection (
   const currentPageSelectable = computed(() => currentPage.value.filter(item => item.selectable))
 
   const selectStrategy = computed(() => {
+    // TODO: this should be documented, data-iterator and data-table docs using with 'single', 'page' and 'all' values
     if (typeof props.selectStrategy === 'object') return props.selectStrategy
 
     switch (props.selectStrategy) {
@@ -122,22 +134,24 @@ export function provideSelection (
     }
   })
 
+  const itemSelected = (key: any) => selectedItems.has(key)
+
   function isSelected (items: SelectableItem | SelectableItem[]) {
-    return wrapInArray(items).every(item => selected.value.has(item.value))
+    return wrapInArray(items).every(item => itemSelected(item.key))
   }
 
   function isSomeSelected (items: SelectableItem | SelectableItem[]) {
-    return wrapInArray(items).some(item => selected.value.has(item.value))
+    return wrapInArray(items).some(item => itemSelected(item.key))
   }
 
   function select (items: SelectableItem[], value: boolean) {
-    const newSelected = selectStrategy.value.select({
+    selectStrategy.value.select({
       items,
       value,
-      selected: new Set(selected.value),
+      selected: selectedItems,
     })
 
-    selected.value = newSelected
+    selected.value = new Set(selectedItems.values())
   }
 
   function toggleSelect (item: SelectableItem) {
@@ -145,19 +159,21 @@ export function provideSelection (
   }
 
   function selectAll (value: boolean) {
-    const newSelected = selectStrategy.value.selectAll({
+    selectStrategy.value.selectAll({
       value,
       allItems: allSelectable.value,
       currentPage: currentPageSelectable.value,
-      selected: new Set(selected.value),
+      selected: selectedItems,
     })
 
-    selected.value = newSelected
+    selected.value = new Set(selectedItems.values())
   }
 
   const someSelected = computed(() => selected.value.size > 0)
   const allSelected = computed(() => {
     const items = selectStrategy.value.allSelected({
+      // required to re-compute when selected changes, otherwise will not be triggered
+      selectedSize: selected.value.size,
       allItems: allSelectable.value,
       currentPage: currentPageSelectable.value,
     })

--- a/packages/vuetify/src/components/VDataTable/composables/select.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/select.ts
@@ -104,7 +104,7 @@ export function provideSelection (
   props: SelectionProps,
   { allItems, currentPage }: { allItems: Ref<SelectableItem[]>, currentPage: Ref<SelectableItem[]> }
 ) {
-  const itemId = props.itemId ?? 'id'
+  const itemId = props.itemId || 'id'
   const extractId = typeof itemId === 'function'
     ? (item: any) => itemId(item)
     : (item: any) => getObjectValueByPath(item, itemId)

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -46,7 +46,6 @@ export type InternalDataTableHeader = Omit<DataTableHeader, 'key' | 'value' | 'c
 }
 
 export interface DataTableItem<T = any> extends InternalItem<T>, GroupableItem<T>, SelectableItem {
-  key: any
   index: number
   columns: {
     [key: string]: any

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -70,6 +70,8 @@ export function getObjectValueByPath (obj: any, path?: string | null, fallback?:
   return getNestedValue(obj, path.split('.'), fallback)
 }
 
+export type SelectItemId = string | undefined | ((item: any) => string)
+
 export type SelectItemKey<T = Record<string, any>> =
   | boolean | null | undefined // Ignored
   | string // Lookup by key, can use dot notation for nested objects


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

This PR adds a new `item-id` prop to `VDataTable` and `VDataIterator` using `id` when not configured (default).

I need to add the new `item-id` to the api and check the `selectStrategy`, looks like can be a custom object, check `selectStrategy` computed (L127) in `packages/vuetify/src/components/VDataTable/composables/select.ts` module in this PR (added TODO).

Pending tasks:
- [x]  `VDataIterator` api docs includes `item-key`  but missing in the props, should be renamed to `item-id`
- [ ] update `VDataTable` and `VDataIterator` examples in docs
- [ ] fix `SelectItemId` return type, maybe we can use `any`
- [x] use logic or instead nullish coalescing when getting the `item-id`

We should review also the `item-value` and change it to `undefined`, in the api docs using `id`.

The performance issue in #19447 is the `isSelected` computed, with this PR just a map lookup using the new `item-id`.

fixes #19447

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->

https://streamable.com/98scf9

<details>
<summary>10K rows VDataTable</summary>

```vue
<template>
  <v-app>
    <v-card title="Devices" flat>
      <template #text>
        <v-text-field
          v-model="search"
          label="Search"
          prepend-inner-icon="mdi-magnify"
          variant="outlined"
          hide-details
          single-line
        />
      </template>

      <v-data-table
        v-model="checkedDevices"
        :items="devices"
        :items-per-page-options="[
          {value: 5, title: '5'},
          {value: 10, title: '10'},
          {value: 25, title: '25'},
          {value: -1, title: 'All'},
        ]"
        :search="search"
        density="compact"
        item-id="id"
        item-value="text"
        items-per-page="5"
        select-strategy="all"
        show-select
        sticky
      />
    </v-card>
  </v-app>
</template>

<script>
  export default {
    name: 'AddEditInitiatives',
    data () {
      return {
        search: '',
        devices: [],
        checkedDevices: [],
      }
    },

    /* watch: {
      checkedDevices: val => {
        console.log(`Watch: ${val.join(', ')}`)
      },
    }, */
    mounted () {
      this.getDevices()
    },

    methods: {
      getDevices () {
        for (let i = 0; i < 10000; i++) {
          this.devices.push({
            id: i + 1,
            text: `Device ${i + 1}`,
            info: {
              serial: `#123456789-${i + 1}`,
              type: 'Phone',
              os: Math.random() > 0.5 ? 'Android' : 'IPhone',
              version: 10 * Math.random(),
              status: Math.random() > 0.5 ? 'Active' : 'Inactive',
            },
          })
        }
      },
    },
  }
</script>
```
</details>
