### PR TITLE
feat(VNavigationDrawer): add force-expand to override hover expand

### DIFF
--- a/packages/api-generator/src/locale/en/VNavigationDrawer.json
+++ b/packages/api-generator/src/locale/en/VNavigationDrawer.json
@@ -6,6 +6,7 @@
     "disableRouteWatcher": "Disables opening of navigation drawer when route changes.",
     "expandOnHover": "Collapses the drawer to a **rail-variant** until hovering with the mouse.",
     "floating": "A floating drawer has no visible container (no border-right).",
+    "forceExpand": "Forces the drawer to remain expanded even when the user is not hovering. Only applies when **expand-on-hover** is enabled.",
     "height": "Sets the height of the navigation drawer.",
     "image": "Apply a specific background image to the component.",
     "miniVariantWidth": "Designates the width assigned when the `mini` prop is turned on.",

--- a/packages/docs/src/examples/v-navigation-drawer/prop-force-expand.vue
+++ b/packages/docs/src/examples/v-navigation-drawer/prop-force-expand.vue
@@ -2,6 +2,7 @@
   <v-card>
     <v-layout>
       <v-navigation-drawer
+        :force-expand="forceExpand"
         expand-on-hover
         permanent
         rail
@@ -9,9 +10,10 @@
         <v-list>
           <v-list-item
             prepend-avatar="https://randomuser.me/api/portraits/women/85.jpg"
-            subtitle="sandra_a88@gmailcom"
+            subtitle="sandra@gmail.com"
             title="Sandra Adams"
-          ></v-list-item>
+          >
+          </v-list-item>
         </v-list>
 
         <v-divider></v-divider>
@@ -22,8 +24,30 @@
           <v-list-item prepend-icon="mdi-star" title="Starred" value="starred"></v-list-item>
         </v-list>
       </v-navigation-drawer>
+      <v-main style="height: 250px">
+        <div class="d-flex justify-end">
 
-      <v-main style="height: 250px"></v-main>
+          <v-switch v-model="forceExpand" class="mx-5" label="Toggle Force Expand"></v-switch>
+        </div>
+
+      </v-main>
     </v-layout>
   </v-card>
 </template>
+
+  <script setup>
+  import { ref } from 'vue'
+
+  const forceExpand = ref(true)
+
+  </script>
+
+<script>
+  export default {
+    data () {
+      return {
+        forceExpand: true,
+      }
+    },
+  }
+</script>

--- a/packages/docs/src/pages/en/components/navigation-drawers.md
+++ b/packages/docs/src/pages/en/components/navigation-drawers.md
@@ -75,6 +75,13 @@ Places the component in **rail** mode and expands once hovered. This **does not*
 
 <ExamplesExample file="v-navigation-drawer/prop-expand-on-hover" />
 
+#### Force Expand
+
+Allows the drawer to remain visually expanded even when the user is not hovering, without disabling **rail** mode.
+Only applies when **expand-on-hover** is enabled.
+
+<ExamplesExample file="v-navigation-drawer/prop-force-expand" />
+
 #### Background images
 
 Apply a custom background to your drawer via the **image** prop. If you need to customize it further, you can use the `image` slot and render your own `v-img`.

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -52,6 +52,7 @@ export const makeVNavigationDrawerProps = propsFactory({
   disableRouteWatcher: Boolean,
   expandOnHover: Boolean,
   floating: Boolean,
+  forceExpand: Boolean,
   modelValue: {
     type: Boolean as PropType<boolean | null>,
     default: null,
@@ -119,10 +120,12 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     const { scopeId } = useScopeId()
 
     const rootEl = ref<HTMLElement>()
-    const isHovering = shallowRef(false)
+    const isHovering = shallowRef<Boolean>(props.forceExpand)
 
     const { runOpenDelay, runCloseDelay } = useDelay(props, value => {
-      isHovering.value = value
+      if (!props.forceExpand) {
+        isHovering.value = value
+      }
     })
 
     const width = computed(() => {
@@ -142,6 +145,9 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
     )
 
     useToggleScope(() => props.expandOnHover && props.rail != null, () => {
+      watch(() => props.forceExpand, () => {
+        isHovering.value = props.forceExpand
+      })
       watch(isHovering, val => emit('update:rail', !val))
     })
 


### PR DESCRIPTION
## Description

Resolves #20591 

Allows the drawer to remain visually expanded even when the user is not hovering, without disabling `rail` mode. 
Only applies when `expand-on-hover` is enabled. Useful for cases like renaming items where a stable expanded view is needed.

## Markup:
```vue
<template>
  <v-app>
    <v-main>
      <v-navigation-drawer expand-on-hover force-expand rail>
        <v-list density="compact" nav>
          <v-list-item></v-list-item>
          <v-list-item></v-list-item>
          <v-list-item></v-list-item>
        </v-list>
      </v-navigation-drawer>
    </v-main>
  </v-app>
</template>
```
