### PR TITLE
fix(VDatePicker): correct week labels

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -57,7 +57,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
   setup (props, { emit, slots }) {
     const daysRef = ref()
 
-    const { daysInMonth, model, weekNumbers, weekDays, weekdayLabels } = useCalendar(props)
+    const { daysInMonth, model, weekNumbers, weekdayLabels } = useCalendar(props)
     const adapter = useDate()
 
     const rangeStart = shallowRef()
@@ -144,7 +144,7 @@ export const VDatePickerMonth = genericComponent<VDatePickerMonthSlots>()({
     useRender(() => (
       <div
         class="v-date-picker-month"
-        style={{ '--v-date-picker-days-in-week': weekDays.value.length }}
+        style={{ '--v-date-picker-days-in-week': props.weekdays.length }}
       >
         { props.showWeek && (
           <div key="weeks" class="v-date-picker-month__weeks">

--- a/packages/vuetify/src/composables/__tests__/calendar.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/calendar.spec.ts
@@ -7,6 +7,9 @@ import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import { createVuetify } from '@/framework'
 
+// Types
+import type { CalendarProps } from '@/composables/calendar'
+
 describe('calendar', () => {
   it('renders days based upon displayValue', () => {
     expect.assertions(2)
@@ -64,6 +67,25 @@ describe('calendar', () => {
           ]
         `)
 
+        return () => {}
+      },
+    }), {
+      global: { plugins: [createVuetify()] },
+    })
+  })
+
+  it.each([
+    [{ }, 'S,M,T,W,T,F,S'],
+    [{ weekdays: [1, 2, 3, 4, 5] }, 'M,T,W,T,F'],
+    [{ firstDayOfWeek: 1 }, 'M,T,W,T,F,S,S'],
+    [{ firstDayOfWeek: 1, weekdays: [1, 2, 3, 4] }, 'M,T,W,T'],
+  ] as [CalendarProps, string][])('calculates weekday labels correctly for %s', (customizedProps: CalendarProps, expected: string) => {
+    expect.assertions(1)
+    mount(defineComponent({
+      props: makeCalendarProps(customizedProps),
+      setup (props) {
+        const calendar = useCalendar({ ...props } as any)
+        expect(calendar.weekdayLabels.value.join(',')).toBe(expected)
         return () => {}
       },
     }), {

--- a/packages/vuetify/src/composables/__tests__/calendar.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/calendar.spec.ts
@@ -75,16 +75,21 @@ describe('calendar', () => {
   })
 
   it.each([
-    [{ }, 'S,M,T,W,T,F,S'],
+    [{}, 'S,M,T,W,T,F,S'],
     [{ weekdays: [1, 2, 3, 4, 5] }, 'M,T,W,T,F'],
     [{ firstDayOfWeek: 1 }, 'M,T,W,T,F,S,S'],
+    [{ firstDayOfWeek: 2 }, 'T,W,T,F,S,S,M'],
+    [{ firstDayOfWeek: 3 }, 'W,T,F,S,S,M,T'],
     [{ firstDayOfWeek: 1, weekdays: [1, 2, 3, 4] }, 'M,T,W,T'],
+    [{ firstDayOfWeek: 1, weekdays: [2, 3, 4] }, 'T,W,T'],
+    [{ firstDayOfWeek: 2, weekdays: [2, 3, 4] }, 'T,W,T'],
+    [{ firstDayOfWeek: 3, weekdays: [2, 3, 4] }, 'W,T,T'],
   ] as [CalendarProps, string][])('calculates weekday labels correctly for %s', (customizedProps: CalendarProps, expected: string) => {
     expect.assertions(1)
     mount(defineComponent({
       props: makeCalendarProps(customizedProps),
       setup (props) {
-        const calendar = useCalendar({ ...props } as any)
+        const calendar = useCalendar(props as any)
         expect(calendar.weekdayLabels.value.join(',')).toBe(expected)
         return () => {}
       },

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -120,15 +120,10 @@ export function useCalendar (props: CalendarProps) {
     v => adapter.getMonth(v)
   )
 
-  const weekDays = computed(() => {
-    const firstDayOfWeek = adapter.toJsDate(adapter.startOfWeek(adapter.date(), props.firstDayOfWeek)).getDay()
-    return props.weekdays.map(day => (day + firstDayOfWeek) % 7)
-  })
-
   const weekdayLabels = computed(() => {
-    const labels = adapter.getWeekdays(props.firstDayOfWeek)
-
-    return weekDays.value.map(day => labels[day])
+    const firstDayOfWeek = adapter.toJsDate(adapter.startOfWeek(adapter.date(), props.firstDayOfWeek)).getDay()
+    return adapter.getWeekdays(props.firstDayOfWeek)
+      .filter((_, i) => props.weekdays.includes((i + firstDayOfWeek) % 7))
   })
 
   const weeksInMonth = computed(() => {
@@ -158,13 +153,14 @@ export function useCalendar (props: CalendarProps) {
 
   function genDays (days: Date[], today: Date): CalendarDay[] {
     return days.filter(date => {
-      return weekDays.value.includes(adapter.toJsDate(date).getDay())
+      return props.weekdays.includes(adapter.toJsDate(date).getDay())
     }).map((date, index) => {
       const isoDate = adapter.toISO(date)
       const isAdjacent = !adapter.isSameMonth(date, month.value)
       const isStart = adapter.isSameDay(date, adapter.startOfMonth(month.value))
       const isEnd = adapter.isSameDay(date, adapter.endOfMonth(month.value))
       const isSame = adapter.isSameDay(date, month.value)
+      const weekdaysCount = props.weekdays.length
 
       return {
         date,
@@ -177,8 +173,8 @@ export function useCalendar (props: CalendarProps) {
         isSelected: model.value.some(value => adapter.isSameDay(date, value)),
         isStart,
         isToday: adapter.isSameDay(date, today),
-        isWeekEnd: index % 7 === 6,
-        isWeekStart: index % 7 === 0,
+        isWeekEnd: index % weekdaysCount === weekdaysCount - 1,
+        isWeekStart: index % weekdaysCount === 0,
         isoDate,
         localized: adapter.format(date, 'dayOfMonth'),
         month: adapter.getMonth(date),
@@ -238,7 +234,6 @@ export function useCalendar (props: CalendarProps) {
     genDays,
     model,
     weeksInMonth,
-    weekDays,
     weekdayLabels,
     weekNumbers,
   }

--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -51,9 +51,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
   setup (props, { attrs, emit, slots }) {
     const adapter = useDate()
 
-    const { daysInMonth, daysInWeek, genDays, model, displayValue, weekNumbers, weekDays } = useCalendar(props as any)
-
-    const dayNames = adapter.getWeekdays()
+    const { daysInMonth, daysInWeek, genDays, model, displayValue, weekNumbers, weekdayLabels } = useCalendar(props as any)
 
     function onClickNext () {
       if (props.viewMode === 'month') {
@@ -97,6 +95,8 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
       const calendarDayProps = VCalendarDay.filterProps(props)
       const calendarHeaderProps = VCalendarHeader.filterProps(props)
 
+      const weekdaysCount = daysInWeek.value.length
+
       return (
         <div class={[
           'v-calendar',
@@ -129,13 +129,13 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
             )}
           </div>
 
-          <div class={['v-calendar__container', `days__${weekDays.value.length}`]}>
+          <div class={['v-calendar__container', `days__${weekdaysCount}`]}>
             { props.viewMode === 'month' && !props.hideDayHeader && (
               <div
                 class={
                   [
                     'v-calendar-weekly__head',
-                    `days__${weekDays.value.length}`,
+                    `days__${weekdaysCount}`,
                     ...(!props.hideWeekNumber ? ['v-calendar-weekly__head-weeknumbers'] : []),
                   ]
                 }
@@ -143,9 +143,9 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
               >
                 { !props.hideWeekNumber ? <div key="weekNumber0" class="v-calendar-weekly__head-weeknumber"></div> : '' }
                 {
-                  weekDays.value.map(weekday => (
+                  weekdayLabels.value.map(weekday => (
                     <div class={ `v-calendar-weekly__head-weekday${!props.hideWeekNumber ? '-with-weeknumber' : ''}` }>
-                      { dayNames[weekday] }
+                      { weekday }
                     </div>
                   ))
                 }
@@ -158,12 +158,12 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                 class={
                   [
                     'v-calendar-month__days',
-                    `days${!props.hideWeekNumber ? '-with-weeknumbers' : ''}__${weekDays.value.length}`,
+                    `days${!props.hideWeekNumber ? '-with-weeknumbers' : ''}__${weekdaysCount}`,
                     ...(!props.hideWeekNumber ? ['v-calendar-month__weeknumbers'] : []),
                   ]
                 }
               >
-                { chunkArray(daysInMonth.value, weekDays.value.length)
+                { chunkArray(daysInMonth.value, weekdaysCount)
                   .map((week, wi) => (
                     [
                       !props.hideWeekNumber ? (


### PR DESCRIPTION
## Description

Note: it might conflict with `weekday-format` (merged to `dev`), but should be easy to resolve

fixes #21645
fixes #21332
closes #21647

## Markup:

```vue
<template>
  <v-app>
    <v-container class="d-flex ga-6" fluid>
      <v-date-picker title="first: default" />
      <v-date-picker :weekdays="[1,2,3,4,5]" title="first: default + weekdays subset" />
      <v-date-picker :first-day-of-week="0" title="first: 0" />
      <v-date-picker :first-day-of-week="1" title="first: 1" />
      <v-date-picker :first-day-of-week="1" :weekdays="[1,2,3,4,5]" title="first: 1 + weekdays subset" show-week />
    </v-container>
    <v-container>
      <v-calendar view-mode="month" />
      <v-calendar view-mode="month" :weekdays="[1,2,3,4,5]" />
      <v-calendar view-mode="month" :first-day-of-week="1" />
      <v-calendar view-mode="month" :first-day-of-week="1" :weekdays="[1,2,3,4,5]" />
    </v-container>
  </v-app>
</template>
```
