### PR TITLE
fix(Docs): Remove Inline API and increase sequence timeout

### DIFF
--- a/packages/docs/src/examples/hotkey/options.vue
+++ b/packages/docs/src/examples/hotkey/options.vue
@@ -41,7 +41,7 @@
                 <v-slider
                   v-model="sequenceTimeout"
                   class="mb-3"
-                  label="Sequence Timeout (ms)"
+                  :label="`Sequence Timeout (${sequenceTimeout}ms)`"
                   max="3000"
                   min="500"
                   step="100"
@@ -158,7 +158,7 @@
   const eventType = ref('keydown')
   const allowInInputs = ref(true)
   const preventDefault = ref(true)
-  const sequenceTimeout = ref(1000)
+  const sequenceTimeout = ref(2000)
   const cleanupFunctions = ref([])
 
   const addMessage = text => {

--- a/packages/docs/src/examples/hotkey/sequences.vue
+++ b/packages/docs/src/examples/hotkey/sequences.vue
@@ -45,7 +45,7 @@
             <v-slider
               v-model="sequenceTimeout"
               class="mb-4"
-              label="Sequence Timeout (ms)"
+              :label="`Sequence Timeout (${sequenceTimeout}ms)`"
               max="3000"
               min="500"
               step="100"
@@ -80,7 +80,7 @@
   import { useHotkey } from 'vuetify'
 
   const messages = ref([])
-  const sequenceTimeout = ref(1000)
+  const sequenceTimeout = ref(2000)
   const cleanupFunctions = ref([])
 
   const addMessage = text => {
@@ -140,7 +140,7 @@
     data () {
       return {
         messages: [],
-        sequenceTimeout: 1000,
+        sequenceTimeout: 2000,
         cleanupFunctions: [],
       }
     },

--- a/packages/docs/src/examples/hotkey/usage.vue
+++ b/packages/docs/src/examples/hotkey/usage.vue
@@ -40,7 +40,13 @@
 
     <template v-slot:configuration>
       <v-checkbox v-model="allowInputs" label="Allow inputs"></v-checkbox>
-      <v-slider v-model="sequenceTimeout" label="Timeout"></v-slider>
+      <div class="text-subtitle-1 mt-3">Sequence Timeout <span class="text-caption text-grey">({{ sequenceTimeout }}ms)</span></div>
+      <v-slider
+        v-model="sequenceTimeout"
+        max="3000"
+        min="500"
+        step="100"
+      ></v-slider>
     </template>
   </ExamplesUsageExample>
 </template>
@@ -56,7 +62,7 @@
   const keys = shallowRef('cmd+b')
   const binding = shallowRef(false)
   const allowInputs = shallowRef(false)
-  const sequenceTimeout = shallowRef(0)
+  const sequenceTimeout = shallowRef(2000)
 
   const and = computed(() => sequenceTimeout.value && allowInputs.value ? '\n  ' : '')
 

--- a/packages/docs/src/pages/en/features/hotkey.md
+++ b/packages/docs/src/pages/en/features/hotkey.md
@@ -57,8 +57,6 @@ The **hotkey** composable takes a key combination string and a callback function
 | - | - |
 | [useHotkey](/api/use-hotkey/) | The useHotkey composable |
 
-<ApiInline hide-links />
-
 ## Guide
 
 The `useHotkey` composable provides a declarative way to handle keyboard shortcuts in your Vue applications. It automatically cleans up event listeners when components are unmounted and supports reactive key combinations.


### PR DESCRIPTION
- Inline API does not work for manually created API docs. useHotkey could not have it's API documentation auto-generated and uses a manual page.
- Increased sequence timeout for examples and enhanced presentation

Fixes #21747
