### PR TITLE
docs: Fix the Calendar next button example

### DIFF
--- a/packages/docs/src/examples/v-calendar/usage.vue
+++ b/packages/docs/src/examples/v-calendar/usage.vue
@@ -41,7 +41,7 @@
         class="ma-2"
         variant="text"
         icon
-        @click="calendar.next()"
+        @click="$refs.calendar.next()"
       >
         <v-icon>mdi-chevron-right</v-icon>
       </v-btn>


### PR DESCRIPTION
## Description
The "next" button on the documentation for Calendar currently does not work. This should fix that.
