### PR TITLE
fix(VList, VTreeview): avoid locked active state when navigating

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -223,7 +223,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
         activate(!isActivated.value, e)
       } else if (root.selectable.value) {
         select(!isSelected.value, e)
-      } else if (props.value != null) {
+      } else if (props.value != null && !isLink.value) {
         select(!isSelected.value, e)
       }
     }


### PR DESCRIPTION
## Description

- fixes the duplicate highlight on the navigation

<details>
<summary>Recording of the problem</summary>

[Screencast from 2025-07-09 14-27-42.webm](https://github.com/user-attachments/assets/2c4d5cd0-eccc-40ab-b985-37c76d086dff)

</details>

follow-up to #21644

## Markup:

<details>
<summary>Playground to run within source code</summary>

```vue
<template>
  <v-app>
    <v-navigation-drawer permanent>
      <v-treeview
        :item-props="addProps"
        :items="items"
        item-value="id"
        no-selection
        open-all
      />
      <v-list
        :item-props="addProps"
        :items="items"
        item-value="id"
        no-selection
      />
    </v-navigation-drawer>
    <v-main>
      <router-view />
    </v-main>
  </v-app>
</template>

<script setup>
  function addProps (item) {
    return !item.children
      ? {
        to: item.id ? `/page${item.id}` : '/',
        nav: true,
      }
      : {}
  }

  const items = [
    {
      id: 9,
      title: 'Applications :',
      children: [
        { id: 0, title: 'Home' },
        { id: 1, title: 'Page 1' },
        { id: 2, title: 'Page 2' },
      ],
    },
  ]
</script>
```

</details>