### PR TITLE
fix(VAutocomplete): Reliably unregister list items when filtering

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -167,7 +167,7 @@ export const VAutocomplete = genericComponent<new <
         : model.value.length
     })
     const form = useForm(props)
-    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
+    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value, { forRegisteredNodes: true })
 
     const displayItems = computed(() => {
       if (props.hideSelected) {
@@ -493,14 +493,14 @@ export const VAutocomplete = genericComponent<new <
                       { slots['prepend-item']?.() }
 
                       { !displayItems.value.length && !props.hideNoData && (slots['no-data']?.() ?? (
-                        <VListItem title={ t(props.noDataText) } />
+                        <VListItem key="no-data" title={ t(props.noDataText) } />
                       ))}
 
                       <VVirtualScroll ref={ vVirtualScrollRef } renderless items={ displayItems.value }>
                         { ({ item, index, itemRef }) => {
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,
-                            key: index,
+                            key: item.value,
                             active: (highlightFirst.value && index === 0) ? true : undefined,
                             onClick: () => select(item, null),
                           })

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -221,7 +221,7 @@ export const VCombobox = genericComponent<new <
       }
     })
 
-    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
+    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value, { forRegisteredNodes: true })
 
     const displayItems = computed(() => {
       if (props.hideSelected) {
@@ -537,14 +537,14 @@ export const VCombobox = genericComponent<new <
                       { slots['prepend-item']?.() }
 
                       { !displayItems.value.length && !props.hideNoData && (slots['no-data']?.() ?? (
-                        <VListItem title={ t(props.noDataText) } />
+                        <VListItem key="no-data" title={ t(props.noDataText) } />
                       ))}
 
                       <VVirtualScroll ref={ vVirtualScrollRef } renderless items={ displayItems.value }>
                         { ({ item, index, itemRef }) => {
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,
-                            key: index,
+                            key: item.value,
                             active: (highlightFirst.value && index === 0) ? true : undefined,
                             onClick: () => select(item, null),
                           })

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -37,6 +37,7 @@ import {
 import {
   animate,
   convertToUnit,
+  debounce,
   genericComponent,
   getCurrentInstance,
   getScrollParent,
@@ -170,9 +171,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     const isMounted = useHydration()
     const { scopeId } = useScopeId()
 
-    watch(() => props.disabled, v => {
-      if (v) isActive.value = false
-    })
+    watch(() => props.disabled, debounce((v: boolean) => v && (isActive.value = false), 100))
 
     const { contentStyles, updateLocation } = useLocationStrategies(props, {
       isRtl,


### PR DESCRIPTION
## Description

- followup to [970f827](https://github.com/vuetifyjs/vuetify/commit/970f827828b2e488ad5bb2e8f1363fd38c5a6102)

TODO:
- [x] avoid regression in VCombobox

fixes #20516

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <h5>VAutocomplete</h5>
      <v-autocomplete :items="items" />
      <h5>VCombobox</h5>
      <v-combobox :items="items" />
      <pre>
Scenario 1:
- type: tt
- press (slowly): {backspace}{backspace}

Scenario 2:
- type: rrr
- press (slowly): {backspace}{backspace}{backspace}

Scenario 3:
- type: ww
- press (slowly): {backspace}{backspace}
      </pre>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { title: 'Atis', value: 'atis' },
    { title: 'Banana', value: 'banana' },
    { title: 'Cranberry', value: 'cranberry' },
    { title: 'Durian', value: 'durian' },
    { title: 'Pineapple', value: 'pineapple' },
    { title: 'Strawberry', value: 'strawberry' },
  ]
</script>
```
