### PR TITLE
fix(VSlideGroup): check hasAffixes in hasNext computed property

### DIFF
--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -377,7 +377,7 @@ export const VSlideGroup = genericComponent<new <T>(
     })
 
     const hasNext = computed(() => {
-      if (!containerRef.value) return false
+      if (!containerRef.value || !hasAffixes.value) return false
 
       const scrollSize = getScrollSize(isHorizontal.value, containerRef.el)
       const clientSize = getClientSize(isHorizontal.value, containerRef.el)


### PR DESCRIPTION
fixes #21115

## Description
Fixes issue #21115 where `hasNext` computed property in VSlideGroup only checks if `containerRef.value` exists before determining whether to enable the next affix. However, it doesn't take into account whether arrows/affixes
should be displayed at all based on the current `hasAffixes` state (which can be simulated by resizing the components container, leading to the issue).

## Changes
Modified `hasNext` computed property to return false when affixes aren't visible:
```js
const hasNext = computed(() => {
  if (!containerRef.value || !hasAffixes.value) return false
  // ... rest 
})

## Markup:
[playground](https://play.vuetifyjs.com/#eNq1VU1v1DAQ/StDLoBENgVUqQpbRDkhBEdOlIObeDcGf8meZLuq+t8ZO8nGm+yCRMWlXc+bzLw3Mx5/f8i8q4oba1ddy7MyWyNXVjLk7281wLrLmbXxZzxUzNXDKZ4l25sWD5Zo06wTW4bC6Lx2bMfdhAJ0uTI1l9e32YBlKVo6JgIW/h0jljvFNNeYGj9UUlS/Bn+4hg2TnqffJcR6usJjLkhhaqfgjluu65x1DJmjeA2i9WVROKZro1rP3UrxgllRWOOQsqEvFNfF1eXqp90eMwVAgZJTlM+m0fCFi3ouE4BqlBqOeBLTsQdULi8NltQD4jfzioruUM+tAKIymvKrWuRVwztHnZB8g3MSsR/MCaaRvJHfn/Toi7zyaOxU6WfLDkUd6yJSmuspjoZqMicdIWTWrFp0oXQx5vh74RS+h5prL3BP9CqjLKtIR6jwnMXZ/k8TkFSuMYrnFYVdyhwb/IlclmjHZBvQEGCORjGp5icQZFVlWroQZ+l93cPNOZ+R5Jkg/4FnvnWmtTmtCyn0ibKNrL/RbfPnCYfLuID/QHdE0h1FpsWSOhotUqiY0OBxHzk1XGwbLOHN5YW9v83ma4W0IrnHILNCeUlz20sH35hdzpwzO3/qKieup6oevegeQCWZ93HWh6xE6GZdELSMSkr/GvaJqT/+c+qZy6Jtp8oa7KE10yMU+pu+QvHL8ZkKh/4BO9pBdPSVExbBcxwyCxV2OzyA4xt4hI0zCp7Tm/i8HwwiEzZNnBVagOT0Al3LX07YsBoTZF30WYaMYZhiqtVBGTz0pHeixqaEtxc0X+9602HmEtudcbQFS3ht78EbKh1lqwdMMbcVuoSrg7dldS30djI9RkoDjezxlW6ljH9+/AaXZ0u7)

