### PR TITLE
docs(VList): fix misnamed prop

### DIFF
--- a/packages/docs/src/pages/en/components/lists.md
+++ b/packages/docs/src/pages/en/components/lists.md
@@ -130,6 +130,6 @@ Lists can contain subheaders, dividers, and can contain 1 or more lines. The sub
 
 #### Action and item groups
 
-A **three-line** list with actions. Utilizing **selection-strategy**, easily connect actions to your tiles.
+A **three-line** list with actions. Utilizing **select-strategy**, easily connect actions to your tiles.
 
 <ExamplesExample file="v-list/misc-actions" />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Prop name `selection-strategy` is actually called `select-strategy`.

