### PR TITLE
feat(VDateInput): add slot for customizing VDatePicker actions

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -15,8 +15,9 @@ import { computed, shallowRef } from 'vue'
 import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
-export interface VDateInputSlots {
+export type VDateInputSlots = {
   default: never
+  actions: never
 }
 
 export const makeVDateInputProps = propsFactory({
@@ -34,7 +35,7 @@ export const makeVDateInputProps = propsFactory({
   }), ['active']),
 }, 'VDateInput')
 
-export const VDateInput = genericComponent()({
+export const VDateInput = genericComponent<VDateInputSlots>()({
   name: 'VDateInput',
 
   props: makeVDateInputProps(),
@@ -146,7 +147,12 @@ export const VDateInput = genericComponent()({
                       onMousedown={ (e: MouseEvent) => e.preventDefault() }
                     >
                       {{
-                        actions: !props.hideActions ? actions : undefined,
+                        actions: () => {
+                          if (slots.actions) {
+                            return slots.actions()
+                          }
+                          return !props.hideActions ? actions() : undefined
+                        },
                       }}
                     </VDatePicker>
                   )


### PR DESCRIPTION
## Description
This PR adds a new slot to the VDateInput component, allowing developers to customize the actions section of the VDatePicker. This enhancement provides greater flexibility in tailoring the date picker to specific application requirements. Resolves #20690.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input>
        <template #actions>
          <v-btn text @click="cancel">cancel-custom</v-btn>
          <v-btn text @click="save">save-custom</v-btn>
        </template>
      </v-date-input>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        cancel () {
          console.log('cancel')
        },
        save () {
          console.log('save')
        },
      }
    },
  }
</script>

```