### PR TITLE
fix(VDataTableRow): provide correct defaults for special slots

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -148,7 +148,6 @@ export const VDataTableRow = genericComponent<new <T>(
                           VCheckboxBtn: {
                             disabled: !item.selectable,
                             modelValue: isSelected([item]),
-                            onClick: withModifiers(() => toggleSelect(item), ['stop']),
                           },
                         }}
                       >

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -2,7 +2,6 @@
 import { VDataTableColumn } from './VDataTableColumn'
 import { VBtn } from '@/components/VBtn'
 import { VCheckboxBtn } from '@/components/VCheckbox'
-import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 
 // Composables
 import { useExpanded } from './composables/expand'
@@ -142,23 +141,14 @@ export const VDataTableRow = genericComponent<new <T>(
               {{
                 default: () => {
                   if (column.key === 'data-table-select') {
-                    return slots['item.data-table-select'] ? (
-                      <VDefaultsProvider
-                        defaults={{
-                          VCheckboxBtn: {
-                            disabled: !item.selectable,
-                            modelValue: isSelected([item]),
-                          },
-                        }}
-                      >
-                        { slots['item.data-table-select']?.({
-                          ...slotProps,
-                          props: {
-                            onClick: withModifiers(() => toggleSelect(item), ['stop']),
-                          },
-                        })}
-                      </VDefaultsProvider>
-                    ) : (
+                    return slots['item.data-table-select']?.({
+                      ...slotProps,
+                      props: {
+                        disabled: !item.selectable,
+                        modelValue: isSelected([item]),
+                        onClick: withModifiers(() => toggleSelect(item), ['stop']),
+                      },
+                    }) ?? (
                       <VCheckboxBtn
                         disabled={ !item.selectable }
                         modelValue={ isSelected([item]) }
@@ -168,24 +158,15 @@ export const VDataTableRow = genericComponent<new <T>(
                   }
 
                   if (column.key === 'data-table-expand') {
-                    return slots['item.data-table-expand'] ? (
-                      <VDefaultsProvider
-                        defaults={{
-                          VBtn: {
-                            icon: isExpanded(item) ? '$collapse' : '$expand',
-                            size: 'small',
-                            variant: 'text',
-                          },
-                        }}
-                      >
-                        { slots['item.data-table-expand']?.({
-                          ...slotProps,
-                          props: {
-                            onClick: withModifiers(() => toggleExpand(item), ['stop']),
-                          },
-                        })}
-                      </VDefaultsProvider>
-                    ) : (
+                    return slots['item.data-table-expand']?.({
+                      ...slotProps,
+                      props: {
+                        icon: isExpanded(item) ? '$collapse' : '$expand',
+                        size: 'small',
+                        variant: 'text',
+                        onClick: withModifiers(() => toggleExpand(item), ['stop']),
+                      },
+                    }) ?? (
                       <VBtn
                         icon={ isExpanded(item) ? '$collapse' : '$expand' }
                         size="small"

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -22,7 +22,7 @@ import type { VDataTableHeaderCellColumnSlotProps } from './VDataTableHeaders'
 import type { GenericProps } from '@/util'
 
 export type VDataTableItemCellColumnSlotProps<T> = Omit<ItemKeySlot<T>, 'value'> & {
-  props: { onClick: (e: MouseEvent) => void }
+  props: Record<string, unknown>
 }
 
 export type VDataTableRowSlots<T> = {


### PR DESCRIPTION
When using the special **item.data-table-select** and **item.data-table-expand** slots, would always return at:

![image](https://github.com/user-attachments/assets/27ab8a38-1a32-449a-81fc-618451955790)

and never actually get to the code that called **slots['item.data-table-expand']** or select.

Since I was fixing that, I brought the slots in line with how we handle defaults in other components, so that you can actually modify these with relative ease now.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container class="pa-md-12">
    <v-data-table :items="items" show-expand show-select>
      <template #item.data-table-select="{ props: selectProps }">
        <v-checkbox-btn v-bind="selectProps" />
      </template>

      <template #item.data-table-expand="{ props: expandProps }">
        <v-btn v-bind="expandProps" />
      </template>

      <template #expanded-row="{ columns, item }">
        <tr>
          <td :colspan="columns.length">
            I'm expanded for item {{ item.id }}!
          </td>
        </tr>
      </template>
    </v-data-table>
  </v-container>
</template>

<script setup>
  const items = [
    { id: 'John', age: 42 },
    { id: 'Jane', age: 36 },
    { id: 'Joe', age: 30 },
  ]
</script>
```
