### PR TITLE
fix(VMenu): avoid scrolling to the off-screen menu

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -129,15 +129,17 @@ export const VMenu = genericComponent<OverlaySlots>()({
         isActive.value &&
         before !== after &&
         overlay.value?.contentEl &&
-        // We're the topmost menu
-        overlay.value?.globalTop &&
+        // We're the menu without open submenus or overlays
+        overlay.value?.localTop &&
         // It isn't the document or the menu body
         ![document, overlay.value.contentEl].includes(after!) &&
         // It isn't inside the menu body
         !overlay.value.contentEl.contains(after)
       ) {
         if (focusTrapSuppressed) {
-          isActive.value = false
+          if (!props.openOnHover || !overlay.value.activatorEl?.contains(after)) {
+            isActive.value = false
+          }
         } else {
           const focusable = focusableChildren(overlay.value.contentEl)
           focusable[0]?.focus()


### PR DESCRIPTION
## Description

- suppress focus trap when `focusin` is triggered shortly after `pointerdown`
- avoids scrolling up as well as the missing focus bug when clicking the field
- keeps hover-menu open on clicked input

fixes #21775
fixes #20569
fixes #21015
fixes #16819

## Markup:

<details>
<summary>Scenario for `stick-to-target` scroll bug and VSelect interaction</summary>

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <div class="d-flex ga-5">
        <v-btn color="green">
          Just a menu on top
          <v-menu activator="parent" stick-to-target>
            <v-list :items="items" border />
          </v-menu>
        </v-btn>
        <v-spacer />
      </div>
      <div v-for="i in 30" :key="i">Lorem ipsum dolor sit</div>
      <v-select :items="items" />
      <div v-for="i in 30" :key="i">Lorem ipsum dolor sit</div>
      <v-btn color="green">
        Just a menu on bottom
        <v-menu activator="parent" stick-to-target>
          <v-list :items="items" border />
        </v-menu>
      </v-btn>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = Array.from({ length: 5 }, (_, i) => `Item #${i + 1}`)
</script>
```

</details>

<details>
<summary>Hover menu should not prevent other menu from closing</summary>

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <!--Button Component-->
      <v-btn color="primary">
        Action Button
        <v-menu activator="parent">
          <v-card>Action Info</v-card>
        </v-menu>
      </v-btn>

      <!--Input component-->
      <v-text-field style="margin-top: 20px">
        <v-menu
          :close-on-content-click="false"
          activator="parent"
          open-on-hover
        >
          Hover Action Menu
        </v-menu>
      </v-text-field>
    </v-container>
  </v-app>
</template>
```

</details>