### PR TITLE
fix(VEmptyState): pass href/to props to VBtn

### DIFF
--- a/packages/vuetify/src/components/VEmptyState/VEmptyState.tsx
+++ b/packages/vuetify/src/components/VEmptyState/VEmptyState.tsx
@@ -185,7 +185,9 @@ export const VEmptyState = genericComponent<VEmptyStateSlots>()({
                   VBtn: {
                     class: 'v-empty-state__action-btn',
                     color: props.color ?? 'surface-variant',
+                    href: props.href,
                     text: props.actionText,
+                    to: props.to,
                   },
                 }}
               >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #21170 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-empty-state
        action-text="Contact Support"
        headline="Whoops, 404"
        href="https://vuetifyjs.com"
        image="https://vuetifyjs.b-cdn.net/docs/images/logos/v.png"
        text="The page you were looking for does not exist"
        title="Page not found"
      />
    </v-container>
  </v-app>
</template>
```
