### PR TITLE
fix(VSkeletonLoader): no wrapper for content

### DIFF
--- a/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.tsx
+++ b/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.tsx
@@ -130,9 +130,11 @@ export const makeVSkeletonLoaderProps = propsFactory({
 export const VSkeletonLoader = genericComponent()({
   name: 'VSkeletonLoader',
 
+  inheritAttrs: false,
+
   props: makeVSkeletonLoaderProps(),
 
-  setup (props, { slots }) {
+  setup (props, { attrs, slots }) {
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)
     const { dimensionStyles } = useDimension(props)
     const { elevationClasses } = useElevation(props)
@@ -150,24 +152,32 @@ export const VSkeletonLoader = genericComponent()({
       }
 
       return (
-        <div
-          class={[
-            'v-skeleton-loader',
-            {
-              'v-skeleton-loader--boilerplate': props.boilerplate,
-            },
-            themeClasses.value,
-            backgroundColorClasses.value,
-            elevationClasses.value,
-          ]}
-          style={[
-            backgroundColorStyles.value,
-            isLoading ? dimensionStyles.value : {},
-          ]}
-          { ...loadingProps }
-        >
-          { isLoading ? items.value : slots.default?.() }
-        </div>
+        <>
+          { isLoading
+            ? (
+              <div
+                class={[
+                  'v-skeleton-loader',
+                  {
+                    'v-skeleton-loader--boilerplate': props.boilerplate,
+                  },
+                  themeClasses.value,
+                  backgroundColorClasses.value,
+                  elevationClasses.value,
+                ]}
+                style={[
+                  backgroundColorStyles.value,
+                  dimensionStyles.value,
+                ]}
+                { ...loadingProps }
+                { ...attrs }
+              >
+                { items.value }
+              </div>
+            )
+            : slots.default?.()
+          }
+        </>
       )
     })
 


### PR DESCRIPTION
## Description

fixes #21286

Note: It is a bit risky, but I feel it is an ideal implementation. Skeleton loader should be replaced entirely by the slot content. But I am not a heavy user of this component and certainly never used it with the slot.

Alternatives:
- additional class to disable the styles (with `:not(.v-skeleton-loader--loaded)`)
- only drop the `v-skeleton-*` classes when `!isLoading`

## Markup:

```vue
<template>
  <v-container class="mx-auto">
    <v-row justify="center">
      <v-col>
        <v-skeleton-loader
          :loading="loading"
          class="mx-auto"
          max-width="450"
          type="card"
        >
          <v-card
            class="mx-auto"
            max-width="450"
            subtitle="subtitles are rad"
            title="Test"
          >
            <v-container>
              <v-row>
                <v-col>
                  <label for="wifi_ssid">SSID</label>
                </v-col>
                <v-col>
                  <output id="wifi_ssid">Some text yo</output>
                </v-col>
              </v-row>
              <v-row align="center">
                <v-col>
                  <label for="wifi_signal">Signal<br>lol<br>again</label>
                </v-col>
                <v-col>
                  <output id="wifi_signal">over 90000</output>
                </v-col>
              </v-row>
            </v-container>
          </v-card>
        </v-skeleton-loader>
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup lang="ts">
  import { onMounted, shallowRef } from 'vue'
  const loading = shallowRef(true)
  onMounted(() => setTimeout(() => {
    loading.value = false
  }, 1500))
</script>
```
