### PR TITLE
fix(VWindow, VTabs): don't override cursor in VWindowItem

### DIFF
--- a/packages/vuetify/src/composables/transition.ts
+++ b/packages/vuetify/src/composables/transition.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { h, mergeProps, Transition, TransitionGroup } from 'vue'
-import { propsFactory } from '@/util'
+import { onlyDefinedProps, propsFactory } from '@/util'
 
 // Types
 import type { Component, FunctionalComponent, PropType, TransitionProps } from 'vue'
@@ -35,7 +35,7 @@ export const MaybeTransition: FunctionalComponent<MaybeTransitionProps> = (props
         : customProps as any,
       typeof transition === 'string'
         ? {}
-        : Object.fromEntries(Object.entries({ disabled, group }).filter(([_, v]) => v !== undefined)),
+        : onlyDefinedProps({ disabled, group }),
       rest as any,
     ),
     slots

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -767,3 +767,9 @@ export type Primitive = string | number | boolean | symbol | bigint
 export function isPrimitive (value: unknown): value is Primitive {
   return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint'
 }
+
+export function onlyDefinedProps (props: Record<string, any>) {
+  const booleanAttributes = ['checked', 'disabled']
+  return Object.fromEntries(Object.entries(props)
+    .filter(([key, v]) => booleanAttributes.includes(key) ? !!v : v !== undefined))
+}


### PR DESCRIPTION
## Description

`disabled` attribute is handled by Vue differently when used on actual `<input>` or `<button>`. It would be great to make it consistent (i.e. make it upstream Vue.js concern), but for now a simple enhancement extracted into reusable helper function should suffice.

CSS rule `[disabled] { cursor: default; }` is part of the `_reset.scss` and I'd rather keep it.

fixes #20090

- [x] verified against regression (#19446)
- includes `checked` to make helper function future-proof (see [HTML spec](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes))

## Markup:

```vue
<template>
  <v-app>
    <v-container class="d-flex flex-column ga-5 py-16">
      <p>
        <b>Outside <v-code>&lt;v-window-item&gt;</v-code></b>
        : This is some text that has a text-selection cursor.
      </p>
      <v-window>
        <v-window-item>
          <p>
            <b>Inside <v-code>&lt;v-window-item&gt;</v-code></b>
            : This text should have a text-selection cursor too.
          </p>
        </v-window-item>
      </v-window>
    </v-container>
  </v-app>
</template>
```