### PR TITLE
fix(VTextarea): replace mask with clip-path

### DIFF
--- a/packages/vuetify/src/components/VTextarea/VTextarea.sass
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.sass
@@ -15,11 +15,21 @@
     .v-field__input
       $a: calc((var(--v-field-padding-top, 0) + var(--v-input-padding-top, 0)) - 6px)
       $b: calc(var(--v-field-padding-top, 0) + var(--v-input-padding-top, 0) + 4px)
+      $scroll-bar-width: 16px
+      $width-to-hide: calc(100% - $scroll-bar-width)
+
+      clip-path: polygon(
+          $width-to-hide 0,
+          100% 0,
+          100% 100%,
+          0 100%,
+          0 $b,
+          $width-to-hide $b,
+          $width-to-hide 0
+      )
 
       flex: 1 1 auto
       outline: none
-      -webkit-mask-image: linear-gradient(to bottom, transparent, transparent $a, black $b)
-      mask-image: linear-gradient(to bottom, transparent, transparent $a, black $b)
 
       &.v-textarea__sizer
         visibility: hidden


### PR DESCRIPTION
## Description

Fixed #21283
---
 
Replace the mask with a clip-path for more flexible width handling, as we need to exclude the scrollbar's width from the clip-path to ensure the top arrow remains visible.

Result:

![image](https://github.com/user-attachments/assets/4ee63565-8322-433b-ba67-772f33b700f1)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-textarea
        label="Textarea Label"
        model-value="1
          2
          3
          4
          5
          6
          7
          8
          9
          10"
      />
    </v-container>
  </v-app>
</template>
```
