### PR TITLE
fix(VFileUploadItem): accept `title` slot

### DIFF
--- a/packages/vuetify/src/labs/VFileUpload/VFileUploadItem.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUploadItem.tsx
@@ -76,7 +76,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
         >
           {{
             ...slots,
-            title: () => props?.title ?? props.file?.name,
+            title: slots.title ?? (() => props?.title ?? props.file?.name),
             prepend: slotProps => (
               <>
                 { !slots.prepend ? (


### PR DESCRIPTION
## Description

- aligns component with API docs claiming there is a `title` slot

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-file-upload multiple title="title" clearable show-size>
        <template v-slot:item="{ props: itemProps }">
          <v-file-upload-item v-bind="itemProps">
            <template v-slot:title="{ title }"> title: {{ title.substring(0, 10) }}... </template>
            <template v-slot:subtitle> subtitle </template>
          </v-file-upload-item>
        </template>
      </v-file-upload>
    </v-container>
  </v-app>
</template>
```
