### PR TITLE
fix(nested): re-register items when their id changes

### DIFF
--- a/packages/vuetify/src/components/VList/VListChildren.tsx
+++ b/packages/vuetify/src/components/VList/VListChildren.tsx
@@ -69,8 +69,9 @@ export const VListChildren = genericComponent<new <T extends InternalListItem>(
       return children ? (
         <VListGroup
           { ...listGroupProps }
-          value={ props.returnObject ? item : itemProps?.value }
-          rawId={ itemProps?.value }
+          key={ itemProps.value ?? itemProps.title }
+          value={ props.returnObject ? item : itemProps.value }
+          rawId={ itemProps.value }
         >
           {{
             activator: ({ props: activatorProps }) => {
@@ -99,6 +100,7 @@ export const VListChildren = genericComponent<new <T extends InternalListItem>(
         slots.item ? slots.item({ props: itemProps }) : (
           <VListItem
             { ...itemProps }
+            key={ itemProps.value ?? itemProps.title }
             value={ props.returnObject ? item : itemProps.value }
             v-slots={ slotsWithItem }
           />

--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -182,6 +182,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
       return children ? (
         <VTreeviewGroup
           { ...treeviewGroupProps }
+          key={ item.value }
           value={ props.returnObject ? item.raw : treeviewGroupProps?.value }
           rawId={ treeviewGroupProps?.value }
         >
@@ -243,6 +244,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
           return (
             <VTreeviewItem
               { ...itemProps }
+              key={ item.value }
               hideActions={ props.hideActions }
               indentLines={ indentLines.leaf }
               value={ props.returnObject ? toRaw(item.raw) : itemProps.value }

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -13,6 +13,7 @@ import {
   toRaw,
   toRef,
   toValue,
+  watch,
 } from 'vue'
 import {
   independentActiveStrategy,
@@ -385,6 +386,13 @@ export const useNestedItem = (id: MaybeRefOrGetter<unknown>, isDisabled: MaybeRe
   onBeforeUnmount(() => {
     if (!parent.isGroupActivator) {
       parent.root.unregister(computedId.value)
+    }
+  })
+
+  watch(computedId, (val, oldVal) => {
+    if (!parent.isGroupActivator) {
+      parent.root.unregister(oldVal)
+      parent.root.register(val, parent.id.value, toValue(isDisabled), isGroup)
     }
   })
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #20934
also added keys to treeview and list items to reduce the amount this happens

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-treeview
        :items="menus ?? []"
        class="py-0"
        density="compact"
        item-title="name"
        item-value="id"
        activatable
        return-object
      />
      <v-btn @click="changeParent">Change parent</v-btn>
      <v-btn @click="prependAnything">Prepend</v-btn>
    </v-container>
  </v-app>
</template>

<script setup>
  import { nextTick, ref } from 'vue'
  const menus = ref([
    {
      name: 'zero',
      id: 0,
    },
    {
      name: 'one',
      id: 1,
      children: [
        {
          name: 'two',
          id: 2,
        },
      ],
    },
  ])
  const prependAnything = () => {
    menus.value.unshift({ name: 'unsifted', id: 25 })
  }
  const changeParent = async () => {
    const tmpList = menus.value?.[1].children?.splice(0, 1)
    // await nextTick()
    menus.value?.splice(0, 0, tmpList[0])
  }
</script>
```
