### PR TITLE
fix(VField): floating label respect paddings to avoid overflow

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -278,7 +278,9 @@
       --v-field-label-scale: #{$field-label-floating-scale}em
       font-size: var(--v-field-label-scale)
       visibility: hidden
-      max-width: 100%
+
+      .v-field--variant-outlined &
+        max-width: 100%
 
       .v-field--center-affix &
         transform: none
@@ -399,7 +401,13 @@
       &__notch
         flex: none
         position: relative
-        max-width: calc(100% - var(--v-input-control-height))
+        max-width: calc(100% - $field-control-affixed-padding * 2)
+
+        @at-root
+          #{selector.append('.v-field--rounded', &)},
+          #{selector.append('[class^="rounded-"]', &)},
+          #{selector.append('[class*=" rounded-"]', &)}
+            max-width: calc(100% - var(--v-input-control-height))
 
         &::before,
         &::after


### PR DESCRIPTION
## Description

- [x] check all examples in the docs
- [x] fix for outlined variant (test on [text field with icons](https://vuetifyjs.com/en/components/text-fields/#icons))

fixes #20734

## Markup:

```vue
<template>
  <v-form>
    <v-container max-width="600">
      <v-text-field
        density="compact"
        variant="solo"
        v-model="label"
      />
      <div class="d-flex ga-3 align-center">
        rounded:
        <v-chip-group filter color="primary" v-model="rounded">
          <v-chip value="sm" text="sm" />
          <v-chip value="lg" text="lg" />
          <v-chip value="xl" text="xl" />
          <v-chip :value="true" text="true" />
          <v-chip value="pill" text="pill" />
        </v-chip-group>
      </div>
      <v-row>
        <v-col cols="12" sm="6">
          <v-text-field :label="label" model-value="asd" prepend-icon="mdi-map-marker" :rounded="rounded" />
          <v-text-field :label="label" model-value="asd" prepend-inner-icon="mdi-map-marker" :rounded="rounded" />
          <v-text-field append-icon="mdi-map-marker" :label="label" model-value="asd" :rounded="rounded" />
          <v-text-field append-inner-icon="mdi-map-marker" :label="label" model-value="asd" :rounded="rounded" />
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field :label="label" model-value="asd" prepend-icon="mdi-map-marker" variant="solo" :rounded="rounded" />
          <v-text-field :label="label" model-value="asd" prepend-inner-icon="mdi-map-marker" variant="solo" :rounded="rounded" />
          <v-text-field append-icon="mdi-map-marker" :label="label" model-value="asd" variant="solo" :rounded="rounded" />
          <v-text-field append-inner-icon="mdi-map-marker" :label="label" model-value="asd" variant="solo" :rounded="rounded" />
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field :label="label" model-value="asd" prepend-icon="mdi-map-marker" variant="outlined" :rounded="rounded" />
          <v-text-field :label="label" model-value="asd" prepend-inner-icon="mdi-map-marker" variant="outlined" :rounded="rounded" />
          <v-text-field append-icon="mdi-map-marker" :label="label" model-value="asd" variant="outlined" :rounded="rounded" />
          <v-text-field append-inner-icon="mdi-map-marker" :label="label" model-value="asd" variant="outlined" :rounded="rounded" />
        </v-col>

        <v-col cols="12" sm="6">
          <v-text-field :label="label" model-value="asd" prepend-icon="mdi-map-marker" variant="outlined" :rounded="rounded" />
          <v-text-field :label="label" model-value="asd" prepend-inner-icon="mdi-map-marker" variant="outlined" :rounded="rounded" />
          <v-text-field append-icon="mdi-map-marker" :label="label" model-value="asd" variant="outlined" :rounded="rounded" />
          <v-text-field append-inner-icon="mdi-map-marker" :label="label" model-value="asd" variant="outlined" :rounded="rounded" />
        </v-col>
      </v-row>
    </v-container>
  </v-form>
</template>

<script setup>
  import { ref } from 'vue'
  const rounded = ref(undefined)
  const label = ref('test test test test test test test test test test test test test test')
</script>
```
