### PR TITLE
feat(VOverlay): align scrim color with MD3

### DIFF
--- a/packages/vuetify/src/components/VOverlay/_variables.scss
+++ b/packages/vuetify/src/components/VOverlay/_variables.scss
@@ -1,3 +1,3 @@
 // Defaults
 $overlay-opacity: 0.32 !default;
-$overlay-scrim-background: rgb(var(--v-theme-on-surface)) !default;
+$overlay-scrim-background: #000 !default;


### PR DESCRIPTION
## Description

It only really affects dark mode. No need for dedicated CSS variable - we might introduce one, when we drop Sass. For now I would leave it to be customized using typical method. Fans of MD3 might be disappointed, but it is pragmatic.

I don't feel like targeting `dev` is necessary. Whoever is going to merge it (assuming it gets approved), can decide on keeping or changing it to `master`.

closes #20244

```diff
- $overlay-scrim-background: rgb(var(--v-theme-on-surface)) !default;
+ $overlay-scrim-background: #000 !default;
```
