### PR TITLE
fix(VNumberInput): align stacked controls in underlined variant

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
@@ -4,9 +4,6 @@
 
 @include tools.layer('components')
   .v-number-input
-    $root: &
-    $control-root: #{selector.append($root, '__control')}
-
     input[type="number"]
       -moz-appearance: textfield
 
@@ -51,10 +48,19 @@
         text-align: center
 
     &--stacked
-      #{$control-root}
+      .v-number-input__control
         flex-direction: column-reverse
         .v-btn
           flex: 1
+
+      .v-field--variant-underlined
+        > .v-field__prepend-inner:has(.v-number-input__control)
+        > .v-field__append-inner:has(.v-number-input__control)
+          // drop input padding
+          padding-top: var(--v-field-padding-top)
+          // and pass it down
+          > *:not(.v-number-input__control, .v-divider--vertical)
+            margin-top: var(--v-input-padding-top, 0)
 
     &--hide-input
       .v-field


### PR DESCRIPTION
fixes #22184

- it won't completely fix `density="compact"`, but would be a progress nonetheless

<details>
<summary>Preview</summary>

<img width="1206" height="354" alt="image" src="https://github.com/user-attachments/assets/cfc65316-f951-4460-892f-51e84c879692" />

</details>

```vue
<template>
  <v-app>
    <div class="d-flex" style="width: 800px;">
    <v-container>
      <v-number-input
        label="Label"
        controlVariant="stacked"
        :model-value="1"
        append-inner-icon="mdi-cow"
        clearable
        persistent-clear />
      <v-number-input
        label="Label"
        controlVariant="stacked"
        variant="outlined"
        :model-value="2"
        suffix="ABCy"
        append-inner-icon="mdi-cow"
        clearable
        persistent-clear
      />
      <v-number-input
        label="Label"
        control-variant="stacked"
        variant="underlined"
        :model-value="3"
        suffix="ABCy"
        append-inner-icon="mdi-cow"
        clearable
        persistent-clear
      />
    </v-container>
    <v-container>
      <v-text-field label="Label"
        controlVariant="stacked"
        model-value="1"
        append-inner-icon="mdi-cow"
        clearable
        persistent-clear />
      <v-text-field
        label="Label"
        controlVariant="stacked"
        variant="outlined"
        model-value="2"
        suffix="ABCy"
        append-inner-icon="mdi-cow"
        clearable
        persistent-clear
      />
      <v-text-field
        label="Label"
        controlVariant="stacked"
        variant="underlined"
        model-value="3"
        suffix="ABCy"
        append-inner-icon="mdi-cow"
        clearable
        persistent-clear
      />
    </v-container>
    </div>
  </v-app>
</template>
```