### PR TITLE
fix(VSelect, VAutocomplete, VCombobox): missing accessibility attributes (#22017)

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -22,11 +22,12 @@ import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useItems } from '@/composables/list-items'
 import { useLocale } from '@/composables/locale'
+import { useMenuActivator } from '@/composables/menuActivator'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
-import { computed, mergeProps, nextTick, ref, shallowRef, toRef, useId, watch } from 'vue'
+import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
 import {
   checkPrintable,
   deepEqual,
@@ -181,12 +182,7 @@ export const VAutocomplete = genericComponent<new <
       },
     })
 
-    const uid = useId()
-    const menuId = computed(() => `menu-${uid}`)
-    const hasRoleCombobox = toRef(() => props.role === 'combobox')
-    const ariaExpanded = toRef(() => hasRoleCombobox.value && menu.value)
-    const ariaControls = toRef(() => !hasRoleCombobox.value ? undefined : menuId.value)
-    const label = computed(() => menu.value ? props.closeText : props.openText)
+    const { menuId, ariaExpanded, ariaControls, ariaLabel } = useMenuActivator(props, menu)
 
     const listRef = ref<VList>()
     const listEvents = useScrolling(listRef, vTextFieldRef)
@@ -657,8 +653,8 @@ export const VAutocomplete = genericComponent<new <
                     icon={ props.menuIcon }
                     onMousedown={ onMousedownMenuIcon }
                     onClick={ noop }
-                    aria-label={ t(label.value) }
-                    title={ t(label.value) }
+                    aria-label={ ariaLabel.value }
+                    title={ ariaLabel.value }
                     tabindex="-1"
                   />
                 ) : undefined }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -694,36 +694,6 @@ describe('VAutocomplete', () => {
     expect(onFocus).toHaveBeenCalledTimes(1)
   })
 
-  it('should show an aria-expanded as true if menu is open', async () => {
-    const { getByRole } = render(() => (
-      <VAutocomplete menu />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: true })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
-  it('should show an aria-expanded as false if menu is closed', () => {
-    const { getByRole } = render(() => (
-      <VAutocomplete />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: false })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
-  it('should show an aria-controls', () => {
-    const { getByRole } = render(() => (
-      <VAutocomplete />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: false })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
   describe('Showcase', () => {
     generate({ stories })
   })

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -23,11 +23,12 @@ import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { transformItem, useItems } from '@/composables/list-items'
 import { useLocale } from '@/composables/locale'
+import { useMenuActivator } from '@/composables/menuActivator'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
-import { computed, mergeProps, nextTick, ref, shallowRef, toRef, useId, watch } from 'vue'
+import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
 import {
   checkPrintable,
   deepEqual,
@@ -215,13 +216,7 @@ export const VCombobox = genericComponent<new <
       },
     })
 
-    const uid = useId()
-    const menuId = computed(() => `menu-${uid}`)
-    const hasRoleCombobox = toRef(() => props.role === 'combobox')
-    const ariaExpanded = toRef(() => hasRoleCombobox.value && menu.value)
-    const ariaControls = toRef(() => !hasRoleCombobox.value ? undefined : menuId.value)
-
-    const label = toRef(() => menu.value ? props.closeText : props.openText)
+    const { menuId, ariaExpanded, ariaControls, ariaLabel } = useMenuActivator(props, menu)
 
     watch(_search, value => {
       showAllItemsForNoMatch.value = false
@@ -720,8 +715,8 @@ export const VCombobox = genericComponent<new <
                     icon={ props.menuIcon }
                     onMousedown={ onMousedownMenuIcon }
                     onClick={ noop }
-                    aria-label={ t(label.value) }
-                    title={ t(label.value) }
+                    aria-label={ ariaLabel.value }
+                    title={ ariaLabel.value }
                     tabindex="-1"
                   />
                 ) : undefined }

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -806,36 +806,6 @@ describe('VCombobox', () => {
     await expect.poll(() => screen.queryAllByRole('option')).toHaveLength(1)
   })
 
-  it('should show an aria-expanded as true if menu is open', async () => {
-    const { getByRole } = render(() => (
-      <VCombobox menu />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: true })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
-  it('should show an aria-expanded as false if menu is closed', () => {
-    const { getByRole } = render(() => (
-      <VCombobox />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: false })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
-  it('should show an aria-controls', () => {
-    const { getByRole } = render(() => (
-      <VCombobox />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: false })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
   describe('Showcase', () => {
     generate({ stories })
   })

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -21,11 +21,12 @@ import { forwardRefs } from '@/composables/forwardRefs'
 import { IconValue } from '@/composables/icons'
 import { makeItemsProps, useItems } from '@/composables/list-items'
 import { useLocale } from '@/composables/locale'
+import { makeMenuActivatorProps, useMenuActivator } from '@/composables/menuActivator'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
-import { computed, mergeProps, nextTick, ref, shallowRef, toRef, useId, watch } from 'vue'
+import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
 import {
   camelizeProps,
   checkPrintable,
@@ -61,14 +62,6 @@ type Value <T, ReturnObject extends boolean, Multiple extends boolean> =
 export const makeSelectProps = propsFactory({
   chips: Boolean,
   closableChips: Boolean,
-  closeText: {
-    type: String,
-    default: '$vuetify.close',
-  },
-  openText: {
-    type: String,
-    default: '$vuetify.open',
-  },
   eager: Boolean,
   hideNoData: Boolean,
   hideSelected: Boolean,
@@ -92,6 +85,7 @@ export const makeSelectProps = propsFactory({
   itemColor: String,
   noAutoScroll: Boolean,
 
+  ...makeMenuActivatorProps(),
   ...makeItemsProps({ itemChildren: false }),
 }, 'Select')
 
@@ -194,13 +188,7 @@ export const VSelect = genericComponent<new <
       },
     })
 
-    const uid = useId()
-    const menuId = computed(() => `menu-${uid}`)
-    const hasRoleCombobox = toRef(() => props.role === 'combobox')
-    const ariaExpanded = toRef(() => hasRoleCombobox.value && menu.value)
-    const ariaControls = toRef(() => !hasRoleCombobox.value ? undefined : menuId.value)
-
-    const label = toRef(() => menu.value ? props.closeText : props.openText)
+    const { menuId, ariaExpanded, ariaControls, ariaLabel } = useMenuActivator(props, menu)
 
     const computedMenuProps = computed(() => {
       return {
@@ -423,10 +411,10 @@ export const VSelect = genericComponent<new <
           onMousedown:control={ onMousedownControl }
           onBlur={ onBlur }
           onKeydown={ onKeydown }
-          aria-label={ t(label.value) }
           aria-expanded={ ariaExpanded.value }
           aria-controls={ ariaControls.value }
-          title={ t(label.value) }
+          aria-label={ ariaLabel.value }
+          title={ ariaLabel.value }
         >
           {{
             ...slots,

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -729,34 +729,25 @@ describe('VSelect', () => {
     })
   })
 
-  it('should show an aria-expanded as true if menu is open', async () => {
+  it('should have reactive accessibility attributes', async () => {
     const { getByRole } = render(() => (
-      <VSelect menu />
-    ))
-
-    const inputField = getByRole('combobox', { expanded: true })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
-
-  it('should show an aria-expanded as false if menu is closed', () => {
-    const { getByRole } = render(() => (
-      <VSelect />
+      <VSelect items={['Foo']} />
     ))
 
     const inputField = getByRole('combobox', { expanded: false })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
-  })
+    expect(inputField).toHaveAttribute('aria-expanded', 'false')
+    expect(inputField).toHaveAttribute('aria-label', 'Open')
+    expect(inputField.getAttribute('aria-controls')).toMatch(/^menu-v-\d+/)
 
-  it('should show an aria-controls', () => {
-    const { getByRole } = render(() => (
-      <VSelect />
-    ))
+    await userEvent.click(inputField)
 
-    const inputField = getByRole('combobox', { expanded: false })
-    expect(inputField).toHaveAttribute('aria-expanded')
-    expect(inputField).toHaveAttribute('aria-controls')
+    expect(inputField).toHaveAttribute('aria-expanded', 'true')
+    expect(inputField).toHaveAttribute('aria-label', 'Close')
+
+    await userEvent.click(screen.getAllByRole('option')[0])
+
+    expect(inputField).toHaveAttribute('aria-expanded', 'false')
+    expect(inputField).toHaveAttribute('aria-label', 'Open')
   })
 
   describe('Showcase', () => {

--- a/packages/vuetify/src/composables/menuActivator.ts
+++ b/packages/vuetify/src/composables/menuActivator.ts
@@ -1,0 +1,43 @@
+// Utilities
+import { computed, toRef, toValue, useId } from 'vue'
+import { propsFactory } from '@/util'
+
+// Types
+import type { MaybeRefOrGetter } from 'vue'
+import { useLocale } from './locale'
+
+// Types
+export interface MenuActivatorProps {
+  closeText: string
+  openText: string
+}
+
+// Composables
+export const makeMenuActivatorProps = propsFactory({
+  closeText: {
+    type: String,
+    default: '$vuetify.close',
+  },
+  openText: {
+    type: String,
+    default: '$vuetify.open',
+  },
+}, 'autocomplete')
+
+export function useMenuActivator (props: MenuActivatorProps, isOpen: MaybeRefOrGetter<boolean>) {
+  const { t } = useLocale()
+
+  const uid = useId()
+  const menuId = computed(() => `menu-${uid}`)
+
+  const ariaExpanded = toRef(() => toValue(isOpen))
+  const ariaControls = toRef(() => menuId.value)
+  const ariaLabel = toRef(() => t(toValue(isOpen) ? props.closeText : props.openText))
+
+  return {
+    menuId,
+    ariaExpanded,
+    ariaControls,
+    ariaLabel,
+  }
+}


### PR DESCRIPTION
## Description

- Fixes: [22017](https://github.com/vuetifyjs/vuetify/issues/22017)
- Includes additional components like `VSelect`, `VAutocomplete` and `VCombobox`

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-select label="Select" :items="['item1', 'item2', 'item3']"  />
    </v-container>
  </v-app>
</template>
```
