### PR TITLE
feat(VNumberInput): parsing min/max values

### DIFF
--- a/packages/vuetify/playgrounds/Playground.number.vue
+++ b/packages/vuetify/playgrounds/Playground.number.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+// References for testing various boundary conditions
+const value1 = ref(20); // Test for max within range
+const value2 = ref(Number.MAX_SAFE_INTEGER + 1); // Test for exceeding max value
+const value3 = ref(Number.MAX_SAFE_INTEGER + 1); // Test for unparseable max value
+
+const value4 = ref(2); // Test for min within range
+const value5 = ref(Number.MIN_SAFE_INTEGER - 1); // Test for exceeding min value
+const value6 = ref(Number.MIN_SAFE_INTEGER - 1); // Test for unparseable min value
+
+// Constants for boundary values
+const minValue = 5;
+const maxValue = 15;
+</script>
+
+<template>
+  <v-app>
+    <v-container>
+      <!-- Test case: Max value within range -->
+      <v-number-input
+        class="max-within-range"
+        :max="maxValue"
+        v-model="value1"
+      />
+
+      <!-- Test case: Max value exceeds safe integer -->
+      <v-number-input
+        class="max-out-of-range1"
+        :max="Number.MAX_SAFE_INTEGER + 2"
+        v-model="value2"
+      />
+
+      <!-- Test case: Max value set to "Infinity" -->
+      <v-number-input
+        class="max-out-of-range2"
+        max="Infinity"
+        v-model="value3"
+      />
+
+      <!-- Test case: Min value within range -->
+      <v-number-input
+        class="min-within-range"
+        :min="minValue"
+        v-model="value4"
+      />
+
+      <!-- Test case: Min value below safe integer -->
+      <v-number-input
+        class="min-out-of-range1"
+        :min="Number.MIN_SAFE_INTEGER - 2"
+        v-model="value5"
+      />
+
+      <!-- Test case: Min value set to "-Infinity" -->
+      <v-number-input
+        class="min-out-of-range2"
+        min="-Infinity"
+        v-model="value6"
+      />
+
+      <!-- Testing VNumberInput with various styles, icons, and options -->
+      <v-number-input prepend-inner-icon="mdi-alert" reverse />
+      <v-number-input prepend-inner-icon="mdi-square" hide-input />
+      <v-number-input hide-input />
+      <v-number-input prepend-inner-icon="mdi-circle-outline" />
+      <v-select prepend-inner-icon="mdi-check" placeholder="Normal padding" />
+
+
+    </v-container>
+  </v-app>
+</template>

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -43,11 +43,11 @@ const makeVNumberInputProps = propsFactory({
     default: null,
   },
   min: {
-    type: Number,
+    type: [Number, String],
     default: Number.MIN_SAFE_INTEGER,
   },
   max: {
-    type: Number,
+    type: [Number, String],
     default: Number.MAX_SAFE_INTEGER,
   },
   step: {
@@ -72,6 +72,9 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
   setup (props, { slots }) {
     const _model = useProxiedModel(props, 'modelValue')
 
+    const min = computed(() => Math.max(Number.isFinite(parseFloat(props.min)) ? parseFloat(props.min) : Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER))
+    const max = computed(() => Math.min(Number.isFinite(parseFloat(props.max)) ? parseFloat(props.max) : Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER))
+
     const model = computed({
       get: () => _model.value,
       // model.value could be empty string from VTextField
@@ -83,7 +86,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         }
 
         const value = Number(val)
-        if (!isNaN(value) && value <= props.max && value >= props.min) {
+        if (!isNaN(value) && value <= max.value && value >= min.value) {
           _model.value = value
         }
       },
@@ -101,11 +104,11 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const canIncrease = computed(() => {
       if (controlsDisabled.value) return false
-      return (model.value ?? 0) as number + props.step <= props.max
+      return (model.value ?? 0) as number + props.step <= max.value
     })
     const canDecrease = computed(() => {
       if (controlsDisabled.value) return false
-      return (model.value ?? 0) as number - props.step >= props.min
+      return (model.value ?? 0) as number - props.step >= min.value
     })
 
     const controlVariant = computed(() => {
@@ -130,7 +133,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     function toggleUpDown (increment = true) {
       if (controlsDisabled.value) return
       if (model.value == null) {
-        model.value = clamp(0, props.min, props.max)
+        model.value = clamp(0, min.value, max.value)
         return
       }
 
@@ -196,7 +199,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (!vTextFieldRef.value) return
       const inputText = vTextFieldRef.value.value
       if (inputText && !isNaN(+inputText)) {
-        model.value = clamp(+(inputText), props.min, props.max)
+        model.value = clamp(+(inputText), min.value, max.value)
       } else {
         model.value = null
       }

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -71,9 +71,14 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
   setup (props, { slots }) {
     const _model = useProxiedModel(props, 'modelValue')
-
-    const min = computed(() => Math.max(Number.isFinite(parseFloat(props.min)) ? parseFloat(props.min) : Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER))
-    const max = computed(() => Math.min(Number.isFinite(parseFloat(props.max)) ? parseFloat(props.max) : Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER))
+    const min = computed(() => Math.max(
+      Number.isFinite(
+        parseFloat(props.min)) ? parseFloat(props.min) : Number.MIN_SAFE_INTEGER, Number.MIN_SAFE_INTEGER)
+    )
+    const max = computed(
+      () => Math.min(Number.isFinite(
+        parseFloat(props.max)) ? parseFloat(props.max) : Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    )
 
     const model = computed({
       get: () => _model.value,

--- a/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -6,7 +6,6 @@ import { VForm } from '@/components/VForm'
 import { render, screen, userEvent } from '@test'
 import { nextTick, ref } from 'vue'
 
-
 describe('VNumberInput', () => {
   it.each([
     { typing: '---', expected: '-' }, // "-" is only allowed once
@@ -15,7 +14,7 @@ describe('VNumberInput', () => {
     { typing: '..', expected: '.' }, // "." is only allowed once
     { typing: '1...0', expected: '1.0' }, // "." is only allowed once
     { typing: '123.45.67', expected: '123.4567' }, // "." is only allowed once
-    { typing: 'ab-c8+.iop9', expected: '-8.9' } // Only numbers, "-", "." are allowed to type in
+    { typing: 'ab-c8+.iop9', expected: '-8.9' }, // Only numbers, "-", "." are allowed to type in
   ])('prevents NaN from arbitrary input', async ({ typing, expected }) => {
     const { element } = render(VNumberInput)
     await userEvent.click(element)
@@ -28,7 +27,7 @@ describe('VNumberInput', () => {
     render(() => (
       <VNumberInput
         clearable
-        v-model={model.value}
+        v-model={ model.value }
         readonly
       />
     ))
@@ -42,9 +41,9 @@ describe('VNumberInput', () => {
     const model = ref(null)
     const { element } = render(() => (
       <VNumberInput
-        v-model={model.value}
-        min={5}
-        max={125}
+        v-model={ model.value }
+        min={ 5 }
+        max={ 125 }
       />
     ))
 
@@ -70,7 +69,7 @@ describe('VNumberInput', () => {
       const model = ref(1)
 
       const { element } = render(() => (
-        <VNumberInput v-model={model.value} readonly/>
+        <VNumberInput v-model={ model.value } readonly />
       ))
 
       await userEvent.click(screen.getByTestId('increment'))
@@ -92,7 +91,7 @@ describe('VNumberInput', () => {
 
       const { element } = render(() => (
         <VForm readonly>
-          <VNumberInput v-model={model.value}/>
+          <VNumberInput v-model={ model.value } />
         </VForm>
       ))
 
@@ -120,30 +119,30 @@ describe('VNumberInput', () => {
         <>
           <VNumberInput
             class="readonly-input-1"
-            v-model={value1.value}
-            min={0}
-            max={50}
+            v-model={ value1.value }
+            min={ 0 }
+            max={ 50 }
             readonly
           />
           <VNumberInput
             class="readonly-input-2"
-            v-model={value2.value}
-            min={0}
-            max={50}
+            v-model={ value2.value }
+            min={ 0 }
+            max={ 50 }
             readonly
           />
           <VNumberInput
             class="disabled-input-1"
-            v-model={value3.value}
-            min={0}
-            max={10}
+            v-model={ value3.value }
+            min={ 0 }
+            max={ 10 }
             disabled
           />
           <VNumberInput
             class="disabled-input-2"
-            v-model={value4.value}
-            min={0}
-            max={10}
+            v-model={ value4.value }
+            min={ 0 }
+            max={ 10 }
             disabled
           />
         </>
@@ -164,9 +163,9 @@ describe('VNumberInput', () => {
 
       render(() => (
         <>
-          <VNumberInput max={15} v-model={value1.value} class="max-within-range"/>
-          <VNumberInput max={Number.MAX_SAFE_INTEGER + 2} v-model={value2.value} class="max-outof-range1"/>
-          <VNumberInput max="Infinity" v-model={value3.value} class="max-outof-range2"/>
+          <VNumberInput max={ 15 } v-model={ value1.value } class="max-within-range" />
+          <VNumberInput max={ Number.MAX_SAFE_INTEGER + 2 } v-model={ value2.value } class="max-outof-range1" />
+          <VNumberInput max="Infinity" v-model={ value3.value } class="max-outof-range2" />
         </>
       ))
 
@@ -191,9 +190,9 @@ describe('VNumberInput', () => {
 
       render(() => (
         <>
-          <VNumberInput min={5} v-model={value1.value} class="min-range-within-range"/>
-          <VNumberInput min={Number.MIN_SAFE_INTEGER - 2} v-model={value2.value} class="min-range-fallback1"/>
-          <VNumberInput min="-Infinity" v-model={value3.value} class="min-range-fallback2"/>
+          <VNumberInput min={ 5 } v-model={ value1.value } class="min-range-within-range" />
+          <VNumberInput min={ Number.MIN_SAFE_INTEGER - 2 } v-model={ value2.value } class="min-range-fallback1" />
+          <VNumberInput min="-Infinity" v-model={ value3.value } class="min-range-fallback2" />
         </>
       ))
 
@@ -217,8 +216,8 @@ describe('VNumberInput', () => {
       const model = ref(0)
       render(() => (
         <VNumberInput
-          step={0.03}
-          v-model={model.value}
+          step={ 0.03 }
+          v-model={ model.value }
         />
       ))
 


### PR DESCRIPTION
Enhanced the `VNumberInput` component to include parsing logic for `min` and `max` properties. Implemented automatic fallback to `Number.MIN_SAFE_INTEGER` and `Number.MAX_SAFE_INTEGER` when values are non-numeric or exceed safe integer ranges. This ensures consistent and reliable behavior under edge cases.

resolves #20788


```vue
<script setup lang="ts">
import { ref } from 'vue';

// References for testing various boundary conditions
const value1 = ref(20); // Test for max within range
const value2 = ref(Number.MAX_SAFE_INTEGER + 1); // Test for exceeding max value
const value3 = ref(Number.MAX_SAFE_INTEGER + 1); // Test for unparseable max value

const value4 = ref(2); // Test for min within range
const value5 = ref(Number.MIN_SAFE_INTEGER - 1); // Test for exceeding min value
const value6 = ref(Number.MIN_SAFE_INTEGER - 1); // Test for unparseable min value

// Constants for boundary values
const minValue = 5;
const maxValue = 15;
</script>

<template>
  <v-app>
    <v-container>
      <!-- Test case: Max value within range -->
      <v-number-input
        class="max-within-range"
        :max="maxValue"
        v-model="value1"
      />

      <!-- Test case: Max value exceeds safe integer -->
      <v-number-input
        class="max-out-of-range1"
        :max="Number.MAX_SAFE_INTEGER + 2"
        v-model="value2"
      />

      <!-- Test case: Max value set to "Infinity" -->
      <v-number-input
        class="max-out-of-range2"
        max="Infinity"
        v-model="value3"
      />

      <!-- Test case: Min value within range -->
      <v-number-input
        class="min-within-range"
        :min="minValue"
        v-model="value4"
      />

      <!-- Test case: Min value below safe integer -->
      <v-number-input
        class="min-out-of-range1"
        :min="Number.MIN_SAFE_INTEGER - 2"
        v-model="value5"
      />

      <!-- Test case: Min value set to "-Infinity" -->
      <v-number-input
        class="min-out-of-range2"
        min="-Infinity"
        v-model="value6"
      />

      <!-- Testing VNumberInput with various styles, icons, and options -->
      <v-number-input prepend-inner-icon="mdi-alert" reverse/>
      <v-number-input prepend-inner-icon="mdi-square" />
      <v-select prepend-inner-icon="mdi-check" placeholder="Normal padding"/>
      <v-number-input prepend-inner-icon="mdi-circle-outline"/>

      <v-number-input append-inner-icon="mdi-alert" reverse/>
      <v-number-input append-inner-icon="mdi-square" />
      <v-select append-inner-icon="mdi-check" placeholder="Normal padding"/>
      <v-number-input append-inner-icon="mdi-circle-outline"/>

      <v-number-input hide-input/>


    </v-container>
  </v-app>
</template>

```
