### PR TITLE
fix(VFileInput): emit change with event on drop

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -89,6 +89,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     'mousedown:control': (e: MouseEvent) => true,
     'update:focused': (focused: boolean) => true,
     'update:modelValue': (files: File | File[]) => true,
+    'change': (e: DragEvent) => true,
   },
 
   setup (props, { attrs, emit, slots }) {
@@ -164,6 +165,8 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       if (!e.dataTransfer) return
 
       model.value = [...e.dataTransfer.files ?? []]
+
+      emit('change', e)
     }
 
     watch(model, newValue => {

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -94,9 +94,10 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
 
   emits: {
     'update:modelValue': (files: File[]) => true,
+    'change': (e: DragEvent) => true,
   },
 
-  setup (props, { attrs, slots }) {
+  setup (props, { attrs, emit, slots }) {
     const { t } = useLocale()
     const { densityClasses } = useDensity(props)
     const model = useProxiedModel(
@@ -156,6 +157,8 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       }
 
       model.value = array
+
+      emit('change', e)
     }
 
     function onClick () {


### PR DESCRIPTION
## Description

Fixes: https://github.com/vuetifyjs/vuetify/issues/21163

Props `@change` not triggered on file drop.

## Markup:

```vue
<template>
  <v-app>
    <v-file-input label="Upload Files" @change="handleUpload" />
  </v-app>
</template>

<script setup>
const handleUpload = $event => {
  if ($event.dataTransfer) {
    alert(`${$event.dataTransfer.files.length} File(s) uploaded`)
  } else {
    alert(`${event.target.files.length} File(s) uploaded`)
  }
}
</script>
```
