### PR TITLE
fix(VDateInput): avoid time values in the field

### DIFF
--- a/packages/vuetify/src/composables/dateFormat.ts
+++ b/packages/vuetify/src/composables/dateFormat.ts
@@ -129,7 +129,7 @@ export function useDateFormat (props: DateFormatProps, locale: Ref<string>) {
   }
 
   function formatDate (value: unknown) {
-    const parts = adapter.toISO(value).split('-')
+    const parts = adapter.toISO(value).split('T')[0].split('-')
 
     return currentFormat.value.order.split('')
       .map(sign => parts['ymd'.indexOf(sign)])


### PR DESCRIPTION
## Description

All date-io adapters seem to print date with time when calling `.toISO(...)`.
It has to be cut off to avoid following result:

![image](https://github.com/user-attachments/assets/c48d42c2-b7ea-4dd9-b671-60361dd5ca5e)
