### PR TITLE
feat(VDataTable): support fixed to the right edge

### DIFF
--- a/packages/api-generator/src/locale/en/VDataTableHeaders.json
+++ b/packages/api-generator/src/locale/en/VDataTableHeaders.json
@@ -5,6 +5,8 @@
     "sortDescIcon": "Icon used for descending sort button.",
     "sticky": "Deprecated, use `fixed-header` instead.",
     "fixedHeader": "Sticks the header to the top of the table.",
+    "lastFixed": "**FOR INTERNAL USE ONLY** Applies right border to the last column fixed to the left.",
+    "firstFixedEnd": "**FOR INTERNAL USE ONLY** Applies left border to the first column fixed to the right.",
     "multiSort": "Sort on multiple columns at the same time.",
     "headerProps": "Additional props to be be passed to the default header"
   },

--- a/packages/api-generator/src/locale/en/VDataTableHeaders.json
+++ b/packages/api-generator/src/locale/en/VDataTableHeaders.json
@@ -4,8 +4,7 @@
     "sortAscIcon": "Icon used for ascending sort button.",
     "sortDescIcon": "Icon used for descending sort button.",
     "sticky": "Deprecated, use `fixed-header` instead.",
-    "fixedHeader": "Sticks the header to the top of the table. From the left",
-    "lastFixed": "Sticks the header to the top of the table. From the right.",
+    "fixedHeader": "Sticks the header to the top of the table.",
     "multiSort": "Sort on multiple columns at the same time.",
     "headerProps": "Additional props to be be passed to the default header"
   },

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -62,8 +62,7 @@
   },
   "VDataTable": {
     "props": {
-      "headerProps": "3.5.0",
-      "lastFixed": "3.9.0"
+      "headerProps": "3.5.0"
     }
   },
   "VExpansionPanels": {

--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -77,17 +77,27 @@
                 height: fit-content
 
   .v-data-table-column--fixed,
+  .v-data-table-column--fixed-end,
   .v-data-table__th--sticky
     background: $table-background
     position: sticky !important
     left: 0
     z-index: 1
 
+  .v-data-table-column--fixed-end
+    left: unset
+    right: 0
+
   .v-data-table-column--last-fixed
     border-right: 1px solid rgba(var(--v-border-color), var(--v-border-opacity))
 
-  .v-data-table.v-table--fixed-header > .v-table__wrapper > table > thead > tr > th.v-data-table-column--fixed
-    z-index: 2
+  .v-data-table-column--first-fixed-end
+    border-left: 1px solid rgba(var(--v-border-color), var(--v-border-opacity))
+
+  .v-data-table.v-table--fixed-header > .v-table__wrapper > table > thead > tr
+    > th.v-data-table-column--fixed,
+    > th.v-data-table-column--fixed-end
+      z-index: 2
 
   .v-data-table-group-header-row
     td

--- a/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
@@ -9,10 +9,16 @@ export const VDataTableColumn = defineFunctionalComponent({
     type: String as PropType<'start' | 'center' | 'end'>,
     default: 'start',
   },
-  fixed: Boolean,
+  fixed: {
+    type: [Boolean, String] as PropType<boolean | 'start' | 'end'>,
+    default: false,
+  },
   fixedOffset: [Number, String],
+  fixedEndOffset: [Number, String],
   height: [Number, String],
   lastFixed: Boolean,
+  firstFixedEnd: Boolean,
+
   noPadding: Boolean,
   tag: String,
   width: [Number, String],
@@ -20,14 +26,23 @@ export const VDataTableColumn = defineFunctionalComponent({
   nowrap: Boolean,
 }, (props, { slots }) => {
   const Tag = props.tag ?? 'td'
+
+  const fixedSide = props.fixed === 'end'
+    ? 'end'
+    : props.fixed
+      ? 'start'
+      : 'none'
+
   return (
     <Tag
       tabindex="0"
       class={[
         'v-data-table__td',
         {
-          'v-data-table-column--fixed': props.fixed,
+          'v-data-table-column--fixed': fixedSide === 'start',
+          'v-data-table-column--fixed-end': fixedSide === 'end',
           'v-data-table-column--last-fixed': props.lastFixed,
+          'v-data-table-column--first-fixed-end': props.firstFixedEnd,
           'v-data-table-column--no-padding': props.noPadding,
           'v-data-table-column--nowrap': props.nowrap,
         },
@@ -37,7 +52,8 @@ export const VDataTableColumn = defineFunctionalComponent({
         height: convertToUnit(props.height),
         width: convertToUnit(props.width),
         maxWidth: convertToUnit(props.maxWidth),
-        left: convertToUnit(props.fixedOffset || null),
+        left: fixedSide === 'start' ? convertToUnit(props.fixedOffset || null) : undefined,
+        right: fixedSide === 'end' ? convertToUnit(props.fixedEndOffset || null) : undefined,
       }}
     >
       { slots.default?.() }

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -96,9 +96,16 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
     function getFixedStyles (column: InternalDataTableHeader, y: number): CSSProperties | undefined {
       if (!(props.sticky || props.fixedHeader) && !column.fixed) return undefined
 
+      const fixedSide = column.fixed === 'end'
+        ? 'end'
+        : column.fixed
+          ? 'start'
+          : 'none'
+
       return {
         position: 'sticky',
-        left: column.fixed ? convertToUnit(column.fixedOffset) : undefined,
+        left: fixedSide === 'start' ? convertToUnit(column.fixedOffset) : undefined,
+        right: fixedSide === 'end' ? convertToUnit(column.fixedEndOffset) : undefined,
         top: (props.sticky || props.fixedHeader) ? `calc(var(--v-table-header-height) * ${y})` : undefined,
       }
     }
@@ -168,6 +175,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           fixed={ column.fixed }
           nowrap={ column.nowrap }
           lastFixed={ column.lastFixed }
+          firstFixedEnd={ column.firstFixedEnd }
           noPadding={ noPadding }
           { ...headerProps }
           onKeydown={ (event: KeyboardEvent) => column.sortable && handleEnterKeyPress(event, column) }

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -61,7 +61,6 @@ export const makeVDataTableHeadersProps = propsFactory({
   color: String,
   disableSort: Boolean,
   fixedHeader: Boolean,
-  lastFixed: Boolean,
   multiSort: Boolean,
   sortAscIcon: {
     type: IconValue,
@@ -95,12 +94,11 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
     const { loaderClasses } = useLoader(props)
 
     function getFixedStyles (column: InternalDataTableHeader, y: number): CSSProperties | undefined {
-      if (!(props.sticky || props.fixedHeader) && !(column.fixed || column.lastFixed)) return undefined
+      if (!(props.sticky || props.fixedHeader) && !column.fixed) return undefined
 
       return {
         position: 'sticky',
-        left: column.fixed || column.lastFixed ? convertToUnit(column.fixedOffset) : undefined,
-        right: column.lastFixed ? convertToUnit(column.fixedOffset ?? 0) : undefined,
+        left: column.fixed ? convertToUnit(column.fixedOffset) : undefined,
         top: (props.sticky || props.fixedHeader) ? `calc(var(--v-table-header-height) * ${y})` : undefined,
       }
     }

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -130,7 +130,9 @@ export const VDataTableRow = genericComponent<new <T>(
               }}
               fixed={ column.fixed }
               fixedOffset={ column.fixedOffset }
+              fixedEndOffset={ column.fixedEndOffset }
               lastFixed={ column.lastFixed }
+              firstFixedEnd={ column.firstFixedEnd }
               maxWidth={ !mobile.value ? column.maxWidth : undefined }
               noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
               nowrap={ column.nowrap }

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -12,7 +12,7 @@ export type DataTableHeader<T = Record<string, any>> = {
   value?: SelectItemKey<T>
   title?: string
 
-  fixed?: boolean
+  fixed?: boolean | 'start' | 'end'
   align?: 'start' | 'end' | 'center'
 
   width?: number | string
@@ -36,7 +36,9 @@ export type InternalDataTableHeader = Omit<DataTableHeader, 'key' | 'value' | 'c
   value: SelectItemKey | null
   sortable: boolean
   fixedOffset?: number
+  fixedEndOffset?: number
   lastFixed?: boolean
+  firstFixedEnd?: boolean
   nowrap?: boolean
   colspan?: number
   rowspan?: number


### PR DESCRIPTION
## Description

- keeps `boolean` type and `lastFixed` to avoid breaking changes

resolves #20020
resolves #21153

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-card max-width="540">
        <v-data-table
          :headers="header"
          :items="items"
          fixed-header
        >
          <template #item.icon>
            <v-icon icon="mdi-truck" />
          </template>
          <template #item.status>
            <v-icon icon="mdi-cow" />
          </template>
          <template #item.actions>
            <v-btn>action btn</v-btn>
          </template>
        </v-data-table>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { category: 'G1', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
    { category: 'G1', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
    { category: 'G1', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
    { category: 'G2', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
    { category: 'G2', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
    { category: 'G2', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
    { category: 'G2', key1: 100000, key2: 200000, key3: 300000, key4: 400000, key5: 500000 },
  ]

  const header = [
    { title: 'Category', key: 'category', width: 95, fixed: true, sortable: false },
    { title: '[-]', key: 'icon', width: 60, fixed: true, sortable: false },
    { title: 'col1', key: 'key1', width: 100 },
    { title: 'col2', key: 'key2', width: 100 },
    { title: 'col3', key: 'key3', width: 150 },
    { title: 'col4', key: 'key4', width: 100 },
    { title: 'col5', key: 'key5', width: 100 },
    { title: 'St.', key: 'status', width: 50, fixed: 'end', sortable: false },
    { title: 'Actions', key: 'actions', width: 160, fixed: 'end' },
  ]
</script>
```
