### PR TITLE
fix(VSelect): reuse compact chip label style

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.sass
@@ -3,9 +3,12 @@
 @use '../../styles/settings'
 @use '../../styles/tools'
 @use './variables' as *
+@use '../VSelect/mixins' as *
 
 @include tools.layer('components')
   .v-autocomplete
+    @include select-compact-chip-label
+
     .v-field
       .v-text-field__prefix,
       .v-text-field__suffix,
@@ -56,15 +59,6 @@
     &__selection
       &:first-child
         margin-inline-start: 0
-
-    &--chips.v-input--density-compact
-      .v-field--variant-solo,
-      .v-field--variant-solo-inverted,
-      .v-field--variant-filled,
-      .v-field--variant-solo-filled
-        .v-label.v-field-label
-          &--floating
-            top: 0px
 
     &--selecting-index
       .v-autocomplete__selection

--- a/packages/vuetify/src/components/VCombobox/VCombobox.sass
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.sass
@@ -3,9 +3,12 @@
 @use '../../styles/settings'
 @use '../../styles/tools'
 @use './variables' as *
+@use '../VSelect/mixins' as *
 
 @include tools.layer('components')
   .v-combobox
+    @include select-compact-chip-label
+
     .v-field
       .v-text-field__prefix,
       .v-text-field__suffix,
@@ -56,15 +59,6 @@
     &__selection
       &:first-child
         margin-inline-start: 0
-
-    &--chips.v-input--density-compact
-      .v-field--variant-solo,
-      .v-field--variant-solo-inverted,
-      .v-field--variant-filled,
-      .v-field--variant-solo-filled
-        .v-label.v-field-label
-          &--floating
-            top: 0px
 
     &--selecting-index
       .v-combobox__selection

--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -3,9 +3,12 @@
 @use '../../styles/settings'
 @use '../../styles/tools'
 @use './variables' as *
+@use './mixins' as *
 
 @include tools.layer('components')
   .v-select
+    @include select-compact-chip-label
+
     .v-field
       .v-text-field__prefix,
       .v-text-field__suffix,

--- a/packages/vuetify/src/components/VSelect/_mixins.scss
+++ b/packages/vuetify/src/components/VSelect/_mixins.scss
@@ -1,0 +1,14 @@
+@mixin select-compact-chip-label {
+  &--chips.v-input--density-compact {
+    .v-field--variant-solo,
+    .v-field--variant-solo-inverted,
+    .v-field--variant-filled,
+    .v-field--variant-solo-filled {
+      .v-label.v-field-label {
+        &--floating {
+          top: 0px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes #19677

## Description
Fix chips size overlapping with label when using compact density and chips for a v-select component.
This wasn't a problem on VAutocomplete and VCombobox due to a css which was missing on VSelect

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select
        chips
        label="Select"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        multiple
        density="compact"
        :closable-chips="true"
      ></v-select>

      <v-autocomplete
        chips
        multiple
        label="Autocomplete"
        density="compact"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :closable-chips="true"
      ></v-autocomplete>

      <v-combobox
        chips
        multiple
        label="Combobox"
        density="compact"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :closable-chips="true"
      ></v-combobox>
    </v-container>
  </v-app>
</template>
```
