### PR TITLE
fix(VCalendar): use adapter for day.date.getTime

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -174,7 +174,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
                       ) : '',
                       week.map(day => (
                           <VCalendarMonthDay
-                            key={ day.date.getTime() }
+                            key={ adapter.toJsDate(day.date).getTime() }
                             { ...calendarDayProps }
                             day={ day }
                             title={ adapter.format(day.date, 'dayOfMonth') }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
resolves #21688 
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
