### PR TITLE
feat(VAlert): High Contrast Support (Forced-colors mode)

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.sass
+++ b/packages/vuetify/src/components/VAlert/VAlert.sass
@@ -147,14 +147,11 @@
 
 @media (forced-colors: active)
   .v-alert
-    border-style: solid
-
-    &--variant-plain
-      border-style: dashed
-
-    &--variant-text,
-    &--variant-plain
-      border-width: thin
+    &:not(
+      &--variant-text,
+      &--variant-plain
+    )
+      border-style: solid
 
     &--variant-outlined,
     &--variant-tonal

--- a/packages/vuetify/src/components/VAlert/VAlert.sass
+++ b/packages/vuetify/src/components/VAlert/VAlert.sass
@@ -144,3 +144,22 @@
     text-transform: $alert-title-text-transform
     word-break: $alert-title-word-break
     word-wrap: $alert-title-word-wrap
+
+@media (forced-colors: active)
+  .v-alert
+    border-style: solid
+
+    &--variant-plain
+      border-style: dashed
+
+    &--variant-text,
+    &--variant-plain
+      border-width: thin
+
+    &--variant-outlined,
+    &--variant-tonal
+      border-width: medium
+
+    &--variant-elevated,
+    &--variant-flat
+      border-width: thick


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This improves the appearance of the VAlert component when in forced-colors mode (For example, High Contrast Mode in Windows):
<img width="2925" height="990" alt="Screenshot 2025-08-22 102723" src="https://github.com/user-attachments/assets/0a0247ed-d75f-4de6-9680-dbf20cf6cc46" />


Since an alert is meant to get the user's attention, this will add a border (when forced-colors mode is active) to all alerts with the width reflecting based on the visual hierarchy of the variants. Since the elevated and flat variants appear to have the strongest visual hierarchy, they both have been grouped with a thick border. As text & plain have the weakest visual hierarchy they have been grouped with a thin border with the plain variant having a dashed border instead of a solid border since it stands out the least. 

_VAlert when not in forced-colors mode (High Contrast Mode in Windows):_
<img width="2974" height="964" alt="Screenshot 2025-08-22 102123" src="https://github.com/user-attachments/assets/6ff9c586-c00c-4c86-ad6f-0f2fa0d5fe5c" />

_VAlert Component when in forced-colors mode (High Contrast Mode in Windows) **before the changes in this pull request**:_
<img width="2962" height="949" alt="Screenshot 2025-08-22 102636" src="https://github.com/user-attachments/assets/9886f6ae-66f1-4261-b0fa-021d03e700e0" />



## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-row dense>
        <v-col v-for="(variant, i) in variants" :key="i" cols="12">
          <v-alert
            :title="`Alert in ${variant}`"
            :variant="variant"
            text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!"
            type="info"
          />
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    data: () => ({
      variants: ['elevated', 'flat', 'tonal', 'outlined', 'text', 'plain'],
    }),
  }
</script>

```
