### PR TITLE
fix(VTimePicker): fix ssr hydration mismatch error

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
@@ -148,8 +148,8 @@ export const VTimePickerClock = genericComponent()({
     function getTransform (i: number) {
       const { x, y } = getPosition(i)
       return {
-        left: `${50 + x * 50}%`,
-        top: `${50 + y * 50}%`,
+        left: `${Math.round(50 + x * 50)}%`,
+        top: `${Math.round(50 + y * 50)}%`,
       }
     }
 


### PR DESCRIPTION
## Description
Rounded left and top values for VTimePickerClock to fix ssr hydration mismatch error
![image](https://github.com/user-attachments/assets/e102df0b-f0cb-474c-bd74-13d4721d5029)

## Markup:
```vue
<v-time-picker />
```
