### PR TITLE
feat(Vselect): Add Bg color to item list

### DIFF
--- a/packages/api-generator/src/locale/en/Select.json
+++ b/packages/api-generator/src/locale/en/Select.json
@@ -4,7 +4,7 @@
     "chips": "Changes display of selections to chips.",
     "closableChips": "Enables the [closable](/api/v-chip/#props-closable) prop on all [v-chip](/components/chips/) components.",
     "hideSelected": "Do not display in the select menu items that are already selected.",
-    "itemBg" : "Sets the background color of the item list container.",
+    "itemBg": "Sets the background color of the item list container.",
     "itemColor": "Sets color of selected items.",
     "listProps": "Pass props through to the `v-list` component. Accepts an object with anything from [v-list](/api/v-list/#props) props, camelCase keys are recommended.",
     "menuProps": "Pass props through to the `v-menu` component. Accepts an object with anything from [v-menu](/api/v-menu/#props) props, camelCase keys are recommended.",

--- a/packages/api-generator/src/locale/en/Select.json
+++ b/packages/api-generator/src/locale/en/Select.json
@@ -4,7 +4,6 @@
     "chips": "Changes display of selections to chips.",
     "closableChips": "Enables the [closable](/api/v-chip/#props-closable) prop on all [v-chip](/components/chips/) components.",
     "hideSelected": "Do not display in the select menu items that are already selected.",
-    "itemBg": "Sets the background color of the item list container.",
     "itemColor": "Sets color of selected items.",
     "listProps": "Pass props through to the `v-list` component. Accepts an object with anything from [v-list](/api/v-list/#props) props, camelCase keys are recommended.",
     "menuProps": "Pass props through to the `v-menu` component. Accepts an object with anything from [v-menu](/api/v-menu/#props) props, camelCase keys are recommended.",

--- a/packages/api-generator/src/locale/en/Select.json
+++ b/packages/api-generator/src/locale/en/Select.json
@@ -4,6 +4,7 @@
     "chips": "Changes display of selections to chips.",
     "closableChips": "Enables the [closable](/api/v-chip/#props-closable) prop on all [v-chip](/components/chips/) components.",
     "hideSelected": "Do not display in the select menu items that are already selected.",
+    "itemBg" : "Sets the background color of the item list container.",
     "itemColor": "Sets color of selected items.",
     "listProps": "Pass props through to the `v-list` component. Accepts an object with anything from [v-list](/api/v-list/#props) props, camelCase keys are recommended.",
     "menuProps": "Pass props through to the `v-menu` component. Accepts an object with anything from [v-menu](/api/v-menu/#props) props, camelCase keys are recommended.",

--- a/packages/api-generator/src/locale/en/VSelect.json
+++ b/packages/api-generator/src/locale/en/VSelect.json
@@ -6,6 +6,7 @@
     "closableChips": "Enables the [closable](/api/v-chip/#props-closable) prop on all [v-chip](/components/chips/) components.",
     "combobox": "The single select variant of **tags**.",
     "hideSelected": "Do not display in the select menu items that are already selected.",
+    "itemBg" : "Sets the background color of the item list container.",
     "itemColor": "Sets color of selected items.",
     "itemChildren": "This property currently has **no effect**.",
     "itemDisabled": "Set property of **items**'s disabled value.",

--- a/packages/api-generator/src/locale/en/VSelect.json
+++ b/packages/api-generator/src/locale/en/VSelect.json
@@ -6,7 +6,7 @@
     "closableChips": "Enables the [closable](/api/v-chip/#props-closable) prop on all [v-chip](/components/chips/) components.",
     "combobox": "The single select variant of **tags**.",
     "hideSelected": "Do not display in the select menu items that are already selected.",
-    "itemBg" : "Sets the background color of the item list container.",
+    "itemBg": "Sets the background color of the item list container.",
     "itemColor": "Sets color of selected items.",
     "itemChildren": "This property currently has **no effect**.",
     "itemDisabled": "Set property of **items**'s disabled value.",

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -89,6 +89,7 @@ export const makeSelectProps = propsFactory({
   },
   openOnClear: Boolean,
   itemColor: String,
+  itemBg: String,
 
   ...makeItemsProps({ itemChildren: false }),
 }, 'Select')
@@ -447,6 +448,7 @@ export const VSelect = genericComponent<new <
                       aria-live="polite"
                       aria-label={ `${props.label}-list` }
                       color={ props.itemColor ?? props.color }
+                      bgColor={ props.itemBg }
                       { ...listEvents }
                       { ...props.listProps }
                     >


### PR DESCRIPTION
## Description
Added prop and documentation for Item list BG color 
fixes #21579 

## Markup:
```
<template>
  <v-select
    v-model="selected"
    :items="['Apple', 'Orange', 'Banana', 'Pear']"
    bg-color="blue"
    item-bg="black"
    item-color="green"
    width="500"
  /></template>

<script setup>
  import { ref } from 'vue'

  const selected = ref('Apple')
</script>

```
