### PR TITLE
fix(VDatePicker): use start of week to calculate week numbers

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -125,9 +125,9 @@
     "lint:fix": "concurrently -n \"tsc,eslint\" \"tsc -p tsconfig.checks.json --noEmit --pretty\" \"eslint --fix src\""
   },
   "devDependencies": {
-    "@date-io/core": "3.0.0",
-    "@date-io/date-fns": "3.0.0",
-    "@date-io/dayjs": "^3.0.0",
+    "@date-io/core": "3.2.0",
+    "@date-io/date-fns": "3.2.0",
+    "@date-io/dayjs": "^3.2.0",
     "@date-io/luxon": "^3.2.0",
     "@date-io/moment": "^3.2.0",
     "@formatjs/intl": "^2.10.1",

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -186,7 +186,7 @@ export function useCalendar (props: CalendarProps) {
 
   const weekNumbers = computed(() => {
     return weeksInMonth.value.map(week => {
-      return week.length ? getWeek(adapter, week[0]) : null
+      return week.length ? getWeek(adapter, week[0], { startOfWeek: Number(props.firstDayOfWeek ?? 0) }) : null
     })
   })
 

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -186,7 +186,7 @@ export function useCalendar (props: CalendarProps) {
 
   const weekNumbers = computed(() => {
     return weeksInMonth.value.map(week => {
-      return week.length ? getWeek(adapter, week[0], { startOfWeek: Number(props.firstDayOfWeek ?? 0) }) : null
+      return week.length ? adapter.getWeek(week[0], props.firstDayOfWeek) : null
     })
   })
 

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -1,5 +1,5 @@
 // Composables
-import { getWeek, useDate } from '@/composables/date/date'
+import { useDate } from '@/composables/date/date'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities

--- a/packages/vuetify/src/composables/date/DateAdapter.ts
+++ b/packages/vuetify/src/composables/date/DateAdapter.ts
@@ -37,6 +37,7 @@ export interface DateAdapter<T = unknown> {
   getDiff (date: T, comparing: T | string, unit?: string): number
   getWeekArray (date: T, firstDayOfWeek?: number | string): T[][]
   getWeekdays (firstDayOfWeek?: number | string): string[]
+  getWeek (date: T, firstDayOfWeek?: number | string, firstWeekMinSize?: number): number
   getMonth (date: T): number
   setMonth (date: T, month: number): T
   getDate (date: T): number

--- a/packages/vuetify/src/composables/date/__tests__/date.spec.ts
+++ b/packages/vuetify/src/composables/date/__tests__/date.spec.ts
@@ -75,6 +75,9 @@ describe('date.ts', () => {
     expect(adapter2.getWeek(new Date('2028-12-31'), 1)).toBe(52)
     expect(adapter2.getWeek(new Date('2029-01-01'), 1)).toBe(1)
     expect(adapter2.getWeek(new Date('2029-01-07'), 1)).toBe(1)
+
+    const adapter3 = new VuetifyDateAdapter({ locale: 'pl-PL' })
+    expect(adapter3.getWeek(new Date('2024-12-29'), 1)).toBe(52)
   })
 
   it('should adjust fallback to week start from locale', () => {

--- a/packages/vuetify/src/composables/date/__tests__/date.spec.ts
+++ b/packages/vuetify/src/composables/date/__tests__/date.spec.ts
@@ -21,4 +21,58 @@ describe('date.ts', () => {
 
     expect(getWeek(adapter, adapter.date('2023-10-10'))).toBe(41)
   })
+
+  it('should correctly calculate weeks between years', () => {
+    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+
+    expect(getWeek(adapter, adapter.date('2024-12-28'))).toBe(52)
+    expect(getWeek(adapter, adapter.date('2024-12-29'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2024-12-30'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2024-12-31'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-01'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-02'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-03'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-04'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-05'))).toBe(2)
+  })
+
+  it('should correctly calculate when year starts with a full week', () => {
+    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+
+    expect(getWeek(adapter, adapter.date('2022-12-25'))).toBe(52)
+    expect(getWeek(adapter, adapter.date('2022-12-31'))).toBe(52)
+    expect(getWeek(adapter, adapter.date('2023-01-01'))).toBe(1)
+    expect(getWeek(adapter, adapter.date('2023-01-07'))).toBe(1)
+  })
+
+  it('should adjust for start of a week', () => {
+    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+
+    expect(getWeek(adapter, adapter.date('2024-12-28'), { startOfWeek: 1 })).toBe(52)
+    expect(getWeek(adapter, adapter.date('2024-12-29'), { startOfWeek: 1 })).toBe(52)
+    expect(getWeek(adapter, adapter.date('2024-12-30'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2024-12-31'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-01'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-02'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-03'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-04'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-05'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2025-01-06'), { startOfWeek: 1 })).toBe(2)
+    expect(getWeek(adapter, adapter.date('2025-01-07'), { startOfWeek: 1 })).toBe(2)
+
+    expect(getWeek(adapter, adapter.date('2028-12-25'), { startOfWeek: 1 })).toBe(52)
+    expect(getWeek(adapter, adapter.date('2028-12-31'), { startOfWeek: 1 })).toBe(52)
+    expect(getWeek(adapter, adapter.date('2029-01-01'), { startOfWeek: 1 })).toBe(1)
+    expect(getWeek(adapter, adapter.date('2029-01-07'), { startOfWeek: 1 })).toBe(1)
+  })
+
+  it('should adjust fallback to week start from locale', () => {
+    const adapter1 = new VuetifyDateAdapter({ locale: 'en-US' })
+    expect(getWeek(adapter1, adapter1.date('2025-01-04'))).toBe(1) // saturday
+    expect(getWeek(adapter1, adapter1.date('2025-01-05'))).toBe(2) // sunday
+
+    const adapter2 = new VuetifyDateAdapter({ locale: 'fr' })
+    expect(getWeek(adapter2, adapter2.date('2025-01-05'))).toBe(1) // sunday
+    expect(getWeek(adapter2, adapter2.date('2025-01-06'))).toBe(2) // monday
+  })
 })

--- a/packages/vuetify/src/composables/date/__tests__/date.spec.ts
+++ b/packages/vuetify/src/composables/date/__tests__/date.spec.ts
@@ -1,6 +1,3 @@
-// Composables
-import { getWeek } from '../date'
-
 // Utilities
 import { VuetifyDateAdapter } from '../adapters/vuetify'
 
@@ -19,60 +16,74 @@ describe('date.ts', () => {
   it('should have the correct days in a month', () => {
     const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
 
-    expect(getWeek(adapter, adapter.date('2023-10-10'))).toBe(41)
+    expect(adapter.getWeek(new Date('2023-10-10'))).toBe(41)
   })
 
   it('should correctly calculate weeks between years', () => {
     const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
 
-    expect(getWeek(adapter, adapter.date('2024-12-28'))).toBe(52)
-    expect(getWeek(adapter, adapter.date('2024-12-29'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2024-12-30'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2024-12-31'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-01'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-02'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-03'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-04'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-05'))).toBe(2)
+    expect(adapter.getWeek(new Date('2024-12-28'))).toBe(52)
+    expect(adapter.getWeek(new Date('2024-12-29'))).toBe(1)
+    expect(adapter.getWeek(new Date('2024-12-30'))).toBe(1)
+    expect(adapter.getWeek(new Date('2024-12-31'))).toBe(1)
+    expect(adapter.getWeek(new Date('2025-01-01'))).toBe(1)
+    expect(adapter.getWeek(new Date('2025-01-02'))).toBe(1)
+    expect(adapter.getWeek(new Date('2025-01-03'))).toBe(1)
+    expect(adapter.getWeek(new Date('2025-01-04'))).toBe(1)
+    expect(adapter.getWeek(new Date('2025-01-05'))).toBe(2)
   })
 
   it('should correctly calculate when year starts with a full week', () => {
-    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+    const adapter1 = new VuetifyDateAdapter({ locale: 'en-US' }) // first day = 7 | minimal days = 1
 
-    expect(getWeek(adapter, adapter.date('2022-12-25'))).toBe(52)
-    expect(getWeek(adapter, adapter.date('2022-12-31'))).toBe(52)
-    expect(getWeek(adapter, adapter.date('2023-01-01'))).toBe(1)
-    expect(getWeek(adapter, adapter.date('2023-01-07'))).toBe(1)
+    expect(adapter1.getWeek(new Date('2022-12-25'))).toBe(53)
+    expect(adapter1.getWeek(new Date('2022-12-31'))).toBe(53)
+    expect(adapter1.getWeek(new Date('2023-01-01'))).toBe(1)
+    expect(adapter1.getWeek(new Date('2023-01-07'))).toBe(1)
+
+    const adapter2 = new VuetifyDateAdapter({ locale: 'pt' }) // first day = 7 | minimal days = 4
+
+    expect(adapter2.getWeek(new Date('2022-12-25'))).toBe(52)
+    expect(adapter2.getWeek(new Date('2022-12-31'))).toBe(52)
+    expect(adapter2.getWeek(new Date('2023-01-01'))).toBe(1)
+    expect(adapter2.getWeek(new Date('2023-01-07'))).toBe(1)
   })
 
   it('should adjust for start of a week', () => {
-    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+    const adapter = new VuetifyDateAdapter({ locale: 'en-US' }) // first day = 7 | minimal days = 1
 
-    expect(getWeek(adapter, adapter.date('2024-12-28'), { startOfWeek: 1 })).toBe(52)
-    expect(getWeek(adapter, adapter.date('2024-12-29'), { startOfWeek: 1 })).toBe(52)
-    expect(getWeek(adapter, adapter.date('2024-12-30'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2024-12-31'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-01'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-02'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-03'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-04'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-05'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2025-01-06'), { startOfWeek: 1 })).toBe(2)
-    expect(getWeek(adapter, adapter.date('2025-01-07'), { startOfWeek: 1 })).toBe(2)
+    expect(adapter.getWeek(new Date('2028-12-25'), 1)).toBe(53)
+    expect(adapter.getWeek(new Date('2028-12-31'), 1)).toBe(53)
+    expect(adapter.getWeek(new Date('2029-01-01'), 1)).toBe(1)
+    expect(adapter.getWeek(new Date('2029-01-07'), 1)).toBe(1)
 
-    expect(getWeek(adapter, adapter.date('2028-12-25'), { startOfWeek: 1 })).toBe(52)
-    expect(getWeek(adapter, adapter.date('2028-12-31'), { startOfWeek: 1 })).toBe(52)
-    expect(getWeek(adapter, adapter.date('2029-01-01'), { startOfWeek: 1 })).toBe(1)
-    expect(getWeek(adapter, adapter.date('2029-01-07'), { startOfWeek: 1 })).toBe(1)
+    const adapter2 = new VuetifyDateAdapter({ locale: 'pt-PT' }) // first day = 7 | minimal days = 4
+
+    expect(adapter2.getWeek(new Date('2024-12-28'), 1)).toBe(52)
+    expect(adapter2.getWeek(new Date('2024-12-29'), 1)).toBe(52)
+    expect(adapter2.getWeek(new Date('2024-12-30'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2024-12-31'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2025-01-01'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2025-01-02'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2025-01-03'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2025-01-04'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2025-01-05'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2025-01-06'), 1)).toBe(2)
+    expect(adapter2.getWeek(new Date('2025-01-07'), 1)).toBe(2)
+
+    expect(adapter2.getWeek(new Date('2028-12-25'), 1)).toBe(52)
+    expect(adapter2.getWeek(new Date('2028-12-31'), 1)).toBe(52)
+    expect(adapter2.getWeek(new Date('2029-01-01'), 1)).toBe(1)
+    expect(adapter2.getWeek(new Date('2029-01-07'), 1)).toBe(1)
   })
 
   it('should adjust fallback to week start from locale', () => {
     const adapter1 = new VuetifyDateAdapter({ locale: 'en-US' })
-    expect(getWeek(adapter1, adapter1.date('2025-01-04'))).toBe(1) // saturday
-    expect(getWeek(adapter1, adapter1.date('2025-01-05'))).toBe(2) // sunday
+    expect(adapter1.getWeek(new Date('2025-01-04'))).toBe(1) // saturday
+    expect(adapter1.getWeek(new Date('2025-01-05'))).toBe(2) // sunday
 
     const adapter2 = new VuetifyDateAdapter({ locale: 'fr' })
-    expect(getWeek(adapter2, adapter2.date('2025-01-05'))).toBe(1) // sunday
-    expect(getWeek(adapter2, adapter2.date('2025-01-06'))).toBe(2) // monday
+    expect(adapter2.getWeek(new Date('2025-01-05'))).toBe(1) // sunday
+    expect(adapter2.getWeek(new Date('2025-01-06'))).toBe(2) // monday
   })
 })

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -6,160 +6,41 @@ import type { DateAdapter } from '../DateAdapter'
 
 type CustomDateFormat = Intl.DateTimeFormatOptions | ((date: Date, formatString: string, locale: string) => string)
 
-// https://simplelocalize.io/data/locales/
-// then `new Intl.Locale(...).getWeekInfo()`
-const weekInfo: Record<string, { firstDay: number, firstWeekSize: number }> = {
-  '001': { firstDay: 1, firstWeekSize: 1 }, // not covered by Intl
-  AD: { firstDay: 1, firstWeekSize: 4 }, // ca-AD
-  AE: { firstDay: 6, firstWeekSize: 1 }, // ar-AE
-  AF: { firstDay: 6, firstWeekSize: 1 }, // uz-AF or ps-AF | tk-AF
-  AG: { firstDay: 0, firstWeekSize: 1 }, // en-AG
-  AI: { firstDay: 1, firstWeekSize: 1 }, // en-AI
-  AL: { firstDay: 1, firstWeekSize: 1 }, // sq-AL
-  AM: { firstDay: 1, firstWeekSize: 1 }, // hy-AM
-  AN: { firstDay: 1, firstWeekSize: 4 }, // nl-AN
-  AR: { firstDay: 1, firstWeekSize: 1 }, // es-AR
-  AS: { firstDay: 0, firstWeekSize: 1 }, // sm-AS or en-AS
-  AT: { firstDay: 1, firstWeekSize: 4 }, // de-AT
-  AU: { firstDay: 1, firstWeekSize: 1 }, // en-AU
-  AX: { firstDay: 1, firstWeekSize: 4 }, // sv-AX
-  AZ: { firstDay: 1, firstWeekSize: 1 }, // az-AZ
-  BA: { firstDay: 1, firstWeekSize: 1 }, // sr-BA or bs-BA | hr-BA
-  BD: { firstDay: 0, firstWeekSize: 1 }, // bn-BD
-  BE: { firstDay: 1, firstWeekSize: 4 }, // fr-BE or nl-BE
-  BG: { firstDay: 1, firstWeekSize: 4 }, // bg-BG
-  BH: { firstDay: 6, firstWeekSize: 1 }, // ar-BH
-  BM: { firstDay: 1, firstWeekSize: 1 }, // en-BM
-  BN: { firstDay: 1, firstWeekSize: 1 }, // ms-BN
-  BR: { firstDay: 0, firstWeekSize: 1 }, // pt-BR
-  BS: { firstDay: 0, firstWeekSize: 1 }, // en-BS
-  BT: { firstDay: 0, firstWeekSize: 1 }, // dz-BT
-  BW: { firstDay: 0, firstWeekSize: 1 }, // tn-BW or en-BW
-  BY: { firstDay: 1, firstWeekSize: 1 }, // be-BY
-  BZ: { firstDay: 0, firstWeekSize: 1 }, // en-BZ
-  CA: { firstDay: 0, firstWeekSize: 1 }, // en-CA or fr-CA
-  CH: { firstDay: 1, firstWeekSize: 4 }, // de-CH or fr-CH | it-CH | rm-CH
-  CL: { firstDay: 1, firstWeekSize: 1 }, // es-CL
-  CM: { firstDay: 1, firstWeekSize: 1 }, // fr-CM or en-CM
-  CN: { firstDay: 1, firstWeekSize: 1 }, // zh-CN
-  CO: { firstDay: 0, firstWeekSize: 1 }, // es-CO
-  CR: { firstDay: 1, firstWeekSize: 1 }, // es-CR
-  CY: { firstDay: 1, firstWeekSize: 1 }, // el-CY
-  CZ: { firstDay: 1, firstWeekSize: 4 }, // cs-CZ
-  DE: { firstDay: 1, firstWeekSize: 4 }, // de-DE
-  DJ: { firstDay: 6, firstWeekSize: 1 }, // fr-DJ
-  DK: { firstDay: 1, firstWeekSize: 4 }, // da-DK
-  DM: { firstDay: 0, firstWeekSize: 1 }, // en-DM
-  DO: { firstDay: 0, firstWeekSize: 1 }, // es-DO
-  DZ: { firstDay: 6, firstWeekSize: 1 }, // ar-DZ
-  EC: { firstDay: 1, firstWeekSize: 1 }, // es-EC
-  EE: { firstDay: 1, firstWeekSize: 4 }, // et-EE
-  EG: { firstDay: 6, firstWeekSize: 1 }, // ar-EG
-  ES: { firstDay: 1, firstWeekSize: 4 }, // es-ES
-  ET: { firstDay: 0, firstWeekSize: 1 }, // am-ET
-  FI: { firstDay: 1, firstWeekSize: 4 }, // fi-FI or sv-FI
-  FJ: { firstDay: 1, firstWeekSize: 4 }, // en-FJ
-  FO: { firstDay: 1, firstWeekSize: 4 }, // fo-FO
-  FR: { firstDay: 1, firstWeekSize: 4 }, // fr-FR
-  GB: { firstDay: 1, firstWeekSize: 4 }, // en-GB
-  'GB-alt-variant': { firstDay: 0, firstWeekSize: 4 }, // not covered by Intl
-  GE: { firstDay: 1, firstWeekSize: 1 }, // ka-GE
-  GF: { firstDay: 1, firstWeekSize: 4 }, // fr-GF
-  GP: { firstDay: 1, firstWeekSize: 4 }, // fr-GP
-  GR: { firstDay: 1, firstWeekSize: 4 }, // el-GR
-  GT: { firstDay: 0, firstWeekSize: 1 }, // es-GT
-  GU: { firstDay: 0, firstWeekSize: 1 }, // en-GU or ch-GU | es-GU
-  HK: { firstDay: 0, firstWeekSize: 1 }, // zh-HK
-  HN: { firstDay: 0, firstWeekSize: 1 }, // es-HN
-  HR: { firstDay: 1, firstWeekSize: 1 }, // hr-HR
-  HU: { firstDay: 1, firstWeekSize: 4 }, // hu-HU
-  ID: { firstDay: 0, firstWeekSize: 1 }, // id-ID or in-ID
-  IE: { firstDay: 1, firstWeekSize: 4 }, // en-IE or ga-IE
-  IL: { firstDay: 0, firstWeekSize: 1 }, // he-IL or iw-IL
-  IN: { firstDay: 0, firstWeekSize: 1 }, // en-IN or hi-IN
-  IQ: { firstDay: 6, firstWeekSize: 1 }, // ar-IQ
-  IR: { firstDay: 6, firstWeekSize: 1 }, // fa-IR
-  IS: { firstDay: 1, firstWeekSize: 4 }, // is-IS
-  IT: { firstDay: 1, firstWeekSize: 4 }, // it-IT
-  JM: { firstDay: 0, firstWeekSize: 1 }, // en-JM
-  JO: { firstDay: 6, firstWeekSize: 1 }, // ar-JO
-  JP: { firstDay: 0, firstWeekSize: 1 }, // ja-JP
-  KE: { firstDay: 0, firstWeekSize: 1 }, // sw-KE
-  KG: { firstDay: 1, firstWeekSize: 1 }, // ky-KG
-  KH: { firstDay: 0, firstWeekSize: 1 }, // km-KH
-  KR: { firstDay: 0, firstWeekSize: 1 }, // ko-KR
-  KW: { firstDay: 6, firstWeekSize: 1 }, // ar-KW
-  KZ: { firstDay: 1, firstWeekSize: 1 }, // kk-KZ
-  LA: { firstDay: 0, firstWeekSize: 1 }, // lo-LA
-  LB: { firstDay: 1, firstWeekSize: 1 }, // ar-LB
-  LI: { firstDay: 1, firstWeekSize: 4 }, // de-LI
-  LK: { firstDay: 1, firstWeekSize: 1 }, // si-LK
-  LT: { firstDay: 1, firstWeekSize: 4 }, // lt-LT
-  LU: { firstDay: 1, firstWeekSize: 4 }, // de-LU or fr-LU | lb-LU
-  LV: { firstDay: 1, firstWeekSize: 1 }, // lv-LV
-  LY: { firstDay: 6, firstWeekSize: 1 }, // ar-LY
-  MC: { firstDay: 1, firstWeekSize: 4 }, // fr-MC
-  MD: { firstDay: 1, firstWeekSize: 1 }, // ro-MD
-  ME: { firstDay: 1, firstWeekSize: 1 }, // sr-ME
-  MH: { firstDay: 0, firstWeekSize: 1 }, // mh-MH or en-MH
-  MK: { firstDay: 1, firstWeekSize: 1 }, // mk-MK
-  MM: { firstDay: 0, firstWeekSize: 1 }, // my-MM
-  MN: { firstDay: 1, firstWeekSize: 1 }, // mn-MN
-  MO: { firstDay: 0, firstWeekSize: 1 }, // zh-MO
-  MQ: { firstDay: 1, firstWeekSize: 4 }, // fr-MQ
-  MT: { firstDay: 0, firstWeekSize: 1 }, // mt-MT or en-MT
-  MV: { firstDay: 5, firstWeekSize: 1 }, // dv-MV
-  MX: { firstDay: 0, firstWeekSize: 1 }, // es-MX
-  MY: { firstDay: 1, firstWeekSize: 1 }, // en-MY or ms-MY
-  MZ: { firstDay: 0, firstWeekSize: 1 }, // pt-MZ
-  NI: { firstDay: 0, firstWeekSize: 1 }, // es-NI
-  NL: { firstDay: 1, firstWeekSize: 4 }, // fy-NL or nl-NL
-  NO: { firstDay: 1, firstWeekSize: 4 }, // nb-NO or nn-NO | no-NO
-  NP: { firstDay: 0, firstWeekSize: 1 }, // ne-NP
-  NZ: { firstDay: 1, firstWeekSize: 1 }, // en-NZ or mi-NZ
-  OM: { firstDay: 6, firstWeekSize: 1 }, // ar-OM
-  PA: { firstDay: 0, firstWeekSize: 1 }, // es-PA
-  PE: { firstDay: 0, firstWeekSize: 1 }, // es-PE
-  PH: { firstDay: 0, firstWeekSize: 1 }, // en-PH
-  PK: { firstDay: 0, firstWeekSize: 1 }, // ur-PK
-  PL: { firstDay: 1, firstWeekSize: 4 }, // pl-PL
-  PR: { firstDay: 0, firstWeekSize: 1 }, // es-PR
-  PT: { firstDay: 0, firstWeekSize: 4 }, // pt-PT
-  PY: { firstDay: 0, firstWeekSize: 1 }, // es-PY
-  QA: { firstDay: 6, firstWeekSize: 1 }, // ar-QA
-  RE: { firstDay: 1, firstWeekSize: 4 }, // fr-RE
-  RO: { firstDay: 1, firstWeekSize: 1 }, // ro-RO
-  RS: { firstDay: 1, firstWeekSize: 1 }, // sr-RS
-  RU: { firstDay: 1, firstWeekSize: 4 }, // ru-RU
-  SA: { firstDay: 0, firstWeekSize: 1 }, // ar-SA
-  SD: { firstDay: 6, firstWeekSize: 1 }, // ar-SD
-  SE: { firstDay: 1, firstWeekSize: 4 }, // sv-SE
-  SG: { firstDay: 0, firstWeekSize: 1 }, // en-SG or ms-SG | ta-SG | zh-SG
-  SI: { firstDay: 1, firstWeekSize: 1 }, // sl-SI
-  SK: { firstDay: 1, firstWeekSize: 4 }, // sk-SK
-  SM: { firstDay: 1, firstWeekSize: 4 }, // it-SM
-  SV: { firstDay: 0, firstWeekSize: 1 }, // es-SV
-  SY: { firstDay: 6, firstWeekSize: 1 }, // ar-SY
-  TH: { firstDay: 0, firstWeekSize: 1 }, // th-TH
-  TJ: { firstDay: 1, firstWeekSize: 1 }, // ru-TJ
-  TM: { firstDay: 1, firstWeekSize: 1 }, // tk-TM
-  TR: { firstDay: 1, firstWeekSize: 1 }, // tr-TR
-  TT: { firstDay: 0, firstWeekSize: 1 }, // en-TT
-  TW: { firstDay: 0, firstWeekSize: 1 }, // zh-TW
-  UA: { firstDay: 1, firstWeekSize: 1 }, // uk-UA
-  UM: { firstDay: 0, firstWeekSize: 1 }, // en-UM
-  US: { firstDay: 0, firstWeekSize: 1 }, // en-US or es-US
-  UY: { firstDay: 1, firstWeekSize: 1 }, // es-UY
-  UZ: { firstDay: 1, firstWeekSize: 1 }, // uz-UZ
-  VA: { firstDay: 1, firstWeekSize: 4 }, // fr-VA or la-VA | de-VA | it-VA
-  VE: { firstDay: 0, firstWeekSize: 1 }, // es-VE
-  VI: { firstDay: 0, firstWeekSize: 1 }, // en-VI
-  VN: { firstDay: 1, firstWeekSize: 1 }, // vi-VN
-  WS: { firstDay: 0, firstWeekSize: 1 }, // sm-WS or en-WS
-  XK: { firstDay: 1, firstWeekSize: 1 }, // sq-XK or sr-XK
-  YE: { firstDay: 0, firstWeekSize: 1 }, // ar-YE
-  ZA: { firstDay: 0, firstWeekSize: 1 }, // af-ZA or 9 more...
-  ZW: { firstDay: 0, firstWeekSize: 1 }, // en-ZW
+function weekInfo (locale: string): { firstDay: number, firstWeekSize: number } | null {
+  // https://simplelocalize.io/data/locales/
+  // then `new Intl.Locale(...).getWeekInfo()`
+  const code = locale.slice(-2).toUpperCase()
+  switch (true) {
+    case locale === 'GB-alt-variant': {
+      return { firstDay: 0, firstWeekSize: 4 }
+    }
+    case locale === '001': {
+      return { firstDay: 1, firstWeekSize: 1 }
+    }
+    case `AG AS BD BR BS BT BW BZ CA CO DM DO ET GT GU HK HN ID IL IN JM JP KE
+    KH KR LA MH MM MO MT MX MZ NI NP PA PE PH PK PR PY SA SG SV TH TT TW UM US
+    VE VI WS YE ZA ZW`.includes(code): {
+      return { firstDay: 0, firstWeekSize: 1 }
+    }
+    case `AI AL AM AR AU AZ BA BM BN BY CL CM CN CR CY EC GE HR KG KZ LB LK LV
+    MD ME MK MN MY NZ RO RS SI TJ TM TR UA UY UZ VN XK`.includes(code): {
+      return { firstDay: 1, firstWeekSize: 1 }
+    }
+    case `AD AN AT AX BE BG CH CZ DE DK EE ES FI FJ FO FR GB GF GP GR HU IE IS
+    IT LI LT LU MC MQ NL NO PL RE RU SE SK SM VA`.includes(code): {
+      return { firstDay: 1, firstWeekSize: 4 }
+    }
+    case `AE AF BH DJ DZ EG IQ IR JO KW LY OM QA SD SY`.includes(code): {
+      return { firstDay: 6, firstWeekSize: 1 }
+    }
+    case code === 'MV': {
+      return { firstDay: 5, firstWeekSize: 1 }
+    }
+    case code === 'PT': {
+      return { firstDay: 0, firstWeekSize: 4 }
+    }
+    default: return null
+  }
 }
 
 function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
@@ -167,7 +48,7 @@ function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
   let currentWeek = []
   const firstDayOfMonth = startOfMonth(date)
   const lastDayOfMonth = endOfMonth(date)
-  const first = firstDayOfWeek ?? weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0
+  const first = firstDayOfWeek ?? weekInfo(locale)?.firstDay ?? 0
   const firstDayWeekIndex = (firstDayOfMonth.getDay() - first + 7) % 7
   const lastDayWeekIndex = (lastDayOfMonth.getDay() - first + 7) % 7
 
@@ -204,7 +85,7 @@ function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
 }
 
 function startOfWeek (date: Date, locale: string, firstDayOfWeek?: number) {
-  const day = firstDayOfWeek ?? weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0
+  const day = firstDayOfWeek ?? weekInfo(locale)?.firstDay ?? 0
 
   const d = new Date(date)
   while (d.getDay() !== day) {
@@ -215,7 +96,7 @@ function startOfWeek (date: Date, locale: string, firstDayOfWeek?: number) {
 
 function endOfWeek (date: Date, locale: string) {
   const d = new Date(date)
-  const lastDay = ((weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0) + 6) % 7
+  const lastDay = ((weekInfo(locale)?.firstDay ?? 0) + 6) % 7
   while (d.getDay() !== lastDay) {
     d.setDate(d.getDate() + 1)
   }
@@ -262,7 +143,7 @@ function date (value?: any): Date | null {
 const sundayJanuarySecond2000 = new Date(2000, 0, 2)
 
 function getWeekdays (locale: string, firstDayOfWeek?: number) {
-  const daysFromSunday = firstDayOfWeek ?? weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0
+  const daysFromSunday = firstDayOfWeek ?? weekInfo(locale)?.firstDay ?? 0
 
   return createRange(7).map(i => {
     const weekday = new Date(sundayJanuarySecond2000)
@@ -429,7 +310,7 @@ function getMonth (date: Date) {
 }
 
 function getWeek (date: Date, locale: string, firstDayOfWeek?: number, firstWeekMinSize?: number) {
-  const weekInfoFromLocale = weekInfo[locale.slice(-2).toUpperCase()]
+  const weekInfoFromLocale = weekInfo(locale)
   const weekStart = firstDayOfWeek ?? weekInfoFromLocale?.firstDay ?? 0
   const minWeekSize = firstWeekMinSize ?? weekInfoFromLocale?.firstWeekSize ?? 1
   function firstWeekSize (year: number) {

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -6,158 +6,158 @@ import type { DateAdapter } from '../DateAdapter'
 
 type CustomDateFormat = Intl.DateTimeFormatOptions | ((date: Date, formatString: string, locale: string) => string)
 
-const firstDay: Record<string, number> = {
-  '001': 1,
-  AD: 1,
-  AE: 6,
-  AF: 6,
-  AG: 0,
-  AI: 1,
-  AL: 1,
-  AM: 1,
-  AN: 1,
-  AR: 1,
-  AS: 0,
-  AT: 1,
-  AU: 1,
-  AX: 1,
-  AZ: 1,
-  BA: 1,
-  BD: 0,
-  BE: 1,
-  BG: 1,
-  BH: 6,
-  BM: 1,
-  BN: 1,
-  BR: 0,
-  BS: 0,
-  BT: 0,
-  BW: 0,
-  BY: 1,
-  BZ: 0,
-  CA: 0,
-  CH: 1,
-  CL: 1,
-  CM: 1,
-  CN: 1,
-  CO: 0,
-  CR: 1,
-  CY: 1,
-  CZ: 1,
-  DE: 1,
-  DJ: 6,
-  DK: 1,
-  DM: 0,
-  DO: 0,
-  DZ: 6,
-  EC: 1,
-  EE: 1,
-  EG: 6,
-  ES: 1,
-  ET: 0,
-  FI: 1,
-  FJ: 1,
-  FO: 1,
-  FR: 1,
-  GB: 1,
-  'GB-alt-variant': 0,
-  GE: 1,
-  GF: 1,
-  GP: 1,
-  GR: 1,
-  GT: 0,
-  GU: 0,
-  HK: 0,
-  HN: 0,
-  HR: 1,
-  HU: 1,
-  ID: 0,
-  IE: 1,
-  IL: 0,
-  IN: 0,
-  IQ: 6,
-  IR: 6,
-  IS: 1,
-  IT: 1,
-  JM: 0,
-  JO: 6,
-  JP: 0,
-  KE: 0,
-  KG: 1,
-  KH: 0,
-  KR: 0,
-  KW: 6,
-  KZ: 1,
-  LA: 0,
-  LB: 1,
-  LI: 1,
-  LK: 1,
-  LT: 1,
-  LU: 1,
-  LV: 1,
-  LY: 6,
-  MC: 1,
-  MD: 1,
-  ME: 1,
-  MH: 0,
-  MK: 1,
-  MM: 0,
-  MN: 1,
-  MO: 0,
-  MQ: 1,
-  MT: 0,
-  MV: 5,
-  MX: 0,
-  MY: 1,
-  MZ: 0,
-  NI: 0,
-  NL: 1,
-  NO: 1,
-  NP: 0,
-  NZ: 1,
-  OM: 6,
-  PA: 0,
-  PE: 0,
-  PH: 0,
-  PK: 0,
-  PL: 1,
-  PR: 0,
-  PT: 0,
-  PY: 0,
-  QA: 6,
-  RE: 1,
-  RO: 1,
-  RS: 1,
-  RU: 1,
-  SA: 0,
-  SD: 6,
-  SE: 1,
-  SG: 0,
-  SI: 1,
-  SK: 1,
-  SM: 1,
-  SV: 0,
-  SY: 6,
-  TH: 0,
-  TJ: 1,
-  TM: 1,
-  TR: 1,
-  TT: 0,
-  TW: 0,
-  UA: 1,
-  UM: 0,
-  US: 0,
-  UY: 1,
-  UZ: 1,
-  VA: 1,
-  VE: 0,
-  VI: 0,
-  VN: 1,
-  WS: 0,
-  XK: 1,
-  YE: 0,
-  ZA: 0,
-  ZW: 0,
+const weekInfo: Record<string, { firstDay: number, firstWeekSize: number }> = {
+  '001': { firstDay: 1, firstWeekSize: 1 }, // not covered by Intl
+  AD: { firstDay: 1, firstWeekSize: 1 },
+  AE: { firstDay: 6, firstWeekSize: 1 }, // ar-AE
+  AF: { firstDay: 6, firstWeekSize: 1 }, // prs-AF or ps-AF
+  AG: { firstDay: 1, firstWeekSize: 1 },
+  AI: { firstDay: 1, firstWeekSize: 1 },
+  AL: { firstDay: 1, firstWeekSize: 1 }, // sq-AL
+  AM: { firstDay: 1, firstWeekSize: 1 }, // hy-AM
+  AN: { firstDay: 1, firstWeekSize: 4 },
+  AR: { firstDay: 1, firstWeekSize: 1 }, // es-AR
+  AS: { firstDay: 0, firstWeekSize: 1 },
+  AT: { firstDay: 1, firstWeekSize: 4 }, // de-AT
+  AU: { firstDay: 1, firstWeekSize: 1 }, // en-AU
+  AX: { firstDay: 1, firstWeekSize: 1 },
+  AZ: { firstDay: 1, firstWeekSize: 1 }, // az-Cyrl-AZ or az-Latn-AZ
+  BA: { firstDay: 1, firstWeekSize: 1 }, // bs-Cyrl-BA or bs-Latn-BA | hr-BA | sr-BA | sr-Cyrl-BA | sr-Latn-BA
+  BD: { firstDay: 0, firstWeekSize: 1 }, // bn-BD
+  BE: { firstDay: 1, firstWeekSize: 4 }, // fr-BE or nl-BE
+  BG: { firstDay: 1, firstWeekSize: 4 }, // bg-BG
+  BH: { firstDay: 6, firstWeekSize: 1 }, // ar-BH
+  BM: { firstDay: 1, firstWeekSize: 1 },
+  BN: { firstDay: 1, firstWeekSize: 1 }, // ms-BN
+  BR: { firstDay: 0, firstWeekSize: 1 }, // pt-BR
+  BS: { firstDay: 1, firstWeekSize: 1 },
+  BT: { firstDay: 1, firstWeekSize: 1 },
+  BW: { firstDay: 1, firstWeekSize: 1 },
+  BY: { firstDay: 1, firstWeekSize: 1 }, // be-BY
+  BZ: { firstDay: 0, firstWeekSize: 1 }, // en-BZ
+  CA: { firstDay: 0, firstWeekSize: 1 }, // en-CA or fr-CA | iu-Cans-CA | iu-Latn-CA | moh-CA
+  CH: { firstDay: 1, firstWeekSize: 4 }, // de-CH or fr-CH | it-CH | rm-CH
+  CL: { firstDay: 1, firstWeekSize: 1 }, // arn-CL or es-CL
+  CM: { firstDay: 1, firstWeekSize: 1 },
+  CN: { firstDay: 1, firstWeekSize: 1 }, // bo-CN or ii-CN | mn-Mong-CN | ug-CN | zh-CN
+  CO: { firstDay: 0, firstWeekSize: 1 }, // es-CO
+  CR: { firstDay: 1, firstWeekSize: 1 }, // es-CR
+  CY: { firstDay: 1, firstWeekSize: 1 }, // el-CY
+  CZ: { firstDay: 1, firstWeekSize: 4 }, // cs-CZ
+  DE: { firstDay: 1, firstWeekSize: 4 }, // de-DE or dsb-DE | hsb-DE
+  DJ: { firstDay: 1, firstWeekSize: 1 },
+  DK: { firstDay: 1, firstWeekSize: 4 }, // da-DK
+  DM: { firstDay: 1, firstWeekSize: 1 },
+  DO: { firstDay: 0, firstWeekSize: 1 }, // es-DO
+  DZ: { firstDay: 6, firstWeekSize: 1 }, // ar-DZ or tzm-Latn-DZ
+  EC: { firstDay: 1, firstWeekSize: 1 }, // es-EC or quz-EC
+  EE: { firstDay: 1, firstWeekSize: 4 }, // et-EE
+  EG: { firstDay: 6, firstWeekSize: 1 }, // ar-EG
+  ES: { firstDay: 1, firstWeekSize: 4 }, // ca-ES or es-ES | eu-ES | gl-ES
+  ET: { firstDay: 0, firstWeekSize: 1 }, // am-ET
+  FI: { firstDay: 1, firstWeekSize: 4 }, // fi-FI or se-FI | smn-FI | sms-FI | sv-FI
+  FJ: { firstDay: 1, firstWeekSize: 4 },
+  FO: { firstDay: 1, firstWeekSize: 4 }, // fo-FO
+  FR: { firstDay: 1, firstWeekSize: 4 }, // br-FR or co-FR | fr-FR | gsw-FR | oc-FR
+  GB: { firstDay: 1, firstWeekSize: 4 }, // cy-GB or en-GB | gd-GB
+  'GB-alt-variant': { firstDay: 0, firstWeekSize: 4 }, // not covered by Intl
+  GE: { firstDay: 1, firstWeekSize: 1 }, // ka-GE
+  GF: { firstDay: 1, firstWeekSize: 1 },
+  GP: { firstDay: 1, firstWeekSize: 1 },
+  GR: { firstDay: 1, firstWeekSize: 4 }, // el-GR
+  GT: { firstDay: 0, firstWeekSize: 1 }, // es-GT or qut-GT
+  GU: { firstDay: 0, firstWeekSize: 1 },
+  HK: { firstDay: 0, firstWeekSize: 1 }, // zh-HK
+  HN: { firstDay: 0, firstWeekSize: 1 }, // es-HN
+  HR: { firstDay: 1, firstWeekSize: 1 }, // hr-HR
+  HU: { firstDay: 1, firstWeekSize: 4 }, // hu-HU
+  ID: { firstDay: 0, firstWeekSize: 1 }, // id-ID or in-ID
+  IE: { firstDay: 1, firstWeekSize: 4 }, // en-IE or ga-IE
+  IL: { firstDay: 0, firstWeekSize: 1 }, // he-IL or iw-IL
+  IN: { firstDay: 0, firstWeekSize: 1 }, // as-IN or bn-IN | en-IN | gu-IN | hi-IN | kn-IN | kok-IN | ml-IN | mr-IN | or-IN | pa-IN | sa-IN | ta-IN | te-IN
+  IQ: { firstDay: 6, firstWeekSize: 1 }, // ar-IQ
+  IR: { firstDay: 6, firstWeekSize: 1 }, // fa-IR
+  IS: { firstDay: 1, firstWeekSize: 4 }, // is-IS
+  IT: { firstDay: 1, firstWeekSize: 4 }, // it-IT
+  JM: { firstDay: 0, firstWeekSize: 1 }, // en-JM
+  JO: { firstDay: 6, firstWeekSize: 1 }, // ar-JO
+  JP: { firstDay: 0, firstWeekSize: 1 }, // ja-JP
+  KE: { firstDay: 0, firstWeekSize: 1 }, // sw-KE
+  KG: { firstDay: 1, firstWeekSize: 1 }, // ky-KG
+  KH: { firstDay: 0, firstWeekSize: 1 }, // km-KH
+  KR: { firstDay: 0, firstWeekSize: 1 }, // ko-KR
+  KW: { firstDay: 6, firstWeekSize: 1 }, // ar-KW
+  KZ: { firstDay: 1, firstWeekSize: 1 }, // kk-KZ
+  LA: { firstDay: 0, firstWeekSize: 1 }, // lo-LA
+  LB: { firstDay: 1, firstWeekSize: 1 }, // ar-LB
+  LI: { firstDay: 1, firstWeekSize: 4 }, // de-LI
+  LK: { firstDay: 1, firstWeekSize: 1 }, // si-LK
+  LT: { firstDay: 1, firstWeekSize: 4 }, // lt-LT
+  LU: { firstDay: 1, firstWeekSize: 4 }, // de-LU or fr-LU | lb-LU
+  LV: { firstDay: 1, firstWeekSize: 1 }, // lv-LV
+  LY: { firstDay: 6, firstWeekSize: 1 }, // ar-LY
+  MC: { firstDay: 1, firstWeekSize: 4 }, // fr-MC
+  MD: { firstDay: 1, firstWeekSize: 1 },
+  ME: { firstDay: 1, firstWeekSize: 1 }, // sr-Cyrl-ME or sr-Latn-ME | sr-ME
+  MH: { firstDay: 0, firstWeekSize: 1 },
+  MK: { firstDay: 1, firstWeekSize: 1 }, // mk-MK
+  MM: { firstDay: 1, firstWeekSize: 1 },
+  MN: { firstDay: 1, firstWeekSize: 1 }, // mn-MN
+  MO: { firstDay: 0, firstWeekSize: 1 }, // zh-MO
+  MQ: { firstDay: 1, firstWeekSize: 1 },
+  MT: { firstDay: 0, firstWeekSize: 1 }, // en-MT or mt-MT
+  MV: { firstDay: 5, firstWeekSize: 1 }, // dv-MV
+  MX: { firstDay: 0, firstWeekSize: 1 }, // es-MX
+  MY: { firstDay: 1, firstWeekSize: 1 }, // en-MY or ms-MY
+  MZ: { firstDay: 1, firstWeekSize: 1 },
+  NI: { firstDay: 0, firstWeekSize: 1 }, // es-NI
+  NL: { firstDay: 1, firstWeekSize: 4 }, // fy-NL or nl-NL
+  NO: { firstDay: 1, firstWeekSize: 4 }, // nb-NO or nn-NO | se-NO | sma-NO | smj-NO
+  NP: { firstDay: 0, firstWeekSize: 1 }, // ne-NP
+  NZ: { firstDay: 1, firstWeekSize: 1 }, // en-NZ or mi-NZ
+  OM: { firstDay: 6, firstWeekSize: 1 }, // ar-OM
+  PA: { firstDay: 0, firstWeekSize: 1 }, // es-PA
+  PE: { firstDay: 0, firstWeekSize: 1 }, // es-PE or quz-PE
+  PH: { firstDay: 0, firstWeekSize: 1 }, // en-PH or fil-PH
+  PK: { firstDay: 0, firstWeekSize: 1 }, // ur-PK
+  PL: { firstDay: 1, firstWeekSize: 4 }, // pl-PL
+  PR: { firstDay: 0, firstWeekSize: 1 }, // es-PR
+  PT: { firstDay: 0, firstWeekSize: 4 }, // pt-PT
+  PY: { firstDay: 0, firstWeekSize: 1 }, // es-PY
+  QA: { firstDay: 6, firstWeekSize: 1 }, // ar-QA
+  RE: { firstDay: 1, firstWeekSize: 1 },
+  RO: { firstDay: 1, firstWeekSize: 1 }, // ro-RO
+  RS: { firstDay: 1, firstWeekSize: 1 }, // sr-Cyrl-RS or sr-Latn-RS | sr-RS
+  RU: { firstDay: 1, firstWeekSize: 4 }, // ba-RU or ru-RU | sah-RU | tt-RU
+  SA: { firstDay: 0, firstWeekSize: 1 }, // ar-SA
+  SD: { firstDay: 6, firstWeekSize: 1 }, // ar-SD
+  SE: { firstDay: 1, firstWeekSize: 4 }, // se-SE or sma-SE | smj-SE | sv-SE
+  SG: { firstDay: 0, firstWeekSize: 1 }, // en-SG or zh-SG
+  SI: { firstDay: 1, firstWeekSize: 1 }, // sl-SI
+  SK: { firstDay: 1, firstWeekSize: 4 }, // sk-SK
+  SM: { firstDay: 0, firstWeekSize: 1 },
+  SV: { firstDay: 0, firstWeekSize: 1 }, // es-SV
+  SY: { firstDay: 6, firstWeekSize: 1 }, // ar-SY or syr-SY
+  TH: { firstDay: 0, firstWeekSize: 1 }, // th-TH
+  TJ: { firstDay: 1, firstWeekSize: 1 }, // tg-Cyrl-TJ
+  TM: { firstDay: 1, firstWeekSize: 1 }, // tk-TM
+  TR: { firstDay: 1, firstWeekSize: 1 }, // tr-TR
+  TT: { firstDay: 0, firstWeekSize: 1 }, // en-TT
+  TW: { firstDay: 0, firstWeekSize: 1 }, // zh-TW
+  UA: { firstDay: 1, firstWeekSize: 1 }, // uk-UA
+  UM: { firstDay: 1, firstWeekSize: 1 },
+  US: { firstDay: 0, firstWeekSize: 1 }, // en-US or es-US
+  UY: { firstDay: 1, firstWeekSize: 1 }, // es-UY
+  UZ: { firstDay: 1, firstWeekSize: 1 }, // uz-Cyrl-UZ or uz-Latn-UZ
+  VA: { firstDay: 1, firstWeekSize: 1 },
+  VE: { firstDay: 0, firstWeekSize: 1 }, // es-VE
+  VI: { firstDay: 1, firstWeekSize: 1 },
+  VN: { firstDay: 1, firstWeekSize: 1 }, // vi-VN
+  WS: { firstDay: 1, firstWeekSize: 1 },
+  XK: { firstDay: 1, firstWeekSize: 1 },
+  YE: { firstDay: 0, firstWeekSize: 1 }, // ar-YE
+  ZA: { firstDay: 0, firstWeekSize: 1 }, // af-ZA or en-ZA | nso-ZA | tn-ZA | xh-ZA | zu-ZA
+  ZW: { firstDay: 0, firstWeekSize: 1 }, // en-ZW
 }
 
 function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
@@ -165,7 +165,7 @@ function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
   let currentWeek = []
   const firstDayOfMonth = startOfMonth(date)
   const lastDayOfMonth = endOfMonth(date)
-  const first = firstDayOfWeek ?? firstDay[locale.slice(-2).toUpperCase()] ?? 0
+  const first = firstDayOfWeek ?? weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0
   const firstDayWeekIndex = (firstDayOfMonth.getDay() - first + 7) % 7
   const lastDayWeekIndex = (lastDayOfMonth.getDay() - first + 7) % 7
 
@@ -202,7 +202,7 @@ function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
 }
 
 function startOfWeek (date: Date, locale: string, firstDayOfWeek?: number) {
-  const day = firstDayOfWeek ?? firstDay[locale.slice(-2).toUpperCase()] ?? 0
+  const day = firstDayOfWeek ?? weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0
 
   const d = new Date(date)
   while (d.getDay() !== day) {
@@ -213,7 +213,7 @@ function startOfWeek (date: Date, locale: string, firstDayOfWeek?: number) {
 
 function endOfWeek (date: Date, locale: string) {
   const d = new Date(date)
-  const lastDay = ((firstDay[locale.slice(-2).toUpperCase()] ?? 0) + 6) % 7
+  const lastDay = ((weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0) + 6) % 7
   while (d.getDay() !== lastDay) {
     d.setDate(d.getDate() + 1)
   }
@@ -260,7 +260,7 @@ function date (value?: any): Date | null {
 const sundayJanuarySecond2000 = new Date(2000, 0, 2)
 
 function getWeekdays (locale: string, firstDayOfWeek?: number) {
-  const daysFromSunday = firstDayOfWeek ?? firstDay[locale.slice(-2).toUpperCase()] ?? 0
+  const daysFromSunday = firstDayOfWeek ?? weekInfo[locale.slice(-2).toUpperCase()]?.firstDay ?? 0
 
   return createRange(7).map(i => {
     const weekday = new Date(sundayJanuarySecond2000)
@@ -424,6 +424,32 @@ function getYear (date: Date) {
 
 function getMonth (date: Date) {
   return date.getMonth()
+}
+
+function getWeek (date: Date, locale: string, firstDayOfWeek?: number, firstWeekMinSize?: number) {
+  const weekInfoFromLocale = weekInfo[locale.slice(-2).toUpperCase()]
+  const weekStart = firstDayOfWeek ?? weekInfoFromLocale?.firstDay ?? 0
+  const minWeekSize = firstWeekMinSize ?? weekInfoFromLocale?.firstWeekSize ?? 1
+  function firstWeekSize (year: number) {
+    const yearStart = new Date(year, 0, 1)
+    return 7 - getDiff(yearStart, startOfWeek(yearStart, locale, weekStart), 'days')
+  }
+
+  let year = getYear(date)
+  const currentWeekEnd = addDays(startOfWeek(date, locale, weekStart), 6)
+  if (year < getYear(currentWeekEnd)) {
+    if (firstWeekSize(year + 1) >= minWeekSize) {
+      year++
+    }
+  }
+
+  const yearStart = new Date(year, 0, 1)
+  const size = firstWeekSize(year)
+  const d1w1 = size >= minWeekSize
+    ? addDays(yearStart, size - 7)
+    : addDays(yearStart, size)
+
+  return 1 + getDiff(date, d1w1, 'weeks')
 }
 
 function getDate (date: Date) {
@@ -698,6 +724,10 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
 
   getMonth (date: Date) {
     return getMonth(date)
+  }
+
+  getWeek (date: Date, firstDayOfWeek?: number | string, firstWeekMinSize?: number) {
+    return getWeek(date, this.locale, firstDayOfWeek ? Number(firstDayOfWeek) : undefined, firstWeekMinSize)
   }
 
   getDate (date: Date) {

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -512,11 +512,13 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
   }
 
   getWeekArray (date: Date, firstDayOfWeek?: number | string) {
-    return getWeekArray(date, this.locale, firstDayOfWeek ? Number(firstDayOfWeek) : undefined)
+    const firstDay = firstDayOfWeek !== undefined ? Number(firstDayOfWeek) : undefined
+    return getWeekArray(date, this.locale, firstDay)
   }
 
   startOfWeek (date: Date, firstDayOfWeek?: number | string): Date {
-    return startOfWeek(date, this.locale, firstDayOfWeek ? Number(firstDayOfWeek) : undefined)
+    const firstDay = firstDayOfWeek !== undefined ? Number(firstDayOfWeek) : undefined
+    return startOfWeek(date, this.locale, firstDay)
   }
 
   endOfWeek (date: Date): Date {
@@ -596,7 +598,8 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
   }
 
   getWeekdays (firstDayOfWeek?: number | string) {
-    return getWeekdays(this.locale, firstDayOfWeek ? Number(firstDayOfWeek) : undefined)
+    const firstDay = firstDayOfWeek !== undefined ? Number(firstDayOfWeek) : undefined
+    return getWeekdays(this.locale, firstDay)
   }
 
   getYear (date: Date) {
@@ -608,7 +611,8 @@ export class VuetifyDateAdapter implements DateAdapter<Date> {
   }
 
   getWeek (date: Date, firstDayOfWeek?: number | string, firstWeekMinSize?: number) {
-    return getWeek(date, this.locale, firstDayOfWeek ? Number(firstDayOfWeek) : undefined, firstWeekMinSize)
+    const firstDay = firstDayOfWeek !== undefined ? Number(firstDayOfWeek) : undefined
+    return getWeek(date, this.locale, firstDay, firstWeekMinSize)
   }
 
   getDate (date: Date) {

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -6,67 +6,69 @@ import type { DateAdapter } from '../DateAdapter'
 
 type CustomDateFormat = Intl.DateTimeFormatOptions | ((date: Date, formatString: string, locale: string) => string)
 
+// https://simplelocalize.io/data/locales/
+// then `new Intl.Locale(...).getWeekInfo()`
 const weekInfo: Record<string, { firstDay: number, firstWeekSize: number }> = {
   '001': { firstDay: 1, firstWeekSize: 1 }, // not covered by Intl
-  AD: { firstDay: 1, firstWeekSize: 1 },
+  AD: { firstDay: 1, firstWeekSize: 4 }, // ca-AD
   AE: { firstDay: 6, firstWeekSize: 1 }, // ar-AE
-  AF: { firstDay: 6, firstWeekSize: 1 }, // prs-AF or ps-AF
-  AG: { firstDay: 1, firstWeekSize: 1 },
-  AI: { firstDay: 1, firstWeekSize: 1 },
+  AF: { firstDay: 6, firstWeekSize: 1 }, // uz-AF or ps-AF | tk-AF
+  AG: { firstDay: 0, firstWeekSize: 1 }, // en-AG
+  AI: { firstDay: 1, firstWeekSize: 1 }, // en-AI
   AL: { firstDay: 1, firstWeekSize: 1 }, // sq-AL
   AM: { firstDay: 1, firstWeekSize: 1 }, // hy-AM
-  AN: { firstDay: 1, firstWeekSize: 4 },
+  AN: { firstDay: 1, firstWeekSize: 4 }, // nl-AN
   AR: { firstDay: 1, firstWeekSize: 1 }, // es-AR
-  AS: { firstDay: 0, firstWeekSize: 1 },
+  AS: { firstDay: 0, firstWeekSize: 1 }, // sm-AS or en-AS
   AT: { firstDay: 1, firstWeekSize: 4 }, // de-AT
   AU: { firstDay: 1, firstWeekSize: 1 }, // en-AU
-  AX: { firstDay: 1, firstWeekSize: 1 },
-  AZ: { firstDay: 1, firstWeekSize: 1 }, // az-Cyrl-AZ or az-Latn-AZ
-  BA: { firstDay: 1, firstWeekSize: 1 }, // bs-Cyrl-BA or bs-Latn-BA | hr-BA | sr-BA | sr-Cyrl-BA | sr-Latn-BA
+  AX: { firstDay: 1, firstWeekSize: 4 }, // sv-AX
+  AZ: { firstDay: 1, firstWeekSize: 1 }, // az-AZ
+  BA: { firstDay: 1, firstWeekSize: 1 }, // sr-BA or bs-BA | hr-BA
   BD: { firstDay: 0, firstWeekSize: 1 }, // bn-BD
   BE: { firstDay: 1, firstWeekSize: 4 }, // fr-BE or nl-BE
   BG: { firstDay: 1, firstWeekSize: 4 }, // bg-BG
   BH: { firstDay: 6, firstWeekSize: 1 }, // ar-BH
-  BM: { firstDay: 1, firstWeekSize: 1 },
+  BM: { firstDay: 1, firstWeekSize: 1 }, // en-BM
   BN: { firstDay: 1, firstWeekSize: 1 }, // ms-BN
   BR: { firstDay: 0, firstWeekSize: 1 }, // pt-BR
-  BS: { firstDay: 1, firstWeekSize: 1 },
-  BT: { firstDay: 1, firstWeekSize: 1 },
-  BW: { firstDay: 1, firstWeekSize: 1 },
+  BS: { firstDay: 0, firstWeekSize: 1 }, // en-BS
+  BT: { firstDay: 0, firstWeekSize: 1 }, // dz-BT
+  BW: { firstDay: 0, firstWeekSize: 1 }, // tn-BW or en-BW
   BY: { firstDay: 1, firstWeekSize: 1 }, // be-BY
   BZ: { firstDay: 0, firstWeekSize: 1 }, // en-BZ
-  CA: { firstDay: 0, firstWeekSize: 1 }, // en-CA or fr-CA | iu-Cans-CA | iu-Latn-CA | moh-CA
+  CA: { firstDay: 0, firstWeekSize: 1 }, // en-CA or fr-CA
   CH: { firstDay: 1, firstWeekSize: 4 }, // de-CH or fr-CH | it-CH | rm-CH
-  CL: { firstDay: 1, firstWeekSize: 1 }, // arn-CL or es-CL
-  CM: { firstDay: 1, firstWeekSize: 1 },
-  CN: { firstDay: 1, firstWeekSize: 1 }, // bo-CN or ii-CN | mn-Mong-CN | ug-CN | zh-CN
+  CL: { firstDay: 1, firstWeekSize: 1 }, // es-CL
+  CM: { firstDay: 1, firstWeekSize: 1 }, // fr-CM or en-CM
+  CN: { firstDay: 1, firstWeekSize: 1 }, // zh-CN
   CO: { firstDay: 0, firstWeekSize: 1 }, // es-CO
   CR: { firstDay: 1, firstWeekSize: 1 }, // es-CR
   CY: { firstDay: 1, firstWeekSize: 1 }, // el-CY
   CZ: { firstDay: 1, firstWeekSize: 4 }, // cs-CZ
-  DE: { firstDay: 1, firstWeekSize: 4 }, // de-DE or dsb-DE | hsb-DE
-  DJ: { firstDay: 1, firstWeekSize: 1 },
+  DE: { firstDay: 1, firstWeekSize: 4 }, // de-DE
+  DJ: { firstDay: 6, firstWeekSize: 1 }, // fr-DJ
   DK: { firstDay: 1, firstWeekSize: 4 }, // da-DK
-  DM: { firstDay: 1, firstWeekSize: 1 },
+  DM: { firstDay: 0, firstWeekSize: 1 }, // en-DM
   DO: { firstDay: 0, firstWeekSize: 1 }, // es-DO
-  DZ: { firstDay: 6, firstWeekSize: 1 }, // ar-DZ or tzm-Latn-DZ
-  EC: { firstDay: 1, firstWeekSize: 1 }, // es-EC or quz-EC
+  DZ: { firstDay: 6, firstWeekSize: 1 }, // ar-DZ
+  EC: { firstDay: 1, firstWeekSize: 1 }, // es-EC
   EE: { firstDay: 1, firstWeekSize: 4 }, // et-EE
   EG: { firstDay: 6, firstWeekSize: 1 }, // ar-EG
-  ES: { firstDay: 1, firstWeekSize: 4 }, // ca-ES or es-ES | eu-ES | gl-ES
+  ES: { firstDay: 1, firstWeekSize: 4 }, // es-ES
   ET: { firstDay: 0, firstWeekSize: 1 }, // am-ET
-  FI: { firstDay: 1, firstWeekSize: 4 }, // fi-FI or se-FI | smn-FI | sms-FI | sv-FI
-  FJ: { firstDay: 1, firstWeekSize: 4 },
+  FI: { firstDay: 1, firstWeekSize: 4 }, // fi-FI or sv-FI
+  FJ: { firstDay: 1, firstWeekSize: 4 }, // en-FJ
   FO: { firstDay: 1, firstWeekSize: 4 }, // fo-FO
-  FR: { firstDay: 1, firstWeekSize: 4 }, // br-FR or co-FR | fr-FR | gsw-FR | oc-FR
-  GB: { firstDay: 1, firstWeekSize: 4 }, // cy-GB or en-GB | gd-GB
+  FR: { firstDay: 1, firstWeekSize: 4 }, // fr-FR
+  GB: { firstDay: 1, firstWeekSize: 4 }, // en-GB
   'GB-alt-variant': { firstDay: 0, firstWeekSize: 4 }, // not covered by Intl
   GE: { firstDay: 1, firstWeekSize: 1 }, // ka-GE
-  GF: { firstDay: 1, firstWeekSize: 1 },
-  GP: { firstDay: 1, firstWeekSize: 1 },
+  GF: { firstDay: 1, firstWeekSize: 4 }, // fr-GF
+  GP: { firstDay: 1, firstWeekSize: 4 }, // fr-GP
   GR: { firstDay: 1, firstWeekSize: 4 }, // el-GR
-  GT: { firstDay: 0, firstWeekSize: 1 }, // es-GT or qut-GT
-  GU: { firstDay: 0, firstWeekSize: 1 },
+  GT: { firstDay: 0, firstWeekSize: 1 }, // es-GT
+  GU: { firstDay: 0, firstWeekSize: 1 }, // en-GU or ch-GU | es-GU
   HK: { firstDay: 0, firstWeekSize: 1 }, // zh-HK
   HN: { firstDay: 0, firstWeekSize: 1 }, // es-HN
   HR: { firstDay: 1, firstWeekSize: 1 }, // hr-HR
@@ -74,7 +76,7 @@ const weekInfo: Record<string, { firstDay: number, firstWeekSize: number }> = {
   ID: { firstDay: 0, firstWeekSize: 1 }, // id-ID or in-ID
   IE: { firstDay: 1, firstWeekSize: 4 }, // en-IE or ga-IE
   IL: { firstDay: 0, firstWeekSize: 1 }, // he-IL or iw-IL
-  IN: { firstDay: 0, firstWeekSize: 1 }, // as-IN or bn-IN | en-IN | gu-IN | hi-IN | kn-IN | kok-IN | ml-IN | mr-IN | or-IN | pa-IN | sa-IN | ta-IN | te-IN
+  IN: { firstDay: 0, firstWeekSize: 1 }, // en-IN or hi-IN
   IQ: { firstDay: 6, firstWeekSize: 1 }, // ar-IQ
   IR: { firstDay: 6, firstWeekSize: 1 }, // fa-IR
   IS: { firstDay: 1, firstWeekSize: 4 }, // is-IS
@@ -97,66 +99,66 @@ const weekInfo: Record<string, { firstDay: number, firstWeekSize: number }> = {
   LV: { firstDay: 1, firstWeekSize: 1 }, // lv-LV
   LY: { firstDay: 6, firstWeekSize: 1 }, // ar-LY
   MC: { firstDay: 1, firstWeekSize: 4 }, // fr-MC
-  MD: { firstDay: 1, firstWeekSize: 1 },
-  ME: { firstDay: 1, firstWeekSize: 1 }, // sr-Cyrl-ME or sr-Latn-ME | sr-ME
-  MH: { firstDay: 0, firstWeekSize: 1 },
+  MD: { firstDay: 1, firstWeekSize: 1 }, // ro-MD
+  ME: { firstDay: 1, firstWeekSize: 1 }, // sr-ME
+  MH: { firstDay: 0, firstWeekSize: 1 }, // mh-MH or en-MH
   MK: { firstDay: 1, firstWeekSize: 1 }, // mk-MK
-  MM: { firstDay: 1, firstWeekSize: 1 },
+  MM: { firstDay: 0, firstWeekSize: 1 }, // my-MM
   MN: { firstDay: 1, firstWeekSize: 1 }, // mn-MN
   MO: { firstDay: 0, firstWeekSize: 1 }, // zh-MO
-  MQ: { firstDay: 1, firstWeekSize: 1 },
-  MT: { firstDay: 0, firstWeekSize: 1 }, // en-MT or mt-MT
+  MQ: { firstDay: 1, firstWeekSize: 4 }, // fr-MQ
+  MT: { firstDay: 0, firstWeekSize: 1 }, // mt-MT or en-MT
   MV: { firstDay: 5, firstWeekSize: 1 }, // dv-MV
   MX: { firstDay: 0, firstWeekSize: 1 }, // es-MX
   MY: { firstDay: 1, firstWeekSize: 1 }, // en-MY or ms-MY
-  MZ: { firstDay: 1, firstWeekSize: 1 },
+  MZ: { firstDay: 0, firstWeekSize: 1 }, // pt-MZ
   NI: { firstDay: 0, firstWeekSize: 1 }, // es-NI
   NL: { firstDay: 1, firstWeekSize: 4 }, // fy-NL or nl-NL
-  NO: { firstDay: 1, firstWeekSize: 4 }, // nb-NO or nn-NO | se-NO | sma-NO | smj-NO
+  NO: { firstDay: 1, firstWeekSize: 4 }, // nb-NO or nn-NO | no-NO
   NP: { firstDay: 0, firstWeekSize: 1 }, // ne-NP
   NZ: { firstDay: 1, firstWeekSize: 1 }, // en-NZ or mi-NZ
   OM: { firstDay: 6, firstWeekSize: 1 }, // ar-OM
   PA: { firstDay: 0, firstWeekSize: 1 }, // es-PA
-  PE: { firstDay: 0, firstWeekSize: 1 }, // es-PE or quz-PE
-  PH: { firstDay: 0, firstWeekSize: 1 }, // en-PH or fil-PH
+  PE: { firstDay: 0, firstWeekSize: 1 }, // es-PE
+  PH: { firstDay: 0, firstWeekSize: 1 }, // en-PH
   PK: { firstDay: 0, firstWeekSize: 1 }, // ur-PK
   PL: { firstDay: 1, firstWeekSize: 4 }, // pl-PL
   PR: { firstDay: 0, firstWeekSize: 1 }, // es-PR
   PT: { firstDay: 0, firstWeekSize: 4 }, // pt-PT
   PY: { firstDay: 0, firstWeekSize: 1 }, // es-PY
   QA: { firstDay: 6, firstWeekSize: 1 }, // ar-QA
-  RE: { firstDay: 1, firstWeekSize: 1 },
+  RE: { firstDay: 1, firstWeekSize: 4 }, // fr-RE
   RO: { firstDay: 1, firstWeekSize: 1 }, // ro-RO
-  RS: { firstDay: 1, firstWeekSize: 1 }, // sr-Cyrl-RS or sr-Latn-RS | sr-RS
-  RU: { firstDay: 1, firstWeekSize: 4 }, // ba-RU or ru-RU | sah-RU | tt-RU
+  RS: { firstDay: 1, firstWeekSize: 1 }, // sr-RS
+  RU: { firstDay: 1, firstWeekSize: 4 }, // ru-RU
   SA: { firstDay: 0, firstWeekSize: 1 }, // ar-SA
   SD: { firstDay: 6, firstWeekSize: 1 }, // ar-SD
-  SE: { firstDay: 1, firstWeekSize: 4 }, // se-SE or sma-SE | smj-SE | sv-SE
-  SG: { firstDay: 0, firstWeekSize: 1 }, // en-SG or zh-SG
+  SE: { firstDay: 1, firstWeekSize: 4 }, // sv-SE
+  SG: { firstDay: 0, firstWeekSize: 1 }, // en-SG or ms-SG | ta-SG | zh-SG
   SI: { firstDay: 1, firstWeekSize: 1 }, // sl-SI
   SK: { firstDay: 1, firstWeekSize: 4 }, // sk-SK
-  SM: { firstDay: 0, firstWeekSize: 1 },
+  SM: { firstDay: 1, firstWeekSize: 4 }, // it-SM
   SV: { firstDay: 0, firstWeekSize: 1 }, // es-SV
-  SY: { firstDay: 6, firstWeekSize: 1 }, // ar-SY or syr-SY
+  SY: { firstDay: 6, firstWeekSize: 1 }, // ar-SY
   TH: { firstDay: 0, firstWeekSize: 1 }, // th-TH
-  TJ: { firstDay: 1, firstWeekSize: 1 }, // tg-Cyrl-TJ
+  TJ: { firstDay: 1, firstWeekSize: 1 }, // ru-TJ
   TM: { firstDay: 1, firstWeekSize: 1 }, // tk-TM
   TR: { firstDay: 1, firstWeekSize: 1 }, // tr-TR
   TT: { firstDay: 0, firstWeekSize: 1 }, // en-TT
   TW: { firstDay: 0, firstWeekSize: 1 }, // zh-TW
   UA: { firstDay: 1, firstWeekSize: 1 }, // uk-UA
-  UM: { firstDay: 1, firstWeekSize: 1 },
+  UM: { firstDay: 0, firstWeekSize: 1 }, // en-UM
   US: { firstDay: 0, firstWeekSize: 1 }, // en-US or es-US
   UY: { firstDay: 1, firstWeekSize: 1 }, // es-UY
-  UZ: { firstDay: 1, firstWeekSize: 1 }, // uz-Cyrl-UZ or uz-Latn-UZ
-  VA: { firstDay: 1, firstWeekSize: 1 },
+  UZ: { firstDay: 1, firstWeekSize: 1 }, // uz-UZ
+  VA: { firstDay: 1, firstWeekSize: 4 }, // fr-VA or la-VA | de-VA | it-VA
   VE: { firstDay: 0, firstWeekSize: 1 }, // es-VE
-  VI: { firstDay: 1, firstWeekSize: 1 },
+  VI: { firstDay: 0, firstWeekSize: 1 }, // en-VI
   VN: { firstDay: 1, firstWeekSize: 1 }, // vi-VN
-  WS: { firstDay: 1, firstWeekSize: 1 },
-  XK: { firstDay: 1, firstWeekSize: 1 },
+  WS: { firstDay: 0, firstWeekSize: 1 }, // sm-WS or en-WS
+  XK: { firstDay: 1, firstWeekSize: 1 }, // sq-XK or sr-XK
   YE: { firstDay: 0, firstWeekSize: 1 }, // ar-YE
-  ZA: { firstDay: 0, firstWeekSize: 1 }, // af-ZA or en-ZA | nso-ZA | tn-ZA | xh-ZA | zu-ZA
+  ZA: { firstDay: 0, firstWeekSize: 1 }, // af-ZA or 9 more...
   ZW: { firstDay: 0, firstWeekSize: 1 }, // en-ZW
 }
 

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -437,10 +437,8 @@ function getWeek (date: Date, locale: string, firstDayOfWeek?: number, firstWeek
 
   let year = getYear(date)
   const currentWeekEnd = addDays(startOfWeek(date, locale, weekStart), 6)
-  if (year < getYear(currentWeekEnd)) {
-    if (firstWeekSize(year + 1) >= minWeekSize) {
-      year++
-    }
+  if (year < getYear(currentWeekEnd) && firstWeekSize(year + 1) >= minWeekSize) {
+    year++
   }
 
   const yearStart = new Date(year, 0, 1)

--- a/packages/vuetify/src/composables/date/date.ts
+++ b/packages/vuetify/src/composables/date/date.ts
@@ -116,30 +116,3 @@ export function useDate (): DateInstance {
 
   return createInstance(options, locale)
 }
-
-function firstWeekSize (adapter: DateAdapter<any>, year: number, startOfWeek = 0) {
-  const yearStart = adapter.startOfYear(adapter.date(`${year}-01-01`))
-  return {
-    yearStart,
-    size: 7 - adapter.getDiff(yearStart, adapter.startOfWeek(yearStart, startOfWeek), 'days')
-  }
-}
-
-type WeekCalculationOptions = { startOfWeek?: number, firstWeekMinSize?: number }
-export function getWeek (adapter: DateAdapter<any>, value: any, { startOfWeek = 0, firstWeekMinSize = 4 }: WeekCalculationOptions = {}) {
-  let year = adapter.getYear(value)
-  const currentWeekEnd = adapter.addDays(adapter.startOfWeek(value, startOfWeek), 6)
-  if (year < adapter.getYear(currentWeekEnd)) {
-    const { size } = firstWeekSize(adapter, year + 1, startOfWeek)
-    if (size >= firstWeekMinSize) {
-      year++
-    }
-  }
-
-  const { yearStart, size } = firstWeekSize(adapter, year, startOfWeek)
-  const d1w1 = size >= firstWeekMinSize
-    ? adapter.addDays(yearStart, size - 7)
-    : adapter.addDays(yearStart, size)
-
-  return 1 + adapter.getDiff(value, d1w1, 'weeks')
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,14 +431,14 @@ importers:
   packages/vuetify:
     devDependencies:
       '@date-io/core':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 3.2.0
+        version: 3.2.0
       '@date-io/date-fns':
-        specifier: 3.0.0
-        version: 3.0.0(date-fns@3.6.0)
+        specifier: 3.2.0
+        version: 3.2.0(date-fns@3.6.0)
       '@date-io/dayjs':
-        specifier: ^3.0.0
-        version: 3.0.0(dayjs@1.11.13)
+        specifier: ^3.2.0
+        version: 3.2.0(dayjs@1.11.13)
       '@date-io/luxon':
         specifier: ^3.2.0
         version: 3.2.0(luxon@3.5.0)
@@ -1351,22 +1351,19 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@date-io/core@3.0.0':
-    resolution: {integrity: sha512-S3j+IAQVBYNkQzchVVhX40eBkGDreBpScy9RXwTS5j2+k07+62pMVPisQ44Gq76Rqy5AOG/EZXCwBpY/jbemvA==}
-
   '@date-io/core@3.2.0':
     resolution: {integrity: sha512-hqwXvY8/YBsT9RwQITG868ZNb1MVFFkF7W1Ecv4P472j/ZWa7EFcgSmxy8PUElNVZfvhdvfv+a8j6NWJqOX5mA==}
 
-  '@date-io/date-fns@3.0.0':
-    resolution: {integrity: sha512-hsLAbsdP8LKfi7OQ729cXMWfmHQEq0hn3ysXfAAoc92j6j6sBq0s0tplnkWu6O4iBUpVCYRPGuNjQQhTaOu2AA==}
+  '@date-io/date-fns@3.2.0':
+    resolution: {integrity: sha512-qkWB6E8lTwlwWq1xodXsY7On3gUoLsibdRu5cSAL1+oklrMOqpKmTzoZ9UFdvTs4Z0RYAi1D9ZelfqOCjT2quQ==}
     peerDependencies:
       date-fns: ^3.2.0
     peerDependenciesMeta:
       date-fns:
         optional: true
 
-  '@date-io/dayjs@3.0.0':
-    resolution: {integrity: sha512-vy7DSwoQiPA2L0stRqW3le7lcEBMjoMMEmbpCNkyoX3xXizKInFvhbnOBmCyusIQ7tL/WsNC4X5bVgdNWX0JLA==}
+  '@date-io/dayjs@3.2.0':
+    resolution: {integrity: sha512-+3LV+3N+cpQbEtmrFo8odg07k02AFY7diHgbi2EKYYANOOCPkDYUjDr2ENiHuYNidTs3tZwzDKckZoVNN4NXxg==}
     peerDependencies:
       dayjs: ^1.8.17
     peerDependenciesMeta:
@@ -3971,7 +3968,7 @@ packages:
     resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -4594,7 +4591,7 @@ packages:
     hasBin: true
 
   ee-first@1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -7557,6 +7554,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.9.7:
@@ -8909,7 +8907,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   uuid@10.0.0:
@@ -10525,19 +10523,17 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@date-io/core@3.0.0': {}
-
   '@date-io/core@3.2.0': {}
 
-  '@date-io/date-fns@3.0.0(date-fns@3.6.0)':
+  '@date-io/date-fns@3.2.0(date-fns@3.6.0)':
     dependencies:
-      '@date-io/core': 3.0.0
+      '@date-io/core': 3.2.0
     optionalDependencies:
       date-fns: 3.6.0
 
-  '@date-io/dayjs@3.0.0(dayjs@1.11.13)':
+  '@date-io/dayjs@3.2.0(dayjs@1.11.13)':
     dependencies:
-      '@date-io/core': 3.0.0
+      '@date-io/core': 3.2.0
     optionalDependencies:
       dayjs: 1.11.13
 


### PR DESCRIPTION
## Description

fixes #20724
fixes #20490

- ~~ISO-ish 4-day requirement for the first week~~ defaults to match `en-US`

## Markup:

```vue
<template>
  <v-app style="background-color: rgba(var(--v-theme-on-surface), 0.2)">
    <v-container>
      <div class="d-flex justify-center align-center ga-3">
        <span class="opacity-70">locale:</span>
        <v-chip-group v-model="currentLocale">
          <v-chip filter label text="en" value="en"></v-chip>
          <v-chip filter label text="pl" value="pl"></v-chip>
          <v-chip filter label text="fr" value="fr"></v-chip>
          <v-chip filter label text="pt" value="pt"></v-chip>
        </v-chip-group>
      </div>
      <div class="d-flex justify-center align-center ga-3">
        <span class="opacity-70">startOfWeek:</span>
        <v-chip-group v-model="startOfWeek">
          <v-chip
            v-for="o in startOfWeekOptions"
            v-bind="o"
            :key="o.value"
            filter
            label
          ></v-chip>
        </v-chip-group>
      </div>
      <div class="d-flex flex-wrap justify-center ga-6">
        <v-locale-provider :locale="currentLocale">
          <v-date-picker
            v-for="d in 6"
            :key="d"
            :elevation="5"
            :first-day-of-week="startOfWeek"
            :model-value="new Date(2023 + d, 0, 1)"
            class="mt-3"
            hide-header
            show-adjacent-months
            show-week
          ></v-date-picker>
        </v-locale-provider>
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const currentLocale = ref('en')
  const startOfWeek = ref(undefined)
  const startOfWeekOptions = 'Sun|Mon|Tue|Wed|Thu|Fri|Sat'
    .split('|')
    .map((x, i) => ({ text: x, value: i }))
</script>
```
