### PR TITLE
Delete items prop from v-infinite-scroll usage

### DIFF
--- a/packages/docs/src/examples/v-infinite-scroll/usage.vue
+++ b/packages/docs/src/examples/v-infinite-scroll/usage.vue
@@ -9,7 +9,6 @@
     <div>
       <v-infinite-scroll
         v-bind="props"
-        :items="items.value"
         @load="load"
       >
         <template v-for="(item, index) in items" :key="item">
@@ -64,7 +63,7 @@
   })
 
   const code = computed(() => {
-    return `<v-infinite-scroll${propsToString(props.value, ['items'])}>${slots.value}</v-infinite-scroll>`
+    return `<v-infinite-scroll>${slots.value}</v-infinite-scroll>`
   })
 
   const script = computed(() => {


### PR DESCRIPTION
## Description
`items` is not a `v-infinite-scroll`  prop.
