### PR TITLE
feat(VCombobox): always show only matching suggestions

### DIFF
--- a/packages/api-generator/src/locale/en/VCombobox.json
+++ b/packages/api-generator/src/locale/en/VCombobox.json
@@ -4,7 +4,8 @@
     "clearOnSelect": "Reset the search text when a selection is made while using the **multiple** prop.",
     "itemChildren": "This property currently has **no effect**.",
     "delimiters": "Accepts an array of strings that will trigger a new tag when typing. Does not replace the normal Tab and Enter keys.",
-    "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props."
+    "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props.",
+    "alwaysFilter": "When enabled, the combobox will only apply filtering **after the user types**, rather than immediately on load. This provides more predictable **matching** and **suggestions** behavior. For optimal UX, consider combining with `:menu-icon=\"false\"` (to hide the dropdown arrow) and `hide-selected` (to avoid showing already-selected items in the suggestions)."
   },
   "slots": {
     "item": "Define a custom item appearance. The root element of this slot must be a **v-list-item** with `v-bind=\"props\"` applied. `props` includes everything required for the default select list behaviour - including title, value, click handlers, virtual scrolling, and anything else that has been added with `item-props`."

--- a/packages/api-generator/src/locale/en/VCombobox.json
+++ b/packages/api-generator/src/locale/en/VCombobox.json
@@ -1,11 +1,11 @@
 {
   "props": {
+    "alwaysFilter": "When enabled, dropdown list will always show items matching non-empty value within the field. Recommended when the list is meant to show suggestions rather than options to choose from. For optimal UX, should be combined with `:menu-icon=\"false\"` and `hide-selected`.",
     "autoSelectFirst": "When searching, will always highlight the first option and select it on blur. `exact` will only highlight and select exact matches.",
     "clearOnSelect": "Reset the search text when a selection is made while using the **multiple** prop.",
     "itemChildren": "This property currently has **no effect**.",
     "delimiters": "Accepts an array of strings that will trigger a new tag when typing. Does not replace the normal Tab and Enter keys.",
-    "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props.",
-    "alwaysFilter": "When enabled, the combobox will only apply filtering **after the user types**, rather than immediately on load. This provides more predictable **matching** and **suggestions** behavior. For optimal UX, consider combining with `:menu-icon=\"false\"` (to hide the dropdown arrow) and `hide-selected` (to avoid showing already-selected items in the suggestions)."
+    "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props."
   },
   "slots": {
     "item": "Define a custom item appearance. The root element of this slot must be a **v-list-item** with `v-bind=\"props\"` applied. `props` includes everything required for the default select list behaviour - including title, value, click handlers, virtual scrolling, and anything else that has been added with `item-props`."

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -60,7 +60,7 @@
   },
   "VCombobox": {
     "props": {
-      "alwaysFilter": "3.11.0",
+      "alwaysFilter": "3.10.4",
       "autocomplete": "3.10.0",
       "clearOnSelect": "3.5.0",
       "listProps": "3.5.0"

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -60,6 +60,7 @@
   },
   "VCombobox": {
     "props": {
+      "alwaysFilter": "3.11.0",
       "autocomplete": "3.10.0",
       "clearOnSelect": "3.5.0",
       "listProps": "3.5.0"

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -190,7 +190,7 @@ export const VCombobox = genericComponent<new <
         : (props.multiple ? model.value.length : search.value.length)
     })
 
-    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
+    const { filteredItems, getMatches } = useFilter(props, items, () => props.alwaysFilter ? search.value : isPristine.value ? '' : search.value)
 
     const displayItems = computed(() => {
       if (props.hideSelected) {

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -190,7 +190,11 @@ export const VCombobox = genericComponent<new <
         : (props.multiple ? model.value.length : search.value.length)
     })
 
-    const { filteredItems, getMatches } = useFilter(props, items, () => props.alwaysFilter ? search.value : isPristine.value ? '' : search.value)
+    const { filteredItems, getMatches } = useFilter(
+      props,
+      items,
+      () => props.alwaysFilter || !isPristine.value ? search.value : ''
+    )
 
     const displayItems = computed(() => {
       if (props.hideSelected) {

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -63,6 +63,10 @@ type Value <T, ReturnObject extends boolean, Multiple extends boolean> =
     : Val<T, ReturnObject> | null
 
 export const makeVComboboxProps = propsFactory({
+  alwaysFilter: {
+    type: Boolean,
+    default: false,
+  },
   autoSelectFirst: {
     type: [Boolean, String] as PropType<boolean | 'exact'>,
   },

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -63,10 +63,7 @@ type Value <T, ReturnObject extends boolean, Multiple extends boolean> =
     : Val<T, ReturnObject> | null
 
 export const makeVComboboxProps = propsFactory({
-  alwaysFilter: {
-    type: Boolean,
-    default: false,
-  },
+  alwaysFilter: Boolean,
   autoSelectFirst: {
     type: [Boolean, String] as PropType<boolean | 'exact'>,
   },

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -771,6 +771,22 @@ describe('VCombobox', () => {
     expect(model.value).toEqual(expected)
   })
 
+  it('should show only matching items when reopening the menu if alwaysFilter is true', async () => {
+    const { element } = render(() => (
+      <VCombobox alwaysFilter items={['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']} />
+    ))
+
+    await userEvent.click(element)
+    await userEvent.keyboard('c')
+    await expect(screen.findAllByRole('option')).resolves.toHaveLength(2)
+    await userEvent.keyboard('al')
+    await expect(screen.findAllByRole('option')).resolves.toHaveLength(1)
+    await userEvent.click(document.body)
+    await expect.poll(() => screen.queryAllByRole('option')).toHaveLength(0)
+    await userEvent.click(element)
+    await expect.poll(() => screen.queryAllByRole('option')).toHaveLength(1)
+  })
+
   describe('Showcase', () => {
     generate({ stories })
   })


### PR DESCRIPTION
## Description

closes #22060
Relates to: https://github.com/vuetifyjs/vuetify/pull/21901

####
- Add new props `alwaysFilter` defaults to `false` to allow the previous behavior consistent with components like `VSelect` and `VAutocomplete`
- ~~If set to `true` it will prevent to set the `isPristine` to `false` on initial load~~
- ~~Instead of passing the `search` immediately check `isPristine` and determine the value to pass~~

## Markup:
```vue
// This example will show the previous behavior
// On menu show it should show all the items
// Pass always-filter to see it filter on load
<template>
  <v-app>
    <v-container>
      <v-combobox
        v-model="msg"
        :items="['Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming', 'California']"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Cali')
</script>

```
