### PR TITLE
feat(VTextField): inline prefix/suffix

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -521,12 +521,12 @@
   /* region MODIFIERS */
   .v-field--reverse
     .v-field__field,
-    .v-field__input,
     .v-field__outline
       flex-direction: row-reverse
 
     .v-field__input, input
       text-align: end
+      justify-content: flex-end
 
   .v-field--variant-filled,
   .v-field--variant-underlined

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -6,9 +6,9 @@
 @include tools.layer('components')
   /* region BLOCK */
   .v-text-field
-    input
+    .v-field__input,
+    .v-text-field__edit
       color: inherit
-      opacity: 0
       flex: $text-field-input-flex
       transition: $text-field-input-transition
       min-width: 0
@@ -24,26 +24,10 @@
     .v-field
       cursor: text
 
-    .v-field__input
-      @at-root #{selector.append('.v-text-field--prefixed', &)}
-        --v-field-padding-start: #{$text-field-input-padding-start}
-
-      @at-root #{selector.append('.v-text-field--suffixed', &)}
-        --v-field-padding-end: #{$text-field-input-padding-end}
-
     .v-input__details
       padding-inline: $text-field-details-padding-inline
       @at-root #{selector.append('.v-input--plain-underlined', &)}
         padding-inline: 0
-
-    .v-field--no-label,
-    .v-field--active
-      input
-        opacity: 1
-
-    .v-field--single-line
-      input
-        transition: none
 
   /* endregion */
   /* region ELEMENTS */
@@ -52,25 +36,15 @@
     &__suffix
       align-items: center
       color: $text-field-affix-color
-      cursor: default
       display: flex
-      opacity: 0
       transition: inherit
       white-space: nowrap
-      min-height: $field-input-min-height
-      padding-top: calc(var(--v-field-padding-top, 4px) + var(--v-input-padding-top, 0))
-      padding-bottom: var(--v-field-padding-bottom, 6px)
-
-      .v-field--active &
-        opacity: 1
 
       .v-field--disabled &
         color: $text-field-disabled-affix-color
 
-    &__prefix
-      padding-inline-start: var(--v-field-padding-start)
-
-    &__suffix
-      padding-inline-end: var(--v-field-padding-end)
-
+    &__prefix,
+    &__suffix,
+    & &__edit
+      flex: none
   /* endregion */

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -139,18 +139,24 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
       })
     }
     function onInput (e: Event) {
-      const el = e.target as HTMLInputElement
-      model.value = el.value
-      if (
-        props.modelModifiers?.trim &&
-        ['text', 'search', 'password', 'tel', 'url'].includes(props.type)
-      ) {
-        const caretPosition = [el.selectionStart, el.selectionEnd]
-        nextTick(() => {
-          el.selectionStart = caretPosition[0]
-          el.selectionEnd = caretPosition[1]
-        })
-      }
+      const el = e.target as HTMLElement
+      model.value = el.innerText
+      const selection = window.getSelection()
+      const { anchorNode, anchorOffset, focusNode, focusOffset } = selection
+      nextTick(() => {
+        selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
+      })
+      // TODO: use window.getSelection()
+      // if (
+      //   props.modelModifiers?.trim &&
+      //   ['text', 'search', 'password', 'tel', 'url'].includes(props.type)
+      // ) {
+      //   const caretPosition = [el.selectionStart, el.selectionEnd]
+      //   nextTick(() => {
+      //     el.selectionStart = caretPosition[0]
+      //     el.selectionEnd = caretPosition[1]
+      //   })
+      // }
     }
 
     useRender(() => {
@@ -167,8 +173,6 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
           class={[
             'v-text-field',
             {
-              'v-text-field--prefixed': props.prefix,
-              'v-text-field--suffixed': props.suffix,
               'v-input--plain-underlined': isPlainOrUnderlined.value,
             },
             props.class,
@@ -210,56 +214,46 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                     props: { class: fieldClass, ...slotProps },
                   }) => {
                     const inputNode = (
-                      <input
-                        ref={ inputRef }
-                        value={ model.value }
+                      <div
                         onInput={ onInput }
                         v-intersect={[{
                           handler: onIntersect,
                         }, null, ['once']]}
-                        autofocus={ props.autofocus }
-                        readonly={ isReadonly.value }
-                        disabled={ isDisabled.value }
-                        name={ props.name }
-                        placeholder={ props.placeholder }
-                        size={ 1 }
-                        type={ props.type }
-                        onFocus={ onFocus }
-                        onBlur={ blur }
                         { ...slotProps }
-                        { ...inputAttrs }
-                      />
-                    )
-
-                    return (
-                      <>
+                      >
                         { props.prefix && (
-                          <span class="v-text-field__prefix">
-                            <span class="v-text-field__prefix__text">
-                              { props.prefix }
-                            </span>
-                          </span>
+                          <span
+                            key="prefix"
+                            class="v-text-field__prefix"
+                          >{ props.prefix }</span>
                         )}
-
-                        { slots.default ? (
-                          <div
-                            class={ fieldClass }
-                            data-no-activator=""
-                          >
-                            { slots.default() }
-                            { inputNode }
-                          </div>
-                        ) : cloneVNode(inputNode, { class: fieldClass })}
-
+                        <span
+                          ref={ inputRef }
+                          contenteditable="true"
+                          class="v-text-field__edit"
+                          onFocus={ onFocus }
+                          onBlur={ blur }
+                          tabindex="0"
+                          { ...inputAttrs }
+                        >{ model.value }</span>
                         { props.suffix && (
-                          <span class="v-text-field__suffix">
-                            <span class="v-text-field__suffix__text">
-                              { props.suffix }
-                            </span>
-                          </span>
+                          <span
+                            key="suffix"
+                            class="v-text-field__suffix"
+                          >{ props.suffix }</span>
                         )}
-                      </>
+                      </div>
                     )
+
+                    return slots.default ? (
+                      <div
+                        class={ fieldClass }
+                        data-no-activator=""
+                      >
+                        { slots.default() }
+                        { inputNode }
+                      </div>
+                    ) : cloneVNode(inputNode, { class: fieldClass })
                   },
                 }}
               </VField>


### PR DESCRIPTION

![Screenshot_20250402_223716](https://github.com/user-attachments/assets/ab8f5b6c-6795-494f-8a61-99b4adeb7f53)

maybe a bit too cursed, idk if there's a way to do this without contenteditable

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-number-input :precision="null" control-variant="stacked" suffix="%" />
      <v-number-input control-variant="stacked" prefix="$" reverse />
    </v-container>
  </v-app>
</template>
```
