### PR TITLE
docs(VSelect): example for `list-props`

### DIFF
--- a/packages/docs/src/components/examples/UsageExample.vue
+++ b/packages/docs/src/components/examples/UsageExample.vue
@@ -218,13 +218,13 @@
   }
 </script>
 
-<style lang="sass">
+<style lang="sass" scoped>
   .usage-example
-    .v-text-field
+    ::v-deep(.v-text-field)
       margin-bottom: 8px
 
   // Hack to get around navigation-drawer default bgColor
   // TODO: find a better way
-  .v-select__content .v-list
+  ::v-deep(.v-select__content .v-list)
     background: rgb(var(--v-theme-surface)) !important
 </style>

--- a/packages/docs/src/examples/v-select/prop-list-props.vue
+++ b/packages/docs/src/examples/v-select/prop-list-props.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-select
+    v-model="selected"
+    :items="['Apple', 'Orange', 'Banana', 'Pear']"
+    :list-props="{ bgColor: 'purple' }"
+    item-color="yellow"
+    label="Label"
+    multiple
+  ></v-select>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const selected = ref(['Apple'])
+</script>
+
+<script>
+  export default {
+    data: () => ({
+      selected: ['Apple'],
+    }),
+  }
+</script>

--- a/packages/docs/src/pages/en/components/selects.md
+++ b/packages/docs/src/pages/en/components/selects.md
@@ -95,6 +95,12 @@ Custom props can be passed directly to `v-menu` using **menu-props** prop. In th
 
 <ExamplesExample file="v-select/prop-menu-props" />
 
+#### List props
+
+Custom props can be passed directly to `v-list` using **list-props** prop. It helps address common use case of customizing dropdown list background color.
+
+<ExamplesExample file="v-select/prop-list-props" />
+
 #### Custom item props
 
 `item-title` and `item-value` are provided for convenience, and additional props can be passed to list items either through the **item** slot (see below) or with the **itemProps** prop.


### PR DESCRIPTION
## Description

resolves #21579

## Markup:

```vue
<template>
  <v-select
    v-model="selected"
    :items="['Apple', 'Orange', 'Banana', 'Pear']"
    :list-props="{ bgColor: 'purple' }"
    item-color="yellow"
    label="Label"
    multiple
  ></v-select>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref(['Apple'])
</script>
```
