### PR TITLE
docs(VInput): correct hint props description

### DIFF
--- a/packages/docs/src/pages/en/components/inputs.md
+++ b/packages/docs/src/pages/en/components/inputs.md
@@ -68,7 +68,7 @@ When the **hide-details** prop is set to `auto` messages will be rendered only i
 
 #### Hint
 
-`v-input` can have **hint** which can tell user how to use the input. **persistent-hint** prop makes the hint visible always if no messages are displayed.
+`v-input` can have **hint** which can tell user how to use the input (when focused). **persistent-hint** prop makes the hint visible always if no `error-messages` are displayed.
 
 <ExamplesExample file="v-input/prop-hint" />
 


### PR DESCRIPTION
## Description
If `persistent-hint` props is true, hint will overwrite `messages` but not `error-messages`. 
It's less confusing to replace the word 'messages' to 'error-messages' I guess.

Note:
| persistent-hint | focus | precedence |
|--------|--------|--------|
| false | false | error-messages > messages ~> hint~ |
| false | true | error-messages > hint > messages |
| true | false | error-messages > hint > messages |
| true | true | error-messages > hint > messages | 

https://github.com/t407o/vuetify/blob/e8b80cd66a0ca76a24e7ef4c92ea1357391b1e81/packages/vuetify/src/components/VInput/VInput.tsx#L113-L121

It looks the behavior of `hint` with `persistent-hint = true` is almost the same as `messages` (always be displayed if no error). I don't know how we use them properly... never mind.



