### PR TITLE
feat(transition): expose create transition classes

### DIFF
--- a/packages/docs/src/examples/transitions/create-css-transition-component.vue
+++ b/packages/docs/src/examples/transitions/create-css-transition-component.vue
@@ -1,49 +1,49 @@
 <template>
   <v-container>
-    <v-row justify="center">
+    <v-row justify="center" style="min-height: 160px;">
       <v-col class="text-center">
         <v-btn
           color="primary"
           @click="show = !show"
         >
-          My Transition
+          Component Transition
         </v-btn>
 
-        <MyTransition>
+        <ComponentTransition>
           <v-card
             v-show="show"
-            width="100"
-            height="100"
-            color="secondary"
             class="mx-auto mt-5"
+            color="secondary"
+            height="100"
+            width="100"
           ></v-card>
-        </MyTransition>
+        </ComponentTransition>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { createCssTransition } from 'vuetify/components/transitions';
+  import { ref } from 'vue'
+  import { createCssTransition } from 'vuetify/components/transitions'
 
-const MyTransition = createCssTransition('my-transition')
+  const ComponentTransition = createCssTransition('component-transition')
 
-const show = ref(false)
+  const show = ref(false)
 </script>
 
 <style lang="scss">
-.my-transition {
-  &-enter-active,
-  &-leave-active {
-    transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  }
+  .component-transition {
+    &-enter-active,
+    &-leave-active {
+      transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    }
 
-  &-enter-from,
-  &-leave-to {
-    opacity: 0;
-    transform: rotate(180deg) scale(0.2) skew(20deg);
-    filter: hue-rotate(90deg);
+    &-enter-from,
+    &-leave-to {
+      opacity: 0;
+      transform: rotate(180deg) scale(0.2) skew(20deg);
+      filter: hue-rotate(90deg);
+    }
   }
-}
 </style>

--- a/packages/docs/src/examples/transitions/create-css-transition-component.vue
+++ b/packages/docs/src/examples/transitions/create-css-transition-component.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-container>
+    <v-row justify="center">
+      <v-col class="text-center">
+        <v-btn
+          color="primary"
+          @click="show = !show"
+        >
+          My Transition
+        </v-btn>
+
+        <MyTransition>
+          <v-card
+            v-show="show"
+            width="100"
+            height="100"
+            color="secondary"
+            class="mx-auto mt-5"
+          ></v-card>
+        </MyTransition>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { createCssTransition } from 'vuetify/components/transitions';
+
+const MyTransition = createCssTransition('my-transition')
+
+const show = ref(false)
+</script>
+
+<style lang="scss">
+.my-transition {
+  &-enter-active,
+  &-leave-active {
+    transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  }
+
+  &-enter-from,
+  &-leave-to {
+    opacity: 0;
+    transform: rotate(180deg) scale(0.2) skew(20deg);
+    filter: hue-rotate(90deg);
+  }
+}
+</style>

--- a/packages/docs/src/examples/transitions/create-css-transition-prop.vue
+++ b/packages/docs/src/examples/transitions/create-css-transition-prop.vue
@@ -2,13 +2,13 @@
   <v-container>
     <v-row justify="center">
       <v-col class="text-center">
-        <v-menu transition="my-transition">
+        <v-menu transition="custom-prop-transition">
           <template v-slot:activator="{ props }">
             <v-btn
               color="primary"
               v-bind="props"
             >
-              My Transition
+              Prop Transition
             </v-btn>
           </template>
 
@@ -29,14 +29,13 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { createCssTransition } from 'vuetify/components/transitions';
+  import { createCssTransition } from 'vuetify/components/transitions'
 
-const MyTransition = createCssTransition('my-transition')
+  createCssTransition('custom-prop-transition')
 </script>
 
 <style lang="scss">
-.my-transition {
+.custom-prop-transition {
   &-enter-active,
   &-leave-active {
     transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);

--- a/packages/docs/src/examples/transitions/create-css-transition-prop.vue
+++ b/packages/docs/src/examples/transitions/create-css-transition-prop.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-container>
+    <v-row justify="center">
+      <v-col class="text-center">
+        <v-menu transition="my-transition">
+          <template v-slot:activator="{ props }">
+            <v-btn
+              color="primary"
+              v-bind="props"
+            >
+              My Transition
+            </v-btn>
+          </template>
+
+          <v-list>
+            <v-list-item
+              v-for="n in 5"
+              :key="n"
+            >
+              <v-list-item-title>
+                Item {{ n }}
+              </v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { createCssTransition } from 'vuetify/components/transitions';
+
+const MyTransition = createCssTransition('my-transition')
+</script>
+
+<style lang="scss">
+.my-transition {
+  &-enter-active,
+  &-leave-active {
+    transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    transform-origin: top center;
+  }
+
+  &-enter-from,
+  &-leave-to {
+    opacity: 0;
+    transform: scaleY(0) rotateX(-60deg);
+    transform-origin: top center;
+    filter: saturate(2) hue-rotate(90deg);
+  }
+}
+</style>

--- a/packages/docs/src/pages/en/styles/transitions.md
+++ b/packages/docs/src/pages/en/styles/transitions.md
@@ -108,30 +108,43 @@ Using multiple custom transitions, it is easy to bring a simple todo list to lif
 
 <ExamplesExample file="transitions/misc-todo" />
 
-<!--
 ## Create your own
 
-You can use Vuetify's transition helper function to easily create your own custom transitions. This function will return an object that you can import into Vue. Using Vue's [functional component](https://vuejs.org/v2/guide/render-function.html#Functional-Components) option will make sure your transition is as efficient as possible. Simply import the function:
+You can use Vuetify's transition helper function to easily create your own custom transitions.
 
 ```js
-import { createSimpleTransition } from 'vuetify/components/transitions/createTransition'
+import { createCssTransition } from 'vuetify/components/transitions';
 
-const myTransition = createSimpleTransition('my-transition')
-
-Vue.component('my-transition', myTransition)
+const MyTransition = createCssTransition('my-transition')
 ```
 
-The **createSimpleTransition** function accepts 1 argument, name. This will be the name that you can hook into with your style. This is an example of what `v-fade-transition` looks like:
+The argument passed to the **createCssTransition** function will be the name of the transition that you can hook into your style. This is an example of what `my-transition` looks like:
 
-```stylus
-.fade-transition
-  &-leave-active
-    position: absolute
+```scss
+.my-transition {
+  &-enter-active,
+  &-leave-active {
+    position: absolute;
+    transition: 1s;
+  }
 
-  &-enter-active, &-leave, &-leave-to
-    transition: $primary-transition
-
-  &-enter, &-leave-to
-    opacity: 0
+  &-enter-from,
+  &-leave-to {
+    opacity: 0;
+  }
+}
 ```
--->
+
+You can now use this custom transition in a few different ways.
+
+#### As a component
+
+The **createCssTransition** function will return a component that you can use in your template.
+
+<ExamplesExample file="transitions/create-css-transition-component" />
+
+#### As a prop
+
+Many of Vuetify’s components contain a **transition** prop. You can send the name of your custom transition to the transition prop.
+
+<ExamplesExample file="transitions/create-css-transition-prop" />

--- a/packages/docs/src/pages/en/styles/transitions.md
+++ b/packages/docs/src/pages/en/styles/transitions.md
@@ -115,7 +115,7 @@ You can use Vuetify's transition helper function to easily create your own custo
 ```js
 import { createCssTransition } from 'vuetify/components/transitions';
 
-const MyTransition = createCssTransition('my-transition')
+createCssTransition('my-transition')
 ```
 
 The argument passed to the **createCssTransition** function will be the name of the transition that you can hook into your style. This is an example of what `my-transition` looks like:
@@ -137,13 +137,13 @@ The argument passed to the **createCssTransition** function will be the name of 
 
 You can now use this custom transition in a few different ways.
 
-#### As a component
+### As a component
 
 The **createCssTransition** function will return a component that you can use in your template.
 
 <ExamplesExample file="transitions/create-css-transition-component" />
 
-#### As a prop
+### As a prop
 
 Many of Vuetify’s components contain a **transition** prop. You can send the name of your custom transition to the transition prop.
 

--- a/packages/vuetify/src/components/transitions/index.ts
+++ b/packages/vuetify/src/components/transitions/index.ts
@@ -43,3 +43,5 @@ export type VSlideYTransition = InstanceType<typeof VSlideYTransition>
 export type VSlideYReverseTransition = InstanceType<typeof VSlideYReverseTransition>
 export type VExpandTransition = InstanceType<typeof VExpandTransition>
 export type VExpandXTransition = InstanceType<typeof VExpandXTransition>
+
+export { createCssTransition, createJavascriptTransition }


### PR DESCRIPTION
## Description
Exposed `createCssTransition` function and added proper documentation on it's usage and example.
fixes #16050

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <v-row justify="center">
      <v-col class="text-center">
        <v-btn
          color="primary"
          @click="show = !show"
        >
          My Transition
        </v-btn>

        <MyTransition>
          <v-card
            v-show="show"
            width="100"
            height="100"
            color="secondary"
            class="mx-auto mt-5"
          ></v-card>
        </MyTransition>
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup>
import { ref } from 'vue'
import { createCssTransition } from 'vuetify/components/transitions';

const MyTransition = createCssTransition('my-transition')

const show = ref(false)
</script>

<style lang="scss">
.my-transition {
  &-enter-active,
  &-leave-active {
    transition: 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
  }

  &-enter-from,
  &-leave-to {
    opacity: 0;
    transform: rotate(180deg) scale(0.2) skew(20deg);
    filter: hue-rotate(90deg);
  }
}
</style>

```
