### PR TITLE
fix(VTreeview): hide extended lines when fluid

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -28,7 +28,6 @@ function flatten (items: ListItem[], flat: ListItem[] = []) {
 }
 
 export const makeVTreeviewProps = propsFactory({
-  fluid: Boolean,
   openAll: Boolean,
   indentLines: [Boolean, String] as PropType<boolean | IndentLinesVariant>,
   search: String,

--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -37,6 +37,7 @@ export type VTreeviewChildrenSlots<T> = {
 }
 
 export const makeVTreeviewChildrenProps = propsFactory({
+  fluid: Boolean,
   disabled: Boolean,
   loadChildren: Function as PropType<(item: unknown) => Promise<void>>,
   loadingIcon: {
@@ -132,7 +133,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
         depth,
         isLast,
         isLastGroup: props.isLastGroup,
-        leafLinks: !props.hideActions,
+        leafLinks: !props.hideActions && !props.fluid,
         separateRoots: props.separateRoots,
         parentIndentLines: props.parentIndentLines,
         variant: props.indentLinesVariant,


### PR DESCRIPTION
## Description

fixes #21794

<details>
<summary>Playground</summary>

```vue
<template>
  <div>
    <v-container max-width="400">
      <v-switch v-model="fluid" label="Fluid" />
      <v-sheet width="400">
        <v-treeview
          :fluid="fluid"
          :items="items2"
          item-value="id"
          activatable
          indent-lines
          open-all
        >
          <template #title="{item}"> {{ item.title }} </template>
          <template #prepend="{ item, isOpen }">
            <v-icon :icon="getIcon(item, isOpen)" />
          </template>
        </v-treeview>
      </v-sheet>
    </v-container>
  </div>
</template>

<script>
  export default {
    data: () => ({
      fluid: true,
      files: {
        html: 'mdi-language-html5',
        js: 'mdi-nodejs',
        pdf: 'mdi-file-pdf-box',
        png: 'mdi-file-image',
        mov: 'mdi-file-video-outline',
        mp4: 'mdi-video-outline',
      },
      items2: [
        {
          id: 115,
          title: 'Documents',
          children: [
            {
              id: 116,
              title: 'Financial',
              children: [
                { id: 17, title: 'November.pdf' },
              ],
            },
            {
              id: 117,
              title: 'Taxes',
              children: [
                { id: 118, title: 'December.pdf' },
                { id: 119, title: 'January.pdf' },
              ],
            },
            {
              id: 120,
              title: 'Later',
              children: [
                { id: 121, title: 'Company logo.png' },
              ],
            },
          ],
        },
        {
          id: 15,
          title: 'Downloads',
          children: [
            { id: 16, title: '2022-03-01 Report.pdf' },
            { id: 18, title: 'Tutorial.html' },
          ],
        },
        {
          id: 19,
          title: 'Videos',
          children: [
            {
              id: 20,
              title: 'Tutorials',
              children: [
                { id: 21, title: 'Basic layouts.mp4' },
                { id: 23, title: 'Empty folder', children: [] },
                { id: 22, title: 'Advanced techniques.mp4' },
              ],
            },
            { id: 24, title: 'Intro.mov' },
            { id: 25, title: 'Conference introduction.mov' },
          ],
        },
      ],
    }),
    methods: {
      getIcon (item, isOpen) {
        if (item.children) return isOpen ? 'mdi-folder-open' : 'mdi-folder'
        return this.files[item.title.split('.').at(-1)] ?? 'mdi-file-outline'
      },
    },
  }
</script>
```

</details>
