### PR TITLE
docs(VDataTable): remove obsolete reference to page.sync

### DIFF
--- a/packages/docs/src/pages/en/components/data-tables/data-and-display.md
+++ b/packages/docs/src/pages/en/components/data-tables/data-and-display.md
@@ -50,7 +50,7 @@ Pagination is used to split up large amounts of data into smaller chunks.
 
 ### External pagination
 
-Pagination can be controlled externally by using the individual props, or by using the **options** prop. Remember that you must apply the **.sync** modifier.
+Pagination can be controlled externally by using the individual props, or by using the **options** prop.
 
 <ExamplesExample file="v-data-table/misc-external-paginate" />
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Makes a small change to the documentation for External Pagination of the Data and Display page of `v-data-table` docs. The docs momentarily confused me when it referred to the need to set a `.sync` attribute, which no longer seems to be part of the component. I just removed the offending sentence.
