### PR TITLE
feat(VProgressCircular): add rounded prop for rounded stroke caps

### DIFF
--- a/packages/api-generator/src/locale/en/VProgressCircular.json
+++ b/packages/api-generator/src/locale/en/VProgressCircular.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "indeterminate": "Constantly animates, use when loading progress is unknown. If set to the string `'disable-shrink'` it will use a simpler animation that does not run on the main thread.",
+    "rounded": "Rounds the ends of the progress arc for a softer appearance. When enabled, the progress stroke will have rounded caps instead of square ends.",
     "modelValue": "The percentage value for current progress.",
     "query": "Animates like **indeterminate** prop but inverse.",
     "rotate": "Rotates the circle start point in degrees.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -191,6 +191,11 @@
       "hideTitle": "3.10.0"
     }
   },
+  "VProgressCircular": {
+    "props": {
+      "rounded": "3.11.0"
+    }
+  },
   "VProgressLinear": {
     "props": {
       "chunkCount": "3.10.0",

--- a/packages/vuetify/src/components/VProgressCircular/VProgressCircular.tsx
+++ b/packages/vuetify/src/components/VProgressCircular/VProgressCircular.tsx
@@ -11,7 +11,7 @@ import { makeTagProps } from '@/composables/tag'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
 
 // Utilities
-import { ref, toRef, watchEffect } from 'vue'
+import { computed, ref, toRef, watchEffect } from 'vue'
 import { clamp, convertToUnit, genericComponent, PREFERS_REDUCED_MOTION, propsFactory, useRender } from '@/util'
 
 // Types
@@ -21,6 +21,7 @@ export const makeVProgressCircularProps = propsFactory({
   bgColor: String,
   color: String,
   indeterminate: [Boolean, String] as PropType<boolean | 'disable-shrink'>,
+  rounded: Boolean,
   modelValue: {
     type: [Number, String],
     default: 0,
@@ -74,7 +75,18 @@ export const VProgressCircular = genericComponent<VProgressCircularSlots>()({
     })
     const diameter = toRef(() => (MAGIC_RADIUS_CONSTANT / (1 - width.value / size.value)) * 2)
     const strokeWidth = toRef(() => width.value / size.value * diameter.value)
-    const strokeDashOffset = toRef(() => convertToUnit(((100 - normalizedValue.value) / 100) * CIRCUMFERENCE))
+    const strokeDashOffset = toRef(() => {
+      const baseLength = ((100 - normalizedValue.value) / 100) * CIRCUMFERENCE
+      return props.rounded && normalizedValue.value > 0 && normalizedValue.value < 100
+        ? convertToUnit(Math.min(CIRCUMFERENCE - 0.01, baseLength + strokeWidth.value))
+        : convertToUnit(baseLength)
+    })
+    const startAngle = computed(() => {
+      const baseAngle = Number(props.rotate)
+      return props.rounded
+        ? baseAngle + (strokeWidth.value / 2) / CIRCUMFERENCE * 360
+        : baseAngle
+    })
 
     watchEffect(() => {
       intersectionRef.value = root.value
@@ -109,7 +121,7 @@ export const VProgressCircular = genericComponent<VProgressCircularSlots>()({
       >
         <svg
           style={{
-            transform: `rotate(calc(-90deg + ${Number(props.rotate)}deg))`,
+            transform: `rotate(calc(-90deg + ${startAngle.value}deg))`,
           }}
           xmlns="http://www.w3.org/2000/svg"
           viewBox={ `0 0 ${diameter.value} ${diameter.value}` }
@@ -138,6 +150,7 @@ export const VProgressCircular = genericComponent<VProgressCircularSlots>()({
             stroke-width={ strokeWidth.value }
             stroke-dasharray={ CIRCUMFERENCE }
             stroke-dashoffset={ strokeDashOffset.value }
+            stroke-linecap={ props.rounded ? 'round' : undefined }
           />
         </svg>
 


### PR DESCRIPTION
## Description

This change adds a `rounded` prop to the `VProgressCircular` component to provide rounded stroke caps for a softer, more polished appearance.

### Why is this change required?

The current `VProgressCircular` component only supports square stroke caps, which can appear harsh or less visually appealing in certain design contexts. Many modern UI libraries and design systems offer rounded stroke caps as a standard option for progress indicators, as they provide:

1. **Better visual consistency** with other rounded UI elements
2. **Softer, more modern appearance** that aligns with current design trends
3. **Enhanced user experience** through more polished visual feedback
4. **Design flexibility** for developers who want to match their brand's aesthetic

### What problem does it solve?

- **Design limitation**: Currently, developers cannot achieve rounded stroke caps on progress circles without custom CSS overrides

### Implementation details
- Add rounded prop to VProgressCircular component
- Apply stroke-linecap: round when rounded is true
- Update documentation with detailed description
- Maintains backward compatibility with default false value

<img width="356" height="129" alt="Screenshot 2025-09-12 at 12 32 53 AM" src="https://github.com/user-attachments/assets/6b406a22-49b4-461d-bf7f-0f1a0b6a06be" />

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <VCol cols="12">
          <v-slider v-model="value" />
        </VCol>
        <v-col cols="2">
          <p class="mb-2">Default</p>
          <v-progress-circular v-model="value" />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">Without prop "rounded"</p>
          <v-progress-circular v-model="value" size="100" width="15" />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">With prop "rounded" in false</p>
          <v-progress-circular
            v-model="value"
            :rounded="false"
            size="100"
            width="15"
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">With prop "rounded" in true</p>
          <v-progress-circular
            v-model="value"
            :rounded="true"
            size="100"
            width="15"
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">Default with prop "rounded" in true</p>
          <v-progress-circular v-model="value" :rounded="true" />
        </v-col>
      </v-row>
      <v-row>
        <v-col cols="2">
          <p class="mb-2">Default</p>
          <v-progress-circular v-model="value" indeterminate />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">Without prop "rounded"</p>
          <v-progress-circular
            v-model="value"
            size="100"
            width="15"
            indeterminate
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">With prop "rounded" in false</p>
          <v-progress-circular
            v-model="value"
            :rounded="false"
            size="100"
            width="15"
            indeterminate
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">With prop "rounded" in true</p>
          <v-progress-circular
            v-model="value"
            :rounded="true"
            size="100"
            width="15"
            indeterminate
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">Default with prop "rounded" in true</p>
          <v-progress-circular v-model="value" :rounded="true" indeterminate />
        </v-col>
      </v-row>
      <v-row>
        <v-col cols="2">
          <p class="mb-2">Default</p>
          <v-progress-circular v-model="value" color="primary" indeterminate />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">Without prop "rounded"</p>
          <v-progress-circular
            v-model="value"
            color="secondary"
            size="100"
            width="15"
            indeterminate
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">With prop "rounded" in false</p>
          <v-progress-circular
            v-model="value"
            :rounded="false"
            color="error"
            size="100"
            width="15"
            indeterminate
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">With prop "rounded" in true</p>
          <v-progress-circular
            v-model="value"
            :rounded="true"
            color="warning"
            size="100"
            width="15"
            indeterminate
          />
        </v-col>
        <v-col cols="2">
          <p class="mb-2">Default with prop "rounded" in true</p>
          <v-progress-circular
            v-model="value"
            :rounded="true"
            color="success"
            indeterminate
          />
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const value = ref(50)
      return {
        value,
      }
    },
  }
</script>

```

