### PR TITLE
fix(VCard): render border in forced-colors mode

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -204,10 +204,10 @@
     opacity: 0
     transition: opacity 0.2s ease-in-out
 
-@media (forced-colors: active)
-  .v-card
-    &:not(
-      &--variant-text,
-      &--variant-plain
-    )
-      border: thin solid
+  @media (forced-colors: active)
+    .v-card
+      &:not(
+        &--variant-text,
+        &--variant-plain
+      )
+        border: thin solid

--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -203,3 +203,11 @@
     pointer-events: none
     opacity: 0
     transition: opacity 0.2s ease-in-out
+
+@media (forced-colors: active)
+  .v-card
+    &:not(
+      &--variant-text,
+      &--variant-plain
+    )
+      border: thin solid


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This addresses the request for High Contrast Support #21515 for the VCard component by adding a border to all v-cards except for the text & plain variant when forced-color mode (For example, High Contrast Mode in Windows) is enabled.

Before: 
<img width="1921" height="1143" alt="image" src="https://github.com/user-attachments/assets/90ace157-e163-4af1-b733-a3af0f7fd5f5" />

After: 
<img width="1951" height="1107" alt="image" src="https://github.com/user-attachments/assets/e55565ce-cdeb-421c-b288-5a78073db358" />

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row dense>
    <v-col v-for="(variant, i) in variants" :key="i" cols="12" md="4">
      <v-card
        :variant="variant"
        class="mx-auto"
        color="surface-variant"
        max-width="344"
        subtitle="Greyhound divisely hello coldly fonwderfully"
        title="Headline"
      >
        <template v-slot:actions>
          <v-btn text="Button"></v-btn>
        </template>
      </v-card>

      <div class="text-center text-caption">{{ variant }}</div>
    </v-col>
  </v-row>
  <v-row dense>
    <v-col v-for="(variant, i) in variants" :key="i" cols="12" md="4">
      <v-card
        :variant="variant"
        class="mx-auto"
        color="surface-variant"
        max-width="344"
        subtitle="Greyhound divisely hello coldly fonwderfully"
        title="Headline (Loading)"
        loading
      >
        <template v-slot:actions>
          <v-btn text="Button"></v-btn>
        </template>
      </v-card>

      <div class="text-center text-caption">{{ variant }}</div>
    </v-col>
  </v-row>
</template>

<script>
  export default {
    data: () => ({
      variants: ['elevated', 'flat', 'tonal', 'outlined', 'text', 'plain'],
    }),
  }
</script>

```
