### PR TITLE
fix(VCarousel): avoid missing progress bar

### DIFF
--- a/packages/vuetify/src/components/VCarousel/VCarousel.sass
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.sass
@@ -43,7 +43,6 @@
   // Element
   .v-carousel__progress
     margin: 0
-    position: absolute
     bottom: 0
     left: 0
     right: 0

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -172,6 +172,7 @@ export const VCarousel = genericComponent<new <T>(
 
                 { props.progress && (
                   <VProgressLinear
+                    absolute
                     class="v-carousel__progress"
                     color={ typeof props.progress === 'string' ? props.progress : undefined }
                     modelValue={ (group.getItemIndex(model.value) + 1) / group.items.value.length * 100 }


### PR DESCRIPTION
## Description

Just a CSS specificity problem. The order of CSS is fine on documentation [page](https://vuetifyjs.com/en/components/carousels/#progress), but then after opening in VPlay, the bar get `position: relative` from VProgressLinear and lands below the carousel, not visible.