### PR TITLE
fix(VCalendar): ensure events spanning multiple days display correctly

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -93,7 +93,7 @@ export const VCalendar = genericComponent<VCalendarSlots>()({
 
     function eventFilter (date: Date, e: {start: Date, end: Date}) {
       return adapter.isSameDay(date, e.start) || adapter.isSameDay(date, e.end) ||
-        (adapter.isAfter(date, adapter.endOfDay(e.start)) && adapter.isBefore(date, adapter.startOfDay(e.end)))
+        adapter.isWithinRange(date, [adapter.endOfDay(e.start), adapter.startOfDay(e.end)])
     }
 
     useRender(() => {


### PR DESCRIPTION
fix(VCalendar): ensure events spanning multiple days display correctly

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fix https://github.com/vuetifyjs/vuetify/issues/22016

Added a between condition when filtering.


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-calendar :events="events" view-mode="week" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const events = ref([{
    allDay: false,
    color: "blue",
    end: new Date(new Date("2025 09 06").setHours(18)),
    start: new Date(new Date("2025 09 04").setHours(15)),
    title: "Test",
  }])
</script>

```
