### PR TITLE
docs(VTabs): fix invisible text

### DIFF
--- a/packages/docs/src/examples/v-tabs/prop-grow.vue
+++ b/packages/docs/src/examples/v-tabs/prop-grow.vue
@@ -8,7 +8,6 @@
 
     <v-tabs
       v-model="tab"
-      bg-color="transparent"
       color="basil"
       grow
     >
@@ -69,6 +68,7 @@
 /* Helper classes */
 .bg-basil {
   background-color: #FFFBE6 !important;
+  color: #000 !important;
 }
 .text-basil {
   color: #356859 !important;


### PR DESCRIPTION
## Description

- when I have dark theme set for the documentation, the `v-theme--dark` class propagates to the card and most of the text is white (invisible)
- `bg-color="transparent"` does not seem to do anything, just a cleanup