### PR TITLE
fix: (VListItem) fix incorrect tab index

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -283,13 +283,13 @@ export const VListItem = genericComponent<VListItemSlots>()({
             dimensionStyles.value,
             props.style,
           ]}
-          tabindex={ isClickable.value ? (list ? -2 : 0) : undefined }
           aria-selected={ ariaSelected.value }
           role={ role.value }
           onClick={ onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && rippleOptions.value }
           { ...link.linkProps }
+          tabindex={ isClickable.value ? (list ? -2 : 0) : undefined }
         >
           { genOverlays(isClickable.value || isActive.value, 'v-list-item') }
 


### PR DESCRIPTION
Fixes regression introduced by #22082 issue #22071 

## Description
Changed order so tabindex will overwrite the tabindex inside `linkProps`

## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```
<template>
  <v-app>
    <v-container>
      <v-select
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        label="Select"
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">

</script>

```
