### PR TITLE
fix(VDataTableHeaders): don't pass slots to VSelect in mobile view

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -265,7 +265,6 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
               onClick:append={ () => selectAll(!allSelected.value) }
             >
               {{
-                ...slots,
                 chip: props => (
                   <VChip
                     onClick={ props.item.raw?.sortable ? () => toggleSort(props.item.raw) : undefined }


### PR DESCRIPTION
## Description
fixes #19873

## Markup:
```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-data-table :headers="headers" :items="items" :mobile="true">
        <template #item="{ item, index }">
          <v-divider v-if="index !== 0" />
          <v-row class="row-mobile ma-0 pa-3">
            <v-col class="item-header-large" cols="6">Column 1</v-col>
            <v-col class="item-value-large" cols="6">{{ item.col1 }}</v-col>

            <v-col class="item-header-large" cols="6">Column 2</v-col>
            <v-col class="item-value-large" cols="6">{{ item.col2 }}</v-col>

            <v-col class="item-header-large" cols="6">Column 3</v-col>
            <v-col class="item-value-large" cols="6">{{ item.col3 }}</v-col>
          </v-row>
        </template>
      </v-data-table>
    </v-container>
  </v-app>
</template>

<script setup>
  const headers = [
    { title: 'Column 1', key: 'col1' },
    { title: 'Column 2', key: 'col2' },
    { title: 'Column 3', key: 'col3' },
  ]

  const items = [
    { col1: 'abc1', col2: 'def1', col3: 'ghi1' },
    { col1: 'abc2', col2: 'def2', col3: 'ghi2' },
    { col1: 'abc3', col2: 'def3', col3: 'ghi3' },
    { col1: 'abc4', col2: 'def4', col3: 'ghi4' },
  ]
</script>
```
