### PR TITLE
fix(v-ripple): avoiding more and more

### DIFF
--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -130,9 +130,9 @@ const ripples = {
     const ripples = el.getElementsByClassName('v-ripple__animation')
 
     if (ripples.length === 0) return
-    const animation = ripples[ripples.length - 1]
+    const animation = Array.from(ripples).findLast(ripple => !ripple.dataset.isHiding);
 
-    if (animation.dataset.isHiding) return
+    if (!animation) return
     else animation.dataset.isHiding = 'true'
 
     const diff = performance.now() - Number(animation.dataset.activated)


### PR DESCRIPTION
In some cases, when calling show continuously, ripples will increase.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

If import @vant/touch emulator, ripples will increase when trigger mousedown.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script>
import '@vant/touch-emulator' // for vant.js
</script>

<template>
<v-btn>Click here</v-btn>
</template>
```
