### PR TITLE
fix(VDateInput): use adapter date

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -88,11 +88,11 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
         const end = value[value.length - 1]
 
         return adapter.isValid(start) && adapter.isValid(end)
-          ? `${adapter.format(start, 'keyboardDate')} - ${adapter.format(end, 'keyboardDate')}`
+          ? `${adapter.format(adapter.date(start), 'keyboardDate')} - ${adapter.format(adapter.date(end), 'keyboardDate')}`
           : ''
       }
 
-      return adapter.isValid(model.value) ? adapter.format(model.value, 'keyboardDate') : ''
+      return adapter.isValid(model.value) ? adapter.format(adapter.date(model.value), 'keyboardDate') : ''
     })
 
     const isInteractive = computed(() => !props.disabled && !props.readonly)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

I tested it with luxon

fixes https://github.com/vuetifyjs/vuetify/issues/21033

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <main>
    <v-date-input />
    <v-date-input multiple="range" />
  </main>
</template>
```
