### PR TITLE
docs(VSlideGroup): Update active class prop

### DIFF
--- a/packages/docs/src/pages/en/components/slide-groups.md
+++ b/packages/docs/src/pages/en/components/slide-groups.md
@@ -41,9 +41,9 @@ Similar to the [v-window](/components/windows) component, `v-slide-group` lets i
 
 ### Props
 
-#### Active class
+#### Selected class
 
-**active-class** prop allows you to pass a class to customize the active items.
+**selected-class** prop allows you to pass a class to customize the active items.
 
 <ExamplesExample file="v-slide-group/prop-active-class" />
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

That's about it. The `active-class` prop is not being used on `slide-groups`. Rather, we are using `selected-class` according to the [API](https://vuetifyjs.com/en/api/v-slide-group/).

