### PR TITLE
fix(validation): 'number' rule should accept 0 and empty string

### DIFF
--- a/packages/vuetify/src/labs/rules/rules.ts
+++ b/packages/vuetify/src/labs/rules/rules.ts
@@ -53,7 +53,7 @@ export function createRules (options: RulesOptions | undefined, locale: LocaleIn
       return (v: any) => (!v || (typeof v === 'string' && /^.+@\S+\.\S+$/.test(v))) || t(err || '$vuetify.rules.email')
     },
     number: (err?: string) => {
-      return (v: string) => !v || !isNaN(Number(v)) || t(err || '$vuetify.rules.number')
+      return (v: string) => !v || !isNaN(v) || t(err || '$vuetify.rules.number')
     },
     integer: (err?: string) => {
       return (v: string) => (/^[\d]*$/.test(v)) || t(err || '$vuetify.rules.integer')


### PR DESCRIPTION
## Description

resolves #22192 instead of #22194

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-form validate-on="eager input " @submit.prevent="">
        <v-text-field
          :rules="[rules.number()]"
          v-model="num"
          label="current behaviour"
        />

        <v-text-field :rules="[rules.correctNumber()]" v-model="num" />

        <div>
          maybe blank should be correct value? if needed, we can use combiation
          of requided and number, like minLength rule?
        </div>
        <v-text-field
          :rules="[rules.number()]"
          v-model="blank"
          label="current behaviour"
        />
        <v-text-field
          :rules="[rules.correctNumberAndBlank()]"
          v-model="blank"
        />
        <v-text-field
          :rules="[
            rules.required(),
            rules.correctNumberAndBlank()
          ]"
          label="correct behaviour, this is combination with `required`"
          v-model="blank"
        />

        <v-btn text="Submit" type="submit" />
      </v-form>
    </v-container>
  </v-app>
</template>

<script setup>
    import { ref } from 'vue'
  //  import { useRules } from 'vuetify/labs/rules' // import dont work, so below is copypaste from repo

    const t = s => s // vuei18n stub

    const rules = {
      required: err => {
        return v => {
          // If the modifier .number is used, the 0 will be a number and it's a falsy value so we need to check for it
          return v === 0 || !!v || t(err || '$vuetify.rules.required');
        };
      },
      number: err => { // as in https://github.com/vuetifyjs/vuetify/blob/39c87f15b1f553f06cc22e7462ae235aec089501/packages/vuetify/src/labs/rules/rules.ts#L55
        return v => !!Number(v) || t(err || '$vuetify.rules.number');
      },
      correctNumber: err => {
        return v => !isNaN(Number(v)) || t(err || '$vuetify.rules.number');
      },
      correctNumberAndBlank: err => {
        return v => !v || !isNaN(Number(v)) || t(err || '$vuetify.rules.number');
      },
    }

    const num = ref('0')
    const blank = ref('')
</script>
```
