### PR TITLE
fix(VAppBar): vertical main layout shift on SSR request

### DIFF
--- a/packages/vuetify/src/components/VAppBar/VAppBar.tsx
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.tsx
@@ -2,7 +2,7 @@
 import './VAppBar.sass'
 
 // Components
-import { makeVToolbarProps, VToolbar } from '@/components/VToolbar/VToolbar'
+import { calculateHeight, makeVToolbarProps, VToolbar } from '@/components/VToolbar/VToolbar'
 
 // Composables
 import { makeLayoutItemProps, useLayoutItem } from '@/composables/layout'
@@ -118,8 +118,12 @@ export const VAppBar = genericComponent<VToolbarSlots>()({
     const height = computed(() => {
       if (scrollBehavior.value.hide && scrollBehavior.value.inverted) return 0
 
-      const height = vToolbarRef.value?.contentHeight ?? 0
-      const extensionHeight = vToolbarRef.value?.extensionHeight ?? 0
+      const height = vToolbarRef.value?.contentHeight ?? calculateHeight(props.height, props.density, false)
+      const extensionHeight = vToolbarRef.value?.extensionHeight ??
+        (props.extended || slots.extension?.()
+          ? calculateHeight(props.extensionHeight, props.density, true)
+          : 0
+        )
 
       if (!canHide.value) return (height + extensionHeight)
 

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -13,6 +13,7 @@ import { useBackgroundColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
 import { provideDefaults } from '@/composables/defaults'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { forwardRefs } from '@/composables/forwardRefs.ts'
 import { useRtl } from '@/composables/locale'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
@@ -226,10 +227,11 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
       )
     })
 
-    return {
+    return forwardRefs({
       contentHeight,
       extensionHeight,
-    }
+      calculateHeight,
+    })
   },
 })
 

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -67,6 +67,15 @@ export const makeVToolbarProps = propsFactory({
   ...makeThemeProps(),
 }, 'VToolbar')
 
+export function calculateHeight (height: number | string, density: Density, forExtensionHeight: boolean) {
+  return parseInt((
+    Number(height) +
+    (density === 'prominent' ? Number(height) : 0) -
+    (density === 'comfortable' ? forExtensionHeight ? 4 : 8 : 0) -
+    (density === 'compact' ? forExtensionHeight ? 8 : 16 : 0)
+  ), 10)
+}
+
 export type VToolbarSlots = {
   default: never
   image: never
@@ -90,19 +99,13 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
     const { rtlClasses } = useRtl()
 
     const isExtended = shallowRef(props.extended === null ? !!(slots.extension?.()) : props.extended)
-    const contentHeight = computed(() => parseInt((
-      Number(props.height) +
-      (props.density === 'prominent' ? Number(props.height) : 0) -
-      (props.density === 'comfortable' ? 8 : 0) -
-      (props.density === 'compact' ? 16 : 0)
-    ), 10))
+    const contentHeight = computed(() => calculateHeight(
+      props.height,
+      props.density,
+      false,
+    ))
     const extensionHeight = computed(() => isExtended.value
-      ? parseInt((
-        Number(props.extensionHeight) +
-        (props.density === 'prominent' ? Number(props.extensionHeight) : 0) -
-        (props.density === 'comfortable' ? 4 : 0) -
-        (props.density === 'compact' ? 8 : 0)
-      ), 10)
+      ? calculateHeight(props.extensionHeight, props.density, true)
       : 0
     )
 

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -13,7 +13,6 @@ import { useBackgroundColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
 import { provideDefaults } from '@/composables/defaults'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
-import { forwardRefs } from '@/composables/forwardRefs.ts'
 import { useRtl } from '@/composables/locale'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
@@ -227,11 +226,10 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
       )
     })
 
-    return forwardRefs({
+    return {
       contentHeight,
       extensionHeight,
-      calculateHeight,
-    })
+    }
   },
 })
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Since we need to await to render the VToolbar from VAppBar, this PR just uses the props to calculate the computed height in VAppBar when VToolbar is not still present: on SSR page request this will prevent the vertical shift layout.

~~https://streamable.com/llbms5~~

resolves #15202 partially, now there is a flickering in the navigation drawer (we should also review the navigation drawer and the hydration missmatch): ~~https://streamable.com/6pjzvc~~

related PR #15229

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->