### PR TITLE
fix(VCombobox): v-combobox placeholder is not consistent with v-textbox

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -469,7 +469,7 @@ export const VCombobox = genericComponent<new <
         slots['append-item'] ||
         slots['no-data']
       )
-      const isDirty = model.value.length > 0
+      const isDirty = model.value.length > 0 && !(model.value[0].value === '' && model.value.length === 1)
       const textFieldProps = VTextField.filterProps(props)
 
       return (


### PR DESCRIPTION
fixes #20660

## Description

See my [comment here](https://github.com/vuetifyjs/vuetify/issues/20660#issuecomment-2501352194).


## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-text-field v-model="msg" placeholder="Enter the message" />

      <v-combobox v-model="msg" placeholder="Enter the message" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('')
</script>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
