### PR TITLE
feat(VClickOutside): Add mousedown modifier for click-outside directive

### DIFF
--- a/packages/vuetify/src/directives/click-outside/index.ts
+++ b/packages/vuetify/src/directives/click-outside/index.ts
@@ -12,6 +12,7 @@ interface ClickOutsideBindingArgs {
 
 interface ClickOutsideDirectiveBinding extends DirectiveBinding {
   value: ((e: MouseEvent) => void) | ClickOutsideBindingArgs
+  modifiers: { mousedown?: boolean }
 }
 
 function defaultConditional () {
@@ -85,11 +86,13 @@ export const ClickOutside = {
   mounted (el: HTMLElement, binding: ClickOutsideDirectiveBinding) {
     const onClick = (e: Event) => directive(e as MouseEvent, el, binding)
     const onMousedown = (e: Event) => {
-      el._clickOutside!.lastMousedownWasOutside = checkEvent(e as MouseEvent, el, binding)
+      // If added mousedown modifier make lastMousedownWasOutside true to pass condition before checkEvent
+      el._clickOutside!.lastMousedownWasOutside = binding.modifiers.mousedown ? true : checkEvent(e as MouseEvent, el, binding)
+      binding.modifiers.mousedown && directive(e as MouseEvent, el, binding)
     }
 
     handleShadow(el, (app: HTMLElement) => {
-      app.addEventListener('click', onClick, true)
+      !binding.modifiers.mousedown && app.addEventListener('click', onClick, true)
       app.addEventListener('mousedown', onMousedown, true)
     })
     if (!el._clickOutside) {
@@ -112,7 +115,7 @@ export const ClickOutside = {
 
       const { onClick, onMousedown } = el._clickOutside[binding.instance!.$.uid]!
 
-      app.removeEventListener('click', onClick, true)
+      !binding.modifiers.mousedown && app.removeEventListener('click', onClick, true)
       app.removeEventListener('mousedown', onMousedown, true)
     })
 


### PR DESCRIPTION
## Description:
Add modifier for click-outside directive to use mousedown event instead of click

## Murkup:
```
<template>
  <v-app>
    <v-container>
      <v-btn id="btn" @click="opened = !opened">Open</v-btn>

      <v-card
        v-if="opened"
        v-click-outside.mousedown="{
          handler: () => opened = false,
          include
        }"
      >
        <v-card-text>
          Some text
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup >
  import { ref } from 'vue'

  const opened = ref(false),
  const include = () => [document.querySelector('#btn')],
</script>
```