### PR TITLE
docs: fix search and favorite results

### DIFF
--- a/packages/docs/src/components/app/search/SearchDialog.vue
+++ b/packages/docs/src/components/app/search/SearchDialog.vue
@@ -137,11 +137,11 @@
     if (!Array.isArray(value)) {
       return []
     }
-    return value
+    return value.filter(Boolean)
   }
 
   const searches = shallowRef(getLocalStorage('searches'))
-  const favorites = shallowRef(getLocalStorage('favorite'))
+  const favorites = shallowRef(getLocalStorage('favorites'))
 
   const locale = 'en'
 
@@ -235,7 +235,9 @@
     source.splice(index, 1)
 
     const target = to.value.slice(0, 6)
-    target.unshift(item)
+    if (item) {
+      target.unshift(item)
+    }
 
     from.value = source
     to.value = target


### PR DESCRIPTION
## Description

Upon refresh, search and favourites are not showing on the Search Results dialog in the doc site. This is due to a `null` value being added to the list of results. This PR makes sure to clean the array results when fetching and adding to it.