### PR TITLE
feat(VCombobox): scroll to first item on search result (#20572)

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -154,6 +154,7 @@ export const VCombobox = genericComponent<new <
         _search.value = val ?? ''
         if (!props.multiple && !hasSelectionSlot.value) {
           model.value = [transformItem(props, val)]
+          vVirtualScrollRef.value?.scrollToIndex(0)
         }
 
         if (val && props.multiple && props.delimiters?.length) {

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -154,7 +154,7 @@ export const VCombobox = genericComponent<new <
         _search.value = val ?? ''
         if (!props.multiple && !hasSelectionSlot.value) {
           model.value = [transformItem(props, val)]
-          vVirtualScrollRef.value?.scrollToIndex(0)
+          nextTick(() => vVirtualScrollRef.value?.scrollToIndex(0))
         }
 
         if (val && props.multiple && props.delimiters?.length) {


### PR DESCRIPTION
## Description

- Fixes: https://github.com/vuetifyjs/vuetify/issues/20572
- Issue is the first item auto selected is hidden by default when you double click on the initial value "foo" and then type "fi" on the input.
  - Actual result: `fi2` onwards shown and `fi1` is hidden.
  - Expected result: `fi1` should still be displayed

## Markup:

```vue
<template>
  <v-combobox
    auto-scroll
    v-model="value"
    :items="items"
    label="Default"
    auto-select-first
  />
</template>

<script>
  export default {
    data: () => ({
      items: [
        'bar',
        'buzz',
        'fi1',
        'fi2',
        'fi3',
        'fi4',
        'fi5',
        'fi6',
        'fizz',
        'foo',
      ],
      value: 'foo',
    }),
  }
</script>
```
