### PR TITLE
fix(VPagination): adapt button width for large values

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -234,6 +234,9 @@
   // VPagination
   .v-pagination
     .v-btn
+      width: auto
+      padding-inline: $button-pagination-padding-inline
+      @include button-density('min-width', $button-icon-density)
       @include tools.rounded($button-pagination-border-radius)
 
       &--rounded
@@ -241,6 +244,12 @@
 
       &__overlay
         transition: none
+
+    &__prev,
+    &__next
+      .v-btn
+        padding-inline: 0
+        @include button-density('width', $button-icon-density)
 
     .v-pagination__item--is-active .v-btn__overlay
       opacity: $button-pagination-active-overlay-opacity

--- a/packages/vuetify/src/components/VBtn/_variables.scss
+++ b/packages/vuetify/src/components/VBtn/_variables.scss
@@ -12,7 +12,7 @@ $button-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !
 $button-banner-actions-padding: 0 8px !default; // @deprecated
 $button-pagination-active-overlay-opacity: var(--v-border-opacity) !default;
 $button-pagination-border-radius: settings.$border-radius-root !default;
-$button-pagination-padding-inline: .75em !default;
+$button-pagination-padding-inline: 5px !default;
 $button-pagination-rounded-border-radius: map.get(settings.$rounded, 'circle') !default;
 $button-border-color: settings.$border-color-root !default;
 $button-border-radius: settings.$border-radius-root !default;

--- a/packages/vuetify/src/components/VBtn/_variables.scss
+++ b/packages/vuetify/src/components/VBtn/_variables.scss
@@ -12,6 +12,7 @@ $button-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !
 $button-banner-actions-padding: 0 8px !default; // @deprecated
 $button-pagination-active-overlay-opacity: var(--v-border-opacity) !default;
 $button-pagination-border-radius: settings.$border-radius-root !default;
+$button-pagination-padding-inline: .75em !default;
 $button-pagination-rounded-border-radius: map.get(settings.$rounded, 'circle') !default;
 $button-border-color: settings.$border-color-root !default;
 $button-border-radius: settings.$border-radius-root !default;


### PR DESCRIPTION
## Description

fixes #20120

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <v-col>
          <v-number-input v-model="page" label="page" />
        </v-col>
        <v-col>
          <v-select v-model="density" :items="densityOptions" label="density" return-object />
        </v-col>
        <v-col>
          <v-select v-model="rounded" :items="roundedOptions" label="rounded" return-object />
        </v-col>
      </v-row>

      <v-pagination
        v-model="page"
        :density="density.value"
        :length="244444"
        :rounded="rounded.value"
        :total-visible="page > 10000 ? 4 : page > 1000 ? 5 : page > 100 ? 6 : 7"
        class="my-12"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'
  const page = ref(1)

  interface DensityOption { title: string, value: 'compact' | 'comfortable' | undefined }
  const densityOptions = [...['compact', 'comfortable'].map(x => ({ title: x, value: x } as DensityOption)), { title: '(default)', value: undefined }]
  const density = ref<DensityOption>(densityOptions.at(-1)!)

  interface RoundedOption { title: string, value: 'sm' | 'xl' | 'pill' | undefined }
  const roundedOptions = [...['sm', 'xl', 'pill'].map(x => ({ title: x, value: x } as RoundedOption)), { title: '(default)', value: undefined }]
  const rounded = ref<RoundedOption>(roundedOptions.at(-1)!)
</script>
```
