### PR TITLE
feat(VWindow): vertical arrows

### DIFF
--- a/packages/docs/src/examples/v-carousel/misc-vertical.vue
+++ b/packages/docs/src/examples/v-carousel/misc-vertical.vue
@@ -19,7 +19,7 @@
 
         <v-overlay
           :scrim="false"
-          content-class="w-100 h-100 d-flex flex-column align-center justify-space-between click-through py-3"
+          content-class="w-100 h-100 d-flex flex-column align-center justify-space-between pointer-pass-through py-3"
           contained
           model-value
           no-click-animation
@@ -123,13 +123,3 @@
     },
   }
 </script>
-
-<style>
-.click-through {
-  pointer-events: none;
-}
-
-.click-through > * {
-  pointer-events: auto;
-}
-</style>

--- a/packages/docs/src/examples/v-carousel/misc-vertical.vue
+++ b/packages/docs/src/examples/v-carousel/misc-vertical.vue
@@ -39,7 +39,7 @@
             </v-sheet>
           </v-scroll-x-transition>
           <v-chip
-            :text="`{{ currentIndex + 1 }} / ${items.length }`"
+            :text="`${ currentIndex + 1 } / ${items.length }`"
             color="#eee"
             size="small"
             variant="flat"

--- a/packages/docs/src/examples/v-carousel/misc-vertical.vue
+++ b/packages/docs/src/examples/v-carousel/misc-vertical.vue
@@ -1,0 +1,128 @@
+<template>
+  <v-defaults-provider :defaults="{ VBtn: { variant: 'outlined', color: '#eee' } }">
+    <v-sheet class="overflow-hidden" max-width="700" rounded="xl">
+      <v-carousel
+        v-model="currentIndex"
+        direction="vertical"
+        height="400"
+        progress="red"
+        vertical-arrows="left"
+        vertical-delimiters="right"
+        hide-delimiter-background
+      >
+        <v-carousel-item
+          v-for="(item, i) in items"
+          :key="i"
+          :src="item.src"
+          cover
+        ></v-carousel-item>
+        <v-overlay
+          :scrim="false"
+          content-class="w-100 h-100 d-flex flex-column align-center justify-space-between click-through py-3"
+          contained
+          model-value
+          no-click-animation
+          persistent
+        >
+          <v-scroll-x-transition mode="out-in" appear>
+            <v-sheet
+              :key="currentIndex"
+              rounded="xl"
+            >
+              <v-list-item
+                :prepend-avatar="`https://randomuser.me/api/portraits/${currentItem.avatarId}.jpg`"
+                :subtitle="currentItem.subtitle"
+                :title="currentItem.authorName"
+                class="pa-1 pr-6"
+              ></v-list-item>
+            </v-sheet>
+          </v-scroll-x-transition>
+          <v-chip color="#eee" size="small" variant="flat">{{ currentIndex + 1 }} / {{ items.length }}</v-chip>
+        </v-overlay>
+      </v-carousel>
+    </v-sheet>
+  </v-defaults-provider>
+</template>
+
+<script setup>
+  import { shallowRef, toRef } from 'vue'
+
+  const currentIndex = shallowRef(0)
+  const currentItem = toRef(() => items[currentIndex.value])
+  const items = [
+    {
+      authorName: 'Bettany Nichols',
+      avatarId: 'women/31',
+      subtitle: '31k followers',
+      src: 'https://cdn.vuetifyjs.com/images/carousel/squirrel.jpg',
+    },
+    {
+      authorName: 'Greg Kovalsky',
+      avatarId: 'men/61',
+      subtitle: '412 followers',
+      src: 'https://cdn.vuetifyjs.com/images/carousel/sky.jpg',
+    },
+    {
+      authorName: 'Emma Kathleen',
+      avatarId: 'women/34',
+      subtitle: '521 followers',
+      src: 'https://cdn.vuetifyjs.com/images/carousel/bird.jpg',
+    },
+    {
+      authorName: 'Anthony McKenzie',
+      avatarId: 'men/78',
+      subtitle: '6k followers',
+      src: 'https://cdn.vuetifyjs.com/images/carousel/planet.jpg',
+    },
+  ]
+</script>
+
+<script>
+  export default {
+    data () {
+      return {
+        currentIndex: 0,
+        items: [
+          {
+            authorName: 'Bettany Nichols',
+            avatarId: 'women/31',
+            subtitle: '31k followers',
+            src: 'https://cdn.vuetifyjs.com/images/carousel/squirrel.jpg',
+          },
+          {
+            authorName: 'Greg Kovalsky',
+            avatarId: 'men/61',
+            subtitle: '412 followers',
+            src: 'https://cdn.vuetifyjs.com/images/carousel/sky.jpg',
+          },
+          {
+            authorName: 'Emma Kathleen',
+            avatarId: 'women/34',
+            subtitle: '521 followers',
+            src: 'https://cdn.vuetifyjs.com/images/carousel/bird.jpg',
+          },
+          {
+            authorName: 'Anthony McKenzie',
+            avatarId: 'men/78',
+            subtitle: '6k followers',
+            src: 'https://cdn.vuetifyjs.com/images/carousel/planet.jpg',
+          },
+        ],
+      }
+    },
+    computed: {
+      currentItem () {
+        return this.items[this.currentIndex]
+      },
+    },
+  }
+</script>
+
+<style scoped>
+.click-through {
+  pointer-events: none;
+  > * {
+    pointer-events: auto;
+  }
+}
+</style>

--- a/packages/docs/src/examples/v-carousel/misc-vertical.vue
+++ b/packages/docs/src/examples/v-carousel/misc-vertical.vue
@@ -16,6 +16,7 @@
           :src="item.src"
           cover
         ></v-carousel-item>
+
         <v-overlay
           :scrim="false"
           content-class="w-100 h-100 d-flex flex-column align-center justify-space-between click-through py-3"
@@ -37,7 +38,12 @@
               ></v-list-item>
             </v-sheet>
           </v-scroll-x-transition>
-          <v-chip color="#eee" size="small" variant="flat">{{ currentIndex + 1 }} / {{ items.length }}</v-chip>
+          <v-chip
+            :text="`{{ currentIndex + 1 }} / ${items.length }`"
+            color="#eee"
+            size="small"
+            variant="flat"
+          ></v-chip>
         </v-overlay>
       </v-carousel>
     </v-sheet>
@@ -118,11 +124,12 @@
   }
 </script>
 
-<style scoped>
+<style>
 .click-through {
   pointer-events: none;
-  > * {
-    pointer-events: auto;
-  }
+}
+
+.click-through > * {
+  pointer-events: auto;
 }
 </style>

--- a/packages/docs/src/pages/en/components/carousels.md
+++ b/packages/docs/src/pages/en/components/carousels.md
@@ -88,3 +88,11 @@ You can show a linear progress bar with the **progress** prop. It will indicate 
 You can control carousel with **v-model**.
 
 <ExamplesExample file="v-carousel/prop-model" />
+
+### Misc
+
+#### Vertical with overlay content
+
+Carousel can be augmented with additional content simply by placing VOverlay next to it.
+
+<ExamplesExample file="v-carousel/misc-vertical" />

--- a/packages/vuetify/src/components/VWindow/VWindow.sass
+++ b/packages/vuetify/src/components/VWindow/VWindow.sass
@@ -41,6 +41,16 @@
         .v-window__right
           transform: translateX(0)
 
+    &--vertical-arrows
+      .v-window__controls
+        flex-direction: column
+        justify-content: center
+        gap: $window-controls-vertical-gap
+        .v-window__left,
+        .v-window__right
+          .v-icon
+            transform: rotate(90deg)
+
 @include tools.layer('transitions')
   .v-window
     &-x-transition,
@@ -84,3 +94,4 @@
 
       &-leave-to
         transform: translateY(100%)
+window__controls

--- a/packages/vuetify/src/components/VWindow/VWindow.sass
+++ b/packages/vuetify/src/components/VWindow/VWindow.sass
@@ -46,6 +46,13 @@
         flex-direction: column
         justify-content: center
         gap: $window-controls-vertical-gap
+
+        &--left
+          align-items: start
+
+        &--right
+          align-items: end
+
         .v-window__left,
         .v-window__right
           .v-icon
@@ -94,4 +101,3 @@
 
       &-leave-to
         transform: translateY(100%)
-window__controls

--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -65,6 +65,7 @@ export const makeVWindowProps = propsFactory({
     type: [Boolean, String],
     validator: (v: any) => typeof v === 'boolean' || v === 'hover',
   },
+  verticalArrows: [Boolean, String] as PropType<boolean | 'left' | 'right'>,
   touch: {
     type: [Object, Boolean] as PropType<boolean | TouchHandlers>,
     default: undefined,
@@ -228,6 +229,7 @@ export const VWindow = genericComponent<new <T>(
           'v-window',
           {
             'v-window--show-arrows-on-hover': props.showArrows === 'hover',
+            'v-window--vertical-arrows': props.verticalArrows,
           },
           themeClasses.value,
           props.class,
@@ -244,7 +246,16 @@ export const VWindow = genericComponent<new <T>(
           { slots.default?.({ group }) }
 
           { props.showArrows !== false && (
-            <div class="v-window__controls">
+            <div
+              class="v-window__controls"
+              style={{
+                alignItems: props.verticalArrows === 'right'
+                  ? 'end'
+                  : props.verticalArrows
+                    ? 'start'
+                    : 'center',
+              }}
+            >
               { arrows.value }
             </div>
           )}

--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -229,7 +229,7 @@ export const VWindow = genericComponent<new <T>(
           'v-window',
           {
             'v-window--show-arrows-on-hover': props.showArrows === 'hover',
-            'v-window--vertical-arrows': props.verticalArrows,
+            'v-window--vertical-arrows': !!props.verticalArrows,
           },
           themeClasses.value,
           props.class,
@@ -247,14 +247,11 @@ export const VWindow = genericComponent<new <T>(
 
           { props.showArrows !== false && (
             <div
-              class="v-window__controls"
-              style={{
-                alignItems: props.verticalArrows === 'right'
-                  ? 'end'
-                  : props.verticalArrows
-                    ? 'start'
-                    : 'center',
-              }}
+              class={[
+                'v-window__controls',
+                { 'v-window__controls--left': props.verticalArrows === 'left' || props.verticalArrows === true },
+                { 'v-window__controls--right': props.verticalArrows === 'right' },
+              ]}
             >
               { arrows.value }
             </div>

--- a/packages/vuetify/src/components/VWindow/_variables.scss
+++ b/packages/vuetify/src/components/VWindow/_variables.scss
@@ -3,3 +3,4 @@
 // VWindow
 $window-transition: .3s cubic-bezier(.25, .8, .50, 1) !default;
 $window-controls-padding: 0 16px !default;
+$window-controls-vertical-gap: 12px !default;

--- a/packages/vuetify/src/styles/utilities/_index.sass
+++ b/packages/vuetify/src/styles/utilities/_index.sass
@@ -5,6 +5,7 @@
 @use '../tools'
 @use './display'
 @use './elevation'
+@use './pointer-events'
 @use './screenreaders'
 
 @include tools.layer('utilities')

--- a/packages/vuetify/src/styles/utilities/_pointer-events.sass
+++ b/packages/vuetify/src/styles/utilities/_pointer-events.sass
@@ -1,0 +1,16 @@
+@use 'sass:list'
+@use '../settings'
+@use '../tools'
+
+@if (settings.$utilities != false and list.length(settings.$utilities) > 0)
+  @include tools.layer('utilities')
+    .pointer-events-none
+      pointer-events: none !important
+
+    .pointer-events-auto
+      pointer-events: auto !important
+
+    .pointer-pass-through
+      pointer-events: none !important
+      > *
+        pointer-events: auto !important


### PR DESCRIPTION
## Description

On v2 `vertical-delimiters` on VCarousel caused the arrows to be hidden (to avoid obstructing the delimiters). I think we can have both coexisting.

Example in Docs is VCarousel scope because the feature is primarily intended for carousels.

![image](https://github.com/user-attachments/assets/5b50d4a1-5f17-4965-aff4-97fe26471899)

## Markup:

```vue
<template>
  <v-app>
    <v-container max-width="700">
      <v-card elevation="24" rounded="xl">
        <v-carousel
          direction="vertical"
          height="400"
          vertical-arrows="left"
          vertical-delimiters="right"
        >
          <v-carousel-item v-for="i in 5" :key="i">
            <v-sheet height="100%">
              <div class="d-flex h-100 justify-center align-center">
                <div class="text-h2">Slide #{{ i }}</div>
              </div>
            </v-sheet>
          </v-carousel-item>
        </v-carousel>
      </v-card>
    </v-container>
  </v-app>
</template>
```
