### PR TITLE
docs: fix styles leaking from TeamMember

### DIFF
--- a/packages/docs/src/components/about/TeamMember.vue
+++ b/packages/docs/src/components/about/TeamMember.vue
@@ -1,6 +1,6 @@
 <template>
   <v-lazy min-height="128">
-    <div class="d-flex team-members">
+    <div class="d-flex team-member">
       <v-avatar color="grey-lighten-2" size="72">
         <v-img v-if="member.avatar" :src="member.avatar" />
         <v-icon v-else color="grey" size="35"> mdi-image</v-icon>
@@ -214,8 +214,9 @@
   }
 </script>
 
-<style>
-  .v-markdown > p {
-    margin: 0;
-  }
+<style lang="sass">
+  .team-member
+    .v-markdown
+      > p
+        margin: 0
 </style>

--- a/packages/docs/src/components/about/TeamMembers.vue
+++ b/packages/docs/src/components/about/TeamMembers.vue
@@ -23,13 +23,3 @@
   const teams = useTeamStore()
   const members = computed(() => teams.members.filter(member => member.team === props.team))
 </script>
-
-<style lang="sass">
-  .team-members
-    .v-markdown
-      > p
-        margin: 0
-
-      a
-        text-decoration: none
-</style>


### PR DESCRIPTION
## Description

- (`about/TeamMembers.vue`) component styles were leaking and affecting `ApiTable.vue`
- (`about/TeamMembers.vue`) page styles were overlapping and not really required

Bug was introduced around 1 month ago ([6b69a72](https://github.com/vuetifyjs/vuetify/commit/6b69a72759b0fc6e934c31df3197e993c9e4fee2)), so hopefully there are no more places that include additional bottom spacing to compensate for leaking styles.

fixes #20664
