### PR TITLE
feat(VBtn,VIconBtn): align sizes, spacing and focus with MD3

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -9,10 +9,10 @@
 @include tools.layer('components')
   .v-btn
     align-items: center
-    border-radius: $button-border-radius
+    border-radius: var(--v-btn-border-radius, #{$button-border-radius})
     display: inline-flex
     flex-direction: row
-    font-weight: $button-font-weight
+    font-weight: var(--v-btn-font-weight, #{$button-font-weight})
     justify-content: center
     letter-spacing: $button-text-letter-spacing
     line-height: $button-line-height
@@ -22,12 +22,15 @@
     text-decoration: none
     text-indent: $button-text-letter-spacing
     text-transform: $button-text-transform
-    transition-property: $button-transition-property
+    transition-property: $button-transition-property, border-radius
     transition-duration: 0.28s
     transition-timing-function: settings.$standard-easing
     user-select: none
     vertical-align: $button-vertical-align
     flex-shrink: 0
+
+    &:active
+      border-radius: var(--v-btn-border-radius-pressed, var(--v-btn-border-radius, #{$button-border-radius}))
 
     .v-locale--is-rtl &
       @if meta.type-of($button-text-letter-spacing) == 'number'
@@ -42,17 +45,9 @@
     @include tools.states('.v-btn__overlay')
     @include tools.variant($button-variants...)
 
-    @supports selector(:focus-visible)
-      &::after
-        pointer-events: none
-        border: 2px solid currentColor
-        border-radius: inherit
-        opacity: 0
-        transition: opacity .2s ease-in-out
-        @include tools.absolute(true)
-
-      &:focus-visible::after
-        opacity: calc(.25 * var(--v-theme-overlay-multiplier))
+    &:focus-visible
+      outline: $button-focus-outline-width solid $button-focus-outline-color
+      outline-offset: $button-focus-outline-offset
 
     &--icon
       border-radius: $button-icon-border-radius
@@ -136,6 +131,10 @@
       justify-content: center
       gap: $button-stacked-gap
 
+      @include tools.layer('overrides')
+        height: fit-content
+        padding-block: calc(var(--v-btn-padding-inline) / 2)
+
       .v-btn__content
         flex-direction: column
         line-height: $button-stacked-line-height
@@ -148,7 +147,7 @@
 
       @at-root
         @include button-sizes($button-stacked-sizes, true)
-        @include button-density('height', $button-stacked-density)
+        @include button-density('min-height', $button-stacked-density)
 
     &--slim
       padding: $button-slim-padding
@@ -198,13 +197,13 @@
     transition: $button-content-transition
 
   .v-btn__prepend
-    margin-inline: $button-margin-start $button-margin-end
+    margin-inline: $button-margin-start var(--v-btn-icon-gap, #{$button-margin-end})
 
     .v-btn--slim &
       margin-inline-start: 0
 
   .v-btn__append
-    margin-inline: $button-margin-end $button-margin-start
+    margin-inline: var(--v-btn-icon-gap, #{$button-margin-end}) $button-margin-start
 
     .v-btn--slim &
       margin-inline-end: 0

--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -31,7 +31,7 @@ import vRipple from '@/directives/ripple'
 
 // Utilities
 import { computed, toDisplayString, toRef, withDirectives } from 'vue'
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -42,6 +42,16 @@ export type VBtnSlots = {
   prepend: never
   append: never
   loader: never
+}
+
+export type VBtnSizeSpec = {
+  height?: string | number
+  fontSize?: string | number
+  fontWeight?: string | number
+  paddingInline?: string | number
+  iconGap?: string | number
+  borderRadius?: string | number
+  borderRadiusPressed?: string | number
 }
 
 export const makeVBtnProps = propsFactory({
@@ -74,6 +84,11 @@ export const makeVBtnProps = propsFactory({
   text: {
     type: [String, Number, Boolean],
     default: undefined,
+  },
+
+  sizes: {
+    type: Object as PropType<Record<string, VBtnSizeSpec>>,
+    default: () => ({}),
   },
 
   ...makeBorderProps(),
@@ -113,6 +128,20 @@ export const VBtn = genericComponent<VBtnSlots>()({
     const { positionClasses } = usePosition(props)
     const { roundedClasses, roundedStyles } = useRounded(props)
     const { sizeClasses, sizeStyles } = useSize(props)
+    const sizeVariables = computed(() => {
+      const spec = props.sizes?.[String(props.size ?? 'default')]
+      if (!spec) return undefined
+      const styles: Record<string, string | undefined> = {
+        '--v-btn-height': convertToUnit(spec.height),
+        '--v-btn-size': convertToUnit(spec.fontSize),
+        '--v-btn-font-weight': spec.fontWeight != null ? String(spec.fontWeight) : undefined,
+        '--v-btn-padding-inline': convertToUnit(spec.paddingInline),
+        '--v-btn-icon-gap': convertToUnit(spec.iconGap),
+        '--v-btn-border-radius': convertToUnit(spec.borderRadius),
+        '--v-btn-border-radius-pressed': convertToUnit(spec.borderRadiusPressed),
+      }
+      return Object.fromEntries(Object.entries(styles).filter(([, v]) => v != null))
+    })
     const group = useGroupItem(props, props.symbol, false)
     const link = useLink(props, attrs)
 
@@ -223,6 +252,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
             dimensionStyles.value,
             locationStyles.value,
             sizeStyles.value,
+            sizeVariables.value,
             roundedStyles.value,
             props.style,
           ]}

--- a/packages/vuetify/src/components/VBtn/_mixins.scss
+++ b/packages/vuetify/src/components/VBtn/_mixins.scss
@@ -6,16 +6,49 @@
 @use './variables' as *;
 
 @mixin button-sizes ($map: $button-sizes, $immediate: false) {
-  @each $sizeName, $multiplier in settings.$size-scales {
+  @each $sizeName, $multiplier in settings.$button-size-scales {
     $size: map.get($map, 'font-size') + math.div(2 * $multiplier, 16);
     $height: map.get($map, 'height') + (settings.$size-scale * $multiplier);
 
     #{if($immediate, &, '')}.v-btn--size-#{$sizeName} {
       --v-btn-size: #{$size};
       --v-btn-height: #{$height};
-      font-size: var(--v-btn-size);
       min-width: tools.roundEven($height * map.get($map, 'width-ratio'));
-      padding: 0 tools.roundEven(math.div($height, map.get($map, 'padding-ratio')));
+
+      @if ($sizeName == 'x-small') {
+        --v-btn-height: 32px;
+        font-size: 14px;
+        font-weight: 500;
+        padding: 0 12px;
+      }
+
+      @if ($sizeName == 'small') {
+        --v-btn-height: 40px;
+        font-size: 14px;
+        font-weight: 500;
+        padding: 0 16px;
+      }
+
+      @if ($sizeName == 'default') {
+        --v-btn-height: 56px;
+        font-size: 16px;
+        font-weight: 500;
+        padding: 0 24px;
+      }
+
+      @if ($sizeName == 'large') {
+        --v-btn-height: 96px;
+        font-size: 24px;
+        font-weight: 400;
+        padding: 0 48px;
+      }
+
+      @if ($sizeName == 'x-large') {
+        --v-btn-height: 136px;
+        font-size: 32px;
+        font-weight: 400;
+        padding: 0 64px;
+    }
     }
   }
 }

--- a/packages/vuetify/src/components/VBtn/_mixins.scss
+++ b/packages/vuetify/src/components/VBtn/_mixins.scss
@@ -17,9 +17,10 @@
     #{$selector} {
       --v-btn-size: #{$size};
       --v-btn-height: #{$height};
+      --v-btn-padding-inline: #{tools.roundEven(math.div($height, map.get($map, 'padding-ratio')))};
       font-size: var(--v-btn-size);
       min-width: tools.roundEven($height * map.get($map, 'width-ratio'));
-      padding: 0 tools.roundEven(math.div($height, map.get($map, 'padding-ratio')));
+      padding: 0 var(--v-btn-padding-inline);
     }
   }
 }

--- a/packages/vuetify/src/components/VBtn/_variables.scss
+++ b/packages/vuetify/src/components/VBtn/_variables.scss
@@ -7,6 +7,10 @@
 // if false, disabled buttons will be greyed out
 $button-colored-disabled: true !default;
 
+$button-focus-outline-color: rgb(var(--v-theme-surface-variant)) !default;
+$button-focus-outline-width: 2px !default;
+$button-focus-outline-offset: 2px !default;
+
 $button-background: rgb(var(--v-theme-surface)) !default;
 $button-color: tools.theme-color('on-surface', var(--v-high-emphasis-opacity)) !default;
 $button-banner-actions-padding: 0 8px !default; // @deprecated

--- a/packages/vuetify/src/components/VIconBtn/VIconBtn.scss
+++ b/packages/vuetify/src/components/VIconBtn/VIconBtn.scss
@@ -5,12 +5,12 @@
 @include tools.layer('components') {
   .v-icon-btn {
     @include tools.border($icon-btn-border...);
-    @include tools.rounded($icon-btn-border-radius);
     @include tools.states('.v-icon-btn__overlay');
     @include tools.variant($icon-btn-variants...);
 
     & {
       align-items: center;
+      border-radius: var(--v-icon-btn-border-radius, #{$icon-btn-border-radius});
       cursor: pointer;
       display: inline-flex;
       flex: none;
@@ -21,24 +21,18 @@
       justify-content: center;
       outline: none;
       position: relative;
-      transition-property: width, height, transform;
+      transition-property: width, height, transform, border-radius;
       transition: 0.2s settings.$standard-easing;
+
+      &:active {
+        border-radius: var(--v-icon-btn-border-radius-pressed, var(--v-icon-btn-border-radius, #{$icon-btn-border-radius}));
+      }
       vertical-align: middle;
       width: #{$icon-btn-width};
 
-      @supports selector(:focus-visible) {
-        &::after {
-          pointer-events: none;
-          border: 2px solid currentColor;
-          border-radius: inherit;
-          opacity: 0;
-          transition: opacity .2s ease-in-out;
-          @include tools.absolute(true);
-        }
-
-        &:focus-visible::after {
-          opacity: calc(.25 * var(--v-theme-overlay-multiplier));
-        }
+      &:focus-visible {
+        outline: $icon-btn-focus-outline-width solid $icon-btn-focus-outline-color;
+        outline-offset: $icon-btn-focus-outline-offset;
       }
     }
 

--- a/packages/vuetify/src/components/VIconBtn/VIconBtn.tsx
+++ b/packages/vuetify/src/components/VIconBtn/VIconBtn.tsx
@@ -18,7 +18,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { toDisplayString } from 'vue'
+import { computed, toDisplayString } from 'vue'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -32,6 +32,18 @@ export type VIconBtnSlots = {
 }
 
 export type VIconBtnSizes = 'x-small' | 'small' | 'default' | 'large' | 'x-large'
+
+export type VIconBtnForm = 'narrow' | 'default' | 'wide'
+
+export type VIconBtnSizeSpec = {
+  size?: number // container height (and default-form width when defaultWidth omitted)
+  iconSize?: number // icon size
+  narrowWidth?: number // container width for narrow form
+  defaultWidth?: number // container width for default form
+  wideWidth?: number // container width for wide form
+  borderRadius?: string | number
+  borderRadiusPressed?: string | number
+}
 
 export const makeVIconBtnProps = propsFactory({
   active: {
@@ -60,7 +72,7 @@ export const makeVIconBtnProps = propsFactory({
     default: 'default',
   },
   sizes: {
-    type: Array as PropType<[VIconBtnSizes, number][]>,
+    type: Array as PropType<[VIconBtnSizes | string, number | VIconBtnSizeSpec][]>,
     default: () => ([
       ['x-small', 16],
       ['small', 24],
@@ -68,6 +80,10 @@ export const makeVIconBtnProps = propsFactory({
       ['large', 48],
       ['x-large', 56],
     ]),
+  },
+  form: {
+    type: String as PropType<VIconBtnForm>,
+    default: 'default',
   },
   text: {
     type: [String, Number, Boolean],
@@ -118,7 +134,33 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
       })(),
     }))
 
-    const btnSizeMap = new Map(props.sizes)
+    const sizeVariables = computed(() => {
+      const map = new Map(props.sizes)
+      const _btnSize = String(props.size) as VIconBtnSizes
+      const sizeEntry = map.has(_btnSize) ? map.get(_btnSize) : undefined
+      const spec = typeof sizeEntry === 'object' && sizeEntry !== null ? sizeEntry as VIconBtnSizeSpec : null
+      const containerSize = spec?.size ?? (typeof sizeEntry === 'number' ? sizeEntry : undefined)
+      const formWidth = spec
+        ? (props.form === 'narrow' ? spec.narrowWidth
+          : props.form === 'wide' ? spec.wideWidth
+          : spec.defaultWidth ?? containerSize)
+        : undefined
+      const btnHeight = props.height ?? containerSize ?? (map.has(_btnSize) ? undefined : _btnSize)
+      const btnWidth = props.width ?? formWidth ?? containerSize ?? (map.has(_btnSize) ? undefined : _btnSize)
+      const defaultIconSize = spec?.iconSize ?? new Map(props.iconSizes).get(_btnSize)
+      return {
+        defaultIconSize,
+        styles: {
+          '--v-icon-btn-rotate': convertToUnit(props.rotate, 'deg'),
+          '--v-icon-btn-height': convertToUnit(btnHeight),
+          '--v-icon-btn-width': convertToUnit(btnWidth),
+          '--v-icon-btn-border-radius': convertToUnit(spec?.borderRadius),
+          '--v-icon-btn-border-radius-pressed': convertToUnit(spec?.borderRadiusPressed),
+        },
+      }
+    })
+
+    const { iconSize } = useIconSizes(props, () => sizeVariables.value.defaultIconSize)
 
     function onClick () {
       if (
@@ -133,13 +175,6 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
 
     useRender(() => {
       const icon = isActive.value ? props.activeIcon ?? props.icon : props.icon
-
-      const _btnSize = props.size as VIconBtnSizes
-      const hasNamedSize = btnSizeMap.has(_btnSize)
-      const btnSize = hasNamedSize ? btnSizeMap.get(_btnSize) : _btnSize
-      const btnHeight = props.height ?? btnSize
-      const btnWidth = props.width ?? btnSize
-      const { iconSize } = useIconSizes(props, () => new Map(props.iconSizes).get(_btnSize))
 
       const iconProps = {
         icon,
@@ -159,6 +194,7 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
               'v-icon-btn--loading': props.loading,
               'v-icon-btn--readonly': props.readonly,
               [`v-icon-btn--${props.size}`]: true,
+              [`v-icon-btn--form-${props.form}`]: props.form !== 'default',
             },
             themeClasses.value,
             colorClasses.value,
@@ -169,11 +205,7 @@ export const VIconBtn = genericComponent<VIconBtnSlots>()({
             props.class,
           ]}
           style={[
-            {
-              '--v-icon-btn-rotate': convertToUnit(props.rotate, 'deg'),
-              '--v-icon-btn-height': convertToUnit(btnHeight),
-              '--v-icon-btn-width': convertToUnit(btnWidth),
-            },
+            sizeVariables.value.styles,
             colorStyles.value,
             roundedStyles.value,
             props.style,

--- a/packages/vuetify/src/components/VIconBtn/_variables.scss
+++ b/packages/vuetify/src/components/VIconBtn/_variables.scss
@@ -3,6 +3,10 @@
 @use '../../styles/tools';
 
 // VIconBtn
+$icon-btn-focus-outline-color: rgb(var(--v-theme-surface-variant)) !default;
+$icon-btn-focus-outline-width: 2px !default;
+$icon-btn-focus-outline-offset: 2px !default;
+
 $icon-btn-background: rgb(var(--v-theme-surface)) !default;
 $icon-btn-color: inherit !default;
 $icon-btn-border-color: settings.$border-color-root !default;

--- a/packages/vuetify/src/styles/settings/_variables.scss
+++ b/packages/vuetify/src/styles/settings/_variables.scss
@@ -288,8 +288,7 @@ $typography: map-deep-merge(
     'button': (
       'size': .875rem,
       'weight': 500,
-      'line-height': 2.6,
-      'letter-spacing': .0892857143em,
+      'line-height': 1.425,
       'font-family': $body-font-family,
       'text-transform': none
     ),
@@ -359,4 +358,12 @@ $size-scales: (
   'default': 0,
   'large': 1,
   'x-large': 2
+) !default;
+
+$button-size-scales: (
+  'x-small': -1,
+  'small': 0,
+  'default': 2,
+  'large': 5,
+  'x-large': 9
 ) !default;


### PR DESCRIPTION
## Description

Just experimenting with MD3 button sizes... it all should be controlled by the blueprint.

<details>
<summary>Preview</summary>

<img width="1697" height="780" alt="image" src="https://github.com/user-attachments/assets/b0c6445a-c7ee-4270-8a60-5a810f5896ad" />

</details>

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-main>
      <v-container class="py-8">
        <!-- VBtn / VIconBtn size matrix -->
        <v-defaults-provider :defaults="btnDefaults">
          <div class="d-flex flex-wrap ga-4 align-center mb-8">
            <div
              v-for="{ size, label } in sizes"
              :key="size"
              class="d-flex flex-column align-center ga-1"
            >
              <v-btn :size="size" :text="!iconOnly && label" />
              <span class="text-caption text-disabled">{{ specs[size] }}</span>
            </div>
          </div>

          <div class="d-flex flex-wrap ga-4 align-center mb-8">
            <div
              v-for="{ size } in sizes"
              :key="size"
              class="d-flex flex-column align-center ga-1"
            >
              <v-icon-btn
                :key="md3 ? 1 : 2"
                :form="iconBtnForm"
                :size="size"
                :sizes="md3 ? md3IconSizes : undefined"
                icon="mdi-star"
                variant="elevated"
              />
              <span class="text-caption text-disabled">{{ size }}</span>
            </div>
          </div>
        </v-defaults-provider>

        <!-- Downstream components that embed VBtn -->
        <v-defaults-provider :defaults="downstreamDefaults">
          <div class="text-overline text-medium-emphasis mb-2">
            Downstream VBtn consumers — Tab through to inspect focus-outline clipping / overlap
          </div>
          <div class="downstream">
            <section>
              <h4>VBtnToggle</h4>
              <v-btn-toggle v-model="toggle" divided>
                <v-btn text="Left" />
                <v-btn text="Center" />
                <v-btn text="Right" />
              </v-btn-toggle>
            </section>

            <section>
              <h4>VBtnGroup (divided)</h4>
              <v-btn-group divided>
                <v-btn text="One" />
                <v-btn text="Two" />
                <v-btn text="Three" />
              </v-btn-group>
            </section>

            <section class="w-100">
              <h4>VToolbar / VAppBarNavIcon / VToolbarItems</h4>
              <v-toolbar rounded>
                <v-app-bar-nav-icon />
                <v-toolbar-title>Toolbar</v-toolbar-title>
                <v-spacer />
                <v-btn icon="mdi-magnify" />
                <v-toolbar-items>
                  <v-btn text="Login" />
                  <v-btn text="Sign up" />
                </v-toolbar-items>
              </v-toolbar>
            </section>

            <section class="w-100">
              <h4>VAlert (closable)</h4>
              <v-alert closable type="info" title="Heads up" text="The close button is a VBtn." />
            </section>

            <section>
              <h4>VRating</h4>
              <v-rating v-model="rating" hover />
              <v-rating v-model="rating" half-increments hover />
            </section>

            <section>
              <h4>VNumberInput</h4>
              <v-number-input v-model="num" style="width: 180px" />
              <v-number-input v-model="num" control-variant="split" style="width: 180px" class="mt-2" />
            </section>

            <section class="w-100">
              <h4>VTabs (default + inset)</h4>
              <v-tabs v-model="tab">
                <v-tab text="Overview" value="o" />
                <v-tab text="Specs" value="s" />
                <v-tab text="Reviews" value="r" />
              </v-tabs>
              <v-tabs v-model="tab" inset class="mt-2">
                <v-tab text="Overview" value="o" />
                <v-tab text="Specs" value="s" />
                <v-tab text="Reviews" value="r" />
              </v-tabs>
            </section>

            <section>
              <h4>VTreeview</h4>
              <v-treeview :items="treeItems" item-value="id" open-all density="compact" />
            </section>

            <section>
              <h4>VFab</h4>
              <div class="fab-box">
                <v-fab icon="mdi-plus" absolute location="bottom end" appear />
              </div>
              <v-fab icon="mdi-pencil" extended text="Edit" class="mt-2" />
            </section>

            <section>
              <h4>VDatePicker</h4>
              <v-date-picker v-model="date" />
            </section>

            <section>
              <h4>VTimePicker</h4>
              <v-time-picker v-model="time" format="ampm" />
            </section>

            <section>
              <h4>VColorPicker</h4>
              <v-color-picker v-model="colorValue" />
            </section>

            <section class="w-100">
              <h4>VDataTable (expandable rows)</h4>
              <v-data-table
                v-model:expanded="expanded"
                :headers="dtHeaders"
                :items="dtItems"
                item-value="name"
                show-expand
              >
                <template #expanded-row="{ columns }">
                  <tr>
                    <td :colspan="columns.length">Expanded content lives here.</td>
                  </tr>
                </template>
              </v-data-table>
            </section>
          </div>
        </v-defaults-provider>
      </v-container>
    </v-main>

    <div class="controls">
      <v-btn
        :text="`color: ${color ?? 'none'}`"
        variant="tonal"
        @click="colorIdx = (colorIdx + 1) % colors.length"
      />
      <v-btn
        :text="`rounded: ${roundedOption.label}`"
        variant="tonal"
        @click="roundedIdx = (roundedIdx + 1) % roundedOptions.length"
      />
      <v-btn
        :text="`icons: ${iconMode}`"
        variant="tonal"
        @click="iconModeIdx = (iconModeIdx + 1) % iconModes.length"
      />
      <v-btn
        :text="`density: ${density}`"
        variant="tonal"
        @click="densityIdx = (densityIdx + 1) % densities.length"
      />
      <v-btn
        :text="`stacked: ${stacked ? 'ON' : 'OFF'}`"
        variant="tonal"
        @click="stacked = !stacked"
      />
      <v-btn
        :text="`md3 sizes: ${md3 ? 'ON' : 'OFF'}`"
        variant="tonal"
        @click="md3 = !md3"
      />
      <v-btn
        :text="`form: ${iconBtnForm}`"
        variant="tonal"
        @click="formIdx = (formIdx + 1) % forms.length"
      />
    </div>
  </v-app>
</template>

<script setup>
  import { computed, ref } from 'vue'

  // MD3 Expressive button sizes (from material-components-android tokens.xml)
  // format: height × horizontal-padding
  const sizes = [
    { size: 'x-small', label: 'XSmall' },
    { size: 'small', label: 'Small' },
    { size: 'default', label: 'Medium' },
    { size: 'large', label: 'Large' },
    { size: 'x-large', label: 'XLarge' },
  ]
  const specs = {
    'x-small': '32×12',
    small: '40×16',
    default: '56×24',
    large: '96×48',
    'x-large': '136×64',
  }
  // MD3 Shape Scale
  const roundedOptions = [
    { label: 'default', value: undefined },
    { label: 'none (0dp)', value: '0' },
    { label: 'extra-small (4dp)', value: 'xs' },
    { label: 'small (8dp)', value: 'sm' },
    { label: 'medium (12dp)', value: 'md' },
    { label: 'large (16dp)', value: 'lg' },
    { label: 'large-inc (20dp)', value: 'lg-inc' },
    { label: 'extra-large (28dp)', value: 'xl' },
    { label: 'extra-large-inc (32dp)', value: 'xl-inc' },
    { label: 'extra-extra-large (48dp)', value: 'xxl' },
    { label: 'full', value: 'pill' },
  ]
  const colors = [undefined, 'primary', 'secondary', 'success', 'error', 'warning', 'info']

  const roundedIdx = ref(0)
  const colorIdx = ref(0)
  const iconModes = ['OFF', 'Prepend', 'Append', 'ON']
  const iconModeIdx = ref(0)
  const iconMode = computed(() => iconModes[iconModeIdx.value])
  const prependIcon = computed(() => iconModeIdx.value === 1)
  const appendIcon = computed(() => iconModeIdx.value === 2)
  const iconOnly = computed(() => iconModeIdx.value === 3)

  const roundedOption = computed(() => roundedOptions[roundedIdx.value])
  const color = computed(() => colors[colorIdx.value])

  // MD3 Expressive spec sizes (material-components-android tokens.xml)
  // borderRadius = square variant (B); borderRadiusPressed = pressed morph (C)
  const md3Sizes = {
    'x-small': { height: 32, fontSize: 14, fontWeight: 500, paddingInline: 12, iconGap: 4, borderRadius: 12, borderRadiusPressed: 8 },
    small: { height: 40, fontSize: 14, fontWeight: 500, paddingInline: 16, iconGap: 8, borderRadius: 12, borderRadiusPressed: 8 },
    default: { height: 56, fontSize: 16, fontWeight: 500, paddingInline: 24, iconGap: 8, borderRadius: 16, borderRadiusPressed: 12 },
    large: { height: 96, fontSize: 24, fontWeight: 400, paddingInline: 48, iconGap: 12, borderRadius: 28, borderRadiusPressed: 16 },
    'x-large': { height: 136, fontSize: 32, fontWeight: 400, paddingInline: 64, iconGap: 16, borderRadius: 28, borderRadiusPressed: 16 },
  }

  const md3 = ref(false)

  // MD3 Expressive icon button spec (material-components-android icon_btn_tokens.xml)
  // widths = icon + 2*padding per form: narrow(4/4/12/16/32) default(6/8/16/32/48) wide(10/14/24/48/72)
  const md3IconSizes = [
    ['x-small', { size: 32, iconSize: 20, narrowWidth: 28, defaultWidth: 32, wideWidth: 40, borderRadius: 12, borderRadiusPressed: 8 }],
    ['small', { size: 40, iconSize: 24, narrowWidth: 32, defaultWidth: 40, wideWidth: 52, borderRadius: 12, borderRadiusPressed: 8 }],
    ['default', { size: 56, iconSize: 24, narrowWidth: 48, defaultWidth: 56, wideWidth: 72, borderRadius: 16, borderRadiusPressed: 12 }],
    ['large', { size: 96, iconSize: 32, narrowWidth: 64, defaultWidth: 96, wideWidth: 128, borderRadius: 28, borderRadiusPressed: 16 }],
    ['x-large', { size: 136, iconSize: 40, narrowWidth: 104, defaultWidth: 136, wideWidth: 184, borderRadius: 28, borderRadiusPressed: 16 }],
  ]

  const densities = ['default', 'comfortable', 'compact']
  const densityIdx = ref(0)
  const density = computed(() => densities[densityIdx.value])

  const stacked = ref(false)

  const forms = ['narrow', 'default', 'wide']
  const formIdx = ref(1)
  const iconBtnForm = computed(() => forms[formIdx.value])

  const btnDefaults = computed(() => ({
    VBtn: {
      color: color.value,
      rounded: roundedOption.value.value,
      prependIcon: prependIcon.value ? 'mdi-cog' : undefined,
      appendIcon: appendIcon.value ? 'mdi-chevron-right' : undefined,
      icon: iconOnly.value ? 'mdi-pencil' : undefined,
      density: density.value,
      stacked: stacked.value || undefined,
      sizes: md3.value ? md3Sizes : undefined,
    },
    VIconBtn: {
      color: color.value,
    },
  }))

  // Downstream showcase — forward only the knobs relevant to the impact
  // analysis (color / rounded / density / md3 sizes); the matrix-only
  // icon/stacked/prepend/append defaults are intentionally excluded.
  const downstreamDefaults = computed(() => ({
    VBtn: {
      color: color.value,
      rounded: roundedOption.value.value,
      density: density.value,
      sizes: md3.value ? md3Sizes : undefined,
    },
  }))

  // Demo state for downstream components
  const toggle = ref(0)
  const rating = ref(3)
  const num = ref(5)
  const tab = ref('o')
  const date = ref(new Date())
  const time = ref('09:30')
  const colorValue = ref('#1976D2')
  const expanded = ref([])

  const treeItems = [
    {
      id: 1,
      title: 'Components',
      children: [
        { id: 2, title: 'VBtn' },
        { id: 3, title: 'VIconBtn' },
      ],
    },
    {
      id: 4,
      title: 'Composables',
      children: [
        { id: 5, title: 'useSize' },
        { id: 6, title: 'useRounded' },
      ],
    },
  ]

  const dtHeaders = [
    { title: 'Dessert', key: 'name' },
    { title: 'Calories', key: 'calories' },
  ]
  const dtItems = [
    { name: 'Frozen Yogurt', calories: 159 },
    { name: 'Ice cream sandwich', calories: 237 },
  ]
</script>

<style>
  .controls {
    position: fixed;
    bottom: 16px;
    right: 16px;
    display: flex;
    flex-direction: column;
    gap: 6px;
    align-items: flex-end;
    z-index: 10;
  }

  .downstream {
    display: flex;
    flex-wrap: wrap;
    gap: 24px;
    align-items: flex-start;
  }

  .downstream > section {
    border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
    border-radius: 8px;
    padding: 16px;
    min-width: 260px;
  }

  .downstream > section > h4 {
    font-size: 0.75rem;
    text-transform: uppercase;
    letter-spacing: 0.5px;
    opacity: 0.7;
    margin-bottom: 12px;
  }

  .fab-box {
    position: relative;
    height: 96px;
    width: 220px;
    border: 1px dashed rgba(var(--v-border-color), 0.4);
    border-radius: 8px;
  }

  /* MD3 shape scale mapped to Vuetify rounded-{value} classes */
  .rounded-xs      { border-radius: 4px  !important; }
  .rounded-sm      { border-radius: 8px  !important; }
  .rounded-md      { border-radius: 12px !important; }
  .rounded-lg      { border-radius: 16px !important; }
  .rounded-lg-inc  { border-radius: 20px !important; }
  .rounded-xl      { border-radius: 28px !important; }
  .rounded-xl-inc  { border-radius: 32px !important; }
  .rounded-xxl     { border-radius: 48px !important; }
</style>
```
