### PR TITLE
fix(VDatePicker): avoid infinite loop when first day is out of range

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.browser.tsx
@@ -57,12 +57,14 @@ describe('VDatePicker', () => {
 
     await commands.abortAfter(5000, 'VDatePicker infinite loop detection')
 
-    firstDay.value = 7
+    firstDay.value = -1.5
     await wait(100)
 
     await userEvent.click(await screen.findByText(21))
     await userEvent.click(await screen.findByText(7))
     await expect.poll(() => model.value).toHaveLength(4)
+
+    expect('Invalid firstDayOfWeek, expected discrete number in range [0-6]').toHaveBeenTipped()
 
     await commands.clearAbortTimeout()
   })

--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { createRange, padStart } from '@/util'
+import { consoleWarn, createRange, padStart } from '@/util'
 
 // Types
 import type { DateAdapter } from '../DateAdapter'
@@ -85,10 +85,11 @@ function getWeekArray (date: Date, locale: string, firstDayOfWeek?: number) {
 }
 
 function startOfWeek (date: Date, locale: string, firstDayOfWeek?: number) {
-  let day = firstDayOfWeek ?? weekInfo(locale)?.firstDay ?? 0
+  let day = (firstDayOfWeek ?? weekInfo(locale)?.firstDay ?? 0) % 7
 
   // prevent infinite loop
   if (![0, 1, 2, 3, 4, 5, 6].includes(day)) {
+    consoleWarn('Invalid firstDayOfWeek, expected discrete number in range [0-6]')
     day = 0
   }
 


### PR DESCRIPTION
## Description

Anticipating a buggy UI where a careless developer (or LLM) creates an input element that does not prevent `first-day-of-week` outside of range.

## Markup:

```vue
<template>
  <v-app>
    <v-container max-width="400">
      <v-slider v-model="value" label="First day of week" max="8" step="1" />
      <pre>value: {{ value }}</pre>
      <v-date-picker :first-day-of-week="value" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { shallowRef } from 'vue'
  const value = shallowRef(0)
</script>
```
