### PR TITLE
docs: update laravel getting started

### DIFF
--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -226,34 +226,38 @@ Alternatively, you can use the [vuetify-nuxt-module](https://github.com/vuetifyj
 
 Check the [documentation](https://nuxt.vuetifyjs.com/) for more information on how to use it.
 
-## Using Laravel Mix
+## Using Laravel
 
-```js
+The `createApp()` setup may differ, especially if your Laravel application uses [inertiajs](https://inertiajs.com/client-side-setup). As long as you chain with`.use()`, Vuetify should be properly registered and available.
+
+```js  { data-resource=resources/js/app.ts }
 import { createApp } from 'vue'
 
 // Vuetify
 import '@mdi/font/css/materialdesignicons.css'
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
 
-// Components
-import App from './App.vue'
+const app = createApp()
 
-const vuetify = createVuetify({
-  components,
-  directives
+// Register Vuetify as plugin
+const vuetify = createVuetify()
+app.use(vuetify).mount("#app")
+```
+
+```js { data-resource=vite-config.ts }
+import vuetify from 'vite-plugin-vuetify'
+// ... other imports
+
+export default defineConfig({
+  plugins: [
+    // ... other plugins
+    vuetify({ autoImport: true }),
+  ],
 })
-
-createApp(App).use(vuetify).mount('#app')
 ```
 
-To import the fonts you need to add to webpack.mix.js:
-
-```js
-mix.copy('node_modules/@mdi/font/fonts/', 'dist/fonts/')
-```
+If font is defined at `resources/views/app.blade.php`, Vuetify's font settings will not take effect.
 
 ## Using CDN
 


### PR DESCRIPTION
## Description
Update Getting Started with Laravel documentation. `vite.config.ts` is preferred over `webpack.mix.js` starting at Laravel 9

<img width="744" alt="Screen Shot 2025-05-08 at 11 20 47 AM" src="https://github.com/user-attachments/assets/18e38d08-486e-42dc-bf68-0a820d25823b" />


## Markup:
N/A
