### PR TITLE
fix(validation): add validation watcher for rules

### DIFF
--- a/packages/vuetify/src/composables/__tests__/validation.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/validation.spec.ts
@@ -173,4 +173,19 @@ describe('validation', () => {
 
     expect(wrapper.vm.isValid).toBe(true)
   })
+
+  it.only('should rerun validation when rules changes', async () => {
+    const wrapper = mountFunction({
+      modelValue: 'bar',
+      rules: [(v: any) => v === 'foo' || 'Invalid'],
+    })
+
+    await wrapper.vm.validate()
+
+    expect(wrapper.vm.isValid).toBe(false)
+
+    await wrapper.setProps({ rules: [(v: any) => v === 'bar' || 'Invalid'] })
+
+    expect(wrapper.vm.isValid).toBe(true)
+  })
 })

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -6,7 +6,7 @@ import { useToggleScope } from '@/composables/toggleScope'
 
 // Utilities
 import { computed, nextTick, onBeforeMount, onBeforeUnmount, onMounted, ref, shallowRef, unref, watch } from 'vue'
-import { getCurrentInstance, getCurrentInstanceName, getUid, propsFactory, wrapInArray } from '@/util'
+import { deepEqual, getCurrentInstance, getCurrentInstanceName, getUid, propsFactory, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -175,6 +175,8 @@ export function useValidation (
   watch([isValid, errorMessages], () => {
     form.update?.(uid.value, isValid.value, errorMessages.value)
   })
+
+  watch(() => props.rules, () => validate())
 
   async function reset () {
     model.value = null


### PR DESCRIPTION
After extended consideration and testing, I think this is a risky change.

fixes #18875

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-checkbox
        label="at least length 3"
        v-model="additionalrule"
      ></v-checkbox>
      <v-form ref="form" v-model="valid">
        <v-text-field
          ref="nameInput"
          v-model="msg"
          :rules="_rules(additionalrule)"
        />
      </v-form>

      <div>Valid: {{valid}}</div>
      <div>AdditionalRule: {{additionalrule}}</div>
      <div>Count of rules: {{_rules(additionalrule).length}}</div>
    </v-container>

    <v-btn ref="reset" @click="form.reset()">Reset Form</v-btn>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'


  const msg = ref<string>('aa')
  const valid = ref<boolean|null>();
  const additionalrule = ref<boolean>(false);
  const form = ref<Form>();
  const nameInput = ref<Validateable>();

  interface Validateable  {
    validate(silent: boolean): Promise<string[]>
  }

  interface Form {
    resetValidation(): void;
    reset(): void;
  }

  function isRequired(v: string): string | true {
    if (v === "") {
      return "required";
    }
    return true;
  }

    function atleastlength3(v: string): string | true {
    if (v != null && v.length < 3) {
      return "must have at least 3 chars";
    }
    return true;
  }


  function _rules(additionalrule: boolean) {
   if (additionalrule) {
      return [isRequired, atleastlength3];
   }
   return [isRequired];
  }
</script>

```
