### PR TITLE
fix(router): check $router.beforeEach exists before using

### DIFF
--- a/packages/vuetify/src/composables/router.tsx
+++ b/packages/vuetify/src/composables/router.tsx
@@ -113,7 +113,7 @@ export function useBackButton (router: Router | undefined, cb: (next: Navigation
   let removeBefore: (() => void) | undefined
   let removeAfter: (() => void) | undefined
 
-  if (IN_BROWSER) {
+  if (IN_BROWSER && router?.beforeEach) {
     nextTick(() => {
       window.addEventListener('popstate', onPopstate)
       removeBefore = router?.beforeEach((to, from, next) => {

--- a/packages/vuetify/src/composables/router.tsx
+++ b/packages/vuetify/src/composables/router.tsx
@@ -116,7 +116,7 @@ export function useBackButton (router: Router | undefined, cb: (next: Navigation
   if (IN_BROWSER && router?.beforeEach) {
     nextTick(() => {
       window.addEventListener('popstate', onPopstate)
-      removeBefore = router?.beforeEach((to, from, next) => {
+      removeBefore = router.beforeEach((to, from, next) => {
         if (!inTransition) {
           setTimeout(() => popped ? cb(next) : next())
         } else {


### PR DESCRIPTION
Make use of $router global safer.

Code breaks if something that isn't a vue-router inhabits the global Vue var "$router". For example, I'm using a different router and it installed itself to the global name "$router" but it doesn't have a beforeEach method. I don't think "$router" has been reserved specifically for vue-router or any router implementation.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
