### PR TITLE
fix(VDataTable): more flexible alignment with grouping

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -44,6 +44,9 @@
               &.v-data-table-column--no-padding
                 padding: 0 8px
 
+              &.v-data-table-column--empty
+                padding: 0
+
               &.v-data-table-column--nowrap
                 text-overflow: ellipsis
                 text-wrap: nowrap
@@ -112,7 +115,7 @@
       opacity: $data-table-loading-opacity
 
   .v-data-table-group-header-row__column
-    padding-left: calc(var(--v-data-table-group-header-row-depth) * 16px) !important
+    padding-inline-start: calc(var(--v-data-table-group-header-row-depth) * 16px) !important
 
   .v-data-table-header__content
     display: flex

--- a/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
@@ -20,6 +20,9 @@ export const VDataTableColumn = defineFunctionalComponent({
   firstFixedEnd: Boolean,
 
   noPadding: Boolean,
+  indent: [Number, String],
+  empty: Boolean,
+
   tag: String,
   width: [Number, String],
   maxWidth: [Number, String],
@@ -42,6 +45,7 @@ export const VDataTableColumn = defineFunctionalComponent({
           'v-data-table-column--first-fixed-end': props.firstFixedEnd,
           'v-data-table-column--no-padding': props.noPadding,
           'v-data-table-column--nowrap': props.nowrap,
+          'v-data-table-column--empty': props.empty,
         },
         `v-data-table-column--align-${props.align}`,
       ]}
@@ -51,6 +55,7 @@ export const VDataTableColumn = defineFunctionalComponent({
         maxWidth: convertToUnit(props.maxWidth),
         left: fixedSide === 'start' ? convertToUnit(props.fixedOffset || null) : undefined,
         right: fixedSide === 'end' ? convertToUnit(props.fixedEndOffset || null) : undefined,
+        paddingInlineStart: props.indent ? convertToUnit(props.indent) : undefined,
       }}
     >
       { slots.default?.() }

--- a/packages/vuetify/src/components/VDataTable/VDataTableGroupHeaderRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableGroupHeaderRow.tsx
@@ -10,7 +10,7 @@ import { useSelection } from './composables/select'
 import { IconValue } from '@/composables/icons'
 
 // Utilities
-import { computed } from 'vue'
+import { computed, toRef } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 // Types
@@ -51,6 +51,8 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
       return extractRows([props.item])
     })
 
+    const colspan = toRef(() => columns.value.length - (columns.value.some(c => c.key === 'data-table-select') ? 1 : 0))
+
     return () => (
       <tr
         class="v-data-table-group-header-row"
@@ -64,7 +66,10 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
             const onClick = () => toggleGroup(props.item)
 
             return slots['data-table-group']?.({ item: props.item, count: rows.value.length, props: { icon, onClick } }) ?? (
-              <VDataTableColumn class="v-data-table-group-header-row__column">
+              <VDataTableColumn
+                class="v-data-table-group-header-row__column"
+                colspan={ colspan.value }
+              >
                 <VBtn
                   size="small"
                   variant="text"
@@ -75,9 +80,7 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
                 <span>({ rows.value.length })</span>
               </VDataTableColumn>
             )
-          }
-
-          if (column.key === 'data-table-select') {
+          } else if (column.key === 'data-table-select') {
             const modelValue = isSelected(rows.value)
             const indeterminate = isSomeSelected(rows.value) && !modelValue
             const selectGroup = (v: boolean) => select(rows.value, v)
@@ -92,7 +95,7 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
             )
           }
 
-          return <td />
+          return ''
         })}
       </tr>
     )

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -147,6 +147,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
 
     const VDataTableHeaderCell = ({ column, x, y }: { column: InternalDataTableHeader, x: number, y: number }) => {
       const noPadding = column.key === 'data-table-select' || column.key === 'data-table-expand'
+      const isEmpty = column.key === 'data-table-group' && column.width === 0 && !column.title
       const headerProps = mergeProps(props.headerProps ?? {}, column.headerProps ?? {})
 
       return (
@@ -174,6 +175,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           lastFixed={ column.lastFixed }
           firstFixedEnd={ column.firstFixedEnd }
           noPadding={ noPadding }
+          empty={ isEmpty }
           tabindex={ column.sortable ? 0 : undefined }
           onClick={ column.sortable ? () => toggleSort(column) : undefined }
           onKeydown={ column.sortable ? (event: KeyboardEvent) => handleEnterKeyPress(event, column) : undefined }
@@ -194,6 +196,8 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
               }
 
               if (slots[columnSlotName]) return slots[columnSlotName]!(columnSlotProps)
+
+              if (isEmpty) return ''
 
               if (column.key === 'data-table-select') {
                 return slots['header.data-table-select']?.(columnSlotProps) ?? (showSelectAll.value && (

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -131,9 +131,13 @@ export const VDataTableRow = genericComponent<new <T>(
             })
             : column.cellProps
 
+          const noPadding = column.key === 'data-table-select' || column.key === 'data-table-expand'
+          const isEmpty = column.key === 'data-table-group' && column.width === 0 && !column.title
+
           return (
             <VDataTableColumn
               align={ column.align }
+              indent={ column.intent }
               class={{
                 'v-data-table__td--expanded-row': column.key === 'data-table-expand',
                 'v-data-table__td--select-row': column.key === 'data-table-select',
@@ -144,7 +148,8 @@ export const VDataTableRow = genericComponent<new <T>(
               lastFixed={ column.lastFixed }
               firstFixedEnd={ column.firstFixedEnd }
               maxWidth={ !mobile.value ? column.maxWidth : undefined }
-              noPadding={ column.key === 'data-table-select' || column.key === 'data-table-expand' }
+              noPadding={ noPadding }
+              empty={ isEmpty }
               nowrap={ column.nowrap }
               width={ !mobile.value ? column.width : undefined }
               { ...cellProps }

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -19,6 +19,7 @@ export type DataTableHeader<T = Record<string, any>> = {
   minWidth?: number | string
   maxWidth?: number | string
   nowrap?: boolean
+  intent?: number
 
   headerProps?: Record<string, any>
   cellProps?: HeaderCellProps


### PR DESCRIPTION
## Description

- removes padding entirely for group column with `title: '', width: 0`
- introduces `indent` field to align group items
- adds colspan to handle longer group names (and support empty column)
- resolves #17863

<details>
<summary>Preview</summary>

<img width="1284" height="951" alt="image" src="https://github.com/user-attachments/assets/f6287714-f1c0-46e8-a677-550bdf148112" />

</details>

## Markup:

```vue
<template>
  <v-app theme="dark">

    <v-sheet class="px-6 py-2 border-b" color="surface">
      <div class="d-flex ga-8 flex-wrap justify-center">
        <v-chip-group v-model="features" multiple>
          <v-chip text="debug lines" value="outline" filter label />
          <v-chip text="show-expand" value="show-expand" filter label />
          <v-chip text="show-select" value="show-select" filter label />
        </v-chip-group>
      </div>
    </v-sheet>

    <v-container :class="{ debugLines: features.includes('outline') }" max-width="800">
      <v-data-table
        v-model="selection"
        :group-by="groupBy"
        :headers="headers"
        :items="tools"
        :items-per-page="-1"
        :show-expand="features.includes('show-expand')"
        :show-select="features.includes('show-select')"
        item-value="name"
      />

      <pre>selection: {{ selection }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { shallowRef } from 'vue'

  const selection = shallowRef([])
  const features = shallowRef(['outline', 'show-select'])

  const groupBy = [
    { key: 'type', order: 'asc' },
    { key: 'length', order: 'asc' },
    { key: 'price', order: 'asc' },
  ]

  const headers = [
    { key: 'data-table-group', width: 0 },
    { title: 'Tool Name', key: 'name', intent: 77 },
    { title: 'Weight(kg)', key: 'weight' },
    { title: 'Length(cm)', key: 'length' },
    { title: 'Price($)', key: 'price' },
    // { key: 'data-table-select' },
  ]

  const tools = [
    { name: 'Hammer', weight: 0.5, length: 30, price: 10, type: 'hand' },
    { name: 'Screwdriver', weight: 0.2, length: 20, price: 5, type: 'hand' },
    { name: 'Drill', weight: 1.5, length: 25, price: 50, type: 'power' },
    { name: 'Saw', weight: 0.7, length: 50, price: 15, type: 'hand' },
    { name: 'Tape Measure', weight: 0.3, length: 10, price: 8, type: 'measuring' },
    { name: 'Level', weight: 0.4, length: 60, price: 12, type: 'very long text in the group column should be supported' },
    { name: 'Wrench', weight: 0.6, length: 25, price: 10, type: 'hand' },
    { name: 'Pliers', weight: 0.3, length: 15, price: 7, type: 'hand' },
    { name: 'Sander', weight: 2.0, length: 30, price: 60, type: 'power' },
    { name: 'Multimeter', weight: 0.5, length: 15, price: 30, type: 'measuring' },
  ]
</script>

<style>
  .debugLines {
    td, th {
      outline: 1px dashed red;
      outline-offset: -4px;
    }
  }
</style>
```
