### PR TITLE
feat: deprecate `firstDayOfWeek` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VDatePicker.json
+++ b/packages/api-generator/src/locale/en/VDatePicker.json
@@ -14,7 +14,6 @@
     "month": "Sets the month.",
     "weekdays": "Array of weekdays.",
     "year": "Sets the year.",
-    "firstDayOfWeek": "Sets the first day of the week, starting with 0 for Sunday.",
     "flat": "Removes  elevation.",
     "format": "Takes a date object and returns it in a specified format.",
     "header": "Text shown when no **display-date** is set.",

--- a/packages/api-generator/src/locale/en/VDatePickerMonth.json
+++ b/packages/api-generator/src/locale/en/VDatePickerMonth.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "allowedDates": "Sets the allowed dates of the month.",
-    "firstDayOfWeek": "Sets the first day of the week, starting with 0 for Sunday.",
     "hideWeekdays": "Hide the days of the week letters.",
     "max": "Sets the maximum date of the month.",
     "min": "Sets the minimum date of the month.",

--- a/packages/api-generator/src/locale/en/generic.json
+++ b/packages/api-generator/src/locale/en/generic.json
@@ -17,6 +17,7 @@
     "eager": "Forces the component's content to render when it mounts. This is useful if you have content that will not be rendered in the DOM that you want crawled for SEO.",
     "end": "Applies margin at the start of the component.",
     "falseValue": "Sets value for falsy state.",
+    "firstDayOfWeek": "Deprecated, Sets the first day of the week, starting with 0 for Sunday.",
     "fullWidth": "Sets the component width to 100%.",
     "height": "Sets the height for the component.",
     "hideNoData": "Hides the menu when there are no options to show.  Useful for preventing the menu from opening before results are fetched asynchronously.  Also has the effect of opening the menu when the `items` array changes if not already open.",

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -22,6 +22,8 @@ export interface CalendarProps {
   weekdays: number[]
   year: number | string | undefined
   weeksInMonth: 'dynamic' | 'static'
+
+  /** @deprecated */
   firstDayOfWeek: number | string | undefined
 
   'onUpdate:modelValue': ((value: unknown[]) => void) | undefined


### PR DESCRIPTION
Marks `first-day-of-week` as deprecated because it does not work when using date adapters. We want developers to use `<v-locale-provider>` instead and get both first day of the week as well as correct week number calculations.

closes #21204