### PR TITLE
feat(VNumberInput): do not clamp value on mounted

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -15,7 +15,7 @@ import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, nextTick, onMounted, ref, shallowRef, toRef, watch, watchEffect } from 'vue'
+import { computed, nextTick, ref, shallowRef, toRef, watch, watchEffect } from 'vue'
 import { clamp, escapeForRegex, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
@@ -193,10 +193,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     watch(() => props.precision, () => formatInputValue())
     watch(() => props.minFractionDigits, () => formatInputValue())
-
-    onMounted(() => {
-      clampModel()
-    })
 
     function inferPrecision (value: number | null) {
       if (value == null) return 0

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -157,24 +157,52 @@ describe('VNumberInput', () => {
   })
 
   describe('native number input quirks', () => {
-    it('should not bypass min', async () => {
+    it('should auto-clamp after interaction', async () => {
       const model = ref(1)
       render(() =>
         <VNumberInput min={ 5 } max={ 15 } v-model={ model.value } />
       )
 
+      await expect.element(screen.getByCSS('input')).toHaveValue('1')
+      expect(model.value).toBe(1)
+
+      await userEvent.click(screen.getByCSS('input'))
+      await userEvent.tab()
+
       await expect.element(screen.getByCSS('input')).toHaveValue('5')
       expect(model.value).toBe(5)
     })
 
-    it('should not bypass max', async () => {
+    it('should apply increments within the range', async () => {
       const model = ref(20)
       render(() =>
         <VNumberInput min={ 5 } max={ 15 } v-model={ model.value } />
       )
 
-      await expect.element(screen.getByCSS('input')).toHaveValue('15')
-      expect(model.value).toBe(15)
+      await expect.element(screen.getByCSS('input')).toHaveValue('20')
+      expect(model.value).toBe(20)
+
+      await userEvent.click(screen.getByCSS('input'))
+      await userEvent.keyboard('{arrowDown}')
+
+      await expect.element(screen.getByCSS('input')).toHaveValue('14')
+      expect(model.value).toBe(14)
+    })
+
+    it('should auto-correct when incrementing against the limit', async () => {
+      const model = ref(-33)
+      render(() =>
+        <VNumberInput min={ -10 } max={ 20 } v-model={ model.value } precision={ 2 } step={ 0.5 } />
+      )
+
+      await expect.element(screen.getByCSS('input')).toHaveValue('-33.00')
+      expect(model.value).toBe(-33)
+
+      await userEvent.click(screen.getByCSS('input'))
+      await userEvent.keyboard('{arrowDown}')
+
+      await expect.element(screen.getByCSS('input')).toHaveValue('-10')
+      expect(model.value).toBe(-10)
     })
 
     it('supports decimal step', async () => {


### PR DESCRIPTION
## Description:

Clamping initial value is not consistent in general - e.g. value can be loaded from API with a slight delay, and then it is not auto-corrected.

Component should respect the value, and only show error state (#21825)

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-card class="mx-auto pa-6 my-4" style="max-width: 900px">
        <v-row>
          <v-col cols="4">
            <v-number-input v-model="model.min" label="Min" />
          </v-col>
          <v-col cols="4">
            <v-number-input v-model="model.value" label="Value" :min="model.min" :max="model.max" />
          </v-col>
          <v-col cols="4">
            <v-number-input v-model="model.max" label="Max" />
          </v-col>
        </v-row>
        <small>Note: currently only "error" state triggers when typing or changing the range</small>
        <br />
        <small>In v4: we will drop auto-clamp onMounted</small>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { reactive } from 'vue'

  const model = reactive({ min: 0, value: 12, max: 10 })
</script>
```
