### PR TITLE
feat(VNumberInput): extract number from pasted text

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -16,7 +16,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, nextTick, onMounted, ref, shallowRef, toRef, watch, watchEffect } from 'vue'
-import { clamp, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { clamp, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -189,18 +189,22 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     function onBeforeinput (e: InputEvent) {
       if (!e.data) return
-      const existingTxt = (e.target as HTMLInputElement)?.value
-      const selectionStart = (e.target as HTMLInputElement)?.selectionStart
-      const selectionEnd = (e.target as HTMLInputElement)?.selectionEnd
+      const inputElement = e.target as HTMLInputElement
+      const { value: existingTxt, selectionStart, selectionEnd } = inputElement ?? {}
+
       const potentialNewInputVal =
         existingTxt
           ? existingTxt.slice(0, selectionStart as number | undefined) + e.data + existingTxt.slice(selectionEnd as number | undefined)
           : e.data
+
+      const potentialNewNumber = extractNumber(potentialNewInputVal, props.precision)
+
       // Only numbers, "-", "." are allowed
       // AND "-", "." are allowed only once
       // AND "-" is only allowed at the start
       if (!/^-?(\d+(\.\d*)?|(\.\d+)|\d*|\.)$/.test(potentialNewInputVal)) {
         e.preventDefault()
+        inputElement!.value = potentialNewNumber
       }
 
       if (props.precision == null) return
@@ -208,10 +212,12 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       // Ignore decimal digits above precision limit
       if (potentialNewInputVal.split('.')[1]?.length > props.precision) {
         e.preventDefault()
+        inputElement!.value = potentialNewNumber
       }
       // Ignore decimal separator when precision = 0
       if (props.precision === 0 && potentialNewInputVal.includes('.')) {
         e.preventDefault()
+        inputElement!.value = potentialNewNumber
       }
     }
 

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -204,4 +204,31 @@ describe('VNumberInput', () => {
       expect(model.value).toBe(0)
     })
   })
+
+  describe('accepts digits from pasted text', () => {
+    it.each([
+      { precision: 0, text: '-00123', expected: -123 },
+      { precision: 2, text: '.250', expected: 0.25 },
+      { precision: 3, text: '000.321', expected: 0.321 },
+      { precision: 0, text: '100.99', expected: 100 },
+      { precision: 1, text: '200.99', expected: 200.9 },
+      { precision: 2, text: ' 1,250.32\n', expected: 1250.32 },
+      { precision: 0, text: '1\'024.00 meters', expected: 1024 },
+      { precision: 0, text: '- 1123.', expected: -1123 },
+    ])('should parse numbers correctly', async ({ precision, text, expected }) => {
+      const model = ref(null)
+      const { element } = render(() => (
+        <VNumberInput
+          v-model={ model.value }
+          precision={ precision }
+        />
+      ))
+      const input = element.querySelector('input') as HTMLInputElement
+      input.focus()
+      navigator.clipboard.writeText(text)
+      await userEvent.paste()
+      input.blur()
+      expect(model.value).toBe(expected)
+    })
+  })
 })

--- a/packages/vuetify/src/util/__tests__/helpers.spec.ts
+++ b/packages/vuetify/src/util/__tests__/helpers.spec.ts
@@ -6,6 +6,7 @@ import {
   deepEqual,
   defer,
   destructComputed,
+  extractNumber,
   getNestedValue,
   getObjectValueByPath,
   getPropertyFromItem,
@@ -370,6 +371,20 @@ describe('helpers', () => {
       vi.advanceTimersByTime(1000)
 
       expect(mockCallback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('extractNumber', () => {
+    it('should parse valid number out of text', () => {
+      expect(extractNumber(' 2,142,400.50 ', 2)).toBe('2142400.50')
+      expect(extractNumber(' 100 %', 1)).toBe('100')
+      expect(extractNumber(' .4099 ', 2)).toBe('.40')
+      expect(extractNumber('v: 15.00 ', 0)).toBe('15')
+      expect(extractNumber('$ 2,132.00', 2)).toBe('2132.00')
+      expect(extractNumber('$ 32.00', 2)).toBe('32.00')
+      expect(extractNumber(' -6.67 USD', 2)).toBe('-6.67')
+      expect(extractNumber('($9,000.00)', 2)).toBe('9000.00')
+      expect(extractNumber(' 23 567.20 ', 2)).toBe('23567.20')
     })
   })
 })

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -778,3 +778,26 @@ export type Primitive = string | number | boolean | symbol | bigint
 export function isPrimitive (value: unknown): value is Primitive {
   return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint'
 }
+
+export function extractNumber (text: string, decimalDigitsLimit: number | null) {
+  const cleanText = text.split('')
+    .filter(x => /[\d\-.]/.test(x))
+    .filter((x, i, all) => (i === 0 && /[-]/.test(x)) || // sign allowed at the start
+        (x === '.' && i === all.indexOf('.')) || // decimal separator allowed only once
+        /\d/.test(x))
+    .join('')
+
+  if (decimalDigitsLimit === 0) {
+    return cleanText.split('.')[0]
+  }
+
+  if (decimalDigitsLimit !== null && /\.\d/.test(cleanText)) {
+    const parts = cleanText.split('.')
+    return [
+      parts[0],
+      parts[1].substring(0, decimalDigitsLimit),
+    ].join('.')
+  }
+
+  return cleanText
+}


### PR DESCRIPTION
## Description

Currently user action is completely ignored if even one character causes `onBeforeinput` to bail. A nicer UX would be to extract the digits to support copy/pasting from spreadsheets or PDFs.

I would prefer to merge it to `master` as it can be considered a bug by many developers at this point.

## Markup:

```vue
<template>
  <v-container>
    <v-row>
      <v-col cols="6" lg="3">
        <h5>(default precision="0" max="200")</h5>
        <v-number-input v-model="example1" clearable hide-details="auto" :max="200" />
        <code class="d-block pt-3">value: {{ example1 ?? 'null' }}</code>
        <input class="border-md pa-2 mt-2" type="number" v-model="example1" />
      </v-col>
      <v-col cols="6" lg="3">
        <h5>(precision="1")</h5>
        <v-number-input v-model="example2" :precision="1" hide-details="auto"></v-number-input>
        <code class="d-block pt-3">value: {{ example2 ?? 'null' }}</code>
        <input class="border-md pa-2 mt-2" type="number" v-model="example2" />
      </v-col>
      <v-col cols="6" lg="3">
        <h5>(precision="5")</h5>
        <v-number-input v-model="example3" :precision="5" hide-details="auto"></v-number-input>
        <code class="d-block pt-3">value: {{ example3 ?? 'null' }}</code>
        <input class="border-md pa-2 mt-2" type="number" v-model="example3" />
      </v-col>
      <v-col cols="6" lg="3">
        <h5>(precision="3" min='4' max='120') w/ initial null</h5>
        <v-number-input v-model="example4" :precision="3" hide-details="auto" :min='4' :max='120'></v-number-input>
        <code class="d-block pt-3">value: {{ example4 ?? 'null' }}</code>
        <input class="border-md pa-2 mt-2" type="number" v-model="example4" />
      </v-col>
    </v-row>
    <v-alert class="mt-12">
      Values to copy/paste:
      <ul>
        <li><v-kdb>421.00</v-kdb></li>
        <li><v-kdb>23 567.20</v-kdb></li>
        <li><v-kdb>8,999.99</v-kdb></li>
        <li><v-kdb>$ 120.95</v-kdb></li>
      </ul>
    </v-alert>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'
  const example1 = ref(150.5)
  const example2 = ref(25.5)
  const example3 = ref(0.052)
  const example4 = ref(null)
</script>
```
