### PR TITLE
fix(VSparkline): accept numeric value for smooth

### DIFF
--- a/packages/vuetify/src/components/VSparkline/VBarline.tsx
+++ b/packages/vuetify/src/components/VSparkline/VBarline.tsx
@@ -123,6 +123,7 @@ export const VBarline = genericComponent<VBarlineSlots>()({
 
     const bars = computed(() => genBars(items.value, boundary.value))
     const offsetX = computed(() => (Math.abs(bars.value[0].x - bars.value[1].x) - lineWidth.value) / 2)
+    const smooth = computed(() => typeof props.smooth === 'boolean' ? (props.smooth ? 2 : 0) : Number(props.smooth))
 
     useRender(() => {
       const gradientData = !props.gradient.slice().length ? [''] : props.gradient.slice().reverse()
@@ -155,8 +156,8 @@ export const VBarline = genericComponent<VBarlineSlots>()({
                     y={ item.y }
                     width={ lineWidth.value }
                     height={ item.height }
-                    rx={ typeof props.smooth === 'number' ? props.smooth : props.smooth ? 2 : 0 }
-                    ry={ typeof props.smooth === 'number' ? props.smooth : props.smooth ? 2 : 0 }
+                    rx={ smooth.value }
+                    ry={ smooth.value }
                 >
                   { props.autoDraw && (
                     <>

--- a/packages/vuetify/src/components/VSparkline/VTrendline.tsx
+++ b/packages/vuetify/src/components/VSparkline/VTrendline.tsx
@@ -149,9 +149,11 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
     }, { immediate: true })
 
     function genPath (fill: boolean) {
+      const smoothValue = typeof props.smooth === 'boolean' ? (props.smooth ? 8 : 0) : Number(props.smooth)
+
       return _genPath(
         genPoints(items.value, boundary.value),
-        props.smooth ? 8 : Number(props.smooth),
+        smoothValue,
         fill,
         parseInt(props.height, 10)
       )

--- a/packages/vuetify/src/components/VSparkline/util/line.ts
+++ b/packages/vuetify/src/components/VSparkline/util/line.ts
@@ -4,7 +4,7 @@ import { propsFactory } from '@/util'
 // Types
 import type { PropType } from 'vue'
 
-export type SparklineItem = number | { value: number }
+export type SparklineItem = string | number | { value: number }
 
 export const makeLineProps = propsFactory({
   autoDraw: Boolean,

--- a/packages/vuetify/src/components/VSparkline/util/line.ts
+++ b/packages/vuetify/src/components/VSparkline/util/line.ts
@@ -55,7 +55,7 @@ export const makeLineProps = propsFactory({
     default: 8,
   },
   showLabels: Boolean,
-  smooth: Boolean,
+  smooth: [Boolean, String, Number],
   width: {
     type: [Number, String],
     default: 300,


### PR DESCRIPTION
## Description

fixes #19262

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-sparkline :model-value="values" :smooth="4" />
      <v-sparkline :model-value="values" smooth />
      <v-sparkline :model-value="values" smooth="1" />
      <v-sparkline :model-value="values" :smooth="1" />
    </v-container>
  </v-app>
</template>

<script setup>
  const values = [80, 75, 60, 55, 65, 60, 62, 58, 55, 65, 60, 68, 62, 58, 65, 70, 65, 75, 70]
</script>
```
