### PR TITLE
feat(VBtn): High Contrast Support (Forced-colors mode)

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -258,3 +258,11 @@
 
     .v-pagination__item--is-active .v-btn__overlay
       opacity: $button-pagination-active-overlay-opacity
+
+@media (forced-colors: active)
+  .v-btn
+    &:not(
+      &--variant-text,
+      &--variant-plain) 
+        border: thin solid
+

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -263,6 +263,7 @@
   .v-btn
     &:not(
       &--variant-text,
-      &--variant-plain) 
-        border: thin solid
+      &--variant-plain
+    )
+      border: thin solid
 

--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -267,3 +267,6 @@
     )
       border: thin solid
 
+    &:focus-visible
+      outline: 2px solid
+      outline-offset: 2px


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This addresses the request for High Contrast Support https://github.com/vuetifyjs/vuetify/issues/21515 for the VBtn component by adding a border to all v-btns except for the text & plain variant when forced-color mode (For example, High Contrast Mode in Windows) is enabled.

Before:
<img width="2217" height="242" alt="Screenshot 2025-07-29 145940" src="https://github.com/user-attachments/assets/b4a1a36b-56cc-4718-87e5-7230cc2f0982" />

After:
<img width="2196" height="246" alt="Screenshot 2025-07-29 150016" src="https://github.com/user-attachments/assets/a920b2c2-e897-40c5-89f8-c3f82db03c6d" />


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row dense>
    <v-col v-for="(variant, i) in variants" :key="i" cols="12" md="4">
      <v-btn :variant="variant" color="primary">
            {{ variant }}
          </v-btn>
    </v-col>
  </v-row>
</template>

<script>
  export default {
    data: () => ({
      variants: ['elevated', 'flat', 'tonal', 'outlined', 'text', 'plain'],
    }),
  }
</script>

```
