### PR TITLE
fix(useVirtual): calculateVisibleItems: return if itemHeight is 0

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -197,7 +197,7 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
     raf = requestAnimationFrame(_calculateVisibleItems)
   }
   function _calculateVisibleItems () {
-    if (!containerRef.value || !viewportHeight.value) return
+    if (!containerRef.value || !viewportHeight.value || !itemHeight.value) return
     const scrollTop = lastScrollTop - markerOffset
     const direction = Math.sign(scrollVelocity)
 


### PR DESCRIPTION
## Description
This PR fixes an issue in `useVirtual` composable for dynamic item heights. If a static `item-height` is not provided, the height is calculated for each item dynamically. However, depending on the timing when the table gets rendered initially, it may happen that the `calculateVisibleItems` function is being called before the item heights have been determined.
If all heights are still 0, `binaryClosest` function calculates an index in the middle of the item array which leads to all items being rendered instead of lazy rendering.
See the behavior in the playground [here](https://play.vuetifyjs.com/#eNqlWHtz2kYQ/yo7lBYxQQKMnTiMiZs0SdtpHHuMp56O8YwP6QSqJZ16OuFQhu/evdOdHgjqJvUftrSP++3rdle+27RS7vbfJomzymhr3DoTNEpCIuibWQxwtrI9IogtyDyk9irgIiOhZABw6k9mLRreSNaslRPHS0o8ylPk6KeCE+DBkq4PeceIKJhLGiyWApnHg4GhSXl7RcKMIj0mUYmhOI90jXT5+BtdG5YffKGenSNLivIBvTA+wXdSAfU26vie+n1NfdjOWloWpTl7ykE0wKwF49xbLY6Evjm6X49Xf1/AcpYXrIzSyhb0i7D9gIaegXVZyDhiJDyICC9cAljZEfNoiCy3JIZkrkifs2hOOTAfVEBBMCCeV8q5IUll1CNhvzTUwvaVPRdxKULsEXrWsAN+dMPAfUQSnqxQLJ+EKe2B262EDUuIxl5uhomNAvjfaIJnu2BXnBZoXw9GOWe8ClWtSSdNkEqtQRXvp5ASfsi3s75JrcxxNeSnkBD7uDjn+sPn9x+uP7yH68vb6RjOUsFZvHiz2eBlirFkqXfNnlLYbs/6mvVVx98wQUJdB0EMn4JU1EBqXoY0XojlIaxaWeNr6vIgEZBSkSVKMIgSxgVIy/0esPiCZbGgHmzB5yyCDjaTTkUO/dIMp4/PstcgWwq4LE5F3f+JPFTGv2DrLqM5FYarSUOkSSoa+CvawbFvWFYXJm9gY7pVCeCorgITk1x9ek4+d9o0dP7KKF9PaUhdwfjbMLQ6Ys68NQje6ZrQnZ/DQB6x7cFwIK0tzdK9D427y0E2IAIR0jF0ZPThZp3QTg+whyFF9rYOnrIrOU0o9azHmIm0WwinkrhP+pMyyopK0dzMiqzx16hccVnnbdQwnFwR76KL5hX9R4ZlrFqlDKjPeEREritpjhLvavGmYX/gzSlsWssXLXRfjdhcVW0ZLwMug2NikWJiS7NUJMYwOikoucNjODoqSMo2FBrIn4IqrUCxwdFw1+od2EuXkviC7AU+agJXbNHAJweADekQ8O9sTRb7QMuzDOhxA/TVftDh62dAb8mKXmdxvAf3uIlbHFfgHilvm86adBzCnVLyjlP6d6XmjLunzRibnBWwx/thh0b3EOwvhM8Z/zkj3GsAF8ol8EkJoYFPD8T51XP+yqnzMYibtTxq1vJxo5YPRPm5Wp5iJ4swzuRxX12VV6YIdBkCjfzyG4v5Noi9KQnCZpSbV+ikUc2vv7GaP+K1vQm8ZlGNTH4qUW7k9kgl97larrWw6njVY+nuXs2q2uDVwwciTES+3+D0MOPDz2JXBCyudVml0S0nmch4DA/t9kYxHME+yrUXB6aDW1FIUKM/m3nW+cTCP5vRtvui3e0vetBp/9DrdLcPamjt4JXWuLtId47jvOWcrJHlYBtPre69E5HECirztdrH0bkNoJLq6XcBfI/z8V4i5oKS7MgkodxDe1O8bsGG9sa6IGLpcBJ7LMIJ/gLkaM8VAdDXqeBBvLBGL6vkNJvjEiPpr7R/FfslgE6a0tl1vdgzE71UTsDst/g4LMJRH1TVgOkPFh/MEYXOvtw7WZwuA19YJkRaf4uLSEr/VTPJ0mVDreJTsYfVl5/aJp3HoLau6K8o9MoM+XoFqDHPyZNKk4bDtVHthLgNtnrqG1Lvdc1vSMGL7zBP7qHqOFUAcvtEWpOrruphdmV53ctXl/gwW97mKhcfpIn/fekVDL8C08N7bxnahLNElotH/SCmV/LN0sGVpowrWxnuhGO4nP+JO2etydRzlbuAeBNtBdYcHqplDhSAVGW44YZsYXXkLq6lOkUxVNO57bVGzokzHGFiR86pc9Lq5Rei9q+CnHb/D0Ux6F8=)

Modifying items in `onMounted` causes the issue.
The table only recovers if you clear the items or if you add more items and scroll past the initial virtual page. 

The proposed solution adds an additional circuit breaker to the `_calculateVisibleItems` function in case `itemHeight` has not yet been calculated.

This PR also fixes #18806

## Markup:
```vue
<template>
  <v-data-table-virtual
    ref="elTable"
    :headers="headers"
    :item-key="itemKey"
    :items="virtualBoats"
    height="400"
    item-value="name"
    fixed-header
  />
  <div class="mt-8 pa-4">
    RENDERED ROWS: <strong>{{ renderedRows }}</strong>
  </div>
  <div class="mt-8 pa-4">
    Total Boats in List: <strong>{{ virtualBoats.length }}</strong>
  </div>
</template>

<script setup>
  import { onMounted, ref } from 'vue'
  import GRow from './GRow.vue'

  const renderedRows = ref(0)
  const elTable = ref()
  const c = ref(1)

  setInterval(() => {
    renderedRows.value =
      elTable.value?.$el.querySelectorAll('tbody tr').length ?? 0
  }, 100)

  const headers = [
    { title: 'Boat Type', key: 'name' },
    { title: 'Speed(knots)', key: 'speed' },
    { title: 'Length(m)', key: 'length' },
    {
      title: 'Price($)',
      key: 'price',
      value: item => formatPrice(item.price),
    },
    { title: 'Year', key: 'year' },
  ]

  const boats = [
    {
      name: 'Speedster',
      speed: 35,
      length: 22,
      price: 300000,
      year: 2021,
    },
    {
      name: 'OceanMaster',
      speed: 25,
      length: 35,
      price: 500000,
      year: 2020,
    },
    {
      name: 'Voyager',
      speed: 20,
      length: 45,
      price: 700000,
      year: 2019,
    },
    {
      name: 'WaveRunner',
      speed: 40,
      length: 19,
      price: 250000,
      year: 2022,
    },
    {
      name: 'SeaBreeze',
      speed: 28,
      length: 31,
      price: 450000,
      year: 2018,
    },
    {
      name: 'HarborGuard',
      speed: 18,
      length: 50,
      price: 800000,
      year: 2017,
    },
    {
      name: 'SlickFin',
      speed: 33,
      length: 24,
      price: 350000,
      year: 2021,
    },
    {
      name: 'StormBreaker',
      speed: 22,
      length: 38,
      price: 600000,
      year: 2020,
    },
    {
      name: 'WindSail',
      speed: 15,
      length: 55,
      price: 900000,
      year: 2019,
    },
    {
      name: 'FastTide',
      speed: 37,
      length: 20,
      price: 280000,
      year: 2022,
    },
  ]

  const virtualBoats = ref([])
  virtualBoats.value = makeBoats(1000)

  function formatPrice (value) {
    return `$${value.toFixed(0).replace(/\d(?=(\d{3})+$)/g, '$&,')}`
  }

  function makeBoats (c) {
    return [...Array(c).keys()].map(i => {
      const boat = { ...boats[i % 10] }
      boat.name = `${boat.name} - ${(Math.random() + 1)
        .toString(36)
        .substring(7)}`
      return boat
    })
  }

  function addBoats (prepend = false, c = 1) {
    const boats = makeBoats(c)
    if (prepend) {
      virtualBoats.value.unshift(...boats)
    } else {
      virtualBoats.value.push(...boats)
    }
  }

  onMounted(() => {
    addBoats(true)
  })

  const itemKey = item => {
    return item.raw.name
  }
</script>
```
