### PR TITLE
fix(VBreadcrumbsDivider): add aria-hidden attribute

### DIFF
--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbsDivider.tsx
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbsDivider.tsx
@@ -18,6 +18,7 @@ export const VBreadcrumbsDivider = genericComponent()({
   setup (props, { slots }) {
     useRender(() => (
       <li
+        aria-hidden="true"
         class={[
           'v-breadcrumbs-divider',
           props.class,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
A divider in a list of breadcrumbs is only visual. It should be ignored by screenreaders.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<v-breadcrumbs :items="['Foo', 'Bar', 'Fizz']"></v-breadcrumbs>
```

```html
<ul class="v-breadcrumbs v-breadcrumbs--density-default">
  <li class="v-breadcrumbs-item">Foo</li>
  <li class="v-breadcrumbs-divider" aria-hidden="true">/</li>
  <li class="v-breadcrumbs-item">Bar</li>
  <li class="v-breadcrumbs-divider" aria-hidden="true">/</li>
  <li class="v-breadcrumbs-item v-breadcrumbs-item--disabled">Fizz</li>
</ul>
```
