### PR TITLE
feat(VToolbar): Add location props 

### DIFF
--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -11,6 +11,7 @@ import { VImg } from '@/components/VImg'
 import { makeBorderProps, useBorder } from '@/composables/border'
 import { useBackgroundColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
+import { makeLocationProps, useLocation } from '@/composables/location'
 import { provideDefaults } from '@/composables/defaults'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
 import { useRtl } from '@/composables/locale'
@@ -55,6 +56,7 @@ export const makeVToolbarProps = propsFactory({
   ...makeBorderProps(),
   ...makeComponentProps(),
   ...makeElevationProps(),
+  ...makeLocationProps(),
   ...makeRoundedProps(),
   ...makeTagProps({ tag: 'header' }),
   ...makeThemeProps(),
@@ -78,6 +80,7 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)
     const { borderClasses } = useBorder(props)
     const { elevationClasses } = useElevation(props)
+    const { locationStyles } = useLocation(props)
     const { roundedClasses } = useRounded(props)
     const { themeClasses } = provideTheme(props)
     const { rtlClasses } = useRtl()
@@ -133,6 +136,7 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
           ]}
           style={[
             backgroundColorStyles.value,
+            locationStyles.value,
             props.style,
           ]}
         >


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
resolves #21458

Added location props and styles to VToolbar
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-card
    height="300"
    image="https://cdn.vuetifyjs.com/images/toolbar/map.jpg"
    border
    flat
  >
    <template v-slot:text>
      <v-toolbar rounded="lg" border floating absolute location="top right">
        <div class="px-4">
          <v-text-field
            density="compact"
            placeholder="Search"
            prepend-inner-icon="mdi-magnify"
            variant="solo"
            width="200"
            flat
            hide-details
            single-line
          ></v-text-field>
        </div>

        <template v-slot:append>
          <v-btn
            color="medium-emphasis"
            density="comfortable"
            icon="mdi-crosshairs-gps"
          ></v-btn>

          <v-btn
            class="ms-1"
            color="medium-emphasis"
            density="comfortable"
            icon="mdi-dots-vertical"
          ></v-btn>
        </template>
      </v-toolbar>
    </template>
  </v-card>
</template>
```
Output:
![image](https://github.com/user-attachments/assets/0be0f1ec-11ca-405c-8979-ffca010fe41a)
