### PR TITLE
fix(VChip): fix plain opacity

### DIFF
--- a/packages/vuetify/src/components/VChip/_variables.scss
+++ b/packages/vuetify/src/components/VChip/_variables.scss
@@ -23,7 +23,7 @@ $chip-label-border-radius: settings.$border-radius-root !default;
 $chip-max-width: 100% !default;
 $chip-overflow: hidden !default;
 $chip-padding-ratio: 2 + math.div(2, 3) !default;
-$chip-plain-opacity: 0.26 !default;
+$chip-plain-opacity: .62 !default;
 $chip-filter-transition: .15s settings.$standard-easing !default;
 $chip-white-space: nowrap !default;
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This pull request fixes the opacity for `v-chip` when set to the `plain` variant, all other components have their plain-opacity set to `.62`, however the `v-chip` had a default of `0.26` which that value seems to be used for `disabled-opacity` in other components.


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
