### PR TITLE
refactor(VField): default slot fallback

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -312,7 +312,13 @@ export const VField = genericComponent<new <T>(
               },
               focus,
               blur,
-            } as VFieldSlot)}
+            } as VFieldSlot) ?? (
+              <div
+                id={ id.value }
+                class="v-field__input"
+                aria-describedby={ messagesId.value }
+              />
+            )}
           </div>
 
           { hasClear && (


### PR DESCRIPTION
A small QOL change for working with VField.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-input>
        <v-field
          append-icon="$vuetify"
          label="Foobar"
          prepend-icon="$vuetify"
        />

        <v-menu activator="parent" eager>
          <v-list v-model:selected="selected">
            <v-list-item title="Foobar" value="one" />
            <v-list-item title="Foobar" value="two" />
          </v-list>
        </v-menu>
      </v-input>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const file = ref()
  const isFocused = ref(false)

  const selected = ref([])
</script>

```
