### PR TITLE
fix(VTreeviewChildren): return-object mess up ListGroup id

### DIFF
--- a/packages/vuetify/src/labs/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/labs/VTreeview/VTreeviewChildren.tsx
@@ -128,7 +128,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
       return children ? (
         <VTreeviewGroup
           { ...treeviewGroupProps }
-          value={ props.returnObject ? item.raw : treeviewGroupProps?.value }
+          value={ treeviewGroupProps?.value }
         >
           {{
             activator: ({ props: activatorProps }) => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <h1>{{ selectedModel }}</h1>
    <v-container>
      <v-treeview
        selectable
        select-strategy="independent"
 :items="items" return-object v-model="selectedModel" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selectedModel = ref([])
  const items = ref([
    {
      id: 1,
      title: 'title 1',
      children: [
        {
          id: 2,
          title: 'title 2',
        },
      ],
    },
  ])
</script>

```
