### PR TITLE
fix(VDatePicker): Prioritize allowed-months and allowed-years

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -213,6 +213,14 @@ export const VDatePicker = genericComponent<new <
       return targets
     })
 
+    const allowedYears = computed(() => {
+      return props.allowedYears || isYearAllowed
+    })
+
+    const allowedMonths = computed(() => {
+      return props.allowedMonths || isMonthAllowed
+    })
+
     function isAllowedInRange (start: unknown, end: unknown) {
       const allowedDates = props.allowedDates
       if (typeof allowedDates !== 'function') return true
@@ -223,7 +231,7 @@ export const VDatePicker = genericComponent<new <
       return false
     }
 
-    function allowedYears (year: number) {
+    function isYearAllowed (year: number) {
       if (typeof props.allowedDates === 'function') {
         const startOfYear = adapter.parseISO(`${year}-01-01`)
         return isAllowedInRange(startOfYear, adapter.endOfYear(startOfYear))
@@ -239,7 +247,7 @@ export const VDatePicker = genericComponent<new <
       return true
     }
 
-    function allowedMonths (month: number) {
+    function isMonthAllowed (month: number) {
       if (typeof props.allowedDates === 'function') {
         const monthTwoDigits = String(month + 1).padStart(2, '0')
         const startOfMonth = adapter.parseISO(`${year.value}-${monthTwoDigits}-01`)
@@ -404,7 +412,7 @@ export const VDatePicker = genericComponent<new <
                       min={ minDate.value }
                       max={ maxDate.value }
                       year={ year.value }
-                      allowedMonths={ allowedMonths }
+                      allowedMonths={ allowedMonths.value }
                       onUpdate:modelValue={ onUpdateMonth }
                     >
                       {{ month: slots.month }}
@@ -416,7 +424,7 @@ export const VDatePicker = genericComponent<new <
                       v-model={ year.value }
                       min={ minDate.value }
                       max={ maxDate.value }
-                      allowedYears={ allowedYears }
+                      allowedYears={ allowedYears.value }
                       onUpdate:modelValue={ onUpdateYear }
                     >
                       {{ year: slots.year }}


### PR DESCRIPTION
fixes #21911

## Description
Prioritize allowed-months and allowed-years

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input
        label="Date selection"
        :allowed-dates="allowedDates"
      />

      <v-date-input
        label="Date selection"
        :allowed-months="[7, 8]"
        :allowed-years="[2024, 2025]"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  function allowedDates (date) {
    const isAllowedYear = [2024, 2025].includes(new Date(date).getFullYear())
    const isAllowedMonth = [7,8].includes(new Date(date).getMonth())
    return isAllowedYear && isAllowedMonth
  }
</script>

```
