### PR TITLE
fix(VChipGroup): consistently select by value when provided

### DIFF
--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -341,7 +341,7 @@ function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
 
     if (item?.value != null) {
       ids.push(item.id)
-    } else if (itemByIndex != null) {
+    } else if (itemByIndex?.useIndexAsValue) {
       ids.push(itemByIndex.id)
     }
   })


### PR DESCRIPTION
## Description

fixes #20129

## Markup:

```vue
<template>
  <v-app>
    <v-chip-group v-model="selectedChip" color="pink" column>
      <v-chip
        v-for="(chip, i) in chips"
        :key="`chip${i}`"
        :text="`${chip.name}: #${chip.id}`"
        :value="chip.id"
        filter
        @click="selectedChip = chip.id"
      />
    </v-chip-group>

    <v-chip-group v-model="selectedChip" color="pink" column>
      <v-chip
        v-for="i in 4"
        :key="`chip${i}`"
        :text="i"
        filter
        @click="selectedChip = i"
      />
    </v-chip-group>
    selected: {{ selectedChip }}
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selectedChip = ref(2)

  const chips = ref([
    { id: 11, name: 'first' },
    { id: 22, name: 'second' },
    { id: 33, name: 'third' },
    { id: 44, name: 'fourth' },
  ])
</script>
```
