### PR TITLE
docs: wrap <v-footer> in <child> in example

### DIFF
--- a/packages/docs/src/examples/application-layout/layout-information-composable.vue
+++ b/packages/docs/src/examples/application-layout/layout-information-composable.vue
@@ -31,12 +31,14 @@
     </v-main>
 
     <v-footer color="surface-light" name="footer" app>
-      <v-btn
-        class="mx-auto"
-        text="Get data"
-        variant="text"
-        @click="print('footer')"
-      ></v-btn>
+      <child v-slot="{ print }">
+        <v-btn
+          class="mx-auto"
+          text="Get data"
+          variant="text"
+          @click="print('footer')"
+        ></v-btn>
+      </child>
     </v-footer>
   </v-layout>
 </template>


### PR DESCRIPTION
In order to get the "GET DATA" button work properly for all layout components.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
