### PR TITLE
fix(select): use current page items for shift click selection

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/select.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/select.ts
@@ -149,7 +149,7 @@ export function provideSelection (
     if (props.selectStrategy !== 'single' && event?.shiftKey && lastSelectedIndex.value !== null) {
       const [start, end] = [lastSelectedIndex.value, index].sort((a, b) => a - b)
 
-      items.push(...allItems.value.slice(start, end + 1))
+      items.push(...currentPage.value.slice(start, end + 1))
     } else {
       items.push(item)
       lastSelectedIndex.value = index

--- a/packages/vuetify/src/components/VDataTable/composables/select.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/select.ts
@@ -144,7 +144,7 @@ export function provideSelection (
 
   function toggleSelect (item: SelectableItem, index?: number, event?: MouseEvent) {
     const items = []
-    index = index ?? allItems.value.findIndex(i => i.value === item.value)
+    index = index ?? currentPage.value.findIndex(i => i.value === item.value)
 
     if (props.selectStrategy !== 'single' && event?.shiftKey && lastSelectedIndex.value !== null) {
       const [start, end] = [lastSelectedIndex.value, index].sort((a, b) => a - b)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #21190 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    v-model="selected"
    :items="items"
    item-value="name"
    show-select
    :sort-by="[{ key: 'location', order: 'asc' }]"
  ></v-data-table>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref([])
  const items = [
    {
      name: '🍎 Apple',
      location: 'Washington',
      height: '0.1',
      base: '0.07',
      volume: '0.0001',
    },
    {
      name: '🍌 Banana',
      location: 'Ecuador',
      height: '0.2',
      base: '0.05',
      volume: '0.0002',
    },
    {
      name: '🍇 Grapes',
      location: 'Italy',
      height: '0.02',
      base: '0.02',
      volume: '0.00001',
    },
    {
      name: '🍉 Watermelon',
      location: 'China',
      height: '0.4',
      base: '0.3',
      volume: '0.03',
    },
    {
      name: '🍍 Pineapple',
      location: 'Thailand',
      height: '0.3',
      base: '0.2',
      volume: '0.005',
    },
    {
      name: '🍒 Cherries',
      location: 'Turkey',
      height: '0.02',
      base: '0.02',
      volume: '0.00001',
    },
    {
      name: '🥭 Mango',
      location: 'India',
      height: '0.15',
      base: '0.1',
      volume: '0.0005',
    },
    {
      name: '🍓 Strawberry',
      location: 'USA',
      height: '0.03',
      base: '0.03',
      volume: '0.00002',
    },
    {
      name: '🍑 Peach',
      location: 'China',
      height: '0.09',
      base: '0.08',
      volume: '0.0004',
    },
    {
      name: '🥝 Kiwi',
      location: 'New Zealand',
      height: '0.05',
      base: '0.05',
      volume: '0.0001',
    },
    {
      name: '🥝 Kiwi123123123',
      location: 'New Zealand123123123',
      height: '0.06',
      base: '0.01',
      volume: '0.0021',
    },
  ]
</script>
```
