### PR TITLE
fix(VDateInput): accept typing/changing more than one date

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -3,6 +3,7 @@ import { VDateInput } from '../VDateInput'
 // Utilities
 import { mount } from '@vue/test-utils'
 import { createVuetify } from '@/framework'
+import { render, screen, userEvent } from '@test'
 
 // global.ResizeObserver = require('resize-observer-polyfill')
 
@@ -105,6 +106,43 @@ describe('VDateInput', () => {
       await input.trigger('blur')
 
       expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+    })
+  })
+
+  describe('typing values', () => {
+    it.each([
+      { multiple: false, typing: '07/01/2022', expected: '07/01/2022' },
+      { multiple: false, typing: '4/15/26', expected: '04/15/2026' },
+      { multiple: 'range', typing: '07/01/2022', expected: '07/01/2022 - 07/01/2022' },
+      { multiple: 'range', typing: '4/15/26', expected: '04/15/2026 - 04/15/2026' },
+      { multiple: 'range', typing: '05/02/2025 - 05/14/2025', expected: '05/02/2025 - 05/14/2025' },
+      { multiple: true, typing: '07/01/2022', expected: '1 selected' },
+      { multiple: true, typing: '05/02/2025 05/14/2025', expected: '2 selected' },
+      { multiple: true, typing: '4/15/25 04/22/25 04/15/25', expected: '3 selected' },
+    ])('should accept pasted and typed values', async ({ multiple, typing, expected }) => {
+      const { element } = render(() => <VDateInput multiple={ multiple } />)
+      const input = screen.getByCSS('input')
+      await userEvent.click(element)
+      await userEvent.keyboard(typing)
+      await userEvent.click(document.body)
+      expect(input).toHaveValue(expected)
+    })
+
+    it.each([
+      { multiple: false, initial: '05/16/2025', typing: '←←←←←×2', expected: '05/12/2025' },
+      { multiple: 'range', initial: '05/16/2025 - 05/24/2025', typing: '←←←←←××3', expected: '05/03/2025 - 05/16/2025' },
+    ])('should accept changes typed from keyboard', async ({ multiple, initial, typing, expected }) => {
+      const { element } = render(() => <VDateInput multiple={ multiple } />)
+      const input = screen.getByCSS('input')
+      await userEvent.click(element)
+      await userEvent.keyboard(`${initial}{Enter}`)
+      expect(input).toHaveValue(initial)
+      const typingSequence = typing
+        .replaceAll('←', '{ArrowLeft}')
+        .replaceAll('×', '{Backspace}')
+      await userEvent.keyboard(typingSequence)
+      await userEvent.click(document.body)
+      expect(input).toHaveValue(expected)
     })
   })
 })


### PR DESCRIPTION
## Description

- follow-up to [#21249](https://github.com/vuetifyjs/vuetify/pull/21249#review-thread-or-comment-id-1323997059)
- makes it possible to enter or edit dates by typing value directly in the text field

Note: considered a bug fix because single value works fine while "multiple" and "range" do not

## Markup:

```vue
<template>
  <div class="d-flex ga-6">
    <v-date-input label="Single" />
    <v-date-input label="Multiple" multiple />
    <v-date-input label="Range" multiple="range" />
  </div>
</template>
```
