### PR TITLE
fix(VField): add type assertion for props access

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -410,6 +410,6 @@ export type VField = InstanceType<typeof VField>
 
 // TODO: this is kinda slow, might be better to implicitly inherit props instead
 export function filterFieldProps (attrs: Record<string, unknown>) {
-  const keys = Object.keys(VField.props).filter(k => !isOn(k) && k !== 'class' && k !== 'style')
+  const keys = Object.keys(VField.props!).filter(k => !isOn(k) && k !== 'class' && k !== 'style')
   return pick(attrs, keys)
 }


### PR DESCRIPTION
👋 Component props option is exposed in https://github.com/vuejs/core/pull/12935, and since `VField.props` type is no longer any, it requires the type assertion to be passing the TS test.