### PR TITLE
fix(VAutocomplete): Let menu close by itself

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -378,7 +378,6 @@ export const VAutocomplete = genericComponent<new <
         nextTick(() => isSelecting.value = false)
       } else {
         if (!props.multiple && search.value == null) model.value = []
-        menu.value = false
         if (!isPristine.value && search.value) {
           _searchLock.value = search.value
         }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -425,7 +425,6 @@ export const VCombobox = genericComponent<new <
       if (val || val === oldVal) return
 
       selectionIndex.value = -1
-      menu.value = false
 
       if (search.value) {
         if (props.multiple) {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -317,11 +317,6 @@ export const VSelect = genericComponent<new <
         })
       }
     }
-    function onBlur (e: FocusEvent) {
-      if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
-        menu.value = false
-      }
-    }
     function onAfterEnter () {
       if (props.eager) {
         vVirtualScrollRef.value?.calculateVisibleItems()
@@ -409,7 +404,6 @@ export const VSelect = genericComponent<new <
           placeholder={ placeholder }
           onClick:clear={ onClear }
           onMousedown:control={ onMousedownControl }
-          onBlur={ onBlur }
           onKeydown={ onKeydown }
           aria-expanded={ ariaExpanded.value }
           aria-controls={ ariaControls.value }


### PR DESCRIPTION
fixes #20003

## Description
Let menu close by itself using its internal logic

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```html
    <v-select
      :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      label="Select"
    />

    <v-combobox
      :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      label="Combobox"
    />

    <v-menu :close-on-content-click="false" label="1 menu">
      <template #activator="{ props }">
        <v-btn v-bind="props">Menu with Autocomplete</v-btn>
      </template>
      <v-sheet class="pa-4" style="width: 300px;">
        <div class="d-flex">
          <v-autocomplete
            :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
            label="Autocomplete"
          />
        </div>
      </v-sheet>
    </v-menu>
```