### PR TITLE
fix(VSelectionControl): correctly pass ripple options

### DIFF
--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -282,8 +282,8 @@ export const VSelectionControl = genericComponent<new <T>(
               class={[
                 'v-selection-control__input',
               ]}
-              v-ripple={ props.ripple && [
-                !props.disabled && !props.readonly,
+              v-ripple={[
+                !props.disabled && !props.readonly && props.ripple,
                 null,
                 ['center', 'circle'],
               ]}

--- a/packages/vuetify/src/components/VStepper/VStepperItem.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperItem.tsx
@@ -144,7 +144,7 @@ export const VStepperItem = genericComponent<VStepperItemSlots>()({
           disabled={ !props.editable }
           type="button"
           v-ripple={[
-            props.ripple && props.editable,
+            props.editable && props.ripple,
             null,
             null,
           ]}


### PR DESCRIPTION
## Description

- VRipple recently got the `keys`option, but currently it is not possible to suppress certain ripple triggers on VCheckbox

closes #21208

## Markup:

> updated after [7ecec03](https://github.com/vuetifyjs/vuetify/commit/7ecec03fb50267507928c6de6751dee16540ea7f)

```vue
<template>
  <v-app>
    <v-container max-width="400">
      select with <v-kbd>Tab</v-kbd>
      <v-list variant="tonal">
        <v-list-item
          class="mb-2"
          tabindex="0"
          title="ripple on keydown:enter blocked"
          v-ripple="{ class: 'text-red', keys: [' '] }"
        />
        <v-list-item
          class="mb-2"
          tabindex="0"
          title="ripple on keydown:space blocked"
          v-ripple="{ class: 'text-red', keys: ['Enter'] }"
        />
        <v-list-item
          class="mb-2"
          tabindex="0"
          title="ripple on keydown blocked"
          v-ripple="{ class: 'text-red', keys: [] }"
        />
        <v-list-item
          class="mb-2"
          tabindex="0"
          title="regular list item"
          v-ripple
        />
      </v-list>
      <v-checkbox
        :ripple="{ class: 'text-red', keys: [' '] }"
        label="v-checkbox only keydown:space"
      />
      <v-checkbox-btn
        :ripple="{ class: 'text-red', keys: [' '] }"
        label="v-checkbox-btn only keydown:space"
      />

      <v-btn
        :ripple="{ class: 'text-red', keys: [' '] }"
        text="only keydown:space"
      />
    </v-container>
  </v-app>
</template>
```
