### PR TITLE
fix(VCalendar): avoid error when model-value is not used

### DIFF
--- a/packages/docs/src/examples/v-calendar/event-click.vue
+++ b/packages/docs/src/examples/v-calendar/event-click.vue
@@ -140,7 +140,7 @@
   const colors = ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey darken-1']
   const names = ['Meeting', 'Holiday', 'PTO', 'Travel', 'Event', 'Birthday', 'Conference', 'Party']
 
-  const focus = ref('')
+  const focus = ref([])
   const type = ref('month')
   const selectedEvent = ref({})
   const selectedElement = ref(null)
@@ -159,7 +159,7 @@
     return event.color
   }
   function setToday () {
-    focus.value = ''
+    focus.value = []
   }
   function prev () {
     calendar.value.prev()
@@ -211,7 +211,7 @@
 <script>
   export default {
     data: () => ({
-      focus: '',
+      focus: [],
       type: 'month',
       typeToLabel: {
         month: 'Month',
@@ -238,7 +238,7 @@
         return event.color
       },
       setToday () {
-        this.focus = ''
+        this.focus = []
       },
       prev () {
         this.$refs.calendar.prev()

--- a/packages/docs/src/examples/v-calendar/prop-type-month.vue
+++ b/packages/docs/src/examples/v-calendar/prop-type-month.vue
@@ -20,7 +20,7 @@
 
   const calendar = ref()
 
-  const today = ref(new Date())
+  const today = ref([new Date()])
   const events = ref([])
   const colors = ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey darken-1']
   const names = ['Meeting', 'Holiday', 'PTO', 'Travel', 'Event', 'Birthday', 'Conference', 'Party']

--- a/packages/docs/src/examples/v-calendar/prop-type-week.vue
+++ b/packages/docs/src/examples/v-calendar/prop-type-week.vue
@@ -57,13 +57,13 @@
     },
   ]
 
-  const today = ref(new Date('2019-01-08'))
+  const today = ref([new Date('2019-01-08')])
 </script>
 
 <script>
   export default {
     data: () => ({
-      today: '2019-01-08',
+      today: ['2019-01-08'],
       weekday: [0, 1, 2, 3, 4, 5, 6],
       weekdays: [
         { title: 'Sun - Sat', value: [0, 1, 2, 3, 4, 5, 6] },

--- a/packages/docs/src/examples/v-calendar/slot-day-body.vue
+++ b/packages/docs/src/examples/v-calendar/slot-day-body.vue
@@ -25,7 +25,7 @@
 
   const calendar = ref()
 
-  const value = ref('')
+  const value = ref([])
   const ready = ref(false)
 
   const cal = computed(() => {
@@ -57,7 +57,7 @@
 <script>
   export default {
     data: () => ({
-      value: '',
+      value: [],
       ready: false,
     }),
     computed: {

--- a/packages/docs/src/examples/v-calendar/slot-day.vue
+++ b/packages/docs/src/examples/v-calendar/slot-day.vue
@@ -33,7 +33,7 @@
 <script setup>
   import { ref } from 'vue'
 
-  const today = ref('2019-01-10')
+  const today = ref(['2019-01-10'])
   const tracked = ref({
     '2019-01-09': [23, 45, 10],
     '2019-01-08': [10],
@@ -52,7 +52,7 @@
 <script>
   export default {
     data: () => ({
-      today: '2019-01-10',
+      today: ['2019-01-10'],
       tracked: {
         '2019-01-09': [23, 45, 10],
         '2019-01-08': [10],

--- a/packages/vuetify/src/composables/calendar.ts
+++ b/packages/vuetify/src/composables/calendar.ts
@@ -90,7 +90,7 @@ export function useCalendar (props: CalendarProps) {
   )
   const displayValue = computed(() => {
     if (props.displayValue) return adapter.date(props.displayValue)
-    if (model.value.length > 0) return adapter.date(model.value[0])
+    if (model.value[0]) return adapter.date(model.value[0])
     if (props.min) return adapter.date(props.min)
     if (Array.isArray(props.allowedDates)) return adapter.date(props.allowedDates[0])
 

--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -223,12 +223,12 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
               }) : (
                 <VCalendarDay
                   { ...calendarDayProps }
-                  day={ genDays([model.value[0] as Date], adapter.date() as Date)[0] }
+                  day={ genDays([(model.value[0] || adapter.date()) as Date], adapter.date() as Date)[0] }
                   dayIndex={ 0 }
                   events={
                     props.events?.filter(e =>
-                      adapter.isSameDay(e.start, genDays([model.value[0] as Date], adapter.date() as Date)[0].date) ||
-                      adapter.isSameDay(e.end, genDays([model.value[0] as Date], adapter.date() as Date)[0].date)
+                      adapter.isSameDay(e.start, genDays([(model.value[0] || adapter.date()) as Date], adapter.date() as Date)[0].date) ||
+                      adapter.isSameDay(e.end, genDays([(model.value[0] || adapter.date()) as Date], adapter.date() as Date)[0].date)
                     )
                   }
                   { ...attrs }


### PR DESCRIPTION
- updates `v-model` in examples
- `undefined` get's passed from [VCalendar.tsx:226](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/labs/VCalendar/VCalendar.tsx#L226)

<details>
<summary>Error in console on Docs</summary>

<img width="1062" height="366" alt="Screenshot from 2025-07-13 16-09-47" src="https://github.com/user-attachments/assets/62cbf0df-d15d-40f5-81b1-f023d8c2a72a" />

</details>

Related to #21642, ⚠ please make sure to review both