### PR TITLE
fix(VDataTable): emit current items immediately

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/paginate.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/paginate.ts
@@ -128,7 +128,7 @@ export function usePaginatedItems <T> (options: {
 
   watch(paginatedItems, val => {
     vm.emit('update:currentItems', val)
-  })
+  }, { immediate: true })
 
   return { paginatedItems }
 }


### PR DESCRIPTION
## Description

Follow-up on [a2f16f4](https://github.com/vuetifyjs/vuetify/commit/a2f16f44f43d8a0996ee4992b01f7a0ef13d42b7) from 8 months ago. `immediate: true` was used in V2 ([VData.ts - line 266](https://github.dev/vuetifyjs/vuetify/blob/v2-stable/packages/vuetify/src/components/VData/VData.ts)), but it was not obvious from the wording in the documentation. I think it was not intentional to write `watch` without it.

fixes #20440

## Markup:

```vue
<template>
  <v-data-table
    :headers="headers"
    :items="items"
    @update:current-items="console.log('current-items', $event)"
  />
</template>

<script setup>
  const headers = [
    { title: 'Vegetable', key: 'name' },
    { title: 'Calories', key: 'calories' },
    { title: 'Fat (g)', key: 'fat' },
    { title: 'Carbs (g)', key: 'carbs' },
    { title: 'Protein (g)', key: 'protein' },
  ]
  const items = Array.from({ length: 50 }).map((_, i) => ({
    name: `Item #${i}`,
    calories: (Math.random() * 300).toFixed(),
    fat: (Math.random() * 60).toFixed(1),
    carbs: (Math.random() * 100).toFixed(),
    protein: (Math.random() * 40).toFixed(),
  }))
</script>
```
