### PR TITLE
docs: update vitepress theme extending demo

### DIFF
--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -343,7 +343,7 @@ import { createVuetify } from 'vuetify'
 const vuetify = createVuetify({ components, directives })
 
 export default {
-  ...DefaultTheme,
+  extends: DefaultTheme,
   enhanceApp({ app }) {
     app.use(vuetify)
   },


### PR DESCRIPTION
current code snippet of adding vuetify to vitepress will break built-in components of vitepress, like Badges, see [issue](https://github.com/vuejs/vitepress/issues/1576).

according to [vitepress documents](https://vitepress.dev/guide/extending-default-theme#registering-global-components), the default theme of vitepress should be extended by the `extends` property.
