### PR TITLE
fix(VBottomNavigation): set inline margin to auto

### DIFF
--- a/packages/vuetify/src/components/VBottomSheet/VBottomSheet.sass
+++ b/packages/vuetify/src/components/VBottomSheet/VBottomSheet.sass
@@ -21,7 +21,7 @@
       flex: 0 1 auto
       left: 0
       right: 0
-      margin-inline: 0
+      margin-inline: auto
       margin-bottom: 0
       transition-duration: $bottom-sheet-transition-duration
       width: 100%


### PR DESCRIPTION
## Description

- Fixes: https://github.com/vuetifyjs/vuetify/issues/21316
- Change `margin-inline` from `0` to `auto` no impact on default behavior

## Markup:

```vue
<template>
  <div class="text-center pa-8">
    <v-btn
      class="ma-auto"
      size="x-large"
      text="Click Me"
      @click="sheet = !sheet"
    ></v-btn>

    <v-bottom-sheet v-model="sheet" max-width="300">
      <v-card height="500">
        <v-card-text> Content </v-card-text>
      </v-card>
    </v-bottom-sheet>
  </div>
</template>
<script setup>
  import { shallowRef } from 'vue'

  const sheet = shallowRef(false)
</script>

```
