### PR TITLE
Fix: Ensure Reactivity for 'to' Attribute in useLink Composable

### DIFF
--- a/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbsItem.tsx
+++ b/packages/vuetify/src/components/VBreadcrumbs/VBreadcrumbsItem.tsx
@@ -55,7 +55,7 @@ export const VBreadcrumbsItem = genericComponent()({
           { !link.isLink.value ? slots.default?.() ?? props.title : (
             <a
               class="v-breadcrumbs-item--link"
-              onClick={ link.navigate }
+              onClick={ link.navigate.value }
               { ...link.linkProps }
             >
               { slots.default?.() ?? props.title }

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -161,7 +161,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
         ))
       ) return
 
-      link.navigate?.(e)
+      link.navigate.value?.(e)
       group?.toggle()
     }
 

--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -149,7 +149,7 @@ export const VCard = genericComponent<VCardSlots>()({
             locationStyles.value,
             props.style,
           ]}
-          onClick={ isClickable.value && link.navigate }
+          onClick={ isClickable.value && link.navigate.value }
           v-ripple={ isClickable.value && props.ripple }
           tabindex={ props.disabled ? -1 : undefined }
           { ...link.linkProps }

--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -155,7 +155,7 @@ export const VChip = genericComponent<VChipSlots>()({
 
       if (!isClickable.value) return
 
-      link.navigate?.(e)
+      link.navigate.value?.(e)
       group?.toggle()
     }
 

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -187,7 +187,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
 
       if (!isClickable.value) return
 
-      link.navigate?.(e)
+      link.navigate.value?.(e)
 
       if (isGroupActivator) return
 

--- a/packages/vuetify/src/composables/__tests__/router.spec.tsx
+++ b/packages/vuetify/src/composables/__tests__/router.spec.tsx
@@ -1,0 +1,191 @@
+// Utilities
+import { shallowMount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import { useLink } from '../router'
+
+describe('useLink', () => {
+  const TestComponent = defineComponent({
+    props: {
+      href: String,
+      replace: Boolean,
+      to: [String, Object],
+      exact: Boolean,
+    },
+    setup (props, { attrs }) {
+      return useLink(props, attrs)
+    },
+    render () {
+      return h('div')
+    },
+  })
+
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: '/',
+        name: 'home',
+        component: {
+          setup: () => () => h('div', 'home'),
+        },
+      },
+      {
+        path: '/page1',
+        name: 'page1',
+        component: {
+          setup: () => () => h('div', 'page1'),
+        },
+      },
+      {
+        path: '/page2',
+        name: 'page2',
+        component: {
+          setup: () => () => h('div', 'page2'),
+        },
+      },
+    ],
+  })
+
+  it('works with "to"', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      props: {
+        to: { name: 'page1' },
+        exact: true,
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const vm = wrapper.vm
+
+    expect(vm.isLink).toBe(true)
+    expect(vm.isClickable).toBe(true)
+    expect(vm.href).toBe('/page1')
+    expect(vm.linkProps.href).toBe('/page1')
+    expect(vm.route?.fullPath).toBe('/page1')
+    expect(vm.navigate).toBeDefined()
+  })
+
+  it('works with "href"', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      props: {
+        href: '/page2',
+      },
+    })
+
+    const vm = wrapper.vm
+
+    expect(vm.isLink).toBe(true)
+    expect(vm.isClickable).toBe(true)
+    expect(vm.href).toBe('/page2')
+    expect(vm.linkProps.href).toBe('/page2')
+    expect(vm.route).toBeUndefined()
+    expect(vm.navigate).toBeUndefined()
+  })
+
+  it('navigates to correct route', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      props: {
+        to: { name: 'page1' },
+        exact: true,
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const vm = wrapper.vm
+
+    await vm.navigate!()
+
+    expect(router.currentRoute.value.fullPath).toBe('/page1')
+  })
+
+  it('handles to property changes', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      props: {
+        to: { name: 'page1' },
+        exact: true,
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const vm = wrapper.vm
+
+    expect(vm.route?.fullPath).toBe('/page1')
+    await vm.navigate!()
+
+    expect(router.currentRoute.value.fullPath).toBe('/page1')
+
+    await wrapper.setProps({
+      to: { name: 'page2' },
+    })
+    expect(vm.route?.fullPath).toBe('/page2')
+    await vm.navigate!()
+
+    expect(router.currentRoute.value.fullPath).toBe('/page2')
+  })
+
+  it('handles when no to property is set initially, then set', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const vm = wrapper.vm
+
+    expect(vm.route).toBeUndefined()
+
+    await wrapper.setProps({
+      to: { name: 'page1' },
+      exact: true,
+    })
+
+    expect(vm.route?.fullPath).toBe('/page1')
+    await vm.navigate!()
+
+    expect(router.currentRoute.value.fullPath).toBe('/page1')
+  })
+  it('correctly sets isActive property', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      props: {
+        to: { name: 'page1' },
+        exact: true,
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const vm = wrapper.vm
+
+    await vm.navigate!()
+    expect(vm.isActive).toBe(true)
+
+    await wrapper.setProps({ to: { name: 'page2' } })
+    expect(vm.isActive).toBe(false)
+  })
+
+  it('handles replace prop', async () => {
+    const wrapper = shallowMount(TestComponent, {
+      props: {
+        to: { name: 'page1' },
+        replace: true,
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    const vm = wrapper.vm
+
+    await vm.navigate!()
+    expect(router.currentRoute.value.fullPath).toBe('/page1')
+    expect(window.history.state.replaced).toBe(true)
+  })
+})

--- a/packages/vuetify/src/composables/router.tsx
+++ b/packages/vuetify/src/composables/router.tsx
@@ -14,6 +14,7 @@ import type {
   RouterLink as _RouterLink,
   useLink as _useLink,
   NavigationGuardNext,
+  RouteLocation,
   RouteLocationNormalizedLoaded,
   RouteLocationRaw,
   Router,
@@ -43,11 +44,13 @@ export interface LinkListeners {
   onClickOnce?: EventProp | undefined
 }
 
-export interface UseLink extends Omit<Partial<ReturnType<typeof _useLink>>, 'href'> {
+export interface UseLink extends Omit<Partial<ReturnType<typeof _useLink>>, 'href'|'route'|'navigate'> {
   isLink: ComputedRef<boolean>
   isClickable: ComputedRef<boolean>
   href: Ref<string | undefined>
   linkProps: Record<string, string | undefined>
+  route: ComputedRef<RouteLocation & { href: string} | undefined>
+  navigate: ComputedRef<ReturnType<typeof _useLink>['navigate'] | undefined>
 }
 
 export function useLink (props: LinkProps & LinkListeners, attrs: SetupContext['attrs']): UseLink {
@@ -65,6 +68,8 @@ export function useLink (props: LinkProps & LinkListeners, attrs: SetupContext['
       isClickable,
       href,
       linkProps: reactive({ href }),
+      route: computed(() => undefined),
+      navigate: computed(() => undefined),
     }
   }
   // vue-router useLink `to` prop needs to be reactive and useLink will crash if undefined
@@ -90,8 +95,8 @@ export function useLink (props: LinkProps & LinkListeners, attrs: SetupContext['
     isLink,
     isClickable,
     isActive,
-    route: link.value?.route,
-    navigate: link.value?.navigate,
+    route: computed(() => link.value?.route.value),
+    navigate: computed(() => link.value?.navigate),
     href,
     linkProps: reactive({
       href,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This PR addresses the following issue:
If a component is initialized without the `to`attribute, adding the attribute later does not involve the client-side router anymore. Clicking on such a component causes the entire application to reload. This issue is caused by the `navigate` and `route` properties returned by the `useLink` composable not being reactive. This PR adds reactivity to these properties.

Additionally, this PR includes unit tests for the `useLink` composable to ensure its functionality and correctness.


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

In the current version, clicking on the 'Not Working' card causes the entire application to reload.
In the fixed version, it utilizes the client-side router.

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-card
        :to="workingTo"
        color="blue"
        height="100"
        width="200"
      >Working</v-card>
      <v-card
        :to="notWorkingTo"
        color="pink"
        height="100"
        width="200"
      >Not Working</v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const workingTo = ref({ name: 'page1' })
  const notWorkingTo = ref(null)

  setTimeout(() => {
    notWorkingTo.value = { name: 'page1' }
  }, 1000)
</script>

```
