### PR TITLE
fix(VDataTable): typo that cause watcher triggered twice

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/options.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/options.ts
@@ -35,7 +35,7 @@ export function useOptions ({
 
     // Reset page when searching
     if (oldOptions && oldOptions.search !== value.search) {
-      page.value = 1
+      value.page = 1
     }
 
     vm.emit('update:options', value)


### PR DESCRIPTION
Fix typo to that the page is mutated instead of the value of the emit.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

There was a typo (`page.value` instead of needed `value.page`) that triggered the watcher twice instead of changing the emit value.

fixes #21555 
