### PR TITLE
docs(VAutocomplete): add filter-keys prop section and example

### DIFF
--- a/packages/docs/src/examples/v-autocomplete/prop-filter-keys.vue
+++ b/packages/docs/src/examples/v-autocomplete/prop-filter-keys.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-container fluid>
+    <v-autocomplete
+      :filter-keys="['title', 'raw.abbr']"
+      :items="states"
+      item-title="name"
+      label="State"
+    ></v-autocomplete>
+  </v-container>
+</template>
+
+<script setup>
+  const states = [
+    { name: 'Florida', abbr: 'FL' },
+    { name: 'Georgia', abbr: 'GA' },
+    { name: 'Nebraska', abbr: 'NE' },
+    { name: 'California', abbr: 'CA' },
+    { name: 'New York', abbr: 'NY' },
+  ]
+</script>
+
+<script>
+  export default {
+    data: () => ({
+      states: [
+        { name: 'Florida', abbr: 'FL' },
+        { name: 'Georgia', abbr: 'GA' },
+        { name: 'Nebraska', abbr: 'NE' },
+        { name: 'California', abbr: 'CA' },
+        { name: 'New York', abbr: 'NY' },
+      ],
+    }),
+  }
+</script>

--- a/packages/docs/src/pages/en/components/autocompletes.md
+++ b/packages/docs/src/pages/en/components/autocompletes.md
@@ -68,7 +68,7 @@ The `custom-filter` prop can be used to filter each individual item with custom 
 
 #### Filter keys
 
-The `filter-keys` prop can be used to filter items by properties other than the default `title`. Properties of the original items passed need to be accessed via the `raw.*` path, as `filter-keys` index the root level of `InternalItem`.
+When user is typing in the field to narrow the list of options, the input text is matched against the `title`. With `filter-keys` you can specify which properties should be used instead. Properties of original objects passed to `items` need to be accessed via the `raw.*` path, as `filter-keys` index the root level of `InternalItem`.
 
 <ExamplesExample file="v-autocomplete/prop-filter-keys" />
 

--- a/packages/docs/src/pages/en/components/autocompletes.md
+++ b/packages/docs/src/pages/en/components/autocompletes.md
@@ -66,6 +66,12 @@ The `custom-filter` prop can be used to filter each individual item with custom 
 
 <ExamplesExample file="v-autocomplete/prop-filter" />
 
+#### Filter keys
+
+The `filter-keys` prop can be used to filter items by properties other than the default `title`. Properties of the original items passed need to be accessed via the `raw.*` path, as `filter-keys` index the root level of `InternalItem`.
+
+<ExamplesExample file="v-autocomplete/prop-filter-keys" />
+
 #### Subheaders and dividers
 
 The `items` prop recognizes special type of `divider` and `subheader`. Those items will be excluded when using filter and can be further customized with dedicated slots.


### PR DESCRIPTION
Closes #21799

## Description

Added section to the documentation page explaining the behavior of the `filter-keys` prop with related example
