### PR TITLE
fix(VTextField): reset field on clear (#21310)

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -127,13 +127,14 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
 
       emit('click:control', e)
     }
-    function onClear (e: MouseEvent) {
+    function onClear (e: MouseEvent, reset: () => void) {
       e.stopPropagation()
 
       onFocus()
 
       nextTick(() => {
         model.value = null
+        reset()
 
         callEvent(props['onClick:clear'], e)
       })
@@ -187,12 +188,13 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
               isDirty,
               isReadonly,
               isValid,
-            }) => (
+              reset,
+            }) => ( 
               <VField
                 ref={ vFieldRef }
                 onMousedown={ onControlMousedown }
                 onClick={ onControlClick }
-                onClick:clear={ onClear }
+                onClick:clear={ (e: MouseEvent) => onClear(e, reset) }
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
                 role={ props.role }


### PR DESCRIPTION
## Description

- Fixes https://github.com/vuetifyjs/vuetify/issues/21310
- Call reset on clear

## Markup:

```vue
<template>
  <v-text-field
    v-model="firstName"
    :rules="rules"
    label="First name"
    clearable
    validate-on="eager"
  ></v-text-field>
</template>

<script setup>
  import { ref } from 'vue'

  const firstName = ref('')

  const rules = [value => !value || 'Must be empty']
</script>

```
