### PR TITLE
docs(VCarousel): remove unused slot

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -50,7 +50,7 @@ export const makeVCarouselProps = propsFactory({
   }),
 }, 'VCarousel')
 
-type VCarouselSlots = VWindowSlots & {
+type VCarouselSlots = Omit<VWindowSlots, 'additional'> & {
   item: {
     props: Record<string, any>
     item: {


### PR DESCRIPTION
## Description

- `additional` slot should not be exposed in API docs for VCarousel because it is not used

