### PR TITLE
Fix/Overlay clearable visibility

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -219,7 +219,11 @@ export const VField = genericComponent<new <T>(
 
       props['onClick:clear']?.(new MouseEvent('click'))
     }
-
+ 
+    const isHovered = ref(false)
+    function changeHover(value: boolean) {
+      isHovered.value = value
+    }
     useRender(() => {
       const isOutlined = props.variant === 'outlined'
       const hasPrepend = !!(slots['prepend-inner'] || props.prependInnerIcon)
@@ -268,6 +272,8 @@ export const VField = genericComponent<new <T>(
             props.style,
           ]}
           onClick={ onClick }
+          onMouseenter={() => changeHover(true)}
+          onMouseleave={() => changeHover(false)}
           { ...attrs }
         >
           <div class="v-field__overlay" />
@@ -319,7 +325,7 @@ export const VField = genericComponent<new <T>(
             } as VFieldSlot)}
           </div>
 
-          { hasClear && (
+          {(hasClear && (isFocused.value || isHovered.value) ) && (
             <VExpandXTransition key="clear">
               <div
                 class="v-field__clearable"

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.browser.tsx
@@ -87,12 +87,13 @@ describe('VFileInput', () => {
     const { element } = render(() => (
       <VFileInput v-model={ model.value } multiple />
     ))
-
+    const input = screen.getByCSS('input')
+    input.focus()
     await userEvent.click(screen.getByLabelText(/clear/i))
 
     expect(element).not.toHaveTextContent('1MB file, 2MB file')
     expect(model.value).toHaveLength(0)
-    expect(screen.getByCSS('input')).toHaveValue('')
+    expect(input).toHaveValue('')
   })
 
   it('should support removing clearable icon', async () => {

--- a/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.cy.tsx
@@ -33,10 +33,10 @@ describe('VNumberInput', () => {
           <VNumberInput
             clearable
             v-model={ model.value }
-            readonly
           />
         </>
     ))
+      .get('.v-field').click()
       .get('.v-field__clearable .v-icon--clickable').click()
       .then(() => {
         expect(model.value).equal(null)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
The PR changes the behavior of the textfields clearable overlay, so it is only shown if the field is focues or hovered

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
solves #20375
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
