### PR TITLE
fix(useDisplay): improve logic for clarity and accuracy

### DIFF
--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -233,15 +233,17 @@ export function useDisplay (
   const mobile = computed(() => {
     if (props.mobile) {
       return true
-    } else if (typeof props.mobileBreakpoint === 'number') {
-      return display.width.value < props.mobileBreakpoint
-    } else if (props.mobileBreakpoint) {
-      return display.width.value < display.thresholds.value[props.mobileBreakpoint]
-    } else if (props.mobile === null) {
-      return display.mobile.value
-    } else {
-      return false
     }
+    if (typeof props.mobileBreakpoint === 'number') {
+      return display.width.value < props.mobileBreakpoint
+    }
+    if (typeof props.mobileBreakpoint === 'string') {
+      return display.width.value < display.thresholds.value[props.mobileBreakpoint]
+    }
+    if (props.mobile === null) {
+      return display.mobile.value
+    }
+    return !!(display.mobile.value && !props.mobileBreakpoint)
   })
 
   const displayClasses = computed(() => {


### PR DESCRIPTION
## Description
3.7.8 creates breaking changes for layouts that use the composable useDisplay().mobile computed value to determine layout status.

The proposed changes are an attempt to keep their changes, while keeping it from breaking useDisplay.

## Markup:
Maintainers should probably quad check this, since this is already breaking production code.

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app theme="dark">
    <v-container>
      $vuetify.mobile is {{ $vuetify.display.mobile }}
      usedisplayMobile is {{ useDisplay().mobile }}
      <pre class="mt-8">
      $vuetify.display.width: {{ $vuetify.display.width }}px
      mobile-breakpoint="md" instructs labels to hide below the 960px (md breakpoint)
      </pre>
      <v-stepper mobile-breakpoint="md">
        <v-stepper-header>
          <template v-for="(item, i) in items" :key="i">
            <v-divider v-if="i" />
            <v-stepper-item v-bind="item" />
          </template>
        </v-stepper-header>
      </v-stepper>

      <pre class="mt-8">
      $vuetify.display.width: {{ $vuetify.display.width }}px
      :mobile-breakpoint="800" instructs labels to hide below the 800px
      </pre>
      <v-stepper :mobile-breakpoint="800">
        <v-stepper-header>
          <template v-for="(item, i) in items" :key="i">
            <v-divider v-if="i" />
            <v-stepper-item v-bind="item" />
          </template>
        </v-stepper-header>
      </v-stepper>
    </v-container>
    <div class="container">
      This table is forced to be small
      <v-data-table :items="items" :mobile-breakpoint="1200" />
    </div>

    This table s not forced to be small
    <v-data-table :items="items" />

    Both tables are always in wide (desktop) display or stacked (mobile) mode at
    the same time. The breakpoint seems to be 1280px. Resizing preview window to
    see the effect.
  </v-app>
</template>

<script setup lang="ts">
  import { useDisplay } from 'vuetify'
  const items = Array.from({ length: 4 }).map((_, i) => ({
    title: `Step ${i + 1}`,
    subtitle: `Step ${i + 1} subtitle`,
    value: i + 1,
  }))
</script>

```
