### PR TITLE
fix(VChip): render border in forced-colors mode

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.sass
+++ b/packages/vuetify/src/components/VChip/VChip.sass
@@ -86,3 +86,11 @@
 
   .v-chip--label
     border-radius: $chip-label-border-radius
+
+  @media (forced-colors: active)
+    .v-chip
+      &:not(
+        &--variant-text,
+        &--variant-plain
+      )
+        border: thin solid


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This addresses the request for High Contrast Support https://github.com/vuetifyjs/vuetify/issues/21515 for the VChip component by adding a border to all v-chips except for the text & plain variant when forced-color mode (For example, High Contrast Mode in Windows) is enabled.

Before:
<img width="2722" height="205" alt="image" src="https://github.com/user-attachments/assets/59e62c66-d403-4083-aee9-a0a1c1e96c43" />

After:
<img width="2697" height="198" alt="image" src="https://github.com/user-attachments/assets/6f52b6c5-b3c2-40ce-aa4b-45df82e7d981" />

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row>
    <v-col v-for="(variant, i) in variants" :key="i" cols="12" md="4">
      <v-chip :variant="variant" color="primary">
        {{ variant }}
      </v-chip>
    </v-col>
  </v-row>
</template>

<script>
  export default {
    data: () => ({
      variants: ['elevated', 'flat', 'tonal', 'outlined', 'text', 'plain'],
    }),
  }
</script>
```
