### PR TITLE
fix(useDisplay): keep default behavior when used without args

### DIFF
--- a/packages/vuetify/src/composables/display.ts
+++ b/packages/vuetify/src/composables/display.ts
@@ -223,7 +223,7 @@ export const makeDisplayProps = propsFactory({
 }, 'display')
 
 export function useDisplay (
-  props: DisplayProps = {},
+  props: DisplayProps = { mobile: null },
   name = getCurrentInstanceName(),
 ) {
   const display = inject(DisplaySymbol)


### PR DESCRIPTION
## Description

follow-up to #20311
and alternative to #20930

resolves #20932

## Markup:

```ts
const { mobile } = useDisplay()
console.log({ mobile }) // used to work before v3.7.8, now it is always false

// workaround: useDisplay({ mobile: null })
```
