### PR TITLE
fix(VDateInput): accept value when picker is hidden

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -221,7 +221,6 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
 
       if (!menu.value || !isFocused.value) {
         menu.value = true
-        return
       }
 
       if (props.updateOn.includes('enter')) {

--- a/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -2,7 +2,9 @@
 import { VDateInput } from '../VDateInput'
 
 // Utilities
+import { commands, render, screen, userEvent } from '@test'
 import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
 import { createVuetify } from '@/framework'
 
 describe('VDateInput', () => {
@@ -20,6 +22,27 @@ describe('VDateInput', () => {
       ...options,
     })
   }
+
+  it('accepts keyboard input even if the picker is hidden', async () => {
+    const model = ref<Date | null>(null)
+    const { element } = render(() => <VDateInput v-model={ model.value } />)
+
+    await userEvent.click(element)
+    await commands.waitStable('.v-picker')
+    expect(screen.getByCSS('.v-picker')).toBeVisible()
+
+    await userEvent.keyboard('{Escape}') // hide picker, but keep the focus
+
+    await commands.waitStable('.v-picker')
+    expect(screen.getByCSS('.v-picker')).not.toBeVisible()
+
+    const input = screen.getByCSS('input') as HTMLInputElement
+    await userEvent.type(input, '02/20/2022{Enter}')
+
+    expect(model.value).toBeDefined()
+    const formatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' })
+    expect(formatter.format(model.value!)).toBe('Feb 20, 2022')
+  })
 
   describe('parseDateString', () => {
     const testCases = [


### PR DESCRIPTION
## Description

`[Enter]` should not clear the input.

related to #21221

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <pre>value: {{ value }} | {{ typeof value }}</pre>
      <v-date-input v-model="value" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const value = ref()
</script>
```