### PR TITLE
fix(group): support `null` values

### DIFF
--- a/packages/vuetify/src/composables/group.ts
+++ b/packages/vuetify/src/composables/group.ts
@@ -169,9 +169,9 @@ export function useGroup (
     'modelValue',
     [],
     v => {
-      if (v == null) return []
+      if (v === undefined) return []
 
-      return getIds(items, wrapInArray(v))
+      return getIds(items, v === null ? [null] : wrapInArray(v))
     },
     v => {
       const arr = getValues(items, v)
@@ -190,7 +190,7 @@ export function useGroup (
     const children = findChildrenWithProvide(key, groupVm?.vnode)
     const index = children.indexOf(vm)
 
-    if (unref(unwrapped.value) == null) {
+    if (unref(unwrapped.value) === undefined) {
       unwrapped.value = index
       unwrapped.useIndexAsValue = true
     }
@@ -339,7 +339,7 @@ function getIds (items: UnwrapRef<GroupItem[]>, modelValue: any[]) {
     const item = items.find(item => deepEqual(value, item.value))
     const itemByIndex = items[value]
 
-    if (item?.value != null) {
+    if (item?.value !== undefined) {
       ids.push(item.id)
     } else if (itemByIndex != null) {
       ids.push(itemByIndex.id)
@@ -356,7 +356,7 @@ function getValues (items: UnwrapRef<GroupItem[]>, ids: any[]) {
     const itemIndex = items.findIndex(item => item.id === id)
     if (~itemIndex) {
       const item = items[itemIndex]
-      values.push(item.value != null ? item.value : itemIndex)
+      values.push(item.value !== undefined ? item.value : itemIndex)
     }
   })
 


### PR DESCRIPTION
## Description

fixes #20550

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <p>MODEL: {{ model }}</p>

      <v-divider class="my-4" />

      <v-select
        v-model="model"
        :items="items"
        item-value="id"
        label="label"
        clearable
        persistent-clear
      />

      <v-divider class="my-4" />

      <v-radio-group v-model="model">
        <v-radio
          v-for="item in items"
          :key="item.id"
          :label="item.title"
          :value="item.id"
        />
        <v-radio :value="null" label="empty (null)" />
      </v-radio-group>

      <v-chip-group v-model="model">
        <v-chip
          v-for="id in ['id_1', 'id_2']"
          :key="`chip${id}`"
          :text="id"
          :value="id"
          filter
        />
        <v-chip key="empty" :value="null" text="empty (null)" filter />
      </v-chip-group>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const model = ref(null)

  const items = [
    { id: 'id_1', title: 'I am item 1' },
    { id: 'id_2', title: 'I am item 2' },
  ]
</script>
```
