### PR TITLE
docs(useHotkey): Fix Eratta

### DIFF
--- a/packages/docs/src/examples/hotkey/platform.vue
+++ b/packages/docs/src/examples/hotkey/platform.vue
@@ -48,7 +48,7 @@
                     <tr>
                       <td><v-hotkey keys="meta+f"></v-hotkey></td>
                       <td>Find in Page</td>
-                      <td>{{ isMac ? 'Cmd on Mac' : 'Windows key on PC' }}</td>
+                      <td>{{ isMac ? 'Cmd on Mac' : 'Ctrl key on PC' }}</td>
                     </tr>
                   </tbody>
                 </v-table>

--- a/packages/docs/src/pages/en/features/hotkey.md
+++ b/packages/docs/src/pages/en/features/hotkey.md
@@ -236,8 +236,12 @@ useHotkey('cmd+k-t', handleAction)
 useHotkey('alt+1', handleAction)
 ```
 
-### Best practices
+## Best practices
+
+::: info
+Hotkeys are a powerful feature, but they utilize APIs that are managed by the browser and the operating system. The reliability of the key bindings you make are subject to factors that can be difficult to control. It's recommended you test your key bindings in the browsers and operating systems you are targeting.
+:::
 
 - **Test cross-platform**: _Verify shortcuts work_ on Windows, macOS, and Linux!
 - **Use modifier combinations**: Prefer `Ctrl+Shift+Key` for custom actions
-- **Document your shortcuts**: Maintain a list of all application hotkeys
+- **Document your shortcuts**: Maintain a list of all application hotkeys in your application

--- a/packages/docs/src/pages/en/introduction/why-vuetify.md
+++ b/packages/docs/src/pages/en/introduction/why-vuetify.md
@@ -101,5 +101,6 @@ Learn more about the inner workings of Vuetify and become a skilled **v-develope
 | [SASS variables](/features/sass-variables/) | Intermediate | 10 min |
 | [Blueprints](/features/blueprints/) | Advanced | 10 min |
 | [Treeshaking](/features/treeshaking/) | Advanced | 15 min |
+| [Hotkeys](/features/hotkey/) | Advanced | 10 min |
 
 Can't find what you're looking for? Help us improve! Please reach out to [hello@vuetifyjs.com](mailto:hello@vuetifyjs.com) with your feedback or join us in the Vuetify [Discord community](https://community.vuetifyjs.com/).

--- a/packages/docs/src/pages/en/labs/introduction.md
+++ b/packages/docs/src/pages/en/labs/introduction.md
@@ -81,6 +81,7 @@ The following is a list of available and up-and-coming components for use with L
 | [v-date-input](/components/date-inputs/) | A date input component | [v3.6.0](/getting-started/release-notes/?version=v3.6.0) |
 | [v-pull-to-refresh](/components/pull-to-refresh/) | A component to update content by screen swipes | [v3.6.0](/getting-started/release-notes/?version=v3.6.0) |
 | [v-stepper-vertical](/components/vertical-steppers/) | Vertical version of v-stepper | [v3.6.5](/getting-started/release-notes/?version=v3.6.5) |
+| [v-hotkey](/components/hotkey/) | A component to display hotkey bindings | [v3.9.0](/getting-started/release-notes/?version=v3.9.0) |
 
 ::: warning
 Lab component APIs are **NOT** finalized and can and will change. You should **EXPECT** for things to break during the course of development.


### PR DESCRIPTION
- Fixes an example that suggests usage of the windows key is supported
- Adds link in introduction/why-vuetify page to useHotkey
- Adds link to VHotkey in labs/introduction
