### PR TITLE
docs(api): init structure for vscode

### DIFF
--- a/packages/api-generator/src/index.ts
+++ b/packages/api-generator/src/index.ts
@@ -4,7 +4,7 @@ import { components } from 'vuetify/dist/vuetify-labs.js'
 import importMap from 'vuetify/dist/json/importMap.json' with { type: 'json' }
 import importMapLabs from 'vuetify/dist/json/importMap-labs.json' with { type: 'json' }
 import { kebabCase } from './helpers/text'
-import type { BaseData, ComponentData, DirectiveData } from './types'
+import type { ComponentData, DirectiveData } from './types'
 import { generateComposableDataFromTypes, generateDirectiveDataFromTypes } from './types'
 import Piscina from 'piscina'
 import { addDescriptions, addDirectiveDescriptions, addPropData, stringifyProps } from './utils'
@@ -13,6 +13,7 @@ import { mkdirp } from 'mkdirp'
 import { createVeturApi } from './vetur'
 import { rimraf } from 'rimraf'
 import { createWebTypesApi } from './web-types'
+import { createVSCodeApi } from './vscode'
 import inspector from 'inspector'
 import yargs from 'yargs'
 import { parseSassVariables } from './helpers/sass'
@@ -127,10 +128,12 @@ const run = async () => {
 
   createVeturApi(componentData)
   createWebTypesApi(componentData, directives)
+  createVSCodeApi(componentData, directives)
   await fs.mkdir(path.resolve('../vuetify/dist/json'), { recursive: true })
   await fs.copyFile(path.resolve('./dist/tags.json'), path.resolve('../vuetify/dist/json/tags.json'))
   await fs.copyFile(path.resolve('./dist/attributes.json'), path.resolve('../vuetify/dist/json/attributes.json'))
   await fs.copyFile(path.resolve('./dist/web-types.json'), path.resolve('../vuetify/dist/json/web-types.json'))
+  await fs.copyFile(path.resolve('./dist/vscode.json'), path.resolve('../vuetify/dist/json/vscode.json'))
   rimraf.sync(path.resolve('./templates/tmp'))
 }
 

--- a/packages/api-generator/src/vscode.ts
+++ b/packages/api-generator/src/vscode.ts
@@ -1,0 +1,190 @@
+import fs from 'fs'
+import { /*capitalize,*/ kebabCase } from './helpers/text'
+import type { ComponentData, DirectiveData } from './types'
+import pkg from '../package.json' with { type: 'json' }
+
+export const createVSCodeApi = (componentData: ComponentData[], directiveData: DirectiveData[]) => {
+  const getDocUrl = (cmp: string, heading?: string) =>
+    `https://vuetifyjs.com/api/${cmp}` + (heading ? `#${heading}` : '')
+
+  /*
+  const createTypedEntity = (name: string, type: string) => {
+    return {
+      name,
+      type,
+    }
+  }
+  */
+
+  const createTag = (component: ComponentData) => {
+    const createTagSlot = ([name, slot]: [string, any]) => {
+      return {
+        name: `#${kebabCase(name)}`,
+        description: slot.description.en || '',
+        references: [
+          {
+            name: `#${kebabCase(name)} API docs`,
+            url: getDocUrl(component.pathName, `slots-${kebabCase(name)}`)
+          }
+        ],
+        // not in schema
+        /*
+        pattern: undefined,
+        'vue-properties': slot.properties && Object.entries(slot.properties ?? {}).map(([name, prop]) => createTypedEntity(name, (prop as any).formatted)),
+        */
+      }
+    }
+
+    const createTagEvent = ([name, event]: [string, any]) => {
+      return {
+        name:`@${kebabCase(name)}`,
+        description: event.description.en || '',
+        references: [
+          {
+            name: `@${kebabCase(name)} API docs`,
+            url: getDocUrl(component.pathName, `events-${kebabCase(name)}`)
+          }
+        ],
+        // not in schema
+        // arguments: [createTypedEntity('argument', event.formatted)],
+      }
+    }
+
+    /*
+    const createTagValue = (type: string) => {
+      return {
+        kind: 'expression',
+        type: type?.trim(),
+      }
+    }
+    */
+
+    const createTagAttribute = ([name, prop]: [string, any]) => {
+      return {
+        name: kebabCase(name),
+        description: prop.description.en || '',
+        references: [
+          {
+            name: `${kebabCase(name)} API docs`,
+            url: getDocUrl(component.fileName, `props-${kebabCase(name)}`)
+          }
+        ],
+        // not in schema - work into description or toss
+        /*
+        default: typeof prop.default !== 'string' ? JSON.stringify(prop.default) : prop.default,
+        required: undefined, // TODO: implement this
+        value: createTagValue(prop.formatted),
+        type: prop.formatted === 'boolean' ? 'boolean' : undefined, // this is deprecated but should be const 'boolean' for compatibility with 2019.2
+        */
+      }
+    }
+
+    return {
+      name: component.displayName,
+      description: '', // TODO: we should probably include component description in locale files
+      attributes: [
+        ...Object.entries(component.props ?? {}).map(createTagAttribute), // props
+        ...Object.entries(component.events ?? {}).map(createTagEvent), // events
+        ...Object.entries(component.slots ?? {}).map(createTagSlot) // slots
+      ],
+      references: [
+        {
+          name: `${component.displayName} docs`,
+          url: getDocUrl(component.pathName)
+        }
+      ],
+      // not in schema - work into description or toss
+      /*
+      aliases: undefined, // TODO: are we using this? deprecated name changes?
+      source: {
+        module: './src/components/index.ts',
+        symbol: component.displayName,
+      },
+      'vue-model': { // TODO: we should expose this in api data if we can
+        prop: 'modelValue',
+        event: 'update:modelValue',
+      },
+      */
+    }
+  }
+
+  const createAttribute = (directive: DirectiveData) => {
+    /*
+    const createAttributeVueArgument = (argument: any) => {
+      return {
+        name: argument,
+        description: argument.description.en,
+        references: [
+          {
+            name: `${argument} API docs`,
+            url: getDocUrl(directive.pathName, 'argument')
+          }
+        ],
+      }
+    }
+      */
+
+    const createAttributeVueModifier = ([name, modifier]: [string, any]) => {
+      return {
+        name,
+        description: modifier.description.en || '',
+        references: [
+          {
+            name: `${name} API docs`,
+            url: getDocUrl(directive.pathName, 'modifiers')
+          }
+        ],
+      }
+    }
+
+    /*
+    const createAttributeValue = (argument: any) => {
+      return {
+        kind: 'expression',
+        type: argument.text,
+      }
+    }
+    */
+
+    return {
+      name: directive.displayName,
+      description: directive?.value?.description?.en || '',
+      references: [
+        {
+          name: `${directive.displayName} docs`,
+          url: getDocUrl(directive.pathName)
+        }
+      ],
+      attributes: [
+        // will need to add to description
+        //...(directive.argument ? [createAttributeVueArgument(directive.argument)] : []),
+        ...(directive.modifiers ? Object.entries(directive.modifiers).map(createAttributeVueModifier) : [])
+      ]
+      // not in schema - work into description or toss
+      /*
+      aliases: undefined,
+      default: '',
+      required: false,
+      value: createAttributeValue(directive.value),
+      source: {
+        module: './src/directives/index.ts',
+        symbol: capitalize(directive.displayName.slice(2)),
+      },
+      */
+    }
+  }
+
+  const tags = componentData.map(createTag)
+  const globalAttributes = directiveData.map(createAttribute)
+
+  const vscode = {
+    $schema: 'http://json-schema.org/draft-07/schema',
+    framework: 'vue',
+    name: 'vuetify',
+    version: pkg.version,
+    tags,
+    globalAttributes,
+  }
+
+  fs.writeFileSync('dist/vscode.json', JSON.stringify(vscode, null, 2))
+}

--- a/packages/api-generator/src/vscode.ts
+++ b/packages/api-generator/src/vscode.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { /*capitalize,*/ kebabCase } from './helpers/text'
+import { /* capitalize, */ kebabCase } from './helpers/text'
 import type { ComponentData, DirectiveData } from './types'
 import pkg from '../package.json' with { type: 'json' }
 
@@ -7,105 +7,92 @@ export const createVSCodeApi = (componentData: ComponentData[], directiveData: D
   const getDocUrl = (cmp: string, heading?: string) =>
     `https://vuetifyjs.com/api/${cmp}` + (heading ? `#${heading}` : '')
 
-  /*
-  const createTypedEntity = (name: string, type: string) => {
-    return {
-      name,
-      type,
-    }
-  }
-  */
+  const descriptionHeader = '**Description**\n'
+  const noDescription = '*no description*'
+  const templateAttributes: Record<string, any> = {}
 
   const createTag = (component: ComponentData) => {
     const createTagSlot = ([name, slot]: [string, any]) => {
-      return {
-        name: `#${kebabCase(name)}`,
-        description: slot.description.en || '',
-        references: [
-          {
-            name: `#${kebabCase(name)} API docs`,
-            url: getDocUrl(component.pathName, `slots-${kebabCase(name)}`)
-          }
-        ],
-        // not in schema
-        /*
-        pattern: undefined,
-        'vue-properties': slot.properties && Object.entries(slot.properties ?? {}).map(([name, prop]) => createTypedEntity(name, (prop as any).formatted)),
-        */
-      }
+      return ['#', 'v-slot:'].map(prefix => (
+        {
+          name: `${prefix}${kebabCase(name)}`,
+          description: [
+            descriptionHeader,
+            `>${slot.description.en || noDescription}\n`,
+            '**Properties:**\n',
+            ...slot.properties
+              ? Object.entries(slot.properties ?? {}).map(([name, prop]) => `>**${name}:**, ${(prop as any).formatted}`)
+              : ['>*no properties*'],
+          ].join('\n') || '',
+          references: [
+            {
+              name: `${prefix}${kebabCase(name)} API docs`,
+              url: getDocUrl(component.pathName, `slots-${kebabCase(name)}`),
+            },
+          ],
+        }
+      ))
     }
 
     const createTagEvent = ([name, event]: [string, any]) => {
+      const argument = event.formatted
       return {
-        name:`@${kebabCase(name)}`,
-        description: event.description.en || '',
+        name: `@${kebabCase(name)}`,
+        description: [
+          descriptionHeader,
+          `>${event.description.en || noDescription}`,
+          ...argument ? ['', `* **argument:** \`${argument}\``] : [],
+        ].join('\n') || '',
         references: [
           {
             name: `@${kebabCase(name)} API docs`,
-            url: getDocUrl(component.pathName, `events-${kebabCase(name)}`)
-          }
+            url: getDocUrl(component.pathName, `events-${kebabCase(name)}`),
+          },
         ],
-        // not in schema
-        // arguments: [createTypedEntity('argument', event.formatted)],
       }
     }
 
-    /*
-    const createTagValue = (type: string) => {
-      return {
-        kind: 'expression',
-        type: type?.trim(),
-      }
-    }
-    */
-
-    const createTagAttribute = ([name, prop]: [string, any]) => {
+    const createTagProp = ([name, prop]: [string, any]) => {
+      const defaultValue = typeof prop.default !== 'string' ? JSON.stringify(prop.default) : prop.default
       return {
         name: kebabCase(name),
-        description: prop.description.en || '',
+        description: [
+          descriptionHeader,
+          `>${prop.description.en || noDescription}\n`,
+          `* **default:** \`${defaultValue}\``,
+        ].join('\n') || '',
         references: [
           {
             name: `${kebabCase(name)} API docs`,
-            url: getDocUrl(component.fileName, `props-${kebabCase(name)}`)
-          }
+            url: getDocUrl(component.fileName, `props-${kebabCase(name)}`),
+          },
         ],
-        // not in schema - work into description or toss
-        /*
-        default: typeof prop.default !== 'string' ? JSON.stringify(prop.default) : prop.default,
-        required: undefined, // TODO: implement this
-        value: createTagValue(prop.formatted),
-        type: prop.formatted === 'boolean' ? 'boolean' : undefined, // this is deprecated but should be const 'boolean' for compatibility with 2019.2
-        */
       }
     }
 
-    return {
-      name: component.displayName,
-      description: '', // TODO: we should probably include component description in locale files
-      attributes: [
-        ...Object.entries(component.props ?? {}).map(createTagAttribute), // props
-        ...Object.entries(component.events ?? {}).map(createTagEvent), // events
-        ...Object.entries(component.slots ?? {}).map(createTagSlot) // slots
-      ],
-      references: [
-        {
-          name: `${component.displayName} docs`,
-          url: getDocUrl(component.pathName)
-        }
-      ],
-      // not in schema - work into description or toss
-      /*
-      aliases: undefined, // TODO: are we using this? deprecated name changes?
-      source: {
-        module: './src/components/index.ts',
-        symbol: component.displayName,
-      },
-      'vue-model': { // TODO: we should expose this in api data if we can
-        prop: 'modelValue',
-        event: 'update:modelValue',
-      },
-      */
+    // slots
+    for (const [name, slot] of Object.entries(component.slots ?? {})) {
+      if (!templateAttributes?.[name]) { templateAttributes[name] = createTagSlot([name, slot]) }
     }
+    return [
+      ...[component.displayName, kebabCase(component.displayName)].map(propName => (
+        {
+          name: propName,
+          description: noDescription, // TODO: include component description in locale files
+          attributes: [
+            ...Object.entries(component.props ?? {}).map(createTagProp), // props
+            ...Object.entries(component.events ?? {}).map(createTagEvent), // events
+          ],
+          // TODO: add reference to api page
+          references: [
+            {
+              name: `${propName} docs`,
+              url: getDocUrl(component.pathName),
+            },
+          ],
+        }
+      )),
+    ]
   }
 
   const createAttribute = (directive: DirectiveData) => {
@@ -127,12 +114,15 @@ export const createVSCodeApi = (componentData: ComponentData[], directiveData: D
     const createAttributeVueModifier = ([name, modifier]: [string, any]) => {
       return {
         name,
-        description: modifier.description.en || '',
+        description: [
+          descriptionHeader,
+          `>${modifier.description.en || noDescription}`,
+        ].join('\n') || '',
         references: [
           {
             name: `${name} API docs`,
-            url: getDocUrl(directive.pathName, 'modifiers')
-          }
+            url: getDocUrl(directive.pathName, 'modifiers'),
+          },
         ],
       }
     }
@@ -148,18 +138,21 @@ export const createVSCodeApi = (componentData: ComponentData[], directiveData: D
 
     return {
       name: directive.displayName,
-      description: directive?.value?.description?.en || '',
+      description: [
+        descriptionHeader,
+        `>${directive?.value?.description?.en || noDescription}`,
+      ].join('\n') || '',
       references: [
         {
           name: `${directive.displayName} docs`,
-          url: getDocUrl(directive.pathName)
-        }
+          url: getDocUrl(directive.pathName),
+        },
       ],
       attributes: [
         // will need to add to description
-        //...(directive.argument ? [createAttributeVueArgument(directive.argument)] : []),
-        ...(directive.modifiers ? Object.entries(directive.modifiers).map(createAttributeVueModifier) : [])
-      ]
+        // ...(directive.argument ? [createAttributeVueArgument(directive.argument)] : []),
+        ...(directive.modifiers ? Object.entries(directive.modifiers).map(createAttributeVueModifier) : []),
+      ],
       // not in schema - work into description or toss
       /*
       aliases: undefined,
@@ -174,7 +167,17 @@ export const createVSCodeApi = (componentData: ComponentData[], directiveData: D
     }
   }
 
-  const tags = componentData.map(createTag)
+  const tags = []
+  for (const component of componentData) {
+    tags.push(...createTag(component))
+  }
+  tags.push({
+    name: 'template',
+    attributes: Object.values(templateAttributes).reduce((k, a) => {
+      a.push(...k)
+      return a
+    }, []),
+  })
   const globalAttributes = directiveData.map(createAttribute)
 
   const vscode = {
@@ -184,6 +187,24 @@ export const createVSCodeApi = (componentData: ComponentData[], directiveData: D
     version: pkg.version,
     tags,
     globalAttributes,
+    // value set example structure, can be applied via valueSet / values on props
+    /*
+    valueSets: [
+      {
+        name: 'x',
+        values: [
+          {
+            name: 'xvals',
+            description: 'x values',
+          },
+          {
+            name: 'xval',
+            description: 'x value',
+          },
+        ],
+      },
+    ],
+    */
   }
 
   fs.writeFileSync('dist/vscode.json', JSON.stringify(vscode, null, 2))


### PR DESCRIPTION
## Description
Adds VSCode IntelliSense support for component/component API descriptions via `html.customData`

## Markup:
Initial Example


https://github.com/user-attachments/assets/47fa74e8-9833-495a-8f8d-2a239be284ff


## TODO:
- [x]  Basic prop/event/directive support
- [x]  Clean up descriptions formatting
- [ ]  Add more styling to descriptions
- [x]  Support Slots via `<template>`
    - Unable to nest slot props. can specify them as globals, but they will appear for all components
- [ ]  Add component descriptions and links
- [ ]  Create reference links to component pages
- [ ]  Add component descriptions
- [ ]  Rework directives to have modifiers/argument details
- [ ]  Possibly add values/value-descriptions for props
    - would be best to add via locale, would need to adjust regular api generation
- [x]  Look into SASS variables support
    - Current support for css postprocessors in `css.customData` is unavailable. SCSS intellisense plugin for vscode provides some functionality (eg sass var defaults on hover) but is buggy and hasnt been maintained for 4+ years