### PR TITLE
fix(VChip): utilize `active-class`

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -186,6 +186,7 @@ export const VChip = genericComponent<VChipSlots>()({
               'v-chip--link': isClickable.value,
               'v-chip--filter': hasFilter,
               'v-chip--pill': props.pill,
+              [`${props.activeClass}`]: props.activeClass && link.isActive?.value,
             },
             themeClasses.value,
             borderClasses.value,


### PR DESCRIPTION
## Description

`active-class` on VChip was working in v2, but not in v3.
I could not find any related issue.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-chip active-class="text-red" text="Home (should be red)" to="/" />
      <v-chip active-class="text-red" text="Another" to="/another" />
      <v-chip text="Regular" />
    </v-container>
  </v-app>
</template>
```
