### PR TITLE
docs: textareas.md - background color

### DIFF
--- a/packages/docs/src/pages/en/components/textareas.md
+++ b/packages/docs/src/pages/en/components/textareas.md
@@ -49,7 +49,7 @@ When using the `auto-grow` prop, textarea's will automatically increase in size 
 
 #### Background color
 
-The `background-color` and `color` props give you more control over styling `v-textarea`'s.
+The `bg-color` and `color` props give you more control over styling `v-textarea`'s.
 
 <ExamplesExample file="v-textarea/prop-background-color" />
 


### PR DESCRIPTION
fix typo background-color to bg-color

## Description
The info of using 'background-color' create confusion should be 'bg-color'.

