### PR TITLE
fix(VNumberInput): apply precision even when disabled/readonly

### DIFF
--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -103,8 +103,8 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     watchEffect(() => {
       if (isFocused.value && !controlsDisabled.value) {
         // ignore external changes
-      } else if (model.value == null || controlsDisabled.value) {
-        _inputText.value = model.value && !isNaN(model.value) ? correctPrecision(model.value) : null
+      } else if (model.value == null) {
+        _inputText.value = null
       } else if (!isNaN(model.value)) {
         _inputText.value = correctPrecision(model.value)
       }

--- a/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/labs/VNumberInput/VNumberInput.tsx
@@ -104,7 +104,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (isFocused.value && !controlsDisabled.value) {
         // ignore external changes
       } else if (model.value == null || controlsDisabled.value) {
-        _inputText.value = model.value && !isNaN(model.value) ? String(model.value) : null
+        _inputText.value = model.value && !isNaN(model.value) ? correctPrecision(model.value) : null
       } else if (!isNaN(model.value)) {
         _inputText.value = correctPrecision(model.value)
       }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes https://github.com/vuetifyjs/vuetify/issues/21005

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input v-model="number" :precision="3" />
      <v-number-input v-model="number" :precision="3" disabled />
      <v-number-input v-model="number" :precision="3" readonly />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const number = ref(1.23)
</script>

```
