### PR TITLE
docs: remove header-color prop reference from time-picker documentation

### DIFF
--- a/packages/docs/src/examples/v-time-picker/prop-color.vue
+++ b/packages/docs/src/examples/v-time-picker/prop-color.vue
@@ -7,7 +7,6 @@
 
       <v-time-picker
         color="pink"
-        header-color="primary"
       ></v-time-picker>
     </v-row>
   </v-container>

--- a/packages/docs/src/pages/en/components/time-pickers.md
+++ b/packages/docs/src/pages/en/components/time-pickers.md
@@ -47,7 +47,7 @@ You can specify allowed times using arrays, objects, and functions. You can also
 
 #### Colors
 
-Time picker colors can be set using the `color` and `header-color` props. If `header-color` prop is not provided  header will use the `color` prop value."
+Time picker colors can be set using the `color` prop.
 
 <ExamplesExample file="v-time-picker/prop-color" />
 


### PR DESCRIPTION
Remove header-color prop reference from time-picker documentation.
Resolves #21963