### PR TITLE
fix(VCard): Move v-card diplsay to flex to adjust the hight of v-card-text

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -4,7 +4,8 @@
 
 @include tools.layer('components')
   .v-card
-    display: block
+    display: flex
+    flex-direction: column
     overflow: hidden
     overflow-wrap: $card-overflow-wrap
     position: relative
@@ -157,6 +158,7 @@
     font-size: $card-text-font-size
     font-weight: $card-text-font-weight
     letter-spacing: $card-text-letter-spacing
+    min-height: 0px
     opacity: $card-text-opacity
     padding: $card-text-padding
     text-transform: $card-text-text-transform

--- a/packages/vuetify/src/components/VTabs/VTabs.sass
+++ b/packages/vuetify/src/components/VTabs/VTabs.sass
@@ -7,6 +7,7 @@
 @include tools.layer('components')
   .v-tabs
     display: flex
+    flex-shrink: 0
     height: var(--v-tabs-height)
 
     @at-root


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
I have changed the display attribute of v-card to flex added flex-direction: column and min-height: 0 to v-card style.
to have the complete v-card-text visible inside the v-card.
Second change is to set the flex-shrink attribute to 0 so that the v-tabs will not shrink.


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card style="height: 50%" id="card">
    <v-tabs v-model="tab" bg-color="primary" id="tabs">
      <v-tab value="one"> Item One</v-tab>
      <v-tab value="two">Item Two</v-tab>
      <v-tab value="three">Item Three</v-tab>
    </v-tabs>

    <v-card-text class="ma-0 pa-0" style="height: 100%">
      <v-tabs-window v-model="tab" id="windowItem" style="height: 100%">
        <v-tabs-window-item
          class="ma-0 pa-0"
          value="one"
          style="overflow-y: auto; background-color: green"
        >
          Height of the card: {{cardHeight}}<br />
          Height of the tabs: {{tabsHeight}}<br />
          Height of the window item:{{widnowItemHeight}}<br /><br />
          Height of the window item should be {{cardHeight - tabsHeight}}
          <br /><br /><br /><br /><br /><br />
          <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
        </v-tabs-window-item>

        <v-tabs-window-item
          value="two"
          minHeight="100%"
          style="overflow-y: auto; background-color: blue"
        >
          Two
        </v-tabs-window-item>

        <v-tabs-window-item value="three"> Three </v-tabs-window-item>
      </v-tabs-window>
    </v-card-text>
  </v-card>
</template>
<style>
  html {
    overflow-y: hidden;
  }
  #app {
    height: 100vh;
  }
</style>

<script>
  export default {
    data: () => ({
      tab: null,
    }),
    computed: {
      cardHeight() {
        return document.getElementById('card').getBoundingClientRect().height
      },
      widnowItemHeight() {
        return document.getElementById('windowItem').getBoundingClientRect()
          .height
      },
      tabsHeight() {
        return document.getElementById('tabs').getBoundingClientRect().height
      },
    },
  }
</script>
```
Before the change, the scroll-down button is not visible andf the height of the v-card-text is not the expected number of pixel:

![image](https://github.com/user-attachments/assets/5de3e697-b908-4aa0-8eb1-887bf8d38729)

After the change the scroll-down butto is visible and the calculated height has the expected number of pixel (heigh of the card - height of the tabs):

![image](https://github.com/user-attachments/assets/ecda8530-43c3-4805-be0d-9f7794eca13e)
