### PR TITLE
feat(nested): auto-reveal selected items

### DIFF
--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -96,6 +96,12 @@
       "glow": "3.8.0"
     }
   },
+  "VList": {
+    "props": {
+      "autoRevealSelected": "3.10.0",
+      "autoRevealDelay": "3.10.0"
+    }
+  },
   "VListItem": {
     "props": {
       "baseColor": "3.3.0",
@@ -149,6 +155,8 @@
   },
   "VTreeview": {
     "props": {
+      "autoRevealSelected": "3.10.0",
+      "autoRevealDelay": "3.10.0",
       "hideActions": "3.10.0",
       "separateRoots": "3.10.0",
       "showLines": "3.10.0"

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -231,7 +231,7 @@ export const useNested = (props: NestedProps) => {
       }
 
       const pathsToReveal = [...selected.value.keys()].map(getPath)
-        .map(path => path.slice(0, -1))
+        .map(path => path.slice(0, -1).filter(v => !opened.value.has(v)))
         .filter(path => path.length > 0)
         .reduce(unique<unknown[]>, [])
 

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -7,12 +7,14 @@ import {
   inject,
   onBeforeMount,
   onBeforeUnmount,
+  onMounted,
   provide,
   ref,
   shallowRef,
   toRaw,
   toRef,
   toValue,
+  watch,
 } from 'vue'
 import {
   independentActiveStrategy,
@@ -29,7 +31,7 @@ import {
   leafSingleSelectStrategy,
   trunkSelectStrategy,
 } from './selectStrategies'
-import { consoleError, getCurrentInstance, propsFactory } from '@/util'
+import { consoleError, createRange, getCurrentInstance, propsFactory } from '@/util'
 
 // Types
 import type { InjectionKey, MaybeRefOrGetter, PropType, Ref } from 'vue'
@@ -62,6 +64,8 @@ export interface NestedProps {
   activeStrategy: ActiveStrategyProp | undefined
   selectStrategy: SelectStrategyProp | undefined
   openStrategy: OpenStrategyProp | undefined
+  autoRevealSelected: boolean
+  autoRevealDelay: string | number | undefined
   activated: any
   selected: any
   opened: any
@@ -124,6 +128,8 @@ export const makeNestedProps = propsFactory({
   activeStrategy: [String, Function, Object] as PropType<ActiveStrategyProp>,
   selectStrategy: [String, Function, Object] as PropType<SelectStrategyProp>,
   openStrategy: [String, Object] as PropType<OpenStrategyProp>,
+  autoRevealSelected: Boolean,
+  autoRevealDelay: [String, Number] as PropType<string | number | undefined>,
   opened: null,
   activated: null,
   selected: null,
@@ -213,6 +219,46 @@ export const useNested = (props: NestedProps) => {
 
     return path
   }
+
+  let revealTimeout: ReturnType<typeof setTimeout> = null!
+  function autoReveal () {
+    clearTimeout(revealTimeout)
+    if (props.autoRevealSelected && selected.value.size > 0) {
+      const delay = Number(props.autoRevealDelay ?? 300)
+
+      function unique<T> (result: T[], n: T, i: number, all: T[]): T[] {
+        return [...result, ...all.indexOf(n) === i ? [n] : []]
+      }
+
+      const pathsToReveal = [...selected.value.keys()].map(getPath)
+        .map(path => path.slice(0, -1))
+        .filter(path => path.length > 0)
+        .reduce(unique<unknown[]>, [])
+
+      if (!pathsToReveal.length) {
+        return
+      }
+
+      const longestPathLength = Math.max(...pathsToReveal.map(path => path.length))
+      const layers = createRange(longestPathLength)
+        .map(depth => pathsToReveal
+          .map(path => path.slice(0, depth + 1))
+          .filter(path => path.length > depth)
+          .map(path => path.pop())
+          .reduce(unique<unknown>, [])
+        )
+
+      function revealLayer () {
+        if (!layers.length) return
+        opened.value = new Set([...opened.value, ...layers.shift()!])
+        revealTimeout = setTimeout(revealLayer, delay)
+      }
+      revealTimeout = setTimeout(revealLayer, delay)
+    }
+  }
+
+  watch(selected, autoReveal)
+  onMounted(autoReveal)
 
   const vm = getCurrentInstance('nested')
 


### PR DESCRIPTION
## Description

- new prop to progressively expand nodes to display current selection
- note: expand animation can sometimes glitch and seems to need additional 100ms when the feature is used on VTreeview

closes #16578

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex ga-6 align-start">
      <v-card class="mx-auto" width="300">
        <v-btn color="primary" text="reload" @click="reload" />
        <v-list
          :key="reload1"
          v-model:opened="opened1"
          v-model:selected="selected1"
          :items="items"
          select-strategy="independent"
          auto-reveal-selected
          item-props
        />
      </v-card>
      <v-card class="mx-auto" width="300">
        <v-btn
          color="primary"
          text="apply selection"
          @click="selected2 = [222, 34]"
        />
        <v-treeview
          v-model:opened="opened2"
          v-model:selected="selected2"
          :items="items"
          auto-reveal-delay="400"
          select-strategy="independent"
          auto-reveal-selected
          item-props
          selectable
        />
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selected1 = [221, 32]
  const reload1 = ref(0)
  function reload () {
    opened1.value = []
    reload1.value++
  }
  const selected2 = ref([])
  const opened1 = ref([])
  const opened2 = ref([])
  const items = [
    { value: 1, title: 'Home', prependIcon: 'mdi-home' },
    {
      value: 2,
      title: 'Admin',
      prependIcon: 'mdi-numeric-1-box-outline',
      children: [
        {
          value: 21,
          title: 'Management',
          prependIcon: 'mdi-account-multiple-outline',
        },
        {
          value: 22,
          title: 'Settings',
          prependIcon: 'mdi-cog-outline',
          children: [
            { value: 221, title: 'General', prependIcon: 'mdi-tools' },
            { value: 222, title: 'Security', prependIcon: 'mdi-security' },
          ],
        },
      ],
    },
    {
      value: 3,
      title: 'Actions',
      prependIcon: 'mdi-numeric-2-box-outline',
      children: [
        { value: 31, title: 'Create', prependIcon: 'mdi-plus-outline' },
        { value: 32, title: 'Read', prependIcon: 'mdi-file-outline' },
        { value: 33, title: 'Update', prependIcon: 'mdi-update' },
        { value: 34, title: 'Delete', prependIcon: 'mdi-delete' },
      ],
    },
  ]
</script>
```
