### PR TITLE
fix(VSelectionControl): label opacity matching regular text

### DIFF
--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -23,10 +23,8 @@
       opacity: var(--v-disabled-opacity)
       pointer-events: none
 
-    &--error,
-    &--disabled
-      .v-label
-        opacity: 1
+    .v-label
+      opacity: 1
 
     &--error:not(.v-selection-control--disabled)
       .v-label

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -18,13 +18,11 @@
       white-space: normal
       word-break: break-word
       height: 100%
+      opacity: 1
 
     &--disabled
       opacity: var(--v-disabled-opacity)
       pointer-events: none
-
-    .v-label
-      opacity: 1
 
     &--error:not(.v-selection-control--disabled)
       .v-label


### PR DESCRIPTION
## Description

fixes #18804

- Q: do we need it for `v-checkbox-btn` as well? I cannot imagine anyone using it with `label` prop, but it is available nevertheless.

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>

      <v-checkbox hide-details label="Checkbox"></v-checkbox>
      <v-checkbox hide-details disabled label="Checkbox disabled"></v-checkbox>
      <v-checkbox hide-details :model-value='true' label="Checkbox selected"></v-checkbox>

      <v-switch hide-details label="Checkbox"></v-switch>
      <v-switch hide-details disabled label="Checkbox disabled"></v-switch>
      <v-switch hide-details :model-value='true' label="Checkbox selected"></v-switch>

      <v-radio label="Radio button"></v-radio>
      <v-radio disabled label="Radio button disabled"></v-radio>
      <v-radio :model-value='true' label="Radio button selected"></v-radio>

    </v-container>
  </v-app>
</template>
```
