### PR TITLE
fix(VCalendar): avoid head expanding on mousedown

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendar.tsx
@@ -24,7 +24,6 @@ import {
   getEndOfMonth,
   getStartOfMonth,
   nextDay,
-  parseTimestamp,
   prevDay,
   relativeDays,
   timestampToDate,
@@ -51,7 +50,6 @@ interface VCalendarRenderProps {
   end: CalendarTimestamp
   component: JSXComponent & { filterProps: <T>(props: T) => Partial<T> }
   maxDays: number
-  weekdays: number[]
   categories: CalendarCategory[]
 }
 
@@ -154,12 +152,6 @@ export const VCalendar = genericComponent<new (
     const lastStart = ref<CalendarTimestamp | null>(null)
     const lastEnd = ref<CalendarTimestamp | null>(null)
 
-    const parsedValue = computed((): CalendarTimestamp => {
-      return (validateTimestamp(props.modelValue)
-        ? parseTimestamp(props.modelValue, true)
-        : (base.parsedStart.value || base.times.today))
-    })
-
     const parsedCategoryDays = computed((): number => {
       return parseInt(String(props.categoryDays)) || 1
     })
@@ -169,10 +161,9 @@ export const VCalendar = genericComponent<new (
     })
 
     const renderProps = computed((): VCalendarRenderProps => {
-      const around = parsedValue.value
+      const around = base.parsedValue.value
       let component: any = null
       let maxDays = props.maxDays
-      let weekdays = base.parsedWeekdays.value
       let categories = parsedCategories.value
       let start = around
       let end = around
@@ -192,19 +183,12 @@ export const VCalendar = genericComponent<new (
         case 'day':
           component = VCalendarDaily
           maxDays = 1
-          weekdays = [start.weekday]
           break
         case '4day':
           component = VCalendarDaily
           end = relativeDays(copyTimestamp(end), nextDay, 3)
           updateFormatted(end)
           maxDays = 4
-          weekdays = [
-            start.weekday,
-            (start.weekday + 1) % 7,
-            (start.weekday + 2) % 7,
-            (start.weekday + 3) % 7,
-          ]
           break
         case 'custom-weekly':
           component = VCalendarWeekly
@@ -223,11 +207,6 @@ export const VCalendar = genericComponent<new (
           end = relativeDays(copyTimestamp(end), nextDay, days)
           updateFormatted(end)
           maxDays = days
-          weekdays = []
-
-          for (let i = 0; i < days; i++) {
-            weekdays.push((start.weekday + i) % 7)
-          }
 
           categories = getCategoryList(categories)
           break
@@ -236,11 +215,11 @@ export const VCalendar = genericComponent<new (
           throw new Error(`${type} is not a valid Calendar type`)
       }
 
-      return { component, start, end, maxDays, weekdays, categories }
+      return { component, start, end, maxDays, categories }
     })
 
     const eventWeekdays = computed((): number[] => {
-      return renderProps.value.weekdays
+      return base.effectiveWeekdays.value
     })
 
     const categoryMode = computed((): boolean => {
@@ -287,7 +266,7 @@ export const VCalendar = genericComponent<new (
     }
 
     function move (amount = 1): void {
-      const moved = copyTimestamp(parsedValue.value)
+      const moved = copyTimestamp(base.parsedValue.value)
       const forward = amount > 0
       const mover = forward ? nextDay : prevDay
       const limit = forward ? DAYS_IN_MONTH_MAX : DAY_MIN
@@ -402,7 +381,7 @@ export const VCalendar = genericComponent<new (
     })
 
     useRender(() => {
-      const { start, end, maxDays, component: Component, weekdays, categories } = renderProps.value
+      const { start, end, maxDays, component: Component, categories } = renderProps.value
       return (
         <Component
           ref={ root }
@@ -413,7 +392,7 @@ export const VCalendar = genericComponent<new (
           start={ start.date }
           end={ end.date }
           maxDays={ maxDays }
-          weekdays={ weekdays }
+          weekdays={ base.effectiveWeekdays.value }
           categories={ categories }
           onClick:date={ (e: MouseEvent, day: CalendarTimestamp) => {
             if (attrs['onUpdate:modelValue']) emit('update:modelValue', day.date)
@@ -428,7 +407,6 @@ export const VCalendar = genericComponent<new (
       ...base,
       lastStart,
       lastEnd,
-      parsedValue,
       parsedCategoryDays,
       renderProps,
       eventWeekdays,

--- a/packages/vuetify/src/labs/VCalendar/composables/calendarBase.ts
+++ b/packages/vuetify/src/labs/VCalendar/composables/calendarBase.ts
@@ -59,6 +59,8 @@ export const makeCalendarBaseProps = propsFactory({
 }, 'VCalendar-base')
 
 export interface CalendarBaseProps {
+  modelValue?: string | number | Date
+  categoryDays?: string | number
   start: string | number | Date
   end: string | number | Date | undefined
   weekdays: string | number[]
@@ -73,21 +75,44 @@ export function useCalendarBase (props: CalendarBaseProps) {
   const { times } = useTimes({ now: props.now })
   const locale = provideLocale(props)
 
+  const parsedStart = computed((): CalendarTimestamp => {
+    if (props.type === 'month') {
+      return getStartOfMonth(parseTimestamp(props.start, true))
+    }
+    return parseTimestamp(props.start, true)
+  })
+
+  const parsedValue = computed((): CalendarTimestamp => {
+    return (validateTimestamp(props.modelValue)
+      ? parseTimestamp(props.modelValue, true)
+      : (parsedStart.value || times.today))
+  })
+
   const parsedWeekdays = computed((): number[] => {
     return Array.isArray(props.weekdays)
       ? props.weekdays
       : (props.weekdays || '').split(',').map(x => parseInt(x, 10))
   })
 
-  const weekdaySkips = computed((): number[] => {
-    return getWeekdaySkips(parsedWeekdays.value)
+  const effectiveWeekdays = computed((): number[] => {
+    const start = parsedValue.value
+    const days = parseInt(String(props.categoryDays)) || 1
+
+    switch (props.type) {
+      case 'day': return [start.weekday]
+      case '4day': return [
+        start.weekday,
+        (start.weekday + 1) % 7,
+        (start.weekday + 2) % 7,
+        (start.weekday + 3) % 7,
+      ]
+      case 'category': return Array.from({ length: days }, (_, i) => (start.weekday + i) % 7)
+      default: return parsedWeekdays.value
+    }
   })
 
-  const parsedStart = computed((): CalendarTimestamp => {
-    if (props.type === 'month') {
-      return getStartOfMonth(parseTimestamp(props.start, true))
-    }
-    return parseTimestamp(props.start, true)
+  const weekdaySkips = computed((): number[] => {
+    return getWeekdaySkips(parsedWeekdays.value)
   })
 
   const parsedEnd = computed((): CalendarTimestamp => {
@@ -160,7 +185,9 @@ export function useCalendarBase (props: CalendarBaseProps) {
   return {
     times,
     locale,
+    parsedValue,
     parsedWeekdays,
+    effectiveWeekdays,
     weekdaySkips,
     parsedStart,
     parsedEnd,

--- a/packages/vuetify/src/labs/VCalendar/composables/calendarBase.ts
+++ b/packages/vuetify/src/labs/VCalendar/composables/calendarBase.ts
@@ -82,6 +82,17 @@ export function useCalendarBase (props: CalendarBaseProps) {
     return parseTimestamp(props.start, true)
   })
 
+  const parsedEnd = computed((): CalendarTimestamp => {
+    const start = parsedStart.value
+    const end: CalendarTimestamp = props.end ? parseTimestamp(props.end) || start : start
+    const value = getTimestampIdentifier(end) < getTimestampIdentifier(start) ? start : end
+
+    if (props.type === 'month') {
+      return getEndOfMonth(value)
+    }
+    return value
+  })
+
   const parsedValue = computed((): CalendarTimestamp => {
     return (validateTimestamp(props.modelValue)
       ? parseTimestamp(props.modelValue, true)
@@ -113,17 +124,6 @@ export function useCalendarBase (props: CalendarBaseProps) {
 
   const weekdaySkips = computed((): number[] => {
     return getWeekdaySkips(parsedWeekdays.value)
-  })
-
-  const parsedEnd = computed((): CalendarTimestamp => {
-    const start = parsedStart.value
-    const end: CalendarTimestamp = props.end ? parseTimestamp(props.end) || start : start
-    const value = getTimestampIdentifier(end) < getTimestampIdentifier(start) ? start : end
-
-    if (props.type === 'month') {
-      return getEndOfMonth(value)
-    }
-    return value
   })
 
   const days = computed((): CalendarTimestamp[] => {

--- a/packages/vuetify/src/labs/VCalendar/composables/calendarWithEvents.tsx
+++ b/packages/vuetify/src/labs/VCalendar/composables/calendarWithEvents.tsx
@@ -204,7 +204,7 @@ export function useCalendarWithEvents (props: CalendarWithEventsProps, slots: an
   })
 
   const eventWeekdays = computed((): number[] => {
-    return base.parsedWeekdays.value
+    return base.effectiveWeekdays.value
   })
 
   function eventColorFunction (e: CalendarEvent): string | undefined {


### PR DESCRIPTION
## Description

- issue occurs when `firstWeekday` is `0` while effective visible week starts at a different (see last example in docs)
- migration to v3 changed the logic resolving `eventWeekdays` ([VCalendar.ts:144](https://github.com/vuetifyjs/vuetify/blob/v2-stable/packages/vuetify/src/components/VCalendar/VCalendar.ts#L144)) - it was meant to get weekdays after applying `props.type`