### PR TITLE
fix(VCombobox): unstable menu state while typing

### DIFF
--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -238,6 +238,33 @@ describe('VCombobox', () => {
       await userEvent.keyboard('antonsen')
       await expect(screen.findByRole('option')).resolves.toHaveTextContent('Antonsen PK')
     })
+
+    // https://github.com/vuetifyjs/vuetify/pull/22045
+    it.only('should keep menu open while typing', async () => {
+      const items = ['Item 1', 'Item 1a', 'Another']
+
+      const { element } = render(() => (
+        <VCombobox items={ items } multiple />
+      ))
+
+      const optionsPerAction = [
+        ['1', 2],
+        ['a', 1],
+        ['x', 0],
+        ['y', 0],
+        ['{Backspace}', 0],
+        ['{Backspace}', 1],
+        ['{Backspace}', 2],
+        ['{Backspace}', 3],
+      ] as const
+
+      await userEvent.click(element)
+      await expect(screen.findAllByRole('option')).resolves.toHaveLength(3)
+      for (const [text, expectedItemsCount] of optionsPerAction) {
+        await userEvent.keyboard(text)
+        await expect.poll(() => screen.queryAllByRole('option')).toHaveLength(expectedItemsCount)
+      }
+    })
   })
 
   describe('prefilled data', () => {


### PR DESCRIPTION
## Description

`hideNoData` was changed to `true` in #21901 and it was hiding regression - every 2nd event, typing with no match opens/closes menu.

`hideNoData` was reverted as a last-minute call before publishing 3.10.0, I have no strong opinions, let's roll with it. As a side-effect, the default behavior is noticably broken:

[Screencast from 2025-09-11 01-44-54.webm](https://github.com/user-attachments/assets/eadfebfc-fb21-4b6d-988b-a01554a96c49)

TODO:
- [ ] new anti-regression tests

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-combobox
        v-model="msg"
        autocomplete="suppress"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('xx')
</script>
```
