### PR TITLE
fix(VAutocomplete): re-evaluate dirty on external change

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -403,6 +403,12 @@ export const VAutocomplete = genericComponent<new <
       }
     })
 
+    watch(model, value => {
+      if (!props.multiple && !hasSelectionSlot.value) {
+        search.value = value[0]?.title ?? ''
+      }
+    })
+
     useRender(() => {
       const hasList = !!(
         (!props.hideNoData || displayItems.value.length) ||


### PR DESCRIPTION
## Description

- copied from VCombobox
- forces the `isDirty` to be evaluated. Otherwise, the computed in [validation.ts:96](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/composables/validation.ts#L96) does not trigger
- [x] verify regression (#19543)  -- no difference after the changes

fixes #20718

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="600">
      <v-card>
        <v-container fluid>
          <v-text-field label="v-text-field" v-model="model" />
          <v-select label="v-select" :items="shortList" v-model="model" />
          <v-combobox
            label="v-combobox"
            :items="shortList"
            v-model="model"
            v-model:search="search1"
          />
          <v-autocomplete
            label="v-autocomplete"
            :items="shortList"
            v-model="model"
            v-model:search="search2"
          />
        </v-container>
        <pre class="px-5 pb-5">{{ JSON.stringify({ search1, search2 }) }}</pre>
      </v-card>
      <pre class="mt-5">
1. Select value in VAutocomplete manually
2. Clear with external button
      </pre>
      <div class="d-flex ga-3">
        <v-btn class="ml-auto" @click="model = null">Clear</v-btn>
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const shortList = [0, 1, 2, 3, 4, 5, 6]

  const model = ref(null)
  const search1 = ref('')
  const search2 = ref('')
</script>
```