### PR TITLE
fix(VField): avoid duplicated emits on clear

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -194,7 +194,10 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       const hasDetails = !!(hasCounter || slots.details)
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const { modelValue: _, ...inputProps } = VInput.filterProps(props)
-      const fieldProps = VField.filterProps(props)
+      const fieldProps = {
+        ...VField.filterProps(props),
+        'onClick:clear': onClear,
+      }
 
       return (
         <VInput
@@ -232,7 +235,6 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                 prependIcon={ props.prependIcon }
                 onMousedown={ onControlMousedown }
                 onClick={ onControlClick }
-                onClick:clear={ onClear }
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
                 { ...fieldProps }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -17,7 +17,7 @@ import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { cloneVNode, computed, nextTick, ref } from 'vue'
-import { callEvent, filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
+import { callEvent, filterInputAttrs, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -192,7 +192,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
                 role={ props.role }
-                { ...fieldProps }
+                { ...omit(fieldProps, ['onClick:clear']) }
                 id={ id.value }
                 active={ isActive.value || isDirty.value }
                 dirty={ isDirty.value || props.dirty }

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -203,7 +203,10 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
       const hasDetails = !!(hasCounter || slots.details)
       const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const { modelValue: _, ...inputProps } = VInput.filterProps(props)
-      const fieldProps = VField.filterProps(props)
+      const fieldProps = {
+        ...VField.filterProps(props),
+        'onClick:clear': onClear,
+      }
 
       return (
         <VInput
@@ -245,7 +248,6 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                 }}
                 onClick={ onControlClick }
                 onMousedown={ onControlMousedown }
-                onClick:clear={ onClear }
                 onClick:prependInner={ props['onClick:prependInner'] }
                 onClick:appendInner={ props['onClick:appendInner'] }
                 { ...fieldProps }


### PR DESCRIPTION
## Description

Note: changes are done in components built on top of VField

fixes #21417

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="600">
      <v-text-field
        label="v-text-field"
        prepend-inner-icon="mdi-cow"
        model-value="text value"
        clearable
        @click:clear="onClear"
      />
      <v-file-input
        label="v-file-input"
        clearable
        @click:clear="onClear"
      />
      <v-textarea
        label="v-textarea"
        prepend-inner-icon="mdi-cow"
        model-value="text value"
        clearable
        @click:clear="onClear"
      />
      <v-select
        label="v-select"
        prepend-inner-icon="mdi-cow"
        model-value="text value"
        clearable
        @click:clear="onClear"
      />
      <v-combobox
        label="v-combobox"
        prepend-inner-icon="mdi-cow"
        model-value="text value"
        clearable
        @click:clear="onClear"
      />
      <v-autocomplete
        label="v-autocomplete"
        prepend-inner-icon="mdi-cow"
        model-value="text value"
        clearable
        @click:clear="onClear"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  function onClear () {
    console.log('Clicked clear!')
  }
</script>
```
