### PR TITLE
fix(VCombobox): check if search value is not empty, if yes filter immediately (#21900)

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -188,7 +188,7 @@ export const VCombobox = genericComponent<new <
         : (props.multiple ? model.value.length : search.value.length)
     })
 
-    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
+    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value && !_search.value ? '' : search.value)
 
     const displayItems = computed(() => {
       if (props.hideSelected) {
@@ -586,7 +586,7 @@ export const VCombobox = genericComponent<new <
                                 </>
                               ),
                               title: () => {
-                                return isPristine.value
+                                return isPristine.value && !search.value
                                   ? item.title
                                   : highlightResult('v-combobox', item.title, getMatches(item)?.title)
                               },


### PR DESCRIPTION
## Description

Fixes: #21900 

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-combobox
        v-model="msg"
        :items="['Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming', 'California']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Cali')
</script>
```
