### PR TITLE
feat(VSelects): support divider and subheader

### DIFF
--- a/packages/docs/src/examples/v-autocomplete/prop-items.vue
+++ b/packages/docs/src/examples/v-autocomplete/prop-items.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-container>
+    <v-autocomplete v-model="selection" :items="items" label="Special items like in VList" chips multiple></v-autocomplete>
+
+    <v-autocomplete v-model="selection" :items="items" label="I have custom divider" chips multiple>
+      <template v-slot:divider="{ props }">
+        <div class="d-flex ga-4 align-center">
+          <v-divider></v-divider>
+          {{ props.text }}
+          <v-divider></v-divider>
+        </div>
+      </template>
+    </v-autocomplete>
+
+    <v-autocomplete v-model="selection" :items="items" label="I have custom subheader" chips multiple>
+      <template v-slot:subheader="{ props }">
+        <v-list-subheader class="font-weight-bold bg-primary">{{ props.title }}</v-list-subheader>
+      </template>
+    </v-autocomplete>
+  </v-container>
+</template>
+
+<script setup>
+  const items = [
+    { type: 'subheader', title: 'Group 1' },
+    { title: 'Item 1.1', value: 11 },
+    { title: 'Item 1.2', value: 12 },
+    { title: 'Item 1.3', value: 13 },
+    { title: 'Item 1.4', value: 14 },
+    { type: 'divider', text: 'or' },
+    { type: 'subheader', title: 'Group 2' },
+    { title: 'Item 2.1', value: 21 },
+    { title: 'Item 2.2', value: 22 },
+    { title: 'Item 2.3', value: 23 },
+  ]
+</script>
+
+<script>
+  export default {
+    data: () => ({
+      items: [
+        { type: 'subheader', title: 'Group 1' },
+        { title: 'Item 1.1', value: 11 },
+        { title: 'Item 1.2', value: 12 },
+        { title: 'Item 1.3', value: 13 },
+        { title: 'Item 1.4', value: 14 },
+        { type: 'divider', text: 'or' },
+        { type: 'subheader', title: 'Group 2' },
+        { title: 'Item 2.1', value: 21 },
+        { title: 'Item 2.2', value: 22 },
+        { title: 'Item 2.3', value: 23 },
+      ],
+    }),
+  }
+</script>

--- a/packages/docs/src/pages/en/components/autocompletes.md
+++ b/packages/docs/src/pages/en/components/autocompletes.md
@@ -66,6 +66,12 @@ The `custom-filter` prop can be used to filter each individual item with custom 
 
 <ExamplesExample file="v-autocomplete/prop-filter" />
 
+#### Subheaders and dividers
+
+The `items` prop recognizes special type of `divider` and `subheader`. Those items will be excluded when using filter and can be further customized with dedicated slots.
+
+<ExamplesExample file="v-autocomplete/prop-items" />
+
 ::: tip
 
 The **v-autocomplete** component updates the search model on focus/blur events. Focus sets search to the current model (if available), and blur clears it.

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -7,7 +7,7 @@ import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VIcon } from '@/components/VIcon'
-import { VList, VListItem } from '@/components/VList'
+import { VList, VListItem, VListSubheader } from '@/components/VList'
 import { VMenu } from '@/components/VMenu'
 import { makeSelectProps } from '@/components/VSelect/VSelect'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
@@ -42,6 +42,7 @@ import {
 
 // Types
 import type { PropType } from 'vue'
+import { VDivider } from '../VDivider'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'
@@ -97,6 +98,8 @@ export const VAutocomplete = genericComponent<new <
     item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
     chip: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
     selection: { item: ListItem<Item>, index: number }
+    subheader: { props: Record<string, unknown>, index: number }
+    divider: { props: Record<string, unknown>, index: number }
     'prepend-item': never
     'append-item': never
     'no-data': never
@@ -490,6 +493,18 @@ export const VAutocomplete = genericComponent<new <
                             active: (highlightFirst.value && index === 0) ? true : undefined,
                             onClick: () => select(item, null),
                           })
+
+                          if (item.raw.type === 'divider') {
+                            return slots.divider?.({ props: item.raw, index }) ?? (
+                              <VDivider { ...item.props } key={ `divider-${index}` } />
+                            )
+                          }
+
+                          if (item.raw.type === 'subheader') {
+                            return slots.subheader?.({ props: item.raw, index }) ?? (
+                              <VListSubheader { ...item.props } key={ `subheader-${index}` } />
+                            )
+                          }
 
                           return slots.item?.({
                             item,

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -6,6 +6,7 @@ import { VAvatar } from '@/components/VAvatar'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
+import { VDivider } from '@/components/VDivider'
 import { VIcon } from '@/components/VIcon'
 import { VList, VListItem, VListSubheader } from '@/components/VList'
 import { VMenu } from '@/components/VMenu'
@@ -42,7 +43,6 @@ import {
 
 // Types
 import type { PropType } from 'vue'
-import { VDivider } from '../VDivider'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -7,7 +7,7 @@ import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VIcon } from '@/components/VIcon'
-import { VList, VListItem } from '@/components/VList'
+import { VList, VListItem, VListSubheader } from '@/components/VList'
 import { VMenu } from '@/components/VMenu'
 import { makeSelectProps } from '@/components/VSelect/VSelect'
 import { VTextField } from '@/components/VTextField'
@@ -43,6 +43,7 @@ import {
 
 // Types
 import type { PropType } from 'vue'
+import { VDivider } from '../VDivider'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'
@@ -101,6 +102,8 @@ export const VCombobox = genericComponent<new <
     item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
     chip: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
     selection: { item: ListItem<Item>, index: number }
+    subheader: { props: Record<string, unknown>, index: number }
+    divider: { props: Record<string, unknown>, index: number }
     'prepend-item': never
     'append-item': never
     'no-data': never
@@ -535,6 +538,18 @@ export const VCombobox = genericComponent<new <
                             active: (highlightFirst.value && index === 0) ? true : undefined,
                             onClick: () => select(item, null),
                           })
+
+                          if (item.raw.type === 'divider') {
+                            return slots.divider?.({ props: item.raw, index }) ?? (
+                              <VDivider { ...item.props } key={ `divider-${index}` } />
+                            )
+                          }
+
+                          if (item.raw.type === 'subheader') {
+                            return slots.subheader?.({ props: item.raw, index }) ?? (
+                              <VListSubheader { ...item.props } key={ `subheader-${index}` } />
+                            )
+                          }
 
                           return slots.item?.({
                             item,

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -6,6 +6,7 @@ import { VAvatar } from '@/components/VAvatar'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
+import { VDivider } from '@/components/VDivider'
 import { VIcon } from '@/components/VIcon'
 import { VList, VListItem, VListSubheader } from '@/components/VList'
 import { VMenu } from '@/components/VMenu'
@@ -43,7 +44,6 @@ import {
 
 // Types
 import type { PropType } from 'vue'
-import { VDivider } from '../VDivider'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'

--- a/packages/vuetify/src/components/VList/VListChildren.tsx
+++ b/packages/vuetify/src/components/VList/VListChildren.tsx
@@ -2,7 +2,7 @@
 import { VListGroup } from './VListGroup'
 import { VListItem } from './VListItem'
 import { VListSubheader } from './VListSubheader'
-import { VDivider } from '../VDivider'
+import { VDivider } from '@/components/VDivider'
 
 // Utilities
 import { createList } from './list'

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -7,6 +7,7 @@ import { VAvatar } from '@/components/VAvatar'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
+import { VDivider } from '@/components/VDivider'
 import { VIcon } from '@/components/VIcon'
 import { VList, VListItem, VListSubheader } from '@/components/VList'
 import { VMenu } from '@/components/VMenu'
@@ -40,7 +41,6 @@ import {
 
 // Types
 import type { Component, PropType } from 'vue'
-import { VDivider } from '../VDivider'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -8,7 +8,7 @@ import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VChip } from '@/components/VChip'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VIcon } from '@/components/VIcon'
-import { VList, VListItem } from '@/components/VList'
+import { VList, VListItem, VListSubheader } from '@/components/VList'
 import { VMenu } from '@/components/VMenu'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
 import { VVirtualScroll } from '@/components/VVirtualScroll'
@@ -40,6 +40,7 @@ import {
 
 // Types
 import type { Component, PropType } from 'vue'
+import { VDivider } from '../VDivider'
 import type { VFieldSlots } from '@/components/VField/VField'
 import type { VInputSlots } from '@/components/VInput/VInput'
 import type { ListItem } from '@/composables/list-items'
@@ -124,6 +125,8 @@ export const VSelect = genericComponent<new <
     item: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
     chip: { item: ListItem<Item>, index: number, props: Record<string, unknown> }
     selection: { item: ListItem<Item>, index: number }
+    subheader: { props: Record<string, unknown>, index: number }
+    divider: { props: Record<string, unknown>, index: number }
     'prepend-item': never
     'append-item': never
     'no-data': never
@@ -428,6 +431,18 @@ export const VSelect = genericComponent<new <
                             key: item.value,
                             onClick: () => select(item, null),
                           })
+
+                          if (item.raw.type === 'divider') {
+                            return slots.divider?.({ props: item.raw, index }) ?? (
+                              <VDivider { ...item.props } key={ `divider-${index}` } />
+                            )
+                          }
+
+                          if (item.raw.type === 'subheader') {
+                            return slots.subheader?.({ props: item.raw, index }) ?? (
+                              <VListSubheader { ...item.props } key={ `subheader-${index}` } />
+                            )
+                          }
 
                           return slots.item?.({
                             item,

--- a/packages/vuetify/src/composables/filter.tsx
+++ b/packages/vuetify/src/composables/filter.tsx
@@ -102,6 +102,10 @@ export function filterItems (
 
     if ((query || customFiltersLength > 0) && !options?.noFilter) {
       if (typeof item === 'object') {
+        if (['divider', 'subheader'].includes(item.raw?.type)) {
+          continue
+        }
+
         const filterKeys = keys || Object.keys(transformed)
 
         for (const key of filterKeys) {


### PR DESCRIPTION
## Description

While workarounds are possible with `#item` slot we lose matches highlights when filtering and introduces anomalies (e.g. try typing "t " in this [example](https://play.vuetifyjs.com/playgrounds/1dMGUw)). Developers also need to remember about `tabindex='-1'` when they use `#item` slot and place checkbox or any focusable element, otherwise keyboard navigation is broken. Once dropdown components accept `type` right from the `items` it will be much easier to achieve functionality they need without compromising on quality.

- add support for **subheader** and **divider** (incl. slots)
- exclude them when filtering
- [x] keep all tests passing
- [x] example in docs

resolves #15721
resolves #5014
closes #19912
closes #5014

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-select multiple label="v-select" v-model="selection" :items="items" chips />
      <v-autocomplete multiple label="v-autocomplete" v-model="selection" :items="items" chips />
      <v-combobox multiple label="v-combobox" v-model="selection" :items="items" chips />

      <h5 class="mt-6">custom divider</h5>
      <v-autocomplete multiple label="v-autocomplete" v-model="selection" :items="items" chips>
        <template #divider="{ props }">
          <div class="d-flex ga-4 align-center">
            <v-divider />
            {{ props.text }}
            <v-divider />
          </div>
        </template>
      </v-autocomplete>
      <h5 class="mt-6">custom subheader</h5>
      <v-autocomplete multiple label="v-autocomplete" v-model="selection" :items="items" chips>
        <template #subheader="{ props }">
          <v-list-subheader class="font-weight-bold bg-primary">{{ props.title }}</v-list-subheader>
        </template>
      </v-autocomplete>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selection = ref([])
  const items = [
    { type: 'subheader', title: 'Group 1' },
    { title: 'Item 1.1', value: 11 },
    { title: 'Item 1.2', value: 12 },
    { title: 'Item 1.3', value: 13 },
    { title: 'Item 1.4', value: 14 },
    { type: 'divider', text: 'or' },
    { type: 'subheader', title: 'Group 2' },
    { title: 'Item 2.1', value: 21 },
    { title: 'Item 2.2', value: 22 },
    { title: 'Item 2.3', value: 23 },
  ]
</script>
```
