### PR TITLE
fix(VBtnToggle): remove overlay multiplier from inactive buttons

### DIFF
--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
@@ -3,6 +3,9 @@
 
 @include tools.layer('components')
   .v-btn-toggle
+    > .v-btn
+      --v-theme-overlay-multiplier: 0
+
     > .v-btn.v-btn--active:not(.v-btn--disabled)
       @include tools.active-states('> .v-btn__overlay', $btn-toggle-selected-opacity)
 


### PR DESCRIPTION
  fix(VBtnToggle): remove overlay multiplier from inactive buttons
  


  ## Description
  Fixes #22004

  Fixes overlay visual issues on inactive buttons in the VBtnToggle component. Currently, inactive buttons in
  button toggles inherit unwanted overlay effects that affect their visual appearance.

  ## Changes
  - Added `--v-theme-overlay-multiplier: 0` to inactive buttons (`.v-btn-toggle > .v-btn`)
  - Preserves existing overlay behavior for active buttons
  - Minimal CSS change with targeted scope

  ## Before/After
  **Before:** Inactive buttons displayed unwanted overlay effects
  **After:** Inactive buttons have clean appearance without overlay artifacts while maintaining proper active
  state styling
