### PR TITLE
fix(VOtpInput): Use rounded prop

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.sass
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.sass
@@ -15,6 +15,11 @@
     .v-field
       height: 100%
 
+      .v-field__outline
+        &__start,
+        &__end
+          flex: 1
+
   .v-otp-input__divider
     margin: $otp-input-divider-margin
 

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -203,6 +203,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
         disabled: toRef(() => props.disabled),
         error: toRef(() => props.error),
         variant: toRef(() => props.variant),
+        rounded: toRef(() => props.rounded),
       },
     }, { scoped: true })
 

--- a/packages/vuetify/src/components/VOtpInput/__tests__/VOtpInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VOtpInput/__tests__/VOtpInput.spec.browser.tsx
@@ -111,7 +111,7 @@ describe('VOtpInput', () => {
     render(() => (
       <VOtpInput
         modelValue={ modelValue.value }
-        onUpdate:modelValue={ val => { modelValue.value = val } }
+        onUpdate:modelValue={ (val: string) => { modelValue.value = val } }
       />
     ))
     const inputs = screen.getAllByCSS('.v-otp-input input')


### PR DESCRIPTION
fixes #20286

## Description
Use rounded prop on VOtpInput's VField 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input rounded="xl" />
    </v-container>
  </v-app>
</template>

```
