### PR TITLE
feat(VNumberInput): show error state when out of range

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -144,7 +144,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     })
     const inputText = computed<string | null>({
       get: () => _inputText.value,
-      async set (val) {
+      set (val) {
         if (val === null || val === '') {
           model.value = null
           _inputText.value = null

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -4,7 +4,7 @@ import { VForm } from '@/components/VForm'
 
 // Utilities
 import { render, screen, userEvent } from '@test'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 
 describe('VNumberInput', () => {
   it.each([
@@ -339,6 +339,79 @@ describe('VNumberInput', () => {
       await userEvent.keyboard(typing)
       await userEvent.click(document.body)
       expect(screen.getByCSS('input')).toHaveValue(expected)
+    })
+  })
+
+  describe('should indicate range error', () => {
+    // enable in 4.0.0
+    it.todo('on mount', async () => {
+      const model = ref(-13)
+      const onChange = vi.fn()
+      render(() => (
+        <VNumberInput
+          v-model={ model.value }
+          min={ 5 }
+          onUpdate:modelValue={ onChange }
+        />
+      ))
+
+      await nextTick()
+      expect(model.value).toBe(-13)
+      expect(onChange).not.toHaveBeenCalled()
+      expect(screen.getByCSS('.v-input')).toHaveClass('v-input--error')
+    })
+
+    it('while typing', async () => {
+      const model = ref(null)
+      const onChange = vi.fn()
+      render(() => (
+        <VNumberInput
+          v-model={ model.value }
+          min={ 5 }
+          onUpdate:modelValue={ onChange }
+        />
+      ))
+
+      const vInput = screen.getByCSS('.v-input')
+
+      await userEvent.tab()
+      await userEvent.keyboard('1')
+      expect(vInput).toHaveClass('v-input--error')
+
+      await userEvent.keyboard('2')
+      expect(vInput).not.toHaveClass('v-input--error')
+      expect(model.value).toBe(12)
+
+      await userEvent.keyboard('{arrowLeft}{arrowLeft}-')
+      expect(vInput).toHaveClass('v-input--error')
+    })
+
+    it('while typing', async () => {
+      const model = ref(0)
+      const onChange = vi.fn()
+      render(() => (
+        <VNumberInput
+          v-model={ model.value }
+          max={ 50 }
+          onUpdate:modelValue={ onChange }
+        />
+      ))
+
+      await nextTick()
+      const vInput = screen.getByCSS('.v-input')
+      expect(vInput).not.toHaveClass('v-input--error')
+
+      model.value = 50.55 // will be rounded to 51
+      await nextTick()
+      expect(vInput).toHaveClass('v-input--error')
+
+      model.value = 99
+      await nextTick()
+      expect(vInput).toHaveClass('v-input--error')
+
+      model.value = 45
+      await nextTick()
+      expect(vInput).not.toHaveClass('v-input--error')
     })
   })
 })


### PR DESCRIPTION
## Description:

It is not obvious when typing the value and it gets out of range. There is also no indication of a problem when `min` and `max` change and the value does not fit in between - forcing developers to always add `rules`.

Note: "error" state will only trigger when typing, changing the range or updating `model-value` with delay. Auto-clamp on mount will be dropped in 4.0.0 to respect the initial value (except enforcing precision, as it is useful to prevent JS quirks)

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-card class="mx-auto pa-6 my-4" style="max-width: 900px">
        <v-row>
          <v-col cols="4">
            <v-number-input v-model="model.min" label="Min" />
          </v-col>
          <v-col cols="4">
            <v-number-input v-model="model.value" label="Value" :min="model.min" :max="model.max" />
          </v-col>
          <v-col cols="4">
            <v-number-input v-model="model.max" label="Max" />
          </v-col>
        </v-row>
        <small>Note: currently "error" state only triggers when typing or changing the range</small>
        <br />
        <small>In v4: we will drop auto-clamp onMounted</small>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { reactive } from 'vue'

  const model = reactive({ min: 0, value: 12, max: 10 })
</script>
```
