### PR TITLE
fix(theme): support unhead v2

### DIFF
--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -294,7 +294,7 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
   function getHead () {
     return {
       style: [{
-        children: styles.value,
+        textContent: styles.value,
         id: 'vuetify-theme-stylesheet',
         nonce: parsedOptions.cspNonce || false as never,
       }],


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This PR writes the Vuetify style tag using `textContent` instead `children`, `children` is deprecated in the current version used here (`1.9.4` ).

Latest Nuxt version 3.16.0 using `unhead v2 rc` and the vuetify style tag without content, just the children attribute with all the css.

Check https://github.com/vuetifyjs/nuxt-module/issues/298

fixes #21112

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
Use the default playground and check the style is there.

![image](https://github.com/user-attachments/assets/4f0e22b1-8485-45d2-bc34-2137a9bbf748)
_using textContent instead children_

![image](https://github.com/user-attachments/assets/f93c74d4-ecd0-4d1a-ab46-83d13e148863)
_vuetify style in the dom_
