### PR TITLE
fix(VMaskInput): Use proper validation value

### DIFF
--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -7,7 +7,7 @@ import { makeMaskProps, useMask } from '@/composables/mask'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, onBeforeMount, ref } from 'vue'
+import { computed, onBeforeMount, ref, toRef } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -60,6 +60,8 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       },
     )
 
+    const validationValue = toRef(() => returnMaskedValue.value ? maskText(model.value) : unmaskText(model.value))
+
     onBeforeMount(() => {
       if (props.returnMaskedValue) {
         emit('update:modelValue', model.value)
@@ -74,7 +76,7 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
           { ...textFieldProps }
           v-model={ model.value }
           ref={ vTextFieldRef }
-          validationValue={ returnMaskedValue.value ? maskText(model.value) : unmaskText(model.value) }
+          validationValue={ validationValue.value }
         >
           {{ ...slots }}
         </VTextField>


### PR DESCRIPTION
Related to #21714

## Description
Use proper value for validation

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container class="pa-md-12">
    <v-row>
      <v-mask-input
        v-model="msg"
        :mask="mask"
        :placeholder="mask"
        :rules="rules"
      />
    </v-row>
    <v-row>
      <v-col cols="3">Model actual value:</v-col>
      <v-col>{{ msg }}</v-col>
    </v-row>
    <v-row>
      <v-col cols="3">Is Model Valid?:</v-col>
      <v-col>{{ isModelValid }}</v-col>
    </v-row>
    <v-row>
      <v-col cols="3">Masked value??</v-col>
      <v-col>{{ msg }}</v-col>
    </v-row>
  </v-container>
</template>

<script setup>
  import { computed, ref } from 'vue'
  const onlyAlphanumericCharacters = /^[a-zA-Z0-9]+$/
  const mask = ref('(AA)-###-###-##-##')
  const rules = [value => onlyAlphanumericCharacters.test(value) || 'Must contain alphanumeric characters']
  const msg = ref('')
  const isModelValid = computed(() => {
    return onlyAlphanumericCharacters.test(msg.value)
  })
</script>

```
