### PR TITLE
fix(VField): missing `controlRef` assignment

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -295,10 +295,11 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                   ...slots,
                   default: ({
                     props: { class: fieldClass, ...slotProps },
+                    controlRef,
                   }) => (
                     <>
                       <input
-                        ref={ inputRef }
+                        ref={ val => inputRef.value = controlRef.value = val as HTMLInputElement }
                         type="file"
                         accept={ inputAccept }
                         readonly={ isReadonly.value }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -212,10 +212,11 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                   ...slots,
                   default: ({
                     props: { class: fieldClass, ...slotProps },
+                    controlRef,
                   }) => {
                     const inputNode = (
                       <input
-                        ref={ inputRef }
+                        ref={ val => inputRef.value = controlRef.value = val as HTMLInputElement }
                         value={ model.value }
                         onInput={ onInput }
                         v-intersect={[{

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -101,7 +101,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
     const vInputRef = ref<VInput>()
     const vFieldRef = ref<VInput>()
     const controlHeight = shallowRef('')
-    const textareaRef = ref<HTMLInputElement>()
+    const textareaRef = ref<HTMLTextAreaElement>()
     const scrollbarWidth = ref(0)
     const { platform } = useDisplay()
     const autocomplete = useAutocomplete(props)
@@ -289,6 +289,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                   ...slots,
                   default: ({
                     props: { class: fieldClass, ...slotProps },
+                    controlRef,
                   }) => (
                     <>
                       { props.prefix && (
@@ -298,7 +299,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                       )}
 
                       <textarea
-                        ref={ textareaRef }
+                        ref={ val => textareaRef.value = controlRef.value = val as HTMLTextAreaElement }
                         class={ fieldClass }
                         value={ model.value }
                         onInput={ onInput }


### PR DESCRIPTION
fixes #22034

- not sure if it changes anything (except exposing ref that Docs claim we want to expose)
- are we missing anything else? `slotProps` on VField side are passed next to the `props`, while components pull variables with the same name, but kinda different things altogether.. incorrect or just confusing?

## Markup:

(same as in the linked issue: [playground](https://play.vuetifyjs.com/#eNqVVNGK2zAQ/JWtKTgHsU2vlFKTpD1CoX1oH0ppH5LA6ez1RUS2hKSEC8b/3pVsn+3SHOlTrJnR7K5GyqYOjM6SO6Xi0xGDNFhYLJVgFlfbCmBxiphS/tMvMllZxivUHeRBi082KjiKvAcBNBbLbVBIuQ0G8BSVMkdBRGkex4TSqLDKI07+js15lO0xO4w1jqP6QmpSKM1Lps9j/lMmeHZIXYdauhqyWjtk3QKDNBn3/mAryAQzxpV9iG63QWfkukeb7T8/KWkw3wYrvwRs14vE7x2scn6i+QrfHaczBF71WvJMD3juiNhyK5D8htbrGgamadJn4MTEEaFpnqskVKZPgzqYxuGQNq1FMkqRlibTXFkwaI9tmLxUUluoXU5zOBr82el/YAENFFqWENKFCN12AKpjLFBosHQ7ZuEXFELCb6lF/iq8GSQUOEmmfrOQ0LGoO5bOa7MjaiCnqZFmdgPLFdTt0EygtrOwC5mcuLGm9aZDGvUxiu5vj658d7hL2Oz+gcfqaPaz2ieSQl+Qpgnn4AUp3L+uabBOPgia+8b387Ihai31NzSGPaKZeN5pzc4xN/53NlSY7LiBjxB6RQjk9l1aYBW0wHUN+Pf6ldpeuyd1Yaqp6Dpjbn4xwfMLjh17nZVGurEXjDz3Hza+LLNcVi8ZDqrrrAlzerzg2dO9Gd3RRdI+RnqGQTMP3sbv4ts3gfv4EL8P5gUTBueT/+QW2/0BDPjngw==))