### PR TITLE
feat(filter): keep dividers and subheaders

### DIFF
--- a/packages/vuetify/src/composables/filter.tsx
+++ b/packages/vuetify/src/composables/filter.tsx
@@ -86,13 +86,16 @@ export function filterItems (
     noFilter?: boolean
   },
 ) {
-  const array: { index: number, matches: Record<string, FilterMatchArrayMultiple | undefined> }[] = []
+  type FilterResult = { index: number, matches: Record<string, FilterMatchArrayMultiple | undefined>, type?: 'divider' | 'subheader' }
+  const array: FilterResult[] = []
   // always ensure we fall back to a functioning filter
   const filter = options?.default ?? defaultFilter
   const keys = options?.filterKeys ? wrapInArray(options.filterKeys) : false
   const customFiltersLength = Object.keys(options?.customKeyFilter ?? {}).length
 
   if (!items?.length) return array
+
+  let lookAheadItem: FilterResult | null = null
 
   loop:
   for (let i = 0; i < items.length; i++) {
@@ -104,6 +107,11 @@ export function filterItems (
     if ((query || customFiltersLength > 0) && !options?.noFilter) {
       if (typeof item === 'object') {
         if (item.type === 'divider' || item.type === 'subheader') {
+          if (lookAheadItem?.type === 'divider' && item.type === 'subheader') {
+            array.push(lookAheadItem) // divider before subheader
+          }
+
+          lookAheadItem = { index: i, matches: { }, type: item.type }
           continue
         }
 
@@ -149,6 +157,11 @@ export function filterItems (
           !defaultMatchesLength
         )
       ) continue
+    }
+
+    if (lookAheadItem) {
+      array.push(lookAheadItem)
+      lookAheadItem = null
     }
 
     array.push({ index: i, matches: { ...defaultMatches, ...customMatches } })


### PR DESCRIPTION
## Description

resolves #7424

## Markup:

```vue
<template>
  <v-container>
    <v-autocomplete
      :items="items"
      autocomplete="off"
      label="I will keep subheaders and dividers when it makes sense"
      multiple
    />
  </v-container>
</template>

<script setup>
  const items = [
    { type: 'subheader', title: 'Group 1' },
    { title: 'Item 1.1', value: 11 },
    { title: 'Item 1.2', value: 12 },
    { title: 'Item 1.3', value: 13 },
    { title: 'Item 1.4', value: 14 },
    { type: 'divider' },
    { type: 'subheader', title: 'Group 2' },
    { title: 'Item 2.1', value: 21 },
    { title: 'Item 2.2', value: 22 },
    { title: 'Item 2.3', value: 23 },
  ]
</script>
```
