### PR TITLE
fix(validation): a disabled field should always be valid

### DIFF
--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -220,7 +220,7 @@ export function useValidation (
   }
 
   async function validate (silent = false) {
-    if (props.disabled) {
+    if (props.disabled || props.readonly) {
       internalErrorMessages.value = []
       isValidating.value = false
       return internalErrorMessages.value

--- a/packages/vuetify/src/composables/validation.ts
+++ b/packages/vuetify/src/composables/validation.ts
@@ -220,6 +220,12 @@ export function useValidation (
   }
 
   async function validate (silent = false) {
+    if (props.disabled) {
+      internalErrorMessages.value = []
+      isValidating.value = false
+      return internalErrorMessages.value
+    }
+
     const results = []
 
     isValidating.value = true


### PR DESCRIPTION
## Motivation and Context
Skip validation if disabled.

~~TODO: Should this occur on readonly as well?~~ Yes

## Markup:
<details>

```vue
<template>
  <v-container class="pa-md-12">
    <v-form v-model="valid">
      <v-text-field :rules="[val => !!val || 'Required']" label="Regular" />
      <v-text-field :rules="[val => !!val || 'Required']" label="Disabled" disabled />
    </v-form>

    <pre>{{ JSON.stringify(valid, null, 2) }}</pre>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'

  const valid = ref(false)
</script>

```
</details>