### PR TITLE
docs: update link to material design icons

### DIFF
--- a/packages/docs/src/pages/en/components/icons.md
+++ b/packages/docs/src/pages/en/components/icons.md
@@ -21,7 +21,7 @@ features:
 
 # Icons
 
-The `v-icon` component provides a large set of glyphs to provide context to various aspects of your application. For a list of all available icons, visit the official [Material Design Icons](https://materialdesignicons.com/) page. To use any of these icons simply use the `mdi-` prefix followed by the icon name.
+The `v-icon` component provides a large set of glyphs to provide context to various aspects of your application. For a list of all available icons, visit the official [Material Design Icons](https://pictogrammers.com/library/mdi/) page. To use any of these icons simply use the `mdi-` prefix followed by the icon name.
 
 <PageFeatures />
 

--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -15,7 +15,7 @@ features:
 
 # Icon Fonts
 
-Out of the box, Vuetify supports 4 popular icon font libraries—[Material Design Icons](https://materialdesignicons.com/), [Material Icons](https://fonts.google.com/icons), [Font Awesome 4](https://fontawesome.com/v4.7.0/) and [Font Awesome 5](https://fontawesome.com/).
+Out of the box, Vuetify supports 4 popular icon font libraries—[Material Design Icons](https://pictogrammers.com/library/mdi/), [Material Icons](https://fonts.google.com/icons), [Font Awesome 4](https://fontawesome.com/v4.7.0/) and [Font Awesome 5](https://fontawesome.com/).
 
 <PageFeatures />
 
@@ -56,11 +56,11 @@ While it is still possible to supply the icon value through the default slot in 
 
 ## Installing icon fonts
 
-You are required to include the specified icon library (even when using the default icons from [Material Design Icons](https://materialdesignicons.com/)). This can be done by including a CDN link or importing the icon library into your application.
+You are required to include the specified icon library (even when using the default icons from [Material Design Icons](https://pictogrammers.com/library/mdi/)). This can be done by including a CDN link or importing the icon library into your application.
 
 ::: info
 
-In this page "Material Icons" is used to refer to the [official google icons](https://fonts.google.com/icons) and "Material Design Icons" refers to the [extended third-party library](https://materialdesignicons.com/)
+In this page "Material Icons" is used to refer to the [official google icons](https://fonts.google.com/icons) and "Material Design Icons" refers to the [extended third-party library](https://pictogrammers.com/library/mdi/)
 
 :::
 


### PR DESCRIPTION
## Description

The material design icons homepage changed from https://materialdesignicons.com to https://pictogrammers.com/library/mdi/. Visiting the old page will still work (for now), but you are greeted with a pop-up window, telling you to update your bookmarks:

![image](https://github.com/user-attachments/assets/7f7123f4-4ac5-47ca-9565-c845feb3db13)