### PR TITLE
feat(VDatePicker): add disable custom class for disabled dates type

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -185,9 +185,17 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
             ))}
 
             { daysInMonth.value.map((item, i) => {
+              function getDisableDayClass () {
+                if (!item.isDisabled) return ''
+                if (item.disabledFrom === 'notAllowed') {
+                  return props.notAllowedDatesClass
+                }
+                return props.outOfRangeDatesClass
+              }
+
               const slotProps = {
                 props: {
-                  class: 'v-date-picker-month__day-btn',
+                  class: `v-date-picker-month__day-btn ${getDisableDayClass()}`,
                   color: item.isSelected || item.isToday ? props.color : undefined,
                   disabled: item.isDisabled,
                   icon: true,

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.month.spec.ts
@@ -351,4 +351,29 @@ describe.skip('VDatePicker.ts', () => {
     expect(wrapper.findAll('.v-date-picker-table--month tbody button.v-date-picker--last-in-range')
       .exists()).toBe(true)
   })
+
+  it('should add custom class for disabled range date', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        allowedDates: val => new Date(val).getDate() % 2 === 0,
+        notAllowedDatesClass: "not-allowed-dates-class"
+      },
+    })
+
+    expect(wrapper.findAll('.not-allowed-dates-class')
+      .exists()).toBe(true)
+  })
+
+  it('should add custom class for disabled range date', async () => {
+    const wrapper = mountFunction({
+      propsData: {
+        min: "2016-06-15",
+        max: "2018-03-20",
+        outOfRangeDatesClass: "out-of-range-dates-class"
+      },
+    })
+
+    expect(wrapper.findAll('.out-of-range-dates-class')
+      .exists()).toBe(true)
+  })
 })


### PR DESCRIPTION
## Description

Resolved #21285

---

Add two additional props to differentiate types of disabled dates:
- `notAllowedDatesClass`: applies a class to dates that are not allowed.
- `outOfRangeDatesClass`: applies a class to dates that are out of range.

**Result:**

![image](https://github.com/user-attachments/assets/a7648980-1a87-4af7-8980-046b61398b7d)


## Markup:

```vue
<template>
  <v-container>
    <v-row justify="space-around">
      <v-date-picker
        v-model="date"
        :allowed-dates="allowedDates"
        not-allowed-dates-class="not-allowed-dates-class"
        out-of-range-dates-class="out-of-range-dates-class"
        max="2018-03-20"
        min="2016-06-15"
      ></v-date-picker>
    </v-row>
  </v-container>
</template>

<script>
  export default {
    data: () => ({
      date: new Date('2018-03-02'),
    }),

    methods: {
      allowedDates: val => {
        return new Date(val).getDate() % 2 === 0
      },
    },
  }
</script>

<style lang="css">
.not-allowed-dates-class {
  background-color: aquamarine;
}

.out-of-range-dates-class {
  background-color: pink;
}
</style>

```
