### PR TITLE
fix(v-ripple): Added option to not trigger v-ripple on enter keypress

### DIFF
--- a/packages/api-generator/src/locale/en/v-ripple.json
+++ b/packages/api-generator/src/locale/en/v-ripple.json
@@ -3,6 +3,7 @@
   "modifiers": {
     "center": "Makes it so that the ripple originates from the center of the element, instead where the user clicked on it.",
     "circle": "Changes the ripple behavior to better match circular elements.",
-    "stop": "Prevents ripples from being triggered on any other elements when the click event is bubbling up."
+    "stop": "Prevents ripples from being triggered on any other elements when the click event is bubbling up.",
+    "noTriggerOnEnter": "Prevents the ripple from being triggered when the enter key is pressed while the element is focused."
   }
 }

--- a/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
+++ b/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
@@ -72,8 +72,6 @@ describe('v-ripple', () => {
     expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
   })
 
-<<<<<<< Updated upstream
-=======
   it('should not trigger ripple on enter key press', () => {
     vi.useFakeTimers()
     const wrapper = mount({
@@ -93,7 +91,6 @@ describe('v-ripple', () => {
     expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
   })
 
->>>>>>> Stashed changes
   it('should only ripple on one element', () => {
     vi.useFakeTimers()
 

--- a/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
+++ b/packages/vuetify/src/directives/ripple/__tests__/ripple.spec.ts
@@ -72,6 +72,28 @@ describe('v-ripple', () => {
     expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
   })
 
+<<<<<<< Updated upstream
+=======
+  it('should not trigger ripple on enter key press', () => {
+    vi.useFakeTimers()
+    const wrapper = mount({
+      directives: { Ripple },
+      template: '<div v-ripple.noTriggerOnEnter />',
+    })
+
+    const keydownEvent = new KeyboardEvent('keydown', { keyCode: keyCodes.enter })
+    wrapper.element.dispatchEvent(keydownEvent)
+
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
+
+    const keyupEvent = new KeyboardEvent('keyup')
+    wrapper.element.dispatchEvent(keyupEvent)
+
+    vi.runAllTimers()
+    expect(wrapper.find('.v-ripple__container').exists()).toBe(false)
+  })
+
+>>>>>>> Stashed changes
   it('should only ripple on one element', () => {
     vi.useFakeTimers()
 

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -3,7 +3,6 @@ import './VRipple.sass'
 
 // Utilities
 import { isObject, keyCodes } from '@/util'
-import { on } from 'events'
 
 // Types
 import type { DirectiveBinding } from 'vue'

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -22,6 +22,7 @@ interface RippleOptions {
   class?: string
   center?: boolean
   circle?: boolean
+  noTriggerOnEnter?: boolean
 }
 
 export interface RippleDirectiveBinding extends Omit<DirectiveBinding, 'modifiers' | 'value'> {
@@ -30,6 +31,7 @@ export interface RippleDirectiveBinding extends Omit<DirectiveBinding, 'modifier
     center?: boolean
     circle?: boolean
     stop?: boolean
+    noTriggerOnEnter?: boolean
   }
 }
 
@@ -250,7 +252,7 @@ function rippleCancelShow (e: MouseEvent | TouchEvent) {
 let keyboardRipple = false
 
 function keyboardRippleShow (e: KeyboardEvent) {
-  if (!keyboardRipple && (e.keyCode === keyCodes.enter || e.keyCode === keyCodes.space)) {
+  if (!keyboardRipple && (((e.keyCode === keyCodes.enter) && !modifiers.noTriggerOnEnter) || e.keyCode === keyCodes.space)) {
     keyboardRipple = true
     rippleShow(e)
   }

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -3,6 +3,7 @@ import './VRipple.sass'
 
 // Utilities
 import { isObject, keyCodes } from '@/util'
+import { on } from 'events'
 
 // Types
 import type { DirectiveBinding } from 'vue'
@@ -252,7 +253,9 @@ function rippleCancelShow (e: MouseEvent | TouchEvent) {
 let keyboardRipple = false
 
 function keyboardRippleShow (e: KeyboardEvent) {
-  if (!keyboardRipple && (((e.keyCode === keyCodes.enter) && !modifiers.noTriggerOnEnter) || e.keyCode === keyCodes.space)) {
+  const el = e.currentTarget as HTMLElement
+  const noTriggerOnEnter = el._ripple?.noEnter
+  if (!keyboardRipple && (((e.keyCode === keyCodes.enter) && !noTriggerOnEnter) || e.keyCode === keyCodes.space)) {
     keyboardRipple = true
     rippleShow(e)
   }
@@ -276,11 +279,13 @@ function updateRipple (el: HTMLElement, binding: RippleDirectiveBinding, wasEnab
   if (!enabled) {
     ripples.hide(el)
   }
-
+  
   el._ripple = el._ripple ?? {}
   el._ripple.enabled = enabled
   el._ripple.centered = modifiers.center
   el._ripple.circle = modifiers.circle
+  el._ripple.noEnter = modifiers.noTriggerOnEnter
+
   if (isObject(value) && value.class) {
     el._ripple.class = value.class
   }

--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -27,6 +27,7 @@ declare global {
       touched?: boolean
       isTouch?: boolean
       showTimer?: number
+      noEnter?: boolean
       showTimerCommit?: (() => void) | null
     }
     _observe?: Record<number, {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
This adds an option to make v-ripple not trigger when you press enter on a component. Right now the effect triggers on pressing space or enter/return, which works for buttons, but on certain other elements like checkboxes, if you want to use the ripple effect you do not want it to trigger on pressing enter. This is due to the fact that checkboxes typically can't be toggled using enter, but can be by using space or clicking. 
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-btn v-ripple.noTriggerOnEnter> Create Group</v-btn>
    </v-container>
  </v-app>
</template>

<script>
import { no } from "@/locale";

export default {
  name: "Playground",
  setup() {
    return {
      //
    };
  },
};
</script>

```
