### PR TITLE
fix(VMenu): Prevent focus change during IME input

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -176,10 +176,10 @@ export const VMenu = genericComponent<OverlaySlots>()({
     }
 
     function onActivatorKeydown (e: KeyboardEvent) {
-      if (props.disabled) return
+      if (props.disabled || e.isComposing) return
 
       const el = overlay.value?.contentEl
-      if (el && isActive.value && !e.isComposing) {
+      if (el && isActive.value) {
         if (e.key === 'ArrowDown') {
           e.preventDefault()
           e.stopImmediatePropagation()

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -179,7 +179,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
       if (props.disabled) return
 
       const el = overlay.value?.contentEl
-      if (el && isActive.value) {
+      if (el && isActive.value && !e.isComposing) {
         if (e.key === 'ArrowDown') {
           e.preventDefault()
           e.stopImmediatePropagation()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes https://github.com/vuetifyjs/vuetify/issues/21001

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete
        v-model="msg"
        placeholder="Type with IME input (my usecase is Vietnamese)"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref()
</script>

```
