### PR TITLE
docs(VFileInput): updated validation example for multiple file upload

### DIFF
--- a/packages/docs/src/examples/v-file-input/prop-validation.vue
+++ b/packages/docs/src/examples/v-file-input/prop-validation.vue
@@ -2,28 +2,27 @@
   <v-file-input
     :rules="rules"
     accept="image/png, image/jpeg, image/bmp"
-    label="Avatar"
-    placeholder="Pick an avatar"
+    label="Photos"
+    placeholder="Upload your photos"
     prepend-icon="mdi-camera"
+    multiple
   ></v-file-input>
 </template>
 
 <script setup>
+  const maxSize = 5000000 // 5 MB
+  const errorMessage = 'Total image size should be less than 5 MB!'
+
   const rules = [
     value => {
-      return !value || !value.length || value[0].size < 2000000 || 'Avatar size should be less than 2 MB!'
+      // Multiple files
+      if (value && Array.isArray(value)) {
+        const totalSize = value.reduce((acc, current) => acc + current.size, 0)
+        return totalSize < maxSize || errorMessage
+      }
+
+      // Single file (if multiple is undefined or set to false)
+      return !value || value.size < maxSize || errorMessage
     },
   ]
-</script>
-
-<script>
-  export default {
-    data: () => ({
-      rules: [
-        value => {
-          return !value || !value.length || value[0].size < 2000000 || 'Avatar size should be less than 2 MB!'
-        },
-      ],
-    }),
-  }
 </script>

--- a/packages/docs/src/pages/en/components/file-inputs.md
+++ b/packages/docs/src/pages/en/components/file-inputs.md
@@ -84,7 +84,7 @@ The displayed size of the selected file(s) can be configured with the **show-siz
 
 #### Validation
 
-Similar to other inputs, you can use the **rules** prop to create your own custom validation parameters.
+Similar to other inputs, you can use the **rules** prop to create your own custom validation parameters. If **multiple** props is set, the`value` passed in the validation functions will be an array.
 
 <ExamplesExample file="v-file-input/prop-validation" />
 


### PR DESCRIPTION
## Description
- Resolves #21099 
- Showcase that validation rule function's `value` arg will be an array if `multiple` prop is passed (multiple file uploads)

## Markup:
N/A
