### PR TITLE
docs(VDataTable): description copy correction

### DIFF
--- a/packages/api-generator/src/locale/en/VDataTable.json
+++ b/packages/api-generator/src/locale/en/VDataTable.json
@@ -77,16 +77,16 @@
     "pagination": "Emits when something changed to the `pagination` which can be provided via the `pagination` prop.",
     "toggleSelectAll": "Emits when the `select-all` checkbox in table header is clicked. This checkbox is enabled by the **show-select** prop.",
     "update:currentItems": "Emits with the items currently being displayed.",
-    "update:expanded": "Emits when the **expanded** property of the **options** prop is updated.",
-    "update:groupBy": "Emits when the **group-by** property of the **options** property is updated.",
-    "update:groupDesc": "Emits when the **group-desc** property of the **options** prop is updated.",
-    "update:itemsPerPage": "Emits when the **items-per-page** property of the **options** prop is updated.",
+    "update:expanded": "Emits when the **expanded** prop is updated.",
+    "update:groupBy": "Emits when the **group-by** prop is updated.",
+    "update:groupDesc": "Emits when the **group-desc** prop is updated.",
+    "update:itemsPerPage": "Emits when the **items-per-page** prop is updated.",
     "update:modelValue": "Emits when the component's model changes.",
-    "update:multiSort": "Emits when the **multi-sort** property of the **options** prop is updated.",
-    "update:mustSort": "Emits when the **must-sort** property of the **options** prop is updated.",
-    "update:options": "Emits when one of the **options** properties is updated.",
-    "update:page": "Emits when the **page** property of the **options** prop is updated.",
-    "update:sortBy": "Emits when the **sortBy** property of the **options** prop is updated.",
-    "update:sortDesc": "Emits when the **sort-desc** property of the **options** prop is updated."
+    "update:multiSort": "Emits when the **multi-sort** prop is updated.",
+    "update:mustSort": "Emits when the **must-sort** prop is updated.",
+    "update:options": "Emits when pagination related properties (page, itemsPerPage, sortBy, groupBy, search) is updated.",
+    "update:page": "Emits when the **page** prop is updated.",
+    "update:sortBy": "Emits when the **sortBy** prop is updated.",
+    "update:sortDesc": "Emits when the **sort-desc** prop is updated."
   }
 }

--- a/packages/api-generator/src/locale/en/VDataTableServer.json
+++ b/packages/api-generator/src/locale/en/VDataTableServer.json
@@ -34,12 +34,12 @@
   },
   "events": {
     "click:row": "Emits when a table row is clicked. This event provides 2 arguments: the first is the native click event, and the second is an object containing the corresponding item for that row. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
-    "update:expanded": "Emits when the **expanded** property of the **options** prop is updated.",
-    "update:groupBy": "Emits when the **group-by** property of the **options** property is updated.",
-    "update:itemsPerPage": "Emits when the **items-per-page** property of the **options** prop is updated.",
+    "update:expanded": "Emits when the **expanded** prop is updated.",
+    "update:groupBy": "Emits when the **group-by** prop is updated.",
+    "update:itemsPerPage": "Emits when the **items-per-page** prop is updated.",
     "update:modelValue": "Emits when the component's model changes.",
-    "update:options": "Emits when one of the **options** properties is updated.",
-    "update:page": "Emits when the **page** property of the **options** prop is updated.",
-    "update:sortBy": "Emits when the **sort-by** property of the **options** prop is updated."
+    "update:options": "Emits when pagination related properties (page, itemsPerPage, sortBy, groupBy, search) is updated.",
+    "update:page": "Emits when the **page** prop is updated.",
+    "update:sortBy": "Emits when the **sortBy** prop is updated."
   }
 }

--- a/packages/api-generator/src/locale/en/VDataTableVirtual.json
+++ b/packages/api-generator/src/locale/en/VDataTableVirtual.json
@@ -33,11 +33,11 @@
   },
   "events": {
     "click:row": "Emits when a table row is clicked. This event provides 2 arguments: the first is the native click event, and the second is an object containing the corresponding item for that row. **NOTE:** will not emit when table rows are defined through a slot such as `item` or `body`.",
-    "update:expanded": "Emits when the **expanded** property of the **options** prop is updated.",
-    "update:groupBy": "Emits when the **group-by** property of the **options** property is updated.",
+    "update:expanded": "Emits when the **expanded** prop is updated.",
+    "update:groupBy": "Emits when the **group-by** prop is updated.",
     "update:modelValue": "Emits when the component's model changes.",
-    "update:options": "Emits when one of the **options** properties is updated.",
-    "update:sortBy": "Emits when the **sort-by** property of the **options** prop is updated."
+    "update:options": "Emits when pagination related properties (page, itemsPerPage, sortBy, groupBy, search) is updated.",
+    "update:sortBy": "Emits when the **sortBy** prop is updated."
   },
   "exposed": {
     "calculateVisibleItems": "Trigger updating the currently rendered items based on scroll position."


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #21377 

Updated event descriptions to correctly refer to their respective props directly instead of the outdated `options` property in `VDataTable`, `VDataTableVirtual`, `VDataTableServer` json file.
