### PR TITLE
fix(VTextField): hide details with counter and hide-details="auto"

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -155,7 +155,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
 
     useRender(() => {
       const hasCounter = !!(slots.counter || (props.counter !== false && props.counter != null))
-      const hasDetails = !!(hasCounter || slots.details)
+      const hasDetails = !!((hasCounter && isFocused.value) || slots.details)
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const { modelValue: _, ...inputProps } = VInput.filterProps(props)
       const fieldProps = filterFieldProps(props)

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
@@ -90,6 +90,18 @@ describe('VTextField', () => {
     expect(element).toHaveTextContent('0')
   })
 
+  // https://github.com/vuetifyjs/vuetify/issues/19998
+  it('If hide-details and counter are set, render details only when focused', async () => {
+    const { element, queryByCSS } = render(() => (
+      <VTextField hide-details="auto" counter></VTextField>
+    ))
+
+    expect(queryByCSS('.v-input__details')).toBeNull()
+
+    await userEvent.click(element)
+    expect(queryByCSS('.v-input__details')).not.toBeNull()
+  })
+
   describe('Showcase', () => {
     generate({ stories })
   })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes https://github.com/vuetifyjs/vuetify/issues/19998

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <p>Counter only</p>
      <v-text-field
        v-model="msg"
        counter
        class="bg-indigo-lighten-2"
        :rules="[requiredValidator]"
        variant="outlined"
      />
      <p>With counter & hide details</p>
      <v-text-field
        v-model="msg"
        counter
        hide-details="auto"
        class="bg-indigo-lighten-2"
        :rules="[requiredValidator]"
        variant="outlined"
      />
      <p>Hide details normal behavior</p>
      <v-text-field
        v-model="msg"
        hide-details="auto"
        class="bg-indigo-lighten-2"
        :rules="[requiredValidator]"
        variant="outlined"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')

  const requiredValidator = value => {
    return !!String(value).trim().length || 'This field is required'
  }
</script>

```
