### PR TITLE
docs: API description column & comprehensive TOC

### DIFF
--- a/packages/api-generator/src/utils.ts
+++ b/packages/api-generator/src/utils.ts
@@ -265,6 +265,7 @@ export async function prettifyType (name: string, item: Definition) {
       semi: false,
       singleQuote: true,
       trailingComma: 'all',
+      printWidth: 40,
     })
   } catch (err: any) {
     console.error('\x1b[31m', `${name}:`, err.message, '\x1b[0m')

--- a/packages/docs/src/components/api/ApiTable.vue
+++ b/packages/docs/src/components/api/ApiTable.vue
@@ -18,27 +18,23 @@
 
       <tbody>
         <template v-for="item in filtered" :key="item.name">
-          <slot
-            name="row"
-            v-bind="{
-              props: {
-                style: 'background: rgba(0,0,0,.1)'
-              },
-              item,
-            }"
-          />
+          <v-hover>
+            <template #default="{ isHovering, props: hoverProps }">
+              <slot
+                name="row"
+                v-bind="{
+                  props: {
+                    ...hoverProps,
+                    style: isHovering && 'background: rgba(0,0,0,0.1)'
+                  },
+                  item
+                }"
+              />
+            </template>
+          </v-hover>
 
           <tr v-if="item.description || (user.dev && item.source)">
-            <td class="text-mono pt-4" colspan="3">
-              <template v-if="item.description">
-                <AppMarkdown
-                  v-if="localeStore.locale !== 'eo-UY'"
-                  :content="item.description"
-                  class="mb-0"
-                />
-                <span v-else>{{ item.description }}</span>
-              </template>
-
+            <td v-if="user.dev && item.source" class="text-mono pt-4" colspan="4">
               <p v-if="user.dev && item.source">
                 <strong>source: {{ item.source }}</strong>
                 <template v-if="user.dev && item.descriptionSource && item.source !== item.descriptionSource">
@@ -48,6 +44,7 @@
               </p>
             </td>
           </tr>
+
         </template>
 
         <tr v-if="!filtered.length">
@@ -77,7 +74,6 @@
 
   const { t } = useI18n()
   const appStore = useAppStore()
-  const localeStore = useLocaleStore()
   const user = useUserStore()
 
   const filtered = computed(() => {
@@ -93,3 +89,11 @@
     })
   })
 </script>
+
+<style scoped lang="sass">
+.api-table
+  :deep(.v-markdown p)
+    margin-bottom: 0
+  :deep(.v-markdown a)
+    display: inline-block
+</style>

--- a/packages/docs/src/components/api/ExposedTable.vue
+++ b/packages/docs/src/components/api/ExposedTable.vue
@@ -1,17 +1,33 @@
 <template>
-  <ApiApiTable>
+  <ApiApiTable :headers="headers">
     <template #row="{ props, item }">
       <tr v-bind="props">
         <ApiNameCell :name="item.name" :new-in="item.newIn" section="exposed" />
+
+        <td>
+          <AppMarkdown
+            v-if="localeStore.locale !== 'eo-UY'"
+            :content="item.description"
+            class="mb-0"
+          />
+          <span v-else>{{ item.description }}</span>
+        </td>
       </tr>
 
       <tr>
-        <AppMarkup
-          :code="item.formatted"
-          :rounded="false"
-          language="ts"
-        />
+        <td class="px-0" colspan="2">
+          <AppMarkup
+            :code="item.formatted"
+            :rounded="false"
+            language="ts"
+          />
+        </td>
       </tr>
     </template>
   </ApiApiTable>
 </template>
+
+<script setup lang="ts">
+  const localeStore = useLocaleStore()
+  const headers = ['name', 'description']
+</script>

--- a/packages/docs/src/components/api/NameCell.vue
+++ b/packages/docs/src/components/api/NameCell.vue
@@ -1,17 +1,26 @@
 <template>
   <td :id="`${section}-${name.replace('$', '')}`">
     <div class="d-inline-flex align-center">
-      <kbd class="name-item text-mono">
-        <AppLink :href="href" class="font-weight-bold">
+      <kbd class="name-item">
+        <AppLink :href="href" class="font-weight-bold text-body-2">
           {{ name }}
         </AppLink>
       </kbd>
 
-      <new-in-chip
-        v-if="newIn"
-        :text="t('new-in', { version: newIn })"
-        :to="to"
-      />
+      <v-tooltip v-if="newIn" interactive>
+        <template #activator="{ props: tooltipProps }">
+          <v-icon
+            v-bind="tooltipProps"
+            class="ms-1 cursor-pointer"
+            color="success"
+            icon="mdi-new-box"
+          />
+        </template>
+        <RouterLink :to="to" class="text-white text-decoration-none d-inline-flex align-center">
+          <span>Added on v{{ newIn }}</span>
+          <v-icon class="ms-1" icon="mdi-page-next" size="small" />
+        </RouterLink>
+      </v-tooltip>
     </div>
   </td>
 </template>
@@ -23,11 +32,10 @@
     newIn: String,
   })
 
-  const { t } = useI18n()
-
   const href = computed(() => {
     return `#${props.section}-${props.name.replace('$', '')}`
   })
+
   const to = computed(() => {
     return rpath(`/getting-started/release-notes/?version=v${props.newIn}`)
   })

--- a/packages/docs/src/components/api/PrismCell.vue
+++ b/packages/docs/src/components/api/PrismCell.vue
@@ -38,3 +38,8 @@
     return insertLinks(highlighted, stripped)
   }
 </script>
+
+<style scoped lang="sass">
+pre
+  font-size: 13px
+</style>

--- a/packages/docs/src/components/api/PropsTable.vue
+++ b/packages/docs/src/components/api/PropsTable.vue
@@ -2,14 +2,28 @@
   <ApiApiTable :headers="headers">
     <template #row="{ props, item }">
       <tr v-bind="props">
+        <!-- Name -->
         <ApiNameCell :name="kebabCase(item.name)" :new-in="item.newIn" section="props" />
 
+        <!-- Type -->
         <td>
           <ApiPrismCell :code="item.formatted" />
         </td>
 
+        <!-- Default -->
         <td>
           <ApiPrismCell :code="item.default" />
+        </td>
+
+        <!-- Description -->
+        <td>
+          <div style="min-width: 300px">
+            <AppMarkdown
+              v-if="localeStore.locale !== 'eo-UY'"
+              :content="item.description"
+            />
+            <span v-else>{{ item.description }}</span>
+          </div>
         </td>
       </tr>
     </template>
@@ -17,5 +31,6 @@
 </template>
 
 <script setup lang="ts">
-  const headers = ['name', 'type', 'default']
+  const localeStore = useLocaleStore()
+  const headers = ['name', 'type', 'default', 'description']
 </script>

--- a/packages/docs/src/components/api/SlotsTable.vue
+++ b/packages/docs/src/components/api/SlotsTable.vue
@@ -1,13 +1,29 @@
 <template>
-  <ApiApiTable>
+  <ApiApiTable :headers="headers">
     <template #row="{ props, item }">
       <tr v-bind="props">
         <ApiNameCell :name="item.name" :new-in="item.newIn" section="slots" />
+
+        <td>
+          <AppMarkdown
+            v-if="localeStore.locale !== 'eo-UY'"
+            :content="item.description"
+            class="mb-0"
+          />
+          <span v-else>{{ item.description }}</span>
+        </td>
       </tr>
 
       <tr v-if="item.formatted !== 'never' && item.text !== 'undefined'">
-        <AppMarkup :code="item.formatted" :rounded="false" language="ts" />
+        <td class="px-0" colspan="2">
+          <AppMarkup :code="item.formatted" :rounded="false" language="ts" />
+        </td>
       </tr>
     </template>
   </ApiApiTable>
 </template>
+
+<script setup lang="ts">
+  const localeStore = useLocaleStore()
+  const headers = ['name', 'description']
+</script>

--- a/packages/docs/src/components/api/View.vue
+++ b/packages/docs/src/components/api/View.vue
@@ -22,12 +22,24 @@
   function generateToc () {
     const toc = []
     for (const section of sections) {
+      // If section exists and section is not empty
       if (section in component.value && Object.keys(component.value[section]).length) {
         toc.push({
           to: `#${section}`,
           text: section.charAt(0).toUpperCase() + section.slice(1),
           level: 2,
         })
+
+        // Add items from section
+        const items = component.value[section]
+        for (const name of Object.keys(items).sort()) {
+          const formattedName = kebabCase(name)
+          toc.push({
+            to: `#${section}-${formattedName}`,
+            text: section === 'sass' ? `$${formattedName}` : formattedName,
+            level: 3,
+          })
+        }
       }
     }
     return toc

--- a/packages/docs/src/components/app/Toc.vue
+++ b/packages/docs/src/components/app/Toc.vue
@@ -7,7 +7,6 @@
     location="right"
     width="256"
     floating
-    sticky
   >
     <template #prepend>
       <AppHeadline

--- a/packages/docs/src/plugins/icons.ts
+++ b/packages/docs/src/plugins/icons.ts
@@ -281,6 +281,7 @@ export {
   mdiMonitorSmall,
   mdiMusicNote,
   mdiNature,
+  mdiNewBox,
   mdiNewspaperVariantOutline,
   mdiNodejs,
   mdiNumeric,


### PR DESCRIPTION
## Description
This is an initial step in redesigning our documentation site, focusing on improving the API pages by reintroducing the description column and a more comprehensive TOC.

<img width="1440" alt="Screen Shot 2025-05-16 at 6 18 25 PM" src="https://github.com/user-attachments/assets/cd22aef7-a7b7-4e98-9416-629c75ba7608" />

## Markup:
N/A