### PR TITLE
fix(VTextField): padding adjustment for `reverse` mode

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -24,12 +24,21 @@
     .v-field
       cursor: text
 
-    .v-field__input
-      @at-root #{selector.append('.v-text-field--prefixed', &)}
-        --v-field-padding-start: #{$text-field-input-padding-start}
+      &:not(.v-field--reverse)
+        .v-field__input
+          @at-root #{selector.append('.v-text-field--prefixed', &)}
+            --v-field-padding-start: #{$text-field-input-padding-start}
 
-      @at-root #{selector.append('.v-text-field--suffixed', &)}
-        --v-field-padding-end: #{$text-field-input-padding-end}
+          @at-root #{selector.append('.v-text-field--suffixed', &)}
+            --v-field-padding-end: #{$text-field-input-padding-end}
+
+      &:is(.v-field--reverse)
+        .v-field__input
+          @at-root #{selector.append('.v-text-field--prefixed', &)}
+            --v-field-padding-end: #{$text-field-input-padding-start}
+
+          @at-root #{selector.append('.v-text-field--suffixed', &)}
+            --v-field-padding-start: #{$text-field-input-padding-end}
 
     .v-input__details
       padding-inline: $text-field-details-padding-inline
@@ -68,9 +77,15 @@
         color: $text-field-disabled-affix-color
 
     &__prefix
-      padding-inline-start: var(--v-field-padding-start)
+      @at-root #{selector.nest('.v-field:not(.v-field--reverse)', &)}
+        padding-inline-start: var(--v-field-padding-start)
+      @at-root #{selector.nest('.v-field:is(.v-field--reverse)', &)}
+        padding-inline-end: var(--v-field-padding-end)
 
     &__suffix
-      padding-inline-end: var(--v-field-padding-end)
+      @at-root #{selector.nest('.v-field:not(.v-field--reverse)', &)}
+        padding-inline-end: var(--v-field-padding-end)
+      @at-root #{selector.nest('.v-field:is(.v-field--reverse)', &)}
+        padding-inline-start: var(--v-field-padding-start)
 
   /* endregion */

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -32,7 +32,7 @@
           @at-root #{selector.append('.v-text-field--suffixed', &)}
             --v-field-padding-end: #{$text-field-input-padding-end}
 
-      &:is(.v-field--reverse)
+      &.v-field--reverse
         .v-field__input
           @at-root #{selector.append('.v-text-field--prefixed', &)}
             --v-field-padding-end: #{$text-field-input-padding-start}

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -79,13 +79,13 @@
     &__prefix
       @at-root #{selector.nest('.v-field:not(.v-field--reverse)', &)}
         padding-inline-start: var(--v-field-padding-start)
-      @at-root #{selector.nest('.v-field:is(.v-field--reverse)', &)}
+      @at-root #{selector.nest('.v-field.v-field--reverse', &)}
         padding-inline-end: var(--v-field-padding-end)
 
     &__suffix
       @at-root #{selector.nest('.v-field:not(.v-field--reverse)', &)}
         padding-inline-end: var(--v-field-padding-end)
-      @at-root #{selector.nest('.v-field:is(.v-field--reverse)', &)}
+      @at-root #{selector.nest('.v-field.v-field--reverse', &)}
         padding-inline-start: var(--v-field-padding-start)
 
   /* endregion */


### PR DESCRIPTION
## Description

fixes #21191

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <v-col>
          <h4>Number fields</h4>
          <v-number-input v-bind="withSuffix" control-variant="stacked" />
          <v-number-input v-bind="withSuffix" control-variant="stacked" :reverse="true" />
          <v-number-input v-bind="withSuffix" />
          <v-number-input v-bind="withSuffix" :reverse="true" />
          <v-divider class="mb-6" />
          <h4>Text fields</h4>
          <v-text-field v-bind="withSuffix" />
          <v-text-field v-bind="withSuffix" :reverse="true" />
        </v-col>
        <v-col>
          <h4>Number fields</h4>
          <v-number-input v-bind="withIcons" control-variant="stacked" />
          <v-number-input v-bind="withIcons" control-variant="stacked" :reverse="true" />
          <v-number-input v-bind="withIcons" />
          <v-number-input v-bind="withIcons" :reverse="true" />
          <v-divider class="mb-6" />
          <h4>Text fields</h4>
          <v-text-field v-bind="withIcons" />
          <v-text-field v-bind="withIcons" :reverse="true" />
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  const withSuffix = {
    suffix: '%',
    modelValue: 123
  }
  const withIcons = {
    ...withSuffix,
    prependInnerIcon: 'mdi-cow',
    appendInnerIcon: 'mdi-cow',
  }
</script>

<style>
.v-text-field__prefix__text {
  outline: 2px dashed oklch(from blue l c h / calc(alpha / 2));
}
.v-text-field__suffix__text {
  outline: 2px dashed oklch(from red l c h / calc(alpha / 2));
}
.v-field__prepend-inner > .v-icon,
.v-field__append-inner > .v-icon {
  outline: 2px dashed oklch(from green l c h / calc(alpha / 2));
}
</style>
```
