### PR TITLE
fix(VCalendar): fix calendar isn't shown when using view-mode day

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -223,12 +223,12 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
               }) : (
                 <VCalendarDay
                   { ...calendarDayProps }
-                  day={ genDays([model.value[0] as Date], adapter.date() as Date)[0] }
+                  day={ genDays([displayValue.value as Date], adapter.date() as Date)[0] }
                   dayIndex={ 0 }
                   events={
                     props.events?.filter(e =>
-                      adapter.isSameDay(e.start, genDays([model.value[0] as Date], adapter.date() as Date)[0].date) ||
-                      adapter.isSameDay(e.end, genDays([model.value[0] as Date], adapter.date() as Date)[0].date)
+                      adapter.isSameDay(e.start, genDays([displayValue.value as Date], adapter.date() as Date)[0].date) ||
+                      adapter.isSameDay(e.end, genDays([displayValue.value as Date], adapter.date() as Date)[0].date)
                     )
                   }
                   { ...attrs }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

Go to VCalendar documentation page for Type Day example: https://vuetifyjs.com/en/components/calendars/#type-day
=> The example isn't worked

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row>
    <v-col>
      <v-sheet>
        <v-calendar color="primary" view-mode="day" />
      </v-sheet>
    </v-col>
  </v-row>
</template>
```
