### PR TITLE
fix(VTextField): assign role to input element

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -185,14 +185,14 @@ describe('VAutocomplete', () => {
     const activeItems = await findAllByRole(menu, 'option', { selected: true })
     expect(activeItems).toHaveLength(2)
 
-    const input = await screen.findByRole('combobox')
-    expect(input).toHaveTextContent('Item 1')
-    expect(input).toHaveTextContent('Item 2')
+    const inputField = await screen.findByCSS('.v-field')
+    expect(inputField).toHaveTextContent('Item 1')
+    expect(inputField).toHaveTextContent('Item 2')
 
     await userEvent.click(activeItems[0])
 
-    expect(input).not.toHaveTextContent('Item 1')
-    expect(input).toHaveTextContent('Item 2')
+    expect(inputField).not.toHaveTextContent('Item 1')
+    expect(inputField).toHaveTextContent('Item 2')
     expect(selectedItems.value).toEqual([{
       text: 'Item 2',
       id: 'item2',
@@ -325,7 +325,7 @@ describe('VAutocomplete', () => {
     await userEvent.click(options[0])
 
     await userEvent.click(element)
-    await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+    await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
     await userEvent.click(document.body)
 
     expect(element).not.toHaveTextContent('Item 1')

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -95,23 +95,23 @@ describe('VCombobox', () => {
       await userEvent.click((await screen.findAllByRole('option'))[0])
       expect(model.value).toStrictEqual(items[0])
       expect(search.value).toBe(items[0].title)
-      expect(screen.getByRole('textbox')).toHaveValue(items[0].title)
+      expect(screen.getByCSS('input')).toHaveValue(items[0].title)
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent(items[0].title)
 
       await userEvent.click(element)
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('Item 2')
       expect(model.value).toBe('Item 2')
       expect(search.value).toBe('Item 2')
-      expect(screen.getByRole('textbox')).toHaveValue('Item 2')
+      expect(screen.getByCSS('input')).toHaveValue('Item 2')
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent('Item 2')
 
       await userEvent.click(element)
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('item3')
       expect(model.value).toBe('item3')
       expect(search.value).toBe('item3')
-      expect(screen.getByRole('textbox')).toHaveValue('item3')
+      expect(screen.getByCSS('input')).toHaveValue('item3')
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent('item3')
     })
 
@@ -138,25 +138,27 @@ describe('VCombobox', () => {
         />
       ))
 
+      const input = screen.getByCSS('input')
+
       await userEvent.click(element)
       await userEvent.click(screen.getAllByRole('option')[0])
       expect(model.value).toStrictEqual([items[0]])
       expect(search.value).toBeUndefined()
-      expect(screen.getByRole('textbox')).toHaveValue('')
+      expect(input).toHaveValue('')
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent(items[0].title)
 
       await userEvent.click(element)
       await userEvent.keyboard('Item 2{tab}')
       expect(model.value).toStrictEqual([items[0], 'Item 2'])
       expect(search.value).toBe('')
-      expect(screen.getByRole('textbox')).toHaveValue('')
+      expect(input).toHaveValue('')
       expect(screen.getAllByCSS('.v-combobox__selection').at(-1)).toHaveTextContent('Item 2')
 
       await userEvent.click(element)
       await userEvent.keyboard('item3{tab}')
       expect(model.value).toStrictEqual([items[0], 'Item 2', 'item3'])
       expect(search.value).toBe('')
-      expect(screen.getByRole('textbox')).toHaveValue('')
+      expect(input).toHaveValue('')
       expect(screen.getAllByCSS('.v-combobox__selection').at(-1)).toHaveTextContent('item3')
     })
   })
@@ -177,10 +179,10 @@ describe('VCombobox', () => {
       await userEvent.click(element)
       await userEvent.keyboard('Item')
       await expect(screen.findAllByRole('option')).resolves.toHaveLength(4)
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('Item 1')
       await expect(screen.findAllByRole('option')).resolves.toHaveLength(2)
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('Item 3')
       expect(screen.queryAllByRole('option')).toHaveLength(0)
     })
@@ -200,10 +202,10 @@ describe('VCombobox', () => {
       await userEvent.click(element)
       await userEvent.keyboard('Item')
       await expect(screen.findAllByRole('option')).resolves.toHaveLength(4)
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('Item 1')
       await expect(screen.findAllByRole('option')).resolves.toHaveLength(2)
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('Item 3')
       expect(screen.queryAllByRole('option')).toHaveLength(0)
     })
@@ -232,7 +234,7 @@ describe('VCombobox', () => {
       await userEvent.keyboard('test')
       await expect(screen.findByRole('option')).resolves.toHaveTextContent('Test1')
 
-      await userEvent.keyboard('{Control>}a{/Ctrl}{Backspace}')
+      await userEvent.keyboard('{Ctrl>}a{/Ctrl}{Backspace}')
       await userEvent.keyboard('antonsen')
       await expect(screen.findByRole('option')).resolves.toHaveTextContent('Antonsen PK')
     })
@@ -254,13 +256,15 @@ describe('VCombobox', () => {
         />
       ))
 
+      const input = screen.getByCSS('input')
+
       await userEvent.click(element)
 
       await expect(screen.findAllByRole('option', { selected: true })).resolves.toHaveLength(2)
       expect(screen.getAllByCSS('.v-chip')).toHaveLength(2)
 
       await userEvent.click(screen.getAllByTestId('close-chip')[0])
-      await expect(screen.findByRole('textbox')).resolves.toBeVisible()
+      await expect(input).toBeVisible()
       expect(screen.getAllByCSS('.v-chip')).toHaveLength(1)
       expect(selectedItems.value).toStrictEqual(['Colorado'])
     })
@@ -305,13 +309,15 @@ describe('VCombobox', () => {
         />
       ))
 
+      const input = screen.getByCSS('input')
+
       await userEvent.click(element)
 
       await expect(screen.findAllByRole('option', { selected: true })).resolves.toHaveLength(2)
       expect(screen.getAllByCSS('.v-chip')).toHaveLength(2)
 
       await userEvent.click(screen.getAllByTestId('close-chip')[0])
-      await expect(screen.findByRole('textbox')).resolves.toBeVisible()
+      await expect(input).toBeVisible()
       expect(screen.getAllByCSS('.v-chip')).toHaveLength(1)
       expect(selectedItems.value).toStrictEqual([{
         title: 'Item 2',
@@ -363,9 +369,9 @@ describe('VCombobox', () => {
 
       const options = await screen.findAllByRole('option', { selected: true })
       expect(options).toHaveLength(2)
-      const input = await screen.findByRole('combobox')
-      expect(input).toHaveTextContent('Item 1')
-      expect(input).toHaveTextContent('Item 2')
+      const inputField = screen.getByCSS('.v-field')
+      expect(inputField).toHaveTextContent('Item 1')
+      expect(inputField).toHaveTextContent('Item 2')
 
       await userEvent.click(options[0])
 
@@ -453,7 +459,7 @@ describe('VCombobox', () => {
     })
   })
 
-  // https://github.com/vuetifyjs/vuetify/issues/17120
+  // // https://github.com/vuetifyjs/vuetify/issues/17120
   it('should display 0 when selected', async () => {
     const items = [0, 1, 2, 3, 4]
 
@@ -470,7 +476,7 @@ describe('VCombobox', () => {
 
     await userEvent.click(screen.getAllByRole('option')[0])
 
-    expect(screen.getByRole('textbox')).toHaveValue('0')
+    expect(screen.getByCSS('input')).toHaveValue('0')
   })
 
   it('should conditionally show placeholder', async () => {
@@ -478,7 +484,7 @@ describe('VCombobox', () => {
       props: { placeholder: 'Placeholder' },
     })
 
-    const input = screen.getByRole('textbox')
+    const input = screen.getByCSS('input')
     await expect.element(input).toHaveAttribute('placeholder', 'Placeholder')
 
     await rerender({ label: 'Label' })

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -220,6 +220,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                         name={ props.name }
                         placeholder={ props.placeholder }
                         size={ 1 }
+                        role={ props.role }
                         type={ props.type }
                         onFocus={ focus }
                         onBlur={ blur }


### PR DESCRIPTION
fixes #18125

## Description
Add role attribute to <input element in VTextField so that when it is passed in as a prop, it is assigned to the input element. This ensures screen readers read out the role of input field
 
This PR fixes the linked issue because VTextField is used in VSelect and role prop is passed as combobox.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select label="Select" :items="['item1', 'item2', 'item3']" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
</script>

```
