### PR TITLE
fix(VSparkline): accept single number

### DIFF
--- a/packages/vuetify/src/components/VSparkline/VBarline.tsx
+++ b/packages/vuetify/src/components/VSparkline/VBarline.tsx
@@ -73,6 +73,7 @@ export const VBarline = genericComponent<VBarlineSlots>()({
       boundary: Boundary
     ): Bar[] {
       const { minX, maxX, minY, maxY } = boundary
+
       const totalValues = values.length
       let maxValue = props.max != null ? Number(props.max) : Math.max(...values)
       let minValue = props.min != null ? Number(props.min) : Math.min(...values)
@@ -80,7 +81,7 @@ export const VBarline = genericComponent<VBarlineSlots>()({
       if (minValue > 0 && props.min == null) minValue = 0
       if (maxValue < 0 && props.max == null) maxValue = 0
 
-      const gridX = maxX / totalValues
+      const gridX = maxX / (totalValues === 1 ? 2 : totalValues)
       const gridY = (maxY - minY) / ((maxValue - minValue) || 1)
       const horizonY = maxY - Math.abs(minValue * gridY)
 
@@ -122,7 +123,10 @@ export const VBarline = genericComponent<VBarlineSlots>()({
     })
 
     const bars = computed(() => genBars(items.value, boundary.value))
-    const offsetX = computed(() => (Math.abs(bars.value[0].x - bars.value[1].x) - lineWidth.value) / 2)
+    const offsetX = computed(() => bars.value.length === 1
+      ? (boundary.value.maxX - lineWidth.value) / 2
+      : (Math.abs(bars.value[0].x - (bars.value[1].x)) - lineWidth.value) / 2
+    )
     const smooth = computed(() => typeof props.smooth === 'boolean' ? (props.smooth ? 2 : 0) : Number(props.smooth))
 
     useRender(() => {

--- a/packages/vuetify/src/components/VSparkline/VTrendline.tsx
+++ b/packages/vuetify/src/components/VSparkline/VTrendline.tsx
@@ -54,6 +54,11 @@ export const VTrendline = genericComponent<VTrendlineSlots>()({
       boundary: Boundary
     ): Point[] {
       const { minX, maxX, minY, maxY } = boundary
+
+      if (values.length === 1) {
+        values = [values[0], values[0]]
+      }
+
       const totalValues = values.length
       const maxValue = props.max != null ? Number(props.max) : Math.max(...values)
       const minValue = props.min != null ? Number(props.min) : Math.min(...values)


### PR DESCRIPTION
fixes #19697

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-defaults-provider
      :defaults="{
        VCard: { class: 'pa-3' },
        VSparkline: {
          gradient: ['#fcaE', '#fca3', '#fca0'],
          color: '#fca',
          height: 100,
          max: 5,
          min: 0,
          fill: true
        }
      }"
    >
      <div class="d-flex justify-center ga-6">
        <div class="d-flex flex-column ga-6" style="width: 300px">
          <v-card v-for="(c, i) in charts" :key="i">
            <v-sparkline :model-value="c" />
          </v-card>
        </div>

        <v-defaults-provider
          :defaults="{
            VCard: { class: 'pa-3' },
            VSparkline: {
              gradient: [],
              type: 'bars',
              lineWidth: 20
            }
          }"
        >
          <div class="d-flex flex-column ga-6" style="width: 300px">
            <v-card v-for="(c, i) in charts" :key="i">
              <v-sparkline :model-value="c" />
            </v-card>
          </div>
        </v-defaults-provider>
      </div>

    </v-defaults-provider>
  </v-app>
</template>

<script setup>
  const charts = [
    [],
    [3],
    [5, 3],
    [1, 2, 1, 5],
  ]
</script>
```
