### PR TITLE
refactor: resolve directives directly

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -27,7 +27,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, toDisplayString, toRef, withDirectives } from 'vue'
@@ -300,7 +300,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
           )}
         </Tag>,
         [[
-          Ripple,
+          vRipple,
           !isDisabled.value && props.ripple,
           '',
           { center: !!props.icon },

--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -27,7 +27,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { genericComponent, propsFactory, useRender } from '@/util'
@@ -95,7 +95,7 @@ export type VCardSlots = VCardItemSlots & {
 export const VCard = genericComponent<VCardSlots>()({
   name: 'VCard',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   props: makeVCardProps(),
 

--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -26,7 +26,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, toDisplayString, toRef } from 'vue'
@@ -112,7 +112,7 @@ export const makeVChipProps = propsFactory({
 export const VChip = genericComponent<VChipSlots>()({
   name: 'VChip',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   props: makeVChipProps(),
 

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelTitle.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelTitle.tsx
@@ -10,7 +10,7 @@ import { makeDimensionProps, useDimension } from '@/composables/dimensions'
 import { IconValue } from '@/composables/icons'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, inject, toRef } from 'vue'
@@ -59,7 +59,7 @@ export const makeVExpansionPanelTitleProps = propsFactory({
 export const VExpansionPanelTitle = genericComponent<VExpansionPanelTitleSlots>()({
   name: 'VExpansionPanelTitle',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   props: makeVExpansionPanelTitleProps(),
 

--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -11,7 +11,7 @@ import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTransitionProps, MaybeTransition } from '@/composables/transition'
 
 // Directives
-import intersect from '@/directives/intersect'
+import vIntersect from '@/directives/intersect'
 
 // Utilities
 import {
@@ -103,7 +103,7 @@ export const makeVImgProps = propsFactory({
 export const VImg = genericComponent<VImgSlots>()({
   name: 'VImg',
 
-  directives: { intersect },
+  directives: { vIntersect },
 
   props: makeVImgProps(),
 

--- a/packages/vuetify/src/components/VLazy/VLazy.tsx
+++ b/packages/vuetify/src/components/VLazy/VLazy.tsx
@@ -6,7 +6,7 @@ import { makeTagProps } from '@/composables/tag'
 import { makeTransitionProps, MaybeTransition } from '@/composables/transition'
 
 // Directives
-import intersect from '@/directives/intersect'
+import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { genericComponent, propsFactory, useRender } from '@/util'
@@ -36,7 +36,7 @@ export const makeVLazyProps = propsFactory({
 export const VLazy = genericComponent()({
   name: 'VLazy',
 
-  directives: { intersect },
+  directives: { vIntersect },
 
   props: makeVLazyProps(),
 

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -24,7 +24,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, onBeforeMount, toDisplayString, toRef, watch } from 'vue'
@@ -111,7 +111,7 @@ export const makeVListItemProps = propsFactory({
 export const VListItem = genericComponent<VListItemSlots>()({
   name: 'VListItem',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   props: makeVListItemProps(),
 

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -21,7 +21,7 @@ import { useToggleScope } from '@/composables/toggleScope'
 import { makeTransitionProps, MaybeTransition } from '@/composables/transition'
 
 // Directives
-import { ClickOutside } from '@/directives/click-outside'
+import vClickOutside from '@/directives/click-outside'
 
 // Utilities
 import {
@@ -115,7 +115,7 @@ export const makeVOverlayProps = propsFactory({
 export const VOverlay = genericComponent<OverlaySlots>()({
   name: 'VOverlay',
 
-  directives: { ClickOutside },
+  directives: { vClickOutside },
 
   inheritAttrs: false,
 

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -13,7 +13,7 @@ import { useDensity } from '@/composables/density'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, inject, nextTick, ref, shallowRef, toRef, useId } from 'vue'
@@ -149,7 +149,7 @@ export const VSelectionControl = genericComponent<new <T>(
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VSelectionControl',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   inheritAttrs: false,
 

--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -12,7 +12,7 @@ import { useElevation } from '@/composables/elevation'
 import { useRtl } from '@/composables/locale'
 
 // Directives
-import Ripple from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, inject } from 'vue'
@@ -56,7 +56,7 @@ export const makeVSliderThumbProps = propsFactory({
 export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
   name: 'VSliderThumb',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   props: makeVSliderThumbProps(),
 

--- a/packages/vuetify/src/components/VStepper/VStepperItem.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperItem.tsx
@@ -11,7 +11,7 @@ import { IconValue } from '@/composables/icons'
 import { genOverlays } from '@/composables/variant'
 
 // Directives
-import { Ripple } from '@/directives/ripple'
+import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed } from 'vue'
@@ -80,7 +80,7 @@ export const makeVStepperItemProps = propsFactory({
 export const VStepperItem = genericComponent<VStepperItemSlots>()({
   name: 'VStepperItem',
 
-  directives: { Ripple },
+  directives: { vRipple },
 
   props: makeVStepperItemProps(),
 

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -12,7 +12,7 @@ import { forwardRefs } from '@/composables/forwardRefs'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Directives
-import Intersect from '@/directives/intersect'
+import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { cloneVNode, computed, nextTick, ref } from 'vue'
@@ -54,7 +54,7 @@ export type VTextFieldSlots = Omit<VInputSlots & VFieldSlots, 'default'> & {
 export const VTextField = genericComponent<VTextFieldSlots>()({
   name: 'VTextField',
 
-  directives: { Intersect },
+  directives: { vIntersect },
 
   inheritAttrs: false,
 

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -14,7 +14,7 @@ import { forwardRefs } from '@/composables/forwardRefs'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Directives
-import Intersect from '@/directives/intersect'
+import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
@@ -59,7 +59,7 @@ type VTextareaSlots = Omit<VInputSlots & VFieldSlots, 'default'> & {
 export const VTextarea = genericComponent<VTextareaSlots>()({
   name: 'VTextarea',
 
-  directives: { Intersect },
+  directives: { vIntersect },
 
   inheritAttrs: false,
 

--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -12,7 +12,7 @@ import { makeTagProps } from '@/composables/tag'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
 
 // Directives
-import { Touch } from '@/directives/touch'
+import vTouch from '@/directives/touch'
 
 // Utilities
 import { computed, provide, ref, shallowRef, toRef, watch } from 'vue'
@@ -100,9 +100,7 @@ export const VWindow = genericComponent<new <T>(
 ) => GenericProps<typeof props, typeof slots>>()({
   name: 'VWindow',
 
-  directives: {
-    Touch,
-  },
+  directives: { vTouch },
 
   props: makeVWindowProps(),
 

--- a/packages/vuetify/src/components/VWindow/VWindowItem.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindowItem.tsx
@@ -6,7 +6,7 @@ import { useSsrBoot } from '@/composables/ssrBoot'
 import { MaybeTransition } from '@/composables/transition'
 
 // Directives
-import Touch from '@/directives/touch'
+import vTouch from '@/directives/touch'
 
 // Utilities
 import { computed, inject, nextTick, shallowRef } from 'vue'
@@ -33,9 +33,7 @@ export const makeVWindowItemProps = propsFactory({
 export const VWindowItem = genericComponent()({
   name: 'VWindowItem',
 
-  directives: {
-    Touch,
-  },
+  directives: { vTouch },
 
   props: makeVWindowItemProps(),
 

--- a/packages/vuetify/src/directives/intersect/__tests__/intersect.spec.browser.tsx
+++ b/packages/vuetify/src/directives/intersect/__tests__/intersect.spec.browser.tsx
@@ -1,5 +1,5 @@
 // Directives
-import Intersect from '../'
+import vIntersect from '../'
 
 // Utilities
 import { scroll, waitIdle } from '@test'
@@ -10,7 +10,7 @@ describe('v-intersect', () => {
     const callback = vi.fn()
 
     render({
-      directives: { Intersect },
+      directives: { vIntersect },
       setup () {
         return () => <div v-intersect={ callback } style="height: 10px" />
       },
@@ -26,7 +26,7 @@ describe('v-intersect', () => {
     const callback = vi.fn()
 
     render({
-      directives: { Intersect },
+      directives: { vIntersect },
       setup () {
         return () => <div v-intersect={[callback, null, ['quiet']]} style="height: 10px" />
       },
@@ -42,7 +42,7 @@ describe('v-intersect', () => {
       const callback = vi.fn()
 
       render({
-        directives: { Intersect },
+        directives: { vIntersect },
         setup () {
           return () => (
             <>

--- a/packages/vuetify/src/directives/scroll/__tests__/scroll.spec.browser.tsx
+++ b/packages/vuetify/src/directives/scroll/__tests__/scroll.spec.browser.tsx
@@ -1,5 +1,5 @@
 // Directives
-import Scroll from '../'
+import vScroll from '../'
 
 // Utilities
 import { render, scroll } from '@test'
@@ -9,7 +9,7 @@ describe('v-scroll', () => {
   function setup (selector = '') {
     const callback = vi.fn()
     const result = render(defineComponent({
-      directives: { Scroll },
+      directives: { vScroll },
       setup () {
         return () => (
           <div data-testid="root" style="overflow: auto; height: 500px; margin-block: 500px">

--- a/packages/vuetify/src/directives/touch/__tests__/touch.spec.browser.tsx
+++ b/packages/vuetify/src/directives/touch/__tests__/touch.spec.browser.tsx
@@ -1,5 +1,5 @@
 // Directives
-import Touch from '../'
+import vTouch from '../'
 
 // Utilities
 import { commands, render } from '@test'
@@ -10,7 +10,7 @@ import type { PropType } from 'vue'
 import type { TouchValue } from '../'
 
 const TestComponent = defineComponent({
-  directives: { Touch },
+  directives: { vTouch },
   props: {
     value: Object as PropType<TouchValue>,
   },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
babel-plugin-vue-jsx can use imported directives without calling `resolveDirective()`

blocked by https://github.com/vuejs/babel-plugin-jsx/pull/759
