### PR TITLE
fix(VSlider): Apply color to slider label

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -193,6 +193,7 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
               <div
                 class={[
                   'v-slider-thumb__label',
+                  textColorClasses.value,
                 ]}
               >
                 <div>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #21527

appy textcolor to slider label

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container class="mt-5">
      <v-slider color="primary" thumb-label="always" thumb-color="red">
      </v-slider>
    </v-container>
  </v-app>
</template>

```

![image](https://github.com/user-attachments/assets/d747eec1-2aad-4090-964c-65a537e5305e)

