### PR TITLE
fix(VSelect): recognize empty string as no value

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -126,14 +126,14 @@ export const VAutocomplete = genericComponent<new <
     const vMenuRef = ref<VMenu>()
     const vVirtualScrollRef = ref<VVirtualScroll>()
     const selectionIndex = shallowRef(-1)
-    const { items, transformIn, transformOut } = useItems(props)
+    const { items, transformIn, transformOut, emptyValues } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(() => vTextFieldRef.value?.color)
     const search = useProxiedModel(props, 'search', '')
     const model = useProxiedModel(
       props,
       'modelValue',
       [],
-      v => transformIn(v === null ? [null] : wrapInArray(v)),
+      v => transformIn(v === null ? [null] : wrapInArray(v, emptyValues.value)),
       v => {
         const transformed = transformOut(v)
         return props.multiple ? transformed : (transformed[0] ?? null)

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -139,7 +139,7 @@ export const VCombobox = genericComponent<new <
       props,
       'modelValue',
       [],
-      v => transformIn(wrapInArray(v)),
+      v => transformIn(wrapInArray(v, [''])),
       v => {
         const transformed = transformOut(v)
         return props.multiple ? transformed : (transformed[0] ?? null)

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -143,12 +143,12 @@ export const VSelect = genericComponent<new <
     const vTextFieldRef = ref<VTextField>()
     const vMenuRef = ref<VMenu>()
     const vVirtualScrollRef = ref<VVirtualScroll>()
-    const { items, transformIn, transformOut } = useItems(props)
+    const { items, transformIn, transformOut, emptyValues } = useItems(props)
     const model = useProxiedModel(
       props,
       'modelValue',
       [],
-      v => transformIn(v === null ? [null] : wrapInArray(v)),
+      v => transformIn(v === null ? [null] : wrapInArray(v, emptyValues.value)),
       v => {
         const transformed = transformOut(v)
         return props.multiple ? transformed : (transformed[0] ?? null)

--- a/packages/vuetify/src/composables/list-items.ts
+++ b/packages/vuetify/src/composables/list-items.ts
@@ -122,7 +122,8 @@ export function transformItems (
 
 export function useItems (props: ItemProps) {
   const items = computed(() => transformItems(props, props.items))
-  const hasNullItem = computed(() => items.value.some(item => item.value === null))
+  const allValues = computed(() => items.value.map(item => item.value))
+  const hasNullItem = computed(() => allValues.value.includes(null))
 
   const itemsMap = shallowRef<Map<Primitive, ListItem[]>>(new Map())
   const keylessItems = shallowRef<ListItem[]>([])
@@ -204,5 +205,7 @@ export function useItems (props: ItemProps) {
       : value.map(({ value }) => value)
   }
 
-  return { items, transformIn, transformOut }
+  const emptyValues = computed(() => ['', null, undefined].filter(v => !allValues.value.includes(v)))
+
+  return { items, transformIn, transformOut, emptyValues }
 }

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -389,11 +389,12 @@ export function arrayDiff (a: any[], b: any[]): any[] {
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 export function wrapInArray<T> (
-  v: T | null | undefined
+  v: T | null | undefined,
+  emptyValues: any[] = []
 ): T extends readonly any[]
     ? IfAny<T, T[], T>
     : NonNullable<T>[] {
-  return v == null
+  return v == null || emptyValues.includes(v)
     ? [] as any
     : Array.isArray(v)
       ? v as any : [v] as any


### PR DESCRIPTION
## Description

Selection controls should correctly reflect empty state. And most of the times empty string is perceived by end users as "no value". There is an edge case if `""` is among options' values - it results in selection in VSelection and VAutocomplete, while VCombobox will not recognize it as selection because it does not care about item value (thus has hardcoded `['']` and won't consume `emptyValues` from `useItems`)

fixes #20660

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-row>
        <v-col>
          <h4>Typical options</h4>
          <v-divider class="my-3" />
          <h5>VTextField</h5>
          <v-text-field v-model="msg1" :items="options1" clearable placeholder="Enter the message" />
          <h5>VSelect</h5>
          <v-select v-model="msg1" :items="options1" clearable placeholder="Select from the options" />
          <h5>VCombobox</h5>
          <v-combobox v-model="msg1" :items="options1" clearable placeholder="Select or type custom value" />
          <h5>VAutocomplete</h5>
          <v-autocomplete v-model="msg1" :items="options1" clearable placeholder="Type to find an item" />

          <pre>{{ JSON.stringify({ msg1 }) }}</pre>
        </v-col>
        <v-col>
          <h4>Options with empty string value</h4>
          <v-divider class="my-3" />
          <h5>VTextField</h5>
          <v-text-field v-model="msg2" :items="options2" clearable placeholder="Enter the message" />
          <h5>VSelect</h5>
          <v-select v-model="msg2" :items="options2" clearable placeholder="Select from the options" />
          <h5>VCombobox</h5>
          <v-combobox v-model="msg2" :items="options2" clearable placeholder="Select or type custom value" />
          <h5>VAutocomplete</h5>
          <v-autocomplete v-model="msg2" :items="options2" clearable placeholder="Type to find an item" />

          <pre>{{ JSON.stringify({ msg2 }) }}</pre>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'
const msg1 = ref('')
const msg2 = ref('')

const options1 = ref([
  { title: 'Alabama', value: 'AL' },
  { title: 'Alaska', value: 'AK' },
  { title: 'American Samoa', value: 'AS' },
  { title: 'Arizona', value: 'AZ' },
  { title: 'Arkansas', value: 'AR' },
])
const options2 = [
  { title: "(I don't want to disclose)", value: '' },
  { title: 'California', value: 'CA' },
  { title: 'Colorado', value: 'CO' },
  { title: 'Connecticut', value: 'CT' },
  { title: 'Delaware', value: 'DE' },
]

setTimeout(() => {
  options1.value.push({ title: 'Empty', value: '' })
}, 2000)
</script>
```