### PR TITLE
fix(VBtnToggle): buttons should be accessible despite overflow (#15398)

### DIFF
--- a/packages/vuetify/src/components/VBtnGroup/VBtnGroup.sass
+++ b/packages/vuetify/src/components/VBtnGroup/VBtnGroup.sass
@@ -11,7 +11,8 @@
     flex-wrap: nowrap
     max-width: 100%
     min-width: 0
-    overflow: hidden
+    overflow-y: hidden
+    overflow-x: auto
     vertical-align: middle
 
     @include tools.border($btn-group-border...)


### PR DESCRIPTION
## Description

- Fixes: https://github.com/vuetifyjs/vuetify/issues/15398

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn-toggle v-model="msg">
        <v-btn v-for="n in 6" :key="n" :value="n">{{ n }}</v-btn>
      </v-btn-toggle>
      <v-text-field v-model="msg" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref(0)

  const callNext = () => {
    msg.value++
  }
</script>
```
