### PR TITLE
fix(VChip): disable close button of disabled chip

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -143,7 +143,7 @@ export const VChip = genericComponent<VChipSlots>()({
     )
     const closeProps = toRef(() => ({
       'aria-label': t(props.closeLabel),
-      'disabled': props.disabled,
+      disabled: props.disabled,
       onClick (e: MouseEvent) {
         e.preventDefault()
         e.stopPropagation()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #21502
Add disabled prop to the closeable button

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->
Form the bug report
<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="text-center">
    <v-chip
      v-if="chip"
      class="ma-2"
      closable
      @click:close="chip = false"
      disabled
    >
      Closable
    </v-chip>

    <v-btn v-if="!chip" color="primary" @click="chip = true">
      Reset Chip
    </v-btn>
  </div>
</template>

<script setup>
  import { ref } from 'vue'

  const chip = ref(true)
</script>

```
