### PR TITLE
export the type for header

### DIFF
--- a/packages/vuetify/src/components/VDataTable/index.ts
+++ b/packages/vuetify/src/components/VDataTable/index.ts
@@ -5,3 +5,5 @@ export { VDataTableRows } from './VDataTableRows'
 export { VDataTableRow } from './VDataTableRow'
 export { VDataTableVirtual } from './VDataTableVirtual'
 export { VDataTableServer } from './VDataTableServer'
+
+export type { DataTableHeader } from './types'; 


### PR DESCRIPTION
## Description
the interface is missing.
we need the ability to use the interface in our codebase, and then to pass the headers dynamically, and we can't because the interface is only internal.

## Markup:

```vue
<script lan="ts">
const headers: MyInterface[] = {}
</script>
<template>
<v-data-table
 :headers="headers" <-- TS errors here -->
/>.   
</template>

```
