### PR TITLE
Fix(virtual.ts): Scroll to last element #20931

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -88,7 +88,7 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
     const start = performance.now()
     offsets[0] = 0
     const length = items.value.length
-    for (let i = 1; i <= length - 1; i++) {
+    for (let i = 1; i <= length; i++) {
       offsets[i] = (offsets[i - 1] || 0) + getSize(i - 1)
     }
     updateTime.value = Math.max(updateTime.value, performance.now() - start)
@@ -131,13 +131,8 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   }
 
   function calculateOffset (index: number) {
-    index = clamp(index, 0, items.value.length - 1)
-    const whole = Math.floor(index)
-    const fraction = index % 1
-    const next = whole + 1
-    const wholeOffset = offsets[whole] || 0
-    const nextOffset = offsets[next] || wholeOffset
-    return wholeOffset + (nextOffset - wholeOffset) * fraction
+    index = clamp(index, 0, items.value.length)
+    return offsets[index]
   }
 
   function calculateIndex (scrollTop: number) {


### PR DESCRIPTION
## Description
Dropdowns sometimes stopped right before the last element, so that you would need to scroll again to see the last element.

This bug sometimes occurred when manually scrolling to the bottom of the dropdown and always occured when opening the dropdown while the last element is selected.

Resolves #20931

## Markup
[Playground](https://play.vuetifyjs.com/#eNpdkF1qwzAQhK8y6CUOdfyTti/GDuQcdSnCWbcC2RaSYijGd+9aamiTJ+3Ozs5+6G0Rznb52ZhsvpKoRO1pMFp6OrUjUM8HaUwoQ9NNo5dqJPsrBdGRps6jUrzqmlaEtxWYD8N0Ic1KdNCFxfwWlj+mbUo8Vuf/ILh1nVXGw5G/RhY1mMl6LLDUY0VvpwE75t9tQ051HgECDc7Wyu9scyQLNI2f/qtCWRRYUyQfKdQezQkKTyj3f9s3YA7gEwn7eVjnEYQRxJqK5+w1Ox7FVpRF9iLSXmpH6d1/Ru39BwhfcnM=)