### PR TITLE
fix(VDatePicker): correct range for `allowed-dates`

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -224,7 +224,13 @@ export const VDatePicker = genericComponent<new <
     function isAllowedInRange (start: unknown, end: unknown) {
       const allowedDates = props.allowedDates
       if (typeof allowedDates !== 'function') return true
-      const days = adapter.getDiff(end, start, 'days')
+
+      const days = 1 + adapter.getDiff(
+        new Date(`${adapter.toISO(end)}T00:00:00Z`),
+        new Date(`${adapter.toISO(start)}T00:00:00Z`),
+        'days',
+      )
+
       for (let i = 0; i < days; i++) {
         if (allowedDates(adapter.addDays(start, i))) return true
       }


### PR DESCRIPTION
## Description

fixes #22160

> Note: Minimal amount of changes. We could move it inside `getDiff` behind additional argument `ignoreTime` or introduce new method for the adapter `adapter.withoutTime(date)`

## Markup:

```vue
<template>
  <v-row>
    <v-col>
      <v-card title="First day allowed">
        <v-date-picker
          v-model="date1"
          :allowed-dates="isFirstDayOfMonth"
          view-mode="months"
        />
      </v-card>
    </v-col>

    <v-col>
      <v-card title="Second last day allowed">
        <v-date-picker
          v-model="date2"
          :allowed-dates="isSecondLast"
          view-mode="months"
        />
      </v-card>
    </v-col>

    <v-col>
      <v-card title="Last day allowed">
        <v-date-picker
          v-model="date3"
          :allowed-dates="isLastDayOfMonth"
          view-mode="months"
        />
      </v-card>
    </v-col>
  </v-row>
</template>

<script setup lang="ts">
  import { ref } from 'vue'
  import { useDate } from 'vuetify'

  const adapter = useDate()

  const date1 = ref()
  const date2 = ref()
  const date3 = ref()

  function isFirstDayOfMonth (v: unknown): boolean {
    return adapter.isSameDay(v, adapter.startOfMonth(v))
  }

  function isSecondLast (v: unknown): boolean {
    return adapter.isSameDay(v, adapter.addDays(adapter.endOfMonth(v), -1))
  }

  function isLastDayOfMonth (v: unknown): boolean {
    return adapter.isSameDay(v, adapter.endOfMonth(v))
  }
</script>
```
