### PR TITLE
fix(VDateInput): assign type to displayFormat function

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -36,7 +36,10 @@ export type VDateInputSlots = Omit<VTextFieldSlots, 'default'> & {
 }
 
 export const makeVDateInputProps = propsFactory({
-  displayFormat: [Function, String],
+  displayFormat: {
+    type: [Function, String] as PropType<string | ((date: typeof VDatePicker['props']['modelValue']) => any)>,
+    default: undefined,
+  },
   location: {
     type: String as PropType<StrategyProps['location']>,
     default: 'bottom start',


### PR DESCRIPTION
fixes #21683

## Description
Assign a type to display-format callback parameter

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container class="pa-md-12">
    <v-date-input
      v-model="date"
      :display-format="(date) => date.toLocaleDateString()"
      label="Date"
    />
  </v-container>
</template>

<script setup lang="ts">
  import { ref } from 'vue'
  const date = ref(new Date())
</script>

```
