### PR TITLE
fix(VCombobox): placeholder visibility for empty string value

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -139,7 +139,7 @@ export const VCombobox = genericComponent<new <
       props,
       'modelValue',
       [],
-      v => transformIn(v === null ? [null] : wrapInArray(v, emptyValues.value)),
+      v => transformIn(wrapInArray(v, emptyValues)),
       v => {
         const transformed = transformOut(v)
         return props.multiple ? transformed : (transformed[0] ?? null)

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -478,8 +478,7 @@ export const VCombobox = genericComponent<new <
         slots['append-item'] ||
         slots['no-data']
       )
-      const isEmptyString = model.value.length === 1 && model.value[0].value === ''
-      const isDirty = model.value.length > 0 && !isEmptyString
+      const isDirty = model.value.length > 0
       const textFieldProps = VTextField.filterProps(props)
 
       return (

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -133,13 +133,13 @@ export const VCombobox = genericComponent<new <
     const vVirtualScrollRef = ref<VVirtualScroll>()
     const selectionIndex = shallowRef(-1)
     let cleared = false
-    const { items, transformIn, transformOut } = useItems(props)
+    const { items, transformIn, transformOut, emptyValues } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(() => vTextFieldRef.value?.color)
     const model = useProxiedModel(
       props,
       'modelValue',
       [],
-      v => transformIn(wrapInArray(v)),
+      v => transformIn(v === null ? [null] : wrapInArray(v, emptyValues.value)),
       v => {
         const transformed = transformOut(v)
         return props.multiple ? transformed : (transformed[0] ?? null)
@@ -478,7 +478,8 @@ export const VCombobox = genericComponent<new <
         slots['append-item'] ||
         slots['no-data']
       )
-      const isDirty = model.value.length > 0
+      const isEmptyString = model.value.length === 1 && model.value[0].value === ''
+      const isDirty = model.value.length > 0 && !isEmptyString
       const textFieldProps = VTextField.filterProps(props)
 
       return (

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -382,19 +382,22 @@ describe('VCombobox', () => {
     })
 
     it('should show placeholder if initial value is empty string', async () => {
-      render(() => (
+      const emptyString = ref('')
+
+      const { getByPlaceholderText } = render(() => (
         <VCombobox
-          v-model={''}
+          v-model={ emptyString.value }
           items={['a', 'b', 'c']}
           multiple
           itemTitle="text"
           itemValue="value"
+          placeholder="placeholder"
           returnObject
         />
       ))
 
-      const inputField = screen.getByCSS('.v-field')
-      expect(inputField).toBeUndefined()
+      const inputField = getByPlaceholderText('placeholder')
+      expect(inputField).toBeDisplayed()
     })
   })
 

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -381,23 +381,18 @@ describe('VCombobox', () => {
       }])
     })
 
-    it('should show placeholder if initial value is empty string', async () => {
+    it('should show placeholder if initial value is empty string', () => {
       const emptyString = ref('')
 
       const { getByPlaceholderText } = render(() => (
         <VCombobox
           v-model={ emptyString.value }
           items={['a', 'b', 'c']}
-          multiple
-          itemTitle="text"
-          itemValue="value"
-          placeholder="placeholder"
-          returnObject
+          placeholder="select something"
         />
       ))
 
-      const inputField = getByPlaceholderText('placeholder')
-      expect(inputField).toBeDisplayed()
+      expect(getByPlaceholderText('select something')).toBeDisplayed()
     })
   })
 

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -392,7 +392,7 @@ describe('VCombobox', () => {
         />
       ))
 
-      expect(getByPlaceholderText('select something')).toBeDisplayed()
+      expect(getByPlaceholderText('select something')).toBeVisible()
     })
   })
 

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -380,6 +380,22 @@ describe('VCombobox', () => {
         id: 'item2',
       }])
     })
+
+    it('should show placeholder if initial value is empty string', async () => {
+      render(() => (
+        <VCombobox
+          v-model={''}
+          items={['a', 'b', 'c']}
+          multiple
+          itemTitle="text"
+          itemValue="value"
+          returnObject
+        />
+      ))
+
+      const inputField = screen.getByCSS('.v-field')
+      expect(inputField).toBeUndefined()
+    })
   })
 
   describe('readonly', () => {

--- a/packages/vuetify/src/composables/list-items.ts
+++ b/packages/vuetify/src/composables/list-items.ts
@@ -122,18 +122,25 @@ export function transformItems (
 
 export function useItems (props: ItemProps) {
   const items = computed(() => transformItems(props, props.items))
-  const hasNullItem = computed(() => items.value.some(item => item.value === null))
-  const allValues = computed(() => items.value.map(item => item.value))
-  const emptyValues = computed(() => ['', null, undefined].filter(v => !allValues.value.includes(v)))
 
+  const hasNullItem = shallowRef(false)
+  const emptyValues = shallowRef<any[]>([])
   const itemsMap = shallowRef<Map<Primitive, ListItem[]>>(new Map())
   const keylessItems = shallowRef<ListItem[]>([])
   watchEffect(() => {
     const _items = items.value
+    let _hasNullItem = false
+    const _emptyValues = new Set()
     const map = new Map()
     const keyless = []
     for (let i = 0; i < _items.length; i++) {
       const item = _items[i]
+      if (item.value === null) {
+        _hasNullItem = true
+      }
+      if (item.value === '' || item.value == null) {
+        _emptyValues.add(item.value)
+      }
       if (isPrimitive(item.value) || item.value === null) {
         let values = map.get(item.value)
         if (!values) {
@@ -145,6 +152,8 @@ export function useItems (props: ItemProps) {
         keyless.push(item)
       }
     }
+    hasNullItem.value = _hasNullItem
+    emptyValues.value = ['', null, undefined].filter(v => !_emptyValues.has(v))
     itemsMap.value = map
     keylessItems.value = keyless
   })

--- a/packages/vuetify/src/composables/list-items.ts
+++ b/packages/vuetify/src/composables/list-items.ts
@@ -123,6 +123,8 @@ export function transformItems (
 export function useItems (props: ItemProps) {
   const items = computed(() => transformItems(props, props.items))
   const hasNullItem = computed(() => items.value.some(item => item.value === null))
+  const allValues = computed(() => items.value.map(item => item.value))
+  const emptyValues = computed(() => ['', null, undefined].filter(v => !allValues.value.includes(v)))
 
   const itemsMap = shallowRef<Map<Primitive, ListItem[]>>(new Map())
   const keylessItems = shallowRef<ListItem[]>([])
@@ -204,5 +206,5 @@ export function useItems (props: ItemProps) {
       : value.map(({ value }) => value)
   }
 
-  return { items, transformIn, transformOut }
+  return { items, transformIn, transformOut, emptyValues }
 }

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -390,7 +390,7 @@ export function arrayDiff (a: any[], b: any[]): any[] {
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 export function wrapInArray<T> (
   v: T | null | undefined,
-  emptyValues: Ref<any[]>
+  emptyValues?: Ref<any[]>
 ): T extends readonly any[]
     ? IfAny<T, T[], T>
     : NonNullable<T>[] {

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -389,11 +389,12 @@ export function arrayDiff (a: any[], b: any[]): any[] {
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 export function wrapInArray<T> (
-  v: T | null | undefined
+  v: T | null | undefined,
+  emptyValues: any[] = []
 ): T extends readonly any[]
     ? IfAny<T, T[], T>
     : NonNullable<T>[] {
-  return v == null
+  return v == null || emptyValues.includes(v)
     ? [] as any
     : Array.isArray(v)
       ? v as any : [v] as any

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -390,11 +390,11 @@ export function arrayDiff (a: any[], b: any[]): any[] {
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 export function wrapInArray<T> (
   v: T | null | undefined,
-  emptyValues: any[] = []
+  emptyValues: Ref<any[]>
 ): T extends readonly any[]
     ? IfAny<T, T[], T>
     : NonNullable<T>[] {
-  return v == null || emptyValues.includes(v)
+  return v == null || emptyValues?.value?.includes(v)
     ? [] as any
     : Array.isArray(v)
       ? v as any : [v] as any


### PR DESCRIPTION
## Description

- Check the model value if it's an empty string and treat it as a not dirty value
- In this way we could show the placeholder from props

fixes #21972

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-combobox
        v-model="d"
        placeholder="placeholder"
        persistent-placeholder
        :items="['a','b','c']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const d = ref('')
</script>

```
