### PR TITLE
fix(VSelects): Don't open menu on items change if menu disabled

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -411,7 +411,7 @@ export const VAutocomplete = genericComponent<new <
     })
 
     watch(() => props.items, (newVal, oldVal) => {
-      if (menu.value) return
+      if (menu.value || menuDisabled.value) return
 
       if (isFocused.value && !oldVal.length && newVal.length) {
         menu.value = true

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -456,7 +456,7 @@ export const VCombobox = genericComponent<new <
     })
 
     watch(() => props.items, (newVal, oldVal) => {
-      if (menu.value) return
+      if (menu.value || menuDisabled.value) return
 
       if (isFocused.value && !oldVal.length && newVal.length) {
         menu.value = true

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -324,7 +324,7 @@ export const VSelect = genericComponent<new <
     })
 
     watch(() => props.items, (newVal, oldVal) => {
-      if (menu.value) return
+      if (menu.value || menuDisabled.value) return
 
       if (isFocused.value && !oldVal.length && newVal.length) {
         menu.value = true


### PR DESCRIPTION
## Description
Adds additional check to watch(() => props.items, ...) - so that VMenu is not opened when menuDisabled.value is true
Changes components: VAutocomplete, VCombobox, VSelect
Fixes #21169 

## Markup:
Coded inside of the github website
Locally patched vuetify 3.7.4 to fix the issue
[vuetify+3.7.4.patch](https://github.com/user-attachments/files/19507710/vuetify%2B3.7.4.patch)
