### PR TITLE
docs: added missing IconAliases properties

### DIFF
--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -506,6 +506,8 @@ const aliases: IconAliases = {
   checkboxOff: '...',
   checkboxIndeterminate: '...',
   delimiter: '...',
+  sortAsc: '...',
+  sortDesc: '...',
   sort: '...',
   expand: '...',
   menu: '...',
@@ -524,6 +526,7 @@ const aliases: IconAliases = {
   file: '...',
   plus: '...',
   minus: '...',
+  calendar:  '...',
 }
 
 const custom: IconSet = {


### PR DESCRIPTION
## Description
Added missing properties 'sortAsc', 'sortDesc' & 'calendar' to custom icon set aliases docs example [[here](https://vuetifyjs.com/en/features/icon-fonts/#creating-a-custom-icon-set)]

fixes type error:
<img width="1095" alt="Screenshot 2025-03-19 at 10 49 20" src="https://github.com/user-attachments/assets/93d70511-d2ab-4656-9505-0a30e31e8e77" />

