### PR TITLE
fix(VSelect): camelize props only for custom use

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -26,6 +26,7 @@ import { makeTransitionProps } from '@/composables/transition'
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, toRef, watch } from 'vue'
 import {
+  camelizeProps,
   checkPrintable,
   deepEqual,
   ensureValidVNode,
@@ -457,6 +458,8 @@ export const VSelect = genericComponent<new <
 
                       <VVirtualScroll ref={ vVirtualScrollRef } renderless items={ displayItems.value } itemKey="value">
                         { ({ item, index, itemRef }) => {
+                          const camelizedProps = camelizeProps(item.props)
+
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,
                             key: item.value,
@@ -481,12 +484,12 @@ export const VSelect = genericComponent<new <
                                       />
                                     ) : undefined }
 
-                                    { item.props.prependAvatar && (
-                                      <VAvatar image={ item.props.prependAvatar } />
+                                    { camelizedProps.prependAvatar && (
+                                      <VAvatar image={ camelizedProps.prependAvatar } />
                                     )}
 
-                                    { item.props.prependIcon && (
-                                      <VIcon icon={ item.props.prependIcon } />
+                                    { camelizedProps.prependIcon && (
+                                      <VIcon icon={ camelizedProps.prependIcon } />
                                     )}
                                   </>
                                 ),

--- a/packages/vuetify/src/composables/list-items.ts
+++ b/packages/vuetify/src/composables/list-items.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { computed, shallowRef, watchEffect } from 'vue'
-import { camelizeProps, deepEqual, getPropertyFromItem, isPrimitive, omit, pick, propsFactory } from '@/util'
+import { deepEqual, getPropertyFromItem, isPrimitive, omit, pick, propsFactory } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -68,7 +68,7 @@ export function transformItem (props: Omit<ItemProps, 'items'>, item: any): List
   const _props = {
     title,
     value,
-    ...camelizeProps(itemProps),
+    ...itemProps,
   }
 
   return {

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -803,12 +803,10 @@ export function extractNumber (text: string, decimalDigitsLimit: number | null) 
   return cleanText
 }
 
-export function camelizeProps (props: Record<string, unknown> | null | undefined) {
-  if (!props) return
-
-  const out: Record<string, unknown> = {}
+export function camelizeProps<T extends Record<string, unknown>> (props: T | null): T {
+  const out = {} as T
   for (const prop in props) {
-    out[camelize(prop)] = props[prop]
+    out[camelize(prop) as keyof T] = props[prop]
   }
   return out
 }


### PR DESCRIPTION
fixes #21533

## Description
Camelize props only for where it's used.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select
        menu
        :item-props="itemProps"
        :items="items"
        label="User"
      ></v-select>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')

  const items = [
      {
      name: 'John',
      department: 'Marketing',
    },
    {
      name: 'Jane',
      department: 'Engineering',
    },
    {
      name: 'Joe',
      department: 'Sales',
    },
    {
      name: 'Janet',
      department: 'Engineering',
    },
    {
      name: 'Jake',
      department: 'Marketing',
    },
    {
      name: 'Jack',
      department: 'Sales',
    },
  ]

  function itemProps (item) {
    return {
      title: item.name,
      'prepend-icon': 'mdi-account',
      subtitle: item.department,
      "data-testid": "test id",
    }
  }
</script>
```