### PR TITLE
fix(VOverlay): `stick-to-target` content visible until target overflows

### DIFF
--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -279,7 +279,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
     const contentBox = getIntrinsicSize(data.contentEl.value, data.isRtl.value)
     const scrollParents = getScrollParents(data.contentEl.value)
-    const viewportMargin = 12
+    const viewportMargin = props.stickToTarget ? 0 : 12 // TOOD: prop.viewportMargin
 
     if (!scrollParents.length) {
       scrollParents.push(document.documentElement)
@@ -302,10 +302,18 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       }
       return scrollBox
     }, undefined!)
-    viewport.x += viewportMargin
-    viewport.y += viewportMargin
-    viewport.width -= viewportMargin * 2
-    viewport.height -= viewportMargin * 2
+
+    if (props.stickToTarget) {
+      viewport.x += Math.min(0, targetBox.x)
+      viewport.y += Math.min(0, targetBox.y)
+      viewport.width = Math.max(viewport.width, targetBox.x + targetBox.width)
+      viewport.height = Math.max(viewport.height, targetBox.y + targetBox.height)
+    } else {
+      viewport.x += viewportMargin
+      viewport.y += viewportMargin
+      viewport.width -= viewportMargin * 2
+      viewport.height -= viewportMargin * 2
+    }
 
     let placement = {
       anchor: preferredAnchor.value,
@@ -397,19 +405,19 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
 
       // shift
       if (overflows.x.before) {
-        if (!props.stickToTarget) x += overflows.x.before
+        x += overflows.x.before
         contentBox.x += overflows.x.before
       }
       if (overflows.x.after) {
-        if (!props.stickToTarget) x -= overflows.x.after
+        x -= overflows.x.after
         contentBox.x -= overflows.x.after
       }
       if (overflows.y.before) {
-        if (!props.stickToTarget) y += overflows.y.before
+        y += overflows.y.before
         contentBox.y += overflows.y.before
       }
       if (overflows.y.after) {
-        if (!props.stickToTarget) y -= overflows.y.after
+        y -= overflows.y.after
         contentBox.y -= overflows.y.after
       }
 
@@ -419,9 +427,9 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
         available.x = viewport.width - overflows.x.before - overflows.x.after
         available.y = viewport.height - overflows.y.before - overflows.y.after
 
-        if (!props.stickToTarget) x += overflows.x.before
+        x += overflows.x.before
         contentBox.x += overflows.x.before
-        if (!props.stickToTarget) y += overflows.y.before
+        y += overflows.y.before
         contentBox.y += overflows.y.before
       }
 


### PR DESCRIPTION
fixes #22055

> Note: keeping `viewportMargin: 0`, as some people may already use `stick-to-target` to get it. It should have its own prop - could be introduced in v3.11.0.

```vue
<template>
  <v-app theme="dark">
    <v-container style="height: 200vh" fluid>
      <v-btn class="top-0 left-0" position="absolute">
        Hover Over Me
        <v-tooltip
          activator="parent"
          location="bottom center"
          text="Tooltip very long text which will overflow and be outside the window"
          model-value
          stick-to-target
        />
      </v-btn>
      <v-btn class="top-0 right-0" position="absolute">
        Hover Over Me
        <v-tooltip
          activator="parent"
          location="bottom center"
          text="Tooltip very long text which will overflow and be outside the window"
          model-value
          stick-to-target
        />
      </v-btn>
      <v-btn class="bottom-0 left-0" position="absolute">
        Hover Over Me
        <v-tooltip
          activator="parent"
          location="bottom center"
          text="Tooltip very long text which will overflow and be outside the window"
          model-value
          stick-to-target
        />
      </v-btn>
      <v-btn class="bottom-0 right-0" position="absolute">
        Hover Over Me
        <v-tooltip
          activator="parent"
          location="bottom center"
          text="Tooltip very long text which will overflow and be outside the window"
          model-value
          stick-to-target
        />
      </v-btn>

      <v-sheet class="mx-auto mt-n12 pa-4 bg-purple" elevation="4" width="100">
        Hover Over Me
        <v-tooltip
          activator="parent"
          location="right bottom"
          text="Tooltip very long text which will overflow and be outside the window"
          width="150"
          model-value
          stick-to-target
        />
      </v-sheet>

      <v-sheet class="mx-auto pa-4 bg-teal-darken-2" elevation="4" style="margin-top: calc(100vh - 100px)" width="100">
        Hover Over Me
        <v-tooltip
          activator="parent"
          location="right center"
          text="Tooltip very long text which will overflow and be outside the window"
          width="150"
          model-value
          stick-to-target
        />
      </v-sheet>
    </v-container>
  </v-app>
</template>
```
