### PR TITLE
refactor(VDateInput): use display props and remove extra code

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -169,12 +169,6 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
       model.value = null
     }
 
-    function onUpdateMenuModel (isMenuOpen: boolean) {
-      if (isMenuOpen) return
-
-      isEditingInput.value = false
-    }
-
     function onBlur () {
       blur()
 
@@ -219,7 +213,6 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
                   location={ props.location }
                   closeOnContentClick={ false }
                   openOnClick={ false }
-                  onUpdate:modelValue={ onUpdateMenuModel }
                 >
                   <VConfirmEdit
                     { ...confirmEditProps }

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -68,7 +68,7 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
   setup (props, { emit, slots }) {
     const { t } = useLocale()
     const adapter = useDate()
-    const { mobile } = useDisplay()
+    const { mobile } = useDisplay(props)
     const { isFocused, focus, blur } = useFocus(props)
     const model = useProxiedModel(
       props,


### PR DESCRIPTION
## Description
1. We were using `makeDisplayProps` but were doing nothing with it. Passed the display props inside `useDisplay`.
2. Since we already have a watcher for `menu`, the `onUpdateMenuModel` function was redundant because both of them are doing the same thing
