### PR TITLE
fix(VDatePicker): return correct range for DST

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.date.spec.ts
@@ -798,3 +798,44 @@ describe('week numbers with time zone', () => {
     expect($weeks[2].innerHTML).toBe('45')
   })
 })
+
+describe('range selection with time zone', () => {
+  beforeEach(() => vi.stubEnv('TZ', 'America/New_York'))
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('should select correct dates near ST/DST transition', async () => {
+    const update = vi.fn()
+    const wrapper = render(VDatePicker, {
+      props: {
+        multiple: 'range',
+        modelValue: ['2025-03-01','2025-03-01'],
+        'onUpdate:modelValue': update,
+      },
+    })
+
+    const btn1 = await wrapper.findByText('8') as HTMLElement
+    btn1.click()
+    expect(update).toHaveBeenNthCalledWith(1, [new Date('2025-03-08T05:00:00.000Z')])
+    const btn2 = await wrapper.findByText('9') as HTMLElement
+    btn2.click()
+    expect(update).toHaveBeenNthCalledWith(2, [new Date('2025-03-08T05:00:00.000Z'), new Date('2025-03-10T03:59:59.999Z')])
+  })
+
+  it('should select correct dates near DST/ST transition', async () => {
+    const update = vi.fn()
+    const wrapper = render(VDatePicker, {
+      props: {
+        multiple: 'range',
+        modelValue: ['2025-10-01','2025-10-01'],
+        'onUpdate:modelValue': update,
+      },
+    })
+
+    const btn1 = await wrapper.findByText('2') as HTMLElement
+    btn1.click()
+    expect(update).toHaveBeenNthCalledWith(1, [new Date('2025-10-02T04:00:00.000Z')])
+    const btn2 = await wrapper.findByText('3') as HTMLElement
+    btn2.click()
+    expect(update).toHaveBeenNthCalledWith(2, [new Date('2025-10-02T04:00:00.000Z'), new Date('2025-10-04T03:59:59.999Z')])
+  })
+})

--- a/packages/vuetify/src/composables/date/date.ts
+++ b/packages/vuetify/src/composables/date/date.ts
@@ -91,9 +91,9 @@ export function createDate (options: DateOptions | undefined, locale: LocaleInst
 
 export function createDateRange (adapter: DateInstance, start: unknown, stop?: unknown) {
   const diff = adapter.getDiff(
-    adapter.endOfDay(stop ?? start),
-    adapter.startOfDay(start),
-    'days'
+    new Date(`${adapter.toISO(stop ?? start)}T00:00:00Z`),
+    new Date(`${adapter.toISO(start)}T00:00:00Z`),
+    'days',
   )
   const datesInRange = [start]
 


### PR DESCRIPTION
fixes #22186

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker v-model="value" month="10" multiple="range" />
      <pre>{{ value }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref([])
</script>
```
