### PR TITLE
fix(VListItem): keyboard navigation when list contains checkboxes

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -215,7 +215,11 @@ export const VList = genericComponent<new <
     function onKeydown (e: KeyboardEvent) {
       const target = e.target as HTMLElement
 
-      if (!contentRef.value || ['INPUT', 'TEXTAREA'].includes(target.tagName)) return
+      if (!contentRef.value ||
+        (target.tagName === 'INPUT' && ['Home', 'End'].includes(e.key)) ||
+        target.tagName === 'TEXTAREA') {
+        return
+      }
 
       if (e.key === 'ArrowDown') {
         focus('next')


### PR DESCRIPTION
## Description

- re-enables ArrowUp/ArrowDown when `<input>` has focus

fixes #21516

## Markup:

<details>
<summary>Details</summary>

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="550">
      <v-treeview
        :items="items"
        item-value="title"
        select-strategy="classic"
        open-all
        selectable
      >
        <template #item="{ props }">
          <v-list-item v-bind="props">
            <template #prepend="{ isSelected, select }">
              <v-checkbox-btn
                :model-value="isSelected"
                @update:model-value="select"
              />
            </template>
            <template v-if="currentItemToEdit === props.title" #append>
              <v-form
                ref="editForm"
                class="d-flex ga-2 align-center"
                @submit.prevent="saveChanges"
              >
                <v-text-field
                  v-model="newName"
                  :rules="[(v) => !!v || 'Required']"
                  class="mb-n6"
                  density="compact"
                  min-width="180"
                  placeholder="type something..."
                  variant="solo-filled"
                  @keydown.space.stop
                  @mousedown.stop
                />
                <v-btn
                  color="success"
                  icon="$complete"
                  size="x-small"
                  type="submit"
                  variant="text"
                  border
                  @click.stop
                />
                <v-btn
                  color="error"
                  icon="$close"
                  size="x-small"
                  variant="text"
                  border
                  @click.stop="currentItemToEdit = null"
                  @keydown.space.stop
                />
              </v-form>
            </template>
            <template v-else #append>
              <div class="d-flex ga-2 align-center">
                <v-btn
                  color="secondary"
                  icon="mdi-pencil"
                  size="x-small"
                  variant="tonal"
                  @click.stop="openEdit(props.title)"
                  @keydown.space.stop
                />
                <v-menu
                  :close-on-content-click="false"
                  activator="parent"
                  location="bottom end"
                  offset="12"
                  attach
                  @update:model-value="onNotesMenuOpen"
                >
                  <template #activator="{ props: menuProps }">
                    <v-btn
                      color="secondary"
                      icon="mdi-text"
                      size="x-small"
                      variant="tonal"
                      v-bind="menuProps"
                      @click.stop
                      @keydown.space.stop
                    />
                  </template>
                  <template #default="{ isActive }">
                    <!-- attach is not really doing anything except helping verify up/down trap without extending the list item height that would feel like unrealistic design choice -->
                    <v-textarea
                      ref="notesField"
                      label="notes"
                      min-width="280"
                      placeholder="type comment..."
                      variant="solo-filled"
                      @click.stop
                      @keydown.stop
                      @mousedown.stop
                    >
                      <template #append-inner>
                        <v-btn
                          color="success"
                          icon="$complete"
                          size="x-small"
                          variant="text"
                          border
                          @click.stop="isActive.value = false"
                        />
                      </template>
                    </v-textarea>
                  </template>
                </v-menu>
              </div>
            </template>
          </v-list-item>
        </template>
      </v-treeview>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const editForm = ref()
  const notesField = ref()
  const newName = ref('Sydney')
  const currentItemToEdit = ref('Sydney')

  function openEdit (v) {
    newName.value = v
    currentItemToEdit.value = v
  }

  async function saveChanges () {
    const { valid } = await editForm.value.validate()
    if (valid) {
      findNode(currentItemToEdit.value, items.value).title = newName.value
      currentItemToEdit.value = null
    }
  }

  function onNotesMenuOpen (v) {
    if (v) {
      setTimeout(() => notesField.value.focus(), 100)
    }
  }

  function findNode (v, items) {
    return items.length
      ? items.find(x => x.title === v) ??
        findNode(v, items.flatMap(x => x.children ?? []))
      : null
  }

  const items = ref([
    {
      title: 'Australia',
      children: [
        {
          title: 'New South Wales',
          children: [
            { title: 'Sydney', value: 'A-SY' },
            { title: 'Newcastle', value: 'A-NE' },
            { title: 'Wollongong', value: 'A-WO' },
          ],
        },
        {
          title: 'Queensland',
          children: [
            { title: 'Brisbane', value: 'A-BR' },
            { title: 'Townsville', value: 'A-TO' },
          ],
        },
      ],
    },
    {
      title: 'Canada',
      children: [
        {
          title: 'Quebec',
          children: [
            { title: 'Montreal', value: 'C-MO' },
          ],
        },
        {
          title: 'Ontario',
          children: [
            { title: 'Ottawa', value: 'C-OT' },
            { title: 'Toronto', value: 'C-TO' },
          ],
        },
      ],
    },
  ])
</script>
```

</details>