### PR TITLE
fix(VNumberInput): clearing v-number-input with backspace resets to 0

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -75,13 +75,14 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     const model = computed({
       get: () => _model.value,
       set (val) {
-        if (val === null) {
-          _model.value = null
+        if (val === null || (typeof val === 'string' && !val)) {
+          _model.value = val
           return
         }
 
-        if (!isNaN(+val) && +val <= props.max && +val >= props.min) {
-          _model.value = +val
+        const value = Number(val)
+        if (!isNaN(value) && value <= props.max && value >= props.min) {
+          _model.value = value
         }
       },
     })
@@ -294,9 +295,9 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
               { incrementControlNode() }
             </div>
-          ) : (!props.reverse
-            ? <>{ dividerNode() }{ controlNode() }</>
-            : undefined)
+          ) : (props.reverse
+            ? undefined
+            : <>{ dividerNode() }{ controlNode() }</>)
 
       const hasAppendInner = slots['append-inner'] || appendInnerControl
 

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -74,9 +74,11 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const model = computed({
       get: () => _model.value,
-      set (val) {
-        if (val === null || (typeof val === 'string' && !val)) {
-          _model.value = val
+      // model.value could be empty string from VTextField
+      // but _model.value should be eventually kept in type Number | null
+      set (val: Number | null | string) {
+        if (val === null || val === '') {
+          _model.value = null
           return
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
The `useValidation` composable doesn't perform validation when the input value changes to `null`. When resetting the input, it sets the value to an empty string. Instead of assigning 0, the model should be reset to match this behavior. Using `null` for resetting is not viable because validation won't be triggered. Therefore, the model value should remain as the empty string in such cases to ensure proper validation behavior.
fixes #20607 
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input
        ref="input"
        :model-value="model"
        :rules="rules"
        validate-on="input"
        @update:model-value="onChange"
      />
      <br />
      <pre>{{ inputToJSON }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, computed } from 'vue'

  const input = ref()

  const model = ref()

  const rules = ref([
    // required validation
    value => {
      console.log('required', value)
      return (
        (value !== null && typeof value !== 'undefined' && value !== '') ||
        'required'
      )
    },
    // min validation
    value => {
      return value >= 5 || 'should be greater or equal 5'
    },
    // max validation
    value => {
      return value <= 10 || 'should be lower or equal 10'
    },
  ])

  const onChange = value => {
    console.log('onChange', value)
    model.value = value
  }

  const inputToJSON = computed(() => {
    return JSON.stringify(input.value, null, 2)
  })
</script>
```
