### PR TITLE
fix(VTextarea): hide autoGrow scrollbar until maxRows is reached

### DIFF
--- a/packages/vuetify/src/components/VTextarea/VTextarea.sass
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.sass
@@ -33,6 +33,12 @@
     &--no-resize
       .v-field__input
         resize: none
+        scrollbar-width: none
+
+      &.v-textarea--height-capped
+        .v-field__input
+          scrollbar-gutter: stable
+          scrollbar-width: thin
 
     .v-field--no-label,
     .v-field--active

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -98,6 +98,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
     const vInputRef = ref<VInput>()
     const vFieldRef = ref<VInput>()
     const controlHeight = shallowRef('')
+    const heightCapped = shallowRef(false)
     const textareaRef = ref<HTMLInputElement>()
     const isActive = computed(() => (
       props.persistentPlaceholder ||
@@ -150,7 +151,10 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
       if (!props.autoGrow) rows.value = Number(props.rows)
     })
     function calculateInputHeight () {
-      if (!props.autoGrow) return
+      if (!props.autoGrow) {
+        heightCapped.value = false
+        return
+      }
 
       nextTick(() => {
         if (!sizerRef.value || !vFieldRef.value) return
@@ -170,9 +174,10 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
         )
         const maxHeight = parseFloat(props.maxRows!) * lineHeight + padding || Infinity
         const newHeight = clamp(height ?? 0, minHeight, maxHeight)
-        rows.value = Math.floor((newHeight - padding) / lineHeight)
 
+        rows.value = Math.floor((newHeight - padding) / lineHeight)
         controlHeight.value = convertToUnit(newHeight)
+        heightCapped.value = height > maxHeight
       })
     }
 
@@ -221,6 +226,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
               'v-text-field--suffixed': props.suffix,
               'v-textarea--auto-grow': props.autoGrow,
               'v-textarea--no-resize': props.noResize || props.autoGrow,
+              'v-textarea--height-capped': heightCapped.value,
               'v-input--plain-underlined': isPlainOrUnderlined.value,
             },
             props.class,

--- a/packages/vuetify/src/components/VTextarea/__tests__/VTextarea.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTextarea/__tests__/VTextarea.spec.browser.tsx
@@ -24,16 +24,16 @@ describe('VTextarea', () => {
     expect(el.offsetHeight).toBe(56)
 
     await userEvent.tab()
-    await userEvent.keyboard('sed d')
+    await userEvent.keyboard(' sed do ')
     await expect.poll(() => el.offsetHeight).toBe(56)
 
-    await userEvent.keyboard('o')
+    await userEvent.keyboard('e')
     await expect.poll(() => el.offsetHeight).toBe(80)
   })
 
   it('should respect max-rows', async () => {
     await page.viewport(500, 500)
-    const model = ref('Lorem ipsum dolor sit amet, consectetur adipiscing elit')
+    const model = ref('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ')
 
     render(() => (
       <Application>
@@ -57,7 +57,7 @@ describe('VTextarea', () => {
 
   it('should emit update rows', async () => {
     await page.viewport(500, 500)
-    const model = ref('Lorem ipsum dolor sit amet, consectetur adipiscing elit')
+    const model = ref('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ')
     const rows = ref(1)
     render(() => (
       <Application>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

fixes #21982

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <div style="width: 278px">
        <v-textarea
          :model-value="text"
          max-rows="9"
          rows="1"
          variant="filled"
          auto-grow
        />
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
  const text = 'foo/bar/foo/bar/foo/bar/foo/bar '.repeat(8)
</script>
```
