### PR TITLE
fix(VDatePicker): improve date comparison logic for min/max constraints

### DIFF
--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -212,7 +212,7 @@ export function useCalendar (props: CalendarProps) {
 
     const date = adapter.date(value)
 
-    if (props.min && adapter.isAfter(adapter.date(props.min), date)) return true
+    if (props.min && adapter.isBefore(adapter.endOfDay(date), adapter.date(props.min))) return true
     if (props.max && adapter.isAfter(date, adapter.date(props.max))) return true
 
     if (Array.isArray(props.allowedDates) && props.allowedDates.length > 0) {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #21380

Fixes an issue where dates were incorrectly disabled due to time component being considered in min/max date comparisons. Modified the `isDisabled` function to use `adapter.endOfDay(date)` for proper date-level validation.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input v-model="date" :min="min" :max="max"> </v-date-input>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const date = ref()

  const today = new Date()
</script>

```
