### PR TITLE
fix: Cannot read properties of undefined (reading 'scrollLeft')

### DIFF
--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -149,8 +149,10 @@ export const VWindow = genericComponent<new <T>(
         scrollableParent = getScrollParent(rootRef.value)
 
         // Save current scroll position
-        savedScrollPosition.x = scrollableParent.scrollLeft
-        savedScrollPosition.y = scrollableParent.scrollTop
+        if (scrollableParent) {
+          savedScrollPosition.x = scrollableParent.scrollLeft
+          savedScrollPosition.y = scrollableParent.scrollTop
+        }
       }
 
       const itemsLength = group.items.value.length


### PR DESCRIPTION
## Description
After upgrading from v3.10.5 to v3.10.6, when I click on a `VTab` in a unit test, e.g.

```
await wrapper.find('#my-tab').trigger('click')
```

I get the following error

```
TypeError: Cannot read properties of undefined (reading 'scrollLeft')
    at flush (~/workspace/my-app/node_modules/vuetify/src/components/VWindow/VWindow.tsx:152:50)
```

It looks like the bug was introduced by [this change](https://github.com/vuetifyjs/vuetify/commit/fb7d36bf66bfc67adb607c7ac0f222c9181251b8) in v3.10.6.

The [nextTick handler](https://github.com/donalmurtagh/vuetify/blob/927dba712ea63397b35174b1a3f0634cfbf9c294/packages/vuetify/src/components/VWindow/VWindow.tsx#L172) checks that `scrollableParent` is defined before accessing its properties, so we should do the same here.
