### PR TITLE
docs(VTimePicker): simplify example with menu and dialog

### DIFF
--- a/packages/docs/src/examples/v-time-picker/misc-dialog-and-menu.vue
+++ b/packages/docs/src/examples/v-time-picker/misc-dialog-and-menu.vue
@@ -1,54 +1,33 @@
 <template>
   <v-container>
     <v-row justify="space-around">
-      <v-col
-        cols="11"
-        sm="5"
-      >
+      <v-col cols="11" sm="5">
         <v-text-field
-          v-model="time"
-          :active="menu2"
-          :focus="menu2"
+          :model-value="time"
           label="Picker in menu"
           prepend-icon="mdi-clock-time-four-outline"
           readonly
         >
           <v-menu
-            v-model="menu2"
+            v-model="showMenu"
             :close-on-content-click="false"
             activator="parent"
-            transition="scale-transition"
+            min-width="0"
           >
-            <v-time-picker
-              v-if="menu2"
-              v-model="time"
-              full-width
-            ></v-time-picker>
+            <v-time-picker v-model="time"></v-time-picker>
           </v-menu>
         </v-text-field>
       </v-col>
 
-      <v-col
-        cols="11"
-        sm="5"
-      >
+      <v-col cols="11" sm="5">
         <v-text-field
-          v-model="time"
-          :active="modal2"
-          :focused="modal2"
+          :model-value="time"
           label="Picker in dialog"
           prepend-icon="mdi-clock-time-four-outline"
           readonly
         >
-          <v-dialog
-            v-model="modal2"
-            activator="parent"
-            width="auto"
-          >
-            <v-time-picker
-              v-if="modal2"
-              v-model="time"
-            ></v-time-picker>
+          <v-dialog v-model="showDialog" activator="parent" width="auto">
+            <v-time-picker v-model="time"></v-time-picker>
           </v-dialog>
         </v-text-field>
       </v-col>
@@ -60,8 +39,8 @@
   import { ref } from 'vue'
 
   const time = ref(null)
-  const menu2 = ref(false)
-  const modal2 = ref(false)
+  const showMenu = ref(false)
+  const showDialog = ref(false)
 </script>
 
 <script>
@@ -69,8 +48,8 @@
     data () {
       return {
         time: null,
-        menu2: false,
-        modal2: false,
+        showMenu: false,
+        showDialog: false,
       }
     },
   }


### PR DESCRIPTION
## Description

- binding to `active` and `focus` do not lock the focus state (I can click next to the clock to blur the field), they also cause console error after few interactions
- `min-width="0"` to keep the picker width static, when the field is wider
- other changes just simplify the example so users are less likely to get confused

resolves #19547

[Playground](https://play.vuetifyjs.com/#eNrFVMtqHDEQ/JVGFyew2s0QTIIZGwK5BnLP5KDM9MSK9UKP3Rjjf3dL2vU87IvB2IeBUXe1VF2l1q87Fny/++bcdp+QXbA2onZKRLzqDEC75701UUiDvgRKyNsD/EshyvH2smPBiR658DaZoWNH1LFUAX2BQE3TMQia/s5nmIKK+D/yUaIapjDAhbYDKr4XKiFVRamxY3OAEn9QUean7G/QgzSg0aQlxnl0aAYuqQmC6kHyXtn+huft+GiT5zZFRd0t6zyKwRp1O8VmlAvpctYsBECxzDgLcm0PP55woZbo7IDcmqIpmkhkiDxVjEKFFQUA0Ue5F9F6AjjhCb9GaGn4QQ7xmhCflskF3ypzbtlVsSauVderdrcALLulXG537lqGP9o2WU5h8pvW73cJBimU/ftW16CetvL++5HCsw7CyTCRol2o8Bo+VT4vceq0opmuE18y08i3u9mDQMvQe+kiBIzJlQKpnfUR7kitEe5h9FbDGb0lZ/UW0F4hQuYMlxnywSSlPk6Z07Acs2USVumq5wrQ7ioT4sDuN+zz9nzbfGH55+u2adim4DaLx63Gfj8AFM99OQ==)