### PR TITLE
docs(api): add dynamic toc support for api pages

### DIFF
--- a/packages/docs/src/components/api/Section.vue
+++ b/packages/docs/src/components/api/Section.vue
@@ -1,16 +1,8 @@
 <template>
-  <div v-if="items?.length" class="mb-4">
-    <!-- <div class="d-flex mb-2">
-      <AppTextField
-        clearable
-        icon="$mdiMagnify"
-        label="Filter"
-        @input="filter = $event"
-      />
-    </div> -->
+  <section v-if="items?.length" class="mb-4" :id="section">
     <AppHeadline :path="`api-headers.${section}`" />
     <TableComponent :items="items" :name="name" />
-  </div>
+  </section>
 </template>
 
 <script setup lang="ts">

--- a/packages/docs/src/components/api/Section.vue
+++ b/packages/docs/src/components/api/Section.vue
@@ -1,5 +1,5 @@
 <template>
-  <section v-if="items?.length" class="mb-4" :id="section">
+  <section v-if="items?.length" :id="section" class="mb-4">
     <AppHeadline :path="`api-headers.${section}`" />
     <TableComponent :items="items" :name="name" />
   </section>

--- a/packages/docs/src/components/api/View.vue
+++ b/packages/docs/src/components/api/View.vue
@@ -8,6 +8,7 @@
   const sections = ['props', 'events', 'slots', 'exposed', 'sass', 'argument', 'modifiers', 'value'] as const
 
   const route = useRoute()
+  const router = useRouter()
 
   const error = shallowRef(false)
   const name = computed(() => {
@@ -17,11 +18,40 @@
     else return `${name.charAt(0).toUpperCase()}${camelize(name.slice(1))}`
   })
   const component = shallowRef<any>({})
+
+  function generateToc() {
+    const toc = []
+    for (const section of sections) {
+      if (section in component.value && Object.keys(component.value[section]).length) {
+        toc.push({
+          to: `#${section}`,
+          text: section.charAt(0).toUpperCase() + section.slice(1),
+          level: 2
+        })
+      }
+    }
+    return toc
+  }
+
+  function updateFrontmatter() {
+    const matched = router.currentRoute.value.matched
+    if (matched.length > 0) {
+      const lastMatch = matched[matched.length - 1]
+      if (lastMatch.instances.default) {
+        (lastMatch.instances.default as any).frontmatter = {
+          ...(lastMatch.instances.default as any).frontmatter,
+          toc: generateToc()
+        }
+      }
+    }
+  }
+
   watch(name, async () => {
     emit('update:name', name.value)
     try {
       component.value = await getApi(name.value)
       error.value = false
+      updateFrontmatter()
     } catch (err) {
       error.value = true
     }

--- a/packages/docs/src/components/api/View.vue
+++ b/packages/docs/src/components/api/View.vue
@@ -19,28 +19,28 @@
   })
   const component = shallowRef<any>({})
 
-  function generateToc() {
+  function generateToc () {
     const toc = []
     for (const section of sections) {
       if (section in component.value && Object.keys(component.value[section]).length) {
         toc.push({
           to: `#${section}`,
           text: section.charAt(0).toUpperCase() + section.slice(1),
-          level: 2
+          level: 2,
         })
       }
     }
     return toc
   }
 
-  function updateFrontmatter() {
+  function updateFrontmatter () {
     const matched = router.currentRoute.value.matched
     if (matched.length > 0) {
       const lastMatch = matched[matched.length - 1]
       if (lastMatch.instances.default) {
         (lastMatch.instances.default as any).frontmatter = {
           ...(lastMatch.instances.default as any).frontmatter,
-          toc: generateToc()
+          toc: generateToc(),
         }
       }
     }

--- a/packages/docs/src/composables/frontmatter.ts
+++ b/packages/docs/src/composables/frontmatter.ts
@@ -33,7 +33,7 @@ export function useFrontmatter () {
   watch(router.currentRoute, route => {
     setTimeout(() => {
       frontmatter.value = (route.matched.at(-1)!.instances.default as any)?.frontmatter
-      timeout = 0
+      timeout = 1
     }, timeout)
   }, { immediate: true })
 


### PR DESCRIPTION
## Description
Adds support for generating and displaying a table of contents for dynamically generated API pages. The TOC is generated based on the available sections (props, events, slots, etc.) and is automatically updated when navigating between API pages.

This change was necessary because the API pages are dynamically generated from `[name].md` and previously didn't have a TOC, making navigation through the documentation more difficult.

## Markup:
This is a documentation-only change that affects the API documentation pages. No markup changes are required as it works with the existing structure of the API pages.