### PR TITLE
fix(VTable): Disable v-table__wrapper roundness when table have a bottom

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -129,6 +129,8 @@
 
   .v-table--has-bottom
     > .v-table__wrapper
+      border-bottom-left-radius: 0
+      border-bottom-right-radius: 0
       > table
         > tbody
           > tr


### PR DESCRIPTION
When a VTable with hover attribute is being wrapped into a rounded component (typically, a VCard), the last TR of the tbody is rounded, despite the fact that the table have a bottom controls bar.

This PR disables bottom roundness of .v-table__wrapper in that case, to prevent hover effect being rounded by mistake.


Fixes #21320
