### PR TITLE
feat(VDateInput): expose menu as v-model

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -39,6 +39,7 @@ export const makeVDateInputProps = propsFactory({
     type: String as PropType<StrategyProps['location']>,
     default: 'bottom start',
   },
+  menu: Boolean,
 
   ...makeDisplayProps(),
   ...makeFocusProps(),
@@ -64,6 +65,7 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
     save: (value: string) => true,
     cancel: () => true,
     'update:modelValue': (val: string) => true,
+    'update:menu': (val: boolean) => true,
   },
 
   setup (props, { emit, slots }) {
@@ -79,7 +81,7 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
       val => Array.isArray(val) ? val.map(item => adapter.date(item)) : val ? adapter.date(val) : val
     )
 
-    const menu = shallowRef(false)
+    const menu = useProxiedModel(props, 'menu')
     const isEditingInput = shallowRef(false)
     const vTextFieldRef = ref<VTextField>()
     const disabledActions = ref<typeof VConfirmEdit['props']['disabled']>(['save'])


### PR DESCRIPTION
fixes #21234

## Description
Lets us have full control over VDateInput's menu property via `v-model:menu`

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input
        v-model="date"
        v-model:menu="menu"
        multiple="range"
        @update:model-value="onUpdateModelValue"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const date = ref()
  const menu = ref(false)

  const onUpdateModelValue = (value) => {
    if (!value) return

    const isFirstSelection = value.length === 1
    menu.value = isFirstSelection
  }
</script>


```
