### PR TITLE
feat(VCalendar): implement click:date

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -37,6 +37,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
     next: null,
     prev: null,
     'update:modelValue': null,
+    'click:date': (value: any, e: MouseEvent) => true,
   },
 
   setup (props, { emit, slots }) {
@@ -156,6 +157,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                           v-slots={{
                             event: slots.event,
                           }}
+                          onClick={ (e: MouseEvent) => emit('click:date', day, e) }
                         ></VCalendarMonthDay>
                       )),
                     ]


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes https://github.com/vuetifyjs/vuetify/issues/20920

It seems that `click:date` exists in vuetify2
https://v2.vuetifyjs.com/ja/api/v-calendar/#events

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <h1>Selcted Date : {{selectedDate}}</h1>
      <v-calendar
        v-model="calender"
        event-overlap-mode="stack"
        @click="onDateClick"
      >
      </v-calendar>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selectedDate = ref()
  const calender = ref()
  const onDateClick = event => {
    selectedDate.value = event
    console.log(event)
  }
</script>

```
