### PR TITLE
feat(Overlay): `stick-to-target` prop

### DIFF
--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -112,6 +112,11 @@
       "persistent": "3.6.0"
     }
   },
+  "VOverlay": {
+    "props": {
+      "stick-to-target": "3.9.0"
+    }
+  },
   "VSelect": {
     "props": {
       "listProps": "3.5.0",

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -51,6 +51,7 @@ export interface StrategyProps {
   location: Anchor
   origin: Anchor | 'auto' | 'overlap'
   offset?: number | string | number[]
+  stickToTarget?: boolean
   maxHeight?: number | string
   maxWidth?: number | string
   minHeight?: number | string
@@ -72,6 +73,7 @@ export const makeLocationStrategyProps = propsFactory({
     default: 'auto',
   },
   offset: [Number, String, Array] as PropType<StrategyProps['offset']>,
+  stickToTarget: Boolean,
 }, 'VOverlay-location-strategies')
 
 export function useLocationStrategies (
@@ -391,19 +393,19 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
       // shift
       if (overflows.x.before) {
-        x += overflows.x.before
+        if (!props.stickToTarget) x += overflows.x.before
         contentBox.x += overflows.x.before
       }
       if (overflows.x.after) {
-        x -= overflows.x.after
+        if (!props.stickToTarget) x -= overflows.x.after
         contentBox.x -= overflows.x.after
       }
       if (overflows.y.before) {
-        y += overflows.y.before
+        if (!props.stickToTarget) y += overflows.y.before
         contentBox.y += overflows.y.before
       }
       if (overflows.y.after) {
-        y -= overflows.y.after
+        if (!props.stickToTarget) y -= overflows.y.after
         contentBox.y -= overflows.y.after
       }
 
@@ -413,9 +415,9 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
         available.x = viewport.width - overflows.x.before - overflows.x.after
         available.y = viewport.height - overflows.y.before - overflows.y.after
 
-        x += overflows.x.before
+        if (!props.stickToTarget) x += overflows.x.before
         contentBox.x += overflows.x.before
-        y += overflows.y.before
+        if (!props.stickToTarget) y += overflows.y.before
         contentBox.y += overflows.y.before
       }
 


### PR DESCRIPTION
## Description

- introduces new prop `stick-to-target`

resolves #19856
resolves #19732

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex justify-center align-center h-100">
      <v-sheet class="overflow-scroll" max-height="400" max-width="600">
        <!-- <div v-for="i in 60">Lorem ipsum dolor sit</div> -->
        <div class="d-flex ga-5">
          <v-btn color="green">
            Stick to target
            <v-menu activator="parent" attach stick-to-target>
              <v-list :items="items" border />
            </v-menu>
          </v-btn>
          <v-spacer />
          <v-btn color="red">
            Keep visible (default)
            <v-menu activator="parent" attach>
              <v-list :items="items" border />
            </v-menu>
          </v-btn>
        </div>
        <div class="d-flex ga-5 text-no-wrap">
          <div v-for="i in 20" :key="i">Lorem ipsum dolor sit</div>
        </div>
        <div v-for="i in 60" :key="i">Lorem ipsum dolor sit</div>
      </v-sheet>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      items: Array.from({ length: 5 }, (_, i) => `Item #${i + 1}`),
    }),
  }
</script>
```
