### PR TITLE
fix(VSelect): keyboard match multiple items with the same prefix

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -269,9 +269,8 @@ export const VSelect = genericComponent<new <
         result = findItemBase()
         if (result !== undefined) return result
 
-        // Still nothing, start a new search with just the new letter
+        // Still nothing, try just the new letter
         keyboardLookupPrefix = e.key.toLowerCase()
-        keyboardLookupIndex = -1
         return findItemBase()
       }
       function findItemBase () {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -255,19 +255,19 @@ export const VSelect = genericComponent<new <
       const items = displayItems.value
       function findItem () {
         let result = findItemBase()
-        if (result !== undefined) return result
+        if (result) return result
 
         if (keyboardLookupPrefix.at(-1) === keyboardLookupPrefix.at(-2)) {
           // No matches but we have a repeated letter, try the next item with that prefix
           keyboardLookupPrefix = keyboardLookupPrefix.slice(0, -1)
           result = findItemBase()
-          if (result !== undefined) return result
+          if (result) return result
         }
 
         // Still nothing, wrap around to the top
         keyboardLookupIndex = -1
         result = findItemBase()
-        if (result !== undefined) return result
+        if (result) return result
 
         // Still nothing, try just the new letter
         keyboardLookupPrefix = e.key.toLowerCase()
@@ -280,22 +280,21 @@ export const VSelect = genericComponent<new <
             i > keyboardLookupIndex &&
             _item.title.toLowerCase().startsWith(keyboardLookupPrefix)
           ) {
-            keyboardLookupIndex = i
-            return _item
+            return [_item, i] as const
           }
         }
         return undefined
       }
 
-      const item = findItem()
-      if (item !== undefined) {
-        if (!props.multiple) {
-          model.value = [item]
-        }
-        const index = displayItems.value.indexOf(item)
-        if (~index && IN_BROWSER) {
-          listRef.value?.focus(index)
-        }
+      const result = findItem()
+      if (!result) return
+
+      const [item, index] = result
+      if (!props.multiple) {
+        model.value = [item]
+      }
+      if (~index) {
+        listRef.value?.focus(index)
       }
     }
 

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -290,11 +290,10 @@ export const VSelect = genericComponent<new <
       if (!result) return
 
       const [item, index] = result
+      keyboardLookupIndex = index
+      listRef.value?.focus(index)
       if (!props.multiple) {
         model.value = [item]
-      }
-      if (~index) {
-        listRef.value?.focus(index)
       }
     }
 

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -274,12 +274,9 @@ export const VSelect = genericComponent<new <
         return findItemBase()
       }
       function findItemBase () {
-        for (let i = 0; i < items.length; i++) {
+        for (let i = keyboardLookupIndex + 1; i < items.length; i++) {
           const _item = items[i]
-          if (
-            i > keyboardLookupIndex &&
-            _item.title.toLowerCase().startsWith(keyboardLookupPrefix)
-          ) {
+          if (_item.title.toLowerCase().startsWith(keyboardLookupPrefix)) {
             return [_item, i] as const
           }
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
- Typing the same letter multiple times (with no matches) will now try the next matching item instead of continuing to build the lookup prefix
- Switching to a different letter (with no matches) begins a new search

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select v-model="selectedItems" :items="items" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selectedItems = ref([])
  const items = ref([
    'Aruba-1',
    'Aruba-2',
    'Aruba-3',
    'Aruba-4',
    'Bonaire-1',
    'Bonaire-2',
    'Bonaire-3',
    'Bonaire-4',
    'Curaçao-1',
    'Curaçao-2',
    'Curaçao-3',
    'Curaçao-4',
  ])
</script>
```

Typing `b` repeatedly will cycle through all "Bonaire-" items instead of getting stuck on the first one.
Typing `b` then `c` within KEYBOARD_LOOKUP_THRESHOLD will select "Curaçao-1" instead of staying on "Bonaire-1"