### PR TITLE
feat(date) Extend the DateAdapter with optional lfunctions attribute

### DIFF
--- a/packages/vuetify/src/composables/date/date.ts
+++ b/packages/vuetify/src/composables/date/date.ts
@@ -25,9 +25,10 @@ export namespace DateModule {
 }
 
 export type InternalDateOptions = {
-  adapter: (new (options: { locale: any, formats?: any }) => DateInstance) | DateInstance
+  adapter: (new (options: { locale: any, formats?: any, functions?: any}) => DateInstance) | DateInstance
   formats?: Record<string, any>
   locale: Record<string, any>
+  functions: Record<string, any>
 }
 
 export type DateOptions = Partial<InternalDateOptions>
@@ -96,6 +97,7 @@ function createInstance (options: InternalDateOptions, locale: LocaleInstance) {
       ? new options.adapter({
         locale: options.locale[locale.current.value] ?? locale.current.value,
         formats: options.formats,
+        functions: options.functions
       })
       : options.adapter
   )

--- a/packages/vuetify/src/composables/date/index.ts
+++ b/packages/vuetify/src/composables/date/index.ts
@@ -1,3 +1,4 @@
 export { createDate, useDate, DateAdapterSymbol } from './date'
 export type { DateAdapter } from './DateAdapter'
 export type { DateOptions, DateInstance, DateModule } from './date'
+export {VuetifyDateAdapter}  from './adapters/vuetify'


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
should solve #19904

exports the VuetifyDateAdapter so it is possible to extend it

implement functions-option 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
<v-card>
<v-row>
<v-col>
{{" Previous Month: "+adapter.getPreviousMonth(new Date())}}

</v-col>
</v-row>
<v-row>
<v-col>
{{" MyDateFunction: "+adapter.getFirstDayOfYear()}}
</v-col>
</v-row>
</v-card>
</template>
<style>
  html {
    overflow-y: hidden;
  }
  #app {
    height: 100vh;
  }
</style>
<script setup lang="ts">
  import { DateOptions, VuetifyDateAdapter,DateAdapter } from '@/composables/date'
  const  adapter: MyDateAdapter = new MyDateAdapter ({ locale: 'de-DE' })


</script>
<script lang="ts">

  export class MyDateAdapter extends VuetifyDateAdapter  {
    getFirstDayOfYear() {
      return new Date(new Date().getFullYear()-1,0,1);
    }
  }
</script>
```
