### PR TITLE
fix(useMask): handle number input in maskText function

### DIFF
--- a/packages/vuetify/src/composables/mask.ts
+++ b/packages/vuetify/src/composables/mask.ts
@@ -106,7 +106,9 @@ export function useMask (props: MaskProps, inputRef: Ref<HTMLInputElement | unde
     return item.convert ? item.convert(char) : char
   }
 
-  function maskText (text: string | null | undefined): string {
+  function maskText (text: string | number | null | undefined): string {
+    if (typeof text === "number") text = String(text);
+
     const trimmedText = text?.trim().replace(/\s+/g, ' ')
 
     if (trimmedText == null) return ''

--- a/packages/vuetify/src/composables/mask.ts
+++ b/packages/vuetify/src/composables/mask.ts
@@ -107,7 +107,7 @@ export function useMask (props: MaskProps, inputRef: Ref<HTMLInputElement | unde
   }
 
   function maskText (text: string | number | null | undefined): string {
-    if (typeof text === "number") text = String(text);
+    if (typeof text === 'number') text = String(text)
 
     const trimmedText = text?.trim().replace(/\s+/g, ' ')
 


### PR DESCRIPTION
**_fix(VMask): Ensure numeric values work correctly with v-model_**

Description:

This PR addresses an issue in the v-mask-input component that occurs when using a v-model bound to a number type.

Currently, if the initial value provided to the mask is a number, the maskText function fails when attempting to execute string operations, such as .trim(), resulting in an error and preventing the mask from being applied correctly.

The proposed solution modifies the maskText function to also accept the number type. A check has been added at the beginning of the function to convert any numeric value to a string before proceeding with the mask processing. This ensures compatibility and the expected behavior of the component without breaking existing functionality for string values.

How to Reproduce the Issue:

The error can be replicated by using a v-mask-input with the v-model initialized as a number, as shown in the example below:

<img width="916" height="533" alt="Pull request" src="https://github.com/user-attachments/assets/b456d2d0-de28-426d-bdbd-00ad1ed58371" />

Before:
<img width="916" height="763" alt="Pull request" src="https://github.com/user-attachments/assets/1ea22732-0fe5-47d7-8f0f-850a5618f460" />

