### PR TITLE
docs: cleanup removed prop `small-chips`

### DIFF
--- a/packages/api-generator/src/locale/en/VFileInput.json
+++ b/packages/api-generator/src/locale/en/VFileInput.json
@@ -8,7 +8,6 @@
     "hideInput": "Display the icon only without the input (file names).",
     "multiple": "Adds the **multiple** attribute to the input, allowing multiple file selections.",
     "showSize": "Sets the displayed size of selected file(s). When using **true** will default to _1000_ displaying (**kB, MB, GB**) while _1024_ will display (**KiB, MiB, GiB**).",
-    "smallChips": "Changes display of selections to chips with the **small** property.",
     "truncateLength": "The length of a filename before it is truncated with ellipsis.",
     "value": "A single or array of [File objects](https://developer.mozilla.org/en-US/docs/Web/API/File)."
   },

--- a/packages/api-generator/src/locale/en/VSelect.json
+++ b/packages/api-generator/src/locale/en/VSelect.json
@@ -19,7 +19,6 @@
     "overflow": "Creates an overflow button - [spec](https://material.io/guidelines/components/buttons.html#buttons-dropdown-buttons).",
     "searchInput": "Use the **.sync** modifier to catch user input from the search input.",
     "segmented": "Creates a segmented button - [spec](https://material.io/guidelines/components/buttons.html#buttons-dropdown-buttons).",
-    "smallChips": "Changes display of selections to chips with the **small** property.",
     "tags": "Tagging functionality, allows the user to create new values not available from the **items** prop."
   },
   "events": {

--- a/packages/docs/src/examples/v-combobox/slot-no-data.vue
+++ b/packages/docs/src/examples/v-combobox/slot-no-data.vue
@@ -7,10 +7,10 @@
       :items="items"
       hint="Maximum of 5 tags"
       label="Add some tags"
+      chips
       hide-selected
       multiple
       persistent-hint
-      small-chips
     >
       <template v-slot:no-data>
         <v-list-item>

--- a/packages/docs/src/examples/v-date-picker/prop-multiple.vue
+++ b/packages/docs/src/examples/v-date-picker/prop-multiple.vue
@@ -30,7 +30,6 @@
             chips
             multiple
             readonly
-            small-chips
             v-bind="attrs"
             v-on="on"
           ></v-combobox>

--- a/packages/docs/src/examples/v-file-input/prop-chips.vue
+++ b/packages/docs/src/examples/v-file-input/prop-chips.vue
@@ -5,10 +5,5 @@
       chips
       multiple
     ></v-file-input>
-    <v-file-input
-      label="File input w/ small chips"
-      multiple
-      small-chips
-    ></v-file-input>
   </div>
 </template>

--- a/packages/vuetify/playgrounds/Playground.items.vue
+++ b/packages/vuetify/playgrounds/Playground.items.vue
@@ -59,7 +59,6 @@
       outlined
       dense
       chips
-      small-chips
       label="Outlined"
       multiple
     ></v-autocomplete>
@@ -71,7 +70,6 @@
       outlined
       dense
       chips
-      small-chips
       label="Outlined"
       multiple
       return-object


### PR DESCRIPTION
## Description

`small-chips` prop does not exist, but the examples were not updated (until now)