### PR TITLE
fix(VAutocomplete): placeholder missing

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -385,7 +385,7 @@ export const VAutocomplete = genericComponent<new <
       } else {
         if (!props.multiple && search.value == null) model.value = []
         menu.value = false
-        if (!model.value.some(({ title }) => title === search.value)) search.value = ''
+        search.value = ''
         selectionIndex.value = -1
       }
     })


### PR DESCRIPTION
fixes: #20718

## Description

As per my comment [here](https://github.com/vuetifyjs/vuetify/issues/20718#issuecomment-2503557304), I have deleted the problematic `if` condition and I have also tested again the reproduction (non regression) of #19929 in the playground reported below

## Markup:


<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model="selection"
        :items="items"
        clearable
        placeholder="select a item"
      ></v-autocomplete>
      <v-btn @click="myResetAction">reset</v-btn>
      <v-autocomplete
        v-model="selected"
        :items="items2"
        auto-select-first
        clearable
      ></v-autocomplete>
      <span>Selected: {{ selected }}</span>
    </v-container>    
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selection = ref()
  const items = ref(['itemA', 'itemB'])

  const items2 = ref(['Option 1', 'Option 2', 'Option 3'])

  const selected = ref(null)

  const myResetAction = () => {
    selection.value = undefined
  }
</script>
```
