### PR TITLE
fix(VTextField): avoid infinite loop with autofocus and dialog

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -104,8 +104,8 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
       if (!isFocused.value) focus()
 
       nextTick(() => {
-        if (inputRef.value !== document.activeElement) {
-          nextTick(() => inputRef.value?.focus())
+        if (inputRef.value !== document.activeElement && isFocused.value) {
+          inputRef.value?.focus()
         }
       })
     }

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.browser.tsx
@@ -81,7 +81,7 @@ describe('VTextField', () => {
     const input1 = screen.getByCSS('input[name="username"]') as HTMLInputElement
     const input2 = screen.getByCSS('input[name="password"]') as HTMLInputElement
 
-    await commands.abortAfter(5000, 'VTextField infinite loop detection')
+    await commands.abortAfter(5000, 'VTextField + password managers » infinite loop detection')
 
     input1.focus()
     input1.value = 'my username'
@@ -121,7 +121,7 @@ describe('VTextField', () => {
       </div>
     ))
 
-    await commands.abortAfter(5000, 'VTextField infinite loop detection')
+    await commands.abortAfter(5000, 'VTextField + autofocus » infinite loop detection')
 
     show.value = true
     await wait(300)


### PR DESCRIPTION
## Description

fixes #21716

## Markup:

```vue
<template>
  <v-btn @click="show = !show">Click to freeze page</v-btn>
  <v-text-field v-if="show" autofocus />
  <v-dialog :model-value="show">
    <v-btn text="just a button" />
  </v-dialog>
</template>

<script setup>
  import { ref } from 'vue'

  const show = ref(false)
</script>
```
