### PR TITLE
docs(VForm): remove hide-details from usage example

### DIFF
--- a/packages/docs/src/examples/v-form/usage.vue
+++ b/packages/docs/src/examples/v-form/usage.vue
@@ -11,7 +11,6 @@
             :counter="10"
             :rules="nameRules"
             label="First name"
-            hide-details
             required
           ></v-text-field>
         </v-col>
@@ -25,7 +24,6 @@
             :counter="10"
             :rules="nameRules"
             label="Last name"
-            hide-details
             required
           ></v-text-field>
         </v-col>
@@ -38,7 +36,6 @@
             v-model="email"
             :rules="emailRules"
             label="E-mail"
-            hide-details
             required
           ></v-text-field>
         </v-col>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
In the [form validation demo](https://vuetifyjs.com/en/components/forms/#usage) the validation error messages are not visible when the fields are invalid. Removing `hide-details` fixes this.

## Fixed Demo:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
https://play.vuetifyjs.com/#eNrVU01v2zAM/SuEL0mQxm6HnQwn2w7badhh17oH1aYXAbLsSVRaoMh/L6UkstOmHyjaQw3YkEjqPfH58fIusabKfvR9unGY5ElB2PZKEK5KDVBsFk1nWtgs2q5GtSyTjVCyLpOQDfmq0ySkRrMPhaDpbuJ2X6WAX8sIF1/KBNqaV18jTqwjvKVFI1HV4wSMLtBIY0mLFsvkuCSvOqcJjac4f5Q0TqFn9yf/+vXDCiWuA/4vjw+nCAz+d9Lg0c1WRTa+9LhpTnDHHPkgIZT4UB1+M/xnkAFbIdWTbYbss33+XJwCeGuTw34YgV12PCU+4ueKN0U2Gjje2srInkIV3vadIaixEU4R3O3QakEih+kMliuY7mOshx/LHBqhLJ4dgnFUcphMYvTgm6NgtEMOl0NfjOrQE0Ue/8gGpiEzY5nIGQ1kHI5/sNcvJCZ/GBekjXqmk6FqG9lfZPqWKtT/aA3FEi7OX8vbOrbwNQK3ZYHWQvNZqNbCiIrnw56+y1VcBe8cqTS46Z1l2pnwINSbdMrS+fd0XpZpOs9SQkt78tezH+QKXnpenO0sLLbev9GxyfZMO6XC5+oezinGwQ==
```
