### PR TITLE
feat(VSelect): add new auto scroll props (#20237)

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -121,8 +121,7 @@ export const VSelect = genericComponent<new <
     returnObject?: ReturnObject
     multiple?: Multiple
     modelValue?: V | null
-    'onUpdate:modelValue'?: (value: V) => void,
-    autoScroll?: boolean,
+    'onUpdate:modelValue'?: (value: V) => void
   },
   slots: Omit<VInputSlots & VFieldSlots, 'default'> & {
     item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -88,12 +88,15 @@ export const makeSelectProps = propsFactory({
   },
   openOnClear: Boolean,
   itemColor: String,
+  autoScroll: Boolean,
 
   ...makeItemsProps({ itemChildren: false }),
 }, 'Select')
 
 export const makeVSelectProps = propsFactory({
-  ...makeSelectProps(),
+  ...makeSelectProps({
+    autoScroll: true,
+  }),
   ...omit(makeVTextFieldProps({
     modelValue: null,
     role: 'combobox',
@@ -118,7 +121,8 @@ export const VSelect = genericComponent<new <
     returnObject?: ReturnObject
     multiple?: Multiple
     modelValue?: V | null
-    'onUpdate:modelValue'?: (value: V) => void
+    'onUpdate:modelValue'?: (value: V) => void,
+    autoScroll?: boolean,
   },
   slots: Omit<VInputSlots & VFieldSlots, 'default'> & {
     item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
@@ -254,7 +258,7 @@ export const VSelect = genericComponent<new <
       if (item !== undefined) {
         model.value = [item]
         const index = displayItems.value.indexOf(item)
-        IN_BROWSER && window.requestAnimationFrame(() => {
+        IN_BROWSER && props.hideSelected && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }
@@ -319,7 +323,7 @@ export const VSelect = genericComponent<new <
         const index = displayItems.value.findIndex(
           item => model.value.some(s => (props.valueComparator || deepEqual)(s.value, item.value))
         )
-        IN_BROWSER && window.requestAnimationFrame(() => {
+        IN_BROWSER && props.autoScroll && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }


### PR DESCRIPTION
## Description

- Resolves: https://github.com/vuetifyjs/vuetify/issues/20237
- Add a new prop for `VSelect` to control auto scroll on selected item by default this is set to `true` so it would still be the same behavior as before

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-select v-model="selected" :items="items" :auto-scroll="false" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref('item10')
  const items = Array.from({ length: 21 }, (_, i) => 'item' + i.toString())
</script>

```
