### PR TITLE
fix(VAutocomplete): allow autocomplte on active element with keyboard only

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -226,6 +226,23 @@ export const VAutocomplete = genericComponent<new <
         menu.value = false
       }
 
+      if(['ArrowDown', 'ArrowUp'].includes(e.key)) {
+        if (model.value.length > 0) {
+            const lastSelectedItem = model.value[model.value.length - 1];
+            const displayIndex = displayItems.value.findIndex(item => 
+              (props.valueComparator || deepEqual)(item.value, lastSelectedItem.value)
+            );
+            
+          if (displayIndex >= 0) {
+            vVirtualScrollRef.value?.scrollToIndex(displayIndex)
+            nextTick(() => {
+              listRef.value?.focus(displayIndex)
+            })
+            return;
+          }
+        }
+      }
+
       if (
         highlightFirst.value &&
         ['Enter', 'Tab'].includes(e.key) &&


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
Autocomplete on active element using only keyboard doesn't work
I added new check for keyboardEvents for value selection.

resolves #21404
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

