### PR TITLE
docs(VMenu): update examples to show pointer

### DIFF
--- a/packages/docs/src/examples/v-menu/misc-transition.vue
+++ b/packages/docs/src/examples/v-menu/misc-transition.vue
@@ -16,6 +16,7 @@
         <v-list-item
           v-for="(item, i) in items"
           :key="i"
+          :value="i"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>
@@ -38,6 +39,7 @@
         <v-list-item
           v-for="(item, i) in items"
           :key="i"
+          :value="i"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>
@@ -59,6 +61,7 @@
         <v-list-item
           v-for="(item, i) in items"
           :key="i"
+          :value="i"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/packages/docs/src/examples/v-menu/misc-use-in-components.vue
+++ b/packages/docs/src/examples/v-menu/misc-use-in-components.vue
@@ -20,6 +20,7 @@
               <v-list-item
                 v-for="(item, i) in items"
                 :key="i"
+                :value="i"
               >
                 <v-list-item-title>{{ item.title }}</v-list-item-title>
               </v-list-item>

--- a/packages/docs/src/examples/v-menu/prop-absolute.vue
+++ b/packages/docs/src/examples/v-menu/prop-absolute.vue
@@ -18,6 +18,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
+          :value="index"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/packages/docs/src/examples/v-menu/prop-close-on-content-click.vue
+++ b/packages/docs/src/examples/v-menu/prop-close-on-content-click.vue
@@ -21,6 +21,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
+          :value="index"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/packages/docs/src/examples/v-menu/prop-disabled.vue
+++ b/packages/docs/src/examples/v-menu/prop-disabled.vue
@@ -14,6 +14,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
+          :value="index"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/packages/docs/src/examples/v-menu/prop-location.vue
+++ b/packages/docs/src/examples/v-menu/prop-location.vue
@@ -19,6 +19,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
+          :value="index"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/packages/docs/src/examples/v-menu/prop-open-on-hover.vue
+++ b/packages/docs/src/examples/v-menu/prop-open-on-hover.vue
@@ -16,6 +16,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
+          :value="index"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/packages/docs/src/examples/v-menu/slot-activator-and-tooltip.vue
+++ b/packages/docs/src/examples/v-menu/slot-activator-and-tooltip.vue
@@ -18,6 +18,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
+          :value="index"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>


### PR DESCRIPTION
Follow the sample in usage section, added value in v-for to display mouse pointer instead of cursor

## Description
Some of  the `v-menu` examples shows cursor when activated:

![image](https://github.com/user-attachments/assets/cced1284-0136-44c5-b620-015eab6496de)


Copy the behavior from the **Usage** section:

![image](https://github.com/user-attachments/assets/443066cc-3b83-4b93-8e37-d4ebabb66371)

