### PR TITLE
fix(VOtpInput): focus jumps to the end when correcting filled input

### DIFF
--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -190,7 +190,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
 
       model.value = clipboardText.split('')
 
-      inputRef.value?.[finalIndex].focus()
+      focusIndex.value = finalIndex
     }
 
     function reset () {
@@ -225,10 +225,7 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     }, { scoped: true })
 
     watch(model, val => {
-      if (val.length === length.value) {
-        focusIndex.value = length.value - 1
-        emit('finish', val.join(''))
-      }
+      if (val.length === length.value) emit('finish', val.join(''))
     }, { deep: true })
 
     watch(focusIndex, val => {

--- a/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
+++ b/packages/vuetify/src/components/VOtpInput/VOtpInput.tsx
@@ -225,7 +225,9 @@ export const VOtpInput = genericComponent<VOtpInputSlots>()({
     }, { scoped: true })
 
     watch(model, val => {
-      if (val.length === length.value) emit('finish', val.join(''))
+      if (val.length === length.value) {
+        emit('finish', val.join(''))
+      }
     }, { deep: true })
 
     watch(focusIndex, val => {


### PR DESCRIPTION
fixes #21680 

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-otp-input :model-value="123456" />
    </v-container>
  </v-app>
</template>
```
