### PR TITLE
fix: set is dirty false if empty string to show the placeholder (#21972)

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -477,7 +477,8 @@ export const VCombobox = genericComponent<new <
         slots['append-item'] ||
         slots['no-data']
       )
-      const isDirty = model.value.length > 0
+      const isEmptyString = model.value.length === 1 && model.value[0].value === ''
+      const isDirty = model.value.length > 0 && !isEmptyString
       const textFieldProps = VTextField.filterProps(props)
 
       return (


### PR DESCRIPTION
## Description

- Fixes: [22107](https://github.com/vuetifyjs/vuetify/issues/22017)
- Check the model value if it's an empty string and treat it as a not dirty value
- In this way we could show the placeholder from props

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-combobox
        v-model="d"
        placeholder="placeholder"
        persistent-placeholder
        :items="['a','b','c']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const d = ref(null)
</script>

```
