### PR TITLE
fix(VDialog): only take focus on open if scrim or retainFocus

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -94,7 +94,11 @@ export const VDialog = genericComponent<OverlaySlots>()({
 
     function onAfterEnter () {
       emit('afterEnter')
-      if (overlay.value?.contentEl && !overlay.value.contentEl.contains(document.activeElement) && (props.scrim || props.retainFocus)) {
+      if (
+        (props.scrim || props.retainFocus) &&
+        overlay.value?.contentEl &&
+        !overlay.value.contentEl.contains(document.activeElement)
+      ) {
         overlay.value.contentEl.focus({ preventScroll: true })
       }
     }

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -94,7 +94,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
 
     function onAfterEnter () {
       emit('afterEnter')
-      if (overlay.value?.contentEl && !overlay.value.contentEl.contains(document.activeElement)) {
+      if (overlay.value?.contentEl && !overlay.value.contentEl.contains(document.activeElement) && props.retainFocus) {
         overlay.value.contentEl.focus({ preventScroll: true })
       }
     }

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -94,7 +94,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
 
     function onAfterEnter () {
       emit('afterEnter')
-      if (overlay.value?.contentEl && !overlay.value.contentEl.contains(document.activeElement) && props.retainFocus) {
+      if (overlay.value?.contentEl && !overlay.value.contentEl.contains(document.activeElement) && (props.scrim || props.retainFocus)) {
         overlay.value.contentEl.focus({ preventScroll: true })
       }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes https://github.com/vuetifyjs/vuetify/issues/21301

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="pa-8 text-center">
    <p>{{seconds}}</p>
    <p><span v-if="sheet">Focus lost in textarea</span></p>

    <v-textarea ref="textArea"> </v-textarea>

    <v-bottom-sheet
      v-model="sheet"
      inset
      hide-overlay
      persistent
      no-click-animation
      :retain-focus="false"
      scroll-strategy="none"
      :scrim="false"
      tabindex="-1"
    >
      <v-card class="text-center" height="200">
        <v-card-text>
          <v-btn text="Close" variant="text" @click="sheet = !sheet"></v-btn>

          <br />
          <br />

          <div>This is a bottom sheet that shouldn't gain focus</div>
        </v-card-text>
      </v-card>
    </v-bottom-sheet>
  </div>
</template>

<script setup>
  import { shallowRef, onMounted } from 'vue'

  const sheet = shallowRef(false)
  const seconds = shallowRef(5)
  const textArea = shallowRef()

  onMounted(() => {
    textArea.value.focus()
    const interval = setInterval(() => {
      seconds.value--
    }, 1000)

    setTimeout(() => {
      sheet.value = true
      clearInterval(interval)
    }, 6000)
  })
</script>

<style>
  *:focus {
    border: red 5px solid !important;
  }
</style>

```
