### PR TITLE
fix(VColorPicker): keep sliders visible when inputs are hidden

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPicker.sass
+++ b/packages/vuetify/src/components/VColorPicker/VColorPicker.sass
@@ -17,6 +17,7 @@
     display: flex
     flex-direction: column
     padding: $color-picker-controls-padding
+    width: 100%
 
   // Modifier
   .v-color-picker--flat


### PR DESCRIPTION
## Description

fixes #21801

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-color-picker hide-inputs />
    </v-container>
  </v-app>
</template>
```
