### PR TITLE
fix(VNumberInput): unneeded padding override inconsistent with other inputs

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
@@ -14,6 +14,16 @@
       &::-webkit-inner-spin-button
         -webkit-appearance: none
 
+    &--reverse
+      .v-number-input__control
+      margin-inline-start: var(--v-field-padding-start)
+
+      .v-field
+        padding-inline-end: var(--v-field-padding-end)
+
+    .v-field
+      padding-inline-end: 0
+
     &--inset
       .v-divider
         height: $number-input-inset-divider-size

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
@@ -14,10 +14,6 @@
       &::-webkit-inner-spin-button
         -webkit-appearance: none
 
-    .v-field
-      padding-inline-end: 0
-      padding-inline-start: 0
-
     &--inset
       .v-divider
         height: $number-input-inset-divider-size


### PR DESCRIPTION

## Description
Removes inconsistent padding on VNumberInput
resolves #20782 

## Markup:
```
    .v-field //removed in src/labs/VNumberInput/VNumberInput.sass
      padding-inline-end: 0
      padding-inline-start: 0

```

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
[playground](https://play.vuetifyjs.com/#eNp1UMtuwyAQ/JUVl0hRCWqPrlup3xHnQM0mQgKMYLFSWf738rCVqFIvsDvM7M5wXlgMo/jy/jQnZB3rCa03kvBzcAD9zKX3tazNODmS2mHYoAq6ZL8xcO18IvABPTqVu8ziOgs+BmaV5tJgoIGBeJZGNDjSDsD/aosxyhsO7MHtRiNjzO/L+RCR+FXfD5cOKCSE9UHc9/Xir/2CtHS9eEqd20g/pn2AOJYzuXGyFh0BTRBwzklKpfAqkyGY8240ihf3xT4q8FIp7W5lWhlw2ij7zSu3UZfmb1Pk6CY75JFkoA5e3/z9vRDWNugoitvdH1tfXDKmHpdfamaYOw==)