### PR TITLE
fix(VField): Fix label accessibility

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -299,6 +299,7 @@ export const VField = genericComponent<new <T>(
                 class={[textColorClasses.value]}
                 floating
                 for={ id.value }
+                aria-hidden={ !isActive.value }
                 style={ textColorStyles.value }
               >
                 { label() }
@@ -396,7 +397,7 @@ export const VField = genericComponent<new <T>(
 
                 { hasFloatingLabel.value && (
                   <div class="v-field__outline__notch">
-                    <VFieldLabel ref={ floatingLabelRef } floating for={ id.value }>
+                    <VFieldLabel ref={ floatingLabelRef } floating for={ id.value } aria-hidden={ !isActive.value }>
                       { label() }
                     </VFieldLabel>
                   </div>
@@ -407,7 +408,7 @@ export const VField = genericComponent<new <T>(
             )}
 
             { isPlainOrUnderlined.value && hasFloatingLabel.value && (
-              <VFieldLabel ref={ floatingLabelRef } floating for={ id.value }>
+              <VFieldLabel ref={ floatingLabelRef } floating for={ id.value } aria-hidden={ !isActive.value }>
                 { label() }
               </VFieldLabel>
             )}

--- a/packages/vuetify/src/components/VField/VFieldLabel.tsx
+++ b/packages/vuetify/src/components/VField/VFieldLabel.tsx
@@ -27,7 +27,6 @@ export const VFieldLabel = genericComponent()({
           props.class,
         ]}
         style={ props.style }
-        aria-hidden={ props.floating || undefined }
         v-slots={ slots }
       />
     ))


### PR DESCRIPTION
fixes #21025

## Description
For floating labels, set `aria-hidden` to true if field is active, false if not active

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-form>
      <v-container>
        <v-row>
          <v-col cols="12" md="4" sm="6">
            <v-text-field
              label="Regular"
              placeholder="Placeholder"
            ></v-text-field>
          </v-col>

          <v-col cols="12" md="4" sm="6">
            <v-text-field
              label="Solo"
              placeholder="Placeholder"
              variant="solo"
            ></v-text-field>
          </v-col>

          <v-col cols="12" md="4" sm="6">
            <v-text-field
              label="Filled"
              placeholder="Placeholder"
              variant="filled"
            ></v-text-field>
          </v-col>

          <v-col cols="12" md="4" sm="6">
            <v-text-field
              label="Outlined"
              placeholder="Placeholder"
              variant="outlined"
            ></v-text-field>
          </v-col>

          <v-col cols="12" md="4" sm="6">
            <v-text-field
              label="Plain"
              placeholder="Placeholder"
              variant="plain"
            ></v-text-field>
          </v-col>

          <v-col cols="12" md="4" sm="6">
            <v-text-field
              label="Underlined"
              placeholder="Placeholder"
              variant="underlined"
            ></v-text-field>
          </v-col>
        </v-row>
      </v-container>
    </v-form>
  </v-app>
</template>
```
