### PR TITLE
fix(VInput): focus and Interactivity of Icon in prepend Slot for File Picker

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -147,6 +147,18 @@ export const VInput = genericComponent<new <T>(
       }
     })
 
+    function prependKeyDown(key: KeyboardEvent) {
+      console.warn('prependKeyDown')
+      if (key.key !== 'Enter' && key.key !== ' ') return
+
+      console.warn('prependKeyDown')
+      key.preventDefault()
+      key.stopPropagation()
+
+      props['onClick:prepend']?.(new MouseEvent('click'))
+    }
+
+
     useRender(() => {
       const hasPrepend = !!(slots.prepend || props.prependIcon)
       const hasAppend = !!(slots.append || props.appendIcon)
@@ -177,7 +189,7 @@ export const VInput = genericComponent<new <T>(
           ]}
         >
           { hasPrepend && (
-            <div key="prepend" class="v-input__prepend">
+            <div key="prepend" class="v-input__prepend" onKeypress={prependKeyDown}>
               { slots.prepend?.(slotProps.value) }
 
               { props.prependIcon && (

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -148,10 +148,8 @@ export const VInput = genericComponent<new <T>(
     })
 
     function prependKeyDown(key: KeyboardEvent) {
-      console.warn('prependKeyDown')
       if (key.key !== 'Enter' && key.key !== ' ') return
 
-      console.warn('prependKeyDown')
       key.preventDefault()
       key.stopPropagation()
 

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -147,11 +147,11 @@ export const VInput = genericComponent<new <T>(
       }
     })
 
-    function prependKeyDown(key: KeyboardEvent) {
-      if (key.key !== 'Enter' && key.key !== ' ') return
+    function prependKeyDown (e: KeyboardEvent) {
+      if (e.key !== 'Enter' && e.key !== ' ') return
 
-      key.preventDefault()
-      key.stopPropagation()
+      e.preventDefault()
+      e.stopPropagation()
 
       props['onClick:prepend']?.(new MouseEvent('click'))
     }
@@ -187,7 +187,7 @@ export const VInput = genericComponent<new <T>(
           ]}
         >
           { hasPrepend && (
-            <div key="prepend" class="v-input__prepend" onKeypress={prependKeyDown}>
+            <div key="prepend" class="v-input__prepend" onKeypress={ prependKeyDown }>
               { slots.prepend?.(slotProps.value) }
 
               { props.prependIcon && (


### PR DESCRIPTION
fixes #20251 

**Description:**

This PR resolves an issue where the icon placed in the prepend slot of an input field was focusable but not interactive. The expected behavior is for the icon to either open the file picker when clicked or not be focusable at all if it's not meant to be interactive.

**Problem:**

- The icon in the prepend slot is focusable, but interacting with it (e.g., clicking) does not trigger the file picker or any other intended action.
- This creates a confusing user experience where the icon appears interactive, but nothing happens when trying to interact with it.

**Solution:**

- Updated the event handling for the prepend icon to ensure it triggers the click prepend  when trigger by keyboard.

**Testing:**

Verified the fix locally .
All relevant tests are passing.

**Recording:**

https://github.com/user-attachments/assets/f3ed4d1e-6c4b-4ab9-a7b1-d9ebbec08c17

