### PR TITLE
docs(VList): deprecate `active-color` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VList.json
+++ b/packages/api-generator/src/locale/en/VList.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "activeColor": "Deprecated, use `color` instead.",
     "itemType": "Designates the key on the supplied items that is used for determining the nodes type.",
     "activatable": "Designates whether the list items are activatable.",
     "disabled": "Puts all children inputs into a disabled state.",

--- a/packages/api-generator/src/locale/en/VListGroup.json
+++ b/packages/api-generator/src/locale/en/VListGroup.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "activeColor": "Deprecated, use `color` instead.",
     "disabled": "Puts all children inputs into a disabled state.",
     "collapseIcon": "Icon to display when the list item is expanded.",
     "expandIcon": "Icon to display when the list item is collapsed.",

--- a/packages/api-generator/src/locale/en/VListItem.json
+++ b/packages/api-generator/src/locale/en/VListItem.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "active": "Controls the **active** state of the item. This is typically used to highlight the component.",
+    "activeColor": "Deprecated, use `color` instead.",
     "color": "Applies specified color to the control when in an **active** state or **input-value** is **true** - supports utility colors (for example `success` or `purple`) or css color (`#033` or `rgba(255, 0, 0, 0.5)`). Find a list of built-in classes on the [colors page](/styles/colors#material-colors),",
     "contained": "Changes the component style by changing how color is applied to the background.",
     "title": "Generates a `v-list-item-title` component with the supplied value. Note that this overrides the native [`title`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) attribute, that must be set with `v-bind:title.attr` instead.",


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Added `activeColor` deprecation message to API generator for `VList`, `VListGroup`, and `VListItem`

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
