### PR TITLE
fix(VNumberInput): focus after click handler executed

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -278,7 +278,14 @@ export const VField = genericComponent<new <T>(
           />
 
           { hasPrepend && (
-            <div key="prepend" class="v-field__prepend-inner">
+            <div
+              key="prepend"
+              class="v-field__prepend-inner"
+              onMousedown={ (e: MouseEvent) => {
+                e.preventDefault()
+                e.stopPropagation()
+              }}
+            >
               { props.prependInnerIcon && (
                 <InputIcon
                   key="prepend-icon"
@@ -368,7 +375,14 @@ export const VField = genericComponent<new <T>(
           )}
 
           { hasAppend && (
-            <div key="append" class="v-field__append-inner">
+            <div
+              key="append"
+              class="v-field__append-inner"
+              onMousedown={ (e: MouseEvent) => {
+                e.preventDefault()
+                e.stopPropagation()
+              }}
+            >
               { slots['append-inner']?.(slotProps.value) }
 
               { props.appendInnerIcon && (


### PR DESCRIPTION
## Description

`VNumberInput` has a "lock" on external changes when the field is focused. I helps prevent typing issues (e.g. type `5.0` and just before I type `1` to get the `5.01` any external change will cause the `.0` to disappear). The annoying behavior without the lock can be reproduced with VTextField when using `v-model:number=...`.

Currently when user is clicking a button placed in `#append-inner`, the click handler fires after the focus and I cannot influence this by simply adding `.stop`. There are 2 options I see:
- (kinda bad)
  - artificial delay (around 100ms) for the internal lock... measured min. 70ms locally
- (ok, unless it breaks something)
  - prevent `mousedown` on inner slots on VField
  - this helps `@click.stop` work as intended

fixes #21213

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-row justify="center">
        <v-col cols="12" md="6">
          <v-number-input :precision="2"
            v-model="numericValue"
            label="Enter a number"
            control-variant="stacked"
            class="my-4"
          >
            <template #append-inner>
              <v-btn
                v-if="numericValue == null || numericValue < 100"
                color="primary"
                size="small"
                text="Add +50"
                @click="numericValue += 50"
              />
            </template>
          </v-number-input>

          <v-text-field
            v-model.number="numericValue"
            label="Enter a number"
            control-variant="stacked"
            :min="0"
            :max="100"
            class="my-4"
          >
            <template #append-inner>
              <v-btn
                v-if="numericValue == null || numericValue < 100"
                variant="outlined"
                size="small"
                text="Add +50"
                @click="numericValue += 50"
              />
            </template>
          </v-text-field>

          <pre>Current value: {{ numericValue }}</pre>

          <v-btn @click="changeValueExternally" class="mt-4">
            Set value to 50 externally
          </v-btn>

          <v-btn @click="setNull" class="mt-4 ml-2"> Set value to null </v-btn>
          <div class="mt-3">
            <v-btn v-if="!interval" @click="startIncrements" prepend-icon="mdi-play">Start increments</v-btn>
            <v-btn v-else @click="stopIncrements" prepend-icon="mdi-stop">Stop</v-btn>
          </div>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const numericValue = ref(10)

  const changeValueExternally = () => numericValue.value = 50
  const setNull = () => numericValue.value = null

  let interval = 0
  const startIncrements = () => {
    clearInterval(interval)
    interval = setInterval(() => numericValue.value += 5, 1000);
  }
  const stopIncrements = () => {
    clearInterval(interval)
  }
</script>
<style>
  .v-input--horizontal .v-input__append {
    margin-inline-start: 0;
  }
</style>
```
