### PR TITLE
fix(VDatePicker): round font-size from 13.6 to 14px

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/_variables.scss
+++ b/packages/vuetify/src/components/VDatePicker/_variables.scss
@@ -5,10 +5,10 @@ $date-picker-controls-height: var(--v-date-picker-controls-height, 56px) !defaul
 $date-picker-header-height: 70px !default;
 
 $date-picker-month-btn-height: 24px !default;
-$date-picker-month-btn-size: 0.85rem !default;
+$date-picker-month-btn-size: 0.875rem !default;
 $date-picker-month-column-gap: 4px !default;
 $date-picker-month-day-size: 40px !default;
-$date-picker-month-font-size: 0.85rem !default;
+$date-picker-month-font-size: 0.875rem !default;
 $date-picker-month-padding: 0 12px 8px !default;
 
 $date-picker-months-grid-gap: 0px 24px !default;


### PR DESCRIPTION
- round font size up based on the assumption that `.85rem` was a mistake.

Note 1: We could potentially apply CSS `round(...)` so developers won't need to adjust Sass variables or CSS if they configure the root font size to be something else than 16px... I would do it for my own projects, but I don't want to introduce magic here... unless someone else sees value in it.

Note 2: MD3 spec says 16pt currently and I can see 16px with 40px button size (instead of 36px) on date picker on Google Search Console. It is however rather an exception.. many places still have 14px.

> It may not be so evident on monitors with high density or scaling.

Before (13.6px)

![image](https://github.com/user-attachments/assets/fbf8b1c2-596c-4cfb-bcd9-9495a7d51878)

After (14px, aligned with other implementations)

![image](https://github.com/user-attachments/assets/c5a6b544-9dfd-4b30-ab14-57fed1710820)

