### PR TITLE
fix(VAutocomplete): resolve items reactivity

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -399,7 +399,7 @@ export const VAutocomplete = genericComponent<new <
       }
     })
 
-    watch(() => props.items, (newVal, oldVal) => {
+    watch(items, (newVal, oldVal) => {
       if (menu.value) return
 
       if (isFocused.value && !oldVal.length && newVal.length) {


### PR DESCRIPTION
resolves #22066
Use useItems composable items instead of getter for reusable, explicit tracking

## Markup:
https://play.vuetifyjs.com/#eNqNVktz2zgM/itYHRp5xpYfmb2ocbuZ7R72sI/ZZnqJe2Ak2GaXIlWScppx898LvizJTmZ6iUl8IAB++EDl/pgZXc1v27Y4dJiV2Y3FphXM4ruNBLj5RIhfufXvSlrGJepocbYPnAm1g7JRNYrZgYkO15vM6g432cnNH2a6Hhh87M6qSlE6tDhEAA4zH48icapnk72IlgaZrvbkFBbnbhptp+VMPXzByo4hqWZbLizqsZkNCqKwWyYMXWPss+c1zuh8zSwbI6VQrOZyRyfj6vxs6W4zs9wKFz4/TGD9Dpztzplo/+IBE2kwF2gsY2bxm+2zwnu4+ugZoU1RFFdQwtXfCj6Q69V5jHjeWF6fiCRaRl7zYSPn407SPkggqYTwkUzIEDR0Mx9Ii7am0ry1YKhLQWK8aZW2cKTGbafwyGy1h2fYatXAJiN1brK37iBApaSx0GrVGlhDjVtK9q/b5cdQhJfHJ6fFEqIJwD61tP3Hq2GajBq/dlxjXYJv9slOQVknbAm579HxOSLh93kyqsQ3hyqhuvP7zw4bIhGQnRBDKFAdQeI7G4KpkwH1pV2m9KIhl6ijQyFZgz7ItpOV5UrCFonE/9DQVQzdJHIRBgMkPgLR1nCDea7RTAn4Eq6baKDm3PEGVWfzSESvBDqR3w9lcgRsGBcldcsJ6jf3p6Bx2mRTcKU54I5ssHQWTpwvI5+vRFi9HmKVQqxGISL5oVOwXCwWyeBbRj+BRBpwsHQxPaarxgdFa7yVdRignjO+hdyfmEAlCEu0BFtM4jfUkQFtvgN/OoFMYZXKiVUw8ySrs2Z513HaX4JUCv+4TmL3YkaHpxt7GQavwqgGTwAkiQwDwXq9Hr490zBQRfC51TsD37+T8CcpygTevHkplUC5syRkCrcM+Kn6JLXUg3Btoj/IOxUC7nORKNRP/emgdRIa6Zfc2CPjdqzp4Y1evUGcnAuOWsErzBckpIvr9DoaYm1n9jm9qKGi3sfVqQSdVbt84D95C/M5kY6wV4/+pYUdWgNdS2usgR5afP8zo3ZRw9mgXL8+KNdpUK7TCPTDcZoNqPxjm5O6+tGXrPr/genCUPF/aK30x2ih7A0aw3aUpWXaoEf/CiYX45SIXm8umRCDlp633r9tvT5OIvHPf2zv9HIwXYabefiE0Mcje55m18WvxWqZucVyUdAivOij/2+C7fMPtw7ASA==
