### PR TITLE
fix(VFileUpload): change uploaded item key for rendering

### DIFF
--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -296,7 +296,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
 
                 return (
                   <VDefaultsProvider
-                    key={ i }
+                    key={ `${file.name}-${i}` }
                     defaults={{
                       VFileUploadItem: {
                         file,
@@ -308,7 +308,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
                   >
                     { slots.item?.(slotProps) ?? (
                       <VFileUploadItem
-                        key={ i }
+                        key={ `${file.name}-${i}` }
                         onClick:remove={ () => onClickRemove(i) }
                         v-slots={ slots }
                       />


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fix #21772

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-file-upload multiple>
        <template #item="{ file, props }">
          <v-chip closable @click:close="props['onClick:remove']">
            {{ file.name }}
          </v-chip>
        </template>
      </v-file-upload>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>
```
