### PR TITLE
feat(VSlideGroup): add content class to VSlideGroup props

### DIFF
--- a/packages/api-generator/src/locale/en/VSlideGroup.json
+++ b/packages/api-generator/src/locale/en/VSlideGroup.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "centerActive": "Forces the selected component to be centered.",
+    "contentClass": "Adds classes to the slide group item.",
     "direction": "Switch between horizontal and vertical modes.",
     "mobileBreakpoint": "Sets the designated mobile breakpoint for the component.",
     "nextIcon": "The appended slot when arrows are shown.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -123,6 +123,11 @@
       "end": "3.2.0"
     }
   },
+  "VSlideGroup": {
+    "props": {
+      "contentClass": "3.9.0"
+    }
+  },
   "VSnackbar": {
     "props": {
       "timer": "3.4.0",

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -50,6 +50,7 @@ type VSlideGroupSlots = {
 
 export const makeVSlideGroupProps = propsFactory({
   centerActive: Boolean,
+  contentClass: null,
   direction: {
     type: String as PropType<'horizontal' | 'vertical'>,
     default: 'horizontal',
@@ -425,7 +426,10 @@ export const VSlideGroup = genericComponent<new <T>(
         <div
           key="container"
           ref={ containerRef }
-          class="v-slide-group__container"
+          class={[
+            'v-slide-group__container',
+            props.contentClass,
+          ]}
           onScroll={ onScroll }
         >
           <div


### PR DESCRIPTION
## Description

- Add new props `contentClass` to `VSlideGroup` 
- Resolves https://github.com/vuetifyjs/vuetify/issues/20853

## Markup:

```vue
<template>
  <v-sheet class="mx-auto" max-width="600">
    <v-slide-group show-arrows content-class="bg-red">
      <v-slide-group-item
        v-for="n in 25"
        :key="n"
        v-slot="{ isSelected, toggle }"
      >
        <v-btn
          :color="isSelected ? 'primary' : undefined"
          class="ma-2"
          rounded
          @click="toggle"
        >
          Options {{ n }}
        </v-btn>
      </v-slide-group-item>
    </v-slide-group>
  </v-sheet>
</template>

<style>
  .bg-red {
    background-color: red;
  }
</style>
```

<image src="https://github.com/user-attachments/assets/955a8b6e-8857-488b-9eb7-4333e23a6684" />
