### PR TITLE
fix(VOtpInput): trim clipboard text and update focus on finish

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -166,7 +166,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
       e.preventDefault()
       e.stopPropagation()
 
-      const clipboardText = e?.clipboardData?.getData('Text').slice(0, length.value) ?? ''
+      const clipboardText = e?.clipboardData?.getData('Text').trim().slice(0, length.value) ?? ''
 
       if (isValidNumber(clipboardText)) return
 
@@ -207,7 +207,10 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     }, { scoped: true })
 
     watch(model, val => {
-      if (val.length === length.value) emit('finish', val.join(''))
+      if (val.length === length.value) {
+        focusIndex.value = length.value - 1
+        emit('finish', val.join(''))
+      }
     }, { deep: true })
 
     watch(focusIndex, val => {

--- a/packages/vuetify/src/components/VOtpInput/__tests__/VOtpInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VOtpInput/__tests__/VOtpInput.spec.browser.tsx
@@ -122,6 +122,53 @@ describe('VOtpInput', () => {
     expect(modelValue.value).toBe('123')
   })
 
+  it('handles paste event', async () => {
+    render(() => (<VOtpInput />))
+    const inputs = screen.getAllByCSS('.v-otp-input input')
+    await userEvent.click(inputs[0])
+    await navigator.clipboard.writeText('123456')
+    await userEvent.paste()
+
+    expect(inputs[0]).toHaveValue('1')
+    expect(inputs[1]).toHaveValue('2')
+    expect(inputs[2]).toHaveValue('3')
+    expect(inputs[3]).toHaveValue('4')
+    expect(inputs[4]).toHaveValue('5')
+    expect(inputs[5]).toHaveValue('6')
+    expect(inputs[5]).toHaveFocus()
+  })
+
+  it('trim paste event content', async () => {
+    render(() => (<VOtpInput />))
+    const inputs = screen.getAllByCSS('.v-otp-input input')
+    await userEvent.click(inputs[0])
+    await navigator.clipboard.writeText('  123456     ')
+    await userEvent.paste()
+
+    expect(inputs[0]).toHaveValue('1')
+    expect(inputs[1]).toHaveValue('2')
+    expect(inputs[2]).toHaveValue('3')
+    expect(inputs[3]).toHaveValue('4')
+    expect(inputs[4]).toHaveValue('5')
+    expect(inputs[5]).toHaveValue('6')
+    expect(inputs[5]).toHaveFocus()
+  })
+
+  it('handles mobile OTP autofill', async () => {
+    render(() => (<VOtpInput />))
+    const inputs = screen.getAllByCSS('.v-otp-input input')
+
+    await userEvent.fill(inputs[0], '123456')
+
+    expect(inputs[0]).toHaveValue('1')
+    expect(inputs[1]).toHaveValue('2')
+    expect(inputs[2]).toHaveValue('3')
+    expect(inputs[3]).toHaveValue('4')
+    expect(inputs[4]).toHaveValue('5')
+    expect(inputs[5]).toHaveValue('6')
+    expect(inputs[5]).toHaveFocus()
+  })
+
   describe('Showcase', () => {
     generate({ stories })
   })


### PR DESCRIPTION
## Description
This PR implements improvements to the `v-otp-input` component, addressing paste trimming and enhancing the autofill focus behavior discussed in #21131.

Specifically, the changes in this PR include:

1.  **Improved Paste Handling:**
    *   Leading/trailing whitespace is now removed using `trim()`.

2.  **Enhanced `finish` event:**
    *   Within the watcher that detects when the model's length equals the target length (signaling a completed OTP, often after autofill), the component now explicitly sets the `focusIndex` to the last input field.
    *   This change ensures that after a successful autofill, the focus is directed to the final input element, which provides a more intuitive user experience compared to the focus remaining on the second element.

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input v-model="otp" />
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const otp = ref('')
      return {
        otp,
      }
    },
  }
</script>
