### PR TITLE
feat(VNumberInput): more flexible precision display

### DIFF
--- a/packages/api-generator/src/locale/en/VNumberInput.json
+++ b/packages/api-generator/src/locale/en/VNumberInput.json
@@ -5,6 +5,7 @@
     "inset": "Applies an indentation to the dividers used in the stepper buttons.",
     "max": "Specifies the maximum allowable value for the input.",
     "min": "Specifies the minimum allowable value for the input.",
+    "minFractionDigits": "Specifies the minimum fraction digits to be displayed (capped to `precision`). Defaults to `precision` when not explicitly set.",
     "precision": "Enforces strict precision. It is expected to be an integer value in range between `0` and `15`, or null for unrestricted.",
     "step": "Defines the interval between allowed values when the user increments or decrements the input"
   },


### PR DESCRIPTION
## Description

resolves #21306

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-card class="mx-auto pa-6 my-4" style="max-width: 1200px">
        <v-row class="mt-3">
          <v-col cols="4">
            <div class="mb-3"><small>(:precision='1')</small></div>
            <v-number-input label="Tax rate" v-model="exampleValue1" suffix="%" :precision="1" :min-fraction-digits='0' :step=".5" />
          </v-col>
          <v-col cols="4">
            <div class="mb-3"><small>(:precision='5' :min-fraction-digits='2')</small></div>
            <v-number-input v-model="exampleValue2" :precision="5" :min-fraction-digits='2' :step=".005" />
          </v-col>
          <v-col cols="4">
            <div class="mb-3"><small>(:precision='2' :min-fraction-digits='1')</small></div>
            <v-number-input v-model="exampleValue3" grouping :precision="example3_precision" :min-fraction-digits="example3_minFractionDigits" :step="1000" />
            <label>
              precision:
              <input type="number" v-model.number="example3_precision" />
            </label>
            <label>
              minFractionDigits:
              <input type="number" v-model.number="example3_minFractionDigits" />
            </label>
          </v-col>
        </v-row>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
import { ref } from 'vue';

const exampleValue1 = ref(6);
const exampleValue2 = ref(0.1);
const exampleValue3 = ref(25000);
const example3_precision = ref(2);
const example3_minFractionDigits = ref(1);
</script>
```
