### PR TITLE
fix(VMenu): close on click outside

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -197,7 +197,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional (e: Event) {
-      return isActive.value && globalTop.value && (
+      return isActive.value && (
         // If using scrim, only close if clicking on it rather than anything opened on top
         !props.scrim || e.target === scrimEl.value || (e instanceof MouseEvent && e.shadowTarget === scrimEl.value)
       )

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -197,7 +197,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional (e: Event) {
-      return isActive.value && (
+      return isActive.value && localTop.value && (
         // If using scrim, only close if clicking on it rather than anything opened on top
         !props.scrim || e.target === scrimEl.value || (e instanceof MouseEvent && e.shadowTarget === scrimEl.value)
       )


### PR DESCRIPTION
fixes #20003
closes #21606

Goes into `dev`, just in case...

TODO:
- [ ] avoid regression with 2nd level of submenu ([demo](https://play.vuetifyjs.com/playgrounds/Ue_EyA))

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex ga-3">
      <v-select
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :menu-props="{ id: '#1' }"
        label="Select"
      />

      <v-combobox
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :menu-props="{ id: '#2' }"
        label="Combobox"
      />

      <v-menu id="#3" :close-on-content-click="false">
        <template #activator="{ props }">
          <v-btn v-bind="props">Menu with Autocomplete</v-btn>
        </template>
        <v-sheet class="d-flex flex-column ga-3 pa-4" style="width: 300px">
          <v-autocomplete
            :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
            :menu-props="{ id: '#3-1' }"
            label="Autocomplete"
          />
          <v-btn>
            Button with tooltip
            <v-tooltip id="#3-2" :open-on-hover="false" activator="parent" open-on-click>Tooltip</v-tooltip>
          </v-btn>
          <v-btn>
            Button with menu
            <v-menu id="#3-3" activator="parent">
              <v-card>Menu content</v-card>
            </v-menu>
          </v-btn>
        </v-sheet>
      </v-menu>
    </v-container>
  </v-app>
</template>
```
