### PR TITLE
fix(VDateInput): apply min/max to text input

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
@@ -54,7 +54,7 @@
           flex: 1
 
       .v-field--variant-underlined
-        > .v-field__prepend-inner:has(.v-number-input__control)
+        > .v-field__prepend-inner:has(.v-number-input__control),
         > .v-field__append-inner:has(.v-number-input__control)
           // drop input padding
           padding-top: var(--v-field-padding-top)

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -135,7 +135,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (
         isFocused.value &&
           !controlsDisabled.value &&
-          Number(_inputText.value) === model.value
+          Number(_inputText.value?.replace(decimalSeparator.value, '.')) === model.value
       ) {
         // ignore external changes while typing
         // e.g. 5.01{backspace}2 » should result in 5.02


### PR DESCRIPTION
## Description

 fixes #22179


<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-card title="single input">
        <v-card-text>
          <VDateInput label="2026 Only" max="12/31/2026" min="1/1/2026" />
          <VDateInput label="Before 2027" max="12/31/2026" />
          <VDateInput label="After 2025" min="1/1/2026" />
          <VDateInput label="Any" />
        </v-card-text>
      </v-card>
      <v-card title="multiple">
        <v-card-text>
          <VDateInput
            label="2026 Only"
            max="12/31/2026"
            min="1/1/2026"
            multiple
          />
          <VDateInput label="Before 2027" max="12/31/2026" multiple />
          <VDateInput label="After 2025" min="1/1/2026" multiple />
          <VDateInput label="Any" multiple />
        </v-card-text>
      </v-card>

      <v-card title="Range">
        <v-card-text>
          <VDateInput
            label="2026 Only"
            max="12/31/2026"
            min="1/1/2026"
            multiple="range"
          />
          <VDateInput label="Before 2027" max="12/31/2026" multiple="range" />
          <VDateInput label="After 2025" min="1/1/2026" multiple="range" />
          <VDateInput label="Any" multiple="range" />
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>
```
