### PR TITLE
fix(VTreeview): merge itemProps and activatorProps on VTreeviewGroup's activator

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -10,7 +10,7 @@ import { makeDensityProps } from '@/composables/density'
 import { IconValue } from '@/composables/icons'
 
 // Utilities
-import { computed, reactive, ref, toRaw } from 'vue'
+import { computed, mergeProps, reactive, ref, toRaw } from 'vue'
 import { genericComponent, getIndentLines, pick, propsFactory, renderSlot } from '@/util'
 
 // Types
@@ -188,8 +188,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
           {{
             activator: ({ props: activatorProps }) => {
               const listItemProps = {
-                ...itemProps,
-                ...activatorProps,
+                ...mergeProps(activatorProps, itemProps),
                 value: itemProps?.value,
                 onToggleExpand: [() => checkChildren(item), activatorProps.onClick] as any,
                 onClick: isClickOnOpen.value


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixed #21891 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <!-- -->
      <VTreeview :items="items" open-on-click />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { VTreeview } from '@/components';
  const props = {
    class: 'red',
    style: 'color: blue',
  }
  const items = [
    {
      id: 1,
      title: 'Item 1',
      props,
      children: [
        {
          id: '1-1',
          title: 'Item 1.1',
          props,
        },
      ],
    },
    {
      id: 2,
      title: 'Item 1.1',
      props,
    },
  ]
</script>
<style>
.red {
  background: red;
}
</style>
```
