### PR TITLE
docs(VProgressLinear): change dark-blue color selection

### DIFF
--- a/packages/docs/src/examples/v-progress-linear/usage.vue
+++ b/packages/docs/src/examples/v-progress-linear/usage.vue
@@ -12,7 +12,7 @@
     <template v-slot:configuration>
       <v-select
         v-model="color"
-        :items="['primary', 'blue-lighten-3', 'error', 'dark-blue']"
+        :items="['primary', 'blue-lighten-3', 'error', 'blue-darken-3']"
         label="Color"
         clearable
       ></v-select>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Updated the usage example color for v-progress-linear, as it was using dark-blue which does not exist and changed it to blue-darken-3 to mirror the blue-lighten-3.

Changed docs: https://vuetifyjs.com/en/components/progress-linear/#buffering
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
