### PR TITLE
docs: team members not showing

### DIFF
--- a/packages/docs/auto-imports.d.ts
+++ b/packages/docs/auto-imports.d.ts
@@ -149,6 +149,7 @@ declare global {
   const useSlots: typeof import('vue')['useSlots']
   const useSponsorsStore: typeof import('./src/stores/sponsors')['useSponsorsStore']
   const useSpotStore: typeof import('./src/stores/spot')['useSpotStore']
+  const useTeamMembersStore: typeof import('./src/stores/team-members')['useTeamMembersStore']
   const useTeamStore: typeof import('./src/stores/team')['useTeamStore']
   const useTemplateRef: typeof import('vue')['useTemplateRef']
   const useTheme: typeof import('vuetify')['useTheme']
@@ -182,8 +183,8 @@ declare global {
   export type { Sponsor } from './src/stores/sponsors'
   import('./src/stores/sponsors')
   // @ts-ignore
-  export type { Member, GithubMember } from './src/stores/team'
-  import('./src/stores/team')
+  export type { Member, GithubMember } from './src/stores/team-members'
+  import('./src/stores/team-members')
   // @ts-ignore
   export type { Item } from './src/utils/api'
   import('./src/utils/api')
@@ -330,7 +331,7 @@ declare module 'vue' {
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
     readonly useSponsorsStore: UnwrapRef<typeof import('./src/stores/sponsors')['useSponsorsStore']>
     readonly useSpotStore: UnwrapRef<typeof import('./src/stores/spot')['useSpotStore']>
-    readonly useTeamStore: UnwrapRef<typeof import('./src/stores/team')['useTeamStore']>
+    readonly useTeamMembersStore: UnwrapRef<typeof import('./src/stores/team-members')['useTeamMembersStore']>
     readonly useTemplateRef: UnwrapRef<typeof import('vue')['useTemplateRef']>
     readonly useTheme: UnwrapRef<typeof import('vuetify')['useTheme']>
     readonly useUserStore: UnwrapRef<typeof import('@vuetify/one')['useUserStore']>

--- a/packages/docs/src/components/about/TeamMember.vue
+++ b/packages/docs/src/components/about/TeamMember.vue
@@ -147,7 +147,7 @@
 
 <script setup lang="ts">
   // Types
-  import type { Member } from '@/stores/team'
+  import type { Member } from '@/stores/team-members'
   import type { PropType } from 'vue'
 
   const props = defineProps({

--- a/packages/docs/src/components/about/TeamMembers.vue
+++ b/packages/docs/src/components/about/TeamMembers.vue
@@ -20,6 +20,7 @@
 
 <script setup>
   const props = defineProps({ team: String })
-  const teams = useTeamStore()
+  const teams = useTeamMembersStore()
+
   const members = computed(() => teams.members.filter(member => member.team === props.team))
 </script>

--- a/packages/docs/src/data/team.json
+++ b/packages/docs/src/data/team.json
@@ -187,7 +187,7 @@
     "discord": "spatlani",
     "focus": ["[vuetifyjs/*](https://github.com/vuetifyjs)"],
     "languages": ["English", "Hindi", "Punjabi"],
-    "linkedin": "in/spatlani",
+    "linkedin": "spatlani",
     "github": "spatlani",
     "avatar": "https://avatars.githubusercontent.com/u/11574195",
     "location": "Delhi, India",
@@ -197,6 +197,8 @@
     "name": "Isaias Briones",
     "team": "core",
     "discord": "ibriones",
+    "linkedin": "ibriones",
+    "avatar": "https://avatars.githubusercontent.com/u/47291268",
     "focus": ["[vuetifyjs/*](https://github.com/vuetifyjs)"],
     "languages": ["English", "Filipino"],
     "location": "Edmonton, AB, Canada"

--- a/packages/docs/src/pages/en/blog/state-of-the-union-2024.md
+++ b/packages/docs/src/pages/en/blog/state-of-the-union-2024.md
@@ -10,7 +10,7 @@ meta:
   import AboutTeamMember from '@/components/about/TeamMember.vue'
   import { VSparkline } from 'vuetify'
 
-  const teams = useTeamStore()
+  const teams = useTeamMembersStore()
   const kael = computed(() => teams.members.find(member => member.github === 'KaelWD'))
 </script>
 

--- a/packages/docs/src/stores/team-members.ts
+++ b/packages/docs/src/stores/team-members.ts
@@ -25,7 +25,7 @@ export type GithubMember = {
   login: string
 }
 
-export const useTeamStore = defineStore('team', () => {
+export const useTeamMembersStore = defineStore('team-members', () => {
   const members = ref<Member[]>([])
 
   for (const key in team) {


### PR DESCRIPTION
## Description
There is a `useTeamStore` from vuetify/one conflicting with the local one in docs. Thus, team members are not showing and state of the union 2024 is empty.

![Screen Shot 2025-04-23 at 11 19 22 PM](https://github.com/user-attachments/assets/21e9b1f6-c00f-4534-821f-867a633575be)

## Markup:
N/A