### PR TITLE
docs(VToolbar): example with tooltips and VSpeedDial

### DIFF
--- a/packages/docs/src/examples/v-toolbar/misc-tooltips-and-speed-dial.vue
+++ b/packages/docs/src/examples/v-toolbar/misc-tooltips-and-speed-dial.vue
@@ -1,0 +1,72 @@
+<template>
+  <v-card>
+    <v-toolbar :collapse="collapse" title="Toolbar">
+      <v-btn
+        class="ml-3"
+        icon="mdi-magnify"
+        v-tooltip:bottom="'Search all products'"
+      ></v-btn>
+
+      <v-btn
+        class="mr-3"
+        icon="mdi-dots-vertical"
+        size="small"
+        variant="elevated"
+      >
+        <v-icon></v-icon>
+        <v-speed-dial :location="dialLocation" activator="parent" open-on-hover>
+          <v-btn
+            v-for="(item, i) in dialActions"
+            :key="i"
+            :color="item.color"
+            :icon="item.icon"
+            v-tooltip="{ location: tooltipLocation, text: item.tooltip }"
+          ></v-btn>
+        </v-speed-dial>
+      </v-btn>
+    </v-toolbar>
+
+    <v-card-text class="text-center pa-8">
+      <v-btn
+        :text="collapse ? 'Expand' : 'Collapse'"
+        color="surface-variant"
+        @click="collapse = !collapse"
+      ></v-btn>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+  import { shallowRef, toRef } from 'vue'
+
+  const collapse = shallowRef(false)
+  const dialLocation = toRef(() => collapse.value ? 'right center' : 'bottom center')
+  const tooltipLocation = toRef(() => collapse.value ? 'bottom' : 'left')
+
+  const dialActions = [
+    { color: 'success', icon: '$success', tooltip: 'Share feedback' },
+    { color: 'warning', icon: 'mdi-alert', tooltip: 'Report problem' },
+    { color: 'purple', icon: 'mdi-bell', tooltip: 'Open notifications' },
+  ]
+</script>
+
+<script>
+  export default {
+    data: () => ({
+      collapse: false,
+      dialActions: [
+        { color: 'success', icon: '$success', tooltip: 'Share feedback' },
+        { color: 'warning', icon: 'mdi-alert', tooltip: 'Report problem' },
+        { color: 'purple', icon: 'mdi-bell', tooltip: 'Open notifications' },
+      ],
+    }),
+    computed: {
+      dialLocation () {
+        return this.collapse ? 'right center' : 'bottom center'
+      },
+      tooltipLocation () {
+        return this.collapse ? 'bottom' : 'left'
+      },
+    },
+  }
+</script>

--- a/packages/docs/src/pages/en/components/toolbars.md
+++ b/packages/docs/src/pages/en/components/toolbars.md
@@ -115,3 +115,9 @@ In this example we offset our card onto the extended content area of a toolbar u
 A floating toolbar is turned into an inline element that only takes up as much space as needed. This is particularly useful when placing toolbars over content.
 
 <ExamplesExample file="v-toolbar/prop-floating-with-search" />
+
+### Tooltips and Speed Dial
+
+Toolbar elements can include menus (like Speed Dial) and tooltips to help users understand the action intent when buttons show only icons to keep interface minimalistic.
+
+<ExamplesExample file="v-toolbar/misc-tooltips-and-speed-dial" />


### PR DESCRIPTION
## Description

- new example guides users to use `v-btn` instead of `v-fab` inside toolbar

resolves #20575

- same code on [playground](https://play.vuetifyjs.com/#eNqFVd9r2zAQ/lduZuAU4pRSBsWk3crY22DQ7q3pgyKfG1FZEpKctgv533eS7VhOtjYvkU6fPt2P784Pu8xZfn5rzGLbYlZmS4+NkczjzUoBLLcFZ7aK67jzWss1s1ByLSUzDq9X2bBcZeCFl8H0u4Otsv5mvLv2atgBcMmcI2Qji8tVNtoF1yqYK1E07EmJ+i097RzwwpRr7b1uCJnfI7N8A0xKMFZXLfcuH+/cLM/jy+TIh67Y/7pSae+KLVovOJMpxok/IV7X0PMTR5kVTHk6QolbSmeVuDTCyJXwSnQyLiZHziBWRSWYhFJqzryIDgXDz35LOWfcC3pBWzoyzKLyZNQGVaFVsdHkdcJ6Gn2X1jpenwmq/hzEGQgF4Zlb4tbKpZGFX/mMbwQXJ3aSQiQKPIu4OYH0WY2IsD4GHEpMoB0MYZfQW4fA5+Dx1ZcQefoz2E/JktofoifLmNZRnRNg2PVCP8im74QivHpQTNgUnDKOFgwrrt7RexmwSbPAV8h/vBqmqhxKyL/35kS5JMw+m661NeNY9KJKId+4FPw55b2GT2ND/qMLhgAP0XSN3ltoszxPRgBtHbfCeHDoWxOxojHaetiB25Dq9csd1lQNTX+wh9rqBnKaJXmXOaqwo4SN3o2XZjWTDs9GVCpsQkbK2ewMrm8OBIstk21MnhVPGyKOyY8p7CbCYEloj5TzIXNHFDkl1j5QTX3su4KIHrp87rpS0QXXco7O5dREhCfD59EyjC7I7zfUp1CTDNeMP+ewnx/zvDCrhHoaecIUYpIm0IToDmMpaO6tJZLLp0SmtUbilGeNUk5oftG0AKW9qGm+xdgGqsegh04BVPtsP88uF18WF5dZWFwtLi6yeazifPIZ6WyPfwGKIPzh)
