### PR TITLE
feat(VTimePicker): remove ampmInTitle prop

### DIFF
--- a/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePicker.tsx
@@ -34,7 +34,6 @@ export const makeVTimePickerProps = propsFactory({
   allowedHours: [Function, Array] as PropType<AllowFunction | number[]>,
   allowedMinutes: [Function, Array] as PropType<AllowFunction | number[]>,
   allowedSeconds: [Function, Array] as PropType<AllowFunction | number[]>,
-  ampmInTitle: Boolean,
   disabled: Boolean,
   format: {
     type: String as PropType<'ampm' | '24hr'>,
@@ -313,8 +312,7 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
             header: () => (
               <VTimePickerControls
                 { ...timePickerControlsProps }
-                ampm={ isAmPm.value || props.ampmInTitle }
-                ampmReadonly={ isAmPm.value && !props.ampmInTitle }
+                ampm={ isAmPm.value }
                 hour={ inputHour.value as number }
                 minute={ inputMinute.value as number }
                 period={ period.value }

--- a/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/labs/VTimePicker/VTimePickerControls.tsx
@@ -18,8 +18,6 @@ type Period = 'am' | 'pm'
 
 export const makeVTimePickerControlsProps = propsFactory({
   ampm: Boolean,
-  ampmInTitle: Boolean,
-  ampmReadonly: Boolean,
   color: String,
   disabled: Boolean,
   hour: Number,
@@ -94,74 +92,64 @@ export const VTimePickerControls = genericComponent()({
               onClick={ () => emit('update:viewMode', 'minute') }
             />
 
-            {
-              props.useSeconds && (
-                <span
-                  class={[
-                    'v-time-picker-controls__time__separator',
-                    { 'v-time-picker-controls--with-seconds__time__separator': props.useSeconds },
-                  ]}
-                  key="secondsDivider"
-                >:</span>
-              )
-            }
+            { props.useSeconds && (
+              <span
+                class={[
+                  'v-time-picker-controls__time__separator',
+                  { 'v-time-picker-controls--with-seconds__time__separator': props.useSeconds },
+                ]}
+                key="secondsDivider"
+              >:</span>
+            )}
 
-            {
-              props.useSeconds && (
+            { props.useSeconds && (
+              <VBtn
+                key="secondsVal"
+                active={ props.viewMode === 'second' }
+                color={ props.viewMode === 'second' ? props.color : undefined }
+                variant="tonal"
+                onClick={ () => emit('update:viewMode', 'second') }
+                class={{
+                  'v-time-picker-controls__time__btn': true,
+                  'v-time-picker-controls__time__btn__active': props.viewMode === 'second',
+                  'v-time-picker-controls__time--with-seconds__btn': props.useSeconds,
+                }}
+                disabled={ props.disabled }
+                text={ props.second == null ? '--' : pad(props.second) }
+              />
+            )}
+
+            { props.ampm && (
+              <div class="v-time-picker-controls__ampm">
                 <VBtn
-                  key="secondsVal"
-                  active={ props.viewMode === 'second' }
-                  color={ props.viewMode === 'second' ? props.color : undefined }
-                  variant="tonal"
-                  onClick={ () => emit('update:viewMode', 'second') }
+                  active={ props.period === 'am' }
+                  color={ props.period === 'am' ? props.color : undefined }
                   class={{
-                    'v-time-picker-controls__time__btn': true,
-                    'v-time-picker-controls__time__btn__active': props.viewMode === 'second',
-                    'v-time-picker-controls__time--with-seconds__btn': props.useSeconds,
+                    'v-time-picker-controls__ampm__am': true,
+                    'v-time-picker-controls__ampm__btn': true,
+                    'v-time-picker-controls__ampm__btn__active': props.period === 'am',
                   }}
                   disabled={ props.disabled }
-                  text={ props.second == null ? '--' : pad(props.second) }
+                  text={ t('$vuetify.timePicker.am') }
+                  variant={ props.disabled && props.period === 'am' ? 'elevated' : 'tonal' }
+                  onClick={ () => props.period !== 'am' ? emit('update:period', 'am') : null }
                 />
-              )
-            }
 
-            {
-              props.ampm && props.ampmInTitle && (
-                <div
-                  class={['v-time-picker-controls__ampm', {
-                    'v-time-picker-controls__ampm--readonly': props.ampmReadonly,
-                  }]}
-                >
-                  <VBtn
-                    active={ props.period === 'am' }
-                    color={ props.period === 'am' ? props.color : undefined }
-                    class={{
-                      'v-time-picker-controls__ampm__am': true,
-                      'v-time-picker-controls__ampm__btn': true,
-                      'v-time-picker-controls__ampm__btn__active': props.period === 'am',
-                    }}
-                    disabled={ props.disabled }
-                    text={ t('$vuetify.timePicker.am') }
-                    variant={ props.disabled && props.period === 'am' ? 'elevated' : 'tonal' }
-                    onClick={ () => props.period !== 'am' ? emit('update:period', 'am') : null }
-                  />
-
-                  <VBtn
-                    active={ props.period === 'pm' }
-                    color={ props.period === 'pm' ? props.color : undefined }
-                    class={{
-                      'v-time-picker-controls__ampm__pm': true,
-                      'v-time-picker-controls__ampm__btn': true,
-                      'v-time-picker-controls__ampm__btn__active': props.period === 'pm',
-                    }}
-                    disabled={ props.disabled }
-                    text={ t('$vuetify.timePicker.pm') }
-                    variant={ props.disabled && props.period === 'pm' ? 'elevated' : 'tonal' }
-                    onClick={ () => props.period !== 'pm' ? emit('update:period', 'pm') : null }
-                  />
-                </div>
-              )
-            }
+                <VBtn
+                  active={ props.period === 'pm' }
+                  color={ props.period === 'pm' ? props.color : undefined }
+                  class={{
+                    'v-time-picker-controls__ampm__pm': true,
+                    'v-time-picker-controls__ampm__btn': true,
+                    'v-time-picker-controls__ampm__btn__active': props.period === 'pm',
+                  }}
+                  disabled={ props.disabled }
+                  text={ t('$vuetify.timePicker.pm') }
+                  variant={ props.disabled && props.period === 'pm' ? 'elevated' : 'tonal' }
+                  onClick={ () => props.period !== 'pm' ? emit('update:period', 'pm') : null }
+                />
+              </div>
+            )}
           </div>
         </div>
       )


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

closes #19637
closes #19957
reverts #20178, there's no other am/pm button, so without setting `ampmInTitle` or `format="24hour"` you can't use pm times at all.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-time-picker v-model="time" />

      <pre>{{ time }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { computed, ref, watch } from 'vue'

  const time = ref()
</script>
```
