### PR TITLE
fix(VSlider): correct step rounding for max value

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -70,6 +70,8 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
     if (!slider) throw new Error('[Vuetify] v-slider-thumb must be used inside v-slider or v-range-slider')
 
     const {
+      min,
+      max,
       thumbColor,
       step,
       disabled,
@@ -103,7 +105,7 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
       e.preventDefault()
 
       const _step = step.value || 0.1
-      const steps = (props.max - props.min) / _step
+      const steps = (max.value - min.value) / _step
       if ([left, right, down, up].includes(e.key)) {
         const increase = vertical.value
           ? [isRtl.value ? left : right, isReversed.value ? down : up]
@@ -111,11 +113,15 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
         const direction = increase.includes(e.key) ? 1 : -1
         const multiplier = e.shiftKey ? 2 : (e.ctrlKey ? 1 : 0)
 
-        value = value + (direction * _step * multipliers.value[multiplier])
+        if (direction === -1 && value === max.value && !multiplier && !Number.isInteger(steps)) {
+          value = value - (steps % 1) * _step
+        } else {
+          value = value + (direction * _step * multipliers.value[multiplier])
+        }
       } else if (e.key === home) {
-        value = props.min
+        value = min.value
       } else if (e.key === end) {
-        value = props.max
+        value = max.value
       } else {
         const direction = e.key === pagedown ? 1 : -1
         value = value - (direction * _step * (steps > 100 ? steps / 10 : 10))
@@ -154,8 +160,8 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
           role="slider"
           tabindex={ disabled.value ? -1 : 0 }
           aria-label={ props.name }
-          aria-valuemin={ props.min }
-          aria-valuemax={ props.max }
+          aria-valuemin={ min.value }
+          aria-valuemax={ max.value }
           aria-valuenow={ props.modelValue }
           aria-readonly={ !!readonly.value }
           aria-orientation={ direction.value }

--- a/packages/vuetify/src/components/VSlider/slider.ts
+++ b/packages/vuetify/src/components/VSlider/slider.ts
@@ -159,7 +159,11 @@ export const useSteps = (props: SliderProps) => {
 
     const clamped = clamp(value, min.value, max.value)
     const offset = min.value % step.value
-    const newValue = Math.round((clamped - offset) / step.value) * step.value + offset
+    let newValue = Math.round((clamped - offset) / step.value) * step.value + offset
+
+    if (newValue + step.value > max.value && clamped > newValue) {
+      newValue = max.value
+    }
 
     return parseFloat(Math.min(newValue, max.value).toFixed(decimals.value))
   }

--- a/packages/vuetify/src/components/VSlider/slider.ts
+++ b/packages/vuetify/src/components/VSlider/slider.ts
@@ -161,7 +161,7 @@ export const useSteps = (props: SliderProps) => {
     const offset = min.value % step.value
     let newValue = Math.round((clamped - offset) / step.value) * step.value + offset
 
-    if (newValue + step.value > max.value && clamped > newValue) {
+    if (clamped > newValue && newValue + step.value > max.value) {
       newValue = max.value
     }
 


### PR DESCRIPTION
fixes #21351

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This PR fixes a bug where v-range-slider (and other slider components) 
couldn't reach the maximum value when the max wasn't perfectly divisible 
by the step size.

For example, with a step of 10 and max of 104, attempting to drag the 
slider to the maximum would stop at 100 instead of reaching 104. This was 
due to the rounding logic in the roundValue function.

The fix adds a special case to ensure the exact maximum value is always 
reachable, while maintaining proper step behavior for all other values.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container class="fill-height">
      <v-row justify="center" align="center">
        <v-col cols="12" md="8">
          <v-card class="pa-6" elevation="4">
            <v-card-title class="text-h5 mb-4">
              v-range-slider Bug Fix Test
            </v-card-title>
            
            <v-card-text>
              <p class="mb-4">Current values: {{ sliderValue2 }}</p>
              
              <div class="d-flex gap-4">
                <v-text-field
                  v-model.number="customMin"
                  label="Custom Min"
                  type="number"
                  hide-details
                ></v-text-field>
                
                <v-text-field
                  v-model.number="customMax"
                  label="Custom Max"
                  type="number"
                  hide-details
                ></v-text-field>
                
                <v-text-field
                  v-model.number="customStep"
                  label="Custom Step"
                  type="number"
                  hide-details
                ></v-text-field>
              </div>
              
              <v-range-slider
                v-model="sliderValue2"
                :min="customMin"
                :max="customMax"
                :step="customStep"
                thumb-label="always"
                class="mt-4"
              ></v-range-slider>
            </v-card-text>
          </v-card>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: 'Playground',
  data() {
    return {
      sliderValue2: [20, 70],
      customMin: 0,
      customMax: 104,
      customStep: 10,
    }
  }
}
</script>
```
