### PR TITLE
fix(VFileInput): avoid text overflow with long file names

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.sass
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.sass
@@ -24,6 +24,9 @@
           &--floating
             top: 0px
 
+    .v-field__input
+      word-break: break-word
+
     input[type="file"]
       height: 100%
       left: 0


### PR DESCRIPTION
## Description

fixes #21707

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="300">
      <v-alert
        text="Choose files with long name fragments that do not contain spaces or dashes"
      />
      <br />
      <v-file-input label="File input" multiple></v-file-input>
      <v-alert
        text="Chips won't break. `truncate-length` will help here once #17972 gets merged."
      />
      <br />
      <v-file-input label="File input w/ chips" chips multiple></v-file-input>
    </v-container>
  </v-app>
</template>
```
