### PR TITLE
fix(VOverlay): prevent flip logic resizeObserver loop

### DIFF
--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -565,6 +565,10 @@ export class CircularBuffer<T = never> {
 
   constructor (public readonly size: number) {}
 
+  get isFull () {
+    return this.#arr.length === this.size
+  }
+
   push (val: T) {
     this.#arr[this.#pointer] = val
     this.#pointer = (this.#pointer + 1) % this.size
@@ -572,6 +576,11 @@ export class CircularBuffer<T = never> {
 
   values (): T[] {
     return this.#arr.slice(this.#pointer).concat(this.#arr.slice(0, this.#pointer))
+  }
+
+  clear () {
+    this.#arr.length = 0
+    this.#pointer = 0
   }
 }
 


### PR DESCRIPTION
fixes #21098
replaces #21229

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <div>
      <v-select
        v-model="location"
        :items="[
          'bottom','top' ,'center' ,'end' ,'left' ,'right' ,'start' ,'bottom top' ,'bottom center' ,'bottom end',
          'bottom left' ,'bottom right' ,'bottom start' ,'top center' ,'top end' ,'top left' ,'top right',
          'top start' ,'center end' ,'center left' ,'center right' ,'center start' ,'end left' ,'end right',
          'end start' ,'left right' ,'left start' ,'right start'
        ]"
        label="Location"
      />
    </div>

    <div class="container">
      lorem<br>
      ipsum<br>
      lorem<br>
      ipsum<br>
      {{ location }}<br>
      This select menu should flicker on chrome browser:<br>

      <div id="select-wrapper">
        <v-select
          :items="[
            'bottom','top' ,'center' ,'end' ,'left' ,'right' ,'start' ,'bottom top' ,'bottom center' ,'bottom end',
            'bottom left' ,'bottom right' ,'bottom start' ,'top center' ,'top end' ,'top left' ,'top right',
            'top start' ,'center end' ,'center left' ,'center right' ,'center start' ,'end left' ,'end right',
            'end start' ,'left right' ,'left start' ,'right start'
          ]"
          :menu-props="{ attach: '#select-wrapper', location: location }"
          label="Select"
        />
      </div>
    </div>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const location = ref(null)
</script>

<style>
.container {
  width: 500px;
  height: 280px;
  border: 1px solid grey;
  overflow-y: auto;
}

#select-wrapper {
  position: relative;
}
</style>
```
