### PR TITLE
docs: remove edit this page button on API pages

### DIFF
--- a/packages/docs/src/components/PageFeatures.vue
+++ b/packages/docs/src/components/PageFeatures.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-4">
     <page-feature-chip
-      v-show="!isApiPage"
+      v-if="!isGeneratedPage"
       :href="contribute"
       prepend-icon="mdi-language-markdown-outline"
       rel="noopener noreferrer"
@@ -105,8 +105,8 @@
     return pins.pins.some(p => p.to === route.path)
   })
 
-  const isApiPage = computed(() => {
-    return route.path.indexOf('/api/') > -1
+  const isGeneratedPage = computed(() => {
+    return route.path.includes('/api/')
   })
 
   const label = computed(() => {

--- a/packages/docs/src/components/PageFeatures.vue
+++ b/packages/docs/src/components/PageFeatures.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="mb-4">
     <page-feature-chip
+      v-show="!isApiPage"
       :href="contribute"
       prepend-icon="mdi-language-markdown-outline"
       rel="noopener noreferrer"
@@ -102,6 +103,10 @@
 
   const pinned = computed(() => {
     return pins.pins.some(p => p.to === route.path)
+  })
+
+  const isApiPage = computed(() => {
+    return route.path.indexOf('/api/') > -1
   })
 
   const label = computed(() => {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Resolves #21296
Hiding button on API page to avoid redirecting to non existing github pages on autogenerated data.
