### PR TITLE
fix(location-strategies): infinite loop on update location

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -309,7 +309,10 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     let x = 0; let y = 0
     const flipped = { x: false, y: false }
     const available = { x: 0, y: 0 }
+
     // Make the retry max x2 to get the correct position
+    // Addition happens on resizeObserver see line 207
+    // eslint-disable-next-line no-unmodified-loop-condition
     while (retries < 2) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
@@ -402,14 +405,14 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       maxWidth: available.x > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.x, minWidth.value === Infinity
-          ? 0
-          : minWidth.value, maxWidth.value))
+            ? 0
+            : minWidth.value, maxWidth.value))
         ),
       maxHeight: available.y > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.y, minHeight.value === Infinity
-          ? 0
-          : minHeight.value, maxHeight.value))
+            ? 0
+            : minHeight.value, maxHeight.value))
         ),
     })
 

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -151,7 +151,7 @@ let retries = 0
 let previousX = 0
 let previousY = 0
 
-function connectedLocationStrategy(data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
+function connectedLocationStrategy (data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
   const activatorFixed = Array.isArray(data.target.value) || isFixedPosition(data.target.value)
   if (activatorFixed) {
     Object.assign(contentStyles.value, {
@@ -310,7 +310,7 @@ function connectedLocationStrategy(data: LocationStrategyData, props: StrategyPr
     const flipped = { x: false, y: false }
     const available = { x: 0, y: 0 }
     // Make the retry max x2 to get the correct position
-    while (true && retries < 2) {
+    while (retries < 2) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
       x += _x
@@ -399,8 +399,18 @@ function connectedLocationStrategy(data: LocationStrategyData, props: StrategyPr
       left: data.isRtl.value ? undefined : convertToUnit(pixelRound(x > 0 ? x : previousX)),
       right: data.isRtl.value ? convertToUnit(pixelRound(x > 0 ? -x : -previousX)) : undefined,
       minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value),
-      maxWidth: available.x > 0 && convertToUnit(pixelCeil(clamp(available.x, minWidth.value === Infinity ? 0 : minWidth.value, maxWidth.value))),
-      maxHeight: available.y > 0 && convertToUnit(pixelCeil(clamp(available.y, minHeight.value === Infinity ? 0 : minHeight.value, maxHeight.value))),
+      maxWidth: available.x > 0 &&
+        convertToUnit(pixelCeil(clamp(
+          available.x, minWidth.value === Infinity
+          ? 0
+          : minWidth.value, maxWidth.value))
+        ),
+      maxHeight: available.y > 0 &&
+        convertToUnit(pixelCeil(clamp(
+          available.y, minHeight.value === Infinity
+          ? 0
+          : minHeight.value, maxHeight.value))
+        ),
     })
 
     return {

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -145,13 +145,13 @@ function getIntrinsicSize (el: HTMLElement, isRtl: boolean) {
   return contentBox
 }
 
-// Prevents infinite loop
-let retries = 0
-// Track the last position
-let previousX = 0
-let previousY = 0
-
 function connectedLocationStrategy (data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
+  // Prevents infinite loop
+  let retries = 0
+  // Track the last position
+  let previousX = 0
+  let previousY = 0
+
   const activatorFixed = Array.isArray(data.target.value) || isFixedPosition(data.target.value)
   if (activatorFixed) {
     Object.assign(contentStyles.value, {
@@ -204,7 +204,6 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
   let observe = false
   const observer = new ResizeObserver(() => {
-    retries += 1
     if (observe) updateLocation()
   })
 
@@ -227,6 +226,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
   // eslint-disable-next-line max-statements
   function updateLocation () {
+    retries++
     observe = false
     requestAnimationFrame(() => observe = true)
 
@@ -313,7 +313,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     // Make the retry max x2 to get the correct position
     // Addition happens on resizeObserver see line 207
     // eslint-disable-next-line no-unmodified-loop-condition
-    while (retries < 2) {
+    while (retries < 3) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
       x += _x


### PR DESCRIPTION
## Description

On Google Chrome browser the repositioning of the `VMenu` on a `VSelect` flips infinitely. This changed will ensure that we only do a maximum of 2x to reposition. The first reposition will position the menu correctly on the second reposition it will resize the menu correctly. Caveat this somehow changes the animation and now it's a little bit awkward, if you guys have an idea how to fix the animation feel free to update or message me about it thanks!

- Fix: #21098 
