### PR TITLE
fix(theme): ability to restore "system"

### DIFF
--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -104,6 +104,7 @@ export interface ThemeInstance {
   toggle: (themeArray?: [string, string]) => void
 
   readonly isDisabled: boolean
+  readonly isSystem: Readonly<Ref<boolean>>
   readonly themes: Ref<Record<string, InternalThemeDefinition>>
 
   readonly name: Readonly<Ref<string>>
@@ -379,6 +380,8 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
 
   const current = toRef(() => computedThemes.value[name.value])
 
+  const isSystem = toRef(() => _name.value === 'system')
+
   const styles = computed(() => {
     const lines: string[] = []
     const important = parsedOptions.unimportant ? '' : ' !important'
@@ -485,7 +488,7 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
   }
 
   function change (themeName: string) {
-    if (!themeNames.value.includes(themeName)) {
+    if (themeName !== 'system' && !themeNames.value.includes(themeName)) {
       consoleWarn(`Theme "${themeName}" not found on the Vuetify theme instance`)
       return
     }
@@ -522,6 +525,7 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
     cycle,
     toggle,
     isDisabled: parsedOptions.isDisabled,
+    isSystem,
     name,
     themes,
     current,


### PR DESCRIPTION
- makes it possible to call `.change('system')`
- exposes `.isSystem` boolean ref

Note: I don't think `theme.cycle(['dark', 'light', 'system'])` is something we should support. It would encourage devs to put out a single button that once every 3 clicks does not do anything (i.e. UX footgun).

fixes #21819

```vue
<template>
  <v-app>
    <v-container> Theme name: {{ theme.name }} <span v-if="theme.isSystem.value">(SYSTEM)</span> </v-container>
    <v-container class="d-flex ga-3">
      <v-btn text="Toggle Light / Dark" @click="theme.toggle()" />
      <v-btn text="use 'system'" @click="theme.change('system')" />
      <v-btn text="Cycle" @click="theme.cycle()" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { useTheme } from 'vuetify'
  const theme = useTheme()
</script>
```
