### PR TITLE
fix(VDataTable): expand rows when items are plain array

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/expand.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/expand.ts
@@ -2,7 +2,7 @@
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { inject, provide, toRef } from 'vue'
+import { inject, provide, toRaw, toRef } from 'vue'
 import { propsFactory } from '@/util'
 
 // Types
@@ -42,18 +42,21 @@ export function provideExpanded (props: ExpandProps) {
 
   function expand (item: DataTableItem, value: boolean) {
     const newExpanded = new Set(expanded.value)
+    const rawValue = toRaw(item.value)
 
     if (!value) {
-      newExpanded.delete(item.value)
+      const item = [...expanded.value].find(x => toRaw(x) === rawValue)!
+      newExpanded.delete(item)
     } else {
-      newExpanded.add(item.value)
+      newExpanded.add(rawValue)
     }
 
     expanded.value = newExpanded
   }
 
   function isExpanded (item: DataTableItem) {
-    return expanded.value.has(item.value)
+    const rawValue = toRaw(item.value)
+    return [...expanded.value].some(x => toRaw(x) === rawValue)
   }
 
   function toggleExpand (item: DataTableItem) {


### PR DESCRIPTION
- when we add plain objects to the Set, model gets "proxied", so they change and won't match - `has()`, `delete()` do not work
- (prior to [#21128](https://github.com/vuetifyjs/vuetify/pull/21128)) only happened when using `return-object` and plain array of items

fixes #22080
reverts #21128

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-data-table
        v-model:expanded="expanded1"
        :headers="headers"
        :items="items1"
        hide-default-footer
        return-object
        show-expand
      >
        <template #expanded-row="data"> {{ data.item }} </template>
      </v-data-table>
      <pre>expanded1: {{ JSON.stringify(expanded1) }}</pre>

      <v-divider />

      <v-data-table
        v-model:expanded="expanded2"
        :headers="headers"
        :items="items2"
        hide-default-footer
        return-object
        show-expand
      >
        <template #expanded-row="data"> {{ data.item }} </template>
      </v-data-table>
      <pre>expanded2: {{ JSON.stringify(expanded2) }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const headers = [
    { title: 'Title', value: 'title' },
    { title: 'value', value: 'value' },
  ]

  const items1 = [
    { title: 'A', value: 1 },
    { title: 'B', value: 2 },
    { title: 'C', value: 3 },
  ]

  const items2 = ref([
    { title: 'A', value: 1 },
    { title: 'B', value: 2 },
    { title: 'C', value: 3 },
  ])

  const expanded1 = ref([items1[0]])
  const expanded2 = ref([items2.value[2]])
</script>
```
