### PR TITLE
fix(VNumberInput): accept external changes when focused

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -132,9 +132,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const _inputText = shallowRef<string | null>(null)
     watchEffect(() => {
-      if (isFocused.value && !controlsDisabled.value) {
-        // ignore external changes
-      } else if (model.value == null) {
+      if (model.value == null) {
         _inputText.value = null
       } else if (!isNaN(model.value)) {
         _inputText.value = correctPrecision(model.value)


### PR DESCRIPTION
## Description

fixes #21735
fixes #21804

## Markup:

```vue
<template>
  <v-app>
	<!-- when running in 3.9.x keyboard space/enter are working, while mouse clicks are rejected -->
	<!-- hypothetical scenario: I want custom buttons to look nice, or a different increment step than up/down -->
    <v-container max-width="200">
      <v-number-input
        v-model="currentNumber"
        control-variant="hidden"
        variant="outlined"
        rounded="pill"
        :step="0.1"
        :precision="1"
      >
        <template #prepend-inner>
          <v-icon-btn
            v-ripple
            icon="mdi-numeric-negative-1"
            variant="outlined"
            @click.stop="currentNumber += 1"
          />
        </template>
        <template #append-inner>
          <v-icon-btn
            v-ripple
            icon="mdi-numeric-positive-1"
            variant="outlined"
            @click.stop="currentNumber += 1"
          />
        </template>
      </v-number-input>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const currentNumber = ref(5.5)
</script>

<style>
  .v-number-input .v-field {
    padding-inline: 6px;

    input {
      text-align: center;
      font-weight: bold;
      font-size: 1.25rem;
      margin-block: -0.125rem;
      line-height: 1;
    }
  }
</style>
```
