### PR TITLE
docs(VDataTableServer): fixes pagination examples

### DIFF
--- a/packages/docs/src/examples/v-data-table/misc-server-side-paginate-and-sort.vue
+++ b/packages/docs/src/examples/v-data-table/misc-server-side-paginate-and-sort.vue
@@ -112,7 +112,7 @@
               return sortOrder === 'desc' ? bValue - aValue : aValue - bValue
             })
           }
-          const paginated = items.slice(start, end == -1 ? undefined : end)
+          const paginated = items.slice(start, end === -1 ? undefined : end)
           resolve({ items: paginated, total: items.length })
         }, 500)
       })

--- a/packages/docs/src/examples/v-data-table/misc-server-side-paginate-and-sort.vue
+++ b/packages/docs/src/examples/v-data-table/misc-server-side-paginate-and-sort.vue
@@ -112,7 +112,7 @@
               return sortOrder === 'desc' ? bValue - aValue : aValue - bValue
             })
           }
-          const paginated = items.slice(start, end)
+          const paginated = items.slice(start, end == -1 ? undefined : end)
           resolve({ items: paginated, total: items.length })
         }, 500)
       })

--- a/packages/docs/src/examples/v-data-table/server-search.vue
+++ b/packages/docs/src/examples/v-data-table/server-search.vue
@@ -139,7 +139,7 @@
               return sortOrder === 'desc' ? bValue - aValue : aValue - bValue
             })
           }
-          const paginated = items.slice(start, end == -1 ? undefined : end)
+          const paginated = items.slice(start, end === -1 ? undefined : end)
           resolve({ items: paginated, total: items.length })
         }, 500)
       })

--- a/packages/docs/src/examples/v-data-table/server-search.vue
+++ b/packages/docs/src/examples/v-data-table/server-search.vue
@@ -139,7 +139,7 @@
               return sortOrder === 'desc' ? bValue - aValue : aValue - bValue
             })
           }
-          const paginated = items.slice(start, end)
+          const paginated = items.slice(start, end == -1 ? undefined : end)
           resolve({ items: paginated, total: items.length })
         }, 500)
       })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When selecting the  'All' pagination setting, the table would display all rows except for the last one, which would be chopped off due to a minor issue in the pagination logic. I added a check to see if the 'end' variable was -1 and if so, set the end parameter of the slice to undefined so it returns the whole array of items. I wanted to make this change to ensure that if anyone used the pagination logic included in the examples as a reference for their own, this minor issue wouldn't slip through the cracks and cause problems.
