### PR TITLE
fix(VInput): Remove redundant aria roles in v-input

### DIFF
--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -232,8 +232,6 @@ export const VInput = genericComponent<new <T>(
             <div
               id={ messagesId.value }
               class="v-input__details"
-              role="alert"
-              aria-live="polite"
             >
               <VMessages
                 active={ hasMessages }


### PR DESCRIPTION
## Description

There was a critical issue using v-input with screen readers. Because it had role="alert" applied immediately upon rendering, screen readers would repeat “alert” as many times as there were v-input components on the screen after page load. For example, if I had 5 input boxes in a page, I had to hear "alert alert alert alert alert" as the page finished loading. This issue significantly interrupted screen reader users' browsing experience.

I also removed aria-live="polite" as it was functionally redundant with role="alert".

Although alert role is no longer present, error messages are still announced correctly when they appear because the messages area is connected via aria-describedby. So, this change simply eliminates the redundant “alert” announcements without compromising the accessibility of the component.

I’ve tested this locally and confirmed that it works as expected. I hope the dev team can integrate this fix into the next patch version.

## Markup:

```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-row>
          <v-col cols="12">
            <h1 class="text-h2 mb-4">Page title</h1>

            <v-card>
              <v-card-title>Form</v-card-title>
              <v-card-text>
                <v-form @submit.prevent="onSubmit">
                  <v-text-field
                    v-model="name"
                    :rules="[rules.required]"
                    label="Name"
                    prepend-icon="mdi-account"
                  />
                  <v-text-field
                    v-model="email"
                    :rules="[rules.required]"
                    label="Email"
                    prepend-icon="mdi-email"
                    type="email"
                  />
                  <v-text-field
                    v-model="password"
                    :rules="[rules.required]"
                    label="Password"
                    prepend-icon="mdi-lock"
                    type="password"
                  />
                  <v-btn color="primary" text="Submit" type="submit" />
                </v-form>
              </v-card-text>
            </v-card>
          </v-col>
        </v-row>
      </v-container>
    </v-main>
  </v-app>
</template>

<script>
  export default {
    name: 'App',
    data () {
      return {
        name: '',
        email: '',
        password: '',
        rules: {
          required: value => !!value || 'This field is required',
        },
      }
    },
    methods: {
      async onSubmit (e) {
        const { valid } = await e
        if (valid) {
          alert(`Hello, ${this.name}!`)
        }
      },
    },
  }
</script>
```
