### PR TITLE
refactor(defaults): improve props read performance

### DIFF
--- a/packages/vuetify/src/composables/__tests__/defaults.bench.tsx
+++ b/packages/vuetify/src/composables/__tests__/defaults.bench.tsx
@@ -1,0 +1,196 @@
+// Components
+import { VBtn } from '@/components/VBtn'
+import { VList } from '@/components/VList'
+
+// Utilities
+import { render } from '@test'
+import { bench } from 'vitest'
+import { nextTick, shallowRef } from 'vue'
+
+describe('render', () => {
+  describe('VBtn', () => {
+    bench('No defaults', async () => {
+      render(() => <VBtn title="foo" prependIcon="$vuetify" />)
+    })
+    bench('Overridden defaults', async () => {
+      render(
+        () => <VBtn title="foo" prependIcon="$vuetify" />,
+        null,
+        {
+          defaults: {
+            VBtn: { prependIcon: '$vuetify-outline' },
+          },
+        }
+      )
+    })
+    bench('Used defaults', async () => {
+      render(
+        () => <VBtn title="foo" />,
+        null,
+        {
+          defaults: {
+            VBtn: { prependIcon: '$vuetify-outline' },
+          },
+        }
+      )
+    })
+  })
+
+  describe('VList', () => {
+    const items = [
+      { title: 'Item 1' },
+      { title: 'Item 2' },
+      { title: 'Item 3' },
+      { title: 'Item 4' },
+      { title: 'Item 5' },
+      {
+        title: 'Group 6',
+        children: [
+          { title: 'Item 6-1' },
+          { title: 'Item 6-2' },
+          { title: 'Item 6-3' },
+          { title: 'Item 6-4' },
+          { title: 'Item 6-5' },
+        ],
+      },
+      { title: 'Item 7' },
+      { title: 'Item 8' },
+      { title: 'Item 9' },
+    ]
+    bench('No defaults', async () => {
+      render(() => <VList items={ items } variant="tonal" />)
+    })
+    bench('Overridden defaults', async () => {
+      render(
+        () => <VList items={ items } variant="tonal" />,
+        null,
+        {
+          defaults: {
+            VListItem: { variant: 'outlined' },
+          },
+        }
+      )
+    })
+    bench('Used defaults', async () => {
+      render(
+        () => <VList items={ items } />,
+        null,
+        {
+          defaults: {
+            VListItem: { variant: 'outlined' },
+          },
+        }
+      )
+    })
+  })
+})
+
+describe('update', () => {
+  describe('VBtn', () => {
+    const title = shallowRef(String(Math.random()))
+    bench('No defaults', async () => {
+      title.value = String(Math.random())
+      await nextTick()
+    }, {
+      setup () {
+        render(() => <VBtn title={ title.value } prependIcon="$vuetify" />)
+      },
+    })
+    bench('Overridden defaults', async () => {
+      title.value = String(Math.random())
+      await nextTick()
+    }, {
+      setup () {
+        render(
+          () => <VBtn title={ title.value } prependIcon="$vuetify" />,
+          null,
+          {
+            defaults: {
+              VBtn: { prependIcon: '$vuetify-outline' },
+            },
+          }
+        )
+      },
+    })
+    bench('Used defaults', async () => {
+      title.value = String(Math.random())
+      await nextTick()
+    }, {
+      setup () {
+        render(
+          () => <VBtn title={ title.value } />,
+          null,
+          {
+            defaults: {
+              VBtn: { prependIcon: '$vuetify-outline' },
+            },
+          }
+        )
+      },
+    })
+  })
+
+  describe('VList', () => {
+    const items = [
+      { title: 'Item 1' },
+      { title: 'Item 2' },
+      { title: 'Item 3' },
+      { title: 'Item 4' },
+      { title: 'Item 5' },
+      {
+        title: 'Group 6',
+        children: [
+          { title: 'Item 6-1' },
+          { title: 'Item 6-2' },
+          { title: 'Item 6-3' },
+          { title: 'Item 6-4' },
+          { title: 'Item 6-5' },
+        ],
+      },
+      { title: 'Item 7' },
+      { title: 'Item 8' },
+      { title: 'Item 9' },
+    ]
+    const color = shallowRef(String(Math.random()))
+    bench('No defaults', async () => {
+      color.value = String(Math.random())
+      await nextTick()
+    }, {
+      setup () {
+        render(() => <VList items={ items } variant="tonal" color={ color.value } />)
+      },
+    })
+    bench('Overridden defaults', async () => {
+      color.value = String(Math.random())
+      await nextTick()
+    }, {
+      setup () {
+        render(
+          () => <VList items={ items } variant="tonal" color={ color.value } />,
+          null,
+          {
+            defaults: {
+              VListItem: { variant: 'outlined' },
+            },
+          }
+        )
+      },
+    })
+    bench('Used defaults', async () => {
+      color.value = String(Math.random())
+      await nextTick()
+    }, {
+      setup () {
+        render(
+          () => <VList items={ items } color={ color.value } />,
+          null,
+          {
+            defaults: {
+              VListItem: { variant: 'outlined' },
+            },
+          }
+        )
+      },
+    })
+  })
+})

--- a/packages/vuetify/vitest.config.ts
+++ b/packages/vuetify/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(configEnv => {
       },
       plugins: [
         AutoImport({
-          include: '**/*.spec.?(browser.)@(ts|tsx)',
+          include: '**/*.(spec|bench).?(browser.)@(ts|tsx)',
           imports: {
             vitest: [
               'describe',


### PR DESCRIPTION
The current approach checks `defaults.value[name][prop] ?? defaults.value.global[prop]` for every single `props.foo` access, even if no defaults are set.

Todo: 

- [ ] Make sure reactivity still works (tests pass so it's good right?)
- [x] Get some actual numbers for comparison
<details>
<summary>It's literally identical lol</summary>

Before:
```
render VBtn
     name                     hz  samples
   · No defaults          628.87      315   slowest
   · Overridden defaults  696.33      349
   · Used defaults        738.52      370   fastest

render VList
     name                     hz  samples
   · No defaults          134.65       68   slowest
   · Overridden defaults  171.18       86
   · Used defaults        180.16       91   fastest

update VBtn
     name                       hz  samples
   · No defaults          5,680.00     2840   fastest
   · Overridden defaults  2,722.00     1361
   · Used defaults        1,761.30      881   slowest

update VList
     name                      hz  samples
   · No defaults           274.08      138   fastest
   · Overridden defaults   118.98       60
   · Used defaults        76.1868       39   slowest
```

After:
```
render VBtn
     name                     hz  samples
   · No defaults          630.36      316   slowest
   · Overridden defaults  711.15      356   fastest
   · Used defaults        698.60      350

render VList
     name                     hz  samples
   · No defaults          132.49       67   slowest
   · Overridden defaults  160.87       81
   · Used defaults        171.01       86   fastest

update VBtn
     name                       hz  samples
   · No defaults          5,700.86     2851   fastest
   · Overridden defaults  2,882.85     1442
   · Used defaults        1,797.28      899   slowest

update VList
     name                      hz  samples
   · No defaults           273.07      137   fastest
   · Overridden defaults   143.68       72
   · Used defaults        96.6851       49   slowest
```
</details>

- [x] See if it makes treeview tolerable
	- nope

