### PR TITLE
docs(api): clarify borderColor usage of VAlert

### DIFF
--- a/packages/api-generator/src/locale/en/VAlert.json
+++ b/packages/api-generator/src/locale/en/VAlert.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "border": "Adds a colored border to the component.",
-    "borderColor": "Specifies the color of the border. Accepts any color value.",
+    "borderColor": "Specifies the color of the border. Only used in combination with **border** prop. Accepts any color value.",
     "closable": "Adds a close icon that can hide the alert.",
     "closeIcon": "Change the default icon used for **closable** alerts.",
     "closeLabel": "Text used for *aria-label* on **closable** alerts. Can also be customized globally in [Internationalization](/customization/internationalization).",


### PR DESCRIPTION
resolves #21100

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Currently it is not clear that the **borderProp** of the [VAlert](https://vuetifyjs.com/en/api/v-alert/#props-border-color) does nothing if not combined with the **border** prop.
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->