### PR TITLE
fix(VColorPicker): disabled EyeDropper when component is disabled

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
@@ -50,7 +50,7 @@ export const VColorPickerPreview = defineComponent({
     onUnmounted(() => abortController.abort())
 
     async function openEyeDropper () {
-      if (!SUPPORTS_EYE_DROPPER) return
+      if (!SUPPORTS_EYE_DROPPER || props.disabled) return
 
       const eyeDropper = new window.EyeDropper()
       try {
@@ -73,7 +73,7 @@ export const VColorPickerPreview = defineComponent({
       >
         { SUPPORTS_EYE_DROPPER && (
           <div class="v-color-picker-preview__eye-dropper" key="eyeDropper">
-            <VBtn onClick={ openEyeDropper } icon="$eyeDropper" variant="plain" density="comfortable" />
+            <VBtn density="comfortable" disabled={ props.disabled } icon="$eyeDropper" variant="plain" onClick={ openEyeDropper } />
           </div>
         )}
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #21179

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-color-picker disabled />
      <v-color-picker />
    </v-container>
  </v-app>
</template>
```
