### PR TITLE
fix(VList): ignore input element interactions

### DIFF
--- a/packages/vuetify/src/components/VList/VListGroup.tsx
+++ b/packages/vuetify/src/components/VList/VListGroup.tsx
@@ -67,6 +67,7 @@ export const VListGroup = genericComponent<VListGroupSlots>()({
 
     function onClick (e: Event) {
       e.stopPropagation()
+      if (['INPUT', 'TEXTAREA'].includes((e.target as Element)?.tagName)) return
       open(!isOpen.value, e)
     }
 

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -184,6 +184,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
 
     function onClick (e: MouseEvent) {
       emit('click', e)
+      if (['INPUT', 'TEXTAREA'].includes((e.target as Element)?.tagName)) return
 
       if (!isClickable.value) return
 
@@ -201,6 +202,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
     }
 
     function onKeyDown (e: KeyboardEvent) {
+      if (['INPUT', 'TEXTAREA'].includes((e.target as Element)?.tagName)) return
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
         e.target!.dispatchEvent(new MouseEvent('click', e))


### PR DESCRIPTION
## Description

fixes #20523

## Markup:

```vue
<template>
  <v-treeview :items="items" selectable>
    <template #title="{item}">
      <v-text-field placeholder="click or type something with spaces" />
    </template>
  </v-treeview>
</template>

<script>
  export default {
    data: () => ({
      items: [
        {
          id: 1,
          title: 'Applications :',
          children: [
            { id: 2, title: 'Calendar : app' },
            { id: 3, title: 'Chrome : app' },
            { id: 4, title: 'Webstorm : app' },
          ],
        },
      ],
    }),
  }
</script>
```
