### PR TITLE
fix(date): week number for DST

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -1,7 +1,11 @@
 // @ts-nocheck
 /* eslint-disable */
 
+// Components
+import { VDatePicker } from '../VDatePicker'
+
 // import { touch } from '@/../test'
+import { render, screen } from '@test'
 import {
   mount,
   MountOptions,
@@ -763,5 +767,34 @@ describe.skip('VDatePicker.ts', () => { // eslint-disable-line max-statements
 
     expect(lastWeekEl.text()).toBe('09')
     expect(lastDayEl.text()).toBe('7')
+  })
+})
+
+describe('week numbers with time zone', () => {
+  beforeEach(() => vi.stubEnv('TZ', 'Europe/Warsaw'))
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('should calculate weeks correctly near ST/DST transition', async () => {
+    render(VDatePicker, {
+      props: {
+        showWeek: true,
+        modelValue: new Date(2025,3,1),
+      },
+    })
+    const $weeks = await screen.findAllByCSS('.v-date-picker-month__weeks > div')
+    expect($weeks[1].innerHTML).toBe('14')
+    expect($weeks[2].innerHTML).toBe('15')
+  })
+
+  it('should calculate weeks correctly near DST/ST transition', async () => {
+    render(VDatePicker, {
+      props: {
+        showWeek: true,
+        modelValue: new Date(2025,10,1),
+      },
+    })
+    const $weeks = await screen.findAllByCSS('.v-date-picker-month__weeks > div')
+    expect($weeks[1].innerHTML).toBe('44')
+    expect($weeks[2].innerHTML).toBe('45')
   })
 })

--- a/packages/vuetify/src/composables/date/__tests__/date.spec.ts
+++ b/packages/vuetify/src/composables/date/__tests__/date.spec.ts
@@ -144,6 +144,15 @@ describe('date.ts', () => {
       expect(result[2]).toEqual(new Date('2025-01-01'))
       expect(result[3]).toEqual(adapter.endOfDay(stop))
     })
+
+    it('should not miss any days near ST/DST transition', () => {
+      // values passed to createDateRange on VDateInput blur when TZ=Europe/Warsaw
+      const start = new Date('2025-03-28T23:00:00.000Z')
+      const stop = new Date('2025-03-30T22:00:00.000Z')
+      const result = createDateRange(adapter, start, stop)
+
+      expect(result).toHaveLength(3)
+    })
   })
 })
 

--- a/packages/vuetify/src/composables/date/__tests__/date.spec.ts
+++ b/packages/vuetify/src/composables/date/__tests__/date.spec.ts
@@ -146,3 +146,22 @@ describe('date.ts', () => {
     })
   })
 })
+
+describe('week numbers with time zone', () => {
+  beforeAll(() => vi.stubEnv('TZ', 'America/Los_Angeles'))
+  afterAll(() => vi.unstubAllEnvs())
+
+  it('should calculate weeks correctly near ST/DST transition', () => {
+    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+    expect(adapter.getWeek(adapter.parseISO('2025-03-15'))).toBe(11)
+    expect(adapter.getWeek(adapter.parseISO('2025-03-16'))).toBe(12)
+    expect(adapter.getWeek(adapter.parseISO('2025-03-17'))).toBe(12)
+  })
+
+  it('should calculate weeks correctly near DST/ST transition', () => {
+    const adapter = new VuetifyDateAdapter({ locale: 'en-US' })
+    expect(adapter.getWeek(adapter.parseISO('2025-11-01'))).toBe(44)
+    expect(adapter.getWeek(adapter.parseISO('2025-11-02'))).toBe(45)
+    expect(adapter.getWeek(adapter.parseISO('2025-11-03'))).toBe(45)
+  })
+})

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -330,7 +330,7 @@ function getWeek (date: Date, locale: string, firstDayOfWeek?: number, firstWeek
     ? addDays(yearStart, size - 7)
     : addDays(yearStart, size)
 
-  return 1 + getDiff(date, d1w1, 'weeks')
+  return 1 + getDiff(endOfDay(date), startOfDay(d1w1), 'weeks')
 }
 
 function getDate (date: Date) {

--- a/packages/vuetify/src/composables/date/date.ts
+++ b/packages/vuetify/src/composables/date/date.ts
@@ -90,7 +90,11 @@ export function createDate (options: DateOptions | undefined, locale: LocaleInst
 }
 
 export function createDateRange (adapter: DateInstance, start: unknown, stop?: unknown) {
-  const diff = adapter.getDiff(stop ?? start, start, 'days')
+  const diff = adapter.getDiff(
+    adapter.endOfDay(stop ?? start),
+    adapter.startOfDay(start),
+    'days'
+  )
   const datesInRange = [start]
 
   for (let i = 1; i < diff; i++) {


### PR DESCRIPTION
## Description

- [x] similar change in `createRange` from #21450

fixes #21366

## Markup:

```vue
<template>
  <v-app>
    <v-container max-width="1200">
      <div class="d-flex ga-6">
        <!-- open DevTools » Sensors -->
        <!-- change Location to Berlin -->
        <!-- reload the page -->
        <v-date-picker :month="3" show-week />
        <v-row>
          <v-col>
            <v-date-input v-model="rangeSelection" :month="2" :year="2025" multiple="range" show-week />
          </v-col>
          <v-col>
            <v-alert type="info" variant="outlined">
              <ul>
                <li>1. select 3/29 ~ 3/31.</li>
                <li>2. re-open the picker.</li>
              </ul>
            </v-alert>
            <pre>rangeSelection: {{ rangeSelection }}</pre>
          </v-col>
        </v-row>
      </div>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const rangeSelection = ref([])
</script>
```
