### PR TITLE
fix(VDatePicker): resolve firstDayOfWeek from locale

### DIFF
--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -57,7 +57,7 @@ export const makeCalendarProps = propsFactory({
   },
   firstDayOfWeek: {
     type: [Number, String],
-    default: 0,
+    default: undefined,
   },
 }, 'calendar')
 
@@ -104,15 +104,13 @@ export function useCalendar (props: CalendarProps) {
   )
 
   const weekDays = computed(() => {
-    const firstDayOfWeek = Number(props.firstDayOfWeek)
-
+    const firstDayOfWeek = adapter.toJsDate(adapter.startOfWeek(adapter.date(), props.firstDayOfWeek)).getDay()
     // Always generate all days, regardless of props.weekdays
     return [0, 1, 2, 3, 4, 5, 6].map(day => (day + firstDayOfWeek) % 7)
   })
 
   const weeksInMonth = computed(() => {
-    const firstDayOfWeek = Number(props.firstDayOfWeek)
-    const weeks = adapter.getWeekArray(month.value, firstDayOfWeek)
+    const weeks = adapter.getWeekArray(month.value, props.firstDayOfWeek)
 
     const days = weeks.flat()
 


### PR DESCRIPTION
## Description

Follow-up to recently merged #21199 that introduced regression - locale changes should affect firstDayOfWeek, but since `0` is now recognized as valid prop value, all locales are locked at Sunday (possible to [reproduce](https://play.vuetifyjs.com/#eNq9VkuP2zYQ/isDXewFTGkf2bYw1ov0klOLHLJoDlUPtDSymaVIgqRkG2v/9w4pPySv27g59GKLw2/eL/75ljhbZG2DXlSb9JtLpomojbYe3qCwyD3+0d3BDiqraxjtsaNcHYGoJmDkhAD078+RmdQFl0gMucJ1ZCm0ch729zAbahq/5QrAL7HGKcRvgBIr3kj/0hFHUiyWfjTp7rIs/O/iqVN1ZDscR6gO6Bqd4wt0hHlnd4SE391NrpJJDM2vxqRkKMXlyWNtJNn5HGBPLePGgPMbibM8mfPidWF1o0pWaKntFOxizsctt2PGWha9YVox19iKF3gzgdv0/iZPoqwojWLiuVBooeZrthKlX5Lcnx5vjyCClaKFQnLn6KpklcQ1fGtciBorUHli5hQbdTgsOHvosZMAZ7g6StCGF8Jv2M9Bxz5WT1mA9FnItKUwLHhnoGW1LlESc9FYS1p+i2wDJUceqIQMZkg+Rwke1574UOUJtFw2IWzh8PyUdfCrRRjZExEO/11EZXsiwuEHrPB9K+hwScSB1IXvlMiMMvm/pNV5bv3n6ivi6/W57TFdzmyfBMRYaRsUg1DUEUfez8YL6vQ8OYfPhSoD/vxm+oqbQE9jWM9vuyQMaTEjfdKPJ4EaWqL1J7aWiWoYDJjNZkA9jhU1atm37xD7ehNSc6L7jQnlseJWCbUY3HRV9ElYGoUl34CuYBV0CAc0JrHwWILXYNEZreJn16JQLLmiCXYSlv2rEygdXm2oUNUgK9daOcdg3SsdVsIvwaGkK0o+8Llue5nsmfrdoh+WeMs695mxuhUltcG0I3x/FpU0tJkRZB4xVcEVIm2Yrlhw5bzeYUnS2RJ50HGytyujMxsu1lIst8M075YFUWhb0PdT1tsidHSFFbR6HPp9YR6XqsWqv0nj+qT0xc058Jf2J2HHYcfR2jpABlUbAce6vYzaNyuBR18atf1dq+1Lg9uvWG5fls32kxXbL9yTGcHF1Bkp/Hi07VQSoeZmPF5PQNzA7BnGb7FypkCU2MtTELC7ITDNoOgyOUsbtvOWETO9PbSiLRs3N9VhvKAaP+7yPKEohHOeLL03bpplRamIjUaWaG2q0GfK1NlHgmW2UV7Qxi11/fEhfUzvHig/zvfpKbqaza1eObQkJU/2D4SoJ1ThlbriE0eFB4nckK5f0jtyx1H5pve394/s9gO7+9Ap34MZzSwXtF/Uun8tXaF8zxB13mZSzPesGQ1XXL8TnpGfLVpGhUOFG7rrulCesQ3CeXb3LqTxPUXPKcr1bpJ0nJT1f4hSMqk4zarhu6uj/fU3A+5mVg==) on "nightly" `v3.8.1-master.2025-04-14`)

## Markup:

```vue
<template>
  <v-app style="background-color: rgba(var(--v-theme-on-surface), 0.2)">
    <v-container max-width="650">
      <div class="d-flex justify-center align-center ga-3">
        <span class="opacity-70">locale:</span>
        <v-chip-group v-model="currentLocale">
          <v-chip filter label text="en" value="en"></v-chip>
          <v-chip filter label text="pl" value="pl"></v-chip>
          <v-chip filter label text="fr" value="fr"></v-chip>
          <v-chip filter label text="pt" value="pt"></v-chip>
        </v-chip-group>
      </div>
      <div class="d-flex justify-center align-center ga-3">
        <span class="opacity-70">startOfWeek:</span>
        <v-chip-group v-model="startOfWeek">
          <v-chip
            v-for="o in startOfWeekOptions"
            v-bind="o"
            :key="o.value"
            filter
            label
          ></v-chip>
        </v-chip-group>
      </div>
      <v-alert v-if="startOfWeek === undefined" class="my-3" type="warning" text="First day of week is expected to respond to locale changes" />
      <v-alert v-else class="my-3" type="info" text="First day of week is expected to be locked with selection above" />
      <div class="d-flex justify-center">
        <v-locale-provider :locale="currentLocale">
          <v-date-picker :first-day-of-week="startOfWeek" hide-header />
        </v-locale-provider>
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const currentLocale = ref('en')
  const startOfWeek = ref(undefined)
  const startOfWeekOptions = 'Sun|Mon|Tue|Wed|Thu|Fri|Sat'
    .split('|')
    .map((x, i) => ({ text: x, value: i }))
</script>
```