### PR TITLE
feat(VDatePicker): disable months and years if not allowed

### DIFF
--- a/packages/api-generator/src/locale/en/VDatePickerMonths.json
+++ b/packages/api-generator/src/locale/en/VDatePickerMonths.json
@@ -2,7 +2,8 @@
   "props": {
     "min": "Sets the minimum selectable date. Months before this date will be disabled.",
     "max": "Sets the maximum selectable date. Months after this date will be disabled.",
-    "year": "Sets the year for the given months."
+    "year": "Sets the year for the given months.",
+    "allowedMonths": "Restricts which months can be selected."
   },
   "slots": {
     "month": "Slot for the month."

--- a/packages/api-generator/src/locale/en/VDatePickerYears.json
+++ b/packages/api-generator/src/locale/en/VDatePickerYears.json
@@ -2,7 +2,8 @@
   "props": {
     "max": "Sets the maximum date of the month.",
     "min": "Sets the minimum date of the month.",
-    "year": "Sets the year."
+    "year": "Sets the year.",
+    "allowedYears": "Restricts which years can be selected."
   },
   "slots": {
     "year": "Slot for the year."

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -194,6 +194,20 @@ export const VDatePicker = genericComponent<new <
       return targets
     })
 
+    function allowedYears (year: number) {
+      if (!Array.isArray(props.allowedDates) || !props.allowedDates.length) return true
+      return props.allowedDates.map(date => adapter.getYear(adapter.date(date))).includes(year)
+    }
+
+    function allowedMonths (month: number) {
+      if (!Array.isArray(props.allowedDates) || !props.allowedDates.length) return true
+      if (!allowedYears(year.value)) return false
+
+      return props.allowedDates
+        .filter(date => adapter.getYear(adapter.date(date)) === year.value)
+        .map(date => adapter.getMonth(adapter.date(date))).includes(month)
+    }
+
     // function onClickAppend () {
     //   inputMode.value = inputMode.value === 'calendar' ? 'keyboard' : 'calendar'
     // }
@@ -340,19 +354,21 @@ export const VDatePicker = genericComponent<new <
                       key="date-picker-months"
                       { ...datePickerMonthsProps }
                       v-model={ month.value }
-                      onUpdate:modelValue={ onUpdateMonth }
                       min={ minDate.value }
                       max={ maxDate.value }
                       year={ year.value }
+                      allowed-months={ allowedMonths }
+                      onUpdate:modelValue={ onUpdateMonth }
                     />
                   ) : viewMode.value === 'year' ? (
                     <VDatePickerYears
                       key="date-picker-years"
                       { ...datePickerYearsProps }
                       v-model={ year.value }
-                      onUpdate:modelValue={ onUpdateYear }
                       min={ minDate.value }
                       max={ maxDate.value }
+                      allowed-years={ allowedYears }
+                      onUpdate:modelValue={ onUpdateYear }
                     />
                   ) : (
                     <VDatePickerMonth

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -18,7 +18,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref, shallowRef, toRef, watch } from 'vue'
-import { createRange, genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { VPickerSlots } from '@/labs/VPicker/VPicker'
@@ -197,8 +197,11 @@ export const VDatePicker = genericComponent<new <
     function isAllowedInRange (start: unknown, end: unknown) {
       const allowedDates = props.allowedDates
       if (typeof allowedDates !== 'function') return true
-      return createRange(adapter.getDiff(end, start, 'days'))
-        .some(count => allowedDates(adapter.addDays(start, count)))
+      const days = adapter.getDiff(end, start, 'days')
+      for (let i = 0; i < days; i++) {
+        if (allowedDates(adapter.addDays(start, i))) return true
+      }
+      return false
     }
 
     function allowedYears (year: number) {

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -208,9 +208,10 @@ export const VDatePicker = genericComponent<new <
       }
 
       if (Array.isArray(props.allowedDates) && props.allowedDates.length) {
-        return props.allowedDates
-          .map(date => adapter.getYear(adapter.date(date)))
-          .includes(year)
+        for (const date of props.allowedDates) {
+          if (adapter.getYear(adapter.date(date)) === year) return true
+        }
+        return false
       }
 
       return true
@@ -225,10 +226,13 @@ export const VDatePicker = genericComponent<new <
       }
 
       if (Array.isArray(props.allowedDates) && props.allowedDates.length) {
-        return props.allowedDates
-          .filter(date => adapter.getYear(adapter.date(date)) === year.value)
-          .map(date => adapter.getMonth(adapter.date(date)))
-          .includes(month)
+        for (const date of props.allowedDates) {
+          if (
+            adapter.getYear(adapter.date(date)) === year.value &&
+            adapter.getMonth(adapter.date(date)) === month
+          ) return true
+        }
+        return false
       }
 
       return true

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -385,7 +385,7 @@ export const VDatePicker = genericComponent<new <
                       min={ minDate.value }
                       max={ maxDate.value }
                       year={ year.value }
-                      allowed-months={ allowedMonths }
+                      allowedMonths={ allowedMonths }
                       onUpdate:modelValue={ onUpdateMonth }
                     />
                   ) : viewMode.value === 'year' ? (
@@ -395,7 +395,7 @@ export const VDatePicker = genericComponent<new <
                       v-model={ year.value }
                       min={ minDate.value }
                       max={ maxDate.value }
-                      allowed-years={ allowedYears }
+                      allowedYears={ allowedYears }
                       onUpdate:modelValue={ onUpdateYear }
                     />
                   ) : (

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -220,7 +220,7 @@ export const VDatePicker = genericComponent<new <
       if (!allowedYears(year.value)) return false
 
       if (typeof props.allowedDates === 'function') {
-        const startOfMonth = adapter.parseISO(`${year.value}-${month}-01`)
+        const startOfMonth = adapter.parseISO(`${year.value}-${month + 1}-01`)
         return isAllowedInRange(startOfMonth, adapter.endOfMonth(startOfMonth))
       }
 

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -218,8 +218,6 @@ export const VDatePicker = genericComponent<new <
     }
 
     function allowedMonths (month: number) {
-      if (!allowedYears(year.value)) return false
-
       if (typeof props.allowedDates === 'function') {
         const startOfMonth = adapter.parseISO(`${year.value}-${month + 1}-01`)
         return isAllowedInRange(startOfMonth, adapter.endOfMonth(startOfMonth))

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonths.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonths.tsx
@@ -35,6 +35,7 @@ export const makeVDatePickerMonthsProps = propsFactory({
   max: null as any as PropType<unknown>,
   modelValue: Number,
   year: Number,
+  allowedMonths: [Array, Function] as PropType<number[] | ((date: number) => boolean)>,
 }, 'VDatePickerMonths')
 
 export const VDatePickerMonths = genericComponent<VDatePickerMonthsSlots>()({
@@ -59,6 +60,7 @@ export const VDatePickerMonths = genericComponent<VDatePickerMonthsSlots>()({
         const text = adapter.format(date, 'monthShort')
         const isDisabled =
           !!(
+            !isMonthAllowed(i) ||
             (props.min && adapter.isAfter(adapter.startOfMonth(adapter.date(props.min)), date)) ||
             (props.max && adapter.isAfter(date, adapter.startOfMonth(adapter.date(props.max))))
           )
@@ -75,6 +77,18 @@ export const VDatePickerMonths = genericComponent<VDatePickerMonthsSlots>()({
     watchEffect(() => {
       model.value = model.value ?? adapter.getMonth(adapter.date())
     })
+
+    function isMonthAllowed (month: number) {
+      if (Array.isArray(props.allowedMonths) && props.allowedMonths.length) {
+        return props.allowedMonths.includes(month)
+      }
+
+      if (typeof props.allowedMonths === 'function') {
+        return props.allowedMonths(month)
+      }
+
+      return true
+    }
 
     useRender(() => (
       <div

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerYears.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerYears.tsx
@@ -40,6 +40,7 @@ export const makeVDatePickerYearsProps = propsFactory({
   min: null as any as PropType<unknown>,
   max: null as any as PropType<unknown>,
   modelValue: Number,
+  allowedYears: [Array, Function] as PropType<number[] | ((date: number) => boolean)>,
 }, 'VDatePickerYears')
 
 export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
@@ -79,6 +80,7 @@ export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
         return {
           text,
           value: i,
+          isDisabled: !isYearAllowed(i),
         }
       })
     })
@@ -93,6 +95,18 @@ export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
       await nextTick()
       yearRef.el?.scrollIntoView({ block: 'center' })
     })
+
+    function isYearAllowed (year: number) {
+      if (Array.isArray(props.allowedYears) && props.allowedYears.length) {
+        return props.allowedYears.includes(year)
+      }
+
+      if (typeof props.allowedYears === 'function') {
+        return props.allowedYears(year)
+      }
+
+      return true
+    }
 
     useRender(() => (
       <div
@@ -109,6 +123,7 @@ export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
               color: model.value === year.value ? props.color : undefined,
               rounded: true,
               text: year.text,
+              disabled: year.isDisabled,
               variant: model.value === year.value ? 'flat' : 'text',
               onClick: () => {
                 if (model.value === year.value) {


### PR DESCRIPTION
fixes #20465

## Description
Disable month and year buttons based on `allowed-dates` prop when:
- [x]  `allowed-dates` is array
- [x]  `allowed-dates` is function (open for suggestion/help)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
        <h2>Date picker</h2>
        <v-date-picker
          mode="month"
          hide-header
          :allowed-dates="['2025-05-01', '2025-03-02', '2024-02-01']"
        ></v-date-picker>

        <h2>Date picker years</h2>
        <VDatePickerYears
          :allowed-years="[2025, 2026]"
          class="mb-10"
        />

        <h2>Date picker months</h2>
        <VDatePickerMonths
          :allowed-months="[2, 3]"
        />
    </v-container>
  </v-app>
</template>

```

## Screenshots
![image](https://github.com/user-attachments/assets/a2ffc6b8-6200-4840-8fe8-6cd115d599e2)
![image](https://github.com/user-attachments/assets/847b66b4-b335-4ae1-bf9c-fce6e2718156)
