### PR TITLE
docs(VStepperVertical): fix "click:prev" event name

### DIFF
--- a/packages/api-generator/src/locale/en/VStepperVerticalItem.json
+++ b/packages/api-generator/src/locale/en/VStepperVerticalItem.json
@@ -2,6 +2,6 @@
   "events": {
     "click:finish": "Event emitted when clicking the finish button",
     "click:next": "Event emitted when clicking the next button",
-    "click:previous": "Event emitted when clicking the previous button"
+    "click:prev": "Event emitted when clicking the previous button"
   }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Fixed missing event description in documentation:
![image](https://github.com/user-attachments/assets/a941dedb-40f8-4762-8e5f-ee993aa3c08e)

<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
