### PR TITLE
feat(VOtpInput): add a bool property masked to show the text or not

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -47,7 +47,10 @@ export const makeVOtpInputProps = propsFactory({
     type: String as PropType<'text' | 'password' | 'number'>,
     default: 'number',
   },
-
+  masked: {
+    type: Boolean,
+    default: false,
+  },
   ...makeDimensionProps(),
   ...makeFocusProps(),
   ...only(makeVFieldProps({
@@ -270,7 +273,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                           min={ props.type === 'number' ? 0 : undefined }
                           maxlength="1"
                           placeholder={ props.placeholder }
-                          type={ props.type === 'number' ? 'text' : props.type }
+                          type={ props.masked ? 'password' : props.type === 'number' ? 'text' : props.type }
                           value={ model.value[i] }
                           onInput={ onInput }
                           onFocus={ e => onFocus(e, i) }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->
resolves #18964
## Description
As mentioned in the issue, I have added a masked attribute that can be used with text and number type to mask the input.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <!-- -->
      <v-otp-input v-model="otp" type="text" masked />
      {{ otp }}
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue';

  import { VOtpInput } from '../src/components/VOtpInput/index.ts'
  export default {
    name: 'Playground',
    components: {
      VOtpInput,
    },
    setup () {
      const otp = ref('')
      return {
        otp,
        //
      }
    },
  }
</script>
```
