### PR TITLE
fix(VDataTable): correct row height when with show-select and compact

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.tsx
+++ b/packages/vuetify/src/components/VTable/VTable.tsx
@@ -12,6 +12,7 @@ import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util
 
 // Types
 import type { PropType } from 'vue'
+import { VDefaultsProvider } from '../VDefaultsProvider'
 
 export type VTableSlots = {
   default: never
@@ -48,42 +49,51 @@ export const VTable = genericComponent<VTableSlots>()({
     const { themeClasses } = provideTheme(props)
     const { densityClasses } = useDensity(props)
 
-    useRender(() => (
-      <props.tag
-        class={[
-          'v-table',
-          {
-            'v-table--fixed-height': !!props.height,
-            'v-table--fixed-header': props.fixedHeader,
-            'v-table--fixed-footer': props.fixedFooter,
-            'v-table--has-top': !!slots.top,
-            'v-table--has-bottom': !!slots.bottom,
-            'v-table--hover': props.hover,
-            'v-table--striped-even': props.striped === 'even',
-            'v-table--striped-odd': props.striped === 'odd',
-          },
-          themeClasses.value,
-          densityClasses.value,
-          props.class,
-        ]}
-        style={ props.style }
-      >
-        { slots.top?.() }
+    useRender(() => {
+      const tableContentDefaults = {
+        VCheckboxBtn: {
+          density: props.density,
+        },
+      }
 
-        { slots.default ? (
-          <div
-            class="v-table__wrapper"
-            style={{ height: convertToUnit(props.height) }}
-          >
-            <table>
-              { slots.default() }
-            </table>
-          </div>
-        ) : slots.wrapper?.()}
+      return (
+        <props.tag
+          class={[
+            'v-table',
+            {
+              'v-table--fixed-height': !!props.height,
+              'v-table--fixed-header': props.fixedHeader,
+              'v-table--fixed-footer': props.fixedFooter,
+              'v-table--has-top': !!slots.top,
+              'v-table--has-bottom': !!slots.bottom,
+              'v-table--hover': props.hover,
+              'v-table--striped-even': props.striped === 'even',
+              'v-table--striped-odd': props.striped === 'odd',
+            },
+            themeClasses.value,
+            densityClasses.value,
+            props.class,
+          ]}
+          style={ props.style }
+        >
+          { slots.top?.() }
+          <VDefaultsProvider defaults={ tableContentDefaults }>
+            { slots.default ? (
+              <div
+                class="v-table__wrapper"
+                style={{ height: convertToUnit(props.height) }}
+              >
+                <table>
+                  { slots.default() }
+                </table>
+              </div>
+            ) : slots.wrapper?.()}
+          </VDefaultsProvider>
 
-        { slots.bottom?.() }
-      </props.tag>
-    ))
+          { slots.bottom?.() }
+        </props.tag>
+      )
+    })
 
     return {}
   },


### PR DESCRIPTION
## Description

fixes #21767

## Markup:

```vue
<template>
  <v-app>
    <v-sheet class="px-6 py-2 border-b" color="surface">
      <div class="d-flex gx-3 flex-wrap">
        <div class="d-flex align-center ga-3">
          <span class="mr-3">Lines:</span>
          <v-chip-group v-model="density" mandatory>
            <v-chip text="default" value="default" filter label />
            <v-chip text="comfortable" value="comfortable" filter label />
            <v-chip text="compact" value="compact" filter label />
          </v-chip-group>
        </div>
        <v-spacer />
        <!-- this toggle affects row height for 'compact' (before changes) -->
        <v-switch v-model="selectable" label="selectable" hide-details />
      </div>
    </v-sheet>
    <v-data-table
      v-model="selected"
      :density="density"
      :items="items"
      :show-select="selectable"
      item-value="name"
    />
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const density = ref('default')
  const selectable = ref(true)

  const selected = ref([])
  const items = [
    { name: '🍎 Apple', location: 'Washington', height: '0.1', base: '0.07', volume: '0.0001' },
    { name: '🍌 Banana', location: 'Ecuador', height: '0.2', base: '0.05', volume: '0.0002' },
    { name: '🍇 Grapes', location: 'Italy', height: '0.02', base: '0.02', volume: '0.00001' },
    { name: '🍉 Watermelon', location: 'China', height: '0.4', base: '0.3', volume: '0.03' },
    { name: '🍍 Pineapple', location: 'Thailand', height: '0.3', base: '0.2', volume: '0.005' },
    { name: '🍒 Cherries', location: 'Turkey', height: '0.02', base: '0.02', volume: '0.00001' },
    { name: '🥭 Mango', location: 'India', height: '0.15', base: '0.1', volume: '0.0005' },
    { name: '🍓 Strawberry', location: 'USA', height: '0.03', base: '0.03', volume: '0.00002' },
    { name: '🍑 Peach', location: 'China', height: '0.09', base: '0.08', volume: '0.0004' },
    { name: '🥝 Kiwi', location: 'New Zealand', height: '0.05', base: '0.05', volume: '0.0001' },
  ]
</script>
```
