### PR TITLE
fix(VField): do not reserve empty space for clear icon

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -224,21 +224,26 @@
 
   .v-field__clearable
     cursor: pointer
+    max-width: 0
     opacity: 0
     overflow: hidden
-    margin-inline: $field-clearable-margin
+    interpolate-size: allow-keywords
     transition: $field-transition-timing
-    transition-property: opacity, transform, width
+    transition-property: opacity, transform, max-width, margin
+    display: flex
+    justify-content: end
+    transform: translateX(calc(-0.5 * var(--v-field-padding-end) - #{$field-clearable-margin}))
 
+    .v-field:hover &,
     .v-field--focused &,
     .v-field--persistent-clear &
+      transform: translateX(calc(-0.5 * var(--v-field-padding-end)))
+      margin-inline: $field-clearable-margin
+      max-width: max-content
       opacity: 1
 
-    @media (hover: hover)
-      .v-field:hover &
-        opacity: 1
-
     @media (hover: none)
+      max-width: max-content
       opacity: 1
 
   /* endregion */

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -221,7 +221,7 @@ export const VField = genericComponent<new <T>(
       const isOutlined = props.variant === 'outlined'
       const hasPrepend = !!(slots['prepend-inner'] || props.prependInnerIcon)
       const hasClear = !!(props.clearable || slots.clear) && !props.disabled
-      const hasAppend = !!(slots['append-inner'] || props.appendInnerIcon || hasClear)
+      const hasAppend = !!(slots['append-inner'] || props.appendInnerIcon)
       const label = () => (
         slots.label
           ? slots.label({


### PR DESCRIPTION
## Description

Another take on the reserved space for clear icon.
- aims to keep fade-in/out on hover/focus
- [ ] verify RTL
- [ ] verify on VSelect with chips

Note1: I am not sure if I like the text shift in the textarea

Note2: we could just drop CSS in favor of JS transition - here is a [minor improvement](https://github.com/J-Sek/vuetify/commit/eddf6bd73a0942306c5b67e522ea617b41115dfe) on top of #20474. It would only need (1) detection for `media (hover: none)` and (2) approval for the behavior change

fixes #20375
closes #20474
closes #20534

## Markup:

```vue
<template>
  <v-container max-width="1000">
    <v-switch v-model="appendIcon" label="append icon" hide-details />
    <v-divider class="mb-6" />
    <v-row>
      <v-col cols="12" md="4">
        <v-text-field v-model="msg" :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" clearable />
        <v-text-field v-model="msg" :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" clearable persistent-clear />
        <v-text-field v-model="msg" :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" />
      </v-col>
      <v-col cols="12" md="4">
        <v-number-input v-model="num" :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" :precision="10" clearable />
        <v-number-input v-model="num" :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" :precision="10" clearable persistent-clear />
        <v-number-input v-model="num" :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" :precision="10" />
      </v-col>
      <v-col cols="12" md="4">
        <v-textarea v-model="msg" rows="2" auto-grow :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" clearable />
        <v-textarea v-model="msg" rows="2" auto-grow :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" clearable persistent-clear />
        <v-textarea v-model="msg" rows="2" auto-grow :append-inner-icon="appendIcon ? 'mdi-cow' : undefined" />
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'
  const num = ref(111111111111.000000001)
  const msg = ref('tax the rich / tax the rich / tax the rich / tax the rich / tax the rich / tax')
  const appendIcon = ref(false)
</script>
```
