### PR TITLE
fix(VDateInput):  cancel action button should always be active

### DIFF
--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -101,7 +101,7 @@ export const VConfirmEdit = genericComponent<new <T> (
           />
 
           <VBtn
-            disabled={ isPristine.value }
+            disabled={ props.enableActions ? false : isPristine.value }
             variant="text"
             color={ props.color }
             onClick={ save }

--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -56,6 +56,7 @@ export const VConfirmEdit = genericComponent<new <T> (
     cancel: () => true,
     save: (value: any) => true,
     'update:modelValue': (value: any) => true,
+    closeMenu: () => true,
   },
 
   setup (props, { emit, slots }) {
@@ -80,7 +81,7 @@ export const VConfirmEdit = genericComponent<new <T> (
       const checkPristine = structuredClone(toRaw(isPristine.value))
       internalModel.value = structuredClone(toRaw(model.value))
       if (props.enableActions && checkPristine){
-          emit('save',internalModel.value)
+          emit('closeMenu')
           return
       }
       emit('cancel')

--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -80,9 +80,9 @@ export const VConfirmEdit = genericComponent<new <T> (
     function cancel () {
       const checkPristine = structuredClone(toRaw(isPristine.value))
       internalModel.value = structuredClone(toRaw(model.value))
-      if (props.enableActions && checkPristine){
-          emit('closeMenu')
-          return
+      if (props.enableActions && checkPristine) {
+        emit('closeMenu')
+        return
       }
       emit('cancel')
     }
@@ -91,7 +91,7 @@ export const VConfirmEdit = genericComponent<new <T> (
     useRender(() => {
       const actions = (
         <>
-          {/*{!!props.enableActions}*/}
+          { /* {!!props.enableActions} */ }
           <VBtn
             disabled={ props.enableActions ? false : isPristine.value }
             variant="text"

--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -34,6 +34,10 @@ export const makeVConfirmEditProps = propsFactory({
     type: String,
     default: '$vuetify.confirmEdit.ok',
   },
+  enableActions: {
+    type: Boolean,
+    default: false,
+  },
 }, 'VConfirmEdit')
 
 export const VConfirmEdit = genericComponent<new <T> (
@@ -73,7 +77,12 @@ export const VConfirmEdit = genericComponent<new <T> (
     }
 
     function cancel () {
+      const checkPristine = structuredClone(toRaw(isPristine.value))
       internalModel.value = structuredClone(toRaw(model.value))
+      if (props.enableActions && checkPristine){
+          emit('save',internalModel.value)
+          return
+      }
       emit('cancel')
     }
 
@@ -81,8 +90,9 @@ export const VConfirmEdit = genericComponent<new <T> (
     useRender(() => {
       const actions = (
         <>
+          {/*{!!props.enableActions}*/}
           <VBtn
-            disabled={ isPristine.value }
+            disabled={ props.enableActions ? false : isPristine.value }
             variant="text"
             color={ props.color }
             onClick={ cancel }

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -147,6 +147,18 @@ export const VInput = genericComponent<new <T>(
       }
     })
 
+    function prependKeyDown(key: KeyboardEvent) {
+      console.warn('prependKeyDown')
+      if (key.key !== 'Enter' && key.key !== ' ') return
+
+      console.warn('prependKeyDown')
+      key.preventDefault()
+      key.stopPropagation()
+
+      props['onClick:prepend']?.(new MouseEvent('click'))
+    }
+
+
     useRender(() => {
       const hasPrepend = !!(slots.prepend || props.prependIcon)
       const hasAppend = !!(slots.append || props.appendIcon)
@@ -177,7 +189,7 @@ export const VInput = genericComponent<new <T>(
           ]}
         >
           { hasPrepend && (
-            <div key="prepend" class="v-input__prepend">
+            <div key="prepend" class="v-input__prepend" onKeypress={prependKeyDown}>
               { slots.prepend?.(slotProps.value) }
 
               { props.prependIcon && (

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -148,10 +148,8 @@ export const VInput = genericComponent<new <T>(
     })
 
     function prependKeyDown(key: KeyboardEvent) {
-      console.warn('prependKeyDown')
       if (key.key !== 'Enter' && key.key !== ' ') return
 
-      console.warn('prependKeyDown')
       key.preventDefault()
       key.stopPropagation()
 

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -147,7 +147,7 @@ export const VInput = genericComponent<new <T>(
       }
     })
 
-    function prependKeyDown(key: KeyboardEvent) {
+    function prependKeyDown (key: KeyboardEvent) {
       if (key.key !== 'Enter' && key.key !== ' ') return
 
       key.preventDefault()
@@ -155,7 +155,6 @@ export const VInput = genericComponent<new <T>(
 
       props['onClick:prepend']?.(new MouseEvent('click'))
     }
-
 
     useRender(() => {
       const hasPrepend = !!(slots.prepend || props.prependIcon)
@@ -187,7 +186,7 @@ export const VInput = genericComponent<new <T>(
           ]}
         >
           { hasPrepend && (
-            <div key="prepend" class="v-input__prepend" onKeypress={prependKeyDown}>
+            <div key="prepend" class="v-input__prepend" onKeypress={ prependKeyDown }>
               { slots.prepend?.(slotProps.value) }
 
               { props.prependIcon && (

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -73,6 +73,11 @@ export const VDateInput = genericComponent()({
 
     const isInteractive = computed(() => !props.disabled && !props.readonly)
 
+    function onClear (e: MouseEvent) {
+      // console.warn('onClear', e)
+      model.value = props.multiple ? [] : null
+    }
+
     function onKeydown (e: KeyboardEvent) {
       if (e.key !== 'Enter') return
 
@@ -115,6 +120,7 @@ export const VDateInput = genericComponent()({
           onBlur={ blur }
           onClick:control={ isInteractive.value ? onClick : undefined }
           onClick:prepend={ isInteractive.value ? onClick : undefined }
+          onClick:clear={ onClear }
         >
           <VMenu
             v-model={ menu.value }

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -103,6 +103,10 @@ export const VDateInput = genericComponent()({
       menu.value = false
     }
 
+    function closeMenu() {
+      menu.value = false
+    }
+
     useRender(() => {
       const confirmEditProps = VConfirmEdit.filterProps(props)
       const datePickerProps = VDatePicker.filterProps(omit(props, ['active']))
@@ -133,6 +137,7 @@ export const VDateInput = genericComponent()({
               { ...confirmEditProps }
               v-model={ model.value }
               onSave={ onSave }
+              onCloseMenu={ closeMenu }
               enableActions
             >
               {{

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -133,6 +133,7 @@ export const VDateInput = genericComponent()({
               { ...confirmEditProps }
               v-model={ model.value }
               onSave={ onSave }
+              enableActions
             >
               {{
                 default: ({ actions, model: proxyModel }) => {

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -74,7 +74,6 @@ export const VDateInput = genericComponent()({
     const isInteractive = computed(() => !props.disabled && !props.readonly)
 
     function onClear (e: MouseEvent) {
-      // console.warn('onClear', e)
       model.value = props.multiple ? [] : null
     }
 
@@ -103,7 +102,7 @@ export const VDateInput = genericComponent()({
       menu.value = false
     }
 
-    function closeMenu() {
+    function closeMenu () {
       menu.value = false
     }
 


### PR DESCRIPTION
fixes #20226 

**Description**

This pull request fixes an issue where the cancel and ok button of date-input not enables, clearable does not clear the model value.

**Changes Made**

Add a prop in VConfirmEdit to show the action buttons and make it true from the VDateInput which enables the action buttons for the date input, VConfirmEdit for other inputs works same as before.

**Testing:**

Verified the fix locally by using multiple conditions in VDateInput.
All relevant tests are passing.

**Recording**
