### PR TITLE
docs(VChip): more precise description for `size` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VChip.json
+++ b/packages/api-generator/src/locale/en/VChip.json
@@ -12,6 +12,7 @@
     "label": "Applies a medium size border radius.",
     "outlined": "Removes background and applies border and text color.",
     "pill": "Remove `v-avatar` padding.",
+    "size": "Sets the height, padding and the font size of the component. Accepts only predefined options: **x-small**, **small**, **default**, **large**, and **x-large**.",
     "value": "The value used when a child of a [v-chip-group](/components/chip-groups)."
   },
   "events": {


### PR DESCRIPTION
## Description

Custom description for `size` to avoid confusion. 

resolves #19356
closes #19374

Ad. [John's comment](https://github.com/vuetifyjs/vuetify/pull/19374#issuecomment-2028479123), I don't agree developers would really benefit from additional 6 props from `useDimension`. Chips are flexible pieces that are usually expected to adapt to the text inside. Using explicit width/height would fight against their nature. IMO padding helper classes are already good enough when I want to bump the size a little.