### PR TITLE
fix(VDialog): fix focus trap when tabbing forward

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -14,7 +14,7 @@ import { useScopeId } from '@/composables/scopeId'
 
 // Utilities
 import { mergeProps, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { focusableChildren, genericComponent, IN_BROWSER, propsFactory, useRender } from '@/util'
+import { focusableChildren, focusChild, genericComponent, IN_BROWSER, propsFactory, useRender } from '@/util'
 
 // Types
 import type { OverlaySlots } from '@/components/VOverlay/VOverlay'
@@ -81,22 +81,17 @@ export const VDialog = genericComponent<OverlaySlots>()({
     }
 
     function onKeydown (e: KeyboardEvent) {
-      if (e.key !== 'Tab' || !overlay.value?.contentEl) return
+      if (e.key !== 'Tab' ||
+        !overlay.value?.contentEl ||
+        // We're the topmost dialog
+        !overlay.value?.globalTop
+      ) return
 
       const focusable = focusableChildren(overlay.value.contentEl)
       if (!focusable.length) return
 
-      const firstElement = focusable[0]
-      const lastElement = focusable[focusable.length - 1]
-      const active = document.activeElement as HTMLElement | null
-
-      if (e.shiftKey && active === firstElement) {
-        e.preventDefault()
-        lastElement.focus()
-      } else if (!e.shiftKey && active === lastElement) {
-        e.preventDefault()
-        firstElement.focus()
-      }
+      e.preventDefault()
+      focusChild(overlay.value.contentEl, e.shiftKey ? 'prev' : 'next')
     }
 
     onBeforeUnmount(() => {

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -66,17 +66,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
         !overlay.value.contentEl.contains(after)
       ) {
         const focusable = focusableChildren(overlay.value.contentEl)
-
-        if (!focusable.length) return
-
-        const firstElement = focusable[0]
-        const lastElement = focusable[focusable.length - 1]
-
-        if (before === firstElement) {
-          lastElement.focus()
-        } else {
-          firstElement.focus()
-        }
+        focusable[0]?.focus()
       }
     }
 
@@ -107,7 +97,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
     if (IN_BROWSER) {
       watch(() => isActive.value && props.retainFocus, val => {
         if (val) {
-          document.addEventListener('focusin', onFocusin)
+          document.addEventListener('focusin', onFocusin, { once: true })
           document.addEventListener('keydown', onKeydown)
         } else {
           document.removeEventListener('focusin', onFocusin)

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -51,34 +51,6 @@ export const VDialog = genericComponent<OverlaySlots>()({
     const { scopeId } = useScopeId()
 
     const overlay = ref<VOverlay>()
-    function onFocusin (e: FocusEvent) {
-      const before = e.relatedTarget as HTMLElement | null
-      const after = e.target as HTMLElement | null
-
-      if (
-        before !== after &&
-        overlay.value?.contentEl &&
-        // We're the topmost dialog
-        overlay.value?.globalTop &&
-        // It isn't the document or the dialog body
-        ![document, overlay.value.contentEl].includes(after!) &&
-        // It isn't inside the dialog body
-        !overlay.value.contentEl.contains(after)
-      ) {
-        const focusable = focusableChildren(overlay.value.contentEl)
-
-        if (!focusable.length) return
-
-        const firstElement = focusable[0]
-        const lastElement = focusable[focusable.length - 1]
-
-        if (before === firstElement) {
-          lastElement.focus()
-        } else {
-          firstElement.focus()
-        }
-      }
-    }
 
     function onKeydown (e: KeyboardEvent) {
       if (e.key !== 'Tab' ||
@@ -95,17 +67,14 @@ export const VDialog = genericComponent<OverlaySlots>()({
     }
 
     onBeforeUnmount(() => {
-      document.removeEventListener('focusin', onFocusin)
       document.removeEventListener('keydown', onKeydown)
     })
 
     if (IN_BROWSER) {
       watch(() => isActive.value && props.retainFocus, val => {
         if (val) {
-          document.addEventListener('focusin', onFocusin)
           document.addEventListener('keydown', onKeydown)
         } else {
-          document.removeEventListener('focusin', onFocusin)
           document.removeEventListener('keydown', onKeydown)
         }
       }, { immediate: true })

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -51,6 +51,34 @@ export const VDialog = genericComponent<OverlaySlots>()({
     const { scopeId } = useScopeId()
 
     const overlay = ref<VOverlay>()
+    function onFocusin (e: FocusEvent) {
+      const before = e.relatedTarget as HTMLElement | null
+      const after = e.target as HTMLElement | null
+
+      if (
+        before !== after &&
+        overlay.value?.contentEl &&
+        // We're the topmost dialog
+        overlay.value?.globalTop &&
+        // It isn't the document or the dialog body
+        ![document, overlay.value.contentEl].includes(after!) &&
+        // It isn't inside the dialog body
+        !overlay.value.contentEl.contains(after)
+      ) {
+        const focusable = focusableChildren(overlay.value.contentEl)
+
+        if (!focusable.length) return
+
+        const firstElement = focusable[0]
+        const lastElement = focusable[focusable.length - 1]
+
+        if (before === firstElement) {
+          lastElement.focus()
+        } else {
+          firstElement.focus()
+        }
+      }
+    }
 
     function onKeydown (e: KeyboardEvent) {
       if (e.key !== 'Tab' ||
@@ -67,14 +95,17 @@ export const VDialog = genericComponent<OverlaySlots>()({
     }
 
     onBeforeUnmount(() => {
+      document.removeEventListener('focusin', onFocusin)
       document.removeEventListener('keydown', onKeydown)
     })
 
     if (IN_BROWSER) {
       watch(() => isActive.value && props.retainFocus, val => {
         if (val) {
+          document.addEventListener('focusin', onFocusin)
           document.addEventListener('keydown', onKeydown)
         } else {
+          document.removeEventListener('focusin', onFocusin)
           document.removeEventListener('keydown', onKeydown)
         }
       }, { immediate: true })

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -51,11 +51,14 @@ export const VDialog = genericComponent<OverlaySlots>()({
     const { scopeId } = useScopeId()
 
     const overlay = ref<VOverlay>()
-    function onFocusin (e: FocusEvent) {
+    async function onFocusin (e: FocusEvent) {
       const before = e.relatedTarget as HTMLElement | null
       const after = e.target as HTMLElement | null
 
+      await nextTick()
+
       if (
+        isActive.value &&
         before !== after &&
         overlay.value?.contentEl &&
         // We're the topmost dialog

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -14,7 +14,7 @@ import { useScopeId } from '@/composables/scopeId'
 
 // Utilities
 import { mergeProps, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { focusableChildren, focusChild, genericComponent, IN_BROWSER, propsFactory, useRender } from '@/util'
+import { focusableChildren, genericComponent, IN_BROWSER, propsFactory, useRender } from '@/util'
 
 // Types
 import type { OverlaySlots } from '@/components/VOverlay/VOverlay'
@@ -81,17 +81,22 @@ export const VDialog = genericComponent<OverlaySlots>()({
     }
 
     function onKeydown (e: KeyboardEvent) {
-      if (e.key !== 'Tab' ||
-        !overlay.value?.contentEl ||
-        // We're the topmost dialog
-        !overlay.value?.globalTop
-      ) return
+      if (e.key !== 'Tab' || !overlay.value?.contentEl) return
 
       const focusable = focusableChildren(overlay.value.contentEl)
       if (!focusable.length) return
 
-      e.preventDefault()
-      focusChild(overlay.value.contentEl, e.shiftKey ? 'prev' : 'next')
+      const firstElement = focusable[0]
+      const lastElement = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+
+      if (e.shiftKey && active === firstElement) {
+        e.preventDefault()
+        lastElement.focus()
+      } else if (!e.shiftKey && active === lastElement) {
+        e.preventDefault()
+        firstElement.focus()
+      }
     }
 
     onBeforeUnmount(() => {

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -80,15 +80,39 @@ export const VDialog = genericComponent<OverlaySlots>()({
       }
     }
 
+    function onKeydown (e: KeyboardEvent) {
+      if (e.key !== 'Tab' || !overlay.value?.contentEl) return
+
+      const focusable = focusableChildren(overlay.value.contentEl)
+      if (!focusable.length) return
+
+      const firstElement = focusable[0]
+      const lastElement = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+
+      if (e.shiftKey && active === firstElement) {
+        e.preventDefault()
+        lastElement.focus()
+      } else if (!e.shiftKey && active === lastElement) {
+        e.preventDefault()
+        firstElement.focus()
+      }
+    }
+
     onBeforeUnmount(() => {
       document.removeEventListener('focusin', onFocusin)
+      document.removeEventListener('keydown', onKeydown)
     })
 
     if (IN_BROWSER) {
       watch(() => isActive.value && props.retainFocus, val => {
-        val
-          ? document.addEventListener('focusin', onFocusin)
-          : document.removeEventListener('focusin', onFocusin)
+        if (val) {
+          document.addEventListener('focusin', onFocusin)
+          document.addEventListener('keydown', onKeydown)
+        } else {
+          document.removeEventListener('focusin', onFocusin)
+          document.removeEventListener('keydown', onKeydown)
+        }
       }, { immediate: true })
     }
 

--- a/packages/vuetify/src/components/VDialog/__test__/VDialog.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDialog/__test__/VDialog.spec.browser.tsx
@@ -44,4 +44,48 @@ describe('VDialog', () => {
     await userEvent.click(element)
     await expect.poll(() => onAfterLeave).toHaveBeenCalledTimes(1)
   })
+
+  it('should focus on the last element when shift + tab key is pressed on the first element', async () => {
+    const model = ref(true)
+    render(() => (
+      <div>
+        <VDialog v-model={ model.value } persistent>
+          <div>
+            <button data-testid="first">First</button>
+            <button data-testid="last">Last</button>
+          </div>
+        </VDialog>
+      </div>
+    ))
+    const first = screen.getByCSS('button[data-testid="first"]')
+    const last = screen.getByCSS('button[data-testid="last"]')
+
+    first.focus()
+    await expect.poll(() => document.activeElement).toBe(first)
+
+    await userEvent.tab({ shift: true })
+    await expect.poll(() => document.activeElement).toBe(last)
+  })
+
+  it('should focus on the first element when Tab key is pressed on the last element', async () => {
+    const model = ref(true)
+    render(() => (
+      <div>
+        <VDialog v-model={ model.value }>
+          <div>
+            <button data-testid="first">First</button>
+            <button data-testid="last">Last</button>
+          </div>
+        </VDialog>
+      </div>
+    ))
+    const first = screen.getByCSS('button[data-testid="first"]')
+    const last = screen.getByCSS('button[data-testid="last"]')
+
+    last.focus()
+    await expect.poll(() => document.activeElement).toBe(last)
+
+    await userEvent.tab()
+    await expect.poll(() => document.activeElement).toBe(first)
+  })
 })


### PR DESCRIPTION
## Description
- Registers a keydown event listener on VDialog to focus on the first focusable element when the Tab key is pressed on the last focusable element in the dialog.
- Added two tests to test focus behavior when focus moves from the first and last buttons in a VDialog.

fixes #21945 

## Markup:
```vue
<template>
  <div class="text-center pa-4">
    <v-dialog v-model="dialog" max-width="400">
      <template v-slot:activator="{ props: activatorProps }">
        <v-btn v-bind="activatorProps"> Open Dialog </v-btn>
      </template>

      <v-btn @click="dialog = false"> Disagree </v-btn>
      <v-btn @click="dialog = false"> Agree </v-btn>
    </v-dialog>
  </div>
</template>

<script setup>
  import { ref } from 'vue'

  const dialog = ref(false)

  // for debugging
  const showPressedKey = (e) => {
    const now = new Date()
    const msg = `[${now.toISOString()}] pressed: ${e.key}${e.shiftKey ? ' with shift key' : ''}`
    console.log(msg)
  }

  window.addEventListener('keydown', showPressedKey)
</script>
```
