### PR TITLE
fix(VFileInput,VFileUpload): handle folders drop

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -9,6 +9,7 @@ import { makeVFieldProps } from '@/components/VField/VField'
 import { makeVInputProps, VInput } from '@/components/VInput/VInput'
 
 // Composables
+import { useFileDrop } from '@/composables/fileDrop'
 import { useFocus } from '@/composables/focus'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useLocale } from '@/composables/locale'
@@ -124,6 +125,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     const isActive = toRef(() => isFocused.value || props.active)
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
     const isDragging = shallowRef(false)
+    const { handleDrop } = useFileDrop()
 
     function onFocus () {
       if (inputRef.value !== document.activeElement) {
@@ -163,16 +165,15 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       e.preventDefault()
       isDragging.value = false
     }
-    function onDrop (e: DragEvent) {
+    async function onDrop (e: DragEvent) {
       e.preventDefault()
       e.stopImmediatePropagation()
       isDragging.value = false
 
-      if (!e.dataTransfer?.files?.length || !inputRef.value) return
+      if (!inputRef.value) return
 
       const dataTransfer = new DataTransfer()
-
-      for (const file of e.dataTransfer.files) {
+      for (const file of await handleDrop(e)) {
         dataTransfer.items.add(file)
       }
 

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -125,7 +125,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     const isActive = toRef(() => isFocused.value || props.active)
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
     const isDragging = shallowRef(false)
-    const { handleDrop } = useFileDrop()
+    const { handleDrop, hasFilesOrFolders } = useFileDrop()
 
     function onFocus () {
       if (inputRef.value !== document.activeElement) {
@@ -170,7 +170,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       e.stopImmediatePropagation()
       isDragging.value = false
 
-      if (!inputRef.value) return
+      if (!inputRef.value || !hasFilesOrFolders(e)) return
 
       const dataTransfer = new DataTransfer()
       for (const file of await handleDrop(e)) {

--- a/packages/vuetify/src/composables/fileDrop.ts
+++ b/packages/vuetify/src/composables/fileDrop.ts
@@ -1,0 +1,50 @@
+// Types
+type FileSelection = { file: File, path: string }
+
+export function useFileDrop () {
+  async function handleDrop (e: DragEvent) {
+    const result: File[] = []
+
+    const entries = [...e.dataTransfer?.items ?? []]
+      .filter(x => x.kind === 'file')
+      .map(x => x.webkitGetAsEntry())
+      .filter(Boolean)
+
+    if (entries.length) {
+      for (const entry of entries) {
+        const files = await traverseFileTree(entry!, appendIfDirectory('.', entry!))
+        result.push(...files.map(x => x.file))
+      }
+    } else {
+      result.push(...[...e.dataTransfer?.files ?? []])
+    }
+
+    return result
+  }
+
+  return { handleDrop }
+}
+
+function traverseFileTree (item: FileSystemEntry, path = ''): Promise<FileSelection[]> {
+  return new Promise<FileSelection[]>((resolve, reject) => {
+    if (item.isFile) {
+      const fileEntry = item as FileSystemFileEntry
+      fileEntry.file((file: File) => resolve([{ file, path }]), reject)
+    } else if (item.isDirectory) {
+      const directoryReader = (item as FileSystemDirectoryEntry).createReader()
+      directoryReader.readEntries(async entries => {
+        const files = [] as FileSelection[]
+        for (const entry of entries) {
+          files.push(...(await traverseFileTree(entry, appendIfDirectory(path, entry))))
+        }
+        resolve(files)
+      })
+    }
+  })
+}
+
+function appendIfDirectory (path: string, item: FileSystemEntry) {
+  return item.isDirectory
+    ? `${path}/${item.name}`
+    : path
+}

--- a/packages/vuetify/src/composables/fileDrop.ts
+++ b/packages/vuetify/src/composables/fileDrop.ts
@@ -2,6 +2,15 @@
 type FileSelection = { file: File, path: string }
 
 export function useFileDrop () {
+  function hasFilesOrFolders (e: DragEvent): boolean {
+    const entries = [...e.dataTransfer?.items ?? []]
+      .filter(x => x.kind === 'file')
+      .map(x => x.webkitGetAsEntry())
+      .filter(Boolean)
+
+    return entries.length > 0 || [...e.dataTransfer?.files ?? []].length > 0
+  }
+
   async function handleDrop (e: DragEvent) {
     const result: File[] = []
 
@@ -22,7 +31,10 @@ export function useFileDrop () {
     return result
   }
 
-  return { handleDrop }
+  return {
+    handleDrop,
+    hasFilesOrFolders,
+  }
 }
 
 function traverseFileTree (item: FileSystemEntry, path = ''): Promise<FileSelection[]> {

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -13,6 +13,7 @@ import { makeVSheetProps, VSheet } from '@/components/VSheet/VSheet'
 // Composables
 import { makeDelayProps } from '@/composables/delay'
 import { makeDensityProps, useDensity } from '@/composables/density'
+import { useFileDrop } from '@/composables/fileDrop'
 import { IconValue } from '@/composables/icons'
 import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
@@ -110,6 +111,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
     const isDragging = shallowRef(false)
     const vSheetRef = ref<InstanceType<typeof VSheet> | null>(null)
     const inputRef = ref<HTMLInputElement | null>(null)
+    const { handleDrop } = useFileDrop()
 
     function onDragover (e: DragEvent) {
       e.preventDefault()
@@ -122,16 +124,15 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       isDragging.value = false
     }
 
-    function onDrop (e: DragEvent) {
+    async function onDrop (e: DragEvent) {
       e.preventDefault()
       e.stopImmediatePropagation()
       isDragging.value = false
 
-      if (!e.dataTransfer?.files?.length || !inputRef.value) return
+      if (!inputRef.value) return
 
       const dataTransfer = new DataTransfer()
-
-      for (const file of e.dataTransfer.files) {
+      for (const file of await handleDrop(e)) {
         dataTransfer.items.add(file)
       }
 


### PR DESCRIPTION
## Description

fixes #21494

## Markup:

```vue
<template>
  <v-app>
    <v-row>
      <v-col class="elevation-5 pa-6" cols="3">
        <div class="text-caption">Drag & Drop verification checklist:</div>
        <v-list class="bg-transparent" density="compact" select-strategy="independent" selectable>
          <v-list-item v-for="c in checklist" :key="c" :title="c" :value="c">
            <template #prepend="{ isSelected, select }">
              <v-checkbox-btn :model-value="isSelected" @update:model-value="select" />
            </template>
          </v-list-item>
        </v-list>
      </v-col>
      <v-col>
        <v-container>
          <v-file-input v-model="files" multiple webkitdirectory />
          <pre>files: {{ files }}</pre>
          <v-file-upload multiple webkitdirectory />
          <img
            alt="Vue logo"
            height="100px"
            src="https://cdn.vuetifyjs.com/docs/images/one/logos/vplay-logo-dark.png"
          >
        </v-container>
      </v-col>
    </v-row>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const files = ref([])

  const checklist = [
    'image below (should be ignored)',
    'selected text (should be ignored)',
    'single file',
    'more files',
    'single folder',
    'more folders',
    'mix of files and folders',
  ]
</script>
```
