### PR TITLE
fix(V-Btn): prevent disabled links from opening on focus + enter key

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -163,7 +163,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
           (e.button !== 0) ||
           attrs.target === '_blank'
         ))
-      ) return
+      )  return e.preventDefault()
 
       if (link.isLink.value) {
         link.navigate?.(e)


### PR DESCRIPTION
## Description
Fixes #22061 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```
<template>
  <v-app>
    <v-container class="d-flex flex-column">
      <v-text-field v-model="msg" />
      <v-btn @click="onClick">Active Button</v-btn>
      <v-btn color="secondary" :disabled="true" @click="onClick">I'm real button!</v-btn>
      <v-btn color="primary" href="http://www.google.com" target="_blank" :disabled="true" @click="onClick">I'm a link!</v-btn>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const msg = ref('Hello World!')
const onClick = () => {
  console.log('hi');
}
</script>

```
