### PR TITLE
feat(VOtpInput): allow to keep focus on paste (#21275)

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -167,12 +167,13 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
       e.stopPropagation()
 
       const clipboardText = e?.clipboardData?.getData('Text').slice(0, length.value) ?? ''
+      const finalIndex = clipboardText.length - 1 === -1 ? index : clipboardText.length - 1
 
       if (isValidNumber(clipboardText)) return
 
       model.value = clipboardText.split('')
 
-      inputRef.value?.[clipboardText.length - 1 ?? index].focus()
+      inputRef.value?.[finalIndex].focus()
     }
 
     function reset () {

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -30,7 +30,6 @@ export const makeVOtpInputProps = propsFactory({
   autofocus: Boolean,
   divider: String,
   focusAll: Boolean,
-  keepFocus: Boolean,
   label: {
     type: String,
     default: '$vuetify.input.otp',
@@ -173,11 +172,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
 
       model.value = clipboardText.split('')
 
-      if (!props.keepFocus) {
-        inputRef.value?.[index].blur()
-      } else {
-        inputRef.value?.[clipboardText.length - 1 ?? index].focus()
-      }
+      inputRef.value?.[clipboardText.length - 1 ?? index].focus()
     }
 
     function reset () {

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -30,6 +30,7 @@ export const makeVOtpInputProps = propsFactory({
   autofocus: Boolean,
   divider: String,
   focusAll: Boolean,
+  keepFocus: Boolean,
   label: {
     type: String,
     default: '$vuetify.input.otp',
@@ -172,7 +173,11 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
 
       model.value = clipboardText.split('')
 
-      inputRef.value?.[index].blur()
+      if (!props.keepFocus) {
+        inputRef.value?.[index].blur()
+      } else {
+        inputRef.value?.[clipboardText.length - 1 ?? index].focus()
+      }
     }
 
     function reset () {


### PR DESCRIPTION
## Description

- Resolves: #21275
- Add new prop to keep focus on paste to `VOtpInput`, retains the default behavior of blur on paste

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input v-model="token" keep-focus  />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const token = ref()
</script>
```
