### PR TITLE
feat(VSlider): introduce track disabled

### DIFF
--- a/packages/api-generator/src/locale/en/VSlider.json
+++ b/packages/api-generator/src/locale/en/VSlider.json
@@ -2,7 +2,8 @@
   "props": {
     "alwaysDirty": "When used with the **thumb-label** prop will always show the thumb label.",
     "inverseLabel": "Reverse the label position. Works with **rtl**.",
-    "vertical": "Changes slider direction to vertical."
+    "vertical": "Changes slider direction to vertical.",
+    "trackDisabled": "Disables clicking on the slider track"
   },
   "slots": {
     "thumb-label": "Slot for the thumb label.",

--- a/packages/docs/src/examples/v-slider/prop-track-disabled.vue
+++ b/packages/docs/src/examples/v-slider/prop-track-disabled.vue
@@ -1,0 +1,6 @@
+<template>
+  <v-slider
+    model-value="30"
+    track-disabled
+  ></v-slider>
+</template>

--- a/packages/vuetify/src/components/VSlider/VSlider.sass
+++ b/packages/vuetify/src/components/VSlider/VSlider.sass
@@ -32,8 +32,15 @@
     .v-input--disabled &
       opacity: var(--v-disabled-opacity)
 
+    .v-slider--track-disabled &
+      cursor: default
+
     .v-input--error:not(.v-input--disabled) &
       color: rgb(var(--v-theme-error))
+
+  .v-slider-thumb
+    .v-slider--track-disabled &
+      cursor: pointer
 
   // Modifiers
   .v-slider.v-input--horizontal

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -106,6 +106,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
               'v-slider--focused': isFocused.value,
               'v-slider--pressed': mousePressed.value,
               'v-slider--disabled': props.disabled,
+              'v-slider--track-disabled': props.trackDisabled,
             },
             rtlClasses.value,
             props.class,

--- a/packages/vuetify/src/components/VSlider/slider.ts
+++ b/packages/vuetify/src/components/VSlider/slider.ts
@@ -123,6 +123,10 @@ export const makeSliderProps = propsFactory({
     type: [Number, String],
     default: 4,
   },
+  trackDisabled: {
+    type: Boolean as PropType<boolean | null>,
+    default: null,
+  },
   direction: {
     type: String as PropType<'horizontal' | 'vertical'>,
     default: 'horizontal',
@@ -194,6 +198,7 @@ export const useSlider = ({
   const trackSize = computed(() => parseInt(props.trackSize, 10))
   const numTicks = computed(() => (max.value - min.value) / step.value)
   const disabled = toRef(props, 'disabled')
+  const trackDisabled = toRef(props, 'trackDisabled')
 
   const thumbColor = computed(() => props.error || props.disabled ? undefined : props.thumbColor ?? props.color)
   const trackColor = computed(() => props.error || props.disabled ? undefined : props.trackColor ?? props.color)
@@ -282,6 +287,10 @@ export const useSlider = ({
 
   function onSliderMousedown (e: MouseEvent) {
     e.preventDefault()
+
+    if (trackDisabled.value && !(e.target as HTMLElement).closest('.v-slider-thumb')) {
+      return
+    }
 
     handleStart(e)
 


### PR DESCRIPTION
## Description

resolves #20872

The current implementation keeps the overall structure and event listeners in place. It simply ignores click events if they do not come from the thumb element. 

I'm happy to discuss alternative options but would like to get some feedback first.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-slider :track-disabled="true" @end="onChange" />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
    methods: {
      onChange (value) {
        console.log(value)
      }
    }
  }
</script>

```
