### PR TITLE
fix(VSkeletonLoader): render background in forced-colors mode

### DIFF
--- a/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.sass
+++ b/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.sass
@@ -60,6 +60,7 @@
       @media (forced-colors: active)
         @media (pointer: fine)
           cursor: progress
+
     &__avatar
       border-radius: 50%
       flex: 0 1 auto


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This addresses the request for High Contrast Support https://github.com/vuetifyjs/vuetify/issues/21515 for the VSkeletonLoader component when in forced-colors mode (e.g. Windows Accessibility > Contrast themes) by rendering the canvastext background on the skeleton-loader when system colors is active as shown below.

![_Vuetify-skeleton](https://github.com/user-attachments/assets/f91f716f-8b20-4340-b4c5-23c8579a4b6f)

**Note:** the cursor will change to progress to give feedback that something is still loading should they hover over the skeleton-loader bone while in forced-colors mode.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-row>
        <v-col cols="12" md="6">
          <v-skeleton-loader
            class="mx-auto"
            max-width="300"
            type="card-avatar, actions"
          />
        </v-col>

        <v-col cols="12" md="6">
          <v-skeleton-loader
            class="mx-auto"
            max-width="300"
            type="image, article"
          />
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>
```
