### PR TITLE
fix(VNumberInput): inner spacing adjustments

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
@@ -15,18 +15,30 @@
         -webkit-appearance: none
 
     .v-field
-      &:not(:has(.v-field__prepend-inner > .v-icon))
+      &:has(.v-field__prepend-inner > .v-number-input__control:first-child)
         padding-inline-start: 0
 
-      &:not(:has(.v-field__append-inner > .v-icon))
+      &:has(.v-field__append-inner > .v-number-input__control:last-child)
         padding-inline-end: 0
 
-    .v-field__prepend-inner:has(.v-number-input__control) > .v-icon
-      margin-inline-end: 12px
+    .v-field__prepend-inner:has(.v-number-input__control)
+      > .v-icon
+        margin-inline-end: 4px
 
-    .v-field__append-inner:has(.v-number-input__control) > .v-icon
-      margin-inline-start: 12px
+      > hr + .v-icon,
+      > .v-number-input__control + .v-icon
+        margin-inline: 8px 0
 
+    .v-field__append-inner:has(.v-number-input__control)
+      > .v-icon
+        margin-inline-start: 4px
+
+      > .v-icon:has(+ hr),
+      > .v-icon:has(+ .v-number-input__control)
+        margin-inline: 0 8px
+
+    .v-field__clearable:has(+ .v-field__append-inner > hr:first-child)
+      margin-inline-end: 8px
 
     &--inset
       .v-divider


### PR DESCRIPTION
## Description

- VNumberInput does not play well with `append-inner-icon` and devs will usually use `#append-inner` to append icons
- I am trying to address the spacing & inconsitency

**Note**: (about the playground) it might appear that suffix is too close to the `hr`, but it has the same 6px distance as the prefix. Please ignore. I think the default spacing should be 2x larger, but it is out of scope for this PR.

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="400">
      <v-alert type="info" density="compact">
    	toggle between <v-code>none</v-code> &amp; <v-code>slot</v-code>
      </v-alert>

      <h5 class="mt-4">prepend</h5>
      <v-btn-toggle v-model="prepend" density="compact">
        <v-btn value="none" text="none" />
        <v-btn value="icon" text="icon" />
        <v-btn value="slot" text="slot" />
      </v-btn-toggle>
      <h5 class="mt-4">append</h5>
      <v-btn-toggle v-model="append" density="compact">
        <v-btn value="none" text="none" />
        <v-btn value="icon" text="icon" />
        <v-btn value="slot" text="slot" />
      </v-btn-toggle>
      <h5 class="mt-4">density</h5>
      <v-btn-toggle class="ml-auto" v-model="density" density="comfortable">
        <v-btn value="default" icon="mdi-view-agenda" />
        <v-btn value="comfortable" icon="mdi-view-sequential" />
        <v-btn value="compact" icon="mdi-format-align-justify" />
      </v-btn-toggle>
      <h5 class="mt-4">misc</h5>
      <div class="d-flex align-center ga-8 pl-2">
        <v-switch
          density="compact"
          label="clearable"
          v-model="clearable"
          hide-details
        />
        <v-switch
          density="compact"
          label="outlined"
          v-model="outlined"
          hide-details
        />
        <v-switch
          density="compact"
          label="reverse"
          v-model="reverse"
          hide-details
        />
      </div>
      <v-divider class="mt-3 mb-6" />

      <v-select
        v-model="selection"
        label="v-select"
        color="success"
        glow
        icon-color="success"
        v-bind="commonProps"
        persistent-clear
        prefix="Weight:"
        suffix="lbs"
        :items="Array.from({ length: 8 }).map((_, i) => 100 + i * 10)"
      >
        <template #prepend-inner v-if="prepend === 'slot'">
          <v-icon color="error" icon="mdi-cow" />
        </template>
        <template #append-inner v-if="append === 'slot'">
          <v-icon color="error" icon="mdi-bell" />
        </template>
      </v-select>

      <v-text-field
        v-model="msg"
        label="v-text-field"
        color="primary"
        glow
        icon-color="primary"
        v-bind="commonProps"
        persistent-clear
        prefix="Weight:"
        suffix="lbs"
      >
        <template #prepend-inner v-if="prepend === 'slot'">
          <v-icon color="error" icon="mdi-cow" />
        </template>
        <template #append-inner v-if="append === 'slot'">
          <v-icon color="error" icon="mdi-bell" />
        </template>
      </v-text-field>

      <v-divider class="mt-3 mb-6" />
      <v-number-input
        v-for="cv in ['hidden', undefined, 'stacked', 'split']"
        :key="cv || 0"
        :control-variant="cv"
        v-model="num"
        label="v-number-input"
        v-bind="commonProps"
        persistent-clear
        prefix="Weight:"
        suffix="lbs"
      >
        <template #prepend-inner v-if="prepend === 'slot'">
          <v-icon color="error" icon="mdi-cow" />
        </template>
        <template #append-inner v-if="append === 'slot'">
          <v-icon color="error" icon="mdi-bell" />
        </template>
      </v-number-input>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { computed, ref } from 'vue'

  const prepend = ref<'none' | 'icon' | 'slot'>('slot')
  const append = ref<'none' | 'icon' | 'slot'>('slot')
  const clearable = ref(true)
  const outlined = ref(true)
  const reverse = ref(false)
  const density = ref<'default' | 'comfortable' | 'compact'>('comfortable')
  const msg = ref('12.50')
  const selection = ref(150)
  const num = ref(32)

  const commonProps = computed(() => ({
    clearable: clearable.value,
    variant: outlined.value ? 'outlined' : undefined,
    density: density.value,
    prependInnerIcon: prepend.value === 'icon' ? 'mdi-weight' : undefined,
    appendInnerIcon: append.value === 'icon' ? 'mdi-sticker-alert' : undefined,
    reverse: reverse.value,
  }))
</script>
```
