### PR TITLE
fix(VTimePickerControls): disable in disabled forms

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
@@ -64,7 +64,7 @@ export const VTimePickerControls = genericComponent()({
             <VBtn
               active={ props.selecting === 1 }
               color={ props.selecting === 1 ? props.color : undefined }
-              disabled={ props.disabled }
+              disabled={ !!props.disabled }
               variant="tonal"
               class={{
                 'v-time-picker-controls__time__btn': true,
@@ -91,7 +91,7 @@ export const VTimePickerControls = genericComponent()({
                 'v-time-picker-controls__time--with-ampm__btn': props.ampm,
                 'v-time-picker-controls__time--with-seconds__btn': props.useSeconds,
               }}
-              disabled={ props.disabled }
+              disabled={ !!props.disabled }
               variant="tonal"
               text={ props.minute == null ? '--' : pad(props.minute) }
               onClick={ () => emit('update:selecting', SelectingTimes.Minute) }
@@ -120,7 +120,7 @@ export const VTimePickerControls = genericComponent()({
                     'v-time-picker-controls__time__btn__active': props.selecting === 3,
                     'v-time-picker-controls__time--with-seconds__btn': props.useSeconds,
                   }}
-                  disabled={ props.disabled }
+                  disabled={ !!props.disabled }
                   text={ props.second == null ? '--' : pad(props.second) }
                 />
               )
@@ -141,9 +141,9 @@ export const VTimePickerControls = genericComponent()({
                       'v-time-picker-controls__ampm__btn': true,
                       'v-time-picker-controls__ampm__btn__active': props.period === 'am',
                     }}
-                    disabled={ props.disabled }
+                    disabled={ !!props.disabled }
                     text={ t('$vuetify.timePicker.am') }
-                    variant={ props.disabled && props.period === 'am' ? 'elevated' : 'tonal' }
+                    variant={ !!props.disabled && props.period === 'am' ? 'elevated' : 'tonal' }
                     onClick={ () => props.period !== 'am' ? emit('update:period', 'am') : null }
                   />
 
@@ -155,9 +155,9 @@ export const VTimePickerControls = genericComponent()({
                       'v-time-picker-controls__ampm__btn': true,
                       'v-time-picker-controls__ampm__btn__active': props.period === 'pm',
                     }}
-                    disabled={ props.disabled }
+                    disabled={ !!props.disabled }
                     text={ t('$vuetify.timePicker.pm') }
-                    variant={ props.disabled && props.period === 'pm' ? 'elevated' : 'tonal' }
+                    variant={ !!props.disabled && props.period === 'pm' ? 'elevated' : 'tonal' }
                     onClick={ () => props.period !== 'pm' ? emit('update:period', 'pm') : null }
                   />
                 </div>

--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
@@ -12,6 +12,7 @@ import { useLocale } from '@/composables/locale'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
+import type { PropType } from 'vue'
 import { SelectingTimes } from './SelectingTimes'
 type Period = 'am' | 'pm'
 

--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
@@ -20,7 +20,10 @@ export const makeVTimePickerControlsProps = propsFactory({
   ampmInTitle: Boolean,
   ampmReadonly: Boolean,
   color: String,
-  disabled: Boolean,
+  disabled: {
+    type: Boolean as PropType<boolean | null>,
+    default: null,
+  },
   hour: Number,
   minute: Number,
   second: Number,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
    <v-form disabled>
        <v-time-picker />
    </v-form>
</template>
```
