### PR TITLE
fix(VMenu): let persistent menus coegist with regular ones

### DIFF
--- a/packages/api-generator/src/locale/en/VMenu.json
+++ b/packages/api-generator/src/locale/en/VMenu.json
@@ -6,6 +6,7 @@
     "closeOnContentClick": "Designates if menu should close when its content is clicked.",
     "closeDelay": "Milliseconds to wait before closing component. Only works with the **open-on-hover** prop.",
     "disableKeys": "Removes all keyboard interaction.",
+    "forceInitialFocus": "Redirects first `focusin` event (for the whole page) to the inner focusable child element.",
     "internalActivator": "Detaches the menu content inside of the component as opposed to the document.",
     "minWidth": "Sets the minimum width for the component. Use `auto` to use the activator width.",
     "offsetX": "Offset the menu on the x-axis. Works in conjunction with direction left/right.",

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -48,6 +48,10 @@ export const makeVMenuProps = propsFactory({
   // disableKeys: Boolean,
   id: String,
   submenu: Boolean,
+  forceInitialFocus: {
+    type: Boolean,
+    default: true,
+  },
 
   ...omit(makeVOverlayProps({
     closeDelay: 250,
@@ -133,7 +137,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
     watch(isActive, val => {
       if (val) {
         parent?.register()
-        if (IN_BROWSER) {
+        if (IN_BROWSER && props.forceInitialFocus) {
           document.addEventListener('focusin', onFocusIn, { once: true })
         }
       } else {


### PR DESCRIPTION
## Description

- introduces `force-initial-focus` (enabled `true` by default) to let user suppress initial focus redirect

resolves #20976

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <div class="d-flex">
        <v-select :items="['a','b','c']" />

        <v-fab
          icon="$vuetify"
          location="left bottom"
          size="large"
          app
        >
          <v-icon />
          <v-speed-dial
            :close-on-content-click="false"
            :force-initial-focus="false"
            activator="parent"
            location="right center"
            model-value
            no-click-animation
            persistent
          >
            <v-btn key="1" icon="$success" />
            <v-btn key="2" icon="$info" />
            <v-btn key="3" icon="$warning" />
            <v-btn key="4" icon="$error" />
          </v-speed-dial>
        </v-fab>
      </div>
    </v-container>
  </v-app>
</template>
```
