### PR TITLE
docs: type inference issue on exposed API documentation

### DIFF
--- a/packages/api-generator/package.json
+++ b/packages/api-generator/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "description": "",
   "scripts": {
-    "build": "node --import tsx --no-warnings src/index.ts",
+    "build": "node --import tsx src/index.ts",
     "lint": "eslint --ext .ts,.json src -f codeframe --max-warnings 0",
     "lint:fix": "node --run lint -- --fix"
   },

--- a/packages/api-generator/src/index.ts
+++ b/packages/api-generator/src/index.ts
@@ -91,7 +91,6 @@ const run = async () => {
     })
   )).filter(BooleanFilter)
 
-
   // Composables
   if (!argv.skipComposables) {
     const composables = await Promise.all((await generateComposableDataFromTypes()).map(async composable => {
@@ -125,8 +124,8 @@ const run = async () => {
       )
     }
   }
-  
-  reportMissingDescriptions();
+
+  reportMissingDescriptions()
   createVeturApi(componentData)
   createWebTypesApi(componentData, directives)
   await fs.mkdir(path.resolve('../vuetify/dist/json'), { recursive: true })

--- a/packages/api-generator/src/index.ts
+++ b/packages/api-generator/src/index.ts
@@ -7,7 +7,7 @@ import { kebabCase } from './helpers/text'
 import type { ComponentData, DirectiveData } from './types'
 import { generateComposableDataFromTypes, generateDirectiveDataFromTypes } from './types'
 import Piscina from 'piscina'
-import { addDescriptions, addDirectiveDescriptions, addPropData, stringifyProps } from './utils'
+import { addDescriptions, addDirectiveDescriptions, addPropData, reportMissingDescriptions, stringifyProps } from './utils'
 import * as os from 'os'
 import { mkdirp } from 'mkdirp'
 import { createVeturApi } from './vetur'
@@ -91,6 +91,7 @@ const run = async () => {
     })
   )).filter(BooleanFilter)
 
+
   // Composables
   if (!argv.skipComposables) {
     const composables = await Promise.all((await generateComposableDataFromTypes()).map(async composable => {
@@ -124,7 +125,8 @@ const run = async () => {
       )
     }
   }
-
+  
+  reportMissingDescriptions();
   createVeturApi(componentData)
   createWebTypesApi(componentData, directives)
   await fs.mkdir(path.resolve('../vuetify/dist/json'), { recursive: true })

--- a/packages/api-generator/src/locale/en/VDataTableVirtual.json
+++ b/packages/api-generator/src/locale/en/VDataTableVirtual.json
@@ -38,5 +38,8 @@
     "update:modelValue": "Emits when the component's model changes.",
     "update:options": "Emits when one of the **options** properties is updated.",
     "update:sortBy": "Emits when the **sort-by** property of the **options** prop is updated."
+  },
+  "exposed": {
+    "calculateVisibleItems": "Trigger updating the currently rendered items based on scroll position."
   }
 }

--- a/packages/api-generator/src/locale/en/VField.json
+++ b/packages/api-generator/src/locale/en/VField.json
@@ -27,12 +27,13 @@
     "update:focused": "Emitted when the input is focused or blurred"
   },
   "slots": {
-    "append-iInner": "Slot that is appended to the input.",
+    "append-inner": "Slot that is appended to the input.",
     "clear": "Slot for custom clear icon (displayed when the **clearable** prop is equal to true).",
     "label": "The default slot of the [v-label](/api/v-label/) or [v-field-label](/api/v-field-label/) component.",
     "prepend-inner": "Slot that is prepended to the input."
   },
   "exposed": {
-    "controlRef": "Reference to the control element of the field."
+    "controlRef": "Reference to the control element of the field.",
+    "fieldIconColor": "The color of the icon."
   }
 }

--- a/packages/api-generator/src/locale/en/VIconBtn.json
+++ b/packages/api-generator/src/locale/en/VIconBtn.json
@@ -8,7 +8,12 @@
     "iconColor": "Explicit color applied to the icon.",
     "iconSize": "The specific size of the icon, can use named sizes.",
     "iconSizes": "An array of tuples that define the icon sizes for each named size.",
+    "loading": "Displays circular progress bar in place of the icon.",
+    "readonly": "Puts the button in a readonly state. Cannot be clicked or navigated to by keyboard.",
     "rotate": "The rotation of the icon in degrees.",
     "sizes": "An array of tuples that define the button sizes for each named size."
+  },
+  "events": {
+    "update:active": "Event that is emitted when the active state changes."
   }
 }

--- a/packages/api-generator/src/utils.ts
+++ b/packages/api-generator/src/utils.ts
@@ -134,12 +134,16 @@ type MissingDescription = {
 
 const missingDescriptions: MissingDescription[] = []
 
-export function reportMissingDescriptions() {
-  if(!missingDescriptions.length) return
-  
-  console.warn('\n\x1b[31mMissing API Descriptions:\x1b[0m')
+export function reportMissingDescriptions () {
+  if (!missingDescriptions.length) return
+
+  const red = '\x1b[31m'
+  const reset = '\x1b[0m'
+  const space = '\x20'
+
+  console.warn(`\n${red}Missing API Descriptions:${reset}`)
   missingDescriptions.forEach(({ name, section, key, locale }) => {
-    console.warn(`\x1b[31m- ${name} (${locale}): [${section}]${`\x20${key}`}\x1b[0m`)
+    console.warn(`${red}- ${name} (${locale}): [${section}]${space + key + reset}`)
   })
 
   // Clear missing descriptions in case of multiple runs
@@ -195,7 +199,6 @@ export async function addDescriptions (name: string, componentData: ComponentDat
       }
     }
   }
-
 }
 
 export async function addDirectiveDescriptions (

--- a/packages/api-generator/templates/component.d.ts
+++ b/packages/api-generator/templates/component.d.ts
@@ -55,4 +55,15 @@ type ExtractExposed<T> = T extends ComponentOptionsBase<any, infer B, any, any, 
 
 type Pretty<T> = { [K in keyof T]: UnwrapRef<T[K]> }
 
-export type ComponentExposed = Pretty<UnionToIntersection<ExtractExposed<__component__['$options']>>>
+// Filter out HTMLInputElement props from exposed
+type CleanHTMLInputElement<T> = {
+  // If key is in HTMLInputElement
+  [K in keyof T as K extends keyof HTMLInputElement
+    ? // If value is the same type in HTMLInputElement
+      T[K] extends HTMLInputElement[K]
+      ? never
+      : K
+    : K]: T[K];
+};
+
+export type ComponentExposed = Pretty<CleanHTMLInputElement<UnionToIntersection<ExtractExposed<__component__['$options']>>>>


### PR DESCRIPTION
## Description
1. `CleanHTMLInputElement` will filter out native `HTMLInputElement` inferred props. Currently, these components are the ones that uses `VTextField` (and consequently an `input`, where the native props are coming from)
2. A non-blocking warning after build that shows the components with missing API descriptions.
![Screen Shot 2025-04-16 at 2 18 01 PM](https://github.com/user-attachments/assets/cf38df8a-b822-4fa2-8e64-095fb4017a27)


## Markup:
N/A