### PR TITLE
fix(VDataTable): enable expand when return-object is true

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/expand.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/expand.ts
@@ -40,20 +40,24 @@ export function provideExpanded (props: ExpandProps) {
     return [...v.values()]
   })
 
+  function getValue (item: DataTableItem) {
+    return typeof item.value === 'string' ? item.value : item.key
+  }
+
   function expand (item: DataTableItem, value: boolean) {
     const newExpanded = new Set(expanded.value)
 
     if (!value) {
-      newExpanded.delete(item.value)
+      newExpanded.delete(getValue(item))
     } else {
-      newExpanded.add(item.value)
+      newExpanded.add(getValue(item))
     }
 
     expanded.value = newExpanded
   }
 
   function isExpanded (item: DataTableItem) {
-    return expanded.value.has(item.value)
+    return expanded.value.has(getValue(item))
   }
 
   function toggleExpand (item: DataTableItem) {

--- a/packages/vuetify/src/components/VDataTable/composables/expand.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/expand.ts
@@ -3,7 +3,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { inject, provide, toRef } from 'vue'
-import { propsFactory } from '@/util'
+import { isObject, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, PropType, Ref } from 'vue'
@@ -40,24 +40,24 @@ export function provideExpanded (props: ExpandProps) {
     return [...v.values()]
   })
 
-  function getValue (item: DataTableItem) {
-    return typeof item.value === 'string' ? item.value : item.key
+  function getItemKey (item: DataTableItem) {
+    return isObject(item.value) ? item.key : item.value
   }
 
   function expand (item: DataTableItem, value: boolean) {
     const newExpanded = new Set(expanded.value)
 
     if (!value) {
-      newExpanded.delete(getValue(item))
+      newExpanded.delete(getItemKey(item))
     } else {
-      newExpanded.add(getValue(item))
+      newExpanded.add(getItemKey(item))
     }
 
     expanded.value = newExpanded
   }
 
   function isExpanded (item: DataTableItem) {
-    return expanded.value.has(getValue(item))
+    return expanded.value.has(getItemKey(item))
   }
 
   function toggleExpand (item: DataTableItem) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes https://github.com/vuetifyjs/vuetify/issues/21096

Changed to use key when it's an object.
There might be a better function name.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    :headers="headers"
    :items="movies"
    item-value="title"
    hide-default-footer
    return-object
    show-expand
  >
    <template
      v-slot:item.data-table-expand="{ internalItem, isExpanded, toggleExpand }"
    >
      <v-btn
        :append-icon="isExpanded(internalItem) ? 'mdi-chevron-up' : 'mdi-chevron-down'"
        :text="isExpanded(internalItem) ? 'Collapse' : 'More info'"
        class="text-none"
        color="medium-emphasis"
        size="small"
        variant="text"
        border
        slim
        @click="toggleExpand(internalItem)"
      ></v-btn>
    </template>

    <template v-slot:expanded-row="{ columns, item }">
      <tr>
        <td :colspan="columns.length" class="py-2">
          <v-sheet rounded="lg" border>
            <v-table density="compact">
              <tbody class="bg-surface-light">
                <tr>
                  <th>Rating</th>
                  <th>Synopsis</th>
                  <th>Cast</th>
                </tr>
              </tbody>

              <tbody>
                <tr>
                  <td>
                    <v-rating
                      :model-value="item.details.rating"
                      color="orange-darken-2"
                      density="comfortable"
                      size="x-small"
                      half-increments
                      readonly
                    ></v-rating>
                  </td>
                  <td>{{ item.details.synopsis }}</td>
                  <td>{{ item.details.cast.join(', ') }}</td>
                </tr>
              </tbody>
            </v-table>
          </v-sheet>
        </td>
      </tr>
    </template>
  </v-data-table>
</template>

<script setup>
  const headers = [
    { title: 'Title', key: 'title', align: 'start', sortable: true },
    { title: 'Director', key: 'director' },
    { title: 'Genre', key: 'genre' },
    { title: 'Year', key: 'year', align: 'end' },
    { title: 'Runtime(min)', key: 'runtime', align: 'end' },
  ]

  const movies = [
    {
      title: 'The Shawshank Redemption',
      director: 'Frank Darabont',
      genre: 'Drama',
      year: 1994,
      runtime: 142,
      details: {
        synopsis:
          'Two imprisoned men bond over years, finding solace and redemption through acts of decency.',
        cast: ['Tim Robbins', 'Morgan Freeman'],
        rating: 3.5,
      },
    },
    {
      title: 'Inception',
      director: 'Christopher Nolan',
      genre: 'Sci-Fi',
      year: 2010,
      runtime: 148,
      details: {
        synopsis:
          'A thief with the ability to enter dreams is tasked with stealing a secret from the subconscious.',
        cast: ['Leonardo DiCaprio', 'Joseph Gordon-Levitt'],
        rating: 5,
      },
    },
    {
      title: 'The Godfather',
      director: 'Francis Ford Coppola',
      genre: 'Crime',
      year: 1972,
      runtime: 175,
      details: {
        synopsis:
          'The aging patriarch of a crime dynasty transfers control to his reluctant son.',
        cast: ['Marlon Brando', 'Al Pacino'],
        rating: 4.5,
      },
    },
    {
      title: 'Pulp Fiction',
      director: 'Quentin Tarantino',
      genre: 'Crime',
      year: 1994,
      runtime: 154,
      details: {
        synopsis:
          'Interwoven stories of criminals, violence, and redemption in Los Angeles.',
        cast: ['John Travolta', 'Samuel L. Jackson'],
        rating: 4.5,
      },
    },
    {
      title: 'The Dark Knight',
      director: 'Christopher Nolan',
      genre: 'Action',
      year: 2008,
      runtime: 152,
      details: {
        synopsis:
          'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.',
        cast: ['Christian Bale', 'Heath Ledger'],
        rating: 4,
      },
    },
  ]
</script>

```
