### PR TITLE
feat(VPie): support touch for segment interaction

### DIFF
--- a/packages/vuetify/src/labs/VPie/VPie.sass
+++ b/packages/vuetify/src/labs/VPie/VPie.sass
@@ -43,6 +43,9 @@
         .v-overlay__content
           pointer-events: none !important
 
+    &__segments
+      border-radius: 50%
+
     &__content-underlay
       border-radius: 50%
       position: absolute

--- a/packages/vuetify/src/labs/VPie/VPieSegment.tsx
+++ b/packages/vuetify/src/labs/VPie/VPieSegment.tsx
@@ -1,8 +1,9 @@
 // Composables
+import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeRevealProps, useReveal } from '@/composables/reveal'
 
 // Utilities
-import { computed, shallowRef, toRef } from 'vue'
+import { computed, toRef } from 'vue'
 import { useInnerSlicePath, useOuterSlicePath, usePieArc } from './utils'
 import { easingPatterns, genericComponent, propsFactory, useTransition } from '@/util'
 
@@ -10,6 +11,7 @@ import { easingPatterns, genericComponent, propsFactory, useTransition } from '@
 import type { PropType } from 'vue'
 
 export const makeVPieSegmentProps = propsFactory({
+  active: Boolean,
   rotate: [Number, String],
   value: {
     type: Number,
@@ -40,8 +42,12 @@ export const VPieSegment = genericComponent()({
 
   props: makeVPieSegmentProps(),
 
+  emits: {
+    'update:active': (val: boolean) => true,
+  },
+
   setup (props) {
-    const isHovering = shallowRef(false)
+    const isActive = useProxiedModel(props, 'active')
 
     const { state: revealState, duration: revealDuration } = useReveal(props)
 
@@ -70,7 +76,7 @@ export const VPieSegment = genericComponent()({
       outerX,
       outerY,
       arcWidth,
-    } = usePieArc(props, isHovering)
+    } = usePieArc(props, isActive)
 
     const arcSize = toRef(() => revealState.value === 'initial' ? 0 : normalizedValue.value)
     const currentArcSize = useTransition(arcSize, transitionConfig)
@@ -78,7 +84,7 @@ export const VPieSegment = genericComponent()({
     const angle = toRef(() => revealState.value === 'initial' ? 0 : (Number(props.rotate ?? 0) + Number(props.gap ?? 0) / 2))
     const currentAngle = useTransition(angle, transitionConfig)
 
-    const arcRadius = toRef(() => 50 * (isHovering.value ? 1 : (1 - hoverZoomRatio.value)))
+    const arcRadius = toRef(() => 50 * (isActive.value ? 1 : (1 - hoverZoomRatio.value)))
     const currentArcRadius = useTransition(arcRadius, transitionConfig)
     const currentArcWidth = useTransition(arcWidth, transitionConfig)
 
@@ -129,8 +135,8 @@ export const VPieSegment = genericComponent()({
             transform={ `rotate(${currentAngle.value} 50 50)` }
             class="v-pie-segment__overlay"
             d={ overlayPath.value }
-            onMouseenter={ () => isHovering.value = true }
-            onMouseleave={ () => isHovering.value = false }
+            onMouseenter={ () => isActive.value = true }
+            onMouseleave={ () => isActive.value = false }
           />
         )}
       </g>

--- a/packages/vuetify/src/labs/VPie/VPieTooltip.tsx
+++ b/packages/vuetify/src/labs/VPie/VPieTooltip.tsx
@@ -6,9 +6,9 @@ import { makeVTooltipProps, VTooltip } from '@/components/VTooltip/VTooltip'
 import { makeTransitionProps, MaybeTransition } from '@/composables/transition'
 
 // Utilities
-import { onBeforeUnmount, onMounted, shallowRef, toRef } from 'vue'
+import { toRef } from 'vue'
 import { formatTextTemplate } from './utils'
-import { genericComponent, getCurrentInstance, pick, propsFactory } from '@/util'
+import { genericComponent, pick, propsFactory } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -21,6 +21,7 @@ export type VPieTooltipSlots = {
 
 export const makeVPieTooltipProps = propsFactory({
   modelValue: Boolean,
+  target: Object as PropType<[x: number, y: number]>,
   item: {
     type: Object as PropType<PieItem | null>,
     default: null,
@@ -43,25 +44,6 @@ export const VPieTooltip = genericComponent<VPieTooltipSlots>()({
   props: makeVPieTooltipProps(),
 
   setup (props, { slots }) {
-    const target = shallowRef<[x: number, y: number]>([0, 0])
-    const vm = getCurrentInstance('VPieTooltip')
-
-    let frame = -1
-    function onMouseMove ({ clientX, clientY }: MouseEvent) {
-      cancelAnimationFrame(frame)
-      frame = requestAnimationFrame(() => {
-        target.value = [clientX, clientY]
-      })
-    }
-
-    onMounted(() => {
-      vm.proxy!.$el.parentNode.addEventListener('mousemove', onMouseMove)
-    })
-
-    onBeforeUnmount(() => {
-      vm.proxy!.$el.parentNode.removeEventListener('mousemove', onMouseMove)
-    })
-
     const tooltipTitleFormatFunction = toRef(() => (segment: PieItem) => {
       return typeof props.titleFormat === 'function'
         ? props.titleFormat(segment)
@@ -78,7 +60,7 @@ export const VPieTooltip = genericComponent<VPieTooltipSlots>()({
       <VTooltip
         offset={ props.offset }
         modelValue={ props.modelValue }
-        target={ target.value }
+        target={ props.target }
         contentClass="v-pie__tooltip-content"
       >
         { !!props.item && (

--- a/packages/vuetify/src/labs/VPie/types.ts
+++ b/packages/vuetify/src/labs/VPie/types.ts
@@ -4,6 +4,7 @@ export interface PieItem {
   value: number
   title: string
   pattern?: string
+  isActive: boolean
   raw?: Record<string, any>
 }
 


### PR DESCRIPTION
## Description

- enables mobile user to activate segment tooltip
- with refactoring:
  - tooltip `target` (coordinates) controlled by SVG interactions
  - rename `isActive` » `isVisible` in VPie.tsx
  - `v-model:active` for VSegment (replaces `isHovering`)

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container
      class="h-100 d-flex flex-column ga-3 align-center justify-center"
    >
      <v-pie :items="items" hover-scale=".2" animation tooltip />
    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { key: 1, title: 'Series A', value: 45, color: '#2b6d40' },
    { key: 2, title: 'Series B', value: 30, color: '#4e9963' },
    { key: 3, title: 'Series C', value: 15, color: '#72c789' },
    { key: 4, title: 'Series D', value: 10, color: '#97f7b0' },
  ]
</script>
```
