### PR TITLE
fix(VDataTable): data table expand button content overflows

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -134,7 +134,7 @@
 
   .v-data-table__tr--mobile
     > .v-data-table__td--expanded-row
-      grid-template-columns: 0
+      grid-template-columns: auto
       justify-content: center
 
     > .v-data-table__td--select-row


### PR DESCRIPTION
## Description

- Button content on `VDataTable` on mobile display / mode data table expand button content overflows

Fixes: https://github.com/vuetifyjs/vuetify/issues/20545

## Markup:

#### Before:
<img src="https://github.com/user-attachments/assets/a7a96182-8b6a-4337-8e69-72ec538a0773" width="500" />
<img src="https://github.com/user-attachments/assets/4f331511-2e91-45c9-bf51-4c01a3c274f4" width="500" />

#### After:
<img src="https://github.com/user-attachments/assets/13da1a84-a5c1-4938-914b-833b723781f1" width="800" />
<img src="https://github.com/user-attachments/assets/9f1e1ec9-762d-4647-98e4-3f00f33b4d01" width="800" />
