### PR TITLE
fix(VBtn): allow text values for letter-spacing Sass variable

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -1,5 +1,6 @@
 @use 'sass:math'
 @use 'sass:map'
+@use 'sass:meta'
 @use '../../styles/settings'
 @use '../../styles/tools'
 @use './mixins' as *
@@ -30,7 +31,8 @@
     flex-shrink: 0
 
     .v-locale--is-rtl &
-      text-indent: -1 * $button-text-letter-spacing
+      @if meta.type-of($button-text-letter-spacing) == 'number'
+        text-indent: -1 * $button-text-letter-spacing
 
     @at-root
       @include button-sizes()


### PR DESCRIPTION
## Description

- resolves #21600

Fixes regression after #21574
- noticed [by Matthew](https://github.com/vuetifyjs/vuetify/pull/21574/files/78470e826d8981a6242c38f3d5e742b07e444fc5#r2155200407)

## Markup:

```sass
$button-text-letter-spacing: initial
```
