### PR TITLE
feat(VNumberInput): add `grouping` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VNumberInput.json
+++ b/packages/api-generator/src/locale/en/VNumberInput.json
@@ -2,8 +2,8 @@
   "props": {
     "controlVariant": "Controls layout of the stepper buttons.",
     "decimalSeparator": "Expects single character to be used as decimal separator.",
-    "grouping ": "Enables grouping using current locale or specific character passed to `group-separator`. Note: `'auto'` is recommended over `true`.",
-    "group-separator ": "Expects single character to be used for grouping digits in large numbers.",
+    "grouping": "Enables grouping using current locale or specific character passed to `group-separator`. Note: `'auto'` is recommended over `true`.",
+    "group-separator": "Expects single character to be used for grouping digits in large numbers.",
     "hideInput": "Hide the input field.",
     "inset": "Applies an indentation to the dividers used in the stepper buttons.",
     "max": "Specifies the maximum allowable value for the input.",

--- a/packages/api-generator/src/locale/en/VNumberInput.json
+++ b/packages/api-generator/src/locale/en/VNumberInput.json
@@ -2,6 +2,8 @@
   "props": {
     "controlVariant": "Controls layout of the stepper buttons.",
     "decimalSeparator": "Expects single character to be used as decimal separator.",
+    "grouping ": "Enables grouping using current locale or specific character passed to `group-separator`. Note: `'auto'` is recommended over `true`.",
+    "group-separator ": "Expects single character to be used for grouping digits in large numbers.",
     "hideInput": "Hide the input field.",
     "inset": "Applies an indentation to the dividers used in the stepper buttons.",
     "max": "Specifies the maximum allowable value for the input.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -263,8 +263,8 @@
   "VNumberInput": {
     "props": {
       "autocomplete": "3.10.0",
-      "grouping": "3.11.0",
-      "groupingSeparator": "3.11.0"
+      "grouping": "4.1.0",
+      "groupingSeparator": "4.1.0"
     }
   },
   "VOtpInput": {

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -264,7 +264,7 @@
     "props": {
       "autocomplete": "3.10.0",
       "grouping": "4.1.0",
-      "groupingSeparator": "4.1.0"
+      "groupSeparator": "4.1.0"
     }
   },
   "VOtpInput": {

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -262,7 +262,9 @@
   },
   "VNumberInput": {
     "props": {
-      "autocomplete": "3.10.0"
+      "autocomplete": "3.10.0",
+      "grouping": "3.11.0",
+      "groupingSeparator": "3.11.0"
     }
   },
   "VOtpInput": {

--- a/packages/docs/src/examples/v-number-input/prop-grouping.vue
+++ b/packages/docs/src/examples/v-number-input/prop-grouping.vue
@@ -8,7 +8,7 @@
           v-model="example1"
           :precision="0"
           grouping="min2"
-        />
+        ></v-number-input>
       </v-col>
 
       <v-col cols="12" md="4" sm="6">
@@ -18,7 +18,7 @@
           :precision="2"
           group-separator="'"
           grouping
-        />
+        ></v-number-input>
       </v-col>
 
       <v-col cols="12" md="4" sm="6">
@@ -28,7 +28,7 @@
             v-model="example3"
             :precision="2"
             grouping
-          />
+          ></v-number-input>
         </v-locale-provider>
       </v-col>
 

--- a/packages/docs/src/examples/v-number-input/prop-grouping.vue
+++ b/packages/docs/src/examples/v-number-input/prop-grouping.vue
@@ -1,0 +1,45 @@
+<template>
+  <v-container fluid>
+    <v-row wrap>
+
+      <v-col cols="12" md="4" sm="6">
+        <h5 class="mt-0 mb-2">grouping="min2"</h5>
+        <v-number-input
+          v-model="example1"
+          :precision="0"
+          grouping="min2"
+        />
+      </v-col>
+
+      <v-col cols="12" md="4" sm="6">
+        <h5 class="mt-0 mb-2">custom separator</h5>
+        <v-number-input
+          v-model="example2"
+          :precision="2"
+          group-separator="'"
+          grouping
+        />
+      </v-col>
+
+      <v-col cols="12" md="4" sm="6">
+        <h5 class="mt-0 mb-2">locale="de"</h5>
+        <v-locale-provider locale="de">
+          <v-number-input
+            v-model="example3"
+            :precision="2"
+            grouping
+          />
+        </v-locale-provider>
+      </v-col>
+
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const example1 = ref(10000)
+  const example2 = ref(12300000)
+  const example3 = ref(250000.5)
+</script>

--- a/packages/docs/src/examples/v-number-input/prop-grouping.vue
+++ b/packages/docs/src/examples/v-number-input/prop-grouping.vue
@@ -17,7 +17,7 @@
           v-model="example2"
           :precision="2"
           group-separator="'"
-          grouping
+          grouping="auto"
         ></v-number-input>
       </v-col>
 
@@ -27,7 +27,7 @@
           <v-number-input
             v-model="example3"
             :precision="2"
-            grouping
+            grouping="auto"
           ></v-number-input>
         </v-locale-provider>
       </v-col>

--- a/packages/docs/src/pages/en/components/number-inputs.md
+++ b/packages/docs/src/pages/en/components/number-inputs.md
@@ -94,3 +94,9 @@ The `step` prop behaves the same as the `step` attribute in the `<input type="nu
 The `precision` prop enforces strict precision. It is expected to be an integer value in range between `0` and `15`. Input will prevent user from typing or pasting an invalid value.
 
 <ExamplesExample file="v-number-input/prop-precision" />
+
+#### Grouping
+
+The `grouping` prop enables digit grouping (e.g. thousands separators). It can be set to `"auto"` for locale-default grouping or `"min2"` for minimum 2-digit grouping. Use `group-separator` to override the separator character.
+
+<ExamplesExample file="v-number-input/prop-grouping" />

--- a/packages/docs/src/pages/en/components/number-inputs.md
+++ b/packages/docs/src/pages/en/components/number-inputs.md
@@ -97,6 +97,6 @@ The `precision` prop enforces strict precision. It is expected to be an integer 
 
 #### Grouping
 
-The `grouping` prop enables digit grouping (e.g. thousands separators). It can be set to `"auto"` for locale-default grouping or `"min2"` for minimum 2-digit grouping. Use `group-separator` to override the separator character.
+The `grouping` prop enables digit grouping (e.g. thousands separators). The value is passed to [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#usegrouping) - `"auto"` should be preferred over `true`. Use `group-separator` to override the separator character.
 
 <ExamplesExample file="v-number-input/prop-grouping" />

--- a/packages/docs/src/pages/en/getting-started/browser-support.md
+++ b/packages/docs/src/pages/en/getting-started/browser-support.md
@@ -33,7 +33,7 @@ This is not an exhaustive list of compatible browsers, but the main targeted one
 | Other Browsers          |         | ❓ Not officially supported       |
 
 <p class="text-body-small">* All browsers on iOS use WebKit and have the same support as Safari</p>
-<p class="text-body-small">** Some components may have incorrect colors due to lack of support for <AppLink href="https://www.w3.org/TR/css-color-5/#relative-colors">relative color syntax</AppLink> (e.g. <v-code>rgb(from ...)</v-code>)</p>
+<p class="text-body-small">** Some components may have incorrect colors due to lack of support for <AppLink href="https://www.w3.org/TR/css-color-5/#relative-colors">relative color syntax</AppLink> (e.g. <v-code>rgb(from ...)</v-code>). VNumberInput locale-aware grouping requires <v-code>Intl.NumberFormat</v-code> with string <v-code>useGrouping</v-code> options (Chrome 106+, Firefox 115+).</p>
 
 This table is updated with minor releases of Vuetify. Chrome, Firefox, and Safari will be supported at least two years back from the Vuetify x.x.0 release date.
 Current start date is December 2023.

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -238,7 +238,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         return
       }
 
-      let inferredPrecision = Math.max(inferPrecision(toNumber(inputText.value)), inferPrecision(props.step))
+      const inferredPrecision = Math.max(inferPrecision(toNumber(inputText.value)), inferPrecision(props.step))
       if (increment) {
         if (canIncrease.value) inputText.value = correctPrecision(model.value + props.step, inferredPrecision)
       } else {

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -113,15 +113,16 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     const groupSeparator = computed(() => props.groupSeparator?.[0] || numericGroupSeparatorFromLocale.value)
 
     function toNumber (val: string | null | undefined) {
-      return Number(val
-        ?.replaceAll(groupSeparator.value, '')
-        .replace(decimalSeparator.value, '.'))
+      const stripped = props.grouping ? val?.replaceAll(groupSeparator.value, '') : val
+      return Number(stripped?.replace(decimalSeparator.value, '.'))
     }
 
     function correctPrecision (val: number, precision?: number | null, trim = true) {
       precision ??= isFocused.value && trim ? undefined : props.precision ?? undefined
       return new Intl.NumberFormat(locale.value, {
-        minimumFractionDigits: props.minFractionDigits ?? precision,
+        minimumFractionDigits: props.minFractionDigits && precision != null
+          ? Math.min(props.minFractionDigits, precision)
+          : (props.minFractionDigits ?? precision),
         maximumFractionDigits: precision,
         useGrouping: props.grouping,
       }).format(val)

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -68,6 +68,14 @@ const makeVNumberInputProps = propsFactory({
     type: String,
     validator: (v: any) => !v || v.length === 1,
   },
+  grouping: {
+    type: [Boolean, String] as PropType<'always' | 'auto' | 'min2' | boolean>,
+    default: false,
+  },
+  groupSeparator: {
+    type: String,
+    validator: (v: any) => !v || v.length === 1,
+  },
 
   ...omit(makeVTextFieldProps(), ['modelValue', 'validationValue']),
 }, 'VNumberInput')
@@ -95,32 +103,29 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const isFocused = shallowRef(props.focused)
 
-    const { decimalSeparator: decimalSeparatorFromLocale } = useLocale()
+    const {
+      current: locale,
+      decimalSeparator: decimalSeparatorFromLocale,
+      numericGroupSeparator: numericGroupSeparatorFromLocale,
+    } = useLocale()
     const decimalSeparator = computed(() => props.decimalSeparator?.[0] || decimalSeparatorFromLocale.value)
+    const groupSeparator = computed(() => props.groupSeparator?.[0] || numericGroupSeparatorFromLocale.value)
 
-    function correctPrecision (val: number, precision = props.precision, trim = true) {
-      const fixed = precision == null
-        ? String(val)
-        : val.toFixed(precision)
+    function toNumber (val: string | null | undefined) {
+      return Number(val
+        ?.replaceAll(groupSeparator.value, '')
+        .replace(decimalSeparator.value, '.'))
+    }
 
-      if (isFocused.value && trim) {
-        return Number(fixed).toString() // trim zeros
-          .replace('.', decimalSeparator.value)
-      }
-
-      if (props.minFractionDigits === null || (precision !== null && precision < props.minFractionDigits)) {
-        return fixed.replace('.', decimalSeparator.value)
-      }
-
-      let [baseDigits, fractionDigits] = fixed.split('.')
-
-      fractionDigits = (fractionDigits ?? '').padEnd(props.minFractionDigits, '0')
-        .replace(new RegExp(`(?<=\\d{${props.minFractionDigits}})0+$`, 'g'), '')
-
-      return [
-        baseDigits,
-        fractionDigits,
-      ].filter(Boolean).join(decimalSeparator.value)
+    function correctPrecision (val: number, precision?: number | null, trim = true) {
+      precision ??= isFocused.value && trim ? undefined : props.precision ?? undefined
+      return new Intl.NumberFormat(locale.value, {
+        minimumFractionDigits: props.minFractionDigits ?? precision,
+        maximumFractionDigits: precision,
+        useGrouping: props.grouping,
+      }).format(val)
+        .replaceAll(numericGroupSeparatorFromLocale.value, groupSeparator.value)
+        .replace(decimalSeparatorFromLocale.value, decimalSeparator.value)
     }
 
     const model = useProxiedModel(props, 'modelValue', null,
@@ -137,7 +142,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (
         isFocused.value &&
           !controlsDisabled.value &&
-          Number(_inputText.value?.replace(decimalSeparator.value, '.')) === val
+          toNumber(_inputText.value) === val
       ) {
         // ignore external changes while typing
         // e.g. 5.01{backspace}2 » should result in 5.02
@@ -147,7 +152,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         _lastParsedValue.value = null
       } else if (!isNaN(val)) {
         _inputText.value = correctPrecision(val)
-        _lastParsedValue.value = Number(_inputText.value.replace(decimalSeparator.value, '.'))
+        _lastParsedValue.value = toNumber(_inputText.value)
       }
     }, { immediate: true })
 
@@ -160,7 +165,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
           _lastParsedValue.value = null
           return
         }
-        const parsedValue = Number(val.replace(decimalSeparator.value, '.'))
+        const parsedValue = toNumber(val)
         if (!isNaN(parsedValue)) {
           _inputText.value = val
           _lastParsedValue.value = parsedValue
@@ -174,7 +179,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     const isOutOfRange = computed(() => {
       if (_lastParsedValue.value === null) return false
-      const numberFromText = Number(_inputText.value?.replace(decimalSeparator.value, '.'))
+      const numberFromText = toNumber(_inputText.value)
       return numberFromText !== clamp(numberFromText, props.min, props.max)
     })
 
@@ -216,11 +221,11 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     watch(() => props.precision, () => formatInputValue())
     watch(() => props.minFractionDigits, () => formatInputValue())
 
-    function inferPrecision (value: number | null) {
+    function inferPrecision (value: number | string | null) {
       if (value == null) return 0
       const str = value.toString()
-      const idx = str.indexOf('.')
-      return ~idx ? str.length - idx : 0
+      const idx = str.indexOf('.') + 1
+      return idx ? str.length - idx : 0
     }
 
     function toggleUpDown (increment = true) {
@@ -230,8 +235,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         return
       }
 
-      let inferredPrecision = Math.max(inferPrecision(model.value), inferPrecision(props.step))
-      if (props.precision != null) inferredPrecision = Math.max(inferredPrecision, props.precision)
+      let inferredPrecision = Math.max(inferPrecision(toNumber(inputText.value)), inferPrecision(props.step))
       if (increment) {
         if (canIncrease.value) inputText.value = correctPrecision(model.value + props.step, inferredPrecision)
       } else {
@@ -331,7 +335,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (controlsDisabled.value) return
       if (!vTextFieldRef.value) return
       const actualText = vTextFieldRef.value.value
-      const parsedValue = Number(actualText.replace(decimalSeparator.value, '.'))
+      const parsedValue = toNumber(actualText)
       if (actualText && !isNaN(parsedValue)) {
         inputText.value = correctPrecision(clamp(parsedValue, props.min, props.max))
       } else {
@@ -352,8 +356,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         inputText.value = null
         return
       }
-      inputText.value = model.value.toString()
-        .replace('.', decimalSeparator.value)
+      inputText.value = correctPrecision(model.value)
     }
 
     function onFocus () {

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -8,6 +8,7 @@ import { VDivider } from '@/components/VDivider'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
 
 // Composables
+import { formatNumber, parseNumber } from './format'
 import { useHold } from './hold'
 import { processGroupedInput, processPlainInput } from './typing'
 import { useForm } from '@/composables/form'
@@ -113,21 +114,21 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     const groupSeparator = computed(() => props.groupSeparator?.[0] || numericGroupSeparatorFromLocale.value)
 
     function toNumber (val: string | null | undefined) {
-      const stripped = props.grouping ? val?.replaceAll(groupSeparator.value, '') : val
-      return Number(stripped?.replace(decimalSeparator.value, '.'))
+      return parseNumber(val, groupSeparator.value, decimalSeparator.value, !!props.grouping)
     }
 
     function correctPrecision (val: number, precision?: number | null, trim = true) {
       precision ??= isFocused.value && trim ? undefined : props.precision ?? undefined
-      return new Intl.NumberFormat(locale.value, {
-        minimumFractionDigits: props.minFractionDigits && precision != null
-          ? Math.min(props.minFractionDigits, precision)
-          : (props.minFractionDigits ?? precision),
-        maximumFractionDigits: precision,
+      return formatNumber(val, {
+        locale: locale.value,
+        precision,
+        minFractionDigits: props.minFractionDigits,
         useGrouping: props.grouping,
-      }).format(val)
-        .replaceAll(numericGroupSeparatorFromLocale.value, groupSeparator.value)
-        .replace(decimalSeparatorFromLocale.value, decimalSeparator.value)
+        localeDecimalSeparator: decimalSeparatorFromLocale.value,
+        localeGroupSeparator: numericGroupSeparatorFromLocale.value,
+        decimalSeparator: decimalSeparator.value,
+        groupSeparator: groupSeparator.value,
+      })
     }
 
     const model = useProxiedModel(props, 'modelValue', null,

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -262,6 +262,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             decimalSeparator: decimalSeparator.value,
             precision: props.precision,
             grouping: props.grouping,
+            locale: locale.value,
           }
         )
         : processPlainInput(

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -110,6 +110,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       decimalSeparator: decimalSeparatorFromLocale,
       numericGroupSeparator: numericGroupSeparatorFromLocale,
     } = useLocale()
+
     const decimalSeparator = computed(() => props.decimalSeparator?.[0] || decimalSeparatorFromLocale.value)
     const groupSeparator = computed(() => props.groupSeparator?.[0] || numericGroupSeparatorFromLocale.value)
 
@@ -124,8 +125,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         precision,
         minFractionDigits: props.minFractionDigits,
         useGrouping: props.grouping,
-        localeDecimalSeparator: decimalSeparatorFromLocale.value,
-        localeGroupSeparator: numericGroupSeparatorFromLocale.value,
         decimalSeparator: decimalSeparator.value,
         groupSeparator: groupSeparator.value,
       })

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -9,6 +9,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 
 // Composables
 import { useHold } from './hold'
+import { processGroupedInput, processPlainInput } from './typing'
 import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useLocale } from '@/composables/locale'
@@ -16,7 +17,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, nextTick, ref, shallowRef, toRef, watch } from 'vue'
-import { clamp, escapeForRegex, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { clamp, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -245,43 +246,38 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
     function onBeforeinput (e: InputEvent) {
       if (controlsDisabled.value) return
-      if (!e.data) return
       const inputElement = e.target as HTMLInputElement
-      const { value: existingTxt, selectionStart, selectionEnd } = inputElement ?? {}
 
-      const potentialNewInputVal =
-        existingTxt
-          ? existingTxt.slice(0, selectionStart as number | undefined) + e.data + existingTxt.slice(selectionEnd as number | undefined)
-          : e.data
+      const result = props.grouping
+        ? processGroupedInput(
+          e.inputType,
+          e.data,
+          inputElement.value ?? '',
+          inputElement.selectionStart ?? 0,
+          inputElement.selectionEnd ?? 0,
+          {
+            groupSeparator: groupSeparator.value,
+            decimalSeparator: decimalSeparator.value,
+            precision: props.precision,
+            grouping: props.grouping,
+          }
+        )
+        : processPlainInput(
+          e.data,
+          inputElement.value ?? '',
+          inputElement.selectionStart ?? 0,
+          inputElement.selectionEnd ?? 0,
+          {
+            decimalSeparator: decimalSeparator.value,
+            precision: props.precision,
+          }
+        )
 
-      const potentialNewNumber = extractNumber(potentialNewInputVal, props.precision, decimalSeparator.value)
-
-      // Allow only numbers, "-" and {decimal separator}
-      // Allow "-" and {decimal separator} only once
-      // Allow "-" only at the start
-      if (!new RegExp(`^-?\\d*${escapeForRegex(decimalSeparator.value)}?\\d*$`).test(potentialNewInputVal)) {
-        e.preventDefault()
-        inputElement!.value = potentialNewNumber
-        nextTick(() => inputText.value = potentialNewNumber)
-      }
-
-      if (props.precision == null) return
-
-      // Ignore decimal digits above precision limit
-      if (potentialNewInputVal.split(decimalSeparator.value)[1]?.length > props.precision) {
-        e.preventDefault()
-        inputElement!.value = potentialNewNumber
-        nextTick(() => inputText.value = potentialNewNumber)
-
-        const cursorPosition = (selectionStart ?? 0) + e.data.length
-        inputElement!.setSelectionRange(cursorPosition, cursorPosition)
-      }
-      // Ignore decimal separator when precision = 0
-      if (props.precision === 0 && potentialNewInputVal.endsWith(decimalSeparator.value)) {
-        e.preventDefault()
-        inputElement!.value = potentialNewNumber
-        nextTick(() => inputText.value = potentialNewNumber)
-      }
+      if (result === null) return
+      e.preventDefault()
+      inputElement.value = result.text
+      inputElement.setSelectionRange(result.cursor, result.cursor)
+      nextTick(() => inputText.value = result.text)
     }
 
     async function onKeydown (e: KeyboardEvent) {

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -8,7 +8,7 @@ import { VDivider } from '@/components/VDivider'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
 
 // Composables
-import { formatNumber, parseNumber } from './format'
+import { formatNumber } from './format'
 import { useHold } from './hold'
 import { processGroupedInput, processPlainInput } from './typing'
 import { useForm } from '@/composables/form'
@@ -76,7 +76,7 @@ const makeVNumberInputProps = propsFactory({
   },
   groupSeparator: {
     type: String,
-    validator: (v: any) => !v || v.length === 1,
+    validator: (v: any) => !v || (v.length === 1 && !/[0-9+-]/.test(v)),
   },
 
   ...omit(makeVTextFieldProps(), ['modelValue', 'validationValue']),
@@ -115,7 +115,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     const groupSeparator = computed(() => props.groupSeparator?.[0] || numericGroupSeparatorFromLocale.value)
 
     function toNumber (val: string | null | undefined) {
-      return parseNumber(val, groupSeparator.value, decimalSeparator.value, !!props.grouping)
+      return Number(val?.replace(decimalSeparator.value, '.').replace(/[^0-9.-]/g, ''))
     }
 
     function correctPrecision (val: number, precision?: number | null, trim = true) {

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -220,8 +220,10 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       },
     }
 
-    watch(() => props.precision, () => formatInputValue())
-    watch(() => props.minFractionDigits, () => formatInputValue())
+    watch(
+      () => [locale.value, decimalSeparator.value, groupSeparator.value, props.precision, props.minFractionDigits],
+      () => formatInputValue()
+    )
 
     function inferPrecision (value: number | string | null) {
       if (value == null) return 0
@@ -276,9 +278,12 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         )
 
       if (result === null) return
+
       e.preventDefault()
+
       inputElement.value = result.text
       inputElement.setSelectionRange(result.cursor, result.cursor)
+
       nextTick(() => inputText.value = result.text)
     }
 

--- a/packages/vuetify/src/components/VNumberInput/__tests__/format.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/format.spec.ts
@@ -1,0 +1,119 @@
+import { formatNumber, parseNumber } from '../format'
+
+interface FormatNumberOptions {
+  locale: string
+  precision?: number | null
+  minFractionDigits?: number | null
+  useGrouping: Intl.NumberFormatOptions['useGrouping']
+  decimalSeparator: string
+  groupSeparator: string
+}
+
+const defaults: FormatNumberOptions = {
+  locale: 'en-US',
+  useGrouping: true,
+  decimalSeparator: '.',
+  groupSeparator: ',',
+}
+
+function opts (overrides: Partial<FormatNumberOptions> = {}): FormatNumberOptions {
+  return { ...defaults, ...overrides }
+}
+
+describe('format', () => {
+  describe('formatNumber', () => {
+    it('formats integer with grouping', () => {
+      expect(formatNumber(1234567, opts())).toBe('1,234,567')
+    })
+
+    it('formats integer without grouping', () => {
+      expect(formatNumber(1234567, opts({ useGrouping: false }))).toBe('1234567')
+    })
+
+    it('respects precision', () => {
+      expect(formatNumber(1.23456, opts({ precision: 2 }))).toBe('1.23')
+    })
+
+    it('respects minFractionDigits', () => {
+      expect(formatNumber(1.2, opts({ minFractionDigits: 3 }))).toBe('1.200')
+    })
+
+    it('caps minFractionDigits to precision', () => {
+      expect(formatNumber(1.2, opts({ minFractionDigits: 5, precision: 2 }))).toBe('1.20')
+    })
+
+    it('swaps separators by part type without collisions (de-DE → custom)', () => {
+      // de-DE uses "." for groups and "," for decimal — swapping by string would collide
+      const o = opts({
+        locale: 'de-DE',
+        decimalSeparator: '.',
+        groupSeparator: ',',
+      })
+      expect(formatNumber(1234567.89, { ...o, precision: 2 })).toBe('1,234,567.89')
+    })
+
+    it('uses custom separators distinct from locale defaults', () => {
+      const o = opts({
+        locale: 'de-DE',
+        decimalSeparator: '·',
+        groupSeparator: ' ',
+      })
+      expect(formatNumber(1234.5, { ...o, precision: 1 })).toBe('1 234·5')
+    })
+
+    it('normalizes Arabic-Indic digits from locale formatter', () => {
+      const result = formatNumber(1234, opts({ locale: 'ar-SA' }))
+      expect(result).toBe('1,234')
+    })
+
+    it('handles negative numbers', () => {
+      expect(formatNumber(-1234.5, opts({ precision: 1 }))).toBe('-1,234.5')
+    })
+
+    it('handles zero', () => {
+      expect(formatNumber(0, opts())).toBe('0')
+    })
+  })
+
+  describe('parseNumber', () => {
+    it('parses plain integer', () => {
+      expect(parseNumber('1234', ',', '.', false)).toBe(1234)
+    })
+
+    it('parses grouped integer', () => {
+      expect(parseNumber('1,234,567', ',', '.', true)).toBe(1234567)
+    })
+
+    it('parses decimal', () => {
+      expect(parseNumber('1234.56', ',', '.', false)).toBe(1234.56)
+    })
+
+    it('parses grouped decimal', () => {
+      expect(parseNumber('1,234.56', ',', '.', true)).toBe(1234.56)
+    })
+
+    it('parses negative number', () => {
+      expect(parseNumber('-1,234.56', ',', '.', true)).toBe(-1234.56)
+    })
+
+    it('parses with custom separators', () => {
+      expect(parseNumber('1 234,56', ' ', ',', true)).toBe(1234.56)
+    })
+
+    it('does not strip group separator when hasGrouping is false', () => {
+      expect(parseNumber('1,234', ',', '.', false)).toBeNaN()
+    })
+
+    it('returns NaN for null', () => {
+      expect(parseNumber(null, ',', '.', true)).toBeNaN()
+    })
+
+    it('returns NaN for undefined', () => {
+      expect(parseNumber(undefined, ',', '.', true)).toBeNaN()
+    })
+
+    it('parses empty string as 0', () => {
+      expect(parseNumber('', ',', '.', true)).toBe(0)
+    })
+  })
+})

--- a/packages/vuetify/src/components/VNumberInput/__tests__/format.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/format.spec.ts
@@ -66,5 +66,4 @@ describe('format', () => {
       expect(result).toBe('1,234')
     })
   })
-
 })

--- a/packages/vuetify/src/components/VNumberInput/__tests__/format.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/format.spec.ts
@@ -1,4 +1,4 @@
-import { formatNumber, parseNumber } from '../format'
+import { formatNumber } from '../format'
 
 interface FormatNumberOptions {
   locale: string
@@ -65,55 +65,6 @@ describe('format', () => {
       const result = formatNumber(1234, opts({ locale: 'ar-SA' }))
       expect(result).toBe('1,234')
     })
-
-    it('handles negative numbers', () => {
-      expect(formatNumber(-1234.5, opts({ precision: 1 }))).toBe('-1,234.5')
-    })
-
-    it('handles zero', () => {
-      expect(formatNumber(0, opts())).toBe('0')
-    })
   })
 
-  describe('parseNumber', () => {
-    it('parses plain integer', () => {
-      expect(parseNumber('1234', ',', '.', false)).toBe(1234)
-    })
-
-    it('parses grouped integer', () => {
-      expect(parseNumber('1,234,567', ',', '.', true)).toBe(1234567)
-    })
-
-    it('parses decimal', () => {
-      expect(parseNumber('1234.56', ',', '.', false)).toBe(1234.56)
-    })
-
-    it('parses grouped decimal', () => {
-      expect(parseNumber('1,234.56', ',', '.', true)).toBe(1234.56)
-    })
-
-    it('parses negative number', () => {
-      expect(parseNumber('-1,234.56', ',', '.', true)).toBe(-1234.56)
-    })
-
-    it('parses with custom separators', () => {
-      expect(parseNumber('1 234,56', ' ', ',', true)).toBe(1234.56)
-    })
-
-    it('does not strip group separator when hasGrouping is false', () => {
-      expect(parseNumber('1,234', ',', '.', false)).toBeNaN()
-    })
-
-    it('returns NaN for null', () => {
-      expect(parseNumber(null, ',', '.', true)).toBeNaN()
-    })
-
-    it('returns NaN for undefined', () => {
-      expect(parseNumber(undefined, ',', '.', true)).toBeNaN()
-    })
-
-    it('parses empty string as 0', () => {
-      expect(parseNumber('', ',', '.', true)).toBe(0)
-    })
-  })
 })

--- a/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
@@ -1,14 +1,12 @@
-import {
-  addGrouping,
-  processGroupedInput,
-  processPlainInput,
-  stripGrouping,
-  toDisplayPosition,
-  toLogicalPosition,
-} from '../typing'
+import { processGroupedInput, processPlainInput } from '../typing'
 
-// Types
-import type { GroupedInputOptions } from '../typing'
+interface GroupedInputOptions {
+  groupSeparator: string
+  decimalSeparator: string
+  precision: number | null
+  grouping: 'always' | 'auto' | 'min2' | boolean
+  locale: string
+}
 
 const defaults: GroupedInputOptions = {
   groupSeparator: ',',
@@ -23,99 +21,6 @@ function opts (overrides: Partial<GroupedInputOptions> = {}): GroupedInputOption
 }
 
 describe('typing', () => {
-  describe('stripGrouping', () => {
-    it.each([
-      ['1,234', ',', '1234'],
-      ['1,234,567', ',', '1234567'],
-      ['-1,234', ',', '-1234'],
-      ['1.234.567', '.', '1234567'],
-      ['1234', ',', '1234'],
-      ['', ',', ''],
-      ['-1,234.56', ',', '-1234.56'],
-    ])('stripGrouping(%s, %s) → %s', (text, sep, expected) => {
-      expect(stripGrouping(text, sep)).toBe(expected)
-    })
-  })
-
-  describe('addGrouping', () => {
-    it.each([
-      ['1234', ',', '.', 'always', '1,234'],
-      ['12345', ',', '.', 'always', '12,345'],
-      ['123', ',', '.', 'always', '123'],
-      ['1234567', ',', '.', 'always', '1,234,567'],
-      ['-1234', ',', '.', 'always', '-1,234'],
-      ['-1234567', ',', '.', 'always', '-1,234,567'],
-      ['1234.56', ',', '.', 'always', '1,234.56'],
-      ['-1234567.89', ',', '.', 'always', '-1,234,567.89'],
-      ['12', ',', '.', 'always', '12'],
-      ['', ',', '.', 'always', ''],
-      ['-', ',', '.', 'always', '-'],
-      // min2: only group when > 4 digits
-      ['1234', ',', '.', 'min2', '1234'],
-      ['12345', ',', '.', 'min2', '12,345'],
-      // false: no grouping
-      ['1234567', ',', '.', false, '1234567'],
-      // true: same as always
-      ['1234', ',', '.', true, '1,234'],
-      // custom separators
-      ['1234,56', '.', ',', 'always', '1.234,56'],
-    ] as const)('addGrouping(%s, %s, %s, %s) → %s', (raw, groupSep, decSep, grouping, expected) => {
-      expect(addGrouping(raw, groupSep, decSep, grouping)).toBe(expected)
-    })
-
-    it.each([
-      // en-US: standard 3-digit groups
-      ['1234', ',', '.', 'always', 'en-US', '1,234'],
-      ['1234', ',', '.', 'auto', 'en-US', '1,234'],
-      ['1234', ',', '.', 'min2', 'en-US', '1234'],
-      ['12345', ',', '.', 'min2', 'en-US', '12,345'],
-      // hi-IN: 3-digit primary group, then 2-digit groups
-      ['1234567890', ',', '.', 'auto', 'hi-IN', '1,23,45,67,890'],
-      ['1234567890', ',', '.', 'always', 'hi-IN', '1,23,45,67,890'],
-      ['-1234567890.5', ',', '.', 'always', 'hi-IN', '-1,23,45,67,890.5'],
-      // custom separator with locale
-      ['1234567890', "'", '.', 'always', 'hi-IN', "1'23'45'67'890"],
-    ] as const)('addGrouping(%s, %s, %s, %s, %s) → %s', (raw, groupSep, decSep, grouping, locale, expected) => {
-      expect(addGrouping(raw, groupSep, decSep, grouping, locale)).toBe(expected)
-    })
-  })
-
-  describe('toLogicalPosition', () => {
-    // "1,234" positions: 0=before "1", 1=after "1", 2=after ",", 3=after "2", 4=after "3", 5=after "4"
-    it.each([
-      ['1,234', ',', 0, 0],
-      ['1,234', ',', 1, 1],
-      ['1,234', ',', 2, 1], // after comma → same as after "1"
-      ['1,234', ',', 3, 2],
-      ['1,234', ',', 4, 3],
-      ['1,234', ',', 5, 4],
-      ['1,234,567', ',', 5, 4],
-      ['1,234,567', ',', 6, 4], // after second comma
-      ['1,234,567', ',', 9, 7],
-      ['', ',', 0, 0],
-    ])('toLogicalPosition(%s, %s, %d) → %d', (text, sep, displayPos, expected) => {
-      expect(toLogicalPosition(text, sep, displayPos)).toBe(expected)
-    })
-  })
-
-  describe('toDisplayPosition', () => {
-    it.each([
-      ['1,234', ',', 0, 0],
-      ['1,234', ',', 1, 1],
-      ['1,234', ',', 2, 3], // logical 2 = after "12" = display 3 (skips comma)
-      ['1,234', ',', 3, 4],
-      ['1,234', ',', 4, 5],
-      ['12,345', ',', 2, 2],
-      ['12,345', ',', 3, 4],
-      ['1,234,567', ',', 1, 1],
-      ['1,234,567', ',', 4, 5],
-      ['1,234,567', ',', 7, 9],
-      ['', ',', 0, 0],
-    ])('toDisplayPosition(%s, %s, %d) → %d', (text, sep, logicalPos, expected) => {
-      expect(toDisplayPosition(text, sep, logicalPos)).toBe(expected)
-    })
-  })
-
   describe('processGroupedInput', () => {
     describe('insertText', () => {
       it('appends digit at end, triggers grouping', () => {
@@ -313,6 +218,15 @@ describe('typing', () => {
         const o = opts({ grouping: 'min2' })
         const result = processGroupedInput('insertText', '5', '1234', 4, 4, o)
         expect(result).toEqual({ text: '12,345', cursor: 6 })
+      })
+    })
+
+    describe('locale-specific grouping', () => {
+      it('uses Indian numbering system for hi-IN', () => {
+        // hi-IN: 3-digit primary group, then 2-digit groups
+        const o = opts({ locale: 'hi-IN' })
+        const result = processGroupedInput('insertFromPaste', '1234567890', '', 0, 0, o)
+        expect(result?.text).toBe('1,23,45,67,890')
       })
     })
   })

--- a/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
@@ -15,6 +15,7 @@ const defaults: GroupedInputOptions = {
   decimalSeparator: '.',
   precision: 0,
   grouping: 'always',
+  locale: 'en-US',
 }
 
 function opts (overrides: Partial<GroupedInputOptions> = {}): GroupedInputOptions {
@@ -52,8 +53,6 @@ describe('typing', () => {
       // min2: only group when > 4 digits
       ['1234', ',', '.', 'min2', '1234'],
       ['12345', ',', '.', 'min2', '12,345'],
-      ['1234', ',', '.', 'auto', '1234'],
-      ['12345', ',', '.', 'auto', '12,345'],
       // false: no grouping
       ['1234567', ',', '.', false, '1234567'],
       // true: same as always
@@ -62,6 +61,22 @@ describe('typing', () => {
       ['1234,56', '.', ',', 'always', '1.234,56'],
     ] as const)('addGrouping(%s, %s, %s, %s) → %s', (raw, groupSep, decSep, grouping, expected) => {
       expect(addGrouping(raw, groupSep, decSep, grouping)).toBe(expected)
+    })
+
+    it.each([
+      // en-US: standard 3-digit groups
+      ['1234', ',', '.', 'always', 'en-US', '1,234'],
+      ['1234', ',', '.', 'auto', 'en-US', '1,234'],
+      ['1234', ',', '.', 'min2', 'en-US', '1234'],
+      ['12345', ',', '.', 'min2', 'en-US', '12,345'],
+      // hi-IN: 3-digit primary group, then 2-digit groups
+      ['1234567890', ',', '.', 'auto', 'hi-IN', '1,23,45,67,890'],
+      ['1234567890', ',', '.', 'always', 'hi-IN', '1,23,45,67,890'],
+      ['-1234567890.5', ',', '.', 'always', 'hi-IN', '-1,23,45,67,890.5'],
+      // custom separator with locale
+      ['1234567890', "'", '.', 'always', 'hi-IN', "1'23'45'67'890"],
+    ] as const)('addGrouping(%s, %s, %s, %s, %s) → %s', (raw, groupSep, decSep, grouping, locale, expected) => {
+      expect(addGrouping(raw, groupSep, decSep, grouping, locale)).toBe(expected)
     })
   })
 

--- a/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
@@ -1,0 +1,400 @@
+import {
+  addGrouping,
+  processGroupedInput,
+  processPlainInput,
+  stripGrouping,
+  toDisplayPosition,
+  toLogicalPosition,
+} from '../typing'
+
+// Types
+import type { GroupedInputOptions } from '../typing'
+
+const defaults: GroupedInputOptions = {
+  groupSeparator: ',',
+  decimalSeparator: '.',
+  precision: 0,
+  grouping: 'always',
+}
+
+function opts (overrides: Partial<GroupedInputOptions> = {}): GroupedInputOptions {
+  return { ...defaults, ...overrides }
+}
+
+describe('typing', () => {
+  describe('stripGrouping', () => {
+    it.each([
+      ['1,234', ',', '1234'],
+      ['1,234,567', ',', '1234567'],
+      ['-1,234', ',', '-1234'],
+      ['1.234.567', '.', '1234567'],
+      ['1234', ',', '1234'],
+      ['', ',', ''],
+      ['-1,234.56', ',', '-1234.56'],
+    ])('stripGrouping(%s, %s) → %s', (text, sep, expected) => {
+      expect(stripGrouping(text, sep)).toBe(expected)
+    })
+  })
+
+  describe('addGrouping', () => {
+    it.each([
+      ['1234', ',', '.', 'always', '1,234'],
+      ['12345', ',', '.', 'always', '12,345'],
+      ['123', ',', '.', 'always', '123'],
+      ['1234567', ',', '.', 'always', '1,234,567'],
+      ['-1234', ',', '.', 'always', '-1,234'],
+      ['-1234567', ',', '.', 'always', '-1,234,567'],
+      ['1234.56', ',', '.', 'always', '1,234.56'],
+      ['-1234567.89', ',', '.', 'always', '-1,234,567.89'],
+      ['12', ',', '.', 'always', '12'],
+      ['', ',', '.', 'always', ''],
+      ['-', ',', '.', 'always', '-'],
+      // min2: only group when > 4 digits
+      ['1234', ',', '.', 'min2', '1234'],
+      ['12345', ',', '.', 'min2', '12,345'],
+      ['1234', ',', '.', 'auto', '1234'],
+      ['12345', ',', '.', 'auto', '12,345'],
+      // false: no grouping
+      ['1234567', ',', '.', false, '1234567'],
+      // true: same as always
+      ['1234', ',', '.', true, '1,234'],
+      // custom separators
+      ['1234,56', '.', ',', 'always', '1.234,56'],
+    ] as const)('addGrouping(%s, %s, %s, %s) → %s', (raw, groupSep, decSep, grouping, expected) => {
+      expect(addGrouping(raw, groupSep, decSep, grouping)).toBe(expected)
+    })
+  })
+
+  describe('toLogicalPosition', () => {
+    // "1,234" positions: 0=before "1", 1=after "1", 2=after ",", 3=after "2", 4=after "3", 5=after "4"
+    it.each([
+      ['1,234', ',', 0, 0],
+      ['1,234', ',', 1, 1],
+      ['1,234', ',', 2, 1], // after comma → same as after "1"
+      ['1,234', ',', 3, 2],
+      ['1,234', ',', 4, 3],
+      ['1,234', ',', 5, 4],
+      ['1,234,567', ',', 5, 4],
+      ['1,234,567', ',', 6, 4], // after second comma
+      ['1,234,567', ',', 9, 7],
+      ['', ',', 0, 0],
+    ])('toLogicalPosition(%s, %s, %d) → %d', (text, sep, displayPos, expected) => {
+      expect(toLogicalPosition(text, sep, displayPos)).toBe(expected)
+    })
+  })
+
+  describe('toDisplayPosition', () => {
+    it.each([
+      ['1,234', ',', 0, 0],
+      ['1,234', ',', 1, 1],
+      ['1,234', ',', 2, 3], // logical 2 = after "12" = display 3 (skips comma)
+      ['1,234', ',', 3, 4],
+      ['1,234', ',', 4, 5],
+      ['12,345', ',', 2, 2],
+      ['12,345', ',', 3, 4],
+      ['1,234,567', ',', 1, 1],
+      ['1,234,567', ',', 4, 5],
+      ['1,234,567', ',', 7, 9],
+      ['', ',', 0, 0],
+    ])('toDisplayPosition(%s, %s, %d) → %d', (text, sep, logicalPos, expected) => {
+      expect(toDisplayPosition(text, sep, logicalPos)).toBe(expected)
+    })
+  })
+
+  describe('processGroupedInput', () => {
+    describe('insertText', () => {
+      it('appends digit at end, triggers grouping', () => {
+        // "123" + "4" at end → "1,234"
+        const result = processGroupedInput('insertText', '4', '123', 3, 3, opts())
+        expect(result).toEqual({ text: '1,234', cursor: 5 })
+      })
+
+      it('appends digit to already grouped', () => {
+        // "1,234" + "5" at end → "12,345"
+        const result = processGroupedInput('insertText', '5', '1,234', 5, 5, opts())
+        expect(result).toEqual({ text: '12,345', cursor: 6 })
+      })
+
+      it('inserts digit in the middle', () => {
+        // "1,234" cursor after "1" (display 1) + "0" → raw "10234" → "10,234", cursor after "0"
+        const result = processGroupedInput('insertText', '0', '1,234', 1, 1, opts())
+        expect(result).toEqual({ text: '10,234', cursor: 2 })
+      })
+
+      it('inserts digit after group separator', () => {
+        // "1,234" cursor at display 2 (after comma, logical 1) + "0" → raw "10234" → "10,234"
+        const result = processGroupedInput('insertText', '0', '1,234', 2, 2, opts())
+        expect(result).toEqual({ text: '10,234', cursor: 2 })
+      })
+
+      it('rejects non-numeric characters', () => {
+        const result = processGroupedInput('insertText', 'a', '1,234', 5, 5, opts())
+        // "1234a" is invalid → extractNumber → "1234" → no change
+        expect(result).toEqual({ text: '1,234', cursor: 5 })
+      })
+
+      it('allows minus at start', () => {
+        const result = processGroupedInput('insertText', '-', '', 0, 0, opts())
+        expect(result).toEqual({ text: '-', cursor: 1 })
+      })
+
+      it('allows decimal separator with precision', () => {
+        const result = processGroupedInput('insertText', '.', '1234', 4, 4, opts({ precision: 2 }))
+        expect(result).toEqual({ text: '1,234.', cursor: 6 })
+      })
+
+      it('rejects decimal separator when precision=0', () => {
+        const result = processGroupedInput('insertText', '.', '1234', 4, 4, opts({ precision: 0 }))
+        expect(result).toEqual({ text: '1,234', cursor: 5 })
+      })
+
+      it('replaces selection with digit', () => {
+        // "1,234" select "23" (display 2-4 → logical 1-3) + "0" → raw "104" → "104"
+        const result = processGroupedInput('insertText', '0', '1,234', 2, 4, opts())
+        expect(result).toEqual({ text: '104', cursor: 2 })
+      })
+
+      it('enforces precision on decimal digits', () => {
+        // "1,234.56" + "7" at end, precision=2 → reject extra digit
+        const result = processGroupedInput('insertText', '7', '1,234.56', 8, 8, opts({ precision: 2 }))
+        expect(result).toEqual({ text: '1,234.56', cursor: 8 })
+      })
+    })
+
+    describe('insertFromPaste', () => {
+      it('pastes clean number', () => {
+        const result = processGroupedInput('insertFromPaste', '5678', '', 0, 0, opts())
+        expect(result).toEqual({ text: '5,678', cursor: 5 })
+      })
+
+      it('cleans dirty pasted text', () => {
+        const result = processGroupedInput('insertFromPaste', 'abc123def', '', 0, 0, opts())
+        expect(result).toEqual({ text: '123', cursor: 3 })
+      })
+
+      it('pastes into existing value', () => {
+        const result = processGroupedInput('insertFromPaste', '56', '1,234', 5, 5, opts())
+        expect(result).toEqual({ text: '123,456', cursor: 7 })
+      })
+    })
+
+    describe('deleteContentBackward', () => {
+      it('deletes last digit', () => {
+        // "1,234" backspace at end → raw "123" → "123"
+        const result = processGroupedInput('deleteContentBackward', null, '1,234', 5, 5, opts())
+        expect(result).toEqual({ text: '123', cursor: 3 })
+      })
+
+      it('deletes digit before group separator', () => {
+        // "1,234" cursor at display 1 (after "1", logical 1) → delete "1" → "234"
+        const result = processGroupedInput('deleteContentBackward', null, '1,234', 1, 1, opts())
+        expect(result).toEqual({ text: '234', cursor: 0 })
+      })
+
+      it('deletes digit when cursor is right after group separator', () => {
+        // "1,234" cursor at display 2 (after comma, logical 1) → delete char at logical 0 = "1" → "234"
+        const result = processGroupedInput('deleteContentBackward', null, '1,234', 2, 2, opts())
+        expect(result).toEqual({ text: '234', cursor: 0 })
+      })
+
+      it('no-op at start', () => {
+        const result = processGroupedInput('deleteContentBackward', null, '1,234', 0, 0, opts())
+        expect(result).toEqual({ text: '1,234', cursor: 0 })
+      })
+
+      it('deletes selection', () => {
+        // "1,234,567" select "234," (display 2-6) → delete → "1567" → "1,567"
+        const result = processGroupedInput('deleteContentBackward', null, '1,234,567', 2, 6, opts())
+        expect(result).toEqual({ text: '1,567', cursor: 1 })
+      })
+
+      it('removes separator when digit count crosses threshold', () => {
+        // "1,000" backspace at end → "100"
+        const result = processGroupedInput('deleteContentBackward', null, '1,000', 5, 5, opts())
+        expect(result).toEqual({ text: '100', cursor: 3 })
+      })
+    })
+
+    describe('deleteContentForward', () => {
+      it('deletes digit at cursor', () => {
+        // "1,234" cursor at display 0 → delete "1" → "234"
+        const result = processGroupedInput('deleteContentForward', null, '1,234', 0, 0, opts())
+        expect(result).toEqual({ text: '234', cursor: 0 })
+      })
+
+      it('deletes digit after group separator', () => {
+        // "1,234" cursor at display 2 (after comma, logical 1) → delete char at logical 1 = "2" → "134"
+        const result = processGroupedInput('deleteContentForward', null, '1,234', 2, 2, opts())
+        expect(result).toEqual({ text: '134', cursor: 1 })
+      })
+
+      it('no-op at end', () => {
+        const result = processGroupedInput('deleteContentForward', null, '1,234', 5, 5, opts())
+        expect(result).toEqual({ text: '1,234', cursor: 5 })
+      })
+    })
+
+    describe('deleteByCut', () => {
+      it('cuts selection', () => {
+        const result = processGroupedInput('deleteByCut', null, '1,234,567', 2, 6, opts())
+        expect(result).toEqual({ text: '1,567', cursor: 1 })
+      })
+    })
+
+    describe('deleteWordBackward', () => {
+      it('deletes digits backward to non-digit boundary', () => {
+        // "1,234.56" cursor at end (display 8, logical 7) → skip "56" (digits), stop at "." → "1,234."
+        const result = processGroupedInput('deleteWordBackward', null, '1,234.56', 8, 8, opts({ precision: 2 }))
+        expect(result).toEqual({ text: '1,234.', cursor: 6 })
+      })
+
+      it('deletes across decimal separator', () => {
+        // "1,234.56" cursor at display 6 (after ".", logical 5) → skip "." (non-digit) then "1234" → "56"
+        const result = processGroupedInput('deleteWordBackward', null, '1,234.56', 6, 6, opts({ precision: 2 }))
+        expect(result).toEqual({ text: '56', cursor: 0 })
+      })
+    })
+
+    describe('deleteWordForward', () => {
+      it('deletes digits forward to non-digit boundary', () => {
+        // "1,234.56" cursor at start → skip "1234" → ".56"
+        const result = processGroupedInput('deleteWordForward', null, '1,234.56', 0, 0, opts({ precision: 2 }))
+        expect(result).toEqual({ text: '.56', cursor: 0 })
+      })
+    })
+
+    describe('unknown inputType', () => {
+      it('returns null for historyUndo', () => {
+        expect(processGroupedInput('historyUndo', null, '1,234', 0, 0, opts())).toBeNull()
+      })
+
+      it('returns null for historyRedo', () => {
+        expect(processGroupedInput('historyRedo', null, '1,234', 0, 0, opts())).toBeNull()
+      })
+    })
+
+    describe('custom separators', () => {
+      it('works with period as group separator and comma as decimal', () => {
+        const o = opts({ groupSeparator: '.', decimalSeparator: ',', precision: 2 })
+        const result = processGroupedInput('insertText', '5', '1.234', 5, 5, o)
+        expect(result).toEqual({ text: '12.345', cursor: 6 })
+      })
+
+      it('handles backspace with custom separators', () => {
+        const o = opts({ groupSeparator: '.', decimalSeparator: ',', precision: 2 })
+        const result = processGroupedInput('deleteContentBackward', null, '1.234', 5, 5, o)
+        expect(result).toEqual({ text: '123', cursor: 3 })
+      })
+    })
+
+    describe('min2 grouping', () => {
+      it('does not group 4 digits', () => {
+        const o = opts({ grouping: 'min2' })
+        const result = processGroupedInput('insertText', '4', '123', 3, 3, o)
+        expect(result).toEqual({ text: '1234', cursor: 4 })
+      })
+
+      it('groups 5 digits', () => {
+        const o = opts({ grouping: 'min2' })
+        const result = processGroupedInput('insertText', '5', '1234', 4, 4, o)
+        expect(result).toEqual({ text: '12,345', cursor: 6 })
+      })
+    })
+  })
+
+  describe('processPlainInput', () => {
+    const plain = (overrides: Partial<{ decimalSeparator: string, precision: number | null }> = {}) => ({
+      decimalSeparator: '.',
+      precision: 0 as number | null,
+      ...overrides,
+    })
+
+    describe('valid input passthrough', () => {
+      it('returns null for valid digit', () => {
+        expect(processPlainInput('5', '12', 2, 2, plain())).toBeNull()
+      })
+
+      it('returns null for minus at start', () => {
+        expect(processPlainInput('-', '', 0, 0, plain())).toBeNull()
+      })
+
+      it('returns null for valid decimal input', () => {
+        expect(processPlainInput('3', '1.2', 3, 3, plain({ precision: 2 }))).toBeNull()
+      })
+
+      it('returns null when precision is null', () => {
+        expect(processPlainInput('.', '123', 3, 3, plain({ precision: null }))).toBeNull()
+      })
+    })
+
+    describe('rejects invalid characters', () => {
+      it.each([
+        { data: 'a', value: '12', sel: 2, expected: '12' },
+        { data: '+', value: '12', sel: 2, expected: '12' },
+        { data: ' ', value: '12', sel: 2, expected: '12' },
+      ])('rejects "$data" in "$value"', ({ data, value, sel, expected }) => {
+        const result = processPlainInput(data, value, sel, sel, plain())
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe(expected)
+      })
+
+      it('extracts digits from mixed input (paste-like)', () => {
+        // "12" + "ab3c" at end → "12ab3c" → extractNumber → "123"
+        const result = processPlainInput('ab3c', '12', 2, 2, plain())
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe('123')
+      })
+
+      it('rejects second minus sign', () => {
+        const result = processPlainInput('-', '-5', 2, 2, plain())
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe('-5')
+      })
+
+      it('rejects second decimal separator', () => {
+        const result = processPlainInput('.', '1.2', 3, 3, plain({ precision: 2 }))
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe('1.2')
+      })
+    })
+
+    describe('precision enforcement', () => {
+      it('rejects decimal separator when precision=0', () => {
+        const result = processPlainInput('.', '42', 2, 2, plain({ precision: 0 }))
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe('42')
+      })
+
+      it('rejects digit beyond precision limit', () => {
+        // "1.23" + "4" at end, precision=2 → "1.234" → exceeds → cleaned "1.23"
+        const result = processPlainInput('4', '1.23', 4, 4, plain({ precision: 2 }))
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe('1.23')
+        expect(result!.cursor).toBe(5) // selectionStart(4) + data.length(1)
+      })
+
+      it('allows digit within precision limit', () => {
+        expect(processPlainInput('3', '1.2', 3, 3, plain({ precision: 2 }))).toBeNull()
+      })
+    })
+
+    describe('custom decimal separator', () => {
+      it('returns null for valid comma-separated input', () => {
+        expect(processPlainInput('5', '1,2', 3, 3, plain({ decimalSeparator: ',', precision: 2 }))).toBeNull()
+      })
+
+      it('rejects period when comma is the decimal separator', () => {
+        const result = processPlainInput('.', '12', 2, 2, plain({ decimalSeparator: ',' }))
+        expect(result).not.toBeNull()
+        expect(result!.text).toBe('12')
+      })
+    })
+
+    describe('selection replacement', () => {
+      it('returns null when replacing selection with valid digit', () => {
+        // "123" select "2" (pos 1-2), type "4" → "143" — valid
+        expect(processPlainInput('4', '123', 1, 2, plain())).toBeNull()
+      })
+    })
+  })
+})

--- a/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/typing.spec.ts
@@ -92,9 +92,19 @@ describe('typing', () => {
         expect(result).toEqual({ text: '123', cursor: 3 })
       })
 
-      it('pastes into existing value', () => {
+      it('pastes at the end of existing value', () => {
         const result = processGroupedInput('insertFromPaste', '56', '1,234', 5, 5, opts())
         expect(result).toEqual({ text: '123,456', cursor: 7 })
+      })
+
+      it('pastes inside existing value', () => {
+        const result = processGroupedInput('insertFromPaste', '34', '125', 2, 2, opts())
+        expect(result).toEqual({ text: '12,345', cursor: 5 })
+      })
+
+      it('correct cursor position when dropping duplicate decimal separator', () => {
+        const result = processGroupedInput('insertFromPaste', ' -4.5', '12.11111', 3, 3, opts({ precision: 5 }))
+        expect(result).toEqual({ text: '12.45111', cursor: 5 })
       })
     })
 
@@ -183,16 +193,6 @@ describe('typing', () => {
       })
     })
 
-    describe('unknown inputType', () => {
-      it('returns null for historyUndo', () => {
-        expect(processGroupedInput('historyUndo', null, '1,234', 0, 0, opts())).toBeNull()
-      })
-
-      it('returns null for historyRedo', () => {
-        expect(processGroupedInput('historyRedo', null, '1,234', 0, 0, opts())).toBeNull()
-      })
-    })
-
     describe('custom separators', () => {
       it('works with period as group separator and comma as decimal', () => {
         const o = opts({ groupSeparator: '.', decimalSeparator: ',', precision: 2 })
@@ -222,7 +222,7 @@ describe('typing', () => {
     })
 
     describe('locale-specific grouping', () => {
-      it('uses Indian numbering system for hi-IN', () => {
+      it('handles Indian numbering system for hi-IN', () => {
         // hi-IN: 3-digit primary group, then 2-digit groups
         const o = opts({ locale: 'hi-IN' })
         const result = processGroupedInput('insertFromPaste', '1234567890', '', 0, 0, o)
@@ -262,44 +262,49 @@ describe('typing', () => {
         { data: '+', value: '12', sel: 2, expected: '12' },
         { data: ' ', value: '12', sel: 2, expected: '12' },
       ])('rejects "$data" in "$value"', ({ data, value, sel, expected }) => {
-        const result = processPlainInput(data, value, sel, sel, plain())
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe(expected)
+        expect(processPlainInput(data, value, sel, sel, plain())).toMatchObject({ text: expected })
       })
 
       it('extracts digits from mixed input (paste-like)', () => {
         // "12" + "ab3c" at end → "12ab3c" → extractNumber → "123"
-        const result = processPlainInput('ab3c', '12', 2, 2, plain())
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe('123')
+        expect(processPlainInput('ab3c', '12', 2, 2, plain())).toMatchObject({ text: '123' })
+      })
+
+      it('preserves cursor position when typing/pasting incorrect characters', () => {
+        // type 'x' at middle of "111|111" → rejected, cursor stays at 3
+        expect(processPlainInput('x', '111111', 3, 3, plain())).toMatchObject({ text: '111111', cursor: 3 })
+        // paste 'asd' → no valid chars extracted, cursor stays at 3
+        expect(processPlainInput('asd', '111111', 3, 3, plain())).toMatchObject({ text: '111111', cursor: 3 })
+        // paste '_5x' → '5' extracted (length 1), cursor at 3+1=4
+        expect(processPlainInput('_5x', '111111', 3, 3, plain())).toMatchObject({ text: '1115111', cursor: 4 })
+        // paste ' 456' → '456' extracted (length 3), cursor at 3+3=6 (selection should not matter)
+        expect(processPlainInput(' 456', '111111', 3, 4, plain())).toMatchObject({ text: '11145611', cursor: 6 })
+        // paste ' 4.56' → '4.56' extracted (length 4), cursor at 3+4=7
+        expect(processPlainInput(' 4.56', '111111', 3, 3, plain({ precision: 3 }))).toMatchObject({ text: '1114.561', cursor: 7 })
+      })
+
+      it('correct cursor position when dropping duplicate decimal separator', () => {
+        expect(processPlainInput(' -4.5', '12.11111', 3, 3, plain({ precision: 5 }))).toMatchObject({ text: '12.45111', cursor: 5 })
       })
 
       it('rejects second minus sign', () => {
-        const result = processPlainInput('-', '-5', 2, 2, plain())
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe('-5')
+        expect(processPlainInput('-', '-5', 2, 2, plain())).toMatchObject({ text: '-5', cursor: 2 })
+        expect(processPlainInput('-', '-5', 1, 1, plain())).toMatchObject({ text: '-5', cursor: 1 })
       })
 
       it('rejects second decimal separator', () => {
-        const result = processPlainInput('.', '1.2', 3, 3, plain({ precision: 2 }))
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe('1.2')
+        expect(processPlainInput('.', '1.2', 3, 3, plain({ precision: 2 }))).toMatchObject({ text: '1.2' })
       })
     })
 
     describe('precision enforcement', () => {
       it('rejects decimal separator when precision=0', () => {
-        const result = processPlainInput('.', '42', 2, 2, plain({ precision: 0 }))
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe('42')
+        expect(processPlainInput('.', '42', 2, 2, plain({ precision: 0 }))).toMatchObject({ text: '42' })
       })
 
       it('rejects digit beyond precision limit', () => {
         // "1.23" + "4" at end, precision=2 → "1.234" → exceeds → cleaned "1.23"
-        const result = processPlainInput('4', '1.23', 4, 4, plain({ precision: 2 }))
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe('1.23')
-        expect(result!.cursor).toBe(5) // selectionStart(4) + data.length(1)
+        expect(processPlainInput('4', '1.23', 4, 4, plain({ precision: 2 }))).toMatchObject({ text: '1.23' })
       })
 
       it('allows digit within precision limit', () => {
@@ -313,16 +318,24 @@ describe('typing', () => {
       })
 
       it('rejects period when comma is the decimal separator', () => {
-        const result = processPlainInput('.', '12', 2, 2, plain({ decimalSeparator: ',' }))
-        expect(result).not.toBeNull()
-        expect(result!.text).toBe('12')
+        expect(processPlainInput('.', '12', 2, 2, plain({ decimalSeparator: ',' }))).toMatchObject({ text: '12' })
       })
     })
 
     describe('selection replacement', () => {
-      it('returns null when replacing selection with valid digit', () => {
+      it('accepts replacing selection digit', () => {
         // "123" select "2" (pos 1-2), type "4" → "143" — valid
         expect(processPlainInput('4', '123', 1, 2, plain())).toBeNull()
+      })
+
+      it('accepts replacing decimal separator', () => {
+        // "12.35" select "." type "4" → "1245" — valid
+        expect(processPlainInput('4', '12.35', 2, 3, plain({ precision: 2 }))).toBeNull()
+      })
+
+      it('accepts replacing digit with decimal separator', () => {
+        // "12345" select "3" type "4" → "12.45" — valid
+        expect(processPlainInput('.', '12345', 2, 3, plain({ precision: 2 }))).toBeNull()
       })
     })
   })

--- a/packages/vuetify/src/components/VNumberInput/format.ts
+++ b/packages/vuetify/src/components/VNumberInput/format.ts
@@ -1,0 +1,68 @@
+const NUMERAL_ZEROS = [
+  0x0660, // Arabic-Indic
+  0x06F0, // Extended Arabic-Indic — Persian, Dari
+  0x0966, // Devanagari
+  0x09E6, // Bengali
+  0x0A66, // Gurmukhi
+  0x0AE6, // Gujarati
+  0x0B66, // Oriya
+  0x0BE6, // Tamil
+  0x0C66, // Telugu
+  0x0CE6, // Kannada
+  0x0D66, // Malayalam
+  0x0E50, // Thai
+  0x0ED0, // Lao
+  0x0F20, // Tibetan
+  0x1040, // Myanmar
+  0x17E0, // Khmer
+  0x1810, // Mongolian
+  0xFF10, // Fullwidth
+]
+
+export function normalizeDigits (str: string): string {
+  return str.replace(/[^\x20-\x7F]/g, char => {
+    const code = char.codePointAt(0)!
+    for (const zero of NUMERAL_ZEROS) {
+      if (code >= zero && code <= zero + 9) {
+        return String(code - zero)
+      }
+    }
+    return char
+  })
+}
+
+export interface FormatNumberOptions {
+  locale: string
+  precision?: number | null
+  minFractionDigits?: number | null
+  useGrouping: Intl.NumberFormatOptions['useGrouping']
+  localeDecimalSeparator: string
+  localeGroupSeparator: string
+  decimalSeparator: string
+  groupSeparator: string
+}
+
+export function formatNumber (val: number, options: FormatNumberOptions): string {
+  const { precision, minFractionDigits } = options
+  const formatted = new Intl.NumberFormat(options.locale, {
+    minimumFractionDigits: minFractionDigits && precision != null
+      ? Math.min(minFractionDigits, precision)
+      : (minFractionDigits ?? precision ?? undefined),
+    maximumFractionDigits: precision ?? undefined,
+    useGrouping: options.useGrouping,
+  }).format(val)
+
+  return normalizeDigits(formatted)
+    .replaceAll(options.localeGroupSeparator, options.groupSeparator)
+    .replace(options.localeDecimalSeparator, options.decimalSeparator)
+}
+
+export function parseNumber (
+  val: string | null | undefined,
+  groupSeparator: string,
+  decimalSeparator: string,
+  hasGrouping: boolean,
+): number {
+  const stripped = hasGrouping ? val?.replaceAll(groupSeparator, '') : val
+  return Number(stripped?.replace(decimalSeparator, '.'))
+}

--- a/packages/vuetify/src/components/VNumberInput/format.ts
+++ b/packages/vuetify/src/components/VNumberInput/format.ts
@@ -19,7 +19,7 @@ const NUMERAL_ZEROS = [
   0xFF10, // Fullwidth
 ]
 
-export function normalizeDigits (str: string): string {
+function normalizeDigits (str: string): string {
   return str.replace(/[^\x20-\x7F]/g, char => {
     const code = char.codePointAt(0)!
     for (const zero of NUMERAL_ZEROS) {
@@ -31,30 +31,33 @@ export function normalizeDigits (str: string): string {
   })
 }
 
-export interface FormatNumberOptions {
+interface FormatNumberOptions {
   locale: string
   precision?: number | null
   minFractionDigits?: number | null
   useGrouping: Intl.NumberFormatOptions['useGrouping']
-  localeDecimalSeparator: string
-  localeGroupSeparator: string
   decimalSeparator: string
   groupSeparator: string
 }
 
 export function formatNumber (val: number, options: FormatNumberOptions): string {
   const { precision, minFractionDigits } = options
-  const formatted = new Intl.NumberFormat(options.locale, {
-    minimumFractionDigits: minFractionDigits && precision != null
-      ? Math.min(minFractionDigits, precision)
-      : (minFractionDigits ?? precision ?? undefined),
-    maximumFractionDigits: precision ?? undefined,
-    useGrouping: options.useGrouping,
-  }).format(val)
+  const formatter = new Intl.NumberFormat(
+    options.locale, {
+      minimumFractionDigits: minFractionDigits && precision != null
+        ? Math.min(minFractionDigits, precision)
+        : (minFractionDigits ?? precision ?? undefined),
+      maximumFractionDigits: precision ?? undefined,
+      useGrouping: options.useGrouping,
+    })
 
-  return normalizeDigits(formatted)
-    .replaceAll(options.localeGroupSeparator, options.groupSeparator)
-    .replace(options.localeDecimalSeparator, options.decimalSeparator)
+  return formatter.formatToParts(val)
+    .map(p => {
+      if (p.type === 'group') return options.groupSeparator
+      if (p.type === 'decimal') return options.decimalSeparator
+      return normalizeDigits(p.value)
+    })
+    .join('')
 }
 
 export function parseNumber (

--- a/packages/vuetify/src/components/VNumberInput/format.ts
+++ b/packages/vuetify/src/components/VNumberInput/format.ts
@@ -59,13 +59,3 @@ export function formatNumber (val: number, options: FormatNumberOptions): string
     })
     .join('')
 }
-
-export function parseNumber (
-  val: string | null | undefined,
-  groupSeparator: string,
-  decimalSeparator: string,
-  hasGrouping: boolean,
-): number {
-  const stripped = hasGrouping ? val?.replaceAll(groupSeparator, '') : val
-  return Number(stripped?.replace(decimalSeparator, '.'))
-}

--- a/packages/vuetify/src/components/VNumberInput/typing.ts
+++ b/packages/vuetify/src/components/VNumberInput/typing.ts
@@ -8,6 +8,7 @@ export interface GroupedInputOptions {
   decimalSeparator: string
   precision: number | null
   grouping: GroupingOption
+  locale: string
 }
 
 export interface InputResult {
@@ -15,17 +16,30 @@ export interface InputResult {
   cursor: number
 }
 
-/** Remove all group separator characters from text */
 export function stripGrouping (text: string, groupSeparator: string): string {
   return text.replaceAll(groupSeparator, '')
 }
 
-/** Insert group separators into the integer part of a raw number string */
+/** Fallback: fixed 3-digit groups */
+function formatWithoutLocale (digits: string, groupSeparator: string, grouping: GroupingOption): string {
+  if (grouping === 'min2' && digits.length <= 4) {
+    return digits
+  }
+
+  const groups: string[] = []
+  for (let i = digits.length; i > 0; i -= 3) {
+    groups.unshift(digits.slice(Math.max(0, i - 3), i))
+  }
+
+  return groups.join(groupSeparator)
+}
+
 export function addGrouping (
   raw: string,
   groupSeparator: string,
   decimalSeparator: string,
   grouping: GroupingOption,
+  locale?: string,
 ): string {
   if (!grouping) return raw
 
@@ -36,17 +50,22 @@ export function addGrouping (
   const sign = integerPart.startsWith('-') ? '-' : ''
   const digits = sign ? integerPart.slice(1) : integerPart
 
-  // min2 / auto: only group when there are at least 2 groups (>3 digits)
-  if ((grouping === 'min2' || grouping === 'auto') && digits.length <= 4) {
-    return raw
+  if (!digits) return raw
+
+  if (locale) {
+    const num = Number(digits)
+    if (!Number.isFinite(num)) return raw
+    const grouped = new Intl.NumberFormat(locale, {
+      useGrouping: grouping,
+      numberingSystem: 'latn',
+    })
+      .formatToParts(num)
+      .map(p => p.type === 'group' ? groupSeparator : p.value)
+      .join('')
+    return sign + grouped + rest
   }
 
-  const groups: string[] = []
-  for (let i = digits.length; i > 0; i -= 3) {
-    groups.unshift(digits.slice(Math.max(0, i - 3), i))
-  }
-
-  return sign + groups.join(groupSeparator) + rest
+  return sign + formatWithoutLocale(digits, groupSeparator, grouping) + rest
 }
 
 /** Count non-separator characters before displayPosition */
@@ -58,7 +77,6 @@ export function toLogicalPosition (text: string, groupSeparator: string, display
   return logical
 }
 
-/** Find display index where logicalPosition non-separator characters precede it */
 export function toDisplayPosition (text: string, groupSeparator: string, logicalPosition: number): number {
   let logical = 0
   for (let i = 0; i <= text.length; i++) {
@@ -110,7 +128,7 @@ export function processPlainInput (
 
 /**
  * Process a beforeinput event for grouped number input.
- * Returns { text, cursor } to apply, or null for unknown inputTypes (let browser handle).
+ * Returns { text, cursor } to apply, or null for interactions that do not need override
  */
 export function processGroupedInput (
   inputType: string,
@@ -120,7 +138,7 @@ export function processGroupedInput (
   selectionEnd: number,
   options: GroupedInputOptions,
 ): InputResult | null {
-  const { groupSeparator, decimalSeparator, precision, grouping } = options
+  const { groupSeparator, decimalSeparator, precision, grouping, locale } = options
   const raw = stripGrouping(value, groupSeparator)
   const logicalStart = toLogicalPosition(value, groupSeparator, selectionStart)
   const logicalEnd = toLogicalPosition(value, groupSeparator, selectionEnd)
@@ -219,14 +237,12 @@ export function processGroupedInput (
       return null
   }
 
-  // Validate: allow only digits, minus (at start, once), and decimal separator (once)
   const validPattern = new RegExp(`^-?\\d*${escapeForRegex(decimalSeparator)}?\\d*$`)
   if (!validPattern.test(newRaw)) {
     newRaw = extractNumber(newRaw, precision, decimalSeparator)
     newLogicalCursor = Math.min(newLogicalCursor, newRaw.length)
   }
 
-  // Enforce precision limits
   if (precision != null) {
     const parts = newRaw.split(decimalSeparator)
     if (parts[1]?.length > precision) {
@@ -239,8 +255,7 @@ export function processGroupedInput (
     }
   }
 
-  // Reformat with grouping
-  const formatted = addGrouping(newRaw, groupSeparator, decimalSeparator, grouping)
+  const formatted = addGrouping(newRaw, groupSeparator, decimalSeparator, grouping, locale)
   const cursor = toDisplayPosition(formatted, groupSeparator, newLogicalCursor)
 
   return { text: formatted, cursor }

--- a/packages/vuetify/src/components/VNumberInput/typing.ts
+++ b/packages/vuetify/src/components/VNumberInput/typing.ts
@@ -3,7 +3,7 @@ import { escapeForRegex, extractNumber } from '@/util'
 
 type GroupingOption = 'always' | 'auto' | 'min2' | boolean
 
-export interface GroupedInputOptions {
+interface GroupedInputOptions {
   groupSeparator: string
   decimalSeparator: string
   precision: number | null
@@ -11,12 +11,12 @@ export interface GroupedInputOptions {
   locale: string
 }
 
-export interface InputResult {
+interface InputResult {
   text: string
   cursor: number
 }
 
-export function stripGrouping (text: string, groupSeparator: string): string {
+function stripGrouping (text: string, groupSeparator: string): string {
   return text.replaceAll(groupSeparator, '')
 }
 
@@ -34,7 +34,7 @@ function formatWithoutLocale (digits: string, groupSeparator: string, grouping: 
   return groups.join(groupSeparator)
 }
 
-export function addGrouping (
+function addGrouping (
   raw: string,
   groupSeparator: string,
   decimalSeparator: string,
@@ -69,7 +69,7 @@ export function addGrouping (
 }
 
 /** Count non-separator characters before displayPosition */
-export function toLogicalPosition (text: string, groupSeparator: string, displayPosition: number): number {
+function toLogicalPosition (text: string, groupSeparator: string, displayPosition: number): number {
   let logical = 0
   for (let i = 0; i < displayPosition && i < text.length; i++) {
     if (text[i] !== groupSeparator) logical++
@@ -77,7 +77,7 @@ export function toLogicalPosition (text: string, groupSeparator: string, display
   return logical
 }
 
-export function toDisplayPosition (text: string, groupSeparator: string, logicalPosition: number): number {
+function toDisplayPosition (text: string, groupSeparator: string, logicalPosition: number): number {
   let logical = 0
   for (let i = 0; i <= text.length; i++) {
     if (logical === logicalPosition) return i

--- a/packages/vuetify/src/components/VNumberInput/typing.ts
+++ b/packages/vuetify/src/components/VNumberInput/typing.ts
@@ -1,0 +1,247 @@
+// Utilities
+import { escapeForRegex, extractNumber } from '@/util'
+
+type GroupingOption = 'always' | 'auto' | 'min2' | boolean
+
+export interface GroupedInputOptions {
+  groupSeparator: string
+  decimalSeparator: string
+  precision: number | null
+  grouping: GroupingOption
+}
+
+export interface InputResult {
+  text: string
+  cursor: number
+}
+
+/** Remove all group separator characters from text */
+export function stripGrouping (text: string, groupSeparator: string): string {
+  return text.replaceAll(groupSeparator, '')
+}
+
+/** Insert group separators into the integer part of a raw number string */
+export function addGrouping (
+  raw: string,
+  groupSeparator: string,
+  decimalSeparator: string,
+  grouping: GroupingOption,
+): string {
+  if (!grouping) return raw
+
+  const decimalIndex = raw.indexOf(decimalSeparator)
+  const integerPart = decimalIndex >= 0 ? raw.slice(0, decimalIndex) : raw
+  const rest = decimalIndex >= 0 ? raw.slice(decimalIndex) : ''
+
+  const sign = integerPart.startsWith('-') ? '-' : ''
+  const digits = sign ? integerPart.slice(1) : integerPart
+
+  // min2 / auto: only group when there are at least 2 groups (>3 digits)
+  if ((grouping === 'min2' || grouping === 'auto') && digits.length <= 4) {
+    return raw
+  }
+
+  const groups: string[] = []
+  for (let i = digits.length; i > 0; i -= 3) {
+    groups.unshift(digits.slice(Math.max(0, i - 3), i))
+  }
+
+  return sign + groups.join(groupSeparator) + rest
+}
+
+/** Count non-separator characters before displayPosition */
+export function toLogicalPosition (text: string, groupSeparator: string, displayPosition: number): number {
+  let logical = 0
+  for (let i = 0; i < displayPosition && i < text.length; i++) {
+    if (text[i] !== groupSeparator) logical++
+  }
+  return logical
+}
+
+/** Find display index where logicalPosition non-separator characters precede it */
+export function toDisplayPosition (text: string, groupSeparator: string, logicalPosition: number): number {
+  let logical = 0
+  for (let i = 0; i <= text.length; i++) {
+    if (logical === logicalPosition) return i
+    if (i < text.length && text[i] !== groupSeparator) logical++
+  }
+  return text.length
+}
+
+/**
+ * Process a beforeinput event for plain (non-grouped) number input.
+ * Returns { text, cursor } when the input needs correction, or null to let browser handle it.
+ */
+export function processPlainInput (
+  data: string | null,
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  options: { decimalSeparator: string, precision: number | null },
+): InputResult | null {
+  if (!data) return null
+
+  const { decimalSeparator, precision } = options
+
+  const potentialNewInputVal = value
+    ? value.slice(0, selectionStart) + data + value.slice(selectionEnd)
+    : data
+
+  const cleaned = extractNumber(potentialNewInputVal, precision, decimalSeparator)
+  const validPattern = new RegExp(`^-?\\d*${escapeForRegex(decimalSeparator)}?\\d*$`)
+
+  if (!validPattern.test(potentialNewInputVal)) {
+    return { text: cleaned, cursor: cleaned.length }
+  }
+
+  if (precision == null) return null
+
+  if (potentialNewInputVal.split(decimalSeparator)[1]?.length > precision) {
+    const cursor = selectionStart + data.length
+    return { text: cleaned, cursor }
+  }
+
+  if (precision === 0 && potentialNewInputVal.endsWith(decimalSeparator)) {
+    return { text: cleaned, cursor: cleaned.length }
+  }
+
+  return null
+}
+
+/**
+ * Process a beforeinput event for grouped number input.
+ * Returns { text, cursor } to apply, or null for unknown inputTypes (let browser handle).
+ */
+export function processGroupedInput (
+  inputType: string,
+  data: string | null,
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  options: GroupedInputOptions,
+): InputResult | null {
+  const { groupSeparator, decimalSeparator, precision, grouping } = options
+  const raw = stripGrouping(value, groupSeparator)
+  const logicalStart = toLogicalPosition(value, groupSeparator, selectionStart)
+  const logicalEnd = toLogicalPosition(value, groupSeparator, selectionEnd)
+  const hasSelection = logicalStart !== logicalEnd
+
+  let newRaw: string
+  let newLogicalCursor: number
+
+  switch (inputType) {
+    case 'insertText': {
+      if (!data) return null
+      newRaw = raw.slice(0, logicalStart) + data + raw.slice(logicalEnd)
+      newLogicalCursor = logicalStart + data.length
+      break
+    }
+    case 'insertFromPaste':
+    case 'insertFromDrop': {
+      if (!data) return null
+      const cleaned = extractNumber(data, precision, decimalSeparator)
+      newRaw = raw.slice(0, logicalStart) + cleaned + raw.slice(logicalEnd)
+      newLogicalCursor = logicalStart + cleaned.length
+      break
+    }
+    case 'deleteContentBackward': {
+      if (hasSelection) {
+        newRaw = raw.slice(0, logicalStart) + raw.slice(logicalEnd)
+        newLogicalCursor = logicalStart
+      } else if (logicalStart > 0) {
+        newRaw = raw.slice(0, logicalStart - 1) + raw.slice(logicalStart)
+        newLogicalCursor = logicalStart - 1
+      } else {
+        // At the start, nothing to delete
+        newRaw = raw
+        newLogicalCursor = 0
+      }
+      break
+    }
+    case 'deleteContentForward': {
+      if (hasSelection) {
+        newRaw = raw.slice(0, logicalStart) + raw.slice(logicalEnd)
+        newLogicalCursor = logicalStart
+      } else if (logicalStart < raw.length) {
+        newRaw = raw.slice(0, logicalStart) + raw.slice(logicalStart + 1)
+        newLogicalCursor = logicalStart
+      } else {
+        // At the end, nothing to delete
+        newRaw = raw
+        newLogicalCursor = logicalStart
+      }
+      break
+    }
+    case 'deleteByCut': {
+      newRaw = raw.slice(0, logicalStart) + raw.slice(logicalEnd)
+      newLogicalCursor = logicalStart
+      break
+    }
+    case 'deleteWordBackward': {
+      if (hasSelection) {
+        newRaw = raw.slice(0, logicalStart) + raw.slice(logicalEnd)
+        newLogicalCursor = logicalStart
+      } else {
+        let deleteEnd = logicalStart
+        // Skip non-digits first (e.g., decimal separator)
+        while (deleteEnd > 0 && !/\d/.test(raw[deleteEnd - 1])) deleteEnd--
+        // Then skip digits
+        while (deleteEnd > 0 && /\d/.test(raw[deleteEnd - 1])) deleteEnd--
+        newRaw = raw.slice(0, deleteEnd) + raw.slice(logicalStart)
+        newLogicalCursor = deleteEnd
+      }
+      break
+    }
+    case 'deleteWordForward': {
+      if (hasSelection) {
+        newRaw = raw.slice(0, logicalStart) + raw.slice(logicalEnd)
+        newLogicalCursor = logicalStart
+      } else {
+        let deleteEnd = logicalStart
+        while (deleteEnd < raw.length && !/\d/.test(raw[deleteEnd])) deleteEnd++
+        while (deleteEnd < raw.length && /\d/.test(raw[deleteEnd])) deleteEnd++
+        newRaw = raw.slice(0, logicalStart) + raw.slice(deleteEnd)
+        newLogicalCursor = logicalStart
+      }
+      break
+    }
+    case 'deleteSoftLineBackward': {
+      newRaw = raw.slice(logicalEnd)
+      newLogicalCursor = 0
+      break
+    }
+    case 'deleteSoftLineForward': {
+      newRaw = raw.slice(0, logicalStart)
+      newLogicalCursor = logicalStart
+      break
+    }
+    default:
+      return null
+  }
+
+  // Validate: allow only digits, minus (at start, once), and decimal separator (once)
+  const validPattern = new RegExp(`^-?\\d*${escapeForRegex(decimalSeparator)}?\\d*$`)
+  if (!validPattern.test(newRaw)) {
+    newRaw = extractNumber(newRaw, precision, decimalSeparator)
+    newLogicalCursor = Math.min(newLogicalCursor, newRaw.length)
+  }
+
+  // Enforce precision limits
+  if (precision != null) {
+    const parts = newRaw.split(decimalSeparator)
+    if (parts[1]?.length > precision) {
+      newRaw = parts[0] + decimalSeparator + parts[1].slice(0, precision)
+      newLogicalCursor = Math.min(newLogicalCursor, newRaw.length)
+    }
+    if (precision === 0 && newRaw.endsWith(decimalSeparator)) {
+      newRaw = newRaw.slice(0, -1)
+      newLogicalCursor = Math.min(newLogicalCursor, newRaw.length)
+    }
+  }
+
+  // Reformat with grouping
+  const formatted = addGrouping(newRaw, groupSeparator, decimalSeparator, grouping)
+  const cursor = toDisplayPosition(formatted, groupSeparator, newLogicalCursor)
+
+  return { text: formatted, cursor }
+}

--- a/packages/vuetify/src/components/VNumberInput/typing.ts
+++ b/packages/vuetify/src/components/VNumberInput/typing.ts
@@ -1,3 +1,5 @@
+/* eslint-disable complexity */
+
 // Utilities
 import { escapeForRegex, extractNumber } from '@/util'
 
@@ -100,30 +102,38 @@ export function processPlainInput (
   if (!data) return null
 
   const { decimalSeparator, precision } = options
+  const beforePart = value.slice(0, selectionStart)
+  let cleanData = extractNumber(data, precision, decimalSeparator)
+  if (cleanData.startsWith('-') && beforePart.length > 0) cleanData = cleanData.slice(1)
+  if (cleanData.includes(decimalSeparator) && beforePart.includes(decimalSeparator)) {
+    cleanData = cleanData.replace(decimalSeparator, '')
+  }
 
-  const potentialNewInputVal = value
-    ? value.slice(0, selectionStart) + data + value.slice(selectionEnd)
-    : data
-
-  const cleaned = extractNumber(potentialNewInputVal, precision, decimalSeparator)
+  const candidate = beforePart + cleanData + value.slice(selectionEnd)
   const validPattern = new RegExp(`^-?\\d*${escapeForRegex(decimalSeparator)}?\\d*$`)
 
-  if (!validPattern.test(potentialNewInputVal)) {
-    return { text: cleaned, cursor: cleaned.length }
+  if (!validPattern.test(candidate)) {
+    return {
+      text: extractNumber(candidate, precision, decimalSeparator),
+      cursor: selectionStart,
+    }
   }
 
-  if (precision == null) return null
-
-  if (potentialNewInputVal.split(decimalSeparator)[1]?.length > precision) {
-    const cursor = selectionStart + data.length
-    return { text: cleaned, cursor }
+  if (precision != null && (candidate.split(decimalSeparator)[1]?.length ?? 0) > precision) {
+    const text = extractNumber(candidate, precision, decimalSeparator)
+    return {
+      text,
+      cursor: text === beforePart + value.slice(selectionEnd)
+        ? selectionStart
+        : selectionStart + cleanData.length,
+    }
   }
 
-  if (precision === 0 && potentialNewInputVal.endsWith(decimalSeparator)) {
-    return { text: cleaned, cursor: cleaned.length }
+  if (cleanData === data) return null
+  return {
+    text: candidate,
+    cursor: selectionStart + cleanData.length,
   }
-
-  return null
 }
 
 /**
@@ -157,9 +167,16 @@ export function processGroupedInput (
     case 'insertFromPaste':
     case 'insertFromDrop': {
       if (!data) return null
-      const cleaned = extractNumber(data, precision, decimalSeparator)
-      newRaw = raw.slice(0, logicalStart) + cleaned + raw.slice(logicalEnd)
-      newLogicalCursor = logicalStart + cleaned.length
+      const rawBefore = raw.slice(0, logicalStart)
+      let cleanData = extractNumber(data, precision, decimalSeparator)
+      if (cleanData.startsWith('-') && rawBefore.length > 0) {
+        cleanData = cleanData.slice(1)
+      }
+      if (cleanData.includes(decimalSeparator) && rawBefore.includes(decimalSeparator)) {
+        cleanData = cleanData.replace(decimalSeparator, '')
+      }
+      newRaw = rawBefore + cleanData + raw.slice(logicalEnd)
+      newLogicalCursor = logicalStart + cleanData.length
       break
     }
     case 'deleteContentBackward': {

--- a/packages/vuetify/src/composables/locale.ts
+++ b/packages/vuetify/src/composables/locale.ts
@@ -11,6 +11,7 @@ export interface LocaleMessages {
 
 export interface LocaleOptions {
   decimalSeparator?: string
+  numericGroupSeparator?: string
   messages?: LocaleMessages
   locale?: string
   fallback?: string
@@ -20,6 +21,7 @@ export interface LocaleOptions {
 export interface LocaleInstance {
   name: string
   decimalSeparator: ShallowRef<string>
+  numericGroupSeparator: ShallowRef<string>
   messages: Ref<LocaleMessages>
   current: Ref<string>
   fallback: Ref<string>

--- a/packages/vuetify/src/locale/adapters/vue-i18n.ts
+++ b/packages/vuetify/src/locale/adapters/vue-i18n.ts
@@ -35,7 +35,7 @@ function inferDecimalSeparator (format: (v: number) => string) {
 function inferNumericGroupSeparator (format: (v: number, options: NumberOptions) => string) {
   const maybeSeparator = format(10000, { useGrouping: true }).at(2)!
   const digits = format(9876543210, { useGrouping: false }).split('')
-  return !digits.includes(maybeSeparator) ? maybeSeparator : ','
+  return !digits.includes(maybeSeparator) ? maybeSeparator : ' '
 }
 
 function createProvideFunction (data: {

--- a/packages/vuetify/src/locale/adapters/vue-i18n.ts
+++ b/packages/vuetify/src/locale/adapters/vue-i18n.ts
@@ -6,7 +6,7 @@ import { toRef, watch } from 'vue'
 
 // Types
 import type { Ref } from 'vue'
-import type { I18n, useI18n } from 'vue-i18n'
+import type { I18n, NumberOptions, useI18n } from 'vue-i18n'
 import type { LocaleInstance, LocaleMessages, LocaleOptions } from '@/composables/locale'
 
 type VueI18nAdapterParams = {
@@ -30,6 +30,10 @@ function useProvided <T> (props: any, prop: string, provided: Ref<T>) {
 
 function inferDecimalSeparator (format: (v: number) => string) {
   return format(0.1).includes(',') ? ',' : '.'
+}
+
+function inferNumericGroupSeparator (format: (v: number, options: NumberOptions) => string) {
+  return format(10000, { useGrouping: true }).at(2)!
 }
 
 function createProvideFunction (data: {
@@ -62,6 +66,7 @@ function createProvideFunction (data: {
       fallback,
       messages,
       decimalSeparator: toRef(() => props.decimalSeparator ?? inferDecimalSeparator(i18n.n)),
+      numericGroupSeparator: toRef(() => inferNumericGroupSeparator(i18n.n)),
       t: (key: string, ...params: unknown[]) => i18n.t(key, params),
       n: i18n.n,
       provide: createProvideFunction({ current, fallback, messages, useI18n: data.useI18n }),
@@ -80,6 +85,7 @@ export function createVueI18nAdapter ({ i18n, useI18n }: VueI18nAdapterParams): 
     fallback,
     messages,
     decimalSeparator: toRef(() => inferDecimalSeparator(i18n.global.n)),
+    numericGroupSeparator: toRef(() => inferNumericGroupSeparator(i18n.global.n)),
     t: (key: string, ...params: unknown[]) => i18n.global.t(key, params),
     n: i18n.global.n,
     provide: createProvideFunction({ current, fallback, messages, useI18n }),

--- a/packages/vuetify/src/locale/adapters/vue-i18n.ts
+++ b/packages/vuetify/src/locale/adapters/vue-i18n.ts
@@ -33,7 +33,9 @@ function inferDecimalSeparator (format: (v: number) => string) {
 }
 
 function inferNumericGroupSeparator (format: (v: number, options: NumberOptions) => string) {
-  return format(10000, { useGrouping: true }).at(2)!
+  const maybeSeparator = format(10000, { useGrouping: true }).at(2)!
+  const digits = format(9876543210, { useGrouping: false }).split('')
+  return !digits.includes(maybeSeparator) ? maybeSeparator : ','
 }
 
 function createProvideFunction (data: {

--- a/packages/vuetify/src/locale/adapters/vue-i18n.ts
+++ b/packages/vuetify/src/locale/adapters/vue-i18n.ts
@@ -6,7 +6,7 @@ import { toRef, watch } from 'vue'
 
 // Types
 import type { Ref } from 'vue'
-import type { I18n, NumberOptions, useI18n } from 'vue-i18n'
+import type { I18n, useI18n } from 'vue-i18n'
 import type { LocaleInstance, LocaleMessages, LocaleOptions } from '@/composables/locale'
 
 type VueI18nAdapterParams = {
@@ -28,14 +28,13 @@ function useProvided <T> (props: any, prop: string, provided: Ref<T>) {
   return internal as Ref<T>
 }
 
-function inferDecimalSeparator (format: (v: number) => string) {
+function inferDecimalSeparator (format: ReturnType<typeof useI18n>['n']) {
   return format(0.1).includes(',') ? ',' : '.'
 }
 
-function inferNumericGroupSeparator (format: (v: number, options: NumberOptions) => string) {
-  const maybeSeparator = format(10000, { useGrouping: true }).at(2)!
-  const digits = format(9876543210, { useGrouping: false }).split('')
-  return !digits.includes(maybeSeparator) ? maybeSeparator : ' '
+function inferNumericGroupSeparator (format: ReturnType<typeof useI18n>['n']) {
+  return format(10000, { useGrouping: true, part: true })
+    .find(p => p.type === 'group')?.value ?? ' '
 }
 
 function createProvideFunction (data: {

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -68,6 +68,11 @@ function inferDecimalSeparator (current: Ref<string>, fallback: Ref<string>) {
   return format(0.1).includes(',') ? ',' : '.'
 }
 
+function inferNumericGroupSeparator (current: Ref<string>, fallback: Ref<string>) {
+  const format = createNumberFunction(current, fallback)
+  return format(10000).at(2)!
+}
+
 function useProvided <T> (props: any, prop: string, provided: Ref<T>) {
   const internal = useProxiedModel(props, prop, props[prop] ?? provided.value)
 
@@ -95,6 +100,7 @@ function createProvideFunction (state: { current: Ref<string>, fallback: Ref<str
       fallback,
       messages,
       decimalSeparator: toRef(() => inferDecimalSeparator(current, fallback)),
+      numericGroupSeparator: toRef(() => inferNumericGroupSeparator(current, fallback)),
       t: createTranslateFunction(current, fallback, messages),
       n: createNumberFunction(current, fallback),
       provide: createProvideFunction({ current, fallback, messages }),
@@ -113,6 +119,7 @@ export function createVuetifyAdapter (options?: LocaleOptions): LocaleInstance {
     fallback,
     messages,
     decimalSeparator: toRef(() => options?.decimalSeparator ?? inferDecimalSeparator(current, fallback)),
+    numericGroupSeparator: toRef(() => options?.numericGroupSeparator ?? inferNumericGroupSeparator(current, fallback)),
     t: createTranslateFunction(current, fallback, messages),
     n: createNumberFunction(current, fallback),
     provide: createProvideFunction({ current, fallback, messages }),

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -70,7 +70,7 @@ function inferDecimalSeparator (current: Ref<string>, fallback: Ref<string>) {
 
 function inferNumericGroupSeparator (current: Ref<string>, fallback: Ref<string>) {
   const format = createNumberFunction(current, fallback)
-  return format(10000).at(2)!
+  return format(10000, { useGrouping: true }).at(2)!
 }
 
 function useProvided <T> (props: any, prop: string, provided: Ref<T>) {

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -71,7 +71,7 @@ function inferDecimalSeparator (current: Ref<string>, fallback: Ref<string>) {
 function inferNumericGroupSeparator (current: Ref<string>, fallback: Ref<string>) {
   return new Intl.NumberFormat([current.value, fallback.value], { useGrouping: true })
     .formatToParts(10000)
-    .find(p => p.type === 'group')?.value ?? ','
+    .find(p => p.type === 'group')?.value ?? ' '
 }
 
 function useProvided <T> (props: any, prop: string, provided: Ref<T>) {

--- a/packages/vuetify/src/locale/adapters/vuetify.ts
+++ b/packages/vuetify/src/locale/adapters/vuetify.ts
@@ -69,8 +69,9 @@ function inferDecimalSeparator (current: Ref<string>, fallback: Ref<string>) {
 }
 
 function inferNumericGroupSeparator (current: Ref<string>, fallback: Ref<string>) {
-  const format = createNumberFunction(current, fallback)
-  return format(10000, { useGrouping: true }).at(2)!
+  return new Intl.NumberFormat([current.value, fallback.value], { useGrouping: true })
+    .formatToParts(10000)
+    .find(p => p.type === 'group')?.value ?? ','
 }
 
 function useProvided <T> (props: any, prop: string, provided: Ref<T>) {


### PR DESCRIPTION
## Description

resolves #22453

- introduces `grouping` to enable fully localized format
- preserves grouping while typing, pasting, cutting and deleting
- replaces Persian and Bengali numerals back to [0..9] digits
- reacts to locale changes

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-row>
        <v-col>
          <h5>(grouping="min2")</h5>
          <v-number-input v-model="example1" :precision="0" grouping="min2" hide-details="auto" />
          <code class="d-block pt-3">value: {{ example1 }}</code>
        </v-col>
        <v-col>
          <h5>(grouping="true", custom separators)</h5>
          <v-number-input
            v-model="example2"
            :precision="2"
            decimal-separator="."
            group-separator="’"
            hide-details="auto"
            grouping
          />
          <code class="d-block pt-3">value: {{ example2 }}</code>
        </v-col>
      </v-row>
      <v-divider class="mt-12" />
      <v-chip-group v-model="locale" class="mb-2" mandatory>
        <v-chip v-for="l in locales" :key="l" :value="l" size="small">{{ l }}</v-chip>
      </v-chip-group>
      <v-locale-provider :locale="locale">
        <v-row>
          <v-col>
            <h5>(grouping="auto")</h5>
            <v-number-input v-model="example3" :precision="2" grouping="auto" hide-details="auto" />
            <code class="d-block pt-3">value: {{ example3 }}</code>
          </v-col>
          <v-col>
            <h5>(precision unrestricted)</h5>
            <v-number-input v-model="example4" :precision="null" grouping="auto" hide-details="auto" />
            <code class="d-block pt-3">value: {{ example4 }}</code>
          </v-col>
        </v-row>
      </v-locale-provider>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const locales = ['ar', 'en', 'de', 'fr', 'hi', 'ja']
  const locale = ref('en')

  const example1 = ref(4052)
  const example2 = ref(12300000)
  const example3 = ref(200021025.5)
  const example4 = ref(0.052)
</script>
```
