### PR TITLE
docs: fix Day.js usage example in the Dates documentation

### DIFF
--- a/packages/docs/src/pages/en/features/dates.md
+++ b/packages/docs/src/pages/en/features/dates.md
@@ -172,13 +172,13 @@ Then configure Vuetify to use DayJs:
 
 ```js { resource="src/plugins/vuetify.js" }
 import { createVuetify } from 'vuetify'
-import DayJsAdapter from '@date-io/dayjs'
-import { enUS } from 'date-fns/locale'
+import DayJsAdapter from '@date-io/dayjs';
+import en from 'dayjs/locale/en';
 
 export default createVuetify({
   date: {
     adapter: DayJsAdapter,
-    locale: { en: enUS },
+    locale: { en },
   },
 })
 ```


### PR DESCRIPTION
Corrected the Day.js import and usage details to match the actual code requirements.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

This change corrects the Day.js import and usage details in the Dates documentation. The previous instructions contained errors in the import statement and usage examples, which could confuse developers integrating Day.js with Vuetify. This update ensures that the documentation now accurately reflects the proper usage, improving the developer experience.



<!-- Remove the Markup section for documentation-only changes -->
