### PR TITLE
fix(VTextField): on click label moves cursor (#21291)

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -84,6 +84,7 @@
         right: 0
         width: 100%
         padding-inline: inherit
+        margin-top: 0
 
       .v-field--active
         input

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -84,6 +84,7 @@
         right: 0
         width: 100%
         padding-inline: inherit
+        margin-top: 0
 
       .v-field--active
         input

--- a/packages/vuetify/src/components/VTextField/VTextField.sass
+++ b/packages/vuetify/src/components/VTextField/VTextField.sass
@@ -11,7 +11,10 @@
       opacity: 0
       flex: $text-field-input-flex
       transition: $text-field-input-transition
+      margin-top: calc(var(--v-field-padding-top, 4px) + var(--v-input-padding-top, 0))
+      min-height: 0
       min-width: 0
+      padding-top: 0
 
       &:focus,
       &:active


### PR DESCRIPTION
## Description

- Fixes: #21291 
- Maintain the looks of the `VTextfield` as it is and prevent cursor movement on click label
- Affected components `VAutocomplete` and `VCombobox` set the `margin-top` to `0` to prevent increase of size

## Markup:

```vue
<template>
  <v-form>
    <v-container fluid>
      <v-row>
        <v-col cols="12" sm="6">
          <p style="margin-bottom: 30px">
            Clicking the input's label (I'm a label) moves the text cursor to
            the beginning of the input field, instead of placing it where the
            user clicked.
          </p>
          <v-text-field
            v-model="password"
            :append-inner-icon="show1 ? 'mdi-eye' : 'mdi-eye-off'"
            :type="show1 ? 'text' : 'password'"
            label="I'm a label"
            name="input-10-1"
            @click:append-inner="show1 = !show1"
            variant="underlined"
          />
        </v-col>
      </v-row>
    </v-container>
  </v-form>
</template>

<script setup>
  import { ref } from 'vue'

  const show1 = ref(false)
  const password = ref('Password')
</script>
```
