### PR TITLE
fix(VTextField): avoid infinite focus loop

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -105,7 +105,8 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
 
       nextTick(() => {
         if (inputRef.value !== document.activeElement) {
-          nextTick(() => inputRef.value?.focus())
+          inputRef.value?.focus()
+          // nextTick(() => inputRef.value?.focus())
         }
       })
     }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -105,8 +105,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
 
       nextTick(() => {
         if (inputRef.value !== document.activeElement) {
-          inputRef.value?.focus()
-          // nextTick(() => inputRef.value?.focus())
+          nextTick(() => inputRef.value?.focus())
         }
       })
     }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -105,7 +105,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
 
       nextTick(() => {
         if (inputRef.value !== document.activeElement) {
-          inputRef.value?.focus()
+          nextTick(() => inputRef.value?.focus())
         }
       })
     }

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
@@ -80,22 +80,16 @@ describe('VTextField', () => {
     const input1 = screen.getByCSS('input[name="username"]') as HTMLInputElement
     const input2 = screen.getByCSS('input[name="password"]') as HTMLInputElement
 
-    const timeout = await commands.abortAfter(5000, 'VTextField infinite loop detection')
+    await commands.abortAfter(5000, 'VTextField infinite loop detection')
 
     input1.focus()
     input1.value = 'my username'
-    input1.dispatchEvent(new InputEvent('input', {
-      bubbles: true,
-      inputType: 'insertFromPaste',
-    }))
+    input1.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertFromPaste' }))
     input1.dispatchEvent(new Event('change', { bubbles: true }))
 
     input2.focus()
     input2.value = 'my password'
-    input2.dispatchEvent(new InputEvent('input', {
-      bubbles: true,
-      inputType: 'insertFromPaste',
-    }))
+    input2.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertFromPaste' }))
     input2.dispatchEvent(new Event('change', { bubbles: true }))
 
     await wait(100)
@@ -106,7 +100,7 @@ describe('VTextField', () => {
     const menuContent = screen.getByCSS('.my-menu-content')
     expect(menuContent).toBeVisible()
 
-    clearTimeout(timeout)
+    await commands.clearAbortTimeout()
   })
 
   it('handles multiple options in validate-on prop', async () => {

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
@@ -4,7 +4,7 @@ import { VBtn } from '@/components/VBtn'
 import { VMenu } from '@/components/VMenu'
 
 // Utilities
-import { generate, render, screen, userEvent, wait } from '@test'
+import { commands, generate, render, screen, userEvent, wait } from '@test'
 import { cloneVNode } from 'vue'
 
 const variants = ['underlined', 'outlined', 'filled', 'solo', 'plain'] as const
@@ -80,9 +80,7 @@ describe('VTextField', () => {
     const input1 = screen.getByCSS('input[name="username"]') as HTMLInputElement
     const input2 = screen.getByCSS('input[name="password"]') as HTMLInputElement
 
-    const timeout = setTimeout(() => {
-      throw new Error('Test timeout. Possible regression - VTextField infinite focus loop')
-    }, 5000)
+    const timeout = await commands.breakExecutionAfter(5000)
 
     input1.focus()
     input1.value = 'my username'

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
@@ -80,7 +80,7 @@ describe('VTextField', () => {
     const input1 = screen.getByCSS('input[name="username"]') as HTMLInputElement
     const input2 = screen.getByCSS('input[name="password"]') as HTMLInputElement
 
-    const timeout = await commands.breakExecutionAfter(5000)
+    const timeout = await commands.abortAfter(5000, 'VTextField infinite loop detection')
 
     input1.focus()
     input1.value = 'my username'

--- a/packages/vuetify/test/setup/browser-commands.ts
+++ b/packages/vuetify/test/setup/browser-commands.ts
@@ -68,7 +68,21 @@ async function setFocusEmulationEnabled (ctx: BrowserCommandContext) {
   return ctx.browser.sendCommand('Emulation.setFocusEmulationEnabled', { enabled: true })
 }
 
-export const commands = { drag, scroll, isDisplayed, percySnapshot, waitStable, setFocusEmulationEnabled }
+async function breakExecutionAfter (ctx: BrowserCommandContext, delay: number) {
+  return setTimeout(() => {
+    throw new Error('Browser was paused. Test timeout')
+  }, delay)
+}
+
+export const commands = {
+  drag,
+  scroll,
+  isDisplayed,
+  percySnapshot,
+  waitStable,
+  setFocusEmulationEnabled,
+  breakExecutionAfter,
+}
 
 export type CustomCommands = {
   [k in keyof typeof commands]: typeof commands[k] extends (ctx: any, ...args: infer A) => any

--- a/packages/vuetify/test/setup/browser-commands.ts
+++ b/packages/vuetify/test/setup/browser-commands.ts
@@ -70,12 +70,13 @@ async function setFocusEmulationEnabled (ctx: BrowserCommandContext) {
 
 let abortTimeout: ReturnType<typeof setTimeout> = null!
 function abortAfter (ctx: BrowserCommandContext, delay: number, name: string) {
-  abortTimeout = setTimeout(() => {
+  abortTimeout = setTimeout(async () => {
     // eslint-disable-next-line no-console
-    console.error(`[Error] Test timeout: Aborting after ${delay}ms for ${name}.`)
+    console.error(`[Error] Test timeout: Aborting after ${delay}ms for ${name} in ${ctx.testPath}`)
     // eslint-disable-next-line no-console
     console.error('[Warning] "chrome" process might still be running and require manual shutdown.')
-    throw new Error('Abort')
+    process.exitCode = 1
+    await ctx.project.vitest.exit(true)
   }, delay)
 }
 

--- a/packages/vuetify/test/setup/browser-commands.ts
+++ b/packages/vuetify/test/setup/browser-commands.ts
@@ -68,12 +68,19 @@ async function setFocusEmulationEnabled (ctx: BrowserCommandContext) {
   return ctx.browser.sendCommand('Emulation.setFocusEmulationEnabled', { enabled: true })
 }
 
-async function abortAfter (ctx: BrowserCommandContext, delay: number, name: string) {
-  return setTimeout(() => {
+let abortTimeout: ReturnType<typeof setTimeout> = null!
+function abortAfter (ctx: BrowserCommandContext, delay: number, name: string) {
+  abortTimeout = setTimeout(() => {
     // eslint-disable-next-line no-console
-    console.error(`[Test timeout] Aborting after ${delay}ms for ${name}`)
+    console.error(`[Error] Test timeout: Aborting after ${delay}ms for ${name}.`)
+    // eslint-disable-next-line no-console
+    console.error('[Warning] "chrome" process might still be running and require manual shutdown.')
     throw new Error('Abort')
   }, delay)
+}
+
+function clearAbortTimeout (ctx: BrowserCommandContext) {
+  clearTimeout(abortTimeout)
 }
 
 export const commands = {
@@ -84,6 +91,7 @@ export const commands = {
   waitStable,
   setFocusEmulationEnabled,
   abortAfter,
+  clearAbortTimeout,
 }
 
 export type CustomCommands = {

--- a/packages/vuetify/test/setup/browser-commands.ts
+++ b/packages/vuetify/test/setup/browser-commands.ts
@@ -68,9 +68,11 @@ async function setFocusEmulationEnabled (ctx: BrowserCommandContext) {
   return ctx.browser.sendCommand('Emulation.setFocusEmulationEnabled', { enabled: true })
 }
 
-async function breakExecutionAfter (ctx: BrowserCommandContext, delay: number) {
+async function abortAfter (ctx: BrowserCommandContext, delay: number, name: string) {
   return setTimeout(() => {
-    throw new Error('Browser was paused. Test timeout')
+    // eslint-disable-next-line no-console
+    console.error(`[Test timeout] Aborting after ${delay}ms for ${name}`)
+    throw new Error('Abort')
   }, delay)
 }
 
@@ -81,7 +83,7 @@ export const commands = {
   percySnapshot,
   waitStable,
   setFocusEmulationEnabled,
-  breakExecutionAfter,
+  abortAfter,
 }
 
 export type CustomCommands = {

--- a/packages/vuetify/test/setup/browser-commands.ts
+++ b/packages/vuetify/test/setup/browser-commands.ts
@@ -68,7 +68,7 @@ async function setFocusEmulationEnabled (ctx: BrowserCommandContext) {
   return ctx.browser.sendCommand('Emulation.setFocusEmulationEnabled', { enabled: true })
 }
 
-let abortTimeout: ReturnType<typeof setTimeout> = null!
+let abortTimeout: ReturnType<typeof setTimeout>
 function abortAfter (ctx: BrowserCommandContext, delay: number, name: string) {
   abortTimeout = setTimeout(async () => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

Password managers attempt use `.focus()` when inserting value.
When 2 fields get focus, the `nextTick` makes them compete for focus in an infinite loop.

fixes #21626

[Playground](https://play.vuetifyjs.com/#eNrFVctu2zAQ/BWCF9uAZcduixaGE7QFGqBAD0VflygHmlrZRCiSpZZ+wMi/dynFD9mCE7SH6sQdzu6Sw1nobstLL4cfnBssA/AJnyIUTguEm9QwNl0mwrlqWQWFUOYpqmJpDRIEfg/WsPAZk1qU5XXKi3UiAtqUs0Ksk5XKcEHo66urlB9l7fMSVKjh5oudK8NurS9Ywn4FQJVv2McwZ9/AeZsFicqa6bCR01oN1tjYqLZyqnuCVnhkJ7kCnZ1uMqbFDDSd/GcJ3ogCUn7OiThRwgVK1EJa0hjwOarz4MBkiSKZo5CZSoSUNhhsYy+FV8IgEW1ATY+SnbOGdOm/vPZXes2V9S1F99d2Fyi4cc9RTpSRwXswmFxKaVFIW/nwL/I0pCF/tViFFJuhYdJq6+OdvCqE35DBZ7E5ey+1kg+0ES+UK63J6LtlrEi5TavuXdz06g4/DFwETiYuYvupjEE9r9Ph0RxTWEqvHLISMNTjnAdTjVClejxZt8e2dUlqUSJTxgUcsWuWWRkKeojB7wB+8x00SLS+26kId2eOv+/06jJ1gUFO6WW3iS2FDkClO8WG7TI7DUamSidQLj4tqXPXwIp9jht1mPKKlfL+04njNwuzmYZywtAH6B/wivqD3DdhMY+64a23BdkZ90P32Gue77z7rrFcCDOnvD7bNjvWNc4EHL9UwIPLmwKOWwQcNwTcZR4LOP6vArZ1f6GAVCqat7YrGZU/9vmrwZvB6C2Pi3eD0Yj3c6FL6Dd+XDV2/wcrLhIw)