### PR TITLE
feat(VNumberInput): custom decimal separator

### DIFF
--- a/packages/api-generator/src/locale/en/VNumberInput.json
+++ b/packages/api-generator/src/locale/en/VNumberInput.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "controlVariant": "The color of the control. It defaults to the value of `variant` prop.",
+    "decimalSeparator": "Expects single character to be used as decimal separator. Defaults to `.` (dot)",
     "hideInput": "Hide the input field.",
     "inset": "Applies an indentation to the dividers used in the stepper buttons.",
     "max": "Specifies the maximum allowable value for the input.",

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -16,7 +16,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, nextTick, onMounted, ref, shallowRef, toRef, watch, watchEffect } from 'vue'
-import { clamp, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { clamp, escapeForRegex, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -60,6 +60,10 @@ const makeVNumberInputProps = propsFactory({
     type: Number as PropType<number | null>,
     default: 0,
   },
+  decimalSeparator: {
+    type: String,
+    validator: (v: any) => !v || v.length === 1,
+  },
 
   ...omit(makeVTextFieldProps(), ['modelValue', 'validationValue']),
 }, 'VNumberInput')
@@ -86,13 +90,16 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const { isFocused, focus, blur } = useFocus(props)
 
-    function correctPrecision (val: number, precision = props.precision) {
+    const decimalSeparator = computed(() => props.decimalSeparator?.[0] || '.')
+
+    function correctPrecision (val: number, precision = props.precision, trim = true) {
       const fixed = precision == null
         ? String(val)
         : val.toFixed(precision)
-      return isFocused.value
+      const textValue = isFocused.value && trim
         ? Number(fixed).toString() // trim zeros
         : fixed
+      return textValue.replace('.', decimalSeparator.value)
     }
 
     const model = useProxiedModel(props, 'modelValue', null,
@@ -118,8 +125,11 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         if (val === null || val === '') {
           model.value = null
           _inputText.value = null
-        } else if (!isNaN(Number(val)) && Number(val) <= props.max && Number(val) >= props.min) {
-          model.value = Number(val)
+          return
+        }
+        const parsedValue = Number(val.replace(decimalSeparator.value, '.'))
+        if (!isNaN(parsedValue) && parsedValue <= props.max && parsedValue >= props.min) {
+          model.value = parsedValue
           _inputText.value = val
         }
       },
@@ -199,12 +209,13 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
           ? existingTxt.slice(0, selectionStart as number | undefined) + e.data + existingTxt.slice(selectionEnd as number | undefined)
           : e.data
 
-      const potentialNewNumber = extractNumber(potentialNewInputVal, props.precision)
+      const potentialNewNumber = extractNumber(potentialNewInputVal, props.precision, decimalSeparator.value)
 
-      // Only numbers, "-", "." are allowed
-      // AND "-", "." are allowed only once
-      // AND "-" is only allowed at the start
-      if (!/^-?(\d+(\.\d*)?|(\.\d+)|\d*|\.)$/.test(potentialNewInputVal)) {
+      // Allow only numbers, "-" and {decimal separator}
+      // Allow "-" and {decimal separator} only once
+      // Allow "-" only at the start
+
+      if (!new RegExp(`^-?\\d*${escapeForRegex(decimalSeparator.value)}?\\d*$`).test(potentialNewInputVal)) {
         e.preventDefault()
         inputElement!.value = potentialNewNumber
       }
@@ -212,12 +223,12 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (props.precision == null) return
 
       // Ignore decimal digits above precision limit
-      if (potentialNewInputVal.split('.')[1]?.length > props.precision) {
+      if (potentialNewInputVal.split(decimalSeparator.value)[1]?.length > props.precision) {
         e.preventDefault()
         inputElement!.value = potentialNewNumber
       }
       // Ignore decimal separator when precision = 0
-      if (props.precision === 0 && potentialNewInputVal.includes('.')) {
+      if (props.precision === 0 && potentialNewInputVal.includes(decimalSeparator.value)) {
         e.preventDefault()
         inputElement!.value = potentialNewNumber
       }
@@ -274,8 +285,9 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (controlsDisabled.value) return
       if (!vTextFieldRef.value) return
       const actualText = vTextFieldRef.value.value
-      if (actualText && !isNaN(Number(actualText))) {
-        inputText.value = correctPrecision(clamp(Number(actualText), props.min, props.max))
+      const parsedValue = Number(actualText.replace(decimalSeparator.value, '.'))
+      if (actualText && !isNaN(parsedValue)) {
+        inputText.value = correctPrecision(clamp(parsedValue, props.min, props.max))
       } else {
         inputText.value = null
       }
@@ -283,13 +295,9 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     function formatInputValue () {
       if (controlsDisabled.value) return
-      if (model.value === null || isNaN(model.value)) {
-        inputText.value = null
-        return
-      }
-      inputText.value = props.precision == null
-        ? String(model.value)
-        : model.value.toFixed(props.precision)
+      inputText.value = model.value !== null && !isNaN(model.value)
+        ? correctPrecision(model.value, props.precision, false)
+        : null
     }
 
     function trimDecimalZeros () {
@@ -299,6 +307,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         return
       }
       inputText.value = model.value.toString()
+        .replace('.', decimalSeparator.value)
     }
 
     function onFocus () {

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -203,6 +203,34 @@ describe('VNumberInput', () => {
       await expect.element(screen.getByCSS('input')).toHaveValue('0.00')
       expect(model.value).toBe(0)
     })
+
+    it('shows custom decimal separator when incrementing', async () => {
+      const model = ref(0)
+      render(() => (
+        <VNumberInput
+          step={ 0.07 }
+          precision={ 2 }
+          decimalSeparator=","
+          v-model={ model.value }
+        />
+      ))
+
+      await userEvent.click(screen.getByTestId('increment'))
+      await expect.element(screen.getByCSS('input')).toHaveValue('0,07')
+      expect(model.value).toBe(0.07)
+
+      await userEvent.click(screen.getByTestId('increment'))
+      await expect.element(screen.getByCSS('input')).toHaveValue('0,14')
+      expect(model.value).toBe(0.14)
+
+      await userEvent.click(screen.getByTestId('decrement'))
+      await expect.element(screen.getByCSS('input')).toHaveValue('0,07')
+      expect(model.value).toBe(0.07)
+
+      await userEvent.click(screen.getByTestId('decrement'))
+      await expect.element(screen.getByCSS('input')).toHaveValue('0,00')
+      expect(model.value).toBe(0)
+    })
   })
 
   describe('accepts digits from pasted text', () => {
@@ -220,6 +248,33 @@ describe('VNumberInput', () => {
       const { element } = render(() => (
         <VNumberInput
           v-model={ model.value }
+          precision={ precision }
+        />
+      ))
+      const input = element.querySelector('input') as HTMLInputElement
+      input.focus()
+      navigator.clipboard.writeText(text)
+      await userEvent.paste()
+      input.blur()
+      expect(model.value).toBe(expected)
+    })
+
+    it.each([
+      { sep: ',', precision: 0, text: '-00123', expected: -123 },
+      { sep: ',', precision: 2, text: ',250', expected: 0.25 },
+      { sep: ',', precision: 3, text: '000,321', expected: 0.321 },
+      { sep: ',', precision: 0, text: '100,99', expected: 100 },
+      { sep: ',', precision: 1, text: '200,99', expected: 200.9 },
+      { sep: ',', precision: 2, text: ' 1,250.32\n', expected: 1.25 },
+      { sep: ',', precision: 0, text: '1\'024.00 meters', expected: 102400 },
+      { sep: ',', precision: 0, text: '- 1123.', expected: -1123 },
+      { sep: ',', precision: 0, text: '- 32,', expected: -32 },
+    ])('should parse numbers with custom separator', async ({ sep, precision, text, expected }) => {
+      const model = ref(null)
+      const { element } = render(() => (
+        <VNumberInput
+          v-model={ model.value }
+          decimalSeparator={ sep }
           precision={ precision }
         />
       ))

--- a/packages/vuetify/src/util/__tests__/helpers.spec.ts
+++ b/packages/vuetify/src/util/__tests__/helpers.spec.ts
@@ -376,15 +376,29 @@ describe('helpers', () => {
 
   describe('extractNumber', () => {
     it('should parse valid number out of text', () => {
-      expect(extractNumber(' 2,142,400.50 ', 2)).toBe('2142400.50')
-      expect(extractNumber(' 100 %', 1)).toBe('100')
-      expect(extractNumber(' .4099 ', 2)).toBe('.40')
-      expect(extractNumber('v: 15.00 ', 0)).toBe('15')
-      expect(extractNumber('$ 2,132.00', 2)).toBe('2132.00')
-      expect(extractNumber('$ 32.00', 2)).toBe('32.00')
-      expect(extractNumber(' -6.67 USD', 2)).toBe('-6.67')
-      expect(extractNumber('($9,000.00)', 2)).toBe('9000.00')
-      expect(extractNumber(' 23 567.20 ', 2)).toBe('23567.20')
+      // dot
+      expect(extractNumber(' 2,142,400.50 ', 2, '.')).toBe('2142400.50')
+      expect(extractNumber(' 100 %', 1, '.')).toBe('100')
+      expect(extractNumber(' .4099 ', 2, '.')).toBe('.40')
+      expect(extractNumber('v: 15.00 ', 0, '.')).toBe('15')
+      expect(extractNumber('$ 2,132.00', 2, '.')).toBe('2132.00')
+      expect(extractNumber('$ 32.00', 2, '.')).toBe('32.00')
+      expect(extractNumber(' -6.67 USD', 2, '.')).toBe('-6.67')
+      expect(extractNumber('($9,000.00)', 2, '.')).toBe('9000.00')
+      expect(extractNumber(' 23 567.20 ', 2, '.')).toBe('23567.20')
+      expect(extractNumber('-200.99 ', 1, '.')).toBe('-200.9')
+
+      // comma
+      expect(extractNumber(' 2,142,400.50 ', 2, ',')).toBe('2,14')
+      expect(extractNumber(' 100 %', 1, ',')).toBe('100')
+      expect(extractNumber(' ,4099 ', 2, ',')).toBe(',40')
+      expect(extractNumber('v: 15.00 ', 0, ',')).toBe('1500')
+      expect(extractNumber('$ 2,132.00', 2, ',')).toBe('2,13')
+      expect(extractNumber('$ 32,00', 2, ',')).toBe('32,00')
+      expect(extractNumber(' -6,67 USD', 2, ',')).toBe('-6,67')
+      expect(extractNumber('($9.000,00)', 2, ',')).toBe('9000,00')
+      expect(extractNumber(' 23 567,20 ', 2, ',')).toBe('23567,20')
+      expect(extractNumber('-200,99 ', 1, ',')).toBe('-200,9')
     })
   })
 })


### PR DESCRIPTION
## Description

- only decimal separator, no dependency on the locale, no grouping
- we would do this simple prop anyway
- needs to be coordinated with #21263, not sure which one will be merged first

resolves #20254

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="400">
      <v-number-input
        v-model="num"
        control-variant="stacked"
        decimal-separator=","
        variant="outlined"
        :precision="2"
        :step=".5"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const num = ref(32.5)
</script>
```
