### PR TITLE
docs(VDataTable): select all via short key example

### DIFF
--- a/packages/docs/src/examples/v-data-table/misc-select-all.vue
+++ b/packages/docs/src/examples/v-data-table/misc-select-all.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-data-table
+    v-model="selected"
+    :items="items"
+    item-value="name"
+    tabindex="0"
+    show-select
+    @keydown.ctrl.a.prevent="onKeydownA"
+    @keydown.meta.a.prevent="onKeydownA"
+  ></v-data-table>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const selected = ref([])
+
+  const items = [
+    { name: 'Alice Johnson', email: 'alice@example.com', age: 42 },
+    { name: 'Bob Smith', email: 'bob@example.com', age: 36 },
+    { name: 'Charlie Davis', email: 'charlie@example.com', age: 24 },
+    { name: 'Diana Prince', email: 'diana@example.com', age: 30 },
+  ]
+
+  function onKeydownA () {
+    selected.value = selected.value.length === 0 ? items.map(item => item.name) : []
+  }
+</script>
+
+<script>
+  export default {
+    data () {
+      return {
+        items: [
+          { name: 'Alice Johnson', email: 'alice@example.com', age: 42 },
+          { name: 'Bob Smith', email: 'bob@example.com', age: 36 },
+          { name: 'Charlie Davis', email: 'charlie@example.com', age: 24 },
+          { name: 'Diana Prince', email: 'diana@example.com', age: 30 },
+        ],
+        selected: [],
+      }
+    },
+    methods: {
+      onKeydownA () {
+        this.selected = this.selected.value.length === 0 ? items.map(item => item.name) : []
+      },
+    },
+  }
+</script>

--- a/packages/docs/src/pages/en/components/data-tables/basics.md
+++ b/packages/docs/src/pages/en/components/data-tables/basics.md
@@ -214,6 +214,14 @@ The `loading` slot allows you to customize your table's display state when fetch
 
 <ExamplesExample file="v-data-table/slot-loading" />
 
+### Misc
+
+#### Select All
+
+The example below shows how to use the `@keydown` event to quickly select all rows in the data table using the `Ctrl+A` or `Cmd+A` keyboard shortcut. To begin using the shortcut, click anywhere inside the table first.
+
+<ExamplesExample file="v-data-table/misc-select-all" />
+
 ## Examples
 
 The following are a collection of examples that demonstrate more advanced and real world use of the `v-data-table` component.


### PR DESCRIPTION
## Description

resolved #21065 

An example showcasing how to have keyboard shortcuts `Ctrl+A` or `Cmd+A`  select all rows in `v-data-table`.

https://github.com/user-attachments/assets/acfd18ef-690b-4295-a46d-c214f2ebd4d4