### PR TITLE
feat(VTreeview): add slot to replace expand toggle btn

### DIFF
--- a/packages/api-generator/src/locale/en/VTreeviewItem.json
+++ b/packages/api-generator/src/locale/en/VTreeviewItem.json
@@ -9,5 +9,8 @@
   },
   "events": {
     "toggleExpand": "Emitted when the item is toggled to expand or collapse."
+  },
+  "slots": {
+    "toggle": "Slot for custom expand icon and loading indicator."
   }
 }

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -224,12 +224,18 @@
       "hideActions": "3.9.0",
       "separateRoots": "3.9.0",
       "indentLines": "3.9.0"
+    },
+    "slots": {
+      "toggle": "3.10.0"
     }
   },
   "VTreeviewItem": {
     "props": {
       "hideActions": "3.9.0",
       "indentLines": "3.9.0"
+    },
+    "slots": {
+      "toggle": "3.10.0"
     }
   },
   "VTooltip": {

--- a/packages/docs/src/examples/v-treeview/slot-toggle.vue
+++ b/packages/docs/src/examples/v-treeview/slot-toggle.vue
@@ -1,0 +1,168 @@
+<template>
+  <v-treeview
+    v-model="model"
+    :items="items"
+    item-value="id"
+    select-strategy="classic"
+    activatable
+    selectable
+  >
+    <template v-slot:toggle="{ props: toggleProps, isOpen, isSelected, isActive, isIndeterminate }">
+      <v-btn
+        v-bind="toggleProps"
+        :active="isOpen"
+        :color="isIndeterminate ? 'warning' : isSelected ? 'success' : isActive ? 'primary' : 'medium-emphasis'"
+        :variant="isOpen ? 'outlined' : 'tonal'"
+      ></v-btn>
+    </template>
+  </v-treeview>
+</template>
+
+<script setup>
+  import { shallowRef } from 'vue'
+
+  const model = shallowRef()
+
+  const items = [
+    {
+      id: '1',
+      title: 'Dashboard',
+      children: [
+        {
+          id: '1-1',
+          title: 'Analytics',
+        },
+        {
+          id: '1-2',
+          title: 'Reports',
+        },
+      ],
+    },
+    {
+      id: '2',
+      title: 'User Management',
+      children: [
+        {
+          id: '2-1',
+          title: 'Users',
+        },
+        {
+          id: '2-2',
+          title: 'Roles',
+        },
+        {
+          id: '2-3',
+          title: 'Permissions',
+        },
+      ],
+    },
+    {
+      id: '3',
+      title: 'Settings',
+      children: [
+        {
+          id: '3-1',
+          title: 'General',
+        },
+        {
+          id: '3-2',
+          title: 'Security',
+        },
+        {
+          id: '3-3',
+          title: 'Notifications',
+        },
+      ],
+    },
+    {
+      id: '4',
+      title: 'Help',
+      children: [
+        {
+          id: '4-1',
+          title: 'Documentation',
+        },
+        {
+          id: '4-2',
+          title: 'Support',
+        },
+      ],
+    },
+  ]
+</script>
+
+<script>
+  export default {
+    data () {
+      return {
+        model: [],
+        items: [
+          {
+            id: '1',
+            title: 'Dashboard',
+            children: [
+              {
+                id: '1-1',
+                title: 'Analytics',
+              },
+              {
+                id: '1-2',
+                title: 'Reports',
+              },
+            ],
+          },
+          {
+            id: '2',
+            title: 'User Management',
+            children: [
+              {
+                id: '2-1',
+                title: 'Users',
+              },
+              {
+                id: '2-2',
+                title: 'Roles',
+              },
+              {
+                id: '2-3',
+                title: 'Permissions',
+              },
+            ],
+          },
+          {
+            id: '3',
+            title: 'Settings',
+            children: [
+              {
+                id: '3-1',
+                title: 'General',
+              },
+              {
+                id: '3-2',
+                title: 'Security',
+              },
+              {
+                id: '3-3',
+                title: 'Notifications',
+              },
+            ],
+          },
+          {
+            id: '4',
+            title: 'Help',
+            children: [
+              {
+                id: '4-1',
+                title: 'Documentation',
+              },
+              {
+                id: '4-2',
+                title: 'Support',
+              },
+            ],
+          },
+        ],
+      }
+    },
+  }
+</script>

--- a/packages/docs/src/examples/v-treeview/slot-toggle.vue
+++ b/packages/docs/src/examples/v-treeview/slot-toggle.vue
@@ -1,19 +1,31 @@
 <template>
   <v-treeview
-    v-model="model"
+    v-model:selected="model"
     :items="items"
     item-value="id"
     select-strategy="classic"
-    activatable
+    open-all
     selectable
   >
-    <template v-slot:toggle="{ props: toggleProps, isOpen, isSelected, isActive, isIndeterminate }">
-      <v-btn
-        v-bind="toggleProps"
-        :active="isOpen"
-        :color="isIndeterminate ? 'warning' : isSelected ? 'success' : isActive ? 'primary' : 'medium-emphasis'"
-        :variant="isOpen ? 'outlined' : 'tonal'"
-      ></v-btn>
+    <template v-slot:toggle="{ props: toggleProps, isOpen, isSelected, isIndeterminate, path, item }">
+      <v-badge
+        :color="isSelected ? 'success' : 'warning'"
+        :model-value="isSelected || isIndeterminate"
+      >
+        <template v-slot:badge>
+          <v-icon
+            v-if="isSelected"
+            icon="$complete"
+            v-tooltip="`All elements in ${item.title} are selected`"
+          ></v-icon>
+          <span v-if="isIndeterminate">{{ selectionsInfo(path) }}</span>
+        </template>
+        <v-btn
+          v-bind="toggleProps"
+          :color="isIndeterminate ? 'warning' : isSelected ? 'success' : 'medium-emphasis'"
+          :variant="isOpen ? 'outlined' : 'tonal'"
+        ></v-btn>
+      </v-badge>
     </template>
   </v-treeview>
 </template>
@@ -21,7 +33,21 @@
 <script setup>
   import { shallowRef } from 'vue'
 
-  const model = shallowRef()
+  const model = shallowRef([])
+
+  function selectionsInfo (path) {
+    const node = path.reduce((current, i) => current.children[i], { children: items })
+
+    const allLeafsIds = (function flatten (n) {
+      return n.children?.flatMap(flatten) ?? [n.id]
+    })(node)
+
+    const selectedCount = allLeafsIds
+      .filter(id => model.value.includes(id))
+      .length
+
+    return `${selectedCount}/${allLeafsIds.length}`
+  }
 
   const items = [
     {
@@ -36,55 +62,23 @@
           id: '1-2',
           title: 'Reports',
         },
-      ],
-    },
-    {
-      id: '2',
-      title: 'User Management',
-      children: [
         {
-          id: '2-1',
-          title: 'Users',
-        },
-        {
-          id: '2-2',
-          title: 'Roles',
-        },
-        {
-          id: '2-3',
-          title: 'Permissions',
-        },
-      ],
-    },
-    {
-      id: '3',
-      title: 'Settings',
-      children: [
-        {
-          id: '3-1',
-          title: 'General',
-        },
-        {
-          id: '3-2',
-          title: 'Security',
-        },
-        {
-          id: '3-3',
-          title: 'Notifications',
-        },
-      ],
-    },
-    {
-      id: '4',
-      title: 'Help',
-      children: [
-        {
-          id: '4-1',
-          title: 'Documentation',
-        },
-        {
-          id: '4-2',
-          title: 'Support',
+          id: '1-3',
+          title: 'Financial',
+          children: [
+            {
+              id: '1-3-1',
+              title: 'Budget',
+            },
+            {
+              id: '1-3-2',
+              title: 'Operations',
+            },
+            {
+              id: '1-3-3',
+              title: 'Costs',
+            },
+          ],
         },
       ],
     },
@@ -109,60 +103,43 @@
                 id: '1-2',
                 title: 'Reports',
               },
-            ],
-          },
-          {
-            id: '2',
-            title: 'User Management',
-            children: [
               {
-                id: '2-1',
-                title: 'Users',
-              },
-              {
-                id: '2-2',
-                title: 'Roles',
-              },
-              {
-                id: '2-3',
-                title: 'Permissions',
-              },
-            ],
-          },
-          {
-            id: '3',
-            title: 'Settings',
-            children: [
-              {
-                id: '3-1',
-                title: 'General',
-              },
-              {
-                id: '3-2',
-                title: 'Security',
-              },
-              {
-                id: '3-3',
-                title: 'Notifications',
-              },
-            ],
-          },
-          {
-            id: '4',
-            title: 'Help',
-            children: [
-              {
-                id: '4-1',
-                title: 'Documentation',
-              },
-              {
-                id: '4-2',
-                title: 'Support',
+                id: '1-3',
+                title: 'Financial',
+                children: [
+                  {
+                    id: '1-3-1',
+                    title: 'Budget',
+                  },
+                  {
+                    id: '1-3-2',
+                    title: 'Operations',
+                  },
+                  {
+                    id: '1-3-3',
+                    title: 'Costs',
+                  },
+                ],
               },
             ],
           },
         ],
       }
+    },
+    methods: {
+      selectionsInfo (path) {
+        const node = path.reduce((current, i) => current.children[i], { children: this.items })
+
+        const allLeafsIds = (function flatten (n) {
+          return n.children?.flatMap(flatten) ?? [n.id]
+        })(node)
+
+        const selectedCount = allLeafsIds
+          .filter(id => this.model.includes(id))
+          .length
+
+        return `${selectedCount}/${allLeafsIds.length}`
+      },
     },
   }
 </script>

--- a/packages/docs/src/pages/en/components/treeview.md
+++ b/packages/docs/src/pages/en/components/treeview.md
@@ -142,6 +142,12 @@ In this example we use a custom **title** slot to apply a line-through the treev
 
 <ExamplesExample file="v-treeview/slot-title" />
 
+#### Toggle
+
+Here, a custom **toggle** slot is utilized to assign a specific color and variant to the button depending on the state of the item.
+
+<ExamplesExample file="v-treeview/slot-toggle" />
+
 ## Examples
 
 The following are a collection of examples that demonstrate more advanced and real world use of the `v-treeview` component.

--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -14,8 +14,8 @@ import { genericComponent, omit, propsFactory, useRender } from '@/util'
 // Types
 import type { PropType } from 'vue'
 import { VTreeviewSymbol } from './shared'
+import type { VTreeviewChildrenSlots } from './VTreeviewChildren'
 import type { InternalListItem } from '@/components/VList/VList'
-import type { VListChildrenSlots } from '@/components/VList/VListChildren'
 import type { ListItem } from '@/composables/list-items'
 import type { GenericProps, IndentLinesVariant } from '@/util'
 
@@ -53,7 +53,7 @@ export const VTreeview = genericComponent<new <T>(
   props: {
     items?: T[]
   },
-  slots: VListChildrenSlots<T>
+  slots: VTreeviewChildrenSlots<T>
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VTreeview',
 

--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -147,7 +147,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
 
       const slotsWithItem = {
         toggle: slots.toggle
-          ? slotProps => slots.toggle?.({ ...slotProps, ...treeItemProps, item: item.raw, internalItem: item })
+          ? slotProps => slots.toggle?.({ ...slotProps, ...treeItemProps, item: item.raw, internalItem: item, loading })
           : undefined,
         prepend: slotProps => (
           <>

--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -15,14 +15,13 @@ import { genericComponent, getIndentLines, pick, propsFactory, renderSlot } from
 
 // Types
 import type { PropType } from 'vue'
-import type { ToggleListItemSlot } from './shared'
+import type { VTreeviewItemSlots } from './VTreeviewItem'
 import type { InternalListItem } from '@/components/VList/VList'
-import type { VListItemSlots } from '@/components/VList/VListItem'
 import type { SelectStrategyProp } from '@/composables/nested/nested'
 import type { GenericProps, IndentLinesVariant, IndentLineType } from '@/util'
 
 export type VTreeviewChildrenSlots<T> = {
-  [K in keyof Omit<VListItemSlots, 'default'>]: VListItemSlots[K] & {
+  [K in keyof Omit<VTreeviewItemSlots, 'default'>]: VTreeviewItemSlots[K] & {
     item: T
     internalItem: InternalListItem<T>
   }
@@ -39,7 +38,6 @@ export type VTreeviewChildrenSlots<T> = {
     internalItem: InternalListItem<T>
     loading: boolean
   }
-  toggle: ToggleListItemSlot
   divider: { props: InternalListItem['props'] }
   subheader: { props: InternalListItem['props'] }
 }
@@ -148,7 +146,9 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
       })
 
       const slotsWithItem = {
-        toggle: slots.toggle ? slotProps => slots.toggle?.(slotProps) : undefined,
+        toggle: slots.toggle
+          ? slotProps => slots.toggle?.({ ...slotProps, ...treeItemProps, item: item.raw, internalItem: item })
+          : undefined,
         prepend: slotProps => (
           <>
             { props.selectable && (!children || (children && !['leaf', 'single-leaf'].includes(props.selectStrategy as string))) && (

--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -15,6 +15,7 @@ import { genericComponent, getIndentLines, pick, propsFactory, renderSlot } from
 
 // Types
 import type { PropType } from 'vue'
+import type { ToggleListItemSlot } from './shared'
 import type { InternalListItem } from '@/components/VList/VList'
 import type { VListItemSlots } from '@/components/VList/VListItem'
 import type { SelectStrategyProp } from '@/composables/nested/nested'
@@ -38,6 +39,7 @@ export type VTreeviewChildrenSlots<T> = {
     internalItem: InternalListItem<T>
     loading: boolean
   }
+  toggle: ToggleListItemSlot
   divider: { props: InternalListItem['props'] }
   subheader: { props: InternalListItem['props'] }
 }
@@ -146,6 +148,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
       })
 
       const slotsWithItem = {
+        toggle: slots.toggle ? slotProps => slots.toggle?.(slotProps) : undefined,
         prepend: slotProps => (
           <>
             { props.selectable && (!children || (children && !['leaf', 'single-leaf'].includes(props.selectStrategy as string))) && (

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -2,8 +2,10 @@
 import './VTreeviewItem.sass'
 
 // Components
+import { VAvatar } from '@/components/VAvatar'
 import { VBtn } from '@/components/VBtn'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
+import { VIcon } from '@/components/VIcon'
 import { VListItemAction } from '@/components/VList'
 import { makeVListItemProps, VListItem } from '@/components/VList/VListItem'
 import { VProgressCircular } from '@/components/VProgressCircular'
@@ -14,15 +16,12 @@ import { IconValue } from '@/composables/icons'
 
 // Utilities
 import { computed, inject, ref, toRaw } from 'vue'
+import { VTreeviewSymbol } from './shared'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
-import { VTreeviewSymbol } from './shared'
 import type { ToggleListItemSlot } from './shared'
-import { VAvatar } from '../VAvatar'
-import { VDefaultsProvider } from '../VDefaultsProvider'
-import { VIcon } from '../VIcon'
 import type { VListItemSlots } from '@/components/VList/VListItem'
 import type { IndentLineType } from '@/util'
 

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -3,6 +3,7 @@ import './VTreeviewItem.sass'
 
 // Components
 import { VBtn } from '@/components/VBtn'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VListItemAction } from '@/components/VList'
 import { makeVListItemProps, VListItem } from '@/components/VList/VListItem'
 import { VProgressCircular } from '@/components/VProgressCircular'
@@ -18,6 +19,7 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 // Types
 import type { PropType } from 'vue'
 import { VTreeviewSymbol } from './shared'
+import type { ToggleListItemSlot } from './shared'
 import { VAvatar } from '../VAvatar'
 import { VDefaultsProvider } from '../VDefaultsProvider'
 import { VIcon } from '../VIcon'
@@ -34,7 +36,11 @@ export const makeVTreeviewItemProps = propsFactory({
   ...makeVListItemProps({ slim: true }),
 }, 'VTreeviewItem')
 
-export const VTreeviewItem = genericComponent<VListItemSlots>()({
+export type VTreeviewItemSlots = VListItemSlots & {
+  toggle: ToggleListItemSlot
+}
+
+export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
   name: 'VTreeviewItem',
 
   props: makeVTreeviewItemProps(),
@@ -118,23 +124,52 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
                   { !props.hideActions && (
                     <VListItemAction start>
                       { props.toggleIcon ? (
-                        <VBtn
-                          density="compact"
-                          icon={ props.toggleIcon }
-                          loading={ props.loading }
-                          variant="text"
-                          onClick={ onClickAction }
-                        >
-                          {{
-                            loader: () => (
-                              <VProgressCircular
-                                indeterminate="disable-shrink"
-                                size="20"
-                                width="2"
-                              />
-                            ),
-                          }}
-                        </VBtn>
+                        <>
+                          { !slots.toggle ? (
+                            <VBtn
+                              key="prepend-toggle"
+                              density="compact"
+                              icon={ props.toggleIcon }
+                              loading={ props.loading }
+                              variant="text"
+                              onClick={ onClickAction }
+                            >
+                              {{
+                                loader: () => (
+                                  <VProgressCircular
+                                    indeterminate="disable-shrink"
+                                    size="20"
+                                    width="2"
+                                  />
+                                ),
+                              }}
+                            </VBtn>
+                          ) : (
+                            <VDefaultsProvider
+                              key="prepend-defaults"
+                              defaults={{
+                                VBtn: {
+                                  density: 'compact',
+                                  icon: props.toggleIcon,
+                                  variant: 'text',
+                                  loading: props.loading,
+                                },
+                                VProgressCircular: {
+                                  indeterminate: 'disable-shrink',
+                                  size: 20,
+                                  width: 2,
+                                },
+                              }}
+                            >
+                              { slots.toggle({
+                                ...slotProps,
+                                props: {
+                                  onClick: onClickAction,
+                                },
+                              })}
+                            </VDefaultsProvider>
+                          )}
+                        </>
                       ) : (
                         <div class="v-treeview-item__level" />
                       )}

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -36,7 +36,7 @@ export const makeVTreeviewItemProps = propsFactory({
 }, 'VTreeviewItem')
 
 export type VTreeviewItemSlots = VListItemSlots & {
-  toggle: ToggleListItemSlot
+  toggle: ToggleListItemSlot & { loading: boolean }
 }
 
 export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
@@ -162,6 +162,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
                             >
                               { slots.toggle({
                                 ...slotProps,
+                                loading: props.loading,
                                 props: {
                                   onClick: onClickAction,
                                 },

--- a/packages/vuetify/src/components/VTreeview/shared.ts
+++ b/packages/vuetify/src/components/VTreeview/shared.ts
@@ -1,8 +1,13 @@
 // Types
 import type { ComputedRef, InjectionKey } from 'vue'
+import type { ListItemSlot } from '@/components/VList/VListItem'
 
 export interface TreeViewProvide {
   visibleIds: ComputedRef<Set<unknown> | null>
+}
+
+export type ToggleListItemSlot = ListItemSlot & {
+  props: { onClick: (e: PointerEvent) => void }
 }
 
 export const VTreeviewSymbol: InjectionKey<TreeViewProvide> = Symbol.for('vuetify:v-treeview')


### PR DESCRIPTION
fixes #20307

## Markup:

```vue
<template>
  <v-app>
    <v-container max-width="500">
      <v-alert text="Icon gets smaller with depth" type="info" />
      <v-treeview
        v-model="model"
        :items="items"
        collapse-icon="mdi-chevron-down"
        expand-icon="mdi-chevron-right"
        item-value="id"
        select-strategy="classic"
        open-all
        selectable
      >
        <template #toggle="{ props: toggleProps, depth }">
          <v-btn v-bind="toggleProps">
            <v-icon :size="24 - 2 * depth" />
          </v-btn>
        </template>

        <template #title="{ item }">
          <span class="text-caption">{{ item.title }}</span>
        </template>
      </v-treeview>
    </v-container>
  </v-app>
</template>

<script setup>
  import { computed, ref } from 'vue'

  const model = ref()

  const GetChildren = (id, depth) => {
    if (depth > 4) return undefined
    const nodes = []
    nodes.push({
      id: `${id}-${1}`,
      title: `Example child item ${id}-${1}`,
      children: GetChildren(`${id}-${1}`, depth + 1),
    })
    return nodes
  }

  const items = computed(() => {
    const nodes = []
    for (let i = 1; i <= 2; i++) {
      nodes.push({
        id: `${i}`,
        title: `Example item ${i}`,
        children: GetChildren(i, 0),
      })
    }
    return nodes
  })
</script>
```
