### PR TITLE
docs(VInput): remove unused script section

### DIFF
--- a/packages/docs/src/examples/v-input/usage.vue
+++ b/packages/docs/src/examples/v-input/usage.vue
@@ -17,20 +17,6 @@
   </v-container>
 </template>
 
-<script>
-  export default {
-    data () {
-      return {
-        text: '',
-      }
-    },
-    methods: {
-      appendIconCallback () {},
-      prependIconCallback () {},
-    },
-  }
-</script>
-
 <style>
   #input-usage .v-input__prepend-outer,
   #input-usage .v-input__append-outer,


### PR DESCRIPTION
## Description
This script section appears to be unnecessary in this example, as the declared variables and functions are not being utilized, so I removed the script section.