### PR TITLE
fix(VBadge): restore unused SASS variables

### DIFF
--- a/packages/vuetify/src/components/VBadge/VBadge.sass
+++ b/packages/vuetify/src/components/VBadge/VBadge.sass
@@ -10,6 +10,7 @@
     align-items: center
     display: inline-flex
     border-radius: $badge-border-radius
+    font-family: $badge-font-family
     font-size: $badge-font-size
     font-weight: $badge-font-weight
     height: $badge-height
@@ -24,6 +25,9 @@
     white-space: nowrap
 
     @include tools.theme($badge-theme...)
+
+    &:has(.v-icon)
+      padding: $badge-icon-padding
 
     .v-badge--bordered &
       &::after


### PR DESCRIPTION
## Description

Applies `$badge-font-family` and `$badge-icon-padding`. Both were not used after migration from v2 to v3. I assume it was not intentional.

resolves #19834

## Markup:

[Demo on Stackblitz](https://stackblitz.com/edit/vuetify-sass-variables-vbadge?file=app.vue%2Cassets%2Fmain.scss%2Cassets%2Fsettings.scss%2Cpackage.json)