### PR TITLE
Doc/20087 v tooltip target cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,5 @@
       "geckodriver",
       "nx"
     ]
-  },
-  "dependencies": {
-    "@vuetify/vuetify-root": "link:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -106,5 +106,8 @@
       "geckodriver",
       "nx"
     ]
+  },
+  "dependencies": {
+    "@vuetify/vuetify-root": "link:"
   }
 }

--- a/packages/docs/src/examples/v-tooltip/misc-at-cursor.vue
+++ b/packages/docs/src/examples/v-tooltip/misc-at-cursor.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="d-flex justify-center" @mouseout="cursor = false">
+    <v-tooltip v-model="cursor" :open-on-hover="false" target="cursor" open-on-click>
+      <template v-slot:activator="{ props }">
+        <v-card
+          v-bind="props"
+          height="300"
+          image="https://picsum.photos/600/300"
+          width="600"
+        ></v-card>
+      </template>
+      <span>I will appear at cursor</span>
+    </v-tooltip>
+  </div>
+</template>
+
+  <script setup>
+  import { ref } from 'vue'
+
+  const cursor = ref(false)
+
+</script>

--- a/packages/docs/src/examples/v-tooltip/misc-at-cursor.vue
+++ b/packages/docs/src/examples/v-tooltip/misc-at-cursor.vue
@@ -14,9 +14,16 @@
   </div>
 </template>
 
-  <script setup>
+<script setup>
   import { ref } from 'vue'
 
   const cursor = ref(false)
+</script>
 
+<script>
+  export default {
+    data: () => ({
+      cursor: false,
+    }),
+  }
 </script>

--- a/packages/docs/src/examples/v-tooltip/prop-interactive.vue
+++ b/packages/docs/src/examples/v-tooltip/prop-interactive.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="d-flex justify-center">
+    <v-tooltip interactive>
+      <template v-slot:activator="{ props: activatorProps }">
+        <v-icon-btn icon="mdi-information-outline" v-bind="activatorProps"></v-icon-btn>
+      </template>
+      <div><a class="text-primary font-weight-medium" href="/blog/announcing-vuetify-3.8/#vtooltip-interactive">Learn more</a> about interactive tooltip.</div>
+    </v-tooltip>
+  </div>
+</template>
+
+    <script setup>
+  import { ref } from 'vue'
+
+  const cursor = ref(false)
+
+  </script>

--- a/packages/docs/src/examples/v-tooltip/prop-interactive.vue
+++ b/packages/docs/src/examples/v-tooltip/prop-interactive.vue
@@ -4,14 +4,10 @@
       <template v-slot:activator="{ props: activatorProps }">
         <v-icon-btn icon="mdi-information-outline" v-bind="activatorProps"></v-icon-btn>
       </template>
-      <div><a class="text-primary font-weight-medium" href="/blog/announcing-vuetify-3.8/#vtooltip-interactive">Learn more</a> about interactive tooltip.</div>
+      <div>
+        <a class="text-primary font-weight-medium" href="/blog/announcing-vuetify-3.8/#vtooltip-interactive">Learn more</a>
+        about interactive tooltip.
+      </div>
     </v-tooltip>
   </div>
 </template>
-
-    <script setup>
-  import { ref } from 'vue'
-
-  const cursor = ref(false)
-
-  </script>

--- a/packages/docs/src/examples/v-tooltip/prop-open-on-click.vue
+++ b/packages/docs/src/examples/v-tooltip/prop-open-on-click.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="text-center d-flex align-center justify-space-around">
+    <v-tooltip :open-on-hover="false" open-on-click>
+      <template v-slot:activator="{ props }">
+        <v-btn v-bind="props">Click me</v-btn>
+      </template>
+      <span>Open on click tooltip</span>
+    </v-tooltip>
+  </div>
+</template>

--- a/packages/docs/src/pages/en/components/tooltips.md
+++ b/packages/docs/src/pages/en/components/tooltips.md
@@ -41,6 +41,12 @@ Tooltips can wrap any element.
 
 ### Props
 
+#### Interactive
+
+The **interactive** prop prevents the tooltip from closing during mouse interactions. For example, if the tooltip contains text that users might want to click or copy.
+
+<ExamplesExample file="v-tooltip/prop-interactive" />
+
 #### Location
 
 Use the **location** prop to specify on which side of the element the tooltip should show. Read more about **location** [here](/components/overlays/#location).

--- a/packages/docs/src/pages/en/components/tooltips.md
+++ b/packages/docs/src/pages/en/components/tooltips.md
@@ -55,8 +55,22 @@ Tooltip color can be set with the `color` prop.
 <ExamplesExample file="v-tooltip/prop-color" />
 -->
 
+#### Open on Click
+
+The **open-on-click** prop allows tooltip to open when the activator is clicked. Useful for touch devices or when manual triggering is preferred.
+
+<ExamplesExample file="v-tooltip/prop-open-on-click"/>
+
 #### Visibility
 
 Tooltip visibility can be programmatically changed using `v-model`.
 
 <ExamplesExample file="v-tooltip/prop-visibility" />
+
+### Misc
+
+#### Tooltip at cursor
+
+Tooltip can appear where the cursor is by using setting the **target** prop to `cursor`. This is currently only available with **open-on-click**.
+
+<ExamplesExample file="v-tooltip/misc-at-cursor" />


### PR DESCRIPTION
## Description
resolves #20087

New examples for **Tooltip** component:
1. `interactive` - enable mouse interactions on tooltip
2. `open-on-click` - clicking the activator toggle opens the tooltip
3. `target=cursor` - open tooltip where cursor is
