### PR TITLE
docs(sass-variables): correct use of `$utilities` and `$color-pack`

### DIFF
--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -73,7 +73,7 @@ Within your style file, import the Vuetify styles and specify the variables you 
 
 ::: info
 
-`'vuetify'` should be used for [global SASS variable](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/styles/settings/_variables.scss).
+`'vuetify'` should be used for [global SASS variable](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/styles/settings/_variables.scss). This is also used for [`$utilities`](/features/sass-variables/#disabling-utility-classes), [`$color-pack`](/features/sass-variables/#disabling-color-packs), and [`$layers`](/features/sass-variables/#enabling-css-cascade-layers).
 
 :::
 

--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -152,8 +152,8 @@ Keep in mind that to obtain settings from Vuetify, you must forward its variable
 
 Utility classes are a powerful feature of Vuetify, but they can also be unnecessary for some projects. Each utility class is generated with a set of options that are defined [here](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/styles/settings/_utilities.scss). Disable individual classes by setting their corresponding variable to `false`:
 
-```scss { resource="src/styles/settings.scss" }
-@forward 'vuetify/settings' with (
+```scss { resource="src/styles/main.scss" }
+@use 'vuetify' with (
   $utilities: (
     "align-content": false,
     "align-items": false,
@@ -232,8 +232,8 @@ Utility classes are a powerful feature of Vuetify, but they can also be unnecess
 
 To disable all utility classes, set the entire `$utilities` variable to `false`:
 
-```scss { resource="src/styles/settings.scss" }
-@forward 'vuetify/settings' with (
+```scss { resource="src/styles/main.scss" }
+@use 'vuetify' with (
   $utilities: false,
 );
 ```
@@ -242,8 +242,8 @@ To disable all utility classes, set the entire `$utilities` variable to `false`:
 
 Color packs are handy for quickly applying a color to a component but mostly unused in production. To disable them, set the `$color-pack` variable to `false`:
 
-```scss { resource="src/styles/settings.scss" }
-@forward 'vuetify/settings' with (
+```scss { resource="src/styles/main.scss" }
+@use 'vuetify' with (
   $color-pack: false,
 );
 ```


### PR DESCRIPTION
## Description

Current examples are not working. `$utilities` and `$color-pack` have to be put in `@use 'vuetify' { ... }` instead of the block for components settings.

Can be verified on [Stackblitz](https://stackblitz.com/edit/vuetify-sass-variables)

I did not ever used `$layers` and I am not sure if they also need this fix. Kael added these to documentation later and I hope he did not just copy/paste the section.