### PR TITLE
feat(VToolbar): allow for explicit false for extension

### DIFF
--- a/packages/api-generator/src/locale/en/VToolbar.json
+++ b/packages/api-generator/src/locale/en/VToolbar.json
@@ -3,7 +3,7 @@
     "absolute": "Applies position: absolute to the component.",
     "bottom": "Aligns the component towards the bottom.",
     "collapse": "Puts the toolbar into a collapsed state reducing its maximum width.",
-    "extended": "Use this prop to increase the height of the toolbar _without_ using the `extension` slot for adding content. May be used in conjunction with the **extension-height** prop, and any of the other props that affect the height of the toolbar, e.g. **prominent**, **dense**, etc., **WITH THE EXCEPTION** of **height**.",
+    "extended": "Use this prop to increase the height of the toolbar _without_ using the `extension` slot for adding content. May be used in conjunction with the **extension-height** prop. When false, will not show extension slot even if content is present.",
     "extensionHeight": "Specify an explicit height for the `extension` slot.",
     "flat": "Removes the toolbar's box-shadow.",
     "floating": "Applies **display: inline-flex** to the component.",

--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -38,7 +38,10 @@ export const makeVToolbarProps = propsFactory({
     default: 'default',
     validator: (v: any) => allowedDensities.includes(v),
   },
-  extended: Boolean,
+  extended: {
+    type: Boolean,
+    default: null,
+  },
   extensionHeight: {
     type: [Number, String],
     default: 48,
@@ -82,7 +85,7 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
     const { themeClasses } = provideTheme(props)
     const { rtlClasses } = useRtl()
 
-    const isExtended = shallowRef(!!(props.extended || slots.extension?.()))
+    const isExtended = shallowRef(props.extended === null ? !!(slots.extension?.()) : props.extended)
     const contentHeight = computed(() => parseInt((
       Number(props.height) +
       (props.density === 'prominent' ? Number(props.height) : 0) -
@@ -110,7 +113,7 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
       const hasImage = !!(slots.image || props.image)
 
       const extension = slots.extension?.()
-      isExtended.value = !!(props.extended || extension)
+      isExtended.value = props.extended === null ? !!extension : props.extended
 
       return (
         <props.tag


### PR DESCRIPTION
## Motivation and Context
fixes #7317 

## Markup:
<details>

```vue
<template>
  <v-container class="pa-md-12">
    <v-toolbar>
      <template #extension>
        Fizzbuzz
      </template>
    </v-toolbar>
    <v-toolbar extended></v-toolbar>
    <v-toolbar :extended="false">
      <template #extension>
        Fizzbuzz
      </template>
    </v-toolbar>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'
</script>

```
</details>