### PR TITLE
fix(VDateInput): do not pass `rounded` to the picker

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -46,7 +46,7 @@ export const makeVDateInputProps = propsFactory({
   ...omit(makeVDatePickerProps({
     weeksInMonth: 'dynamic' as const,
     hideHeader: true,
-  }), ['active', 'location']),
+  }), ['active', 'location', 'rounded']),
 }, 'VDateInput')
 
 export const VDateInput = genericComponent<VDateInputSlots>()({
@@ -129,7 +129,7 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
 
     useRender(() => {
       const confirmEditProps = VConfirmEdit.filterProps(props)
-      const datePickerProps = VDatePicker.filterProps(omit(props, ['active', 'location']))
+      const datePickerProps = VDatePicker.filterProps(omit(props, ['active', 'location', 'rounded']))
       const textFieldProps = VTextField.filterProps(props)
 
       return (


### PR DESCRIPTION
## Description

- noticed by colleague on Discord

![image](https://github.com/user-attachments/assets/36226b50-8e65-4150-9f97-1651ad45190b)

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-select rounded="pill" :items="['item', 'item2', 'item3']" />
      <v-date-input rounded="pill" />
      <v-date-input rounded="xl" />
    </v-container>
  </v-app>
</template>
```
