### PR TITLE
fix(VSelects): avoid error with `null` items

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -495,13 +495,13 @@ export const VAutocomplete = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw.type === 'divider') {
+                          if (item.raw?.type === 'divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw.type === 'subheader') {
+                          if (item.raw?.type === 'subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -541,13 +541,13 @@ export const VCombobox = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw.type === 'divider') {
+                          if (item.raw?.type === 'divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw.type === 'subheader') {
+                          if (item.raw?.type === 'subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -470,13 +470,13 @@ export const VSelect = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw.type === 'divider') {
+                          if (item.raw?.type === 'divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw.type === 'subheader') {
+                          if (item.raw?.type === 'subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )


### PR DESCRIPTION
## Description

- `item.raw` can be null
- follow-up to #21348

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-select
        :items="['asd', null]"
        label="v-select"
      />
      <v-autocomplete
        :items="['asd', null]"
        label="v-autocomplete"
      />
      <v-combobox
        :items="['asd', null]"
        label="v-combobox"
      />
    </v-container>
  </v-app>
</template>
```
