### PR TITLE
feat(theme): add toggle function

### DIFF
--- a/packages/api-generator/src/locale/en/useTheme.json
+++ b/packages/api-generator/src/locale/en/useTheme.json
@@ -1,5 +1,8 @@
 {
   "exposed": {
+    "change": "Change to a specific theme.",
+    "toggle": "Toggle between two themes.",
+    "cycle": "Cycle between all or a subset of themes.",
     "computedThemes": "Object containing all parsed theme definitions.",
     "current": "Current theme object.",
     "global": "Reference to the global theme instance.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -1,4 +1,11 @@
 {
+  "useTheme": {
+    "exposed": {
+      "change": "3.9.0",
+      "toggle": "3.9.0",
+      "cycle": "3.9.0"
+    }
+  },
   "VAppBar": {
     "props": {
       "scrollBehavior": "3.2.0"

--- a/packages/docs/src/data/page-to-api.json
+++ b/packages/docs/src/data/page-to-api.json
@@ -173,7 +173,7 @@
   "features/scrolling": ["useGoTo"],
   "features/global-configuration": ["VDefaultsProvider"],
   "features/internationalization": ["useLocale", "VLocaleProvider"],
-  "features/theme": ["VThemeProvider"],
+  "features/theme": ["useTheme", "VThemeProvider"],
   "styles/transitions": [
     "VDialogBottomTransition",
     "VDialogTopTransition",

--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -153,7 +153,39 @@ export default createVuetify({
 
 ## Changing theme
 
-This is used when you need to change the theme during runtime
+Changing themes at runtime is as easy as calling the **toggle** method on the theme instance. The **toggle** method accepts a theme name or an array of theme names. If no argument is passed, it will toggle between all available themes.
+
+```html
+<template>
+  <v-app>
+    <!-- Toggle between all available themes -->
+    <v-btn @click="theme.toggle()">
+      Toggle All Themes
+    </v-btn>
+
+    <!-- Change to a specific theme -->
+    <v-btn @click="theme.toggle('dark')">
+      Change to Dark Theme
+    </v-btn>
+
+    <!-- Toggle between specific themes -->
+    <v-btn @click="theme.toggle(['dark', 'utopia'])">
+      Toggle Specific Themes
+    </v-btn>
+  </v-app>
+</template>
+
+<script setup>
+  import { useTheme } from 'vuetify'
+
+  const theme = useTheme()
+</script>
+```
+
+<details>
+<summary>Usage before v3.9</summary>
+
+In versions before v3.9, you manually change the global name value on the theme instance:
 
 ```html { resource="src/App.vue" }
 <template>
@@ -173,6 +205,10 @@ function toggleTheme () {
 }
 </script>
 ```
+
+</details>
+
+<br>
 
 You should keep in mind that most of the Vuetify components support the **theme** prop. When used a new context is created for _that_ specific component and **all** of its children. In the following example, the [v-btn](/components/buttons/) uses the **dark** theme because it is applied to its parent [v-card](/components/cards/).
 

--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -153,25 +153,42 @@ export default createVuetify({
 
 ## Changing theme
 
-Changing themes at runtime is as easy as calling the **toggle** method on the theme instance. The **toggle** method accepts a theme name or an array of theme names. If no argument is passed, it will toggle between all available themes.
+The theme instance has 3 functions to change the theme:
+
+- **change**: Changes to a specific name
+- **toggle**: Toggle between two themes / defaults to light and dark
+- **cycle**: Cycles between all or a specific subset of themes in any order
 
 ```html
 <template>
   <v-app>
-    <!-- Toggle between all available themes -->
-    <v-btn @click="theme.toggle()">
-      Toggle All Themes
-    </v-btn>
+    <v-main>
+      <v-container>
+        <!-- Toggle between Light / Dark -->
+        <v-btn
+          @click="theme.toggle()"
+          text="Toggle Light / Dark"
+        ></v-btn>
 
-    <!-- Change to a specific theme -->
-    <v-btn @click="theme.toggle('dark')">
-      Change to Dark Theme
-    </v-btn>
+        <!-- Change to a specific theme -->
+        <v-btn
+          @click="theme.change('dark')"
+          text="Change to Dark"
+        ></v-btn>
 
-    <!-- Toggle between specific themes -->
-    <v-btn @click="theme.toggle(['dark', 'utopia'])">
-      Toggle Specific Themes
-    </v-btn>
+        <!-- Cycle between all themes -->
+        <v-btn
+          @click="theme.cycle()"
+          text="Cycle All Themes"
+        ></v-btn>
+
+        <!-- Cycle between specific themes -->
+        <v-btn
+          @click="theme.cycle(['custom', 'light', 'utopia'])"
+          text="Cycle Specific Themes"
+        ></v-btn>
+      </v-container>
+    </v-main>
   </v-app>
 </template>
 

--- a/packages/docs/src/pages/en/features/theme.md
+++ b/packages/docs/src/pages/en/features/theme.md
@@ -155,9 +155,9 @@ export default createVuetify({
 
 The theme instance has 3 functions to change the theme:
 
-- **change**: Changes to a specific name
+- **change**: Change to a specific name
 - **toggle**: Toggle between two themes / defaults to light and dark
-- **cycle**: Cycles between all or a specific subset of themes in any order
+- **cycle**: Cycle between all or a specific subset of themes in any order
 
 ```html
 <template>

--- a/packages/vuetify/src/composables/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/theme.spec.ts
@@ -228,4 +228,58 @@ describe('createTheme', () => {
     // Verify updateDOM is called during reactivity
     expect(mockUpdateHead).toHaveBeenCalled()
   })
+
+  it('should properly handle theme toggling functionality', async () => {
+    const theme = createTheme({
+      defaultTheme: 'light',
+      themes: {
+        custom: { dark: false },
+      },
+    })
+
+    // Test 1: Toggle through all available themes when no argument provided
+    expect(theme.name.value).toBe('light')
+
+    theme.toggle()
+    expect(theme.name.value).toBe('dark')
+
+    theme.toggle()
+    expect(theme.name.value).toBe('custom')
+
+    theme.toggle()
+    expect(theme.name.value).toBe('light')
+
+    // Test 2: Toggle to a specific theme
+    theme.toggle('dark')
+    expect(theme.name.value).toBe('dark')
+
+    theme.toggle('custom')
+    expect(theme.name.value).toBe('custom')
+
+    theme.toggle('light')
+    expect(theme.name.value).toBe('light')
+
+    // Test 3: Toggle between a limited set of themes
+    theme.toggle(['light', 'dark'])
+    expect(theme.name.value).toBe('dark')
+
+    theme.toggle(['light', 'dark'])
+    expect(theme.name.value).toBe('light')
+
+    theme.toggle(['light', 'dark'])
+    expect(theme.name.value).toBe('dark')
+
+    // Test 4: Handling of event objects
+    theme.toggle(new Event('click'))
+    expect(theme.name.value).toBe('custom')
+
+    theme.toggle(new Event('click'))
+    expect(theme.name.value).toBe('light')
+
+    // Test 5: Error when toggling to a non-existent theme
+    const consoleMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    theme.toggle('nonexistent')
+    expect(consoleMock).toHaveBeenCalledWith('[Vue warn]: Vuetify: Theme "nonexistent" not found on the Vuetify theme instance')
+    consoleMock.mockReset()
+  })
 })

--- a/packages/vuetify/src/composables/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/theme.spec.ts
@@ -229,11 +229,12 @@ describe('createTheme', () => {
     expect(mockUpdateHead).toHaveBeenCalled()
   })
 
-  it('should properly handle theme toggling functionality', async () => {
+  it('should change, toggle, and cycle theme', async () => {
     const theme = createTheme({
       defaultTheme: 'light',
       themes: {
         custom: { dark: false },
+        utopia: { dark: true },
       },
     })
 
@@ -244,41 +245,32 @@ describe('createTheme', () => {
     expect(theme.name.value).toBe('dark')
 
     theme.toggle()
-    expect(theme.name.value).toBe('custom')
-
-    theme.toggle()
     expect(theme.name.value).toBe('light')
 
-    // Test 2: Toggle to a specific theme
-    theme.toggle('dark')
+    // Test 2: Change to a specific theme
+    theme.change('dark')
     expect(theme.name.value).toBe('dark')
 
-    theme.toggle('custom')
+    // Test 3: Cycle between a limited set of themes
+    theme.cycle()
     expect(theme.name.value).toBe('custom')
 
-    theme.toggle('light')
+    theme.cycle()
+    expect(theme.name.value).toBe('utopia')
+
+    theme.cycle()
     expect(theme.name.value).toBe('light')
 
-    // Test 3: Toggle between a limited set of themes
-    theme.toggle(['light', 'dark'])
-    expect(theme.name.value).toBe('dark')
+    // Test 4: Cycle between a subset of themes
+    theme.cycle(['light', 'utopia'])
+    expect(theme.name.value).toBe('utopia')
 
-    theme.toggle(['light', 'dark'])
+    theme.cycle(['light', 'utopia'])
     expect(theme.name.value).toBe('light')
 
-    theme.toggle(['light', 'dark'])
-    expect(theme.name.value).toBe('dark')
-
-    // Test 4: Handling of event objects
-    theme.toggle(new Event('click'))
-    expect(theme.name.value).toBe('custom')
-
-    theme.toggle(new Event('click'))
-    expect(theme.name.value).toBe('light')
-
-    // Test 5: Error when toggling to a non-existent theme
+    // Test 5: Error when changing to a non-existent theme
     const consoleMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    theme.toggle('nonexistent')
+    theme.change('nonexistent')
     expect(consoleMock).toHaveBeenCalledWith('[Vue warn]: Vuetify: Theme "nonexistent" not found on the Vuetify theme instance')
     consoleMock.mockReset()
   })


### PR DESCRIPTION
## Motivation and Context
- Make it easier to change the theme
- Reduce cognitive load when working with themes
- More to come in future P.R.s

## Markup:
<details>

```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <!-- Toggle between Light / Dark -->
        <v-btn @click="theme.toggle()">
          Toggle Light / Dark
        </v-btn>

        <!-- Change to a specific theme -->
        <v-btn @click="theme.change('dark')">
          Change to Dark
        </v-btn>

        <!-- Cycle between all themes -->
        <v-btn @click="theme.cycle()">
          Cycle All Themes
        </v-btn>

        <!-- Cycle between specific themes -->
        <v-btn @click="theme.cycle(['custom', 'light', 'utopia'])">
          Cycle Specific Themes
        </v-btn>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { useTheme } from 'vuetify'

  const theme = useTheme()
</script>
```
</details>