### PR TITLE
fix(VSpeedDial): avoid position glitch when reopening menu

### DIFF
--- a/packages/vuetify/src/components/VSpeedDial/VSpeedDial.sass
+++ b/packages/vuetify/src/components/VSpeedDial/VSpeedDial.sass
@@ -22,6 +22,8 @@
         flex-direction: column-reverse
 
     > *
-      @for $i from 1 through 10
+      &:nth-child(1)
+        transition-delay: 0.001s
+      @for $i from 2 through 10
         &:nth-child(#{$i})
           transition-delay: 0.05s * ($i - 1)


### PR DESCRIPTION
## Description

fixes #21017

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <!-- rage-click open/close to see if items stay within menu boundaries -->
      <v-fab app icon="mdi-arrow-up" location="bottom center">
        <v-icon />
        <v-speed-dial
          location="top"
          activator="parent"
          transition="slide-y-reverse-transition"
        >
          <v-btn
            v-for="i in 9"
            :key="i"
            prepend-icon="mdi-home"
            color="primary"
            :text="`Hello #${i}`"
            size="small"
          />
        </v-speed-dial>
      </v-fab>
    </v-container>
  </v-app>
</template>

```
