### PR TITLE
fix(VFileInput): on drop internal input unpopulated (#21248)

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -153,11 +153,11 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       e.preventDefault()
     }
     async function onDrop (e: DragEvent) {
-        e.preventDefault()
-        if (!e.dataTransfer) return
-        model.value = [...e.dataTransfer.files ?? []]
-        if (inputRef.value) inputRef.value.files = e.dataTransfer.files
-        await nextTick()
+      e.preventDefault()
+      if (!e.dataTransfer) return
+      model.value = [...e.dataTransfer.files ?? []]
+      if (inputRef.value) inputRef.value.files = e.dataTransfer.files
+      await nextTick()
     }
     function onChange (e: Event) {
       if (e.target && e.target instanceof HTMLInputElement) {

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -141,26 +141,30 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
 
       emit('click:control', e)
     }
-    function onClear (e: MouseEvent) {
+    async function onClear (e: MouseEvent) {
       e.stopPropagation()
-
       onFocus()
-
-      nextTick(() => {
-        model.value = []
-
-        callEvent(props['onClick:clear'], e)
-      })
+      model.value = []
+      if (inputRef.value) inputRef.value.files = null
+      await nextTick()
+      callEvent(props['onClick:clear'], e)
     }
     function onDragover (e: DragEvent) {
       e.preventDefault()
     }
-    function onDrop (e: DragEvent) {
-      e.preventDefault()
-
-      if (!e.dataTransfer) return
-
-      model.value = [...e.dataTransfer.files ?? []]
+    async function onDrop (e: DragEvent) {
+        e.preventDefault()
+        if (!e.dataTransfer) return
+        model.value = [...e.dataTransfer.files ?? []]
+        if (inputRef.value) inputRef.value.files = e.dataTransfer.files
+        await nextTick()
+    }
+    function onChange (e: Event) {
+      if (e.target && e.target instanceof HTMLInputElement) {
+        const target = e.target
+        model.value = [...target.files ?? []]
+        if (inputRef.value) inputRef.value.files = target.files
+      }
     }
 
     watch(model, newValue => {
@@ -245,12 +249,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
 
                           onFocus()
                         }}
-                        onChange={ e => {
-                          if (!e.target) return
-
-                          const target = e.target as HTMLInputElement
-                          model.value = [...target.files ?? []]
-                        }}
+                        onChange={ onChange }
                         onFocus={ onFocus }
                         onBlur={ blur }
                         { ...slotProps }


### PR DESCRIPTION
## Description

- Fixes: https://github.com/vuetifyjs/vuetify/issues/21248
----

- On file drop on `VFileInput` component the internal `input` element files value is unpopulated or not updated
- The issue is also observed on clear, the files value remains even if clear button was clicked and file was removed
- Minor refactor and code cleanup


## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-file-input
        v-model="file"
        ref="fileInput"
        @update:model-value="updateFileList"
      />
      <pre>
Number of files in internal &lt;input&gt; tag = {{ inputFieldFiles }}</pre
      >
    </v-container>
  </v-app>
</template>

<script setup>
import { ref, computed, watch, nextTick } from 'vue'

const file = ref()
const fileInput = ref()

const inputFieldFiles = ref(0)
function updateFileList() {
  inputFieldFiles.value = fileInput.value.files.length
}
</script>
```
