### PR TITLE
chore: un-deprecate firstDayOfWeek

### DIFF
--- a/packages/api-generator/src/locale/en/generic.json
+++ b/packages/api-generator/src/locale/en/generic.json
@@ -18,7 +18,7 @@
     "end": "Applies margin at the start of the component.",
     "falseIcon": "The icon used when inactive.",
     "falseValue": "Sets value for falsy state.",
-    "firstDayOfWeek": "Deprecated, Sets the first day of the week, starting with 0 for Sunday.",
+    "firstDayOfWeek": "Sets the first day of the week, starting with 0 for Sunday.",
     "fullWidth": "Sets the component width to 100%.",
     "height": "Sets the height for the component.",
     "hideNoData": "Hides the menu when there are no options to show.  Useful for preventing the menu from opening before results are fetched asynchronously.  Also has the effect of opening the menu when the `items` array changes if not already open.",

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -22,8 +22,6 @@ export interface CalendarProps {
   weekdays: number[]
   year: number | string | undefined
   weeksInMonth: 'dynamic' | 'static'
-
-  /** @deprecated */
   firstDayOfWeek: number | string | undefined
 
   'onUpdate:modelValue': ((value: unknown[]) => void) | undefined


### PR DESCRIPTION
Looking a this after a while.. users sometimes get a dropdown to change week start - overriding their locale preferences. It is a valid scenario and I don't see any way to achieve this with VLocaleProvider