### PR TITLE
fix(VDateInput): use common date range parser

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -7,6 +7,7 @@ import { VBtn } from '@/components/VBtn'
 // Composables
 import { makeCalendarProps, useCalendar } from '@/composables/calendar'
 import { useDate } from '@/composables/date/date'
+import { useDateRange } from '@/composables/dateRange'
 import { MaybeTransition } from '@/composables/transition'
 
 // Utilities
@@ -59,6 +60,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
 
     const { daysInMonth, model, weekNumbers } = useCalendar(props)
     const adapter = useDate()
+    const { createRange } = useDateRange()
 
     const rangeStart = shallowRef()
     const rangeStop = shallowRef()
@@ -111,17 +113,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
           rangeStop.value = adapter.endOfDay(_value)
         }
 
-        const diff = adapter.getDiff(rangeStop.value, rangeStart.value, 'days')
-        const datesInRange = [rangeStart.value]
-
-        for (let i = 1; i < diff; i++) {
-          const nextDate = adapter.addDays(rangeStart.value, i)
-          datesInRange.push(nextDate)
-        }
-
-        datesInRange.push(rangeStop.value)
-
-        model.value = datesInRange
+        model.value = createRange(rangeStart.value, rangeStop.value)
       } else {
         rangeStart.value = value
         rangeStop.value = undefined

--- a/packages/vuetify/src/composables/dateRange.ts
+++ b/packages/vuetify/src/composables/dateRange.ts
@@ -1,0 +1,26 @@
+// Composables
+import { useDate } from '@/composables/date/date'
+
+export function useDateRange () {
+  const adapter = useDate()
+
+  function createRange (start: unknown, stop?: unknown) {
+    const diff = adapter.getDiff(stop ?? start, start, 'days')
+    const datesInRange = [start]
+
+    for (let i = 1; i < diff; i++) {
+      const nextDate = adapter.addDays(start, i)
+      datesInRange.push(nextDate)
+    }
+
+    if (stop) {
+      datesInRange.push(adapter.endOfDay(stop))
+    }
+
+    return datesInRange
+  }
+
+  return {
+    createRange,
+  }
+}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

Fixes #21448

## Description
Use common function to create date range.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input label="Date input" multiple="range" v-model="val" />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      val: [],
    }),
    watch: {
      val(newVal) {
        console.log('VALUE CHANGED', newVal)
      },
    },
  }
</script>

```
