### PR TITLE
feat(location-strategies): infinite loop on update location

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -309,7 +309,10 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     let x = 0; let y = 0
     const flipped = { x: false, y: false }
     const available = { x: 0, y: 0 }
+
     // Make the retry max x2 to get the correct position
+    // Addition happens on resizeObserver see line 207
+    // eslint-disable-next-line no-unmodified-loop-condition
     while (retries < 2) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
@@ -402,14 +405,14 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       maxWidth: available.x > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.x, minWidth.value === Infinity
-          ? 0
-          : minWidth.value, maxWidth.value))
+            ? 0
+            : minWidth.value, maxWidth.value))
         ),
       maxHeight: available.y > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.y, minHeight.value === Infinity
-          ? 0
-          : minHeight.value, maxHeight.value))
+            ? 0
+            : minHeight.value, maxHeight.value))
         ),
     })
 

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -211,9 +211,8 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     if (oldTarget && !Array.isArray(oldTarget)) observer.unobserve(oldTarget)
     if (newTarget && !Array.isArray(newTarget)) observer.observe(newTarget)
 
-    // TODO: Check or test effect on other components
-    // if (oldContentEl) observer.unobserve(oldContentEl)
-    // if (newContentEl) observer.observe(newContentEl)
+    if (oldContentEl) observer.unobserve(oldContentEl)
+    if (newContentEl) observer.observe(newContentEl)
   }, {
     immediate: true,
   })
@@ -310,10 +309,8 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     const flipped = { x: false, y: false }
     const available = { x: 0, y: 0 }
 
-    // Make the retry max x2 to get the correct position
-    // Addition happens on resizeObserver see line 207
     // eslint-disable-next-line no-unmodified-loop-condition
-    while (retries < 3) {
+    while (retries < 2) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
       x += _x
@@ -399,9 +396,9 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       transformOrigin: `${placement.origin.side} ${placement.origin.align}`,
       // transform: `translate(${pixelRound(x)}px, ${pixelRound(y)}px)`,
       top: convertToUnit(pixelRound(y > 0 ? y : previousY)),
-      left: data.isRtl.value ? undefined : convertToUnit(pixelRound(x > 0 ? x : previousX)),
+      left: data.isRtl.value ? undefined : convertToUnit(12),
       right: data.isRtl.value ? convertToUnit(pixelRound(x > 0 ? -x : -previousX)) : undefined,
-      minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value),
+      minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width - 28) : minWidth.value),
       maxWidth: available.x > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.x, minWidth.value === Infinity

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -151,7 +151,7 @@ let retries = 0
 let previousX = 0
 let previousY = 0
 
-function connectedLocationStrategy(data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
+function connectedLocationStrategy (data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
   const activatorFixed = Array.isArray(data.target.value) || isFixedPosition(data.target.value)
   if (activatorFixed) {
     Object.assign(contentStyles.value, {
@@ -310,7 +310,7 @@ function connectedLocationStrategy(data: LocationStrategyData, props: StrategyPr
     const flipped = { x: false, y: false }
     const available = { x: 0, y: 0 }
     // Make the retry max x2 to get the correct position
-    while (true && retries < 2) {
+    while (retries < 2) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
       x += _x
@@ -399,8 +399,18 @@ function connectedLocationStrategy(data: LocationStrategyData, props: StrategyPr
       left: data.isRtl.value ? undefined : convertToUnit(pixelRound(x > 0 ? x : previousX)),
       right: data.isRtl.value ? convertToUnit(pixelRound(x > 0 ? -x : -previousX)) : undefined,
       minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value),
-      maxWidth: available.x > 0 && convertToUnit(pixelCeil(clamp(available.x, minWidth.value === Infinity ? 0 : minWidth.value, maxWidth.value))),
-      maxHeight: available.y > 0 && convertToUnit(pixelCeil(clamp(available.y, minHeight.value === Infinity ? 0 : minHeight.value, maxHeight.value))),
+      maxWidth: available.x > 0 &&
+        convertToUnit(pixelCeil(clamp(
+          available.x, minWidth.value === Infinity
+          ? 0
+          : minWidth.value, maxWidth.value))
+        ),
+      maxHeight: available.y > 0 &&
+        convertToUnit(pixelCeil(clamp(
+          available.y, minHeight.value === Infinity
+          ? 0
+          : minHeight.value, maxHeight.value))
+        ),
     })
 
     return {

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -145,13 +145,13 @@ function getIntrinsicSize (el: HTMLElement, isRtl: boolean) {
   return contentBox
 }
 
-// Prevents infinite loop
-let retries = 0
-// Track the last position
-let previousX = 0
-let previousY = 0
-
 function connectedLocationStrategy (data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
+  // Prevents infinite loop
+  let retries = 0
+  // Track the last position
+  let previousX = 0
+  let previousY = 0
+
   const activatorFixed = Array.isArray(data.target.value) || isFixedPosition(data.target.value)
   if (activatorFixed) {
     Object.assign(contentStyles.value, {
@@ -204,7 +204,6 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
   let observe = false
   const observer = new ResizeObserver(() => {
-    retries += 1
     if (observe) updateLocation()
   })
 
@@ -227,6 +226,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
   // eslint-disable-next-line max-statements
   function updateLocation () {
+    retries++
     observe = false
     requestAnimationFrame(() => observe = true)
 
@@ -313,7 +313,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     // Make the retry max x2 to get the correct position
     // Addition happens on resizeObserver see line 207
     // eslint-disable-next-line no-unmodified-loop-condition
-    while (retries < 2) {
+    while (retries < 3) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
       x += _x

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -148,9 +148,6 @@ function getIntrinsicSize (el: HTMLElement, isRtl: boolean) {
 function connectedLocationStrategy (data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
   // Prevents infinite loop
   let retries = 0
-  // Track the last position
-  let previousX = 0
-  let previousY = 0
 
   const activatorFixed = Array.isArray(data.target.value) || isFixedPosition(data.target.value)
   if (activatorFixed) {
@@ -310,7 +307,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
     const available = { x: 0, y: 0 }
 
     // eslint-disable-next-line no-unmodified-loop-condition
-    while (retries < 2) {
+    while (retries < 4) {
       const { x: _x, y: _y, overflows } = checkOverflow(placement)
 
       x += _x
@@ -382,10 +379,6 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
         contentBox.y += overflows.y.before
       }
 
-      // Save the last position for some reason x and y are 0 after while loop
-      previousX = x
-      previousY = y
-
       break
     }
 
@@ -395,10 +388,10 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       '--v-overlay-anchor-origin': `${placement.anchor.side} ${placement.anchor.align}`,
       transformOrigin: `${placement.origin.side} ${placement.origin.align}`,
       // transform: `translate(${pixelRound(x)}px, ${pixelRound(y)}px)`,
-      top: convertToUnit(pixelRound(y > 0 ? y : previousY)),
-      left: data.isRtl.value ? undefined : convertToUnit(12),
-      right: data.isRtl.value ? convertToUnit(pixelRound(x > 0 ? -x : -previousX)) : undefined,
-      minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width - 28) : minWidth.value),
+      top: y !== 0 && convertToUnit(pixelRound(y)),
+      left: data.isRtl.value ? undefined : x !== 0 && convertToUnit((x)),
+      right: data.isRtl.value ? x !== 0 && convertToUnit(pixelRound(-x)) : undefined,
+      minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value),
       maxWidth: available.x > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.x, minWidth.value === Infinity

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -325,8 +325,8 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
         const hasOverflowX = overflows.x.before || overflows.x.after
         const hasOverflowY = overflows.y.before || overflows.y.after
 
-        let reset = false;
-        ['x', 'y'].forEach(key => {
+        let reset = false
+        ;['x', 'y'].forEach(key => {
           if (
             (key === 'x' && hasOverflowX && !flipped.x) ||
             (key === 'y' && hasOverflowY && !flipped.y)

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -406,10 +406,10 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
         ),
     })
 
-    const postMinWidth = Number(contentStyles.value['minWidth'])
-    const postLeft = Number(contentStyles.value['left'])
-    contentStyles.value['minWidth'] = convertToUnit(postLeft <= 12 ? postMinWidth : postMinWidth - 24)
-    contentStyles.value['left'] = convertToUnit(postLeft > 12 ? postLeft - 12 : postLeft)
+    const postMinWidth = Number(contentStyles.value.minWidth)
+    const postLeft = Number(contentStyles.value.left)
+    contentStyles.value.minWidth = convertToUnit(postLeft <= 12 ? postMinWidth : postMinWidth - 24)
+    contentStyles.value.left = convertToUnit(postLeft > 12 ? postLeft - 12 : postLeft)
 
     return {
       available,

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -389,9 +389,9 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       transformOrigin: `${placement.origin.side} ${placement.origin.align}`,
       // transform: `translate(${pixelRound(x)}px, ${pixelRound(y)}px)`,
       top: y !== 0 && convertToUnit(pixelRound(y)),
-      left: data.isRtl.value ? undefined : x !== 0 && convertToUnit((x)),
+      left: data.isRtl.value ? undefined : x !== 0 && x,
       right: data.isRtl.value ? x !== 0 && convertToUnit(pixelRound(-x)) : undefined,
-      minWidth: convertToUnit(axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value),
+      minWidth: axis === 'y' ? Math.min(minWidth.value, targetBox.width) : minWidth.value,
       maxWidth: available.x > 0 &&
         convertToUnit(pixelCeil(clamp(
           available.x, minWidth.value === Infinity
@@ -405,6 +405,11 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
             : minHeight.value, maxHeight.value))
         ),
     })
+
+    const postMinWidth = Number(contentStyles.value['minWidth'])
+    const postLeft = Number(contentStyles.value['left'])
+    contentStyles.value['minWidth'] = convertToUnit(postLeft <= 12 ? postMinWidth : postMinWidth - 24)
+    contentStyles.value['left'] = convertToUnit(postLeft > 12 ? postLeft - 12 : postLeft)
 
     return {
       available,


### PR DESCRIPTION
## Description

- Unable to re-open my previously closed PR, re-opening a new PR
- https://github.com/vuetifyjs/vuetify/pull/21143

Reduce the number of reposition to a max of `2`, if we only set it to `1` it will be a little off the mark with the correct position and size. This is to prevent infinite reposition, and to make it settle to a certain location after the max retries we need to pass a location to the child `VMenu` for example `:menu-props={ location: "top"}` after 2 tries of reposition and resizing it will settle at the top. See the example here: #21098.

If you guys are okay with this enhancement or you have a better idea on how to tackle this problem let me know thanks!

On this [VPlay](https://play.vuetifyjs.com/#eNqdUstugzAQ/JWVe+ASIGkUKaI0UpVPaG9JDgaWYNWwlm0gUZR/r3nldextd4dZZna8uzCj0/BLqaCpkUUstlgqyS1u9hVA3Phcqb50TSYaSCU35nPPUqosFxXqPRthAEkayzjREN5GQpn6ZfTvr34KYcCgxNRCiVUNpqBaZpBLkf6iBqogLTSVCImm1qCOJv60oXcgMid/WOO32tl78tB7HtD7yMnhCUrH+x4Q9ohFwt2su8nO23IpctKV4N4MvC05Fzwj7/BC6NT7SpPqWBfg1vK0iMB7e5blwfWReL9EHDojUyq3Og6ntOLwIUXXmlQLZd3tbK02cTi0I2TPcsg6uEUKl2F1KzLrZK3mc3X6GEYFimNhI3hf32cJ6cwdGxbqBIakyOCo8TyC1KDOJbX+OQJeW+rH1yGSF7vTbxUZYQVVEWh0HkSDE8lJH+Wy64wtg1WwWLKuWAcLNsu5NDh7es+HP7fw5TU=) add the `location: "top"` to see and test.

```vue
<template>
  <v-app>
    <div>
      <v-select
        label="Location"
        v-model="location"
        :items="[
          'bottom','top' ,'center' ,'end' ,'left' ,'right' ,'start' ,'bottom top' ,'bottom center' ,'bottom end',
          'bottom left' ,'bottom right' ,'bottom start' ,'top center' ,'top end' ,'top left' ,'top right',
          'top start' ,'center end' ,'center left' ,'center right' ,'center start' ,'end left' ,'end right',
          'end start' ,'left right' ,'left start' ,'right start'
        ]"
      />
    </div>

    <div class="container">
      lorem<br />
      ipsum<br />
      lorem<br />
      ipsum<br />
      {{ location }}<br />
      This select menu should flicker on chrome browser:<br />

      <div id="select-wrapper">
        <v-select
          label="Select"
          :items="['California', 'Colorado']"
          :menu-props="{ attach: '#select-wrapper', location: location }"
        />
      </div>
    </div>
  </v-app>
</template>

<script setup>
import { ref } from "vue"

const location = ref(null)
</script>

<style>
  .container {
    width: 500px;
    height: 280px;
    border: 1px solid grey;
    overflow-y: auto;
  }

  #select-wrapper {
    position: relative;
  }
</style>
```
