### PR TITLE
feat(defaults): allow using camelCase props

### DIFF
--- a/packages/vuetify/src/composables/__tests__/defaults.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/defaults.spec.ts
@@ -52,4 +52,24 @@ describe('defaults', () => {
     expect(wrapper.attributes('style')).toContain('background: blue;')
     expect(wrapper.attributes('style')).toContain('caret-color: blue;')
   })
+
+  it('handles default props in camelCase and kebab-case', () => {
+    const vuetify = createVuetify({
+      defaults: {
+        VBtn: {
+          'min-height': '101px',
+          minWidth: '103px',
+        },
+      },
+    })
+
+    const wrapper = mount<any>(VBtn, {
+      global: {
+        plugins: [vuetify],
+      },
+    })
+
+    expect(wrapper.attributes('style')).toContain('min-height: 101px;')
+    expect(wrapper.attributes('style')).toContain('min-width: 103px;')
+  })
 })

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -108,9 +108,14 @@ export function internalUseDefaults (
       if (prop === 'class' || prop === 'style') {
         return [componentDefaults.value?.[prop], propValue].filter(v => v != null)
       } else if (typeof prop === 'string' && !propIsDefined(vm.vnode, prop)) {
-        return componentDefaults.value?.[prop] !== undefined ? componentDefaults.value?.[prop]
-          : defaults.value?.global?.[prop] !== undefined ? defaults.value?.global?.[prop]
-          : propValue
+        const kebabProp = toKebabCase(prop)
+        const fromComponentDefaults = componentDefaults.value?.[prop] ?? componentDefaults.value?.[kebabProp]
+        const fromGlobalDefaults = defaults.value?.global?.[prop] ?? defaults.value?.global?.[kebabProp]
+        return fromComponentDefaults !== undefined
+          ? fromComponentDefaults
+          : fromGlobalDefaults !== undefined
+            ? fromGlobalDefaults
+            : propValue
       }
       return propValue
     },


### PR DESCRIPTION
fixes #21323

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

It allows to take into account both *kebab-case* and *camelCase* when providing `defaults` properties in the [setup](https://vuetifyjs.com/en/features/global-configuration/#setup) from the global configuration

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```js
// vuetify.js
import { createVuetify } from 'vuetify'

export const vuetify = createVuetify({
  theme: {
    defaultTheme: 'light',
  },
  defaults: {
    VBtn: {
      // OK
      appendIcon: '$vuetify',
      // OK
      'prepend-icon': '$vuetify',
    },
  },
})
```

```vue
// App.vue
<template>
  <v-btn>Foo</v-btn>
</template>
```


