### PR TITLE
fix(VFileUploadItem): apply classes, styles as props

### DIFF
--- a/packages/vuetify/src/labs/VFileUpload/VFileUploadItem.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUploadItem.tsx
@@ -66,9 +66,13 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
       return (
         <VListItem
           { ...listItemProps }
+          class={[
+            'v-file-upload-item',
+            props.class,
+          ]}
           title={ props.title ?? props.file?.name }
           subtitle={ props.showSize ? humanReadableFileSize(props.file?.size, base.value) : props.file?.type }
-          class="v-file-upload-item"
+          style={ props.style }
         >
           {{
             ...slots,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #21740 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-file-upload v-model="model" clearable multiple show-size>
    <template #item="{ props: itemProps }">
      <v-file-upload-item
        :style="{ backgroundColor: 'red' }"
        class="test"
        v-bind="itemProps"
        lines="one"
        nav
      >
        <template #prepend>
          <v-avatar size="32" rounded />
        </template>

        <template #clear="{ props: clearProps }">
          <v-btn color="primary" v-bind="clearProps" />
        </template>
      </v-file-upload-item>
    </template>
  </v-file-upload>
</template>

<script setup>
  import { shallowRef } from 'vue'

  const model = shallowRef(null)
</script>
```
