### PR TITLE
fix(VDialog): focus trap should ignore invisible and inert elements

### DIFF
--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -651,10 +651,27 @@ export function callEvent<T extends any[]> (handler: EventProp<T> | EventProp<T>
 }
 
 export function focusableChildren (el: Element, filterByTabIndex = true) {
-  const targets = ['button', '[href]', 'input:not([type="hidden"])', 'select', 'textarea', '[tabindex]']
-    .map(s => `${s}${filterByTabIndex ? ':not([tabindex="-1"])' : ''}:not([disabled])`)
+  const targets = [
+    'button',
+    '[href]',
+    'input:not([type="hidden"])',
+    'select',
+    'textarea',
+    'details:not(:has(> summary))',
+    'details > summary',
+    '[tabindex]',
+    '[contenteditable]:not([contenteditable="false"])',
+    'audio[controls]',
+    'video[controls]',
+  ]
+    .map(s => `${s}${filterByTabIndex ? ':not([tabindex="-1"])' : ''}:not([disabled], [inert])`)
     .join(', ')
-  return [...el.querySelectorAll(targets)] as HTMLElement[]
+  return ([...el.querySelectorAll(targets)] as HTMLElement[])
+    .filter(x => !x.closest('[inert]')) // does not have inert parent
+    .filter(x => !!x.offsetParent || x.getClientRects().length > 0) // is rendered
+    .filter(x => !x.parentElement?.closest('details:not([open])') ||
+      (x.tagName === 'SUMMARY' && x.parentElement?.tagName === 'DETAILS')
+    )
 }
 
 export function getNextElement (elements: HTMLElement[], location?: 'next' | 'prev', condition?: (el: HTMLElement) => boolean) {


### PR DESCRIPTION
- extends the selector for focusable elements
- verifies that elements are actually rendered

fixes #18400

TODO:
- [x] verify collapsed `<details>`
- [x] include `[contenteditable]:not([contenteditable="false"])` for VEditor or any RichText editor
- [x] include `audio[controls]` and `video[controls]`

> **Note**: with the current approach (`keydown`), video/audio controls are not fully accessible. We should revisit #22101 and maybe set some invisible element before and after the dialog content so we don't rely on focusable items detection.

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-row>
        <v-col>
          <v-dialog width="500">
            <template #activator="{ props }">
              <v-btn v-bind="props" text="Open Dialog" />
            </template>

            <template #default="{ isActive }">
              <v-card title="Dialog">
                <v-card-text>
                  Content goes here...

                  <v-text-field style="display: none" />
                  <v-text-field style="position: fixed" />
                  <v-text-field inert />
                </v-card-text>

                <v-card-actions>
                  <v-spacer />

                  <v-btn text="Close" @click="isActive.value = false" />
                  <v-btn text="Save" @click="isActive.value = false" />
                </v-card-actions>
                <v-text-field inert />
                <div contenteditable>
                  <p>Edit me</p>
                </div>
                <div contenteditable="false">
                  <p>Edit disabled</p>
                </div>
                <video max-width="450" src="https://cdn.jsek.work/cdn/vt-sunflowers.mp4" controls muted />
                <audio src="https://cdn.jsek.work/cdn/vt-sunflowers.mp4" controls />
                <details>
                  <summary>Expandable</summary>
                  Hidden content<v-btn text="I am only focusable if section is expanded" />
                </details>
              </v-card>
            </template>
          </v-dialog>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>
```
