### PR TITLE
fix(VSelect): remove multiple check for keyboard lookup

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -238,7 +238,7 @@ export const VSelect = genericComponent<new <
       // html select hotkeys
       const KEYBOARD_LOOKUP_THRESHOLD = 1000 // milliseconds
 
-      if (props.multiple || !checkPrintable(e)) return
+      if (!checkPrintable(e)) return
 
       const now = performance.now()
       if (now - keyboardLookupLastTime > KEYBOARD_LOOKUP_THRESHOLD) {


### PR DESCRIPTION
fixes #20358 

Description

This PR addresses an issue where the keyboard navigation in the v-select component was not working properly when multiple was set to true. Users were unable to use the keyboard for select any item.
please let me know if debouncing should be applied in this.

Changes Made

Remove the condition in the return statement which stops the function execution

Testing:

Verified the fix locally by passing .
All relevant tests are passing.

Recording

https://github.com/user-attachments/assets/c9a9c1a0-6fbe-4d55-8070-34a3d0369204

