### PR TITLE
fix(VSelects): avoid breaking change when resolving item type

### DIFF
--- a/packages/docs/src/examples/v-autocomplete/prop-items.vue
+++ b/packages/docs/src/examples/v-autocomplete/prop-items.vue
@@ -22,13 +22,13 @@
 
 <script setup>
   const items = [
-    { type: 'subheader', title: 'Group 1' },
+    { type: '$subheader', title: 'Group 1' },
     { title: 'Item 1.1', value: 11 },
     { title: 'Item 1.2', value: 12 },
     { title: 'Item 1.3', value: 13 },
     { title: 'Item 1.4', value: 14 },
-    { type: 'divider', text: 'or' },
-    { type: 'subheader', title: 'Group 2' },
+    { type: '$divider', text: 'or' },
+    { type: '$subheader', title: 'Group 2' },
     { title: 'Item 2.1', value: 21 },
     { title: 'Item 2.2', value: 22 },
     { title: 'Item 2.3', value: 23 },
@@ -39,13 +39,13 @@
   export default {
     data: () => ({
       items: [
-        { type: 'subheader', title: 'Group 1' },
+        { type: '$subheader', title: 'Group 1' },
         { title: 'Item 1.1', value: 11 },
         { title: 'Item 1.2', value: 12 },
         { title: 'Item 1.3', value: 13 },
         { title: 'Item 1.4', value: 14 },
-        { type: 'divider', text: 'or' },
-        { type: 'subheader', title: 'Group 2' },
+        { type: '$divider', text: 'or' },
+        { type: '$subheader', title: 'Group 2' },
         { title: 'Item 2.1', value: 21 },
         { title: 'Item 2.2', value: 22 },
         { title: 'Item 2.3', value: 23 },

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -495,13 +495,13 @@ export const VAutocomplete = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw.type === 'divider') {
+                          if (item.raw?.type === 'divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw.type === 'subheader') {
+                          if (item.raw?.type === 'subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -495,13 +495,13 @@ export const VAutocomplete = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw?.type === 'divider') {
+                          if (item.raw?.type === '$divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw?.type === 'subheader') {
+                          if (item.raw?.type === '$subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -541,13 +541,13 @@ export const VCombobox = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw?.type === 'divider') {
+                          if (item.raw?.type === '$divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw?.type === 'subheader') {
+                          if (item.raw?.type === '$subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -541,13 +541,13 @@ export const VCombobox = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw.type === 'divider') {
+                          if (item.raw?.type === 'divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw.type === 'subheader') {
+                          if (item.raw?.type === 'subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -470,13 +470,13 @@ export const VSelect = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw?.type === 'divider') {
+                          if (item.raw?.type === '$divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw?.type === 'subheader') {
+                          if (item.raw?.type === '$subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -470,13 +470,13 @@ export const VSelect = genericComponent<new <
                             onClick: () => select(item, null),
                           })
 
-                          if (item.raw.type === 'divider') {
+                          if (item.raw?.type === 'divider') {
                             return slots.divider?.({ props: item.raw, index }) ?? (
                               <VDivider { ...item.props } key={ `divider-${index}` } />
                             )
                           }
 
-                          if (item.raw.type === 'subheader') {
+                          if (item.raw?.type === 'subheader') {
                             return slots.subheader?.({ props: item.raw, index }) ?? (
                               <VListSubheader { ...item.props } key={ `subheader-${index}` } />
                             )

--- a/packages/vuetify/src/composables/filter.tsx
+++ b/packages/vuetify/src/composables/filter.tsx
@@ -102,7 +102,7 @@ export function filterItems (
 
     if ((query || customFiltersLength > 0) && !options?.noFilter) {
       if (typeof item === 'object') {
-        if (['divider', 'subheader'].includes(item.raw?.type)) {
+        if (['$divider', '$subheader'].includes(item.raw?.type)) {
           continue
         }
 


### PR DESCRIPTION
## Description

Additional change on top of #21660.
In my opinion, the risk was acceptable, but we can drop it to zero by prefixing the `type` values. We could drop the prefix with 4.0.0 so the behavior is aligned with VList.

Note to myself: (once merged) update the description for [#21348](https://github.com/vuetifyjs/vuetify/pull/21348)

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-select multiple label="v-select" v-model="selection" :items="items" chips />
      <v-autocomplete multiple label="v-autocomplete" v-model="selection" :items="items" chips />
      <v-combobox multiple label="v-combobox" v-model="selection" :items="items" chips />

      <h5 class="mt-6">custom divider</h5>
      <v-autocomplete multiple label="v-autocomplete" v-model="selection" :items="items" chips>
        <template #divider="{ props }">
          <div class="d-flex ga-4 align-center">
            <v-divider />
            {{ props.text }}
            <v-divider />
          </div>
        </template>
      </v-autocomplete>
      <h5 class="mt-6">custom subheader</h5>
      <v-autocomplete multiple label="v-autocomplete" v-model="selection" :items="items" chips>
        <template #subheader="{ props }">
          <v-list-subheader class="font-weight-bold bg-primary">{{ props.title }}</v-list-subheader>
        </template>
      </v-autocomplete>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selection = ref([])
  const items = [
    { type: '$subheader', title: 'Group 1' },
    { title: 'Item 1.1', value: 11 },
    { title: 'Item 1.2', value: 12 },
    { title: 'Item 1.3', value: 13 },
    { title: 'Item 1.4', value: 14 },
    { type: '$divider', text: 'or' },
    { type: '$subheader', title: 'Group 2' },
    { title: 'Item 2.1', value: 21 },
    { title: 'Item 2.2', value: 22 },
    { title: 'Item 2.3', value: 23 },
  ]
</script>
```
