### PR TITLE
fix(VFileUpload): file name not passed correctly

### DIFF
--- a/packages/vuetify/src/labs/VFileUpload/VFileUploadItem.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUploadItem.tsx
@@ -72,6 +72,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
         >
           {{
             ...slots,
+            title: () => props?.title ?? props.file?.name,
             prepend: slotProps => (
               <>
                 { !slots.prepend ? (


### PR DESCRIPTION
## Description

- Fixes: https://github.com/vuetifyjs/vuetify/issues/21319

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <VFileUpload v-model="files">
        <template #title>
          <p>Drag and Drop Here</p>
        </template>
      </VFileUpload>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const files = ref([])
</script>

```
