### PR TITLE
fix(VTimePicker): Value not changing on wheel

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerClock.tsx
@@ -66,6 +66,7 @@ export const VTimePickerClock = genericComponent()({
     const isDragging = ref(false)
     const valueOnMouseDown = ref(null as number | null)
     const valueOnMouseUp = ref(null as number | null)
+    const wheelTimeout = ref<NodeJS.Timeout | undefined>(undefined)
 
     const { textColorClasses, textColorStyles } = useTextColor(() => props.color)
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)
@@ -115,6 +116,8 @@ export const VTimePickerClock = genericComponent()({
       if (value !== props.displayedValue) {
         update(value)
       }
+      clearTimeout(wheelTimeout.value)
+      wheelTimeout.value = setTimeout(() => emit('change', value), 1000)
     }
 
     function isInner (value: number) {


### PR DESCRIPTION

## Description
Added Debounce to `wheel()` which will `emit('change')` switching hours to minutes and updating value
fixes #21524 

## Markup:
```
<template>
  <v-app>
    <v-container>
      <v-time-picker v-model="data" format="24hr" scrollable />
      <p>Current Time: {{ data }}</p>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const data = ref()
</script>
```
