### PR TITLE
fix(VDatePicker): completely hide days not in weekdays array

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
@@ -23,10 +23,10 @@
 
   .v-date-picker-month__days
     display: grid
-    grid-template-columns: min-content min-content min-content min-content min-content min-content min-content
+    grid-template-columns: repeat(var(--v-date-picker-days-in-week), min-content)
     column-gap: $date-picker-month-column-gap
     flex: 1 1
-    justify-content: space-around
+    justify-content: center
 
   .v-date-picker-month__day
     align-items: center

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
@@ -10,13 +10,10 @@
     --v-date-picker-month-day-diff: 4px
 
   .v-date-picker-month__weeks
-    display: grid
-    grid-template-rows: min-content min-content min-content min-content min-content min-content min-content
+    display: flex
+    flex-direction: column
     column-gap: $date-picker-month-column-gap
     font-size: $date-picker-month-font-size
-
-    + .v-date-picker-month__days
-      grid-row-gap: 0
 
   .v-date-picker-month__weekday
     font-size: $date-picker-month-font-size
@@ -25,8 +22,6 @@
     display: grid
     grid-template-columns: repeat(var(--v-date-picker-days-in-week), min-content)
     column-gap: $date-picker-month-column-gap
-    flex: 1 1
-    justify-content: center
 
   .v-date-picker-month__day
     align-items: center

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -57,7 +57,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
   setup (props, { emit, slots }) {
     const daysRef = ref()
 
-    const { daysInMonth, model, weekNumbers } = useCalendar(props)
+    const { daysInMonth, model, weekNumbers, weekDays, weekdayLabels } = useCalendar(props)
     const adapter = useDate()
 
     const rangeStart = shallowRef()
@@ -142,7 +142,10 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
     }
 
     useRender(() => (
-      <div class="v-date-picker-month">
+      <div
+        class="v-date-picker-month"
+        style={{ '--v-date-picker-days-in-week': weekDays.value.length }}
+      >
         { props.showWeek && (
           <div key="weeks" class="v-date-picker-month__weeks">
             { !props.hideWeekdays && (
@@ -165,7 +168,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
             key={ daysInMonth.value[0].date?.toString() }
             class="v-date-picker-month__days"
           >
-            { !props.hideWeekdays && adapter.getWeekdays(props.firstDayOfWeek).map(weekDay => (
+            { !props.hideWeekdays && weekdayLabels.value.map(weekDay => (
               <div
                 class={[
                   'v-date-picker-month__day',

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -122,8 +122,7 @@ export function useCalendar (props: CalendarProps) {
 
   const weekDays = computed(() => {
     const firstDayOfWeek = adapter.toJsDate(adapter.startOfWeek(adapter.date(), props.firstDayOfWeek)).getDay()
-    // Always generate all days, regardless of props.weekdays
-    return [0, 1, 2, 3, 4, 5, 6].map(day => (day + firstDayOfWeek) % 7)
+    return props.weekdays.map(day => (day + firstDayOfWeek) % 7)
   })
 
   const weeksInMonth = computed(() => {
@@ -223,7 +222,7 @@ export function useCalendar (props: CalendarProps) {
       return !props.allowedDates(date)
     }
 
-    return !props.weekdays.includes(adapter.toJsDate(date).getDay())
+    return false
   }
 
   return {

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -125,6 +125,12 @@ export function useCalendar (props: CalendarProps) {
     return props.weekdays.map(day => (day + firstDayOfWeek) % 7)
   })
 
+  const weekdayLabels = computed(() => {
+    const labels = adapter.getWeekdays(props.firstDayOfWeek)
+
+    return weekDays.value.map(day => labels[day])
+  })
+
   const weeksInMonth = computed(() => {
     const weeks = adapter.getWeekArray(month.value, props.firstDayOfWeek)
 
@@ -233,6 +239,7 @@ export function useCalendar (props: CalendarProps) {
     model,
     weeksInMonth,
     weekDays,
+    weekdayLabels,
     weekNumbers,
   }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
reverts b1f270b
alternate to #21619
fixes #21492
fixes #19718

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker />
      <v-date-picker :weekdays="[1, 2, 3, 4, 5]" />
      <v-date-picker show-week />
      <v-date-picker :weekdays="[1, 2, 3, 4, 5]" show-week />

      <v-calendar
        :weekdays="[1, 2, 3, 4, 5]"
        view-mode="month"
        hide-week-number
      />
      <v-calendar
        :weekdays="[1, 2, 3, 4, 5]"
        view-mode="month"
      />
    </v-container>
  </v-app>
</template>
```
