### PR TITLE
feat(VAlert): better aligment with prepend icon

### DIFF
--- a/packages/api-generator/src/locale/en/VIconBtn.json
+++ b/packages/api-generator/src/locale/en/VIconBtn.json
@@ -6,8 +6,6 @@
     "baseVariant": "When active is a boolean, this variant is used when active is false.",
     "hideOverlay": "Hides overlay from being displayed when active or focused.",
     "iconColor": "Explicit color applied to the icon.",
-    "iconSize": "The specific size of the icon, can use named sizes.",
-    "iconSizes": "An array of tuples that define the icon sizes for each named size.",
     "loading": "Displays circular progress bar in place of the icon.",
     "readonly": "Puts the button in a readonly state. Cannot be clicked or navigated to by keyboard.",
     "rotate": "The rotation of the icon in degrees.",

--- a/packages/api-generator/src/locale/en/generic.json
+++ b/packages/api-generator/src/locale/en/generic.json
@@ -25,6 +25,8 @@
     "hideOnLeave": "Hides the leaving element (no exit animation).",
     "group": "Creates a `transition-group` component. You can find more information in the [vue docs](https://vuejs.org/api/built-in-components.html#transitiongroup).",
     "icon": "Apply a specific icon using the [v-icon](/components/icons/) component.",
+    "iconSize": "The specific size of the icon, can use named sizes.",
+    "iconSizes": "An array of tuples that define the icon sizes for each named size.",
     "image": "Apply a specific image using [v-img](/components/images/).",
     "items": "An array of strings or objects used for automatically generating children components.",
     "label": "Sets the text of the [v-label](/api/v-label/) or [v-field-label](/api/v-field-label/) component.",

--- a/packages/vuetify/src/components/VAlert/VAlert.sass
+++ b/packages/vuetify/src/components/VAlert/VAlert.sass
@@ -1,3 +1,4 @@
+@use '../../styles/settings'
 @use '../../styles/tools'
 @use './variables' as *
 
@@ -42,6 +43,10 @@
         &.v-alert--border-bottom
           padding-bottom: $alert-padding + $alert-border-thin-width + $modifier
 
+    &:not(:has(.v-alert-title))
+      .v-alert__content
+        padding-top: calc(($alert-title-line-height - settings.$line-height-root * 1rem) / 2)
+
   .v-alert__border
     border-radius: inherit
     bottom: 0
@@ -70,6 +75,7 @@
   .v-alert__close
     flex: 0 1 auto
     grid-area: close
+    margin-block: -2px
 
   .v-alert__content
     align-self: center
@@ -78,7 +84,6 @@
 
   .v-alert__append,
   .v-alert__close
-    align-self: flex-start
     margin-inline-start: $alert-append-margin-inline-start
 
   .v-alert__append
@@ -94,6 +99,7 @@
     align-items: center
     grid-area: prepend
     margin-inline-end: $alert-prepend-margin-inline-end
+    min-height: $alert-title-line-height
 
     .v-alert--prominent &
       align-self: center

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -14,6 +14,7 @@ import { makeDensityProps, useDensity } from '@/composables/density'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { IconValue } from '@/composables/icons'
+import { makeIconSizeProps, useIconSizes } from '@/composables/iconSizes'
 import { useLocale } from '@/composables/locale'
 import { makeLocationProps, useLocation } from '@/composables/location'
 import { makePositionProps, usePosition } from '@/composables/position'
@@ -60,10 +61,6 @@ export const makeVAlertProps = propsFactory({
     type: [Boolean, String, Function, Object] as PropType<false | IconValue>,
     default: null,
   },
-  iconSize: {
-    type: Number,
-    default: null,
-  },
   modelValue: {
     type: Boolean,
     default: true,
@@ -80,6 +77,7 @@ export const makeVAlertProps = propsFactory({
   ...makeDensityProps(),
   ...makeDimensionProps(),
   ...makeElevationProps(),
+  ...makeIconSizeProps(),
   ...makeLocationProps(),
   ...makePositionProps(),
   ...makeRoundedProps(),
@@ -116,6 +114,7 @@ export const VAlert = genericComponent<VAlertSlots>()({
       return props.icon ?? `$${props.type}`
     })
 
+    const { iconSize } = useIconSizes(props, props.prominent ? 44 : 28)
     const { themeClasses } = provideTheme(props)
     const { colorClasses, colorStyles, variantClasses } = useVariant(() => ({
       color: props.color ?? props.type,
@@ -192,7 +191,7 @@ export const VAlert = genericComponent<VAlertSlots>()({
                   key="prepend-icon"
                   density={ props.density }
                   icon={ icon.value }
-                  size={ props.iconSize ?? (props.prominent ? 44 : 28) }
+                  size={ iconSize }
                 />
               ) : (
                 <VDefaultsProvider
@@ -202,7 +201,7 @@ export const VAlert = genericComponent<VAlertSlots>()({
                     VIcon: {
                       density: props.density,
                       icon: icon.value,
-                      size: props.prominent ? 44 : 28,
+                      size: iconSize,
                     },
                   }}
                   v-slots:default={ slots.prepend }

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -77,7 +77,7 @@ export const makeVAlertProps = propsFactory({
   ...makeDensityProps(),
   ...makeDimensionProps(),
   ...makeElevationProps(),
-  ...makeIconSizeProps(),
+  ...makeIconSizeProps({ iconSize: null }),
   ...makeLocationProps(),
   ...makePositionProps(),
   ...makeRoundedProps(),
@@ -114,7 +114,7 @@ export const VAlert = genericComponent<VAlertSlots>()({
       return props.icon ?? `$${props.type}`
     })
 
-    const { iconSize } = useIconSizes(props, props.prominent ? 44 : 28)
+    const { iconSize } = useIconSizes(props, () => props.prominent ? 44 : 28)
     const { themeClasses } = provideTheme(props)
     const { colorClasses, colorStyles, variantClasses } = useVariant(() => ({
       color: props.color ?? props.type,
@@ -142,6 +142,12 @@ export const VAlert = genericComponent<VAlertSlots>()({
       const hasPrepend = !!(slots.prepend || icon.value)
       const hasTitle = !!(slots.title || props.title)
       const hasClose = !!(slots.close || props.closable)
+
+      const iconProps = {
+        density: props.density,
+        icon: icon.value,
+        size: iconSize.value,
+      }
 
       return isActive.value && (
         <props.tag
@@ -187,23 +193,12 @@ export const VAlert = genericComponent<VAlertSlots>()({
           { hasPrepend && (
             <div key="prepend" class="v-alert__prepend">
               { !slots.prepend ? (
-                <VIcon
-                  key="prepend-icon"
-                  density={ props.density }
-                  icon={ icon.value }
-                  size={ iconSize }
-                />
+                <VIcon key="prepend-icon" { ...iconProps } />
               ) : (
                 <VDefaultsProvider
                   key="prepend-defaults"
                   disabled={ !icon.value }
-                  defaults={{
-                    VIcon: {
-                      density: props.density,
-                      icon: icon.value,
-                      size: iconSize,
-                    },
-                  }}
+                  defaults={{ VIcon: { ...iconProps } }}
                   v-slots:default={ slots.prepend }
                 />
               )}

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -60,6 +60,10 @@ export const makeVAlertProps = propsFactory({
     type: [Boolean, String, Function, Object] as PropType<false | IconValue>,
     default: null,
   },
+  iconSize: {
+    type: Number,
+    default: null,
+  },
   modelValue: {
     type: Boolean,
     default: true,
@@ -188,7 +192,7 @@ export const VAlert = genericComponent<VAlertSlots>()({
                   key="prepend-icon"
                   density={ props.density }
                   icon={ icon.value }
-                  size={ props.prominent ? 44 : 28 }
+                  size={ props.iconSize ?? (props.prominent ? 44 : 28) }
                 />
               ) : (
                 <VDefaultsProvider

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -77,7 +77,7 @@ export const makeVAlertProps = propsFactory({
   ...makeDensityProps(),
   ...makeDimensionProps(),
   ...makeElevationProps(),
-  ...makeIconSizeProps({ iconSize: null }),
+  ...makeIconSizeProps(),
   ...makeLocationProps(),
   ...makePositionProps(),
   ...makeRoundedProps(),

--- a/packages/vuetify/src/composables/iconSizes.ts
+++ b/packages/vuetify/src/composables/iconSizes.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { computed, toRef } from 'vue'
+import { computed } from 'vue'
 import { propsFactory } from '@/util'
 
 // Types
@@ -8,16 +8,13 @@ import type { VIconBtnSizes } from '@/labs/VIconBtn/VIconBtn'
 
 // Types
 export interface IconSizeProps {
-  iconSize: VIconBtnSizes | number | string | null
+  iconSize?: VIconBtnSizes | number | string
   iconSizes: [VIconBtnSizes, number][]
 }
 
 // Composables
 export const makeIconSizeProps = propsFactory({
-  iconSize: {
-    type: [Number, String] as PropType<VIconBtnSizes | number | string | null>,
-    default: 'default',
-  },
+  iconSize: [Number, String] as PropType<VIconBtnSizes | number | string>,
   iconSizes: {
     type: Array as PropType<[VIconBtnSizes, number][]>,
     default: () => ([
@@ -30,11 +27,13 @@ export const makeIconSizeProps = propsFactory({
   },
 }, 'iconSize')
 
-export function useIconSizes (props: IconSizeProps, fallback: ComputedGetter<VIconBtnSizes | number | string>) {
+export function useIconSizes (props: IconSizeProps, fallback: ComputedGetter<VIconBtnSizes | number | string | undefined>) {
   const iconSize = computed(() => {
     const iconSizeMap = new Map(props.iconSizes)
-    const _iconSize = props.iconSize as VIconBtnSizes ?? toRef(fallback).value ?? 'default'
-    return iconSizeMap.get(_iconSize) ?? _iconSize
+    const _iconSize = props.iconSize as VIconBtnSizes ?? fallback() ?? 'default'
+    return iconSizeMap.has(_iconSize)
+      ? iconSizeMap.get(_iconSize)
+      : _iconSize
   })
 
   return { iconSize }

--- a/packages/vuetify/src/composables/iconSizes.ts
+++ b/packages/vuetify/src/composables/iconSizes.ts
@@ -1,20 +1,21 @@
 // Utilities
+import { computed, toRef } from 'vue'
 import { propsFactory } from '@/util'
 
 // Types
-import type { PropType } from 'vue'
+import type { ComputedGetter, PropType } from 'vue'
 import type { VIconBtnSizes } from '@/labs/VIconBtn/VIconBtn'
 
 // Types
 export interface IconSizeProps {
-  iconSize: VIconBtnSizes | number | string
+  iconSize: VIconBtnSizes | number | string | null
   iconSizes: [VIconBtnSizes, number][]
 }
 
 // Composables
 export const makeIconSizeProps = propsFactory({
   iconSize: {
-    type: [Number, String] as PropType<VIconBtnSizes | number | string>,
+    type: [Number, String] as PropType<VIconBtnSizes | number | string | null>,
     default: 'default',
   },
   iconSizes: {
@@ -29,10 +30,12 @@ export const makeIconSizeProps = propsFactory({
   },
 }, 'iconSize')
 
-export function useIconSizes (props: IconSizeProps, fallback: VIconBtnSizes | number | string) {
-  const iconSizeMap = new Map(props.iconSizes)
-  const _iconSize = props.iconSize as VIconBtnSizes ?? fallback
-  const iconSize = iconSizeMap.get(_iconSize) ?? _iconSize
+export function useIconSizes (props: IconSizeProps, fallback: ComputedGetter<VIconBtnSizes | number | string>) {
+  const iconSize = computed(() => {
+    const iconSizeMap = new Map(props.iconSizes)
+    const _iconSize = props.iconSize as VIconBtnSizes ?? toRef(fallback).value ?? 'default'
+    return iconSizeMap.get(_iconSize) ?? _iconSize
+  })
 
   return { iconSize }
 }

--- a/packages/vuetify/src/composables/iconSizes.ts
+++ b/packages/vuetify/src/composables/iconSizes.ts
@@ -1,0 +1,38 @@
+// Utilities
+import { propsFactory } from '@/util'
+
+// Types
+import type { PropType } from 'vue'
+import type { VIconBtnSizes } from '@/labs/VIconBtn/VIconBtn'
+
+// Types
+export interface IconSizeProps {
+  iconSize: VIconBtnSizes | number | string
+  iconSizes: [VIconBtnSizes, number][]
+}
+
+// Composables
+export const makeIconSizeProps = propsFactory({
+  iconSize: {
+    type: [Number, String] as PropType<VIconBtnSizes | number | string>,
+    default: 'default',
+  },
+  iconSizes: {
+    type: Array as PropType<[VIconBtnSizes, number][]>,
+    default: () => ([
+      ['x-small', 10],
+      ['small', 16],
+      ['default', 24],
+      ['large', 28],
+      ['x-large', 32],
+    ]),
+  },
+}, 'iconSize')
+
+export function useIconSizes (props: IconSizeProps, fallback: VIconBtnSizes | number | string) {
+  const iconSizeMap = new Map(props.iconSizes)
+  const _iconSize = props.iconSize as VIconBtnSizes ?? fallback
+  const iconSize = iconSizeMap.get(_iconSize) ?? _iconSize
+
+  return { iconSize }
+}

--- a/packages/vuetify/src/labs/VIconBtn/VIconBtn.tsx
+++ b/packages/vuetify/src/labs/VIconBtn/VIconBtn.tsx
@@ -139,9 +139,14 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
       const btnSize = hasNamedSize ? btnSizeMap.get(_btnSize) : _btnSize
       const btnHeight = props.height ?? btnSize
       const btnWidth = props.width ?? btnSize
-      const { iconSize } = useIconSizes(props, _btnSize)
+      const { iconSize } = useIconSizes(props, () => _btnSize)
 
-      const iconProps = { icon, size: iconSize, iconColor: props.iconColor, opacity: props.opacity }
+      const iconProps = {
+        icon,
+        size: iconSize.value,
+        iconColor: props.iconColor,
+        opacity: props.opacity,
+      }
 
       return (
         <props.tag
@@ -201,7 +206,7 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
                   color={ typeof props.loading === 'boolean' ? undefined : props.loading }
                   indeterminate="disable-shrink"
                   width="2"
-                  size={ iconSize }
+                  size={ iconSize.value }
                 />
               )}
             </span>

--- a/packages/vuetify/src/labs/VIconBtn/VIconBtn.tsx
+++ b/packages/vuetify/src/labs/VIconBtn/VIconBtn.tsx
@@ -139,7 +139,7 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
       const btnSize = hasNamedSize ? btnSizeMap.get(_btnSize) : _btnSize
       const btnHeight = props.height ?? btnSize
       const btnWidth = props.width ?? btnSize
-      const { iconSize } = useIconSizes(props, () => _btnSize)
+      const { iconSize } = useIconSizes(props, () => new Map(props.iconSizes).get(_btnSize))
 
       const iconProps = {
         icon,

--- a/packages/vuetify/src/labs/VIconBtn/VIconBtn.tsx
+++ b/packages/vuetify/src/labs/VIconBtn/VIconBtn.tsx
@@ -10,6 +10,7 @@ import { VProgressCircular } from '@/components/VProgressCircular'
 import { makeBorderProps, useBorder } from '@/composables/border'
 import { makeComponentProps } from '@/composables/component'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { makeIconSizeProps, useIconSizes } from '@/composables/iconSizes'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
@@ -50,17 +51,6 @@ export const makeVIconBtnProps = propsFactory({
   hideOverlay: Boolean,
   icon: [String, Function, Object] as PropType<IconValue>,
   iconColor: String,
-  iconSize: [Number, String] as PropType<VIconBtnSizes | number | string>,
-  iconSizes: {
-    type: Array as PropType<[VIconBtnSizes, number][]>,
-    default: () => ([
-      ['x-small', 10],
-      ['small', 16],
-      ['default', 24],
-      ['large', 28],
-      ['x-large', 32],
-    ]),
-  },
   loading: Boolean,
   opacity: [Number, String],
   readonly: Boolean,
@@ -87,6 +77,7 @@ export const makeVIconBtnProps = propsFactory({
   ...makeBorderProps(),
   ...makeComponentProps(),
   ...makeElevationProps(),
+  ...makeIconSizeProps(),
   ...makeRoundedProps(),
   ...makeTagProps({ tag: 'button' }),
   ...makeThemeProps(),
@@ -128,7 +119,6 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
     }))
 
     const btnSizeMap = new Map(props.sizes)
-    const iconSizeMap = new Map(props.iconSizes)
 
     function onClick () {
       if (
@@ -149,13 +139,7 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
       const btnSize = hasNamedSize ? btnSizeMap.get(_btnSize) : _btnSize
       const btnHeight = props.height ?? btnSize
       const btnWidth = props.width ?? btnSize
-
-      const _iconSize = props.iconSize as VIconBtnSizes
-      const hasNamedIconSize = iconSizeMap.has(_iconSize)
-
-      const iconSize = !_iconSize
-        ? hasNamedSize ? iconSizeMap.get(_btnSize) : iconSizeMap.get('default')
-        : hasNamedIconSize ? iconSizeMap.get(_iconSize) : _iconSize
+      const { iconSize } = useIconSizes(props, _btnSize)
 
       const iconProps = { icon, size: iconSize, iconColor: props.iconColor, opacity: props.opacity }
 


### PR DESCRIPTION
## Description

resolves #20636

## Markup:

<details>
<summary>Playground</summary>

```vue
<template>
  <v-app>
    <v-container :max-width="650" class="space-y-6">
      <div class="d-flex ga-6">
        <v-switch hide-details color="primary" v-model="dense" label="compact" />
        <v-switch hide-details color="primary" v-model="prominent" label="prominent" />
        <v-switch hide-details color="primary" v-model="closable" label="closable" />
      </div>

      <v-alert v-bind='alertConfigWithTitle' />
      <v-alert v-bind='alertConfigWithTitleAndText' />
      <v-alert v-bind='alertConfigWithShortText' />
      <v-alert v-bind='alertConfigWithLongText' />

      <div class="mt-6 d-flex ga-3 align-center">
        <v-number-input hide-details density="compact" variant="outlined" v-model="iconSize" label="icon size" max-width="200" suffix="px" @update:model-value="onIconSizeNumberChange" />
        <v-chip-group v-model="iconSizeText">
          <v-chip v-for="size in ['x-small','small','default','large','x-large']" filter :text="size" :value="size" />
        </v-chip-group>
      </div>
      <v-switch hide-details color="primary" v-model="customSizesEnabled" label="custom sizes" />

      <v-alert v-bind='alertConfigWithTitle' :icon-size="currentIconSize" :icon-sizes="iconSizes" />
      <v-alert v-bind='alertConfigWithTitleAndText' :icon-size="currentIconSize" :icon-sizes="iconSizes" />
      <v-alert v-bind='alertConfigWithShortText' :icon-size="currentIconSize" :icon-sizes="iconSizes" />
      <v-alert v-bind='alertConfigWithLongText' :icon-size="currentIconSize" :icon-sizes="iconSizes" />

      <v-icon-btn
        rounded="circle"
        base-variant="flat"
        color="#f9dedc"
        icon="mdi-cow"
        :icon-size="currentIconSize" :icon-sizes="iconSizes"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { computed, ref, watch } from 'vue'
  const dense = ref(false)
  const closable = ref(false)
  const prominent = ref(false)
  const iconSize = ref(24)
  const iconSizeText = ref(null)
  const useTextSize = ref(false)

  watch(iconSizeText, (v) => useTextSize.value = !!v)
  function onIconSizeNumberChange () {
    iconSizeText.value = null
  }

  const currentIconSize = computed(() => useTextSize.value ? iconSizeText.value : iconSize.value)

  const customSizesEnabled = ref(false)
  const iconSizes = computed(() => customSizesEnabled.value ? [
    ['x-small', 5],
    ['small', 15],
    ['default', 25],
    ['large', 35],
    ['x-large', 45],
  ] : undefined)

  const alertConfig = computed(() => ({
    icon: 'mdi-adjust',
    density: dense.value ? 'compact' : undefined,
    closable: closable.value,
    prominent: prominent.value
  }))
  const alertConfigWithTitle = computed(() => ({
    ...alertConfig.value,
    title: 'Past date not allowed',
  }))
  const alertConfigWithTitleAndText = computed(() => ({
    ...alertConfigWithTitle.value,
    text: 'You requested date that is in the past. Please adjust your selection.',
  }))
  const alertConfigWithShortText = computed(() => ({
    ...alertConfig.value,
    text: 'You requested date that is in the past. Please adjust your selection.',
  }))
  const alertConfigWithLongText = computed(() => ({
    ...alertConfig.value,
    text: 'You requested date that is in the past. Please adjust your selection. More text more text more text.',
  }))
</script>

<style>
  .space-y-6 > * + * {
    margin-top: 24px
  }
  /* outline to help us see alignment */
  .v-alert .v-alert__prepend {
    position: relative;
  }
  .v-alert .v-alert__prepend:after {
    pointer-events: none;
    position: absolute;
    display: block;
    content: '';
    inset: 0;
    width: 999px;
    border: 1px #0008 dashed;
  }
</style>
```
</details>