### PR TITLE
feat(VNumberInput): support append/prepend inner slots/icons

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.sass
@@ -14,9 +14,13 @@
       &::-webkit-inner-spin-button
         -webkit-appearance: none
 
-    .v-field
-      padding-inline-end: 0
-      padding-inline-start: 0
+    &:not(&--append-inner-slot)
+      .v-field
+        padding-inline-end: 0
+
+    &:not(&--prepend-inner-slot)
+      .v-field
+        padding-inline-start: 0
 
     &--inset
       .v-divider

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -55,7 +55,7 @@ const makeVNumberInputProps = propsFactory({
     default: 1,
   },
 
-  ...omit(makeVTextFieldProps({}), ['appendInnerIcon', 'modelValue', 'prependInnerIcon']),
+  ...omit(makeVTextFieldProps({}), ['modelValue']),
 }, 'VNumberInput')
 
 export const VNumberInput = genericComponent<VNumberInputSlots>()({
@@ -328,6 +328,8 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             'v-number-input',
             {
               'v-number-input--default': controlVariant.value === 'default',
+              'v-number-input--append-inner-slot': !!slots['append-inner'] || props.appendInnerIcon,
+              'v-number-input--prepend-inner-slot': !!slots['prepend-inner'] || props.prependInnerIcon,
               'v-number-input--hide-input': props.hideInput,
               'v-number-input--inset': props.inset,
               'v-number-input--reverse': props.reverse,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Add proper support of append/prepend inner slots/icons in VNumberInput

fixes #20782

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input
        append-inner-icon="mdi-map-marker"
        prepend-inner-icon="mdi-map-marker"
      />
      <v-number-input
        append-inner-icon="mdi-map-marker"
        prepend-inner-icon="mdi-map-marker"
        hide-input
      />
    </v-container>
  </v-app>
</template>

<style>
  /*
  uncomment to revert to default v-field-preppended padding


  .v-field.v-field--prepended {
    padding-inline-start: 12px;
  }

  */
</style>





```
