### PR TITLE
docs(VDataTable): remove unused mobile prop from headers type

### DIFF
--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -28,8 +28,6 @@ export type DataTableHeader<T = Record<string, any>> = {
   sortRaw?: DataTableCompareFunction
   filter?: FilterFunction
 
-  mobile?: boolean
-
   children?: DataTableHeader<T>[]
 }
 


### PR DESCRIPTION
## Description

`mobile` should not appear on [API docs for v-data-table](https://vuetifyjs.com/en/api/v-data-table/#props-headers), because it is not utilized anywhere.

~~I wish I could fully verify the change locally, but the project does not build at the moment due to chai TS issues. Hopefully it is the only place to change.~~ Verified locally.