### PR TITLE
fix(VSelect, VAutocomplete, VCombobox): open menu on icon click

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -278,14 +278,7 @@ export const VField = genericComponent<new <T>(
           />
 
           { hasPrepend && (
-            <div
-              key="prepend"
-              class="v-field__prepend-inner"
-              onMousedown={ (e: MouseEvent) => {
-                e.preventDefault()
-                e.stopPropagation()
-              }}
-            >
+            <div key="prepend" class="v-field__prepend-inner">
               { props.prependInnerIcon && (
                 <InputIcon
                   key="prepend-icon"
@@ -377,14 +370,7 @@ export const VField = genericComponent<new <T>(
           )}
 
           { hasAppend && (
-            <div
-              key="append"
-              class="v-field__append-inner"
-              onMousedown={ (e: MouseEvent) => {
-                e.preventDefault()
-                e.stopPropagation()
-              }}
-            >
+            <div key="append" class="v-field__append-inner">
               { slots['append-inner']?.(slotProps.value) }
 
               { props.appendInnerIcon && (

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -46,6 +46,26 @@ const stories = Object.fromEntries(Object.entries({
 )]))
 
 describe('VSelect', () => {
+  it('should toggle menu with dropdown icon', async () => {
+    const { element } = render(() => (
+      <VSelect items={['Item #1', 'Item #2']} />
+    ))
+
+    const menuIcon = screen.getByCSS('.v-icon')
+    expect(screen.queryAllByCSS('.v-list-item')).toHaveLength(0)
+    expect(element).not.toHaveClass('v-select--active-menu')
+
+    await userEvent.click(menuIcon)
+    await commands.waitStable('.v-list')
+    expect(screen.queryAllByCSS('.v-list-item')).toHaveLength(2)
+    expect(element).toHaveClass('v-select--active-menu')
+
+    await userEvent.click(menuIcon)
+    await commands.waitStable('.v-list')
+    expect(screen.queryAllByCSS('.v-list-item')).toHaveLength(0)
+    expect(element).not.toHaveClass('v-select--active-menu')
+  })
+
   it('should render selection slot', () => {
     const items = [
       { title: 'a' },


### PR DESCRIPTION
## Description

Fixes #21607

Reverts #21217

Developers facing problems with VNumberInput are advised to use `@mousedown.stop` on the injected buttons.

This reverts commit 14524423646a06fe6962183cda84a38c68feb6fe.