### PR TITLE
docs(v-data-table): prevent object reference mutation in add and save methods

### DIFF
--- a/packages/docs/src/examples/v-data-table/misc-crud.vue
+++ b/packages/docs/src/examples/v-data-table/misc-crud.vue
@@ -123,7 +123,7 @@
 
   function add () {
     isEditing.value = false
-    record.value = DEFAULT_RECORD
+    record.value = {...DEFAULT_RECORD}
     dialog.value = true
   }
 
@@ -163,7 +163,7 @@
 
   function reset () {
     dialog.value = false
-    record.value = DEFAULT_RECORD
+    record.value = {...DEFAULT_RECORD}
     books.value = [
       { id: 1, title: 'To Kill a Mockingbird', author: 'Harper Lee', genre: 'Fiction', year: 1960, pages: 281 },
       { id: 2, title: '1984', author: 'George Orwell', genre: 'Dystopian', year: 1949, pages: 328 },


### PR DESCRIPTION
## Description
Instead of assigning the new `record` value in the add and save methods to the `DEFAULT_RECORD` reference, it must be assigned to its value, otherwise you'll run into object reference mutation, so when you add another record you'll be mutating the old object reference.