### PR TITLE
fix(VNumberInput): consistent color of control icons

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -351,7 +351,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             aria-hidden="true"
             data-testid="increment"
             disabled={ !canIncrease.value }
-            flat
             height={ controlNodeDefaultHeight.value }
             icon={ incrementIcon.value }
             key="increment-btn"
@@ -360,6 +359,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             onPointerup={ onControlMouseup }
             onPointercancel={ onControlMouseup }
             size={ controlNodeSize.value }
+            variant="text"
             tabindex="-1"
           />
         ) : (
@@ -368,10 +368,10 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             defaults={{
               VBtn: {
                 disabled: !canIncrease.value,
-                flat: true,
                 height: controlNodeDefaultHeight.value,
                 size: controlNodeSize.value,
                 icon: incrementIcon.value,
+                variant: 'text',
               },
             }}
           >
@@ -386,7 +386,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             aria-hidden="true"
             data-testid="decrement"
             disabled={ !canDecrease.value }
-            flat
             height={ controlNodeDefaultHeight.value }
             icon={ decrementIcon.value }
             key="decrement-btn"
@@ -395,6 +394,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             onPointerup={ onControlMouseup }
             onPointercancel={ onControlMouseup }
             size={ controlNodeSize.value }
+            variant="text"
             tabindex="-1"
           />
         ) : (
@@ -403,10 +403,10 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             defaults={{
               VBtn: {
                 disabled: !canDecrease.value,
-                flat: true,
                 height: controlNodeDefaultHeight.value,
                 size: controlNodeSize.value,
                 icon: decrementIcon.value,
+                variant: 'text',
               },
             }}
           >


### PR DESCRIPTION
## Description

- changes `variant` to `text`
- (side effect) the underlay on the disabled button is gone - actually, it always bothered me, it dragged unnecessary attention
	- if there is any good reason to keep it, let me know (see [preview](https://play.vuetifyjs.com/#eNrtVE2L2zAQ/SuDKTgLlr3ZsNCabOm2vfTSU8llvQdFHm/UlWUjySYh5L93ZFtOQiml0N56sa158/E0z7ynY2SNyPoOnawO6Xcb5ZGs28Y4OIIwyB1uRgxOUJmmhnjKjQtdaNwPqaLR1sEEwMN14eJYaAC3wxpzGL4BSqx4p9y3MRiX3LzGyQhlmX+f6HS6KXSUDPwe2zal9kRu7bBuFXV/79PWPeNtO3wOh60jUv4bQBKphyKqS8mG2UzJl51jflQRhaS2sdLJIZFvbaM6h2dQNYJPoGtaML7+jArFrfUDOLs7Rz8IJcUrhd+ElQ7DU3EQChc3ITELlHfLuZHDvWMCtUNTRBMOUESosKf7lkUE20PYXALbzhHoiwiQ2soSYfOJm/JReNJ2GpDtluf1TMWWtabpqcCEKXlAiMcRNl+7eovmi247R5LBjlI/o+NS2Ryc6TCBWuocbunN9znc0b9xClebmdM8koCqNJr5kiWrFO7BPwhVXa3hhbPVxYWHQj0QYNIzgJ7VTYmKqnuuOhJoXl8YQ7cGJ51CypEa/Pmq45zF+LicK+xPJ/qt/rJdgM5r8IGwhyAFxX7S4re/RNUYgSU89dxIrkkZDz9PCv9zjRPYfHQUOMI8P/YEYi/+f/n/jvweGQ1tnV0YHR2tMLJ1YNF1o9/NLm2wuvTmwZfJnkZL9vzJkClncUt2us7GPtQhOiXRKr1Pl2/JY1fpu/Q+SiquLF477hh7/gG/A/Hr))

fixes #21931

## Markup:

```vue
<template>
  <v-app>
    <v-defaults-provider
      :defaults="{ VNumberInput: { hideDetails: true, min: 0, max: 2 } }"
    >
      <v-container class="d-flex flex-column ga-3" max-width="400">
        <v-number-input v-model="value" bg-color="white" />
        <v-card title="in card">
          <v-card-actions>
            <v-number-input v-model="value" bg-color="white" />
          </v-card-actions>
        </v-card>
        <v-number-input v-model="value" bg-color="black" />
        <v-card title="in card">
          <v-card-actions>
            <v-number-input v-model="value" bg-color="black" />
          </v-card-actions>
        </v-card>
      </v-container>
    </v-defaults-provider>
    <v-btn
      icon="mdi-theme-light-dark"
      position="absolute"
      location="top right"
      class="ma-2"
      @click="$vuetify.theme.cycle()"
    />
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref(0)
</script>
```
