### PR TITLE
feat(locationStrategies): support CSS zoom

### DIFF
--- a/packages/vuetify/src/util/animation.ts
+++ b/packages/vuetify/src/util/animation.ts
@@ -3,7 +3,7 @@ import { Box } from '@/util/box'
 
 /** @see https://stackoverflow.com/a/57876601/2074736 */
 export function nullifyTransforms (el: HTMLElement): Box {
-  const rect = el.getBoundingClientRect()
+  const rect = new Box(el.getBoundingClientRect())
   const style = getComputedStyle(el)
   const tx = style.transform
 

--- a/packages/vuetify/src/util/box.ts
+++ b/packages/vuetify/src/util/box.ts
@@ -4,16 +4,21 @@ export class Box {
   width: number
   height: number
 
-  constructor ({ x, y, width, height }: {
+  constructor (args: DOMRect | {
     x: number
     y: number
     width: number
     height: number
   }) {
-    this.x = x
-    this.y = y
-    this.width = width
-    this.height = height
+    const pageScale = document.body.currentCSSZoom ?? 1
+    const factor = args instanceof DOMRect ? 1 + (1 - pageScale) / pageScale : 1
+
+    const { x, y, width, height } = args
+
+    this.x = x * factor
+    this.y = y * factor
+    this.width = width * factor
+    this.height = height * factor
   }
 
   get top () { return this.y }
@@ -37,14 +42,17 @@ export function getOverflow (a: Box, b: Box) {
 
 export function getTargetBox (target: HTMLElement | [x: number, y: number]): Box {
   if (Array.isArray(target)) {
+    const pageScale = document.body.currentCSSZoom ?? 1
+    const factor = 1 + (1 - pageScale) / pageScale
+
     return new Box({
-      x: target[0],
-      y: target[1],
-      width: 0,
-      height: 0,
+      x: target[0] * factor,
+      y: target[1] * factor,
+      width: 0 * factor,
+      height: 0 * factor,
     })
   } else {
-    return target.getBoundingClientRect()
+    return new Box(target.getBoundingClientRect())
   }
 }
 
@@ -58,11 +66,12 @@ export function getElementBox (el: HTMLElement) {
         height: document.documentElement.clientHeight,
       })
     } else {
+      const pageScale = document.body.currentCSSZoom ?? 1
       return new Box({
         x: visualViewport.scale > 1 ? 0 : visualViewport.offsetLeft,
         y: visualViewport.scale > 1 ? 0 : visualViewport.offsetTop,
-        width: visualViewport.width * visualViewport.scale,
-        height: visualViewport.height * visualViewport.scale,
+        width: visualViewport.width * visualViewport.scale / pageScale,
+        height: visualViewport.height * visualViewport.scale / pageScale,
       })
     }
   } else {


### PR DESCRIPTION
## Description

When the zoom is forced with CSS, browser calculates wrong offsets for elements (`getBoundingClientRect`) and transforms for tooltips and menus are skewed.

- [x] fix VMenu
- [x] fix VTooltip
- [x] fix VPie (absolute target)
- [x] fix viewport size calculation

fixes #20719

> **NOTE:** Safari does not support `document.body.currentCSSZoom`, but you should be able to set this value manually (and keep in sync with forced zoom value).

## Markup:

> Note: you have to `pnpm build` for the playground to pick up changes in the **box.ts**

<details>
<summary>dev/index.html</summary>

```diff
<!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="zoom: .75;">
  <!-- -->
  <body>
    <div id="app"></div>
+    <script>window.pageScale = 0.75</script>
    <script type="module" src="/index.js"></script>
  </body>
</html>
```

</details>

<details>
<summary>dev/Playground.vue</summary>

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <div class="d-flex justify-space-around pa-16">
        <v-btn>
          Start
          <v-tooltip
            activator="parent"
            location="start"
          >Tooltip</v-tooltip>
        </v-btn>

        <v-btn>
          End
          <v-tooltip
            activator="parent"
            location="end"
          >Tooltip</v-tooltip>
        </v-btn>

        <v-btn>
          Top
          <v-tooltip
            activator="parent"
            location="top"
          >Tooltip</v-tooltip>
        </v-btn>

        <v-select :items="['a','b']" max-width="200" />

        <v-btn>
          Bottom
          <v-tooltip
            activator="parent"
            location="bottom"
          >Tooltip</v-tooltip>
        </v-btn>
      </div>
      <div class="d-flex ga-16 justify-center">
        <v-btn>
          Show Menu
          <v-menu activator="parent" stick-to-target>
            <v-list>
              <v-list-item title="option 1" />
              <v-list-item title="option 2" />
            </v-list>
          </v-menu>
        </v-btn>
        <v-pie :items="items" hover-scale=".2" animation tooltip />
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { key: 1, title: 'Series A', value: 45, color: '#2b6d40' },
    { key: 2, title: 'Series B', value: 30, color: '#4e9963' },
    { key: 3, title: 'Series C', value: 15, color: '#72c789' },
    { key: 4, title: 'Series D', value: 10, color: '#97f7b0' },
  ]
</script>
```

</details>