### PR TITLE
fix(VOTPInput): enable autofill support

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -268,7 +268,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                           disabled={ props.disabled }
                           inputmode={ props.type === 'number' ? 'numeric' : 'text' }
                           min={ props.type === 'number' ? 0 : undefined }
-                          maxlength={ i === 0 ? props.length : '1' }
+                          maxlength={ i === 0 ? length.value : '1' }
                           placeholder={ props.placeholder }
                           type={ props.type === 'number' ? 'text' : props.type }
                           value={ model.value[i] }

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -268,7 +268,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
                           disabled={ props.disabled }
                           inputmode={ props.type === 'number' ? 'numeric' : 'text' }
                           min={ props.type === 'number' ? 0 : undefined }
-                          maxlength="1"
+                          maxlength={ i === 0 ? props.length : '1' }
                           placeholder={ props.placeholder }
                           type={ props.type === 'number' ? 'text' : props.type }
                           value={ model.value[i] }


### PR DESCRIPTION
## Description
This PR enhances the `v-otp-input` component to properly support autofill functionality, particularly on mobile devices. The current implementation, with `maxlength="1"` on each input field, prevents browsers from recognizing and autofilling the entire OTP string.

This change modifies the component to set `maxlength` to the total number of OTP digits on the *first* input field only. This allows the browser to autofill the entire OTP string into the first input, while the component's existing logic correctly distributes the digits to the individual input fields. This approach was inspired by the solution described in https://stackoverflow.com/a/76906193/14799432.

**Previous attempts to address this issue by removing the `maxlength` attribute entirely (as suggested in https://github.com/vuetifyjs/vuetify/issues/18678#issuecomment-1997778980) resulted in a regression. While removing `maxlength` did enable autofill, it also allowed users to enter more than one digit on the last input field, leading to visual stacking of characters when more digits than expected were entered.**

This PR resolves #18678 while avoiding that regression by only modifying the `maxlength` of the *first* input.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input v-model="otp" />
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const otp = ref('')
      return {
        otp,
      }
    },
  }
</script>
```
