### PR TITLE
fix(VChipGroup): render selected in forced-colors mode

### DIFF
--- a/packages/vuetify/src/components/VChipGroup/VChipGroup.sass
+++ b/packages/vuetify/src/components/VChipGroup/VChipGroup.sass
@@ -17,6 +17,14 @@
         .v-chip__overlay
           opacity: $chip-group-selected-opacity
 
+        @media (forced-colors: active)
+          background: highlight
+          color: highlighttext
+          forced-color-adjust: preserve-parent-color
+
+          &:focus-visible
+            outline-offset: 2px
+
   // Modifiers
   .v-chip-group--column
     .v-slide-group__content

--- a/packages/vuetify/src/components/VChipGroup/VChipGroup.sass
+++ b/packages/vuetify/src/components/VChipGroup/VChipGroup.sass
@@ -13,17 +13,32 @@
     .v-chip
       margin: $chip-group-margin
 
+      @media (forced-colors: active)
+        background-color: buttonface !important
+        color: buttontext !important
+
+        &:hover
+          color: highlight !important
+
       &.v-chip--selected:not(.v-chip--disabled)
         .v-chip__overlay
           opacity: $chip-group-selected-opacity
 
         @media (forced-colors: active)
-          background: highlight
-          color: highlighttext
+          color: highlight !important
           forced-color-adjust: preserve-parent-color
 
           &:focus-visible
             outline-offset: 2px
+
+          &.v-chip--variant-elevated,
+          &.v-chip--variant-flat
+            background-color: highlight !important
+            color: highlighttext !important
+
+          &.v-chip--variant-outlined,
+          &.v-chip--variant-tonal
+            border-width: medium 
 
   // Modifiers
   .v-chip-group--column


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This addresses the request for High Contrast Support https://github.com/vuetifyjs/vuetify/issues/21515 for the VChipGroup component by fixing the rendering of the selected v-chip when using a `v-chip-group` when in forced-colors mode (e.g. Windows Accessibility > Contrast themes)  

Before & After gif
![VChipGroup](https://github.com/user-attachments/assets/92c3468b-63d6-48fa-a340-0ac7712ccede)

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-chip-group>
    <v-chip>Chip 1</v-chip>

    <v-chip>Chip 2</v-chip>

    <v-chip>Chip 3</v-chip>
  </v-chip-group>
</template>
```
