### PR TITLE
fix(VSelect): Select placeholder overlap

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.sass
+++ b/packages/vuetify/src/components/VSelect/VSelect.sass
@@ -23,10 +23,13 @@
           opacity: 1
           flex: 0 0
           position: absolute
+          left: 0
+          right: 0
           width: 100%
           transition: none
           pointer-events: none
           caret-color: transparent
+          padding-inline: inherit
 
     .v-field--dirty
       .v-select__selection


### PR DESCRIPTION
fixes #21922

## Description
Fix VSelect placeholder overlap with menu icon

## Markup:


<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-select
        width="200px"
        placeholder="This is a long placeholder asdas. asd asd asd"
      />
    </v-container>
  </v-app>
</template>
```
