### PR TITLE
refactor(group/layout/helpers): remove findChildrenWithProvide reliance

### DIFF
--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -3,7 +3,7 @@ import { useProxiedModel } from './proxiedModel'
 
 // Utilities
 import { computed, inject, onBeforeUnmount, onMounted, onUpdated, provide, reactive, toRef, unref, useId, watch } from 'vue'
-import { consoleWarn, deepEqual, findChildrenWithProvide, getCurrentInstance, propsFactory, wrapInArray } from '@/util'
+import { consoleWarn, deepEqual, getCurrentInstance, propsFactory, wrapInArray } from '@/util'
 
 // Types
 import type { ComponentInternalInstance, ComputedRef, ExtractPropTypes, InjectionKey, PropType, Ref, UnwrapRef } from 'vue'
@@ -180,26 +180,16 @@ export function useGroup (
     }
   )
 
-  const groupVm = getCurrentInstance('useGroup')
-
-  function register (item: GroupItem, vm: ComponentInternalInstance) {
+  function register (item: GroupItem) {
     // Is there a better way to fix this typing?
     const unwrapped = item as unknown as UnwrapRef<GroupItem>
 
-    const key = Symbol.for(`${injectKey.description}:id`)
-    const children = findChildrenWithProvide(key, groupVm?.vnode)
-    const index = children.indexOf(vm)
-
     if (unref(unwrapped.value) == null) {
-      unwrapped.value = index
+      unwrapped.value = items.length
       unwrapped.useIndexAsValue = true
     }
 
-    if (index > -1) {
-      items.splice(index, 0, unwrapped)
-    } else {
-      items.push(unwrapped)
-    }
+    items.push(unwrapped)
   }
 
   function unregister (id: string) {

--- a/packages/vuetify/src/composables/layout.ts
+++ b/packages/vuetify/src/composables/layout.ts
@@ -15,10 +15,10 @@ import {
   shallowRef,
   useId,
 } from 'vue'
-import { convertToUnit, findChildrenWithProvide, getCurrentInstance, propsFactory } from '@/util'
+import { convertToUnit, propsFactory } from '@/util'
 
 // Types
-import type { ComponentInternalInstance, CSSProperties, InjectionKey, Prop, Ref } from 'vue'
+import type { CSSProperties, InjectionKey, Prop, Ref } from 'vue'
 
 export type Position = 'top' | 'left' | 'right' | 'bottom'
 
@@ -37,7 +37,6 @@ interface LayoutItem extends Layer {
 
 interface LayoutProvide {
   register: (
-    vm: ComponentInternalInstance,
     options: {
       id: string
       order: Ref<number>
@@ -115,8 +114,6 @@ export function useLayoutItem (options: {
 
   const id = options.id ?? `layout-item-${useId()}`
 
-  const vm = getCurrentInstance('useLayoutItem')
-
   provide(VuetifyLayoutItemKey, { id })
 
   const isKeptAlive = shallowRef(false)
@@ -126,7 +123,7 @@ export function useLayoutItem (options: {
   const {
     layoutItemStyles,
     layoutItemScrimStyles,
-  } = layout.register(vm, {
+  } = layout.register({
     ...options,
     active: computed(() => isKeptAlive.value ? false : options.active.value),
     id,
@@ -246,8 +243,6 @@ export function createLayout (props: { overlaps?: string[], fullHeight?: boolean
     return items.value.find(item => item.id === id)
   }
 
-  const rootVm = getCurrentInstance('createLayout')
-
   const isMounted = shallowRef(false)
   onMounted(() => {
     isMounted.value = true
@@ -255,7 +250,6 @@ export function createLayout (props: { overlaps?: string[], fullHeight?: boolean
 
   provide(VuetifyLayoutKey, {
     register: (
-      vm: ComponentInternalInstance,
       {
         id,
         order,
@@ -273,11 +267,7 @@ export function createLayout (props: { overlaps?: string[], fullHeight?: boolean
       activeItems.set(id, active)
       disableTransitions && disabledTransitions.set(id, disableTransitions)
 
-      const instances = findChildrenWithProvide(VuetifyLayoutItemKey, rootVm?.vnode)
-      const instanceIndex = instances.indexOf(vm)
-
-      if (instanceIndex > -1) registered.value.splice(instanceIndex, 0, id)
-      else registered.value.push(id)
+      registered.value.push(id)
 
       const index = computed(() => items.value.findIndex(i => i.id === id))
       const zIndex = computed(() => rootZIndex.value + (layers.value.length * 2) - (index.value * 2))

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -4,16 +4,13 @@ import { IN_BROWSER } from '@/util/globals'
 
 // Types
 import type {
-  ComponentInternalInstance,
   ComponentPublicInstance,
   ComputedGetter,
-  InjectionKey,
   PropType,
   Ref,
   ToRefs,
   VNode,
   VNodeArrayChildren,
-  VNodeChild,
   WatchOptions,
 } from 'vue'
 
@@ -526,29 +523,6 @@ export function toKebabCase (str = '') {
 toKebabCase.cache = new Map<string, string>()
 
 export type MaybeRef<T> = T | Ref<T>
-
-export function findChildrenWithProvide (
-  key: InjectionKey<any> | symbol,
-  vnode?: VNodeChild,
-): ComponentInternalInstance[] {
-  if (!vnode || typeof vnode !== 'object') return []
-
-  if (Array.isArray(vnode)) {
-    return vnode.map(child => findChildrenWithProvide(key, child)).flat(1)
-  } else if (vnode.suspense) {
-    return findChildrenWithProvide(key, vnode.ssContent!)
-  } else if (Array.isArray(vnode.children)) {
-    return vnode.children.map(child => findChildrenWithProvide(key, child)).flat(1)
-  } else if (vnode.component) {
-    if (Object.getOwnPropertySymbols(vnode.component.provides).includes(key as symbol)) {
-      return [vnode.component]
-    } else if (vnode.component.subTree) {
-      return findChildrenWithProvide(key, vnode.component.subTree).flat(1)
-    }
-  }
-
-  return []
-}
 
 export class CircularBuffer<T = never> {
   readonly #arr: Array<T> = []


### PR DESCRIPTION
Apparently this will break Vue vapor mode. I removed it's usage in layout and group and everything seems to still work fine. Docs are a bit jacked up but that could be something we're doing wrong. Needs more investigation but this is at least a start. There are obviously some issues and 2 unit tests fail.

This is to get the conversation going.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card>
    <v-layout>
      <v-app-bar color="primary">
        <v-app-bar-nav-icon variant="text" @click.stop="drawer = !drawer" />

        <v-toolbar-title>My files</v-toolbar-title>

        <v-spacer />

        <template v-if="$vuetify.display.mdAndUp">
          <v-btn icon="mdi-magnify" variant="text" />

          <v-btn icon="mdi-filter" variant="text" />
        </template>

        <v-btn icon="mdi-dots-vertical" variant="text" />
      </v-app-bar>

      <v-navigation-drawer
        v-model="drawer"
        :location="$vuetify.display.mobile ? 'bottom' : undefined"
        temporary
      >
        <v-list
          :items="items"
        />
      </v-navigation-drawer>

      <v-main style="height: 500px;">
        <v-card-text>
          The navigation drawer will appear from the bottom on smaller size screens.
        </v-card-text>
      </v-main>
    </v-layout>
  </v-card>
</template>
<script setup>
  import { ref, watch } from 'vue'

  const items = [
    {
      title: 'Foo',
      value: 'foo',
    },
    {
      title: 'Bar',
      value: 'bar',
    },
    {
      title: 'Fizz',
      value: 'fizz',
    },
    {
      title: 'Buzz',
      value: 'buzz',
    },
  ]

  const drawer = ref(false)
  const group = ref(null)

  watch(group, () => {
    drawer.value = false
  })
</script>

```
