### PR TITLE
docs(unit-test): stub visualViewport to prevent crashes in JSDOM

### DIFF
--- a/packages/vuetify/test/setup/unit-setup.ts
+++ b/packages/vuetify/test/setup/unit-setup.ts
@@ -1,5 +1,10 @@
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/vue'
+
+// Stub visualViewport so Vuetify components (e.g. VMenu) don't crash in JSDOM
+if (!globalThis.visualViewport) {
+  vi.stubGlobal('visualViewport', new EventTarget())
+}
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
Stub visualViewport so Vuetify components (e.g. VMenu) don't crash in JSDOM
Resolves #21692