### PR TITLE
fix(nested): detect and warn about multiple `null` values

### DIFF
--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -206,7 +206,7 @@ export const useNested = (props: NestedProps) => {
     const path: unknown[] = []
     let parent: unknown = toRaw(id)
 
-    while (parent != null) {
+    while (parent !== undefined) {
       path.unshift(parent)
       parent = parents.value.get(parent)
     }
@@ -358,7 +358,10 @@ export const useNestedItem = (id: MaybeRefOrGetter<unknown>, isDisabled: MaybeRe
   const parent = inject(VNestedSymbol, emptyNested)
 
   const uidSymbol = Symbol('nested item')
-  const computedId = computed(() => toRaw(toValue(id)) ?? uidSymbol)
+  const computedId = computed(() => {
+    const idValue = toRaw(toValue(id))
+    return idValue !== undefined ? idValue : uidSymbol
+  })
 
   const item = {
     ...parent,


### PR DESCRIPTION
## Description

- reverts (accidental?) change from [refactoring](https://github.com/vuetifyjs/vuetify/commit/9b07be93d4f0a57727033ab912b4b8adbd33befd#diff-9e9ae93c534ad2f413745ba1b6de47726b919dcb966ea267faaa99f75b337a96L347), so multiple `null`s trigger warning (like it worked before 3.8.3)
	- I wish somebody else could take a look and think about possible regression

fixes #21815

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete v-model="value" :items="items" clearable />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref(null)
  const items = [
    { value: null, title: 'null 1' },
    { value: null, title: 'null 2' },
    { value: 3, title: 'Value 3' },
    { value: 4, title: 'Value 4' },
    { value: 5, title: 'Value 5' },
    { value: 6, title: 'Value 6' },
  ]
</script>
```
