### PR TITLE
feat(VDateInput): pass-through picker slots

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -16,10 +16,11 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref, shallowRef, watch } from 'vue'
-import { genericComponent, omit, propsFactory, useRender, wrapInArray } from '@/util'
+import { genericComponent, omit, pick, propsFactory, useRender, wrapInArray } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
+import type { VDatePickerSlots } from '@/components/VDatePicker/VDatePicker'
 import type { StrategyProps } from '@/components/VOverlay/locationStrategies'
 import type { VTextFieldSlots } from '@/components/VTextField/VTextField'
 import type { GenericProps } from '@/util'
@@ -31,10 +32,11 @@ export type VDateInputActionsSlot = {
   isPristine: boolean
 }
 
-export type VDateInputSlots = Omit<VTextFieldSlots, 'default'> & {
-  actions: VDateInputActionsSlot
-  default: never
-}
+export type VDateInputSlots = Omit<VTextFieldSlots, 'default'> &
+  Pick<VDatePickerSlots, 'title' | 'header' | 'day' | 'month' | 'year'> & {
+    actions: VDateInputActionsSlot
+    default: never
+  }
 
 export const makeVDateInputProps = propsFactory({
   displayFormat: {
@@ -245,6 +247,7 @@ export const VDateInput = genericComponent<new <
     useRender(() => {
       const confirmEditProps = VConfirmEdit.filterProps(props)
       const datePickerProps = VDatePicker.filterProps(omit(props, ['active', 'location', 'rounded']))
+      const datePickerSlots = pick(slots, ['title', 'header', 'day', 'month', 'year'])
       const textFieldProps = VTextField.filterProps(omit(props, ['placeholder']))
 
       return (
@@ -312,6 +315,7 @@ export const VDateInput = genericComponent<new <
                             onMousedown={ (e: MouseEvent) => e.preventDefault() }
                           >
                             {{
+                              ...datePickerSlots,
                               actions: !props.hideActions ? () => slots.actions?.({ save, cancel, isPristine }) ?? actions() : undefined,
                             }}
                           </VDatePicker>


### PR DESCRIPTION
## Description

- enables deeper customization without forcing devs to rebuild the component

## Markup:

```vue
<template>
  <v-app>
    <v-container class="text-center">
      <v-date-input hide-header>
        <template #day="{ props, item }">
          <v-btn
            v-bind="props"
            :color="!item.isSelected && isWeekend(item.isoDate) ? 'grey' : undefined"
            :text="item.localized"
            :variant="!item.isSelected && isWeekend(item.isoDate) ? 'flat' : 'outlined'"
            rounded="lg"
          />
        </template>
        <template #month="{ props, month }">
          <v-btn v-bind="props" rounded="lg" variant="outlined">
            {{ monthText(month.value) }}
          </v-btn>
        </template>
        <template #year="{ props, year }">
          <v-badge :model-value="year.value % 4 === 0" dot>
            <v-btn v-bind="props" rounded="lg" variant="outlined">
              {{ year.value }}
            </v-btn>
          </v-badge>
        </template>
      </v-date-input>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { useDate } from 'vuetify'
  const adapter = useDate()

  function monthText (v: number) {
    return adapter.format(adapter.parseISO(`2000-${v + 1}-01`), 'month')
  }

  function isWeekend (date: string) {
    return new Date(date).getDay() > 4
  }
</script>
```