### PR TITLE
docs(hotkey): fix links and usage demo

### DIFF
--- a/packages/docs/src/data/page-to-api.json
+++ b/packages/docs/src/data/page-to-api.json
@@ -171,6 +171,7 @@
   "directives/tooltip": ["v-tooltip"],
   "features/dates": ["useDate"],
   "features/display-and-platform": ["useDisplay"],
+  "features/hotkey": ["useHotkey"],
   "features/scrolling": ["useGoTo"],
   "features/global-configuration": ["VDefaultsProvider"],
   "features/internationalization": ["useLocale", "VLocaleProvider"],

--- a/packages/docs/src/examples/hotkey/usage.vue
+++ b/packages/docs/src/examples/hotkey/usage.vue
@@ -30,7 +30,7 @@
       </template>
 
       <template v-slot:actions>
-        <span class="ps-2">Current hotkey:</span> <v-hotkey :display-mode="displayMode" :keys></v-hotkey>
+        <span class="ps-2">Current hotkey:</span> <v-hotkey :keys></v-hotkey>
 
         <v-spacer></v-spacer>
 
@@ -51,16 +51,12 @@
 
   const name = 'hotkey'
   const model = ref('default')
-  const options = ['text', 'symbol', 'icon']
+  const options = []
   const logs = ref([])
   const keys = shallowRef('cmd+b')
   const binding = shallowRef(false)
   const allowInputs = shallowRef(false)
   const sequenceTimeout = shallowRef(0)
-
-  const displayMode = computed(() => {
-    return model.value === 'default' ? undefined : model.value
-  })
 
   const and = computed(() => sequenceTimeout.value && allowInputs.value ? '\n  ' : '')
 
@@ -70,17 +66,22 @@
 }` : ''
   })
 
-  const code = `<template>
-  <div>Hello world</div>
-</template>`
+  const code = toRef(() => `<span>Current hotkey:</span>
+<v-hotkey keys="${keys.value}" />
+<pre>log: {{ log }}</pre>`)
 
-  const script = computed(() => {
+  const script = toRef(() => {
     return `<script setup>
+  import { shallowRef } from 'vue'
   import { useHotkey } from 'vuetify'
 
-  function onHotkey () {}
+  const log = shallowRef('')
 
-  const unwatch = useHotkey('${keys.value}', onHotkey${args.value})
+  function onHotkey () {
+    log.value += '\\n- Hotkey pressed'
+  }
+
+  useHotkey('${keys.value}', onHotkey${args.value})
 <\\/script>`.replace('\\/', '/')
   })
 

--- a/packages/docs/src/pages/en/features/hotkey.md
+++ b/packages/docs/src/pages/en/features/hotkey.md
@@ -10,7 +10,7 @@ related:
   - /features/accessibility/
   - /features/global-configuration/
 features:
-  github: /composables/hotkey.ts
+  github: /composables/hotkey
   label: 'E: hotkey'
   report: true
 ---


### PR DESCRIPTION
## Description

fixes #21747

- [x] fixes GitHub link
- [x] drops display mode to simplify usage demo
- [x] fixes code for playground
- [x] registers `useHotkey` for inline API, but I was not able to verify it locally.. it only shows inactive dropdown