### PR TITLE
feat(VTimePicker): accept external changes to the period

### DIFF
--- a/packages/api-generator/src/locale/en/VTimePicker.json
+++ b/packages/api-generator/src/locale/en/VTimePicker.json
@@ -9,6 +9,7 @@
     "max": "Maximum allowed time.",
     "min": "Minimum allowed time.",
     "hide-header": "Hide the header of the picker.",
+    "period": "Sets period for 12hr format.",
     "readonly": "Puts picker in readonly state.",
     "scrollable": "Allows changing hour/minute with mouse scroll.",
     "useSeconds": "Toggles the use of seconds in picker.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -189,7 +189,8 @@
   },
   "VTimePicker": {
     "props": {
-      "hideTitle": "3.10.0"
+      "hideTitle": "3.10.0",
+      "period": "3.10.0"
     }
   },
   "VTreeview": {

--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
@@ -45,6 +45,11 @@ export const makeVTimePickerProps = propsFactory({
     type: String as PropType<VTimePickerViewMode>,
     default: 'hour',
   },
+  period: {
+    type: String as PropType<Period>,
+    default: 'am',
+    validator: (v: any) => ['am', 'pm'].includes(v),
+  },
   modelValue: null as any as PropType<any>,
   readonly: Boolean,
   scrollable: Boolean,
@@ -74,7 +79,7 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
     const lazyInputHour = ref(null as number | null)
     const lazyInputMinute = ref(null as number | null)
     const lazyInputSecond = ref(null as number | null)
-    const period = ref('am' as Period)
+    const period = useProxiedModel(props, 'period', 'am')
     const viewMode = useProxiedModel(props, 'viewMode', 'hour')
     const controlsRef = ref<VTimePickerControls | null>(null)
     const clockRef = ref<VTimePickerClock | null>(null)
@@ -165,6 +170,8 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
     const isAmPm = computed((): boolean => {
       return props.format === 'ampm'
     })
+
+    watch(() => props.period, val => setPeriod(val))
 
     watch(() => props.modelValue, val => setInputData(val))
 


### PR DESCRIPTION
## Description

resolves #15405

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <div class="d-flex justify-center ga-12">
        <v-switch v-model="useSeconds" label="with seconds" />
        <v-switch v-model="use24h" label="24h format" />
      </div>
      <v-row class="justify-center ga-10" no-gutters>
        <v-card class="pa-6">
          <v-time-picker
            v-model="time"
            v-model:period="period"
            :ampm-in-title="!use24h"
            :format="use24h ? '24hr' : 'ampm'"
            :use-seconds="useSeconds"
            scrollable
          />
        </v-card>
        <v-card class="pa-6" width="300">
          <pre class="mb-6">value: <b>{{ time }}</b></pre>
          <v-select
            v-if="!use24h"
            v-model="period"
            :items="['am', 'pm']"
            label="Period"
            clearable
          />
        </v-card>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const useSeconds = ref(false)
  const use24h = ref(false)

  const time = ref('11:15')
  const period = ref('am')
</script>
```
