### PR TITLE
docs: meta title on api pages

### DIFF
--- a/packages/docs/src/App.vue
+++ b/packages/docs/src/App.vue
@@ -21,8 +21,16 @@
   const path = computed(() => route.path.replace(`/${locale.value}/`, ''))
 
   const meta = computed(() => {
+    let title = route.meta.title
+
+    // API pages
+    if (route.meta.title === 'API') {
+      const name = route.params.name as string
+      title = `${name.charAt(0).toUpperCase()}${camelize(name.slice(1))} API`
+    }
+
     return genAppMetaInfo({
-      title: `${route.meta.title}${path.value === '' ? '' : ' — Vuetify'}`,
+      title: `${title}${path.value === '' ? '' : ' — Vuetify'}`,
       description: frontmatter.value?.meta.description,
       keywords: frontmatter.value?.meta.keywords,
       assets: frontmatter.value?.assets,


### PR DESCRIPTION
## Description
More context on meta title for API pages

Before: 
<img width="540" alt="Screen Shot 2025-05-21 at 12 11 29 AM" src="https://github.com/user-attachments/assets/77f90fb8-bdef-4e18-b471-3ba81d3d63cb" />

After:
<img width="514" alt="Screen Shot 2025-05-21 at 12 11 58 AM" src="https://github.com/user-attachments/assets/e169557e-a036-43f4-bc60-c59d6a81f5ad" />


## Markup:
N/A
