### PR TITLE
fix(VCalendar): show all days of multi-day events

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -152,7 +152,9 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                           color={ adapter.isSameDay(adapter.date(), day.date) ? 'primary' : undefined }
                           day={ day }
                           title={ day ? adapter.format(day.date, 'dayOfMonth') : 'NaN' }
-                          events={ props.events?.filter(e => adapter.isSameDay(day.date, e.start) || adapter.isSameDay(day.date, e.end)) }
+                          events={ props.events?.filter(e => adapter.isSameDay(day.date, e.start) ||
+                            adapter.isSameDay(day.date, e.end) ||
+                            adapter.isWithinRange(day.date, [e.start, e.end]))}
                           v-slots={{
                             event: slots.event,
                           }}
@@ -169,7 +171,9 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                   { ...calendarDayProps }
                   day={ day }
                   dayIndex={ i }
-                  events={ props.events?.filter(e => adapter.isSameDay(e.start, day.date) || adapter.isSameDay(e.end, day.date)) }
+                  events={ props.events?.filter(e => adapter.isSameDay(e.start, day.date) ||
+                    adapter.isSameDay(e.end, day.date) ||
+                    adapter.isWithinRange(day.date, [e.start, e.end]))}
                 ></VCalendarDay>
               ))
             )}
@@ -182,7 +186,8 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                 events={
                   props.events?.filter(e =>
                     adapter.isSameDay(e.start, genDays([displayValue.value as Date], adapter.date() as Date)[0].date) ||
-                    adapter.isSameDay(e.end, genDays([displayValue.value as Date], adapter.date() as Date)[0].date)
+                    adapter.isSameDay(e.end, genDays([displayValue.value as Date], adapter.date() as Date)[0].date) ||
+                    adapter.isWithinRange(genDays([displayValue.value as Date], adapter.date() as Date)[0].date, [e.start, e.end])
                   )
                 }
               ></VCalendarDay>


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

For showing the event, a check was added to the filter, to also include days, that lay between the start and end date of an event.

fixes #19065

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <v-col cols="12">
          <div style="height: 600px">
            <v-calendar :events="events" view-mode="month" />
          </div>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      const today = new Date()

      const plus2 = new Date()
      plus2.setDate(today.getDate() + 4)

      return {
        events: [
          {
            title: 'Test 1',
            start: today,
            end: plus2,
            color: 'red',
          },
        ],
      }
    },
  }
</script>

```
