### PR TITLE
fix(VListItem): remove aria-selected on VListItem

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -244,7 +244,6 @@ export const VListItem = genericComponent<VListItemSlots>()({
             props.style,
           ]}
           tabindex={ isClickable.value ? (list ? -2 : 0) : undefined }
-          aria-selected={ root.activatable.value ? isActivated.value : isSelected.value }
           onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && props.ripple }


### PR DESCRIPTION
## Description
I have removed the attribute 'aria-selected' from '/components/VList/VListItem.tsx' to resolve #20666 . 
It is marked as good first issue, and I wanted to get familiar with the vuetify dev environment, to contribute in future.

## Playground file to replicate
```
<template>
  <v-app>
    <v-container>
      <v-list lines="one">
        <v-list-item
          v-for="n in 3"
          :key="n"
          :title="'Item ' + n"
          subtitle="Lorem ipsum dolor sit amet consectetur adipisicing elit"
        ></v-list-item>
      </v-list>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>

```
