### PR TITLE
fix(VTreeview): support prepend icon and avatar

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -3,7 +3,7 @@ import { VTreeviewGroup } from './VTreeviewGroup'
 import { makeVTreeviewItemProps, VTreeviewItem } from './VTreeviewItem'
 import { VCheckboxBtn } from '@/components/VCheckbox'
 import { VDivider } from '@/components/VDivider'
-import { VListSubheader } from '@/components/VList'
+import { VListItemAction, VListSubheader } from '@/components/VList'
 
 // Composables
 import { makeDensityProps } from '@/composables/density'
@@ -149,7 +149,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
         prepend: slotProps => (
           <>
             { props.selectable && (!children || (children && !['leaf', 'single-leaf'].includes(props.selectStrategy as string))) && (
-              <div>
+              <VListItemAction start>
                 <VCheckboxBtn
                   key={ item.value }
                   modelValue={ slotProps.isSelected }
@@ -169,7 +169,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
                     selectItem(slotProps.select, slotProps.isSelected)
                   }}
                 />
-              </div>
+              </VListItemAction>
             )}
 
             { slots.prepend?.({ ...slotProps, ...treeItemProps, item: item.raw, internalItem: item }) }
@@ -210,6 +210,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
                   <VTreeviewItem
                     ref={ el => activatorItems.value[index] = el as VTreeviewItem }
                     { ...listItemProps }
+                    hasCustomPrepend={ !!slots.prepend }
                     hideActions={ props.hideActions }
                     indentLines={ indentLines.node }
                     value={ props.returnObject ? item.raw : itemProps.value }
@@ -253,6 +254,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
           return (
             <VTreeviewItem
               { ...itemProps }
+              hasCustomPrepend={ !!slots.prepend }
               hideActions={ props.hideActions }
               indentLines={ indentLines.leaf }
               value={ props.returnObject ? toRaw(item.raw) : itemProps.value }

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.sass
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.sass
@@ -28,6 +28,12 @@
         > .v-icon
           margin-inline-start: $treeview-item-first-icon-margin-start
 
+    &:has(.v-treeview-indent-lines)
+      .v-list-item-action:first-child,
+      .v-treeview-indent-lines + .v-list-item-action
+        > .v-selection-control
+          margin-inline: min(0px, calc(-1 * (var(--v-selection-control-size) - #{$treeview-indent-size}) / 2))
+
   .v-treeview-indent-lines
     position: absolute
     left: 0

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -18,12 +18,16 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 // Types
 import type { PropType } from 'vue'
 import { VTreeviewSymbol } from './shared'
+import { VAvatar } from '../VAvatar'
+import { VDefaultsProvider } from '../VDefaultsProvider'
+import { VIcon } from '../VIcon'
 import type { VListItemSlots } from '@/components/VList/VListItem'
 import type { IndentLineType } from '@/util'
 
 export const makeVTreeviewItemProps = propsFactory({
   loading: Boolean,
   hideActions: Boolean,
+  hasCustomPrepend: Boolean,
   indentLines: Array as PropType<IndentLineType[]>,
   toggleIcon: IconValue,
 
@@ -73,7 +77,11 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
 
     useRender(() => {
       const listItemProps = VListItem.filterProps(props)
-      const hasPrepend = slots.prepend || props.toggleIcon || props.indentLines
+      const hasPrepend = slots.prepend ||
+        props.toggleIcon ||
+        props.indentLines ||
+        props.prependIcon ||
+        props.prependAvatar
 
       return (
         <VListItem
@@ -132,7 +140,46 @@ export const VTreeviewItem = genericComponent<VListItemSlots>()({
                       )}
                     </VListItemAction>
                   )}
-                  { slots.prepend?.(slotProps) }
+
+                  { !props.hasCustomPrepend ? (
+                    <>
+                      { slots.prepend?.(slotProps) }
+                      { props.prependAvatar && (
+                        <VAvatar
+                          key="prepend-avatar"
+                          density={ props.density }
+                          image={ props.prependAvatar }
+                        />
+                      )}
+
+                      { props.prependIcon && (
+                        <VIcon
+                          key="prepend-icon"
+                          density={ props.density }
+                          icon={ props.prependIcon }
+                        />
+                      )}
+                    </>
+                  ) : (
+                    <VDefaultsProvider
+                      key="prepend-defaults"
+                      defaults={{
+                        VAvatar: {
+                          density: props.density,
+                          image: props.appendAvatar,
+                        },
+                        VIcon: {
+                          density: props.density,
+                          icon: props.appendIcon,
+                        },
+                        VListItemAction: {
+                          start: true,
+                        },
+                      }}
+                    >
+                      { slots.prepend?.(slotProps) }
+                    </VDefaultsProvider>
+                  )}
                 </>
               )
             } : undefined,


### PR DESCRIPTION
## Description

- make the tree support `prependIcon` and `prependAvatar` (mostly copied from VListItem)
- changes `<div>` around checkbox to `<v-list-item-action start>`
- there is a chance that devs already have CSS workarounds to shift checkboxes or space out prepended icons. We need a clear hint in release notes for 3.10.0 --- it is better than dragging bad defaults until v4

resolves #21812

## Markup:

```vue
<template>
  <v-app>
    <v-toolbar class="pl-8" height="50">
      <span class="mr-3">Density:</span>
      <v-chip-group v-model="density" mandatory>
        <v-chip text="default" value="default" filter label />
        <v-chip text="comfortable" value="comfortable" filter label />
        <v-chip text="compact" value="compact" filter label />
        <v-chip text="narrow" value="narrow" filter label />
      </v-chip-group>
    </v-toolbar>
    <v-toolbar class="pl-8 border-t" height="50">
      <span class="mr-3">Lines:</span>
      <v-chip-group v-model="indentLines" mandatory>
        <v-chip :value="false" text="none" filter label />
        <v-chip :value="true" text="default" filter label />
        <v-chip text="simple" value="simple" filter label />
      </v-chip-group>
    </v-toolbar>
    <v-toolbar class="px-3 border-t" height="50">
      <div class="d-flex ga-6 pl-6">
        <v-switch v-model="actionIcons" color="success" label="action icons" hide-details />
        <v-switch v-model="alternativeIcons" :disabled="!actionIcons" color="success" label="alternative action icons" hide-details />
        <v-switch v-model="prependSlot" color="success" label="prepend slot" hide-details />
        <v-switch v-model="selectable" color="success" label="selectable" hide-details />
        <v-switch v-model="dark" color="success" label="dark" hide-details />
      </div>
    </v-toolbar>
    <v-main>
      <v-container class="d-flex ga-8 justify-center" fluid>

        <v-sheet width="400">
          <v-treeview
            :collapse-icon="alternativeIcons ? 'mdi-minus-box-outline' : undefined"
            :density="density"
            :expand-icon="alternativeIcons ? 'mdi-plus-box-outline' : undefined"
            :hide-actions="!actionIcons"
            :indent-lines="indentLines"
            :items="items1"
            :selectable="selectable"
            item-value="id"
            max-width="400"
            select-strategy="classic"
            open-all
            open-on-click
          />
        </v-sheet>

        <v-sheet width="400">
          <v-treeview
            :collapse-icon="alternativeIcons ? 'mdi-minus-box-outline' : undefined"
            :density="density"
            :expand-icon="alternativeIcons ? 'mdi-plus-box-outline' : undefined"
            :hide-actions="!actionIcons"
            :indent-lines="indentLines"
            :items="items2"
            :selectable="selectable"
            item-value="id"
            select-strategy="classic"
            open-all
            open-on-click
          >
            <template v-if="prependSlot" #prepend="{ item, isOpen }">
              <v-icon :icon="getIcon(item, isOpen)" />
            </template>
          </v-treeview>
        </v-sheet>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup lang="ts">
  import { ref, watch } from 'vue'
  import { useTheme } from 'vuetify'

  const { change: changeTheme } = useTheme()
  changeTheme('dark')
  const dark = ref(true)
  watch(dark, v => changeTheme(v ? 'dark' : 'light'))

  const indentLines = ref<boolean | 'simple'>(true)
  const selectable = ref(true)
  const density = ref<any>('default')
  const actionIcons = ref(true)
  const alternativeIcons = ref(false)
  const prependSlot = ref(true)

  const files = {
    html: 'mdi-language-html5',
    js: 'mdi-nodejs',
    ts: 'mdi-language-typescript',
    json: 'mdi-code-json',
    md: 'mdi-language-markdown',
    pdf: 'mdi-file-pdf-box',
    png: 'mdi-file-image',
    txt: 'mdi-file-document-outline',
    xls: 'mdi-file-excel',
    mov: 'mdi-file-video-outline',
    avi: 'mdi-file-video-outline',
    mp4: 'mdi-file-video-outline',
  }

  function getIcon (item, isOpen) {
    if (item.children) return isOpen ? 'mdi-folder-open' : 'mdi-folder'
    if (item.prependIcon) return undefined
    return files[item.title.split('.').at(-1)] ?? 'mdi-file-outline'
  }

  const items1 = [
    {
      id: 5,
      title: 'project',
      props: { prependIcon: 'mdi-cube' },
      children: [
        {
          id: 10,
          title: 'material2',
          props: { prependIcon: 'mdi-cube' },
          children: [
            {
              id: 11,
              title: 'src',
              props: { prependIcon: 'mdi-cube' },
              children: [
                { id: 12, props: { prependIcon: 'mdi-bug' }, title: 'v-btn.ts' },
                { id: 13, props: { prependIcon: 'mdi-bug' }, title: 'v-card.ts' },
                { id: 14, props: { prependIcon: 'mdi-bug' }, title: 'v-window.ts' },
              ],
            },
          ],
        },
      ],
    },
  ]

  const items2 = [
    {
      id: 115,
      title: 'Documents',
      props: { prependIcon: 'mdi-file-multiple', subtitle: 'subtitle subtitle' },
      children: [
        {
          id: 116,
          title: 'Financial',
          props: { prependIcon: 'mdi-cash', subtitle: 'subtitle subtitle' },
          children: [
            { id: 17, title: 'November.pdf' },
          ],
        },
        {
          id: 117,
          title: 'Taxes',
          props: { prependIcon: 'mdi-bank', subtitle: 'subtitle subtitle' },
          children: [
            {
              id: 125,
              title: 'Last year',
              props: { prependIcon: 'mdi-calendar', subtitle: 'subtitle subtitle' },
              children: [
                { id: 118, title: 'December.pdf' },
              ],
            },
            { id: 119, title: 'January.pdf' },
          ],
        },
        {
          id: 120,
          title: 'Later',
          children: [
            { id: 121, title: 'Company logo.png' },
          ],
        },
      ],
    },
  ]
</script>

<style>
  .v-treeview.v-list-item--density-narrow {
    --icon-size: 20px;
    .v-list-item-action {
      display: none;
    }
    .v-list-item-title {
      font-size: 0.875rem;
      line-height: 20px;
    }
    .v-list-item__prepend > .v-icon {
      width: var(--icon-size);
      height: var(--icon-size);
      font-size: var(--icon-size);
    }
    .v-list-item--density-narrow.v-list-item--one-line {
      min-height: 28px;
      max-height: 28px;
    }
  }
</style>
```
