### PR TITLE
fix(VNumberInput): allow typing negative decimal values with comma separator

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -16,7 +16,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, nextTick, onMounted, ref, shallowRef, toRef, watch, watchEffect } from 'vue'
-import { clamp, consoleError, escapeForRegex, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { clamp, escapeForRegex, extractNumber, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
fixes #22183
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->


<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <!-- Description for bug demonstration -->
      To reproduce the bug: Enter "-0,1" and "-,01" (minus and comma) using your
      keyboard in the first input below.
      <v-number-input :precision="2" decimal-separator="," :step="0.01" />
      <v-divider />
      Enter "-0.1" and "-.01" (minus and dot) in the second input below. This
      input works as expected.
      <v-number-input :precision="2" decimal-separator="." :step="0.01" />
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
  setup() {
    return {};
  },
};
</script>

```
