### PR TITLE
fix(VTreeview): active state from router

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -75,7 +75,7 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
         <VListItem
           ref={ vListItemRef }
           { ...listItemProps }
-          active={ vListItemRef.value?.isActivated }
+          active={ vListItemRef.value?.isActivated || undefined }
           class={[
             'v-treeview-item',
             {


### PR DESCRIPTION
## Description

- makes it possible to use VTreeview as a navigation item

Note: very quick PR, I did not check for any regression

## Markup:

```vue
<template>
  <v-app>
    <v-navigation-drawer permanent>
      <v-alert>
        <small>
          (after patch) item is activated when route changes
        </small>
      </v-alert>
      <v-treeview
        :item-props="addProps"
        :items="items"
        open-all
      />
      <v-alert>
        <small>
          VList worked before. In both cases <b>item-value="id"</b> interrupts active state
        </small>
      </v-alert>
      <v-list :item-props="addProps" :items="items" />
    </v-navigation-drawer>
    <v-main>
      <router-view />
    </v-main>
  </v-app>
</template>

<script setup>
  function addProps (item) {
    return !item.children
      ? {
        to: item.id ? `/page${item.id}` : '/',
        nav: true,
      }
      : {}
  }

  const items = [
    {
      id: 9,
      title: 'Applications :',
      children: [
        { id: 0, title: 'Home' },
        { id: 1, title: 'Page 1' },
        { id: 2, title: 'Page 2' },
      ],
    },
  ]
</script>
```
