### PR TITLE
fix(validation): use correct translation placeholders

### DIFF
--- a/packages/vuetify/src/labs/rules/rules.ts
+++ b/packages/vuetify/src/labs/rules/rules.ts
@@ -62,13 +62,13 @@ export function createRules (options: RulesOptions | undefined, locale: LocaleIn
       return (v: string) => (/^[A-Z]*$/.test(v)) || t(err || '$vuetify.rules.capital')
     },
     maxLength: (len: number, err?: string) => {
-      return (v: any) => (!v || v.length <= len) || t(err || '$vuetify.rules.maxLength', [len])
+      return (v: any) => (!v || v.length <= len) || t(err || '$vuetify.rules.maxLength', len)
     },
     minLength: (len: number, err?: string) => {
-      return (v: any) => (!v || v.length >= len) || t(err || '$vuetify.rules.minLength', [len])
+      return (v: any) => (!v || v.length >= len) || t(err || '$vuetify.rules.minLength', len)
     },
     strictLength: (len: number, err?: string) => {
-      return (v: any) => (!v || v.length === len) || t(err || '$vuetify.rules.strictLength', [len])
+      return (v: any) => (!v || v.length === len) || t(err || '$vuetify.rules.strictLength', len)
     },
     exclude: (forbiddenCharacters: string[], err?: string) => {
       return (v: string) => {


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When using validation in combination with vue-i18n (/`createVueI18nAdapter`) translation of messages containing placeholders are incorrect. This is due to the placeholders always being passed as an array (`[len]` in all cases). This leads to vue-i18n `JSON.stringify`ing the placeholder and thus leading to for example "You must enter a maximum of [ 1 ] characters" with the brackets surrounding the number. This seems to "accidentally" work with the vuetify adapter as this always `String(...)`s the value: https://github.com/vuetifyjs/vuetify/blob/80e154b8c295458b9ced262b3e20403fe07376c3/packages/vuetify/src/locale/adapters/vuetify.ts#L19

Checking other usages of `t()` in the Vuetify codebase also shows that parameters are passed as is, optionally adding more arguments like here: https://github.com/vuetifyjs/vuetify/blob/80e154b8c295458b9ced262b3e20403fe07376c3/packages/vuetify/src/components/VCarousel/VCarousel.tsx#L156

So using `[len]` instead of `len` seems wrong to me. And it just accidentally happens to seem to work fine for arrays with just one element due to how the string conversion works as the vuetify adapter applies.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
This is hard to reproduce with just the playground, as the rules plugin isn't enabled (by default) and to actually reproduce the issue when using vue-i18n obviously also requires that to be installed and configured. But at least a starting point for the template is:
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        :rules="[rules.maxLength(1)]"
      />
    </v-container>
  </v-app>
</template>

<script>
  import { useRules } from '@/labs/rules'

  export default {
    name: 'Playground',
    setup () {
      return {
        rules: useRules(),
      }
    },
  }
</script>
```

Which in addition requires modifying `index.js` as well:
```js
import { createRulesPlugin } from '@/labs/rules/index.js'
```
Plus in `export default viteSSR()`:
```js
app.use(createRulesPlugin({}, vuetify.locale))
```

My actual test case that it also works using vue-i18n was to just link the Vuetify clone (with fix) to my actual project.