### PR TITLE
docs: replace hyphens in search term for algolia

### DIFF
--- a/packages/docs/src/components/app/search/SearchDialog.vue
+++ b/packages/docs/src/components/app/search/SearchDialog.vue
@@ -82,7 +82,7 @@
           <ais-configure
             :facetFilters="[`lang:${locale}`]"
             :hitsPerPage="50"
-            :query="searchString"
+            :query="searchTerm"
           />
 
           <ais-hits v-slot="{ items }">
@@ -118,6 +118,9 @@
 
   const model = defineModel<boolean>()
   const searchString = defineModel('search', { type: String, default: '' })
+
+  // Algolia doesn't tokenize hyphens by default. Sanitize search string.
+  const searchTerm = computed(() => searchString.value.replace(/-/g, ' '))
 
   const list = ref<InstanceType<typeof SearchResults>>()
   const searchClient = algoliasearch(


### PR DESCRIPTION
## Description
Replace hyphens with spaces on search term passed to algolia (hyphens are not tokenized). This prevents empty search results in doc search dialog.

Reference: https://www.algolia.com/doc/guides/managing-results/optimize-search-results/typo-tolerance/how-to/how-to-search-in-hyphenated-attributes/

## Markup:
N/A