### PR TITLE
feat(VTimeline): side prop for individual items

### DIFF
--- a/packages/api-generator/src/locale/en/VTimeline.json
+++ b/packages/api-generator/src/locale/en/VTimeline.json
@@ -8,7 +8,7 @@
     "linePosition": "Shift the position of the line. By default the line will evenly split items before/after.",
     "lineThickness": "Thickness of the timeline line.",
     "mirror": "Mirror the before/after ordering of timeline items.",
-    "side": "Display all timeline items on one side of the timeline, either **before** or **after**.",
+    "side": "Display all timeline items on one side of the timeline, either **start** or **end**.",
     "truncateLine": "Truncate timeline directly at the **start** or **end** of the line, or on **both** ends."
   }
 }

--- a/packages/api-generator/src/locale/en/VTimelineItem.json
+++ b/packages/api-generator/src/locale/en/VTimelineItem.json
@@ -10,7 +10,7 @@
     "iconColor": "Color of the icon.",
     "index": "Used to allow dynamically shown items to be re-inserted in the correct position.",
     "lineInset": "Specifies the distance between the line and the dot of the item.",
-    "side": "Show the item either **before** or **after** the timeline. This will override the implicit ordering of items, but will in turn be overriden by the `v-timeline` **single-side** prop.",
+    "side": "Display the item on one side of the timeline, either **start** or **end**. This will override the implicit ordering of items, unless `v-timeline` has it's own **side** prop defined.",
     "size": "Size of the item dot"
   },
   "slots": {

--- a/packages/vuetify/src/components/VTimeline/VTimeline.sass
+++ b/packages/vuetify/src/components/VTimeline/VTimeline.sass
@@ -23,7 +23,9 @@
       grid-column-gap: $timeline-item-padding
       width: 100%
 
-      .v-timeline-item:nth-child(2n)
+      .v-timeline--side-end > .v-timeline-item,
+      &:not(.v-timeline--side-start) > .v-timeline-item--side-end,
+      &:not(.v-timeline--side-start) > .v-timeline-item:nth-child(2n+1):not(.v-timeline-item--side-start)
         .v-timeline-item__body
           grid-row: 3
           padding-block-start: $timeline-item-padding
@@ -33,7 +35,9 @@
           padding-block-end: $timeline-item-padding
           align-self: flex-end
 
-      .v-timeline-item:nth-child(2n+1)
+      .v-timeline--side-start > .v-timeline-item,
+      &:not(.v-timeline--side-end) > .v-timeline-item--side-start,
+      &:not(.v-timeline--side-end) > .v-timeline-item:nth-child(2n):not(.v-timeline-item--side-end)
         .v-timeline-item__body
           grid-row: 1
           padding-block-end: $timeline-item-padding
@@ -53,7 +57,9 @@
       @include timeline-last-item()
         padding-block-end: $timeline-item-padding
 
-      .v-timeline-item:nth-child(2n)
+      .v-timeline--side-start > .v-timeline-item,
+      &:not(.v-timeline--side-end) > .v-timeline-item--side-start,
+      &:not(.v-timeline--side-end) > .v-timeline-item:nth-child(2n):not(.v-timeline-item--side-end)
         .v-timeline-item__body
           grid-column: 1
           padding-inline-end: $timeline-item-padding
@@ -62,7 +68,9 @@
           grid-column: 3
           padding-inline-start: $timeline-item-padding
 
-      .v-timeline-item:nth-child(2n+1)
+      .v-timeline--side-end > .v-timeline-item,
+      &:not(.v-timeline--side-start) > .v-timeline-item--side-end,
+      &:not(.v-timeline--side-start) > .v-timeline-item:nth-child(2n+1):not(.v-timeline-item--side-start)
         .v-timeline-item__body
           grid-column: 3
           padding-inline-start: $timeline-item-padding

--- a/packages/vuetify/src/components/VTimeline/VTimelineItem.tsx
+++ b/packages/vuetify/src/components/VTimeline/VTimelineItem.tsx
@@ -15,9 +15,10 @@ import { ref, shallowRef, watch } from 'vue'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
-import type { PropType } from 'vue'
+import type { Prop, PropType } from 'vue'
 
 // Types
+export type TimelineItemSide = 'start' | 'end' | undefined
 export type VTimelineItemSlots = {
   default: never
   icon: never
@@ -36,6 +37,10 @@ export const makeVTimelineItemProps = propsFactory({
   icon: IconValue,
   iconColor: String,
   lineInset: [Number, String],
+  side: {
+    type: String,
+    validator: (v: any) => v == null || ['start', 'end'].includes(v),
+  } as Prop<TimelineItemSide>,
 
   ...makeComponentProps(),
   ...makeDimensionProps(),
@@ -68,6 +73,8 @@ export const VTimelineItem = genericComponent<VTimelineItemSlots>()({
           'v-timeline-item',
           {
             'v-timeline-item--fill-dot': props.fillDot,
+            'v-timeline-item--side-start': props.side === 'start',
+            'v-timeline-item--side-end': props.side === 'end',
           },
           props.class,
         ]}


### PR DESCRIPTION
## Description

Restores control over `side` for individual VTimeline items

resolves #19363

![image](https://github.com/user-attachments/assets/b676e45d-997b-40f5-8c6e-96a3e0827c8c)

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-btn-toggle v-model="direction">
      <v-btn value="vertical">vertical</v-btn>
      <v-btn value="horizontal">horizontal</v-btn>
    </v-btn-toggle>
    <v-container>
      <h4>Default</h4>
      <v-timeline :direction="direction">
        <v-timeline-item
          v-for="(item, i) in items"
          :key="i"
          size="x-small"
        >
          <v-card :color="item.color" :title="`Item ${i + 1}`" />
        </v-timeline-item>
      </v-timeline>
    </v-container>
    <v-container>
      <h4>Side on items</h4>
      <v-timeline :direction="direction">
        <v-timeline-item
          v-for="(item, i) in items"
          :key="i"
          :side="item.side"
          size="x-small"
        >
          <v-card :color="item.color" :title="`Item ${i + 1} | ${item.side}`" />
        </v-timeline-item>
      </v-timeline>
    </v-container>
    <v-container>
      <h4>Side on timeline overrides side on items (start)</h4>
      <v-timeline :direction="direction" side="start">
        <v-timeline-item
          v-for="(item, i) in items"
          :key="i"
          :side="item.side"
          size="x-small"
        >
          <v-card :color="item.color">
            <v-card-title>Item {{ i + 1 }} | <s>{{ item.side }}</s> | start</v-card-title>
          </v-card>
        </v-timeline-item>
      </v-timeline>
    </v-container>
    <v-container>
      <h4>Side on timeline overrides side on items (end)</h4>
      <v-timeline :direction="direction" side="end">
        <v-timeline-item
          v-for="(item, i) in items"
          :key="i"
          :side="item.side"
          size="x-small"
        >
          <v-card :color="item.color">
            <v-card-title>Item {{ i + 1 }} | <s>{{ item.side }}</s> | end</v-card-title>
          </v-card>
        </v-timeline-item>
      </v-timeline>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const items = [
    { side: 'start', color: 'green-lighten-1' },
    { side: 'start', color: 'indigo-lighten-2' },
    { side: 'end', color: 'red-lighten-2' },
    { side: 'end', color: 'purple-lighten-2' },
  ]
  const direction = ref('vertical')
</script>
```
