### PR TITLE
docs: fix breakpoint range for 'xs' from 0 - 595 to 0 - 599

### DIFF
--- a/packages/docs/src/pages/en/features/display-and-platform.md
+++ b/packages/docs/src/pages/en/features/display-and-platform.md
@@ -147,7 +147,7 @@ In the following example, we use a switch statement and the current breakpoint n
 ```ts
 {
   // Breakpoints
-  xs: boolean // 0 - 595
+  xs: boolean // 0 - 599
   sm: boolean // 600 - 959
   md: boolean // 960 - 1279
   lg: boolean // 1280 - 1919


### PR DESCRIPTION
I'm pretty sure xs breakpoint is from 0 - 599 and 595 was a typo

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
