### PR TITLE
docs: add Epicmax support section to home page

### DIFF
--- a/packages/docs/components.d.ts
+++ b/packages/docs/components.d.ts
@@ -124,6 +124,7 @@ declare module 'vue' {
     GettingStartedWireframeExamples: typeof import('./src/components/getting-started/WireframeExamples.vue')['default']
     HomeActionBtns: typeof import('./src/components/home/ActionBtns.vue')['default']
     HomeEntry: typeof import('./src/components/home/Entry.vue')['default']
+    HomeEpicmaxSupport: typeof import('./src/components/home/EpicmaxSupport.vue')['default']
     HomeFeatures: typeof import('./src/components/home/Features.vue')['default']
     HomeFooter: typeof import('./src/components/home/Footer.vue')['default']
     HomeLogo: typeof import('./src/components/home/Logo.vue')['default']

--- a/packages/docs/src/components/home/EpicmaxSupport.vue
+++ b/packages/docs/src/components/home/EpicmaxSupport.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="bg-light-blue-darken-4 py-8">
     <h2 class="v-heading mb-2 text-h4 text-sm-h4">{{ t("epicmax.title") }}</h2>
-    <p class="mx-auto" style="width: 700px">{{ t("epicmax.message") }}</p>
+    <p class="mx-auto" style="max-width: 700px">{{ t("epicmax.message") }}</p>
     <v-btn
       :aria-label="t('epicmax.learn-more')"
       class="px-16 text-light-blue-darken-4"

--- a/packages/docs/src/components/home/EpicmaxSupport.vue
+++ b/packages/docs/src/components/home/EpicmaxSupport.vue
@@ -1,0 +1,24 @@
+<template>
+  <section class="bg-light-blue-darken-4 py-8">
+    <h2 class="v-heading mb-2 text-h4 text-sm-h4">{{ t("epicmax.title") }}</h2>
+    <p class="mx-auto" style="width: 700px">{{ t("epicmax.message") }}</p>
+    <v-btn
+      :aria-label="t('epicmax.learn-more')"
+      class="px-16 text-light-blue-darken-4"
+      color="grey-lighten-5"
+      href="https://www.epicmax.co/?ref=vuetify"
+      rounded="0"
+      size="large"
+      variant="flat"
+    >
+      <span
+        class="text-capitalize font-weight-regular"
+        v-text="t('epicmax.learn-more')"
+      />
+    </v-btn>
+  </section>
+</template>
+
+<script setup>
+  const { t } = useI18n()
+</script>

--- a/packages/docs/src/i18n/messages/en.json
+++ b/packages/docs/src/i18n/messages/en.json
@@ -148,6 +148,11 @@
   "enable-pwa-refresh": "Enable Refresh Prompt",
   "enable-pwa-refresh-message": "Display the refresh prompt when new documentation updates have been downloaded.",
   "enterprise": "Enterprise",
+  "epicmax": {
+    "learn-more": "Learn more",
+    "title": "Need support with your Vuetify project?",
+    "message": "Epicmax is here to support you - whether it's migrating to Vue3, adjusting your Vue.js code, or building custom front-ends."
+  },
   "email-address": "Email address",
   "esc": "Esc",
   "extra-extra-large": "Extra extra large",

--- a/packages/docs/src/pages/en/index.md
+++ b/packages/docs/src/pages/en/index.md
@@ -45,3 +45,5 @@ Check out these beautiful apps, plugins, and themes built using Vuetify.{style="
 <br>
 <br>
 <br>
+
+<HomeEpicmaxSupport />


### PR DESCRIPTION
## Summary
This PR adds Epicmax support section for `home`  page.

## Description
PR contains new component for the section and markup changes.

## Markup:
```vue
<template>
  <section class="bg-light-blue-darken-4 py-8">
    <h2 class="v-heading mb-2 text-h4 text-sm-h4">{{ t("epicmax.title") }}</h2>
    <p class="mx-auto" style="max-width: 700px">{{ t("epicmax.message") }}</p>
    <v-btn
      :aria-label="t('epicmax.learn-more')"
      class="px-16 text-light-blue-darken-4"
      color="grey-lighten-5"
      href="https://www.epicmax.co/?ref=vuetify"
      rounded="0"
      size="large"
      variant="flat"
    >
      <span
        class="text-capitalize font-weight-regular"
        v-text="t('epicmax.learn-more')"
      />
    </v-btn>
  </section>
</template>

<script setup>
  const { t } = useI18n()
</script>
```
