### PR TITLE
feat(utilities): make border-radius responsive

### DIFF
--- a/packages/docs/src/examples/border-radius/misc-breakpoints.vue
+++ b/packages/docs/src/examples/border-radius/misc-breakpoints.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="d-flex justify-center">
+    <v-card
+      class="rounded-lg rounded-md-xl"
+      width="300px"
+    >
+      <v-card-text>
+        Adjust screen size to see border radius changes 
+      </v-card-text>
+    </v-card>
+  </div>
+</template>

--- a/packages/docs/src/pages/en/styles/border-radius.md
+++ b/packages/docs/src/pages/en/styles/border-radius.md
@@ -140,6 +140,12 @@ Setting the **rounded** property applies a component specific border-radius clas
 
 <ExamplesExample file="border-radius/misc-components" />
 
+### Breakpoints
+
+The `border-radius` utilities supports responsive breakpoints as seen in the other parts of the framework. The base class `.rounded-{value}` corresponds to the `xs` breakpoint, while the classes `.rounded-{breakpoint}-{value}` can be used for the rest of the breakpoints (`sm`, `md`, `lg`, `xl`).
+
+<ExamplesExample file="border-radius/misc-breakpoints" />
+
 ## SASS variables
 
 You can also use the following SASS variables to customize the border color and width:
@@ -163,3 +169,4 @@ Disable border-radius class generation by setting the $rounded variable to **fal
   $rounded: false
 );
 ```
+

--- a/packages/vuetify/src/styles/settings/_utilities.scss
+++ b/packages/vuetify/src/styles/settings/_utilities.scss
@@ -366,46 +366,55 @@ $utilities: () !default;
 
       // Border radius
       "rounded": (
+        responsive: true,
         property: border-radius,
         class: rounded,
         values: variables.$rounded
       ),
       "rounded-top": (
+        responsive: true,
         property: border-top-left-radius border-top-right-radius,
         class: rounded-t,
         values: variables.$rounded
       ),
       "rounded-end": (
+        responsive: true,
         property: (ltr: border-top-right-radius border-bottom-right-radius, rtl: border-top-left-radius border-bottom-left-radius),
         class: rounded-e,
         values: variables.$rounded
       ),
       "rounded-bottom": (
+        responsive: true,
         property: border-bottom-left-radius border-bottom-right-radius,
         class: rounded-b,
         values: variables.$rounded
       ),
       "rounded-start": (
+        responsive: true,
         property: (ltr: border-top-left-radius border-bottom-left-radius, rtl: border-top-right-radius border-bottom-right-radius),
         class: rounded-s,
         values: variables.$rounded
       ),
       "rounded-top-start": (
+        responsive: true,
         property: (ltr: border-top-left-radius, rtl: border-top-right-radius),
         class: rounded-ts,
         values: variables.$rounded
       ),
       "rounded-top-end": (
+        responsive: true,
         property: (ltr: border-top-right-radius, rtl: border-top-left-radius),
         class: rounded-te,
         values: variables.$rounded
       ),
       "rounded-bottom-end": (
+        responsive: true,
         property: (ltr: border-bottom-right-radius, rtl: border-bottom-left-radius),
         class: rounded-be,
         values: variables.$rounded
       ),
       "rounded-bottom-start": (
+        responsive: true,
         property: (ltr: border-bottom-left-radius, rtl: border-bottom-right-radius),
         class: rounded-bs,
         values: variables.$rounded


### PR DESCRIPTION
## Description
Add responsive capabilities to border-radius to allow for the use of breakpoints. Also updating the border-radius documentation to document the new feature and provide an example for how to use it. 

resolves #20732

## Markup:
```vue
<template>
  <div class="d-flex justify-center">
    <v-card
      class="rounded-lg rounded-md-xl"
      width="300px"
    >
      <v-card-text>
        Adjust screen size to see border radius changes 
      </v-card-text>
    </v-card>
  </div>
</template>
```
