### PR TITLE
docs(VRating): remove onClick from v-rating item slot props

### DIFF
--- a/packages/docs/src/examples/v-rating/slot-item.vue
+++ b/packages/docs/src/examples/v-rating/slot-item.vue
@@ -5,7 +5,6 @@
         <v-icon
           :color="props.isFilled ? colors[props.index] : 'grey-lighten-1'"
           size="large"
-          @click="props.onClick"
         >
           {{ props.isFilled ? 'mdi-star-circle' : 'mdi-star-circle-outline' }}
         </v-icon>


### PR DESCRIPTION
remove onClick from v-rating item slot props

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Click events are handled by a parent HTML element inside the v-rating component.
Therefore, they don't have to be implemented in the item slot. Also, the onClick function does not exist on the slot props.
