### PR TITLE
docs: app bar fully visible in mobile

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/docs"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --force",
     "build": "vite build",
     "preview": "vite preview",
     "preview-https": "HTTPS=true vite preview",
@@ -26,7 +26,7 @@
     "@vue/compiler-dom": "^3.5.13",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
-    "@vuetify/one": "^2.1.0",
+    "@vuetify/one": "^2.1.1",
     "algoliasearch": "^4.24.0",
     "fflate": "^0.8.2",
     "isomorphic-fetch": "^3.0.0",

--- a/packages/docs/src/components/app/Btn.vue
+++ b/packages/docs/src/components/app/Btn.vue
@@ -4,6 +4,7 @@
     :variant="variant"
     class="text-body-2 text-capitalize px-3 app-btn"
     color="medium-emphasis"
+    :size="smAndUp ? 'default' : 'small'"
   >
     <slot />
 

--- a/packages/docs/vite.config.mts
+++ b/packages/docs/vite.config.mts
@@ -377,6 +377,8 @@ export default defineConfig(({ command, mode, isSsrBuild }) => {
         'fflate',
         '@cosmicjs/sdk',
       ],
+      // In development mode, prevent pre-bundling of @vuetify libs for HMR linking
+      exclude: process.env.NODE_ENV ==='development' ? ['@vuetify/one'] : [],
     },
 
     ssr: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ overrides:
   '@types/node': 22.5.4
   tough-cookie: 5.0.0-rc.4
 
-pnpmfileChecksum: sha256-grQ7keQLE6IY6tCi9f26NtYQ2j+RuK1OR3hPnrfzUSE=
+pnpmfileChecksum: hdycaw5dzspbcs5sui7ue3czcu
 
 patchedDependencies:
   '@mdi/js@7.4.47':
-    hash: 3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f
+    hash: wt4lkgr52gphla2wb445bnli3i
     path: patches/@mdi__js@7.4.47.patch
   '@testing-library/vue':
-    hash: 15ba1e1b9f291286e3951cdf39b2e27f55b6727bc0315792f3e4558c0a3a7db8
+    hash: 3limad3b7od6m3nrz2f3jnaixy
     path: patches/@testing-library__vue.patch
   vue-gtag-next:
-    hash: 3469e25ae2dc6bd97138e6a2b767743de8123979b246ebc2bdbb581c76efbfbf
+    hash: mkgavjrgdsvimm3nsmkswaflk4
     path: patches/vue-gtag-next.patch
 
 importers:
@@ -43,7 +43,7 @@ importers:
         version: 7.4.47
       '@mdi/js':
         specifier: 7.4.47
-        version: 7.4.47(patch_hash=3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f)
+        version: 7.4.47(patch_hash=wt4lkgr52gphla2wb445bnli3i)
       '@mdi/svg':
         specifier: 7.4.47
         version: 7.4.47
@@ -247,8 +247,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4(vue@3.5.13(typescript@5.5.4))
       '@vuetify/one':
-        specifier: ^2.1.0
-        version: 2.1.0(@mdi/js@7.4.47(patch_hash=3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f))(lodash-es@4.17.21)(vue@3.5.13(typescript@5.5.4))(vuetify@packages+vuetify)
+        specifier: ^2.1.1
+        version: 2.1.2(@mdi/js@7.4.47(patch_hash=wt4lkgr52gphla2wb445bnli3i))(lodash-es@4.17.21)(vue@3.5.13(typescript@5.5.4))(vuetify@packages+vuetify)
       algoliasearch:
         specifier: ^4.24.0
         version: 4.24.0
@@ -284,7 +284,7 @@ importers:
         version: 3.5.13(typescript@5.5.4)
       vue-gtag-next:
         specifier: ^1.14.0
-        version: 1.14.0(patch_hash=3469e25ae2dc6bd97138e6a2b767743de8123979b246ebc2bdbb581c76efbfbf)(vue@3.5.13(typescript@5.5.4))
+        version: 1.14.0(patch_hash=mkgavjrgdsvimm3nsmkswaflk4)(vue@3.5.13(typescript@5.5.4))
       vue-i18n:
         specifier: ^11.1.1
         version: 11.1.1(vue@3.5.13(typescript@5.5.4))
@@ -312,7 +312,7 @@ importers:
         version: 6.0.5(@vue/compiler-dom@3.5.13)(eslint@8.57.0)(rollup@4.40.0)(typescript@5.5.4)(vue-i18n@11.1.1(vue@3.5.13(typescript@5.5.4)))(vue@3.5.13(typescript@5.5.4))
       '@mdi/js':
         specifier: 7.4.47
-        version: 7.4.47(patch_hash=3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f)
+        version: 7.4.47(patch_hash=wt4lkgr52gphla2wb445bnli3i)
       '@mdi/svg':
         specifier: 7.4.47
         version: 7.4.47
@@ -489,7 +489,7 @@ importers:
         version: 14.6.1(@vuetify/testing-library-dom@1.0.2)
       '@testing-library/vue':
         specifier: ^8.1.0
-        version: 8.1.0(patch_hash=15ba1e1b9f291286e3951cdf39b2e27f55b6727bc0315792f3e4558c0a3a7db8)(@vue/compiler-sfc@3.5.13)(vue@3.5.13(typescript@5.5.4))
+        version: 8.1.0(patch_hash=3limad3b7od6m3nrz2f3jnaixy)(@vue/compiler-sfc@3.5.13)(vue@3.5.13(typescript@5.5.4))
       '@types/node':
         specifier: 22.5.4
         version: 22.5.4
@@ -2902,7 +2902,7 @@ packages:
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
+      '@testing-library/dom': npm:@vuetify/testing-library-dom@1.0.2
 
   '@testing-library/vue@8.1.0':
     resolution: {integrity: sha512-ls4RiHO1ta4mxqqajWRh8158uFObVrrtAPoxk7cIp4HrnQUj/ScKzqz53HxYpG3X6Zb7H2v+0eTGLSoy8HQ2nA==}
@@ -3412,8 +3412,8 @@ packages:
       vue: ^3.0.0
       vuetify: ^3.0.0
 
-  '@vuetify/one@2.1.0':
-    resolution: {integrity: sha512-Ld/r7e3ULaSrZtmWZg3B3PADuf7xLmo25oCZvpwhBFgmbjIPPZGzqBfpMRNhacP2+qOsQPR5xjYyWcM/3uc4vg==}
+  '@vuetify/one@2.1.2':
+    resolution: {integrity: sha512-jIKWfyLArjhgraIPUhLmRFPRF+hLClCsgs3/FyNPMsl6WcBThR+j6Yk5a+V+cJaReptIfJL68d8/ob49Omz7dA==}
     peerDependencies:
       '@mdi/js': 7.4.47
       lodash-es: ^4.17.21
@@ -11502,7 +11502,7 @@ snapshots:
 
   '@mdi/font@7.4.47': {}
 
-  '@mdi/js@7.4.47(patch_hash=3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f)': {}
+  '@mdi/js@7.4.47(patch_hash=wt4lkgr52gphla2wb445bnli3i)': {}
 
   '@mdi/svg@7.4.47': {}
 
@@ -12386,7 +12386,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': '@vuetify/testing-library-dom@1.0.2'
 
-  '@testing-library/vue@8.1.0(patch_hash=15ba1e1b9f291286e3951cdf39b2e27f55b6727bc0315792f3e4558c0a3a7db8)(@vue/compiler-sfc@3.5.13)(vue@3.5.13(typescript@5.5.4))':
+  '@testing-library/vue@8.1.0(patch_hash=3limad3b7od6m3nrz2f3jnaixy)(@vue/compiler-sfc@3.5.13)(vue@3.5.13(typescript@5.5.4))':
     dependencies:
       '@babel/runtime': 7.24.4
       '@testing-library/dom': '@vuetify/testing-library-dom@1.0.2'
@@ -13075,9 +13075,9 @@ snapshots:
       vue: 3.5.13(typescript@5.5.4)
       vuetify: link:packages/vuetify
 
-  '@vuetify/one@2.1.0(@mdi/js@7.4.47(patch_hash=3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f))(lodash-es@4.17.21)(vue@3.5.13(typescript@5.5.4))(vuetify@packages+vuetify)':
+  '@vuetify/one@2.1.2(@mdi/js@7.4.47(patch_hash=wt4lkgr52gphla2wb445bnli3i))(lodash-es@4.17.21)(vue@3.5.13(typescript@5.5.4))(vuetify@packages+vuetify)':
     dependencies:
-      '@mdi/js': 7.4.47(patch_hash=3c2a78b1509745df3a3100e3e59075dd87718e67632cc14dc64dd9ac34098f9f)
+      '@mdi/js': 7.4.47(patch_hash=wt4lkgr52gphla2wb445bnli3i)
       lodash-es: 4.17.21
       vue: 3.5.13(typescript@5.5.4)
       vuetify: link:packages/vuetify
@@ -20094,7 +20094,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-gtag-next@1.14.0(patch_hash=3469e25ae2dc6bd97138e6a2b767743de8123979b246ebc2bdbb581c76efbfbf)(vue@3.5.13(typescript@5.5.4)):
+  vue-gtag-next@1.14.0(patch_hash=mkgavjrgdsvimm3nsmkswaflk4)(vue@3.5.13(typescript@5.5.4)):
     dependencies:
       vue: 3.5.13(typescript@5.5.4)
 


### PR DESCRIPTION
## Description
In mobile screens, the login button is cut off. This change will update the login button to an icon button.

Before:
![image](https://github.com/user-attachments/assets/fb15aa9c-cee4-4fbe-b6b1-b75afde999a0)

After:
<img width="321" alt="Screen Shot 2025-04-21 at 11 44 07 PM" src="https://github.com/user-attachments/assets/fb1943fd-a7ad-431d-a625-b6c3f652de02" />

## Note
https://github.com/vuetifyjs/one/pull/23 needs to be merged & released first. Then this PR will be updated to the latest `@vuetify/one` release version