### PR TITLE
feat(VTabs): slots for prev/next

### DIFF
--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -259,6 +259,10 @@
   "VTabs": {
     "props": {
       "spaced": "3.10.0"
+    },
+    "slots": {
+      "next": "3.11.0",
+      "prev": "3.11.0"
     }
   },
   "VTextField": {

--- a/packages/vuetify/src/components/VTabs/VTabs.tsx
+++ b/packages/vuetify/src/components/VTabs/VTabs.tsx
@@ -21,6 +21,7 @@ import { VTabsSymbol } from './shared'
 import { convertToUnit, genericComponent, isObject, pick, propsFactory, useRender } from '@/util'
 
 // Types
+import type { VSlideGroupSlots } from 'lib/components/VSlideGroup/VSlideGroup'
 import type { PropType } from 'vue'
 import type { GenericProps } from '@/util'
 
@@ -30,7 +31,7 @@ export type VTabsSlot<T> = {
   item: T
 }
 
-export type VTabsSlots<T> = {
+export type VTabsSlots<T> = Pick<VSlideGroupSlots, 'next' | 'prev'> & {
   default: never
   tab: VTabsSlot<T>
   item: VTabsSlot<T>
@@ -144,19 +145,23 @@ export const VTabs = genericComponent<new <T = TabItem>(
             { ...scopeId }
             { ...attrs }
           >
-            { slots.default?.() ?? items.value.map(item => (
-              slots.tab?.({ item }) ?? (
-                <VTab
-                  { ...item }
-                  key={ item.text }
-                  value={ item.value }
-                  spaced={ props.spaced }
-                  v-slots={{
-                    default: slots[`tab.${item.value}`] ? () => slots[`tab.${item.value}`]?.({ item }) : undefined,
-                  }}
-                />
-              )
-            ))}
+            {{
+              default: slots.default ?? (() => items.value.map(item => (
+                slots.tab?.({ item }) ?? (
+                  <VTab
+                    { ...item }
+                    key={ item.text }
+                    value={ item.value }
+                    spaced={ props.spaced }
+                    v-slots={{
+                      default: slots[`tab.${item.value}`] ? () => slots[`tab.${item.value}`]?.({ item }) : undefined,
+                    }}
+                  />
+                )
+              ))),
+              prev: slots.prev,
+              next: slots.next,
+            }}
           </VSlideGroup>
 
           { hasWindow && (


### PR DESCRIPTION
## Description

resolves #21969

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="600">
      <v-card>
        <v-tabs
          bg-color="teal-darken-3"
          slider-color="teal-lighten-3"
          show-arrows
        >
          <v-tab
            v-for="i in 30"
            :key="i"
            :text="'Item ' + i"
            :value="'tab-' + i"
          />

          <template #prev>
            <v-btn icon="$prev" rounded="lg" size="small" v-tooltip:left="'Move left'" />
          </template>
          <template #next>
            <v-btn icon="$next" rounded="lg" size="small" v-tooltip:right="'Move right'" />
          </template>
        </v-tabs>
      </v-card>
    </v-container>

    <v-container max-width="300" class="mt-12">
      <v-card>
        <v-tabs
          bg-color="teal-darken-3"
          direction="vertical"
          slider-color="teal-lighten-3"
          style="max-height: 450px"
          show-arrows
        >
          <v-tab v-for="i in 30" :key="i" :text="'Item ' + i" :value="'tab-' + i"/>

          <template #prev>
            <v-icon-btn
              class="ma-2"
              icon="$prev"
              rotate="90"
              rounded="lg"
              size="small"
              v-tooltip:top="'Move up'"
            />
          </template>
          <template #next>
            <v-icon-btn
              class="ma-2"
              icon="$next"
              rotate="90"
              rounded="lg"
              size="small"
              v-tooltip:bottom="'Move down'"
            />
          </template>
        </v-tabs>
      </v-card>
    </v-container>
  </v-app>
</template>
```
