### PR TITLE
fix(VFileUpload): filter files based on accepted type if passed (#21150)

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -94,6 +94,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
 
   setup (props, { attrs, emit, slots }) {
     const { t } = useLocale()
+    const inputRef = ref<HTMLInputElement>()
     const model = useProxiedModel(
       props,
       'modelValue',
@@ -136,7 +137,6 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     const isActive = toRef(() => isFocused.value || props.active)
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
     const isDragging = shallowRef(false)
-    const inputRef = ref<HTMLInputElement>()
 
     function onFocus () {
       if (inputRef.value !== document.activeElement) {

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -176,7 +176,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
 
       const dataTransfer = new DataTransfer()
 
-      model.value = filterFilesByAcceptType(acceptType, files)
+      model.value = filterFilesByAcceptType(files, acceptType)
 
       for (const file of model.value) {
         dataTransfer.items.add(file)
@@ -189,9 +189,9 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       const acceptType = inputRef.value?.accept
       const files = (e.target as HTMLInputElement)?.files
 
-      if (!files || !acceptType) return
+      if (!files) return
 
-      model.value = filterFilesByAcceptType(acceptType, files)
+      model.value = filterFilesByAcceptType(files, acceptType)
     }
 
     watch(model, newValue => {

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -100,7 +100,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       'modelValue',
       props.modelValue,
       val => wrapInArray(val),
-      val => {
+      (val, event) => {
         const acceptType = inputRef?.value?.accept
         const newValue = filterFilesByAcceptType(val, acceptType)
         if (inputRef.value) {
@@ -109,7 +109,10 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
             dataTransfer.items.add(file)
           }
           inputRef.value.files = dataTransfer.files
-          inputRef.value.dispatchEvent(new Event('change', { bubbles: true }))
+          const eventType = event?.type
+          if (eventType && (eventType === 'change' || eventType === 'input')) {
+            inputRef.value.dispatchEvent(new Event(eventType, { bubbles: true }))
+          }
         }
         return !props.multiple && Array.isArray(newValue) ? newValue[0] : newValue
       },

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -94,7 +94,6 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
 
   setup (props, { attrs, emit, slots }) {
     const { t } = useLocale()
-    const inputRef = ref<HTMLInputElement>()
     const model = useProxiedModel(
       props,
       'modelValue',

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -105,7 +105,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
         const newValue = filterFilesByAcceptType(val, acceptType)
         if (inputRef.value) {
           const dataTransfer = new DataTransfer()
-          for (const file of newValue) { 
+          for (const file of newValue) {
             dataTransfer.items.add(file)
           }
           inputRef.value.files = dataTransfer.files

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -94,6 +94,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
 
   setup (props, { attrs, emit, slots }) {
     const { t } = useLocale()
+    const inputRef = ref<HTMLInputElement>()
     const model = useProxiedModel(
       props,
       'modelValue',

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.browser.tsx
@@ -48,7 +48,7 @@ describe('VFileInput', () => {
   it('should add file', async () => {
     const model = ref()
     const { element } = render(() => (
-      <VFileInput v-model={ model.value } accept='text/plain' />
+      <VFileInput v-model={ model.value } accept="text/plain" />
     ))
 
     const input = screen.getByCSS('input')

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.browser.tsx
@@ -48,7 +48,7 @@ describe('VFileInput', () => {
   it('should add file', async () => {
     const model = ref()
     const { element } = render(() => (
-      <VFileInput v-model={ model.value } />
+      <VFileInput v-model={ model.value } accept='text/plain' />
     ))
 
     const input = screen.getByCSS('input')

--- a/packages/vuetify/src/composables/proxiedModel.ts
+++ b/packages/vuetify/src/composables/proxiedModel.ts
@@ -21,7 +21,7 @@ export function useProxiedModel<
   prop: Prop,
   defaultValue?: Props[Prop],
   transformIn: (value?: Props[Prop]) => Inner = (v: any) => v,
-  transformOut: (value: Inner) => Props[Prop] = (v: any) => v,
+  transformOut: (value: Inner, event?: Event) => Props[Prop] = (v: any) => v,
 ) {
   const vm = getCurrentInstance('useProxiedModel')
   const internal = ref(props[prop] !== undefined ? props[prop] : defaultValue) as Ref<Props[Prop]>
@@ -52,8 +52,8 @@ export function useProxiedModel<
       const externalValue = props[prop]
       return transformIn(isControlled.value ? externalValue : internal.value)
     },
-    set (internalValue) {
-      const newValue = transformOut(internalValue)
+    set (internalValue, event?: Event) {
+      const newValue = transformOut(internalValue, event)
       const value = toRaw(isControlled.value ? props[prop] : internal.value)
       if (value === newValue || transformIn(value) === internalValue) {
         return

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -134,7 +134,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       let files = Array.from(e.dataTransfer?.files ?? [])
 
       if (acceptType) {
-        files = files.filter((file) => file.type === acceptType)
+        files = files.filter(file => file.type === acceptType)
       }
 
       const dataTransfer = new DataTransfer()
@@ -167,7 +167,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       const acceptType = inputRef.value?.accept
 
       model.value = Array.from(target.files ?? [])
-        .filter((file) => file.type === acceptType)
+        .filter(file => file.type === acceptType)
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -110,7 +110,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
         const newValue = filterFilesByAcceptType(val, acceptType)
         if (inputRef.value) {
           const dataTransfer = new DataTransfer()
-          for (const file of newValue) { 
+          for (const file of newValue) {
             dataTransfer.items.add(file)
           }
           inputRef.value.files = dataTransfer.files

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -134,7 +134,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       if (!initialFiles || initialFiles.length === 0 || !inputRef.value) return
 
       if (acceptType) {
-        files = filterFilesByAcceptType(acceptType, initialFiles)
+        files = filterFilesByAcceptType(initialFiles, acceptType)
       }
 
       const dataTransfer = new DataTransfer()
@@ -169,9 +169,9 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       const acceptType = inputRef.value?.accept
       const files = (e.target as HTMLInputElement)?.files
 
-      if (!files || !acceptType) return
+      if (!files) return
 
-      model.value = filterFilesByAcceptType(acceptType, files)
+      model.value = filterFilesByAcceptType(files, acceptType)
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -99,6 +99,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
   setup (props, { attrs, slots }) {
     const { t } = useLocale()
     const { densityClasses } = useDensity(props)
+    const inputRef = ref<HTMLInputElement | null>(null)
     const model = useProxiedModel(
       props,
       'modelValue',
@@ -121,7 +122,6 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
 
     const isDragging = shallowRef(false)
     const vSheetRef = ref<InstanceType<typeof VSheet> | null>(null)
-    const inputRef = ref<HTMLInputElement | null>(null)
 
     function onDragover (e: DragEvent) {
       e.preventDefault()

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -129,6 +129,14 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
 
       if (!e.dataTransfer?.files?.length || !inputRef.value) return
 
+      const acceptType = inputRef.value?.accept
+
+      let files = Array.from(e.dataTransfer?.files ?? [])
+
+      if (acceptType) {
+        files = files.filter((file) => file.type === acceptType)
+      }
+
       const dataTransfer = new DataTransfer()
 
       for (const file of e.dataTransfer.files) {
@@ -152,6 +160,16 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       inputRef.value.value = ''
     }
 
+    function onInputChange (e: Event) {
+      if (!e.target) return
+
+      const target = e.target as HTMLInputElement
+      const acceptType = inputRef.value?.accept
+
+      model.value = Array.from(target.files ?? [])
+        .filter((file) => file.type === acceptType)
+    }
+
     useRender(() => {
       const hasTitle = !!(slots.title || props.title)
       const hasIcon = !!(slots.icon || props.icon)
@@ -167,12 +185,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
           disabled={ props.disabled }
           multiple={ props.multiple }
           name={ props.name }
-          onChange={ e => {
-            if (!e.target) return
-
-            const target = e.target as HTMLInputElement
-            model.value = [...target.files ?? []]
-          }}
+          onChange={ onInputChange }
           { ...inputAttrs }
         />
       )

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -813,7 +813,7 @@ export function camelizeProps (props: Record<string, unknown> | null | undefined
   return out
 }
 
-export function filterFilesByAcceptType (files: null | FileList, acceptType?: string): File[] {
+export function filterFilesByAcceptType (files: null | FileList | File[], acceptType?: string): File[] {
   if (!files) return []
   if (!acceptType) return Array.from(files)
   return Array.from(files).filter(file => file.type === acceptType)

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -815,6 +815,5 @@ export function camelizeProps (props: Record<string, unknown> | null | undefined
 
 export function filterFilesByAcceptType (acceptType: string, files: null | FileList): File[] {
   if (!acceptType || !files) return []
-  return Array.from(files).filter((file) => file.type === acceptType)
+  return Array.from(files).filter(file => file.type === acceptType)
 }
-

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -812,3 +812,9 @@ export function camelizeProps (props: Record<string, unknown> | null | undefined
   }
   return out
 }
+
+export function filterFilesByAcceptType (acceptType: string, files: null | FileList): File[] {
+  if (!acceptType || !files) return []
+  return Array.from(files).filter((file) => file.type === acceptType)
+}
+

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -813,7 +813,8 @@ export function camelizeProps (props: Record<string, unknown> | null | undefined
   return out
 }
 
-export function filterFilesByAcceptType (acceptType: string, files: null | FileList): File[] {
-  if (!acceptType || !files) return []
+export function filterFilesByAcceptType (files: null | FileList, acceptType?: string): File[] {
+  if (!files) return []
+  if (!acceptType) return Array.from(files)
   return Array.from(files).filter(file => file.type === acceptType)
 }


### PR DESCRIPTION
## Description

Component `VFileUpload` allows unsupported files to be included in the list if accept type is passed.

- Filter file on input via drop or browse
- Fixes: #21150

<br />

<img src="https://github.com/user-attachments/assets/e747aae1-58bd-44dd-9611-e261e93c558e" width="300" />
