### PR TITLE
fix(VSelect): add aria-label a11y

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -408,6 +408,7 @@ export const VSelect = genericComponent<new <
                       onFocusin={ onFocusin }
                       tabindex="-1"
                       aria-live="polite"
+                      aria-label={ `${props.label}-list` }
                       color={ props.itemColor ?? props.color }
                       { ...listEvents }
                       { ...props.listProps }


### PR DESCRIPTION

## Description

Missing `aria-label` on `VList` inside `VSelect`. Used axe developer tool to check if now fixed.

<img src="https://github.com/user-attachments/assets/3815ca31-afdd-42d7-a282-38d41fbec160" width="500" />

Fixes: https://github.com/vuetifyjs/vuetify/issues/21164

## Markup:

```vue
<template>
  <v-app>
    <v-select
      label="Select"
      :menu="true"
      :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
    />
  </v-app>
</template>
```
