### PR TITLE
fix(VOverlay): handle transition prop correctly for target assignment

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -40,6 +40,7 @@ import {
   getCurrentInstance,
   getScrollParent,
   IN_BROWSER,
+  isObject,
   propsFactory,
   standardEasing,
   useRender,
@@ -332,7 +333,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                 appear
                 persisted
                 transition={ props.transition }
-                target={ target.value }
+                target={ isObject(props.transition) ? target.value : undefined }
                 onAfterEnter={ onAfterEnter }
                 onAfterLeave={ onAfterLeave }
               >

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -42,6 +42,7 @@ import {
   getCurrentInstance,
   getScrollParent,
   IN_BROWSER,
+  isObject,
   omit,
   propsFactory,
   standardEasing,
@@ -397,7 +398,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                 appear
                 persisted
                 transition={ props.transition }
-                target={ target.value }
+                target={ isObject(props.transition) ? target.value : undefined }
                 onAfterEnter={ onAfterEnter }
                 onAfterLeave={ onAfterLeave }
               >

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -42,7 +42,6 @@ import {
   getCurrentInstance,
   getScrollParent,
   IN_BROWSER,
-  isObject,
   omit,
   propsFactory,
   standardEasing,
@@ -398,7 +397,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                 appear
                 persisted
                 transition={ props.transition }
-                target={ isObject(props.transition) ? target.value : undefined }
+                target={ target.value }
                 onAfterEnter={ onAfterEnter }
                 onAfterLeave={ onAfterLeave }
               >

--- a/packages/vuetify/src/composables/transition.ts
+++ b/packages/vuetify/src/composables/transition.ts
@@ -17,10 +17,11 @@ interface MaybeTransitionProps extends TransitionProps {
   transition?: null | string | boolean | TransitionProps & { component?: any }
   disabled?: boolean
   group?: boolean
+  target?: HTMLElement | [x: number, y: number]
 }
 
 export const MaybeTransition: FunctionalComponent<MaybeTransitionProps> = (props, { slots }) => {
-  const { transition, disabled, group, ...rest } = props
+  const { transition, disabled, group, target, ...rest } = props
 
   const {
     component = group ? TransitionGroup : Transition,
@@ -31,7 +32,7 @@ export const MaybeTransition: FunctionalComponent<MaybeTransitionProps> = (props
   if (isObject(transition)) {
     transitionProps = mergeProps(
       customProps,
-      onlyDefinedProps({ disabled, group }),
+      onlyDefinedProps({ disabled, group, target }),
       rest,
     )
   } else {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

This PR fixes an issue in the `VOverlay` component where the `target` prop was being passed to `MaybeTransition` regardless of the type of the `transition` prop. The `target` prop should only be passed when the `transition` prop is an object, not when it's a string transition name.

**Problem:**
The `MaybeTransition` component was receiving a `target` value even when using string-based transitions, which cause an invalid attribute to appear in the DOM (`target="[object HTMLButtonElement]"`)

**Solution:**
Added a conditional check using `isObject(props.transition)` to only pass the `target` prop to `MaybeTransition` when the transition prop is an object. This ensures the target is only used for custom transition configurations that actually need it.

**Changes:**
- Import `isObject` utility function
- Add conditional check: `target={ isObject(props.transition) ? target.value : undefined }`

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <!-- <v-menu
        transition="slide-y-transition"
      >
        <template #activator="{ props }">
          <v-btn
            color="primary"
            v-bind="props"
          >
            Slide Y Transition
          </v-btn>
        </template>
        <v-list>
          <v-list-item
            v-for="(item, i) in items"
            :key="i"
            :value="i"
          >
            <v-list-item-title>{{ item.title }}</v-list-item-title>
          </v-list-item>
        </v-list>
      </v-menu> -->
      <v-btn
        color="primary"
      >
        Parent activator

        <v-menu activator="parent">
          <v-list>
            <v-list-item
              v-for="(item, index) in items"
              :key="index"
              :value="index"
            >
              <v-list-item-title>{{ item.title }}</v-list-item-title>
            </v-list-item>
          </v-list>
        </v-menu>
      </v-btn>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { title: 'Click Me' },
    { title: 'Click Me' },
    { title: 'Click Me' },
    { title: 'Click Me 2' },
  ]
</script>
```