### PR TITLE
fix(VBtn): correct letter-spacing compensation for RTL

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -29,6 +29,9 @@
     vertical-align: $button-vertical-align
     flex-shrink: 0
 
+    .v-locale--is-rtl &
+      text-indent: -1 * $button-text-letter-spacing
+
     @at-root
       @include button-sizes()
       @include button-density('height', $button-density)


### PR DESCRIPTION
`letter-spacing` requires `text-indent` to make the button content appear centered (especially with numbers in `.v-btn--icon` that appear in VDatePicker). RTL layout requires negative offset.

Before:

![image](https://github.com/user-attachments/assets/b4123994-832e-4b2e-9929-aaf129494506)

After:

![image](https://github.com/user-attachments/assets/1de63d9c-35d3-4949-beed-fe18abb22f10)
