### PR TITLE
docs(internationalization): Correct example for overriding i18n strings

### DIFF
--- a/packages/docs/src/pages/en/features/internationalization.md
+++ b/packages/docs/src/pages/en/features/internationalization.md
@@ -186,6 +186,7 @@ const messages = {
   en: {
     ...en,
     dataFooter: {
+      ...en.dataFooter,
       itemsPerPageText: 'Items per page:',
       pageText: '{0}-{1} of {2}',
     },
@@ -193,6 +194,7 @@ const messages = {
   sv: {
     ...sv,
     dataFooter: {
+      ...sv.dataFooter,
       itemsPerPageText: 'Element per sida:',
       pageText: '{0}-{1} av {2}',
     },


### PR DESCRIPTION
Based on experiences with vuetify 3.9.2 and vue-i18n 11.1.4. Correct the translation keys in the example as well.


## Description
Fixes incorrect documentation for overriding vuetify i18n strings.
If the documentation is in fact correct as it is now, then the override functionality is bugged. The following example did however work fine in my case.

## Markup:

```vue
import { createVuetify } from 'vuetify'
import {en as vuetify_text_en, sv as vuetify_text_sv} from 'vuetify/locale'

export const vuetify = createVuetify({
  theme: {
    defaultTheme: 'light',
    //
  },
  locale: {
    //t: (key, ...params) => i18n.t(key, params),
    messages: {
      en: {
        ...vuetify_text_en,
        dataFooter: {
          itemsPerPageText: 'Rows per page:',
          pageText: '{0}-{1} av {2}',
        }  
      },
      sv: {
        ...vuetify_text_sv,
        dataFooter: {
          ...vuetify_text_sv.dataFooter,
          itemsPerPageText: 'Rader per sida:',
          pageText: '{0}-{1} av {2}'
        },
      },
    },
    locale: "sv"
  },
})
```

Playground: [play.vuetifyjs.com](https://play.vuetifyjs.com/#eNqVVN1q2zAUfpWDbtJCLDUJgxLS0N2MXZZRdjOPosQniTZZFpLipgS/+44tO3WcMlKDsc7P951f69eRebcW5R6D2rzxP57Nmcpt4QIcYe1QBvwZbVDBxhU5jFrfUWo6RzQgPbT6l4CH8IJmDL68UPtywCJ0sZYaiSw1eGjo1oXxoYPBw3kWN8fUAIQd5jiH5gyQ4UbudXiOypFW210YjaNNiPpbNVIMdYIJEeZw8xffxsA5t9LJ3N/CwxLU5N7wEC2tumXL0Xu5RX/iAEDTE6BmGvbh3ZjJIL8VRUB3hgFQAXP/hO6JyJ8JRlX8KF49WHSUwRbnXTnxqVWt2/GuSo6TCmQJx2nVd6sAOiGWXz++/G+2vrwm20sUf/c9S/SjumRWF0WvV5m8urBeXSdEd+q+3XxT5suUdXOvblPDxs2Wf7W2zpxWfEGJWU1rtazdFmUirW2OjUAbGKQy6FoVwHfUuoDXwumsU5FfXXUS5EojiA4thvBaE9kXoheVRL92ygbwGPZ2uRBRJBNlG/+sJJeWfsnCUMbNBNLW4FN2mknKqKRaTtkuBOvnQqwzQ7AMtSodNxiEsbl4JDfh9iaoHJOsyB9n/AufTkWmfOjrOfo8WTlaP3TEkrK2u02ceuhXxGo9KcTkjs9iiFaXaLnydYwPudvr4FMhZvxeaLVqoUKZDA88H7ILKqdElzgku0N3bccGsLOuDWwXnWtWkDaQVWMWcTTa2BM23kjtMe5l7/aN6t//AKwCzkk=)