### PR TITLE
fix(VNumberInput): keep focus when incrementing in the list

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -263,6 +263,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
       if (['ArrowDown', 'ArrowUp'].includes(e.key)) {
         e.preventDefault()
+        e.stopPropagation()
         clampModel()
         // _model is controlled, so need to wait until props['modelValue'] is updated
         await nextTick()


### PR DESCRIPTION
## Description

resolves #17083

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-main>
      <v-container :max-width="650">
        <p>
          Text field outside of list (type number), value can be inc/decremented
          with arrow keys
        </p>
        <v-text-field type="number" />
        <v-list>
          <v-list-item
            title="Field 1"
            subtitle="Text field in list, arrow keys don't work here"
          >
            <template #append>
              <v-text-field
                label="v-text-field"
                type="number"
                width="200"
                hide-details
              />
            </template>
          </v-list-item>
          <v-list-item
            title="Field 2"
            subtitle="Text field in list, arrow keys don't work here"
          >
            <template #append>
              <v-number-input
                label="v-number-input"
                width="200"
                hide-details
              />
            </template>
          </v-list-item>
        </v-list>
      </v-container>
    </v-main>
  </v-app>
</template>
```
