### PR TITLE
fix(virtual): patch unreliable scrollend event

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -136,6 +136,8 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   let lastScrollTop = 0
   let scrollVelocity = 0
   let lastScrollTime = 0
+  let lastItemsChange = 0
+  let forcedScrollendTimeout = 0 as any
 
   watch(viewportHeight, (val, oldVal) => {
     if (oldVal) {
@@ -168,6 +170,13 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
 
     lastScrollTop = scrollTop
     lastScrollTime = scrollTime
+
+    // while scroll event is triggered upon items change
+    // the scrollend event does not trigger automatically
+    clearTimeout(forcedScrollendTimeout)
+    if (scrollTime - lastItemsChange < 300) {
+      forcedScrollendTimeout = setTimeout(handleScrollend, 100)
+    }
 
     calculateVisibleItems()
   }
@@ -237,6 +246,7 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   })
 
   watch(items, () => {
+    lastItemsChange = performance.now()
     sizes = Array.from({ length: items.value.length })
     offsets = Array.from({ length: items.value.length })
     updateOffsets.immediate()


### PR DESCRIPTION
## Description

Context:
- initial items array size should be at least 50 (or more on taller screens or zoom out)
- items reduction should eliminate scrollbar to effectively trigger `scroll` (easiest to achieve by reducing array to as many items as fit on the screen)

[Diagnosis](https://github.com/vuetifyjs/vuetify/issues/20566#issuecomment-2517019602) leads me to a rather dumb patch - force call of `scrollend` handler when `scroll` was triggered shortly after `items` were changed.

Shortly = 0.3s
Debounce = 0.1s

I did not want to use `nextTick` not `rAF`, because delay between `items` change and `scroll` handler execution may be impacted by browser load (or device performance characteristics).

fixes #20566

## Markup:

```vue
<template>
  <v-data-table-virtual
    :headers="headers"
    :items="items"
    height="500"
    item-value="name"
    fixed-header
  >
  </v-data-table-virtual>
  <div class="ma-5 d-flex">
    <v-switch v-model="less" color="primary" label="Less Boats" />
  </div>
</template>

<script>
  export default {
    data() {
      return {
        headers: [
          { title: 'Boat Type', align: 'start', key: 'name' },
          { title: 'Speed (knots)', align: 'start', key: 'speed' },
          { title: 'Length (m)', align: 'start', key: 'length' },
          { title: 'Price ($)', align: 'start', key: 'price' },
          { title: 'Year', align: 'start', key: 'year' },
        ],
        boats: Array.from({ length: 80 }).map((_, i) => ({
          name: `Speedster #${i}`,
          speed: 35,
          length: 22,
          price: 300000,
          year: 2021,
        })),
        less: false,
      }
    },
    computed: {
      items() {
        if (this.less) {
          return this.boats.slice(0, 3)
        }
        return this.boats
      },
    },
  }
</script>
```