### PR TITLE
fix(VDateInput): always enable date input cancel action

### DIFF
--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -25,6 +25,7 @@ export type VConfirmEditSlots<T> = {
 
 export const makeVConfirmEditProps = propsFactory({
   modelValue: null,
+  hideActions: Boolean,
   color: String,
   cancelText: {
     type: String,
@@ -118,7 +119,7 @@ export const VConfirmEdit = genericComponent<new <T> (
             })
           }
 
-          { !actionsUsed && actions() }
+          { !props.hideActions && !actionsUsed && actions() }
         </>
       )
     })

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -1,4 +1,5 @@
 // Components
+import { VBtn } from '@/components/VBtn'
 import { makeVConfirmEditProps, VConfirmEdit } from '@/components/VConfirmEdit/VConfirmEdit'
 import { makeVDatePickerProps, VDatePicker } from '@/components/VDatePicker/VDatePicker'
 import { VMenu } from '@/components/VMenu/VMenu'
@@ -33,7 +34,6 @@ export type VDateInputSlots = Omit<VTextFieldSlots, 'default'> & {
 }
 
 export const makeVDateInputProps = propsFactory({
-  hideActions: Boolean,
   location: {
     type: String as PropType<StrategyProps['location']>,
     default: 'bottom start',
@@ -128,6 +128,34 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
       model.value = null
     }
 
+    function defaultActions ({
+      save,
+      cancel,
+      isPristine,
+    }: {
+      save: () => void
+      cancel: () => void
+      isPristine: boolean
+    }) {
+      return (
+        <>
+          <VBtn
+            variant="text"
+            text={ t(props.cancelText) }
+            onClick={ cancel }
+          />
+
+          <VBtn
+            variant="text"
+            color={ props.color }
+            disabled={ isPristine }
+            text={ t(props.okText) }
+            onClick={ save }
+          />
+        </>
+      )
+    }
+
     useRender(() => {
       const confirmEditProps = VConfirmEdit.filterProps(props)
       const datePickerProps = VDatePicker.filterProps(omit(props, ['active', 'location', 'rounded']))
@@ -163,12 +191,13 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
                 >
                   <VConfirmEdit
                     { ...confirmEditProps }
+                    hide-actions
                     v-model={ model.value }
                     onSave={ onSave }
                     onCancel={ () => menu.value = false }
                   >
                     {{
-                      default: ({ actions, model: proxyModel, save, cancel, isPristine }) => {
+                      default: ({ model: proxyModel, save, cancel, isPristine }) => {
                         return (
                           <VDatePicker
                             { ...datePickerProps }
@@ -185,7 +214,9 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
                             onMousedown={ (e: MouseEvent) => e.preventDefault() }
                           >
                             {{
-                              actions: !props.hideActions ? () => slots.actions?.({ save, cancel, isPristine }) ?? actions() : undefined,
+                              actions: !props.hideActions
+                                ? () => slots.actions?.({ save, cancel, isPristine }) ?? defaultActions({ save, cancel, isPristine })
+                                : undefined,
                             }}
                           </VDatePicker>
                         )


### PR DESCRIPTION
fixes #20226

## Description
This PR does two things:
1. Customization options for actions of VConfirmEdit was quite poor. To improve this, I added a prop called `hide-actions` that hides default actions so that users can customize it as they want. Check example below:
```vue
      <v-confirm-edit v-model="model" hide-actions>
        <template #default="{model: proxyModel, isPristine, save, cancel}">
          <v-card>
            <v-card-text>
              <v-text-field :model-value="proxyModel" />
            </v-card-text>

            <v-card-actions>
              <v-btn :disable="!isPristine" :disabled="isPristine" @click="save">
                Save
              </v-btn>

              <v-btn @click="cancel">
                Cancel
              </v-btn>
            </v-card-actions>
          </v-card>
        </template>
      </v-confirm-edit>
```

2. Utilizing this prop, the VDateInput is now able to always have an enabled Cancel button. Also, the Save button of VDateInput now gets the color that is passed from the prop as shown below:
<img width="334" alt="image" src="https://github.com/user-attachments/assets/1b4c29aa-b26f-42a9-9f40-732b5009ed39" />