### PR TITLE
fix(VNavigationDrawer): swipe glitch

### DIFF
--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -27,7 +27,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { useToggleScope } from '@/composables/toggleScope'
 
 // Utilities
-import { computed, nextTick, ref, shallowRef, toRef, Transition, watch } from 'vue'
+import { computed, nextTick, readonly, ref, shallowRef, toRef, Transition, watch } from 'vue'
 import { genericComponent, propsFactory, toPhysical, useRender } from '@/util'
 
 // Types
@@ -183,7 +183,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
       position: location,
       layoutSize,
       elementSize: width,
-      active: computed(() => isActive.value || isDragging.value),
+      active: readonly(isActive),
       disableTransitions: computed(() => isDragging.value),
       absolute: computed(() =>
         // eslint-disable-next-line @typescript-eslint/no-use-before-define


### PR DESCRIPTION
fixes: #19874

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #19874 

```typescript
// file: components/VNavigationDrawer/VNavigationDrawer.tsx
// line: 180
const { layoutItemStyles, layoutItemScrimStyles } = useLayoutItem({
  id: props.name,
  order: computed(() => parseInt(props.order, 10)),
  position: location,
  layoutSize,
  elementSize: width,
  active: computed(() => isActive.value || isDragging.value), // <-- This line
  disableTransitions: computed(() => isDragging.value),
  absolute: computed(() =>
    // eslint-disable-next-line @typescript-eslint/no-use-before-define
    props.absolute || (isSticky.value && typeof isStuck.value !== 'string')
  ),
})
```
The value of `active` on line 186 of `VNavigationDrawer.tsx` changes depending on `isDragging`.

```typescript
// file: composables/layout.ts
// line: 291
const styles = {
  [position.value]: 0,
  zIndex: zIndex.value,
  transform: `translate${isHorizontal ? 'X' : 'Y'}(${(active.value ? 0 : -(size === 0 ? 100 : size)) * (isOppositeHorizontal || isOppositeVertical ? -1 : 1)}${unit})`, // <-- This line
  position: absolute.value || rootZIndex.value !== ROOT_ZINDEX ? 'absolute' : 'fixed',
  ...(transitionsEnabled.value ? undefined : { transition: 'none' }),
} as const
```

As `active` becomes `true`, the `transform` property on line 295 of `composables/layout.ts` is set to translateX(0). So at this point, a glitch occurs.

```typescript
// file: components/VNavigationDrawer/touch.ts
// line: 186
useToggleScope(isDragging, () => {
  const transform = el.value?.style.transform ?? null
  const transition = el.value?.style.transition ?? null

  watchEffect(() => {
    el.value?.style.setProperty('transform', dragStyles.value?.transform || 'none')
    el.value?.style.setProperty('transition', dragStyles.value?.transition || null)
  })

  onScopeDispose(() => {
    el.value?.style.setProperty('transform', transform)
    el.value?.style.setProperty('transition', transition)
  })
})
```

The `transform` value is adjusted based on `isDragging`, and this moment is controlled by `useToggleScope`.
There's no need for two separate composables to manage the same property.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-navigation-drawer class="bg-red" />
    <v-container>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
