### PR TITLE
fix(VMenu, VTooltip): scroll strategy reposition for horizontal overflow

### DIFF
--- a/packages/vuetify/src/util/getScrollParent.ts
+++ b/packages/vuetify/src/util/getScrollParent.ts
@@ -25,7 +25,9 @@ export function hasScrollbar (el?: Element | null) {
   if (!el || el.nodeType !== Node.ELEMENT_NODE) return false
 
   const style = window.getComputedStyle(el)
-  return style.overflowY === 'scroll' || (style.overflowY === 'auto' && el.scrollHeight > el.clientHeight)
+  const hasVerticalScrollbar = style.overflowY === 'scroll' || (style.overflowY === 'auto' && el.scrollHeight > el.clientHeight)
+  const hasHorizontalScrollbar = style.overflowX === 'scroll' || (style.overflowX === 'auto' && el.scrollWidth > el.clientWidth)
+  return hasVerticalScrollbar || hasHorizontalScrollbar
 }
 
 function isPotentiallyScrollable (el?: Element | null) {


### PR DESCRIPTION
## Description

fixes #20625

## Markup:

```vue
<template>
  <v-app>
    <v-container class="overflow-auto">
      <div style="width: 200vw; padding-left: 300px">
        <v-btn color="primary">
          `overflow-auto`
          <v-menu scroll-strategy="reposition" activator="parent">
            <v-list :items="items" item-props />
          </v-menu>
        </v-btn>
      </div>
    </v-container>

    <v-container class="overflow-scroll">
      <div style="width: 200vw; padding-left: 300px">
        <v-btn color="primary">
          `overflow-scroll`
          <v-menu scroll-strategy="reposition" activator="parent">
            <v-list :items="items" item-props />
          </v-menu>
        </v-btn>
      </div>
    </v-container>

    <v-container class="overflow-auto pa-12 border-lg" style="max-height: 300px">
      <v-container class="overflow-auto border-md" style="height: 600px">
        <div style="width: 200vw; padding-left: 300px">
          <v-btn color="primary">
            nested
            <v-menu scroll-strategy="reposition" activator="parent">
              <v-list :items="items" item-props />
            </v-menu>
          </v-btn>
        </div>
      </v-container>
    </v-container>
  </v-app>
</template>

<script setup>
const items = [
  { title: 'Option 1' },
  { title: 'Option 2' },
  { title: 'Option 3' },
  { title: 'Option 4' },
]
</script>
```
