### PR TITLE
fix(VProgressLinear): accept pointer events unless `clickable` is used

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
@@ -28,7 +28,7 @@
     width: 100%
     transition-property: width, left, right
     transition: inherit
-    
+
   @media (forced-colors: active)
     .v-progress-linear__buffer
       background-color: highlight
@@ -40,10 +40,13 @@
     height: 100%
     justify-content: center
     left: 0
-    pointer-events: none
     position: absolute
     top: 0
     width: 100%
+
+  .v-progress-linear--clickable
+    .v-progress-linear__content
+      pointer-events: none
 
   .v-progress-linear__determinate,
   .v-progress-linear__indeterminate

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
@@ -121,6 +121,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
             'v-progress-linear--rounded': props.rounded,
             'v-progress-linear--rounded-bar': props.roundedBar,
             'v-progress-linear--striped': props.striped,
+            'v-progress-linear--clickable': props.clickable,
           },
           roundedClasses.value,
           themeClasses.value,


### PR DESCRIPTION
## Description

- judging by git blame history for the [VProgressLinear.sass:43](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass?rgh-link-date=2025-07-03T18%3A42%3A36.000Z#L43), it looks like a mistake or simplification
- changes aim to let user put interactive elements inside the content slot when `clickable` is not used

resolves #21690

## Markup:

<details>
<summary>Playground</summary>

```vue
<template>
  <v-app>
    <v-container max-width="500">
      <v-progress-linear
        :clickable="false"
        color="#0070CB"
        height="30"
        model-value="66"
        rounded
        striped
      >
        <v-chip class="ml-2" size="x-small" text="Operation #1" variant="flat" />
        <v-btn
          class="ml-auto mr-2"
          color="red"
          rounded="pill"
          size="x-small"
          text="Stop"
        />
      </v-progress-linear>

      <div class="pt-4" />
      <v-progress-linear
        v-model="value"
        color="success"
        height="25"
        rounded="lg"
        clickable
      >
        <small>{{ value.toFixed(1) }}% (clickable)</small>
      </v-progress-linear>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref(33)
</script>
```

</details>