### PR TITLE
docs(VDataTable): update slot-headers example to use header cells

### DIFF
--- a/packages/docs/src/examples/v-data-table/slot-headers.vue
+++ b/packages/docs/src/examples/v-data-table/slot-headers.vue
@@ -7,13 +7,13 @@
     <template v-slot:headers="{ columns, isSorted, getSortIcon, toggleSort }">
       <tr>
         <template v-for="column in columns" :key="column.key">
-          <td>
+          <th>
             <span class="mr-2 cursor-pointer" @click="() => toggleSort(column)">{{ column.title }}</span>
             <template v-if="isSorted(column)">
               <v-icon :icon="getSortIcon(column)"></v-icon>
             </template>
             <v-icon v-if="column.removable" icon="$close" @click="() => remove(column.key)"></v-icon>
-          </td>
+          </th>
         </template>
       </tr>
     </template>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Noticed that the example https://vuetifyjs.com/en/components/data-tables/basics/#headers-slot was missing the horizontal divider below the headers - it was using `<td>` instead of `<th>`.   Minor change to make this example consistent with the others on that docs page.

[Original](https://vuetifyjs.com/en/components/data-tables/basics/#headers-slot) on the left, [updated version (play.vuetify.js)](https://play.vuetifyjs.com/#eNqtmNtu4zYQhl+FNVrEBmzF8Wk3Qhy0yPaQbi8K9KpY54KWaZuILAoU5TY1/O4dSqJISqStbZqLRBqRw48zQ86PfDn1Mh7d/pCmwTEnvbD3IMghjbEgj6sEoYfjaIMFHgm8jgkK9wRvCM+Wq171tOqhkMIMadqQLCNcSJs0jY44zgnYE3wgq17hDhwq9+g4ymImDJcnFLE4PyTZENHsD8YF2QzRjgj5+ByxZIgE2+1iIt/RufYoffL62V5hyzg4Lt0imqgFJPUreas/BfBi+Cu97K13sGQpBg8xziTsgY8mKMp5xvgoZTQRhIPX76OYRq/wuT9Ay0eDt18uNFj1bKcIPZ7UvgNBBQT5fH64lUvZA5swxibpFhZUEdMLNWYUuaQQRkgY/IYpRmiNWQ+35bDmgrdWXbS8NhersKqdcXJgR1lC7f1XMN9GMcscnxsRLRyRClemrRVR9wYA38ynYzdgUlXU+Cod6kMAJus7vGYRp6lAGRF5Wsygh1TW6Alwt+iMtpwd0A0crxs5HEG6k0ygqvDRUo7qfymXPimcohZCdPOpPFSofzce72AJfqTJbnAzVONwTHcJjMsE5kKbITJglCdP26BUix2EaIvjjNT2Ojn2h3P191SzPOGYcUqym2HlP9IGw4ngOVRxa/ZPGHYh0avJWwy8HeY9Yb7OrJmRtHSa+ztngsC5N2enpa3T/GcO56X/nZ5MweCd+TIw86uuQ0hwM7kyLzIinP1DEvQn2+Vm7lRUQ3Q3v6+tEK4QLYxBEIMQTWa1pdpXiLRJ0oKXZkIbGM8RQREn+IAynGz+otHexTKZfrBZNFrFYgzQLMH0K2l+hBuWcifBYmIT3LXDoVerEfSgEkBR+gCe8jTCr8a50QTT8dwmmAZ6zxXColMUPl6B+BlOOeFryMrGCTLXu/KEYqbzU3NMA22ssqHm+UB+JXH8htYEQ9k7OD40AjJuYtw7ClQPKiHUu4/hNxbHNGWpk+C+URTjQBsUg4r2BQY1ycfwC0vIW8QOaxfEbKxXqOqiBfHRUReLQIevxJgpg4/jE0ty510xmzcCMdG+K4S5OntWaTZLYnItFJ+p+Czv7jbD/K4Rh0mrLBeaqmbQkSkJ7Jp8KS/VbZ5EgsJ1XEkA2fsVWtVKg0Jxwn1rvQdbGoM665dGKSLKJ6ke0DfLpbzZ4eKG5WRnL3u52deLjk7+Ljr6hmxxHkNnL9eVqiBEpTLp12GqVg/VtW/F8Gt6+4X+7uvxl/r8hV5vpvv9Pf89ff+9vf//6P/v0QDy56V+UhrAXwuXpYBfDmhJEOirzC0MGufdHm435VYdOFAvyQW/ZNCywc3bGOpsnf+Ntyko/KLC6KaeoNosxj3uCqq5o2uQLdHhFx5O8eEWIB0iqS/s65BOUeIXJlfDaUgUr0xxSJUuqC7Z4pcuhnhwghoixhYRzrybtmucbWnjlzdOieOWOR6p05Y7XRgd0scvf5wSyC2DvFLIIYe6cDakkV8eGRLJnW9DKHnFkkMwdYFsiie/gDJElJvSkFIeOdWWVDaialTnQfVwIGLPNuC7RneorULC7GkW6P9gmK+d9ZbJUv61FVjvPEzyOC5+vfwLb/Gavw==) on the right 

<img width="1796" alt="Screenshot 2024-09-10 at 21 57 44" src="https://github.com/user-attachments/assets/3c9166db-e28f-4bf3-8a2a-0516e7f7b8e2">



