### PR TITLE
fix(VTreeview): search when using `return-object`

### DIFF
--- a/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeview.tsx
@@ -90,8 +90,10 @@ export const VTreeview = genericComponent<new <T>(
       const getPath = vListRef.value?.getPath
       if (!getPath) return null
       return new Set(filteredItems.value.flatMap(item => {
-        return [...getPath(item.props.value), ...getChildren(item.props.value)]
-      }))
+        return props.returnObject
+          ? [...getPath(item.raw), ...getChildren(item.raw)]
+          : [...getPath(item.props.value), ...getChildren(item.props.value)]
+      }).map(toRaw))
     })
 
     function getChildren (id: unknown) {


### PR DESCRIPTION
## Description

Keep the `search` working without forcing `item-value`.

## Markup:

```vue
<template>
  <v-card class="mx-auto" elevation="5" max-width="500">
    <v-sheet class="pa-4 bg-primary">
      <v-text-field
        v-model="search"
        prepend-inner-icon="mdi-magnify"
        variant="outlined"
        hide-details
      />
    </v-sheet>
    <v-card-text>
      <v-treeview
        :items="items"
        :search="search"
        open-all
        return-object
      />
    </v-card-text>
  </v-card>
</template>

<script setup>
  import { ref } from 'vue'
  const search = ref(null)
  const items = [
    {
      id: 1,
      title: 'Vuetify Human Resources',
      children: [
        {
          id: 2,
          title: 'Core team',
          children: [
            { id: 201, title: 'John' },
            { id: 202, title: 'Kael' },
            { id: 203, title: 'Nekosaur' },
            { id: 204, title: 'Jacek' },
            { id: 205, title: 'Andrew' },
          ],
        },
        {
          id: 3,
          title: 'Administrators',
          children: [
            { id: 301, title: 'Mike' },
            { id: 302, title: 'Hunt' },
          ],
        },
        {
          id: 4,
          title: 'Contributors',
          children: [
            { id: 401, title: 'Phlow' },
            { id: 402, title: 'Brandon' },
            { id: 403, title: 'Sean' },
          ],
        },
      ],
    },
  ]
</script>
```
