### PR TITLE
fix(date): align `fullDate` format with documentation and other adapters

### DIFF
--- a/packages/vuetify/src/composables/date/adapters/vuetify.ts
+++ b/packages/vuetify/src/composables/date/adapters/vuetify.ts
@@ -168,7 +168,7 @@ function format (
   let options: Intl.DateTimeFormatOptions = {}
   switch (formatString) {
     case 'fullDate':
-      options = { year: 'numeric', month: 'long', day: 'numeric' }
+      options = { year: 'numeric', month: 'short', day: 'numeric' }
       break
     case 'fullDateWithWeekday':
       options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }


### PR DESCRIPTION
## Description

fixes #21667

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <div>{{ fullDate }}</div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { useDate } from 'vuetify'
  const adapter = useDate()
  const fullDate = adapter.format(new Date(), 'fullDate')
</script>
```
