### PR TITLE
feat(VDateInput): sync with placeholder, infer from locale

### DIFF
--- a/packages/api-generator/src/locale/en/VDateInput.json
+++ b/packages/api-generator/src/locale/en/VDateInput.json
@@ -2,7 +2,7 @@
   "props": {
     "hideActions": "Hide the Cancel and OK buttons, and automatically update the value when a date is selected.",
     "displayFormat": "The format of the date that is displayed in the input. Can use any format [here](/features/dates/#format-options) or a custom function.",
-    "inputFormat": "Format for manual date input. Use yyyy, mm, dd with separators '.', '-', '/' (e.g. 'yyyy-mm-dd', 'dd/mm/yyyy') or a custom function.",
+    "inputFormat": "Format for manual date input. Use yyyy, mm, dd with separators '.', '-', '/' (e.g. 'yyyy-mm-dd', 'dd/mm/yyyy').",
     "location": "Specifies the date picker's location. Can combine by using a space separated string.",
     "updateOn": "Specifies when the text input should update the model value. If empty, the text field will go into read-only state."
   }

--- a/packages/vuetify/src/composables/dateFormat.ts
+++ b/packages/vuetify/src/composables/dateFormat.ts
@@ -57,7 +57,7 @@ export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
 
   function inferFromLocale () {
     return Intl.DateTimeFormat(locale.value ?? 'en-US', { year: 'numeric', month: '2-digit', day: '2-digit' })
-      .format(new Date(1999, 11, 7))
+      .format(adapter.toJsDate(adapter.parseISO('1999-12-07')))
       .replace(/(07)|(٠٧)|(٢٩)|(۱۶)|(০৭)/, 'dd')
       .replace(/(12)|(١٢)|(٠٨)|(۰۹)|(১২)/, 'mm')
       .replace(/(1999)|(2542)|(١٩٩٩)|(١٤٢٠)|(۱۳۷۸)|(১৯৯৯)/, 'yyyy')
@@ -90,7 +90,7 @@ export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
     }
 
     function autoFixYear (year: number) {
-      const currentYear = new Date().getFullYear()
+      const currentYear = adapter.getYear(adapter.date())
       if (year > 100 || currentYear % 100 >= 50) {
         return year
       }

--- a/packages/vuetify/src/composables/dateFormat.ts
+++ b/packages/vuetify/src/composables/dateFormat.ts
@@ -73,7 +73,7 @@ export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
 
   function parseDate (dateString: string) {
     function parseDateParts (text: string): Record<'y' |'m' | 'd', number> {
-      const parts = text.split(currentFormat.value.separator)
+      const parts = text.trim().split(currentFormat.value.separator)
       return {
         y: Number(parts[currentFormat.value.order.indexOf('y')]),
         m: Number(parts[currentFormat.value.order.indexOf('m')]),
@@ -111,6 +111,10 @@ export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
     return adapter.parseISO(`${year}-${pad(month)}-${pad(day)}`)
   }
 
+  function isValid (text: string) {
+    return !!parseDate(text)
+  }
+
   function formatDate (value: unknown) {
     const parts = adapter.toISO(value).split('-')
     return currentFormat.value.order.split('')
@@ -119,6 +123,7 @@ export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
   }
 
   return {
+    isValid,
     parseDate,
     formatDate,
     parserFormat: toRef(() => currentFormat.value.format),

--- a/packages/vuetify/src/composables/dateFormat.ts
+++ b/packages/vuetify/src/composables/dateFormat.ts
@@ -1,0 +1,126 @@
+// Composables
+import { useDate } from '@/composables/date/date'
+
+// Utilities
+import { toRef } from 'vue'
+import { propsFactory } from '@/util'
+
+// Types
+import type { Ref } from 'vue'
+
+// Types
+export interface DateFormatProps {
+  inputFormat?: string
+}
+
+class DateFormatSpec {
+  constructor (
+    public readonly order: string, // mdy | dmy | ymd
+    public readonly separator: string // / | - | .
+  ) { }
+
+  get format () {
+    return this.order.split('')
+      .map(sign => `${sign}${sign}`)
+      .join(this.separator)
+      .replace('yy', 'yyyy')
+  }
+
+  static canBeParsed (v: any) {
+    if (typeof v !== 'string') return false
+    const lowercase = v.toLowerCase()
+    return ['y', 'm', 'd'].every(sign => lowercase.includes(sign)) &&
+      ['/', '-', '.'].some(sign => v.includes(sign))
+  }
+
+  static parse (v: string) {
+    if (!DateFormatSpec.canBeParsed(v)) {
+      throw new Error(`[${v}] cannot be parsed into date format specification`)
+    }
+    const order = v.toLowerCase().split('')
+      .filter((c, i, all) => 'dmy'.includes(c) && all.indexOf(c) === i)
+      .join('')
+    const separator = ['/', '-', '.'].find(sign => v.includes(sign))!
+    return new DateFormatSpec(order, separator)
+  }
+}
+
+export const makeDateFormatProps = propsFactory({
+  inputFormat: {
+    type: String,
+    validator: (v: string) => !v || DateFormatSpec.canBeParsed(v),
+  },
+}, 'lazy')
+
+export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
+  const adapter = useDate()
+
+  function inferFromLocale () {
+    return Intl.DateTimeFormat(locale.value ?? 'en-US', { year: 'numeric', month: '2-digit', day: '2-digit' })
+      .format(new Date(1999, 11, 7))
+      .replace(/(07)|(٠٧)|(٢٩)|(۱۶)|(০৭)/, 'dd')
+      .replace(/(12)|(١٢)|(٠٨)|(۰۹)|(১২)/, 'mm')
+      .replace(/(1999)|(2542)|(١٩٩٩)|(١٤٢٠)|(۱۳۷۸)|(১৯৯৯)/, 'yyyy')
+      .replace(/[^ymd\-/.]/g, '')
+      .replace(/\.$/, '')
+  }
+
+  const currentFormat = toRef(() => {
+    return DateFormatSpec.canBeParsed(props.inputFormat)
+      ? DateFormatSpec.parse(props.inputFormat!)
+      : DateFormatSpec.parse(inferFromLocale())
+  })
+
+  function parseDate (dateString: string) {
+    function parseDateParts (text: string): Record<'y' |'m' | 'd', number> {
+      const parts = text.split(currentFormat.value.separator)
+      return {
+        y: Number(parts[currentFormat.value.order.indexOf('y')]),
+        m: Number(parts[currentFormat.value.order.indexOf('m')]),
+        d: Number(parts[currentFormat.value.order.indexOf('d')]),
+      }
+    }
+
+    function validateDateParts (dateParts: Record<string, number>) {
+      const { y: year, m: month, d: day } = dateParts
+      if (!year || !month || !day) return null
+      if (month < 1 || month > 12) return null
+      if (day < 1 || day > 31) return null
+      return { year: autoFixYear(year), month, day }
+    }
+
+    function autoFixYear (year: number) {
+      const currentYear = new Date().getFullYear()
+      if (year > 100 || currentYear % 100 >= 50) {
+        return year
+      }
+
+      const currentCentury = ~~(currentYear / 100) * 100
+      return year < 50
+        ? currentCentury + year
+        : (currentCentury - 100) + year
+    }
+
+    const dateParts = parseDateParts(dateString)
+    const validatedParts = validateDateParts(dateParts)
+    if (!validatedParts) return null
+
+    const { year, month, day } = validatedParts
+
+    const pad = (v: number) => String(v).padStart(2, '0')
+    return adapter.parseISO(`${year}-${pad(month)}-${pad(day)}`)
+  }
+
+  function formatDate (value: unknown) {
+    const parts = adapter.toISO(value).split('-')
+    return currentFormat.value.order.split('')
+      .map(sign => parts['ymd'.indexOf(sign)])
+      .join(currentFormat.value.separator)
+  }
+
+  return {
+    parseDate,
+    formatDate,
+    parserFormat: toRef(() => currentFormat.value.format),
+  }
+}

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -6,6 +6,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 
 // Composables
 import { useDate } from '@/composables/date'
+import { makeDateFormatProps, useDateFormat } from '@/composables/dateFormat'
 import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeFocusProps, useFocus } from '@/composables/focus'
 import { forwardRefs } from '@/composables/forwardRefs'
@@ -35,7 +36,6 @@ export type VDateInputSlots = Omit<VTextFieldSlots, 'default'> & {
 
 export const makeVDateInputProps = propsFactory({
   displayFormat: [Function, String],
-  inputFormat: [Function, String],
   location: {
     type: String as PropType<StrategyProps['location']>,
     default: 'bottom start',
@@ -45,6 +45,7 @@ export const makeVDateInputProps = propsFactory({
     default: () => ['blur', 'enter'],
   },
 
+  ...makeDateFormatProps(),
   ...makeDisplayProps({
     mobile: null,
   }),
@@ -53,7 +54,6 @@ export const makeVDateInputProps = propsFactory({
     hideActions: true,
   }),
   ...makeVTextFieldProps({
-    placeholder: 'mm/dd/yyyy',
     prependIcon: '$calendar',
   }),
   ...omit(makeVDatePickerProps({
@@ -74,8 +74,9 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
   },
 
   setup (props, { emit, slots }) {
-    const { t } = useLocale()
+    const { t, current: currentLocale } = useLocale()
     const adapter = useDate()
+    const { parseDate, formatDate, parserFormat } = useDateFormat(props, currentLocale)
     const { mobile } = useDisplay(props)
     const { isFocused, focus, blur } = useFocus(props)
 
@@ -98,77 +99,10 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
       if (typeof props.displayFormat === 'function') {
         return props.displayFormat(date)
       }
-
-      return adapter.format(date, props.displayFormat ?? 'keyboardDate')
-    }
-
-    function parseDateString (dateString: string, format: string) {
-      function countConsecutiveChars (str: string, startIndex: number): number {
-        const char = str[startIndex]
-        let count = 0
-        while (str[startIndex + count] === char) count++
-        return count
+      if (props.displayFormat) {
+        return adapter.format(date, props.displayFormat ?? 'keyboardDate')
       }
-
-      function parseDateParts (dateString: string, format: string) {
-        const dateParts: Record<string, number> = {}
-        let stringIndex = 0
-        const upperFormat = format.toUpperCase()
-
-        for (let formatIndex = 0; formatIndex < upperFormat.length;) {
-          const formatChar = upperFormat[formatIndex]
-          const charCount = countConsecutiveChars(upperFormat, formatIndex)
-          const dateValue = dateString.slice(stringIndex, stringIndex + charCount)
-
-          if (['Y', 'M', 'D'].includes(formatChar)) {
-            const numValue = parseInt(dateValue)
-            if (isNaN(numValue)) return null
-            dateParts[formatChar] = numValue
-          }
-
-          formatIndex += charCount
-          stringIndex += charCount
-        }
-
-        return dateParts
-      }
-
-      function validateDateParts (dateParts: Record<string, number>) {
-        const { Y: year, M: month, D: day } = dateParts
-        if (!year || !month || !day) return null
-        if (month < 1 || month > 12) return null
-        if (day < 1 || day > 31) return null
-        return { year, month, day }
-      }
-
-      const dateParts = parseDateParts(dateString, format)
-      if (!dateParts) return null
-
-      const validatedParts = validateDateParts(dateParts)
-      if (!validatedParts) return null
-
-      const { year, month, day } = validatedParts
-
-      return { year, month, day }
-    }
-
-    function parseUserInput (value: string) {
-      if (typeof props.inputFormat === 'function') {
-        return props.inputFormat(value)
-      }
-
-      if (typeof props.inputFormat === 'string') {
-        const formattedDate = parseDateString(value, props.inputFormat)
-
-        if (!formattedDate) {
-          return model.value
-        }
-
-        const { year, month, day } = formattedDate
-        return adapter.parseISO(`${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`)
-      }
-
-      return adapter.isValid(value) ? adapter.date(value) : model.value
+      return formatDate(date)
     }
 
     const display = computed(() => {
@@ -270,13 +204,13 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
     }
 
     function onUserInput ({ value }: HTMLInputElement) {
-      model.value = !value ? emptyModelValue() : parseUserInput(value)
+      model.value = !value ? emptyModelValue() : parseDate(value)
     }
 
     useRender(() => {
       const confirmEditProps = VConfirmEdit.filterProps(props)
       const datePickerProps = VDatePicker.filterProps(omit(props, ['active', 'location', 'rounded']))
-      const textFieldProps = VTextField.filterProps(props)
+      const textFieldProps = VTextField.filterProps(omit(props, ['placeholder']))
 
       return (
         <VTextField
@@ -286,6 +220,7 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
           style={ props.style }
           modelValue={ display.value }
           inputmode={ inputmode.value }
+          placeholder={ props.placeholder ?? parserFormat.value }
           readonly={ isReadonly.value }
           onKeydown={ isInteractive.value ? onKeydown : undefined }
           focused={ menu.value || isFocused.value }

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -15,7 +15,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref, shallowRef, watch } from 'vue'
-import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { createRange, genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -76,7 +76,7 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
   setup (props, { emit, slots }) {
     const { t, current: currentLocale } = useLocale()
     const adapter = useDate()
-    const { parseDate, formatDate, parserFormat } = useDateFormat(props, currentLocale)
+    const { isValid, parseDate, formatDate, parserFormat } = useDateFormat(props, currentLocale)
     const { mobile } = useDisplay(props)
     const { isFocused, focus, blur } = useFocus(props)
 
@@ -204,7 +204,29 @@ export const VDateInput = genericComponent<VDateInputSlots>()({
     }
 
     function onUserInput ({ value }: HTMLInputElement) {
-      model.value = !value ? emptyModelValue() : parseDate(value)
+      if (!value.trim()) {
+        model.value = emptyModelValue()
+      } else if (!props.multiple) {
+        if (isValid(value)) {
+          model.value = parseDate(value)
+        }
+      } else {
+        const parts = value.trim().split(/\D+-\D+|[^\d\-/.]+/)
+        if (parts.every(isValid)) {
+          if (props.multiple === 'range') {
+            model.value = getRange(parts)
+          } else {
+            model.value = parts.map(parseDate)
+          }
+        }
+      }
+    }
+
+    function getRange (inputDates: string[]) {
+      const [start, stop] = inputDates.map(parseDate).toSorted((a, b) => adapter.isAfter(a, b) ? 1 : -1)
+      const diff = adapter.getDiff(stop ?? start, start, 'days')
+      return [start, ...createRange(diff, 1)
+        .map(i => adapter.addDays(start, i))]
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -2,6 +2,7 @@
 import { VDateInput } from '../VDateInput'
 
 // Utilities
+import { render, screen, userEvent } from '@test'
 import { mount } from '@vue/test-utils'
 import { createVuetify } from '@/framework'
 
@@ -235,6 +236,61 @@ describe('VDateInput', () => {
       await input.trigger('blur')
 
       expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+    })
+  })
+
+  describe('typing values', () => {
+    it.each([
+      { multiple: false, typing: '07/01/2022', expected: '07/01/2022' },
+      { multiple: false, typing: '4/15/26', expected: '04/15/2026' },
+      { multiple: 'range', typing: '07/01/2022', expected: '07/01/2022 - 07/01/2022' },
+      { multiple: 'range', typing: '4/15/26', expected: '04/15/2026 - 04/15/2026' },
+      { multiple: 'range', typing: '05/02/2025 - 05/14/2025', expected: '05/02/2025 - 05/14/2025' },
+      { multiple: true, typing: '07/01/2022', expected: '1 selected' },
+      { multiple: true, typing: '05/02/2025 05/14/2025', expected: '2 selected' },
+      { multiple: true, typing: '4/15/25 04/22/25 04/15/25', expected: '3 selected' },
+    ])('should accept pasted and typed values', async ({ multiple, typing, expected }) => {
+      const { element } = render(() => <VDateInput multiple={ multiple } />)
+      const input = screen.getByCSS('input')
+      await userEvent.click(element)
+      await userEvent.keyboard(typing)
+      await userEvent.click(document.body)
+      expect(input).toHaveValue(expected)
+    })
+
+    it.each([
+      { format: 'yyyy-mm-dd', multiple: false, typing: '2022-01-07', expected: '2022-01-07' },
+      { format: 'yyyy-mm-dd', multiple: false, typing: '26-4-15', expected: '2026-04-15' },
+      { format: 'yyyy-mm-dd', multiple: 'range', typing: '2022-01-07', expected: '2022-01-07 - 2022-01-07' },
+      { format: 'yyyy-mm-dd', multiple: 'range', typing: '26-4-15', expected: '2026-04-15 - 2026-04-15' },
+      { format: 'dd.mm.yyyy', multiple: 'range', typing: '01.05.2025 - 22.05.2025', expected: '01.05.2025 - 22.05.2025' },
+      { format: 'yyyy-mm-dd', multiple: true, typing: '2022-01-07', expected: '1 selected' },
+      { format: 'dd.mm.yyyy', multiple: true, typing: '01.05.2025 22.05.2025', expected: '2 selected' },
+      { format: 'dd.mm.yyyy', multiple: true, typing: ' 03.05.25 05.05.25  07.05.25 ', expected: '3 selected' },
+    ])('should accept pasted and typed values with custom format', async ({ format, multiple, typing, expected }) => {
+      const { element } = render(() => <VDateInput multiple={ multiple } inputFormat={ format } />)
+      const input = screen.getByCSS('input')
+      await userEvent.click(element)
+      await userEvent.keyboard(typing)
+      await userEvent.click(document.body)
+      expect(input).toHaveValue(expected)
+    })
+
+    it.each([
+      { multiple: false, initial: '05/16/2025', typing: '←←←←←×2', expected: '05/12/2025' },
+      { multiple: 'range', initial: '05/16/2025 - 05/24/2025', typing: '←←←←←××3', expected: '05/03/2025 - 05/16/2025' },
+    ])('should accept changes typed from keyboard', async ({ multiple, initial, typing, expected }) => {
+      const { element } = render(() => <VDateInput multiple={ multiple } />)
+      const input = screen.getByCSS('input')
+      await userEvent.click(element)
+      await userEvent.keyboard(`${initial}{Enter}`)
+      expect(input).toHaveValue(initial)
+      const typingSequence = typing
+        .replaceAll('←', '{ArrowLeft}')
+        .replaceAll('×', '{Backspace}')
+      await userEvent.keyboard(typingSequence)
+      await userEvent.click(document.body)
+      expect(input).toHaveValue(expected)
     })
   })
 })

--- a/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -58,11 +58,6 @@ describe('VDateInput', () => {
         input: '2024-01-01',
         expected: { year: 2024, month: 0, day: 1 },
       },
-      {
-        format: (value: string) => new Date(2024, 0, 1),
-        input: '2024-01-01',
-        expected: { year: 2024, month: 0, day: 1 },
-      },
     ]
 
     testCases.forEach(({ format, input, expected }) => {
@@ -158,7 +153,7 @@ describe('VDateInput', () => {
   })
 
   describe('update-on prop', () => {
-    const TEST_DATE = '2025-01-01'
+    const TEST_DATE = '05/21/2025'
 
     it('should update modelValue only on enter key press', async () => {
       const wrapper = mountFunction(


### PR DESCRIPTION
## Description

- drops 'function' mode
- detects the separator and sign order
- infers format from locale
- supplements placeholder
- included #21375 to avoid breaking `multiple`

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-defaults-provider :defaults="{ VDateInput: { persistentPlaceholder: true, persistentHint: true } }">
      <v-container max-width="400" class="d-flex flex-column ga-6 py-6">

        <v-locale-provider locale="de-DE">
          <!-- without locale configured -->
          <v-date-input label="matching locale" input-format="dd.mm.yyyy" hint="locale: de-DE (dd.mm.yyyy)" />
        </v-locale-provider>

        <v-locale-provider locale="en-GB">
          <!-- without locale configured -->
          <v-date-input label="from locale" hint="locale: en-GB (dd/mm/yyyy)" />
        </v-locale-provider>

        <v-locale-provider locale="hr-HR">
          <!-- without locale configured -->
          <v-date-input label="from locale" hint="locale: hr-HR (dd. mm. yyyy.)" />
        </v-locale-provider>

        <!-- without locale configured -->
        <v-date-input label="just format" input-format="dd.mm.yyyy" hint="locale: en-US (mm/dd/yyyy)" />

        <v-locale-provider locale="az-AZ">
          <!-- different than locale -->
          <v-date-input label="override locale" input-format="dd-mm-yyyy" hint="locale: az-AZ (yyyy-mm-dd)" />
        </v-locale-provider>
      </v-container>
    </v-defaults-provider>
  </v-app>
</template>
```
