### PR TITLE
docs(sass-variables): mention how to use variable values containing commas

### DIFF
--- a/packages/docs/src/pages/en/features/sass-variables.md
+++ b/packages/docs/src/pages/en/features/sass-variables.md
@@ -88,6 +88,12 @@ Within your style file, specify the variables you want to override, and that's i
 
 :::
 
+::: warning
+
+If your values contain commas, such as if you are setting `$body-font-family` with multiple fonts, you must surround the value with parentheses, like this: `$body-font-family: ('Roboto', sans-serif)`. Otherwise the commas will be reported as a syntax error.
+
+:::
+
 ## Variable API
 
 There are many SASS/SCSS variables that can be customized across the entire Vuetify framework. You can browse all the variables using the tool below:


### PR DESCRIPTION
## Description

This PR adds a note to the documentation about how to set SCSS variables that have commas inside them.

Currently, neither this project nor the SASS project have documentation about commas in values in a `@use` block.

The following code doesn't work, because the comma is interpreted by the SCSS parser as the end of the value, and it expects another variable name after the comma:

```scss
@use 'vuetify/settings' with (
  $body-font-family: 'Roboto Variable', sans-serif
);
```

Surrounding the whole value in quotes doesn't work either.

With a lot of trial and error, I figured out that this syntax works:

```scss
@use 'vuetify/settings' with (
  $body-font-family: ('Roboto Variable', sans-serif)
);
```

I figured this should be documented to save other people the headache.