### PR TITLE
feat(VNagivationDrawer, VOverlay): add `retain-focus` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VDialog.json
+++ b/packages/api-generator/src/locale/en/VDialog.json
@@ -9,7 +9,6 @@
     "noClickAnimation": "Disables the bounce effect when clicking outside of a `v-dialog`'s content when using the **persistent** prop.",
     "openOnHover": "Designates whether component should activate when its activator is hovered.",
     "persistent": "Clicking outside of the element or pressing **esc** key will not deactivate it.",
-    "retainFocus": "Tab focus will return to the first child of the dialog by default. Disable this when using external tools that require focus such as TinyMCE or vue-clipboard.",
     "scrollable": "When set to true, expects a `v-card` and a `v-card-text` component with a designated height. For more information, check out the [scrollable example](/components/dialogs#scrollable)."
   },
   "events": {

--- a/packages/api-generator/src/locale/en/VMenu.json
+++ b/packages/api-generator/src/locale/en/VMenu.json
@@ -5,7 +5,7 @@
     "closeOnClick": "Designates if menu should close on outside-activator click.",
     "closeOnContentClick": "Designates if menu should close when its content is clicked.",
     "closeDelay": "Milliseconds to wait before closing component. Only works with the **open-on-hover** prop.",
-    "disableInitialFocus": "Prevents automatic redirect of first `focusin` event. Intended to use on permanently open menus or VSpeedDial.",
+    "disableInitialFocus": "Deprecated, use `capture-focus` instead. Prevents automatic redirect of first `focusin` event. Intended to use on permanently open menus or VSpeedDial.",
     "disableKeys": "Removes all keyboard interaction.",
     "internalActivator": "Detaches the menu content inside of the component as opposed to the document.",
     "minWidth": "Sets the minimum width for the component. Use `auto` to use the activator width.",

--- a/packages/api-generator/src/locale/en/generic.json
+++ b/packages/api-generator/src/locale/en/generic.json
@@ -20,6 +20,7 @@
     "falseValue": "Sets value for falsy state.",
     "firstDayOfWeek": "Sets the first day of the week, starting with 0 for Sunday. (Note: not guaranteed to work when using custom date adapters.)",
     "firstDayOfYear": "Sets the day that determines the first week of the year, starting with 0 for Sunday. For ISO 8601 this should be 4. (Note: not guaranteed to work when using custom date adapters.)",
+    "retainFocus": "Captures and keeps focus within the content element when using **Tab** and **Shift**+**Tab**. Recommended to be `false` when using external tools that require focus such as TinyMCE or vue-clipboard.",
     "fullWidth": "Sets the component width to 100%.",
     "height": "Sets the height for the component.",
     "hideNoData": "Hides the menu when there are no options to show.  Useful for preventing the menu from opening before results are fetched asynchronously.  Also has the effect of opening the menu when the `items` array changes if not already open.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -210,6 +210,7 @@
   },
   "VMenu": {
     "props": {
+      "retainFocus": "3.11.0",
       "stickToTarget": "3.10.0",
       "submenu": "3.7.0",
       "viewportMargin": "3.11.0"
@@ -217,6 +218,7 @@
   },
   "VNavigationDrawer": {
     "props": {
+      "retainFocus": "3.11.0",
       "persistent": "3.6.0"
     }
   },
@@ -227,6 +229,7 @@
   },
   "VOverlay": {
     "props": {
+      "retainFocus": "3.11.0",
       "stickToTarget": "3.10.0",
       "viewportMargin": "3.11.0"
     }

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -149,6 +149,8 @@
   },
   "VDialog": {
     "props": {
+      "captureFocus": "3.11.0",
+      "retainFocus": "3.11.0",
       "stickToTarget": "3.10.0",
       "viewportMargin": "3.11.0"
     }
@@ -210,6 +212,7 @@
   },
   "VMenu": {
     "props": {
+      "captureFocus": "3.11.0",
       "retainFocus": "3.11.0",
       "stickToTarget": "3.10.0",
       "submenu": "3.7.0",
@@ -218,6 +221,7 @@
   },
   "VNavigationDrawer": {
     "props": {
+      "captureFocus": "3.11.0",
       "retainFocus": "3.11.0",
       "persistent": "3.6.0"
     }
@@ -229,6 +233,7 @@
   },
   "VOverlay": {
     "props": {
+      "captureFocus": "3.11.0",
       "retainFocus": "3.11.0",
       "stickToTarget": "3.10.0",
       "viewportMargin": "3.11.0"

--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -14,7 +14,7 @@ import { useScopeId } from '@/composables/scopeId'
 
 // Utilities
 import { mergeProps, nextTick, ref, watch } from 'vue'
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { OverlaySlots } from '@/components/VOverlay/VOverlay'
@@ -23,13 +23,14 @@ export const makeVDialogProps = propsFactory({
   fullscreen: Boolean,
   scrollable: Boolean,
 
-  ...makeVOverlayProps({
+  ...omit(makeVOverlayProps({
+    captureFocus: true,
     origin: 'center center' as const,
     scrollStrategy: 'block' as const,
     transition: { component: VDialogTransition },
     zIndex: 2400,
     retainFocus: true,
-  }),
+  }), ['disableInitialFocus']),
 }, 'VDialog')
 
 export const VDialog = genericComponent<OverlaySlots>()({

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -48,6 +48,7 @@ export const makeVMenuProps = propsFactory({
   submenu: Boolean,
 
   ...omit(makeVOverlayProps({
+    captureFocus: true,
     closeDelay: 250,
     closeOnContentClick: true,
     locationStrategy: 'connected' as const,

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -18,7 +18,6 @@ import {
   computed,
   inject,
   mergeProps,
-  nextTick,
   onBeforeUnmount,
   onDeactivated,
   provide,
@@ -33,7 +32,6 @@ import {
   focusChild,
   genericComponent,
   getNextElement,
-  IN_BROWSER,
   isClickInsideElement,
   omit,
   propsFactory,
@@ -48,7 +46,6 @@ export const makeVMenuProps = propsFactory({
   // disableKeys: Boolean,
   id: String,
   submenu: Boolean,
-  disableInitialFocus: Boolean,
 
   ...omit(makeVOverlayProps({
     closeDelay: 250,
@@ -103,68 +100,13 @@ export const VMenu = genericComponent<OverlaySlots>()({
       },
     })
 
-    onBeforeUnmount(() => {
-      parent?.unregister()
-      document.removeEventListener('focusin', onFocusIn)
-    })
+    onBeforeUnmount(() => parent?.unregister())
     onDeactivated(() => isActive.value = false)
 
-    let focusTrapSuppressed = false
-    let focusTrapSuppressionTimeout = -1
-
-    async function onPointerdown () {
-      focusTrapSuppressed = true
-      focusTrapSuppressionTimeout = window.setTimeout(() => {
-        focusTrapSuppressed = false
-      }, 100)
-    }
-
-    async function onFocusIn (e: FocusEvent) {
-      const before = e.relatedTarget as HTMLElement | null
-      const after = e.target as HTMLElement | null
-
-      await nextTick()
-
-      if (
-        isActive.value &&
-        before !== after &&
-        overlay.value?.rootEl &&
-        overlay.value?.contentEl &&
-        // We're the menu without open submenus or overlays
-        overlay.value?.localTop &&
-        // It isn't the document or the menu body
-        ![document, overlay.value.rootEl].includes(after!) &&
-        // It isn't inside the menu body
-        !overlay.value.rootEl.contains(after)
-      ) {
-        if (focusTrapSuppressed) {
-          if (!props.openOnHover && !overlay.value.activatorEl?.contains(after)) {
-            isActive.value = false
-          }
-        } else {
-          const focusable = focusableChildren(overlay.value.contentEl)
-          focusable[0]?.focus()
-
-          document.removeEventListener('pointerdown', onPointerdown)
-        }
-      }
-    }
-
     watch(isActive, val => {
-      if (val) {
-        parent?.register()
-        if (IN_BROWSER && !props.disableInitialFocus) {
-          document.addEventListener('pointerdown', onPointerdown)
-          document.addEventListener('focusin', onFocusIn, { once: true })
-        }
-      } else {
-        parent?.unregister()
-        if (IN_BROWSER) {
-          clearTimeout(focusTrapSuppressionTimeout)
-          document.removeEventListener('pointerdown', onPointerdown)
-          document.removeEventListener('focusin', onFocusIn)
-        }
-      }
+      val
+        ? parent?.register()
+        : parent?.unregister()
     }, { immediate: true })
 
     function onClickOutside (e: MouseEvent) {
@@ -187,7 +129,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
           e.shiftKey ? 'prev' : 'next',
           (el: HTMLElement) => el.tabIndex >= 0
         )
-        if (!nextElement) {
+        if (!nextElement && !props.retainFocus) {
           isActive.value = false
           overlay.value?.activatorEl?.focus()
         }

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -29,7 +29,7 @@ import { useToggleScope } from '@/composables/toggleScope'
 
 // Utilities
 import { computed, nextTick, readonly, ref, shallowRef, toRef, Transition, watch } from 'vue'
-import { genericComponent, propsFactory, toPhysical, useRender } from '@/util'
+import { genericComponent, omit, propsFactory, toPhysical, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -92,7 +92,7 @@ export const makeVNavigationDrawerProps = propsFactory({
   ...makeElevationProps(),
   ...makeLayoutItemProps(),
   ...makeRoundedProps(),
-  ...makeFocusTrapProps({ disableInitialFocus: true }),
+  ...omit(makeFocusTrapProps({ captureFocus: false }), ['disableInitialFocus']),
   ...makeTagProps({ tag: 'nav' }),
   ...makeThemeProps(),
 }, 'VNavigationDrawer')

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -92,7 +92,7 @@ export const makeVNavigationDrawerProps = propsFactory({
   ...makeElevationProps(),
   ...makeLayoutItemProps(),
   ...makeRoundedProps(),
-  ...omit(makeFocusTrapProps({ captureFocus: false }), ['disableInitialFocus']),
+  ...omit(makeFocusTrapProps(), ['disableInitialFocus']),
   ...makeTagProps({ tag: 'nav' }),
   ...makeThemeProps(),
 }, 'VNavigationDrawer')

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -16,6 +16,7 @@ import { provideDefaults } from '@/composables/defaults'
 import { makeDelayProps, useDelay } from '@/composables/delay'
 import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeElevationProps, useElevation } from '@/composables/elevation'
+import { makeFocusTrapProps, useFocusTrap } from '@/composables/focusTrap'
 import { makeLayoutItemProps, useLayoutItem } from '@/composables/layout'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
@@ -91,6 +92,7 @@ export const makeVNavigationDrawerProps = propsFactory({
   ...makeElevationProps(),
   ...makeLayoutItemProps(),
   ...makeRoundedProps(),
+  ...makeFocusTrapProps({ disableInitialFocus: true }),
   ...makeTagProps({ tag: 'nav' }),
   ...makeThemeProps(),
 }, 'VNavigationDrawer')
@@ -140,6 +142,8 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
       !isTemporary.value &&
       location.value !== 'bottom'
     )
+
+    useFocusTrap(props, { isActive, localTop: isTemporary, contentEl: rootEl })
 
     useToggleScope(() => props.expandOnHover && props.rail != null, () => {
       watch(isHovering, val => emit('update:rail', !val))

--- a/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
+++ b/packages/vuetify/src/components/VNavigationDrawer/VNavigationDrawer.tsx
@@ -251,6 +251,7 @@ export const VNavigationDrawer = genericComponent<VNavigationDrawerSlots>()({
               stickyStyles.value,
               props.style,
             ]}
+            inert={ !isActive.value }
             { ...scopeId }
             { ...attrs }
           >

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -41,6 +41,7 @@ import {
   getCurrentInstance,
   getScrollParent,
   IN_BROWSER,
+  omit,
   propsFactory,
   standardEasing,
   useRender,
@@ -124,7 +125,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
   props: {
     _disableGlobalStack: Boolean,
 
-    ...makeVOverlayProps(),
+    ...omit(makeVOverlayProps(), ['disableInitialFocus']),
   },
 
   emits: {

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -200,7 +200,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional (e: Event) {
-      return isActive.value && globalTop.value && (
+      return isActive.value && localTop.value && (
         // If using scrim, only close if clicking on it rather than anything opened on top
         !props.scrim || e.target === scrimEl.value || (e instanceof MouseEvent && e.shadowTarget === scrimEl.value)
       )

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -8,6 +8,7 @@ import { makeActivatorProps, useActivator } from './useActivator'
 import { useBackgroundColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
 import { makeDimensionProps, useDimension } from '@/composables/dimensions'
+import { makeFocusTrapProps, useFocusTrap } from '@/composables/focusTrap'
 import { useHydration } from '@/composables/hydration'
 import { makeLazyProps, useLazy } from '@/composables/lazy'
 import { useRtl } from '@/composables/locale'
@@ -108,6 +109,7 @@ export const makeVOverlayProps = propsFactory({
   ...makeLazyProps(),
   ...makeLocationStrategyProps(),
   ...makeScrollStrategyProps(),
+  ...makeFocusTrapProps(),
   ...makeThemeProps(),
   ...makeTransitionProps(),
 }, 'VOverlay')
@@ -202,6 +204,8 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         !props.scrim || e.target === scrimEl.value || (e instanceof MouseEvent && e.shadowTarget === scrimEl.value)
       )
     }
+
+    useFocusTrap(props, { isActive, localTop, contentEl })
 
     IN_BROWSER && watch(isActive, val => {
       if (val) {

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -206,7 +206,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       )
     }
 
-    useFocusTrap(props, { isActive, localTop, contentEl })
+    useFocusTrap(props, { isActive, localTop, contentEl, activatorEl })
 
     IN_BROWSER && watch(isActive, val => {
       if (val) {

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -91,6 +91,9 @@ export const makeVSnackbarProps = propsFactory({
   }), [
     'persistent',
     'noClickAnimation',
+    'retainFocus',
+    'captureFocus',
+    'disableInitialFocus',
     'scrim',
     'scrollStrategy',
     'stickToTarget',

--- a/packages/vuetify/src/components/VTooltip/VTooltip.tsx
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.tsx
@@ -39,6 +39,8 @@ export const makeVTooltipProps = propsFactory({
   }), [
     'absolute',
     'retainFocus',
+    'captureFocus',
+    'disableInitialFocus',
     'persistent',
   ]),
 }, 'VTooltip')

--- a/packages/vuetify/src/components/VTooltip/VTooltip.tsx
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.tsx
@@ -38,6 +38,7 @@ export const makeVTooltipProps = propsFactory({
     transition: null,
   }), [
     'absolute',
+    'retainFocus',
     'persistent',
   ]),
 }, 'VTooltip')

--- a/packages/vuetify/src/composables/focusTrap.ts
+++ b/packages/vuetify/src/composables/focusTrap.ts
@@ -3,18 +3,20 @@ import { nextTick, onBeforeUnmount, toRef, toValue, watch } from 'vue'
 import { focusableChildren, IN_BROWSER, propsFactory } from '@/util'
 
 // Types
-import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { Ref } from 'vue'
 
 // Types
 export interface FocusTrapProps {
   retainFocus: boolean
-  disableInitialFocus: boolean
+  captureFocus: boolean
+  disableInitialFocus?: boolean // deprecated
 }
 
 // Composables
 export const makeFocusTrapProps = propsFactory({
   retainFocus: Boolean,
-  disableInitialFocus: Boolean,
+  captureFocus: Boolean,
+  disableInitialFocus: Boolean, // deprecated
 }, 'focusTrap')
 
 const registry = new Map<symbol, {
@@ -98,7 +100,7 @@ export function useFocusTrap (
     }
   }
 
-  const shouldCapture = toRef(() => isActive.value && !props.disableInitialFocus)
+  const shouldCapture = toRef(() => isActive.value && props.captureFocus && !props.disableInitialFocus)
 
   IN_BROWSER && watch(shouldCapture, val => {
     if (val) {

--- a/packages/vuetify/src/composables/focusTrap.ts
+++ b/packages/vuetify/src/composables/focusTrap.ts
@@ -119,10 +119,14 @@ export function useFocusTrap (
     const before = e.relatedTarget as HTMLElement | null
     const after = e.target as HTMLElement | null
 
+    document.removeEventListener('pointerdown', onPointerdown)
+    document.removeEventListener('keydown', captureOnKeydown)
+
     await nextTick()
 
     if (
       isActive.value &&
+      !focusTrapSuppressed &&
       before !== after &&
       contentEl.value &&
       // We're the menu without open submenus or overlays
@@ -132,18 +136,8 @@ export function useFocusTrap (
       // It isn't inside the container body
       !contentEl.value.contains(after)
     ) {
-      if (focusTrapSuppressed) {
-        if (!activatorEl?.value?.contains(after)) {
-          // TODO: callback for VMenu and VTooltip, or skip for VDialog... suppressOnClickOutside?
-          // if (!props.openOnHover) isActive.value = false
-        }
-      } else {
-        const focusable = focusableChildren(contentEl.value)
-        focusable[0]?.focus()
-
-        document.removeEventListener('pointerdown', onPointerdown)
-        document.removeEventListener('keydown', captureOnKeydown)
-      }
+      const focusable = focusableChildren(contentEl.value)
+      focusable[0]?.focus()
     }
   }
 
@@ -166,7 +160,7 @@ export function useFocusTrap (
         const focusable = focusableChildren(contentEl.value)
         if (focusable.length > 0) {
           e.preventDefault()
-          focusable[0]?.focus()
+          focusable[0].focus()
         }
       }
     }

--- a/packages/vuetify/src/composables/focusTrap.ts
+++ b/packages/vuetify/src/composables/focusTrap.ts
@@ -1,0 +1,116 @@
+// Utilities
+import { nextTick, onBeforeUnmount, toRef, toValue, watch } from 'vue'
+import { focusableChildren, IN_BROWSER, propsFactory } from '@/util'
+
+// Types
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+// Types
+export interface FocusTrapProps {
+  retainFocus: boolean
+  disableInitialFocus: boolean
+}
+
+// Composables
+export const makeFocusTrapProps = propsFactory({
+  retainFocus: Boolean,
+  disableInitialFocus: Boolean,
+}, 'focusTrap')
+
+const registry = new Map<symbol, {
+  isActive: Ref<boolean>
+  contentEl: Ref<HTMLElement | undefined>
+}>()
+
+function onKeydown (e: KeyboardEvent) {
+  const activeElement = document.activeElement as HTMLElement | null
+  if (e.key !== 'Tab' || !activeElement) return
+
+  const parentTraps = Array.from(registry.values())
+    .filter(({ isActive, contentEl }) => isActive.value && contentEl.value?.contains(activeElement))
+    .map(x => x.contentEl.value)
+
+  let closestTrap
+  let currentParent = activeElement.parentElement
+  while (currentParent) {
+    if (parentTraps.includes(currentParent)) {
+      closestTrap = currentParent
+      break
+    }
+    currentParent = currentParent.parentElement
+  }
+
+  if (!closestTrap) return
+
+  const focusable = focusableChildren(closestTrap)
+    .filter(x => !x.classList.contains('v-list'))
+
+  if (!focusable.length) return
+
+  const focusedIndex = focusable.indexOf(activeElement)
+  let newIndex = focusedIndex + (e.shiftKey ? -1 : 1)
+  if (newIndex === -1) {
+    newIndex = focusable.length - 1
+  } else if (newIndex === focusable.length) {
+    newIndex = 0
+  }
+
+  e.preventDefault()
+  focusable[newIndex].focus()
+}
+
+export function useFocusTrap (
+  props: FocusTrapProps,
+  { isActive, localTop, contentEl }: {
+    isActive: Readonly<Ref<boolean>>
+    localTop: Readonly<Ref<boolean>>
+    contentEl: Readonly<Ref<HTMLElement | undefined>>
+  }
+) {
+  const trapId = Symbol('trap')
+  watch(() => props.retainFocus, val => {
+    if (val) {
+      registry.set(trapId, { isActive, contentEl })
+    } else {
+      registry.delete(trapId)
+    }
+  }, { immediate: true })
+
+  async function captureFocus (e: FocusEvent) {
+    const before = e.relatedTarget as HTMLElement | null
+    const after = e.target as HTMLElement | null
+
+    await nextTick()
+
+    if (
+      isActive.value &&
+      before !== after &&
+      contentEl.value &&
+      // We're the menu without open submenus or overlays
+      toValue(localTop) &&
+      // It isn't the document or the container body
+      ![document, contentEl.value].includes(after!) &&
+      // It isn't inside the container body
+      !contentEl.value.contains(after)
+    ) {
+      const focusable = focusableChildren(contentEl.value)
+      focusable[0]?.focus()
+    }
+  }
+
+  const shouldCapture = toRef(() => isActive.value && !props.disableInitialFocus)
+
+  IN_BROWSER && watch(shouldCapture, val => {
+    if (val) {
+      document.addEventListener('focusin', captureFocus, { once: true })
+    } else {
+      document.removeEventListener('focusin', captureFocus)
+    }
+  }, { immediate: true })
+
+  onBeforeUnmount(() => {
+    document.removeEventListener('focusin', captureFocus)
+  })
+
+  IN_BROWSER && document.addEventListener('keydown', onKeydown)
+}


### PR DESCRIPTION
- introduces `retain-focus` for VOverlay (VMenu) and VNavigationDrawer
  - consolidated with the same prop on VDialog
- supports multiple coexisting traps (only keeps focus within the closest trap)
- respects VList navigation with arrows only

closes #16140

> Note: considering `activate`, `deactivate` (like in [VueUse](https://vueuse.org/integrations/useFocusTrap/))

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-app-bar>
      <v-app-bar-nav-icon @click="sidebar = !sidebar" />
    </v-app-bar>
    <v-navigation-drawer v-model="sidebar" capture-focus retain-focus temporary>
      <div class="d-flex flex-column ga-3">
        <v-btn text="Button 1" />
        <v-btn text="Button 2" />
        <v-btn>
          Menu with list
          <v-menu activator="parent" location="right" retain-focus>
            <v-list>
              <v-list-item title="foo" @click="" />
              <v-list-item title="bar" @click="" />
              <v-list-item title="baz" @click="" />
            </v-list>
          </v-menu>
        </v-btn>
        <v-btn>
          Menu with buttons
          <v-menu activator="parent" location="right" retain-focus>
            <v-sheet>
              <v-btn-group direction="vertical">
                <v-btn text="foo" @click="" />
                <v-btn text="bar" @click="" />
                <v-btn text="baz" @click="" />
              </v-btn-group>
            </v-sheet>
          </v-menu>
        </v-btn>
      </div>
    </v-navigation-drawer>
    <v-main>
      <v-container>
        <v-row class="gc-6">
          <v-menu :close-on-content-click="false" width="500" retain-focus>
            <template #activator="{ props }">
              <v-btn v-bind="props" text="Open Menu" />
            </template>

            <template #default="{ isActive }">
              <v-card title="Menu">
                <v-card-text>
                  <v-text-field />
                </v-card-text>

                <v-card-actions>
                  <v-btn text="Close" @click="isActive.value = false" />
                  <v-btn text="Save" @click="isActive.value = false" />
                </v-card-actions>
              </v-card>
            </template>
          </v-menu>
          <v-btn prepend-icon="mdi-earth">
            Dialog with radio group
            <v-dialog
              v-slot="{ isActive }"
              activator="parent"
              height="300"
              width="auto"
              capture-focus
              retain-focus
              scrollable
            >
              <v-card title="Select an option">
                <template #subtitle>
                  <small> would be better to let <v-kbd>Tab</v-kbd> escape to the actions, as the list might be very long </small>
                </template>
                <v-divider />
                <v-card-text class="px-4" style="height: 300px;">
                  <v-radio-group hide-details>
                    <v-radio v-for="i in 10" :key="i" :label="`Option #${i}`" :value="i" />
                  </v-radio-group>
                </v-card-text>
                <v-divider />
                <v-card-actions>
                  <v-btn text="Close" @click="isActive.value = false" />
                  <v-btn color="surface-variant" text="Save" variant="flat" @click="isActive.value = false" />
                </v-card-actions>
              </v-card>
            </v-dialog>
          </v-btn>
          <v-btn text="Open sidebar" @click="sidebar = true" />
          <!-- <v-btn text="Dummy" /> -->
        </v-row>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const sidebar = ref(false)
</script>
```
