### PR TITLE
feat(VColorInput): pip customization

### DIFF
--- a/packages/api-generator/src/locale/en/VColorInput.json
+++ b/packages/api-generator/src/locale/en/VColorInput.json
@@ -1,0 +1,9 @@
+{
+  "props": {
+    "hidePip": "Hide pip icon",
+    "colorPip": "Synchronize pip color with current value",
+    "pipIcon": "The icon used for pip",
+    "pipLocation": "Move pip icon to a different slot",
+    "pipVariant": "Variant of the pip control"
+  }
+}

--- a/packages/docs/src/examples/v-color-input/prop-pip-location.vue
+++ b/packages/docs/src/examples/v-color-input/prop-pip-location.vue
@@ -4,30 +4,31 @@
       <v-col cols="12" sm="6">
         <v-color-input
           hide-details="auto"
-          label="Colored Pip"
-          model-value="#7C0799"
-          color-pip
-          hide-actions
         ></v-color-input>
       </v-col>
       <v-col cols="12" sm="6">
         <v-color-input
           hide-details="auto"
-          label="Colored Pip (tonal)"
-          model-value="#1493DB"
-          pip-variant="tonal"
-          color-pip
-          hide-actions
+          pip-location="prepend-inner"
         ></v-color-input>
       </v-col>
       <v-col cols="12" sm="6">
         <v-color-input
           hide-details="auto"
-          label="Colored Pip (flat)"
-          model-value="#74DB14"
-          pip-variant="flat"
-          color-pip
-          hide-actions
+          pip-location="append-inner"
+        ></v-color-input>
+      </v-col>
+      <v-col cols="12" sm="6">
+        <v-color-input
+          hide-details="auto"
+          pip-location="append"
+        ></v-color-input>
+      </v-col>
+      <v-col cols="12" sm="6">
+        <v-color-input
+          hide-details="auto"
+          label="I need no icon"
+          hide-pip
         ></v-color-input>
       </v-col>
     </v-row>

--- a/packages/docs/src/examples/v-color-input/prop-pip-variant.vue
+++ b/packages/docs/src/examples/v-color-input/prop-pip-variant.vue
@@ -1,24 +1,16 @@
 <template>
   <v-container>
     <v-row>
-      <v-col
-        cols="12"
-        md="6"
-      >
+      <v-col cols="12" sm="6">
         <v-color-input
           hide-details="auto"
-          label="Select a color"
+          pip-variant="tonal"
         ></v-color-input>
       </v-col>
-
-      <v-col
-        cols="12"
-        md="6"
-      >
+      <v-col cols="12" sm="6">
         <v-color-input
           hide-details="auto"
-          label="Select a color"
-          prepend-inner-icon=""
+          pip-variant="outlined"
         ></v-color-input>
       </v-col>
     </v-row>

--- a/packages/docs/src/examples/v-color-input/usage.vue
+++ b/packages/docs/src/examples/v-color-input/usage.vue
@@ -6,32 +6,38 @@
     :options="options"
   >
     <div>
-      <v-color-input v-bind="props"></v-color-input>
+      <v-color-input model-value="#14BCD3" v-bind="props"></v-color-input>
     </div>
 
     <template v-slot:configuration>
+      <v-select v-model="pipVariant" :items="pipVariants" label="Pip variant" clearable></v-select>
+
       <v-checkbox v-model="colorPip" label="Color Pip"></v-checkbox>
-
-      <v-checkbox v-model="clear" label="Clearable"></v-checkbox>
-
+      <v-checkbox v-model="clearable" label="Clearable"></v-checkbox>
       <v-checkbox v-model="disabled" label="Disabled"></v-checkbox>
+      <v-checkbox v-model="hideActions" label="Hide picker actions"></v-checkbox>
     </template>
   </ExamplesUsageExample>
 </template>
 
 <script setup>
   const name = 'v-color-input'
+
+  const pipVariants = ['flat', 'tonal', 'outlined']
+
   const model = ref('default')
   const options = ['outlined', 'underlined', 'solo', 'solo-filled', 'solo-inverted']
-  const clear = ref(false)
+  const clearable = ref(false)
+  const hideActions = ref(false)
+  const pipVariant = ref()
   const colorPip = ref(true)
-  const counter = ref(false)
   const disabled = ref(false)
   const props = computed(() => {
     return {
-      clearable: clear.value || undefined,
-      colorPip: colorPip.value || false,
-      counter: counter.value || undefined,
+      clearable: clearable.value || undefined,
+      'color-pip': colorPip.value || undefined,
+      'pip-variant': pipVariant.value || undefined,
+      'hide-actions': hideActions.value || undefined,
       disabled: disabled.value || undefined,
       label: 'Color input',
       variant: model.value === 'default' ? undefined : model.value,

--- a/packages/docs/src/pages/en/components/color-inputs.md
+++ b/packages/docs/src/pages/en/components/color-inputs.md
@@ -66,14 +66,20 @@ The `v-color-input` component provides a clean interface for selecting colors.
 
 The `v-color-input` component extends the [v-text-field](/components/text-fields/) and [v-color-picker](/components/color-pickers/) component; and supports all of their props.
 
-#### Pip icon
+#### Pip location
 
-You can move the pip icon within the input or entirely by utilizing the **prepend-icon** and **prepend-inner-icon** properties.
+You can move the pip icon within the input by utilizing the `pip-location` or hide it entirely with `hide-pip`.
 
-<ExamplesExample file="v-color-input/prop-prepend-icon" />
+<ExamplesExample file="v-color-input/prop-pip-location" />
 
 #### Color Pip
 
 The `color-pip` is a boolean that determines whether the pip icon color matches the selected color.
 
 <ExamplesExample file="v-color-input/prop-color-pip" />
+
+#### Pip variant
+
+The `pip-variant` lets you further customize the pip icon.
+
+<ExamplesExample file="v-color-input/prop-pip-variant" />

--- a/packages/vuetify/src/labs/VColorInput/VColorInput.sass
+++ b/packages/vuetify/src/labs/VColorInput/VColorInput.sass
@@ -5,3 +5,11 @@
   /* region INPUT */
   .v-color-input
     padding: 0
+
+    @at-root
+      @include tools.density('v-color-input.v-input', $color-input-pip-density) using ($modifier)
+        .v-color-input__pip
+          --v-avatar-height: #{$color-input-pip-avatar-size + $modifier}
+
+    .v-color-input__pip.v-avatar--variant-text
+      --v-avatar-height: min-content

--- a/packages/vuetify/src/labs/VColorInput/VColorInput.tsx
+++ b/packages/vuetify/src/labs/VColorInput/VColorInput.tsx
@@ -2,9 +2,9 @@
 import './VColorInput.sass'
 
 // Components
+import { VAvatar } from '@/components/VAvatar'
 import { makeVColorPickerProps, VColorPicker } from '@/components/VColorPicker/VColorPicker'
 import { makeVConfirmEditProps, VConfirmEdit } from '@/components/VConfirmEdit/VConfirmEdit'
-import { VIcon } from '@/components/VIcon/VIcon'
 import { VMenu } from '@/components/VMenu/VMenu'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
 
@@ -17,6 +17,7 @@ import { computed, shallowRef } from 'vue'
 import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
+import type { PropType } from 'vue'
 import type { VTextFieldSlots } from '@/components/VTextField/VTextField'
 
 export type VColorInputActionsSlot = {
@@ -30,11 +31,24 @@ export type VColorInputSlots = Omit<VTextFieldSlots, 'default'> & {
   default: never
 }
 
+const availablePipLocations = ['prepend', 'prepend-inner', 'append', 'append-inner'] as const
+export type PipLocation = typeof availablePipLocations[number]
+
 export const makeVColorInputProps = propsFactory({
-  pip: Boolean,
+  hidePip: Boolean,
+  colorPip: Boolean,
   pipIcon: {
     type: String,
     default: '$color',
+  },
+  pipLocation: {
+    type: String as PropType<PipLocation>,
+    default: 'prepend',
+    validator: (v: any) => availablePipLocations.includes(v),
+  },
+  pipVariant: {
+    type: String as PropType<VAvatar['$props']['variant']>,
+    default: 'text',
   },
 
   ...makeFocusProps(),
@@ -93,9 +107,23 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
     useRender(() => {
       const confirmEditProps = VConfirmEdit.filterProps(props)
       const colorPickerProps = VColorPicker.filterProps(omit(props, ['active', 'color']))
-      const textFieldProps = VTextField.filterProps(omit(props, ['prependInnerIcon']))
+      const textFieldProps = VTextField.filterProps(props)
 
-      const hasPrepend = !!(slots.prepend || props.pipIcon)
+      const slotWithPip = props.hidePip
+        ? undefined
+        : {
+          [props.pipLocation]: (arg: any) => (
+            <>
+              <VAvatar
+                class="v-color-input__pip"
+                color={ props.colorPip ? model.value as string : undefined }
+                variant={ props.pipVariant }
+                icon={ props.pipIcon }
+              />
+              { slots[props.pipLocation]?.(arg) }
+            </>
+          ),
+        }
 
       return (
         <VTextField
@@ -118,18 +146,7 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
         >
           {{
             ...slots,
-            prepend: props.pipIcon ? arg => (
-              <>
-               { hasPrepend && (
-                  <VIcon
-                    color={ props.pip ? model.value as string : undefined }
-                    icon={ props.pipIcon }
-                  />
-               )}
-
-                { slots.prepend?.(arg) }
-              </>
-            ) : undefined,
+            ...slotWithPip,
             default: () => (
               <>
                 <VMenu

--- a/packages/vuetify/src/labs/VColorInput/_variables.scss
+++ b/packages/vuetify/src/labs/VColorInput/_variables.scss
@@ -1,2 +1,4 @@
 // Defaults
 $color-input-pip-default-color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity)) !default;
+$color-input-pip-avatar-size: 40px !default;
+$color-input-pip-density: ('default': 0, 'comfortable': -2, 'compact': -3) !default;


### PR DESCRIPTION
- introduces `hide-pip`
- introduces `pip-location`
- renames existing `pip` to `color-pip` (as it was named in the docs)
- introduces `pip-variant`

resolves #21712

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-sheet class="px-6 py-2 border-b" color="surface">
      <div class="d-flex gx-3 flex-wrap">
        <div class="d-flex align-center ga-3">
          <span class="mr-3">Lines:</span>
          <v-chip-group v-model="density" mandatory>
            <v-chip text="default" value="default" filter label />
            <v-chip text="comfortable" value="comfortable" filter label />
            <v-chip text="compact" value="compact" filter label />
          </v-chip-group>
        </div>
        <v-spacer />
        <v-switch
          v-model="hasLabel"
          :color="selection"
          :label="`label ${hasLabel ? 'ON' : 'OFF'}`"
          hide-details
        />
      </div>
    </v-sheet>
    <v-sheet class="px-6 py-2 border-b" color="surface">
      <div class="d-flex gx-3 flex-wrap">
        <div class="d-flex align-center ga-3">
          <span class="mr-3">Variant:</span>
          <v-chip-group v-model="variant" mandatory>
            <v-chip text="filled" value="filled" filter label />
            <v-chip text="outlined" value="outlined" filter label />
            <v-chip text="solo" value="solo" filter label />
            <v-chip text="solo-inverted" value="solo-inverted" filter label />
            <v-chip text="solo-filled" value="solo-filled" filter label />
            <v-chip text="underlined" value="underlined" filter label />
          </v-chip-group>
        </div>
      </div>
    </v-sheet>
    <v-main class="pt-12">
      <v-container v-for="th in ['light', 'dark']" :key="th" max-width="900">
        <v-defaults-provider :defaults="{ VColorInput: config }">
          <v-card
            :theme="th"
            class="d-flex flex-wrap ga-6 pa-6"
            elevation="12"
            rounded="lg"
          >
            <v-color-input v-model="selection" />
            <v-color-input v-model="selection" pip-location="prepend-inner" pip-variant="flat" />
            <v-color-input v-model="selection" pip-location="append-inner" pip-variant="tonal" />
            <v-color-input v-model="selection" pip-location="append" />
          </v-card>
        </v-defaults-provider>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref, toRef } from 'vue'

  const hasLabel = ref(true)
  const density = ref('default')
  const variant = ref('filled')
  const selection = ref('#1681AF')

  const config = toRef(() => ({
    density: density.value,
    variant: variant.value,
    label: hasLabel.value ? 'Color input' : undefined,
    colorPip: true,
    clearable: true,
    hideActions: true,
    hideDetails: true,
  }))
</script>
```
