### PR TITLE
fix(VAutocomplete/VCombobox): consistent open/close transition

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -24,7 +24,6 @@ import { useItems } from '@/composables/list-items'
 import { useLocale } from '@/composables/locale'
 import { useMenuActivator } from '@/composables/menuActivator'
 import { useProxiedModel } from '@/composables/proxiedModel'
-import { makeTransitionProps } from '@/composables/transition'
 
 // Utilities
 import { computed, mergeProps, nextTick, ref, shallowRef, watch } from 'vue'
@@ -73,7 +72,6 @@ export const makeVAutocompleteProps = propsFactory({
     modelValue: null,
     role: 'combobox',
   }), ['validationValue', 'dirty', 'appendInnerIcon']),
-  ...makeTransitionProps({ transition: false }),
 }, 'VAutocomplete')
 
 type ItemType<T> = T extends readonly (infer U)[] ? U : never
@@ -126,6 +124,7 @@ export const VAutocomplete = genericComponent<new <
     const vMenuRef = ref<VMenu>()
     const vVirtualScrollRef = ref<VVirtualScroll>()
     const selectionIndex = shallowRef(-1)
+    const _searchLock = shallowRef<string | null>(null)
     const { items, transformIn, transformOut } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(() => vTextFieldRef.value?.color)
     const search = useProxiedModel(props, 'search', '')
@@ -145,10 +144,13 @@ export const VAutocomplete = genericComponent<new <
         : model.value.length
     })
     const form = useForm(props)
-    const { filteredItems, getMatches } = useFilter(props, items, () => isPristine.value ? '' : search.value)
+    const { filteredItems, getMatches } = useFilter(
+      props,
+      items,
+      () => _searchLock.value ?? (isPristine.value ? '' : search.value))
 
     const displayItems = computed(() => {
-      if (props.hideSelected) {
+      if (props.hideSelected && _searchLock.value === null) {
         return filteredItems.value.filter(filteredItem => !model.value.some(s => s.value === filteredItem.value))
       }
       return filteredItems.value
@@ -314,6 +316,7 @@ export const VAutocomplete = genericComponent<new <
         isPristine.value = true
         vTextFieldRef.value?.focus()
       }
+      _searchLock.value = null
     }
 
     function onFocusin (e: FocusEvent) {
@@ -353,6 +356,7 @@ export const VAutocomplete = genericComponent<new <
       } else {
         const add = set !== false
         model.value = add ? [item] : []
+        _searchLock.value = isPristine.value ? '' : (search.value ?? '')
         search.value = add && !hasSelectionSlot.value ? item.title : ''
 
         // watch for search watcher to trigger
@@ -375,6 +379,9 @@ export const VAutocomplete = genericComponent<new <
       } else {
         if (!props.multiple && search.value == null) model.value = []
         menu.value = false
+        if (!isPristine.value && search.value) {
+          _searchLock.value = search.value
+        }
         search.value = ''
         selectionIndex.value = -1
       }
@@ -388,8 +395,8 @@ export const VAutocomplete = genericComponent<new <
       isPristine.value = !val
     })
 
-    watch(menu, () => {
-      if (!props.hideSelected && menu.value && model.value.length) {
+    watch(menu, val => {
+      if (!props.hideSelected && val && model.value.length && isPristine.value) {
         const index = displayItems.value.findIndex(
           item => model.value.some(s => item.value === s.value)
         )
@@ -397,6 +404,7 @@ export const VAutocomplete = genericComponent<new <
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }
+      if (val) _searchLock.value = null
     })
 
     watch(items, (newVal, oldVal) => {
@@ -463,7 +471,6 @@ export const VAutocomplete = genericComponent<new <
                   maxHeight={ 310 }
                   openOnClick={ false }
                   closeOnContentClick={ false }
-                  transition={ props.transition }
                   onAfterEnter={ onAfterEnter }
                   onAfterLeave={ onAfterLeave }
                   { ...props.menuProps }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -3,8 +3,9 @@ import { VAutocomplete } from '../VAutocomplete'
 import { VForm } from '@/components/VForm'
 
 // Utilities
-import { generate, render, screen, userEvent, waitAnimationFrame, waitIdle } from '@test'
+import { generate, render, screen, userEvent, wait, waitAnimationFrame, waitIdle } from '@test'
 import { findAllByRole, queryAllByRole, within } from '@testing-library/vue'
+import { commands } from '@vitest/browser/context'
 import { cloneVNode, ref } from 'vue'
 
 const variants = ['underlined', 'outlined', 'filled', 'solo', 'plain'] as const
@@ -82,6 +83,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.click(container)
+    await wait(100) // waitStable was very flaky here
 
     const menu = await screen.findByRole('listbox')
 
@@ -128,6 +130,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.click(container)
+    await commands.waitStable('.v-list')
 
     const menu = await screen.findByRole('listbox')
 
@@ -179,6 +182,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.click(container)
+    await wait(100)
 
     const menu = await screen.findByRole('listbox')
 
@@ -354,6 +358,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.click(element)
+    await commands.waitStable('.v-list')
 
     await userEvent.click(screen.getAllByRole('option')[0])
     expect(selectedItems.value).toBe(1)
@@ -422,6 +427,7 @@ describe('VAutocomplete', () => {
 
       const menuIcon = screen.getByRole('button', { name: /open/i })
       await userEvent.click(menuIcon)
+      await commands.waitStable('.v-list')
 
       const listItems = screen.getAllByRole('option')
       expect(listItems).toHaveLength(2)
@@ -444,8 +450,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.type(element, 'f')
-    const listItems = screen.getAllByRole('option')
-    expect(listItems).toHaveLength(2)
+    await expect.poll(() => screen.findAllByRole('option')).toHaveLength(2)
     expect(selectedItems.value).toBeUndefined()
   })
 
@@ -535,6 +540,7 @@ describe('VAutocomplete', () => {
       const getItems = () => screen.queryAllByRole('option')
 
       await userEvent.click(element)
+      await commands.waitStable('.v-list')
       await expect.poll(getItems).toHaveLength(6)
 
       await userEvent.keyboard('Cal')
@@ -615,7 +621,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.click(element)
-
+    await commands.waitStable('.v-list')
     const items = await screen.findAllByRole('option')
     expect(items).toHaveLength(2)
 
@@ -633,7 +639,7 @@ describe('VAutocomplete', () => {
     expect(screen.queryByRole('listbox')).toBeNull()
 
     await rerender({ items: ['Foo', 'Bar'] })
-    await expect(screen.findByRole('listbox')).resolves.toBeDisplayed()
+    await expect(screen.findByRole('listbox')).resolves.toBeVisible()
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/19346

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -307,7 +307,7 @@ export const VCombobox = genericComponent<new <
       }
 
       if (e.key === 'Enter' && search.value) {
-        select(transformItem(props, search.value))
+        select(transformItem(props, search.value), true, true)
         if (hasSelectionSlot.value) _search.value = ''
       }
 
@@ -375,7 +375,7 @@ export const VCombobox = genericComponent<new <
       _searchLock.value = null
     }
     /** @param set - null means toggle */
-    function select (item: ListItem | undefined, set: boolean | null = true) {
+    function select (item: ListItem | undefined, set: boolean | null = true, keepMenu = false) {
       if (!item || item.props.disabled) return
 
       if (props.multiple) {
@@ -403,7 +403,7 @@ export const VCombobox = genericComponent<new <
 
         // watch for search watcher to trigger
         nextTick(() => {
-          menu.value = false
+          menu.value = keepMenu
           isPristine.value = true
         })
       }

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -3,7 +3,8 @@ import { VCombobox } from '../VCombobox'
 import { VForm } from '@/components/VForm'
 
 // Utilities
-import { generate, render, screen, userEvent, waitAnimationFrame, waitIdle } from '@test'
+import { generate, render, screen, userEvent, wait, waitAnimationFrame, waitIdle } from '@test'
+import { commands } from '@vitest/browser/context'
 import { cloneVNode, ref } from 'vue'
 
 const variants = ['underlined', 'outlined', 'filled', 'solo', 'plain'] as const
@@ -92,9 +93,10 @@ describe('VCombobox', () => {
       ))
 
       await userEvent.click(element)
+      await wait(100)
       await userEvent.click((await screen.findAllByRole('option'))[0])
       expect(model.value).toStrictEqual(items[0])
-      expect(search.value).toBe(items[0].title)
+      await expect.poll(() => search.value).toBe(items[0].title)
       expect(screen.getByCSS('input')).toHaveValue(items[0].title)
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent(items[0].title)
 
@@ -141,6 +143,7 @@ describe('VCombobox', () => {
       const input = screen.getByCSS('input')
 
       await userEvent.click(element)
+      await wait(100)
       await userEvent.click(screen.getAllByRole('option')[0])
       expect(model.value).toStrictEqual([items[0]])
       expect(search.value).toBeUndefined()
@@ -366,6 +369,7 @@ describe('VCombobox', () => {
       ))
 
       await userEvent.click(element)
+      await wait(100)
 
       const options = await screen.findAllByRole('option', { selected: true })
       expect(options).toHaveLength(2)
@@ -473,10 +477,11 @@ describe('VCombobox', () => {
     ))
 
     await userEvent.click(element)
+    await wait(100)
 
     await userEvent.click(screen.getAllByRole('option')[0])
 
-    expect(screen.getByCSS('input')).toHaveValue('0')
+    await expect.poll(() => screen.getByCSS('input')).toHaveValue('0')
   })
 
   it('should conditionally show placeholder', async () => {
@@ -544,6 +549,8 @@ describe('VCombobox', () => {
     expect(screen.queryAllByRole('listbox')).toHaveLength(0)
 
     await userEvent.click(element)
+    await commands.waitStable('.v-list')
+
     expect(screen.queryAllByRole('listbox')).toHaveLength(1)
     await userEvent.keyboard('{Escape}')
     await expect.poll(() => screen.queryAllByRole('listbox')).toHaveLength(0)
@@ -563,6 +570,8 @@ describe('VCombobox', () => {
       ))
 
       await userEvent.click(element)
+      await commands.waitStable('.v-list')
+
       expect(screen.getAllByRole('option')).toHaveLength(6)
 
       await userEvent.keyboard('Cal')
@@ -585,6 +594,8 @@ describe('VCombobox', () => {
       ))
 
       await userEvent.click(element)
+      await commands.waitStable('.v-list')
+
       expect(screen.getAllByRole('option')).toHaveLength(6)
 
       await userEvent.keyboard('Cal')
@@ -607,6 +618,8 @@ describe('VCombobox', () => {
       ))
 
       await userEvent.click(element)
+      await commands.waitStable('.v-list')
+
       expect(screen.getAllByRole('option')).toHaveLength(6)
 
       await userEvent.keyboard('Cal')
@@ -668,6 +681,7 @@ describe('VCombobox', () => {
     })
 
     await userEvent.click(element)
+    await commands.waitStable('.v-list')
     await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
     await userEvent.click(screen.getAllByRole('option')[0])
@@ -734,8 +748,9 @@ describe('VCombobox', () => {
     ))
 
     await userEvent.click(element)
+    await wait(100)
     await userEvent.click(screen.getAllByRole('option')[0])
-    expect(model.value).toStrictEqual({ title: 'Item 1', value: 'item1' })
+    await expect.poll(() => model.value).toStrictEqual({ title: 'Item 1', value: 'item1' })
 
     await userEvent.click(document.body)
     expect(model.value).toStrictEqual({ title: 'Item 1', value: 'item1' })


### PR DESCRIPTION
(reopened #20768)

verified interactions:

- [x] click to open » select using mouse
- [x] click to open » type something » click outside (or use `[Esc]`)
- [x] set initial value to `42` » focus with  `[Tab]` » use `[Backspace]` remove `2`
- [x] (outstanding bug, not a regression) focus VCombobox with `[Tab]` » use `[Enter]`
- [x]  chips + custom selection not in items --- cannot reproduce

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="600">
      <v-card>
        <v-container fluid>
          <v-select
            label="v-select"
            :items="shortList"
            v-model="model"
            clearable
            persistent-clear
          />
          <v-combobox
            label="v-combobox"
            :items="shortList"
            v-model="model"
            clearable
            persistent-clear
          />
          <v-autocomplete
            label="v-autocomplete"
            :items="shortList"
            v-model="model"
            clearable
            persistent-clear
          />
        </v-container>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const shortList = Array.from({ length: 100 }, (_, i) => i)

  const model = ref(41)
</script>
```
