### PR TITLE
fix(VMaskInput): fix caret position while editing

### DIFF
--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -118,7 +118,7 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
 
       const inputElement = e.target as HTMLInputElement
 
-      caretPosition.value = inputElement.selectionEnd || 0
+      caretPosition.value = inputElement.selectionStart || 0
       inputAction.value = e.key
 
       const hasSelection = inputElement.selectionStart !== inputElement.selectionEnd

--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -130,6 +130,7 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
     }
 
     function handleClipboardEvent (e: Event) {
+      caretPosition.value = vTextFieldRef.value?.selectionEnd || 0
       inputAction.value = e.type
     }
 

--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -135,7 +135,7 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       e.preventDefault()
 
       const inputElement = e.target as HTMLInputElement
-      const pastedString = e.clipboardData?.getData('text')
+      const pastedString = removeMaskDelimiters(e.clipboardData?.getData('text') || '')
 
       if (!pastedString) return
 

--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -39,8 +39,6 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
     const mask = useMask(props)
     const returnMaskedValue = computed(() => props.mask && props.returnMaskedValue)
 
-    const validationValue = toRef(() => returnMaskedValue.value ? model.value : mask.unmask(model.value))
-
     const model = useProxiedModel(
       props,
       'modelValue',
@@ -70,6 +68,8 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
         return val
       },
     )
+
+    const validationValue = toRef(() => returnMaskedValue.value ? model.value : mask.unmask(model.value))
 
     function removeMaskDelimiters (val: string): string {
       return val.split('').filter(ch => !isMaskDelimiter(ch)).join('')

--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -122,15 +122,15 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       }
     })
 
-    function handleKeyDown (e: KeyboardEvent) {
+    function onKeyDown (e: KeyboardEvent) {
       if (e.metaKey) return
 
-      caretPosition.value = vTextFieldRef.value?.selectionEnd || 0
+      caretPosition.value = (e.target as HTMLInputElement).selectionEnd || 0
       inputAction.value = e.key
     }
 
-    function handleClipboardEvent (e: Event) {
-      caretPosition.value = vTextFieldRef.value?.selectionEnd || 0
+    function onClipboardEvent (e: Event) {
+      caretPosition.value = (e.target as HTMLInputElement).selectionEnd || 0
       inputAction.value = e.type
     }
 
@@ -143,9 +143,9 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
           v-model={ model.value }
           ref={ vTextFieldRef }
           validationValue={ validationValue.value }
-          onKeydown={ handleKeyDown }
-          onPaste={ handleClipboardEvent }
-          onCut={ handleClipboardEvent }
+          onKeydown={ onKeyDown }
+          onPaste={ onClipboardEvent }
+          onCut={ onClipboardEvent }
         >
           {{ ...slots }}
         </VTextField>

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -70,8 +70,8 @@ describe('VMaskInput', () => {
       it('when typing', async () => {
         const { input, model } = renderComponent({ defaultModel: '', defaultMask: '####' })
         await userEvent.type(input, '123')
-        expect(input.selectionStart).toBe(input.value.length)
         expect(model.value).toBe('123')
+        expect(input.selectionStart).toBe(input.value.length)
       })
 
       it('when typing before before delimiter', async () => {
@@ -81,8 +81,8 @@ describe('VMaskInput', () => {
 
         await userEvent.type(input, '1')
 
-        expect(input.selectionStart).toBe(14)
         expect(model.value).toBe('(AS)-123-XYZ-14-56')
+        expect(input.selectionStart).toBe(14)
       })
 
       it('when typing such that cursor lands before delimiter.', async () => {
@@ -92,8 +92,8 @@ describe('VMaskInput', () => {
 
         await userEvent.type(input, 'S')
 
-        expect(input.selectionStart).toBe(5)
         expect(model.value).toBe('(AS)-')
+        expect(input.selectionStart).toBe(5)
       })
 
       it('when typing in the middle of input', async () => {
@@ -102,8 +102,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(13)
 
         await userEvent.type(input, '1')
-        expect(input.selectionStart).toBe(14)
         expect(model.value).toBe('(AS)-123-XYZ-14-56')
+        expect(input.selectionStart).toBe(14)
       })
 
       it('when selected in the middle', async () => {
@@ -112,8 +112,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(9, 11)
 
         await userEvent.type(input, 'A')
-        expect(input.selectionStart).toBe(10)
         expect(model.value).toBe('(AS)-123-AZ4-56-7')
+        expect(input.selectionStart).toBe(10)
       })
 
       it('when selected such that one character before, one at and one after delimiter', async () => {
@@ -122,8 +122,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(11, 14)
 
         await userEvent.type(input, '1')
-        expect(input.selectionStart).toBe(13)
         expect(model.value).toBe('(AS)-123-XY1-56-7')
+        expect(input.selectionStart).toBe(13)
       })
     })
 
@@ -134,8 +134,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(3)
 
         await userEvent.type(input, '{backspace}')
-        expect(input.selectionStart).toBe(2)
         expect(model.value).toBe('124')
+        expect(input.selectionStart).toBe(2)
       })
 
       it('backspace pressed when cursor is after delimiter', async () => {
@@ -144,8 +144,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(3)
 
         await userEvent.type(input, '{backspace}')
-        expect(input.selectionStart).toBe(2)
         expect(model.value).toBe('12-34')
+        expect(input.selectionStart).toBe(2)
       })
 
       it('backspace pressed such that cursor lands after delimiter', async () => {
@@ -154,8 +154,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(4)
 
         await userEvent.type(input, '{backspace}')
-        expect(input.selectionStart).toBe(2)
         expect(model.value).toBe('12-4')
+        expect(input.selectionStart).toBe(2)
       })
 
       it('backspace pressed in the middle of input', async () => {
@@ -164,8 +164,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(15)
 
         await userEvent.type(input, '{backspace}')
-        expect(input.selectionStart).toBe(14)
         expect(model.value).toBe('(AS)-123-XYZ-46-7')
+        expect(input.selectionStart).toBe(14)
       })
 
       it('backspace pressed with selection in middle', async () => {
@@ -174,8 +174,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(10, 12)
 
         await userEvent.type(input, '{backspace}')
-        expect(input.selectionStart).toBe(10)
         expect(model.value).toBe('(AS)-123-X45-67-')
+        expect(input.selectionStart).toBe(10)
       })
 
       it('selection contains one character before, one at and one after delimiter', async () => {
@@ -184,8 +184,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(11, 14)
 
         await userEvent.type(input, '{backspace}')
-        expect(input.selectionStart).toBe(11)
         expect(model.value).toBe('(AS)-123-XY5-67-')
+        expect(input.selectionStart).toBe(11)
       })
     })
 
@@ -196,8 +196,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(2)
 
         await userEvent.type(input, '{delete}')
-        expect(input.selectionStart).toBe(2)
         expect(model.value).toBe('124')
+        expect(input.selectionStart).toBe(2)
       })
 
       it('forward delete pressed when cursor is after delimiter', async () => {
@@ -206,8 +206,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(3)
 
         await userEvent.type(input, '{delete}')
-        expect(input.selectionStart).toBe(3)
         expect(model.value).toBe('12-4')
+        expect(input.selectionStart).toBe(3)
       })
 
       it('forward delete pressed in the middle of input', async () => {
@@ -216,8 +216,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(14)
 
         await userEvent.type(input, '{delete}')
-        expect(input.selectionStart).toBe(14)
         expect(model.value).toBe('(AS)-123-XYZ-46-7')
+        expect(input.selectionStart).toBe(14)
       })
 
       it('forward delete pressed with selection in middle', async () => {
@@ -226,8 +226,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(10, 12)
 
         await userEvent.type(input, '{delete}')
-        expect(input.selectionStart).toBe(10)
         expect(model.value).toBe('(AS)-123-X45-67-')
+        expect(input.selectionStart).toBe(10)
       })
 
       it('selection contains one character before, one at and one after delimiter', async () => {
@@ -236,8 +236,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(11, 14)
 
         await userEvent.type(input, '{delete}')
-        expect(input.selectionStart).toBe(11)
         expect(model.value).toBe('(AS)-123-XY5-67-')
+        expect(input.selectionStart).toBe(11)
       })
     })
 
@@ -248,8 +248,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(10, 12)
         await userEvent.keyboard('{Ctrl>}x{/Ctrl}')
 
-        expect(input.selectionStart).toBe(10)
         expect(model.value).toBe('(AS)-123-X45-67-')
+        expect(input.selectionStart).toBe(10)
       })
 
       it('selection contains one character before, one at and one after delimiter', async () => {
@@ -258,8 +258,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(11, 14)
 
         await userEvent.keyboard('{Ctrl>}x{/Ctrl}')
-        expect(input.selectionStart).toBe(11)
         expect(model.value).toBe('(AS)-123-XY5-67-')
+        expect(input.selectionStart).toBe(11)
       })
     })
 
@@ -272,8 +272,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(2)
         await userEvent.paste()
 
-        expect(input.selectionStart).toBe(4)
         expect(model.value).toBe('1234')
+        expect(input.selectionStart).toBe(4)
       })
 
       it('pasted when cursor is in middle', async () => {
@@ -283,8 +283,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(2)
         await userEvent.paste()
 
-        expect(input.selectionStart).toBe(3)
         expect(model.value).toBe('12345')
+        expect(input.selectionStart).toBe(3)
       })
 
       it('pasted when cursor is after delimiter', async () => {
@@ -294,8 +294,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(13)
         await userEvent.paste()
 
-        expect(input.selectionStart).toBe(16)
         expect(model.value).toBe('(AS)-123-XYZ-12-')
+        expect(input.selectionStart).toBe(16)
       })
 
       it('pasted when cursor is before delimiter', async () => {
@@ -305,8 +305,8 @@ describe('VMaskInput', () => {
         await insertCaretAt(2)
         await userEvent.paste()
 
-        expect(input.selectionStart).toBe(5)
         expect(model.value).toBe('12-34')
+        expect(input.selectionStart).toBe(5)
       })
 
       it('pasted when selection is in middle', async () => {
@@ -316,9 +316,9 @@ describe('VMaskInput', () => {
         await insertCaretAt(10, 12)
         await userEvent.paste()
 
+        expect(model.value).toBe('(AS)-123-XCD-45-67')
         // TODO: Fix this test
         expect(input.selectionStart).toBe(12)
-        expect(model.value).toBe('(AS)-123-XCD-45-67')
       })
 
       it('pasted when selection is in middle', async () => {
@@ -328,9 +328,9 @@ describe('VMaskInput', () => {
         await insertCaretAt(1, 3)
         await userEvent.paste()
 
+        expect(model.value).toBe('(CD)-123-XCD-45-67')
         // TODO: Fix this test
         expect(input.selectionStart).toBe(5)
-        expect(model.value).toBe('(CD)-123-XCD-45-67')
       })
 
       it('pasted when selection contains one character before, one at and one after delimiter', async () => {
@@ -340,9 +340,9 @@ describe('VMaskInput', () => {
         await insertCaretAt(11, 14)
         await userEvent.paste()
 
+        expect(model.value).toBe('(AS)-123-XYA-05-67')
         // TODO: Fix this test
         expect(input.selectionStart).toBe(14)
-        expect(model.value).toBe('(AS)-123-XYA-05-67')
       })
     })
   })

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -291,22 +291,22 @@ describe('VMaskInput', () => {
         {
           inputCaret: [10, 12],
           inputText: 'CD',
-          outputText: '(AS)-123-XCD-45-67', // TODO: Fix this output
-          outputCaret: 12, // TODO: Fix this output
+          outputText: '(AS)-123-XCD-45-67',
+          outputCaret: 13,
         },
         // pasted when selection is in middle
         {
           inputCaret: [1, 3],
           inputText: 'CD',
-          outputText: '(CD)-123-XCD-45-67', // TODO: Fix this output
-          outputCaret: 5, // TODO: Fix this output
+          outputText: '(CD)-123-XYZ-45-67',
+          outputCaret: 5,
         },
         // pasted when selection contains one character before, one at and one after delimiter
         {
           inputCaret: [11, 14],
           inputText: 'A0',
-          outputText: '(AS)-123-XYA-05-67', // TODO: Fix this output
-          outputCaret: 14, // TODO: Fix this output
+          outputText: '(AS)-123-XYA-05-67',
+          outputCaret: 14,
         },
       ])('should work as expected when pasting', async ({ defaultModel, defaultMask, inputText, inputCaret, outputText, outputCaret }) => {
         const { input, model, insertCaretAt } = renderComponent({ defaultModel, defaultMask })

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -1,7 +1,7 @@
 import { VMaskInput } from '../VMaskInput'
 
 // Utilities
-import { render, screen } from '@test'
+import { render, screen, userEvent } from '@test'
 import { ref } from 'vue'
 
 describe('VMaskInput', () => {
@@ -30,5 +30,320 @@ describe('VMaskInput', () => {
 
     await expect.element(screen.getByCSS('input')).toHaveValue('(456) 7')
     expect(inputValue.value).toBe('(456) 7')
+  })
+
+  describe('Caret Position and Formatting', () => {
+    const renderComponent = ({
+      defaultModel = '(AS)-123-XYZ-45-67',
+      defaultMask = '(AA)-###-NNN-##-##',
+    }: {
+      defaultModel?: string
+      defaultMask?: string
+    } = {}) => {
+      const model = ref(defaultModel)
+
+      const wrapper = render(() => (
+        <VMaskInput
+          v-model={ model.value }
+          mask={ defaultMask }
+          returnMaskedValue
+        />
+      ))
+
+      const input = screen.getByCSS('input') as HTMLInputElement
+
+      const insertCaretAt = async (start: number, end?: number) => {
+        await userEvent.click(input)
+        input.setSelectionRange(start, end || start)
+        return input.selectionStart
+      }
+
+      return {
+        model,
+        input,
+        wrapper,
+        insertCaretAt,
+      }
+    }
+
+    describe('Insertion', () => {
+      it('when typing', async () => {
+        const { input, model } = renderComponent({ defaultModel: '', defaultMask: '####' })
+        await userEvent.type(input, '123')
+        expect(input.selectionStart).toBe(input.value.length)
+        expect(model.value).toBe('123')
+      })
+
+      it('when typing before before delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(12)
+
+        await userEvent.type(input, '1')
+
+        expect(input.selectionStart).toBe(14)
+        expect(model.value).toBe('(AS)-123-XYZ-14-56')
+      })
+
+      it('when typing such that cursor lands before delimiter.', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultModel: '(A' })
+
+        await insertCaretAt(2)
+
+        await userEvent.type(input, 'S')
+
+        expect(input.selectionStart).toBe(5)
+        expect(model.value).toBe('(AS)-')
+      })
+
+      it('when typing in the middle of input', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(13)
+
+        await userEvent.type(input, '1')
+        expect(input.selectionStart).toBe(14)
+        expect(model.value).toBe('(AS)-123-XYZ-14-56')
+      })
+
+      it('when selected in the middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(9, 11)
+
+        await userEvent.type(input, 'A')
+        expect(input.selectionStart).toBe(10)
+        expect(model.value).toBe('(AS)-123-AZ4-56-7')
+      })
+
+      it('when selected such that one character before, one at and one after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(11, 14)
+
+        await userEvent.type(input, '1')
+        expect(input.selectionStart).toBe(13)
+        expect(model.value).toBe('(AS)-123-XY1-56-7')
+      })
+    })
+
+    describe('Backward Delete / Backspace', () => {
+      it('when backspace is pressed', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '####', defaultModel: '1234' })
+
+        await insertCaretAt(3)
+
+        await userEvent.type(input, '{backspace}')
+        expect(input.selectionStart).toBe(2)
+        expect(model.value).toBe('124')
+      })
+
+      it('backspace pressed when cursor is after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '##-##', defaultModel: '12-34' })
+
+        await insertCaretAt(3)
+
+        await userEvent.type(input, '{backspace}')
+        expect(input.selectionStart).toBe(2)
+        expect(model.value).toBe('12-34')
+      })
+
+      it('backspace pressed such that cursor lands after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '##-##', defaultModel: '12-34' })
+
+        await insertCaretAt(4)
+
+        await userEvent.type(input, '{backspace}')
+        expect(input.selectionStart).toBe(2)
+        expect(model.value).toBe('12-4')
+      })
+
+      it('backspace pressed in the middle of input', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(15)
+
+        await userEvent.type(input, '{backspace}')
+        expect(input.selectionStart).toBe(14)
+        expect(model.value).toBe('(AS)-123-XYZ-46-7')
+      })
+
+      it('backspace pressed with selection in middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(10, 12)
+
+        await userEvent.type(input, '{backspace}')
+        expect(input.selectionStart).toBe(10)
+        expect(model.value).toBe('(AS)-123-X45-67-')
+      })
+
+      it('selection contains one character before, one at and one after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(11, 14)
+
+        await userEvent.type(input, '{backspace}')
+        expect(input.selectionStart).toBe(11)
+        expect(model.value).toBe('(AS)-123-XY5-67-')
+      })
+    })
+
+    describe('Forward Delete', () => {
+      it('when forward delete is pressed', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '####', defaultModel: '1234' })
+
+        await insertCaretAt(2)
+
+        await userEvent.type(input, '{delete}')
+        expect(input.selectionStart).toBe(2)
+        expect(model.value).toBe('124')
+      })
+
+      it('forward delete pressed when cursor is after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '##-##', defaultModel: '12-34' })
+
+        await insertCaretAt(3)
+
+        await userEvent.type(input, '{delete}')
+        expect(input.selectionStart).toBe(3)
+        expect(model.value).toBe('12-4')
+      })
+
+      it('forward delete pressed in the middle of input', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(14)
+
+        await userEvent.type(input, '{delete}')
+        expect(input.selectionStart).toBe(14)
+        expect(model.value).toBe('(AS)-123-XYZ-46-7')
+      })
+
+      it('forward delete pressed with selection in middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(10, 12)
+
+        await userEvent.type(input, '{delete}')
+        expect(input.selectionStart).toBe(10)
+        expect(model.value).toBe('(AS)-123-X45-67-')
+      })
+
+      it('selection contains one character before, one at and one after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(11, 14)
+
+        await userEvent.type(input, '{delete}')
+        expect(input.selectionStart).toBe(11)
+        expect(model.value).toBe('(AS)-123-XY5-67-')
+      })
+    })
+
+    describe('Cut', () => {
+      it('cut with selection in middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(10, 12)
+        await userEvent.keyboard('{Ctrl>}x{/Ctrl}')
+
+        expect(input.selectionStart).toBe(10)
+        expect(model.value).toBe('(AS)-123-X45-67-')
+      })
+
+      it('selection contains one character before, one at and one after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        await insertCaretAt(11, 14)
+
+        await userEvent.keyboard('{Ctrl>}x{/Ctrl}')
+        expect(input.selectionStart).toBe(11)
+        expect(model.value).toBe('(AS)-123-XY5-67-')
+      })
+    })
+
+    describe('Paste', () => {
+      it('pasted when cursor is at end', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '####', defaultModel: '12' })
+
+        navigator.clipboard.writeText('34')
+
+        await insertCaretAt(2)
+        await userEvent.paste()
+
+        expect(input.selectionStart).toBe(4)
+        expect(model.value).toBe('1234')
+      })
+
+      it('pasted when cursor is in middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '#####', defaultModel: '1245' })
+
+        navigator.clipboard.writeText('3')
+        await insertCaretAt(2)
+        await userEvent.paste()
+
+        expect(input.selectionStart).toBe(3)
+        expect(model.value).toBe('12345')
+      })
+
+      it('pasted when cursor is after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultModel: '(AS)-123-XYZ-' })
+
+        navigator.clipboard.writeText('12')
+        await insertCaretAt(13)
+        await userEvent.paste()
+
+        expect(input.selectionStart).toBe(16)
+        expect(model.value).toBe('(AS)-123-XYZ-12-')
+      })
+
+      it('pasted when cursor is before delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent({ defaultMask: '##-##', defaultModel: '12-' })
+
+        navigator.clipboard.writeText('34')
+        await insertCaretAt(2)
+        await userEvent.paste()
+
+        expect(input.selectionStart).toBe(5)
+        expect(model.value).toBe('12-34')
+      })
+
+      it('pasted when selection is in middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        navigator.clipboard.writeText('CD')
+        await insertCaretAt(10, 12)
+        await userEvent.paste()
+
+        // TODO: Fix this test
+        expect(input.selectionStart).toBe(12)
+        expect(model.value).toBe('(AS)-123-XCD-45-67')
+      })
+
+      it('pasted when selection is in middle', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        navigator.clipboard.writeText('CD')
+        await insertCaretAt(1, 3)
+        await userEvent.paste()
+
+        // TODO: Fix this test
+        expect(input.selectionStart).toBe(5)
+        expect(model.value).toBe('(CD)-123-XCD-45-67')
+      })
+
+      it('pasted when selection contains one character before, one at and one after delimiter', async () => {
+        const { input, model, insertCaretAt } = renderComponent()
+
+        navigator.clipboard.writeText('A0')
+        await insertCaretAt(11, 14)
+        await userEvent.paste()
+
+        // TODO: Fix this test
+        expect(input.selectionStart).toBe(14)
+        expect(model.value).toBe('(AS)-123-XYA-05-67')
+      })
+    })
   })
 })

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -301,6 +301,13 @@ describe('VMaskInput', () => {
           outputText: '(CD)-123-XYZ-45-67',
           outputCaret: 5,
         },
+        // pasted with junk delimiters when selection is in middle
+        {
+          inputCaret: [1, 3],
+          inputText: '_CD',
+          outputText: '(CD)-123-XYZ-45-67',
+          outputCaret: 5,
+        },
         // pasted when selection contains one character before, one at and one after delimiter
         {
           inputCaret: [11, 14],


### PR DESCRIPTION
fixes #21776

## Description
Fix caret position while editing mask value from middle

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <v-mask-input
          v-model="msg"
          :mask="mask"
          :placeholder="mask"
        />
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, computed } from 'vue';
  const mask = ref('(AA)-###-NNN-##-##')
  const msg = ref('AS123XYZ4567');
</script>

```
