### PR TITLE
fix(VDataTableColumn): columns are not keyboard-accessible fixes #20899

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
@@ -22,6 +22,7 @@ export const VDataTableColumn = defineFunctionalComponent({
   const Tag = props.tag ?? 'td'
   return (
     <Tag
+      tabindex="0"
       class={[
         'v-data-table__td',
         {

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -102,7 +102,11 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
         top: (props.sticky || props.fixedHeader) ? `calc(var(--v-table-header-height) * ${y})` : undefined,
       }
     }
-
+    function handleEnterKeyPress (event: KeyboardEvent, column: InternalDataTableHeader) {
+      if (event.key === 'Enter' && !props.disableSort) {
+        toggleSort(column)
+      }
+    }
     function getSortIcon (column: InternalDataTableHeader) {
       const item = sortBy.value.find(item => item.key === column.key)
 
@@ -166,6 +170,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           lastFixed={ column.lastFixed }
           noPadding={ noPadding }
           { ...headerProps }
+          onKeydown={ (event: KeyboardEvent) => column.sortable && handleEnterKeyPress(event, column) }
         >
           {{
             default: () => {


### PR DESCRIPTION
fixes #20899 

## Description
Added default tabindex to 0 for the cells in the table.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table :headers="headers" :items="items" />
</template>

<script>
  export default {
    data: () => ({
      headers: [
        { title: 'Dessert (100g serving)', align: 'start', key: 'name' },
        { title: 'Calories', key: 'calories', align: 'end', sortable: false },
        { title: 'Fat (g)', key: 'fat', align: 'end' },
        { title: 'Carbs (g)', key: 'carbs', align: 'end' },
        { title: 'Protein (g)', key: 'protein', align: 'end' },
        { title: 'Iron (%)', key: 'iron', align: 'end' },
      ],
      items: [
        {
          name: 'Frozen Yogurt',
          calories: 159,
          fat: 6.0,
          carbs: 24,
          protein: 4.0,
          iron: '1',
        },
        {
          name: 'Jelly bean',
          calories: 375,
          fat: 0.0,
          carbs: 94,
          protein: 0.0,
          iron: '0',
        },
        {
          name: 'KitKat',
          calories: 518,
          fat: 26.0,
          carbs: 65,
          protein: 7,
          iron: '6',
        },
        {
          name: 'Eclair',
          calories: 262,
          fat: 16.0,
          carbs: 23,
          protein: 6.0,
          iron: '7',
        },
        {
          name: 'Gingerbread',
          calories: 356,
          fat: 16.0,
          carbs: 49,
          protein: 3.9,
          iron: '16',
        },
        {
          name: 'Ice cream sandwich',
          calories: 237,
          fat: 9.0,
          carbs: 37,
          protein: 4.3,
          iron: '1',
        },
        {
          name: 'Lollipop',
          calories: 392,
          fat: 0.2,
          carbs: 98,
          protein: 0,
          iron: '2',
        },
        {
          name: 'Cupcake',
          calories: 305,
          fat: 3.7,
          carbs: 67,
          protein: 4.3,
          iron: '8',
        },
        {
          name: 'Honeycomb',
          calories: 408,
          fat: 3.2,
          carbs: 87,
          protein: 6.5,
          iron: '45',
        },
        {
          name: 'Donut',
          calories: 452,
          fat: 25.0,
          carbs: 51,
          protein: 4.9,
          iron: '22',
        },
      ],
    }),
  }
</script>


```
