### PR TITLE
feat(VOverlay): add `open-on-touch` prop

### DIFF
--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -42,6 +42,7 @@ interface ActivatorProps extends DelayProps {
   activatorProps: Record<string, any>
 
   openOnClick: boolean | undefined
+  openOnTouch: boolean
   openOnHover: boolean
   openOnFocus: boolean | undefined
 
@@ -60,6 +61,7 @@ export const makeActivatorProps = propsFactory({
     type: Boolean,
     default: undefined,
   },
+  openOnTouch: Boolean,
   openOnHover: Boolean,
   openOnFocus: {
     type: Boolean,
@@ -113,6 +115,13 @@ export function useActivator (
       }
       isActive.value = !isActive.value
     },
+    onTouchstart: (e: TouchEvent) => {
+      activatorEl.value = (e.currentTarget || e.target) as HTMLElement
+      if (!isActive.value) {
+        cursorTarget.value = [e.touches[0].clientX, e.touches[0].clientY]
+      }
+      isActive.value = !isActive.value
+    },
     onMouseenter: (e: MouseEvent) => {
       if (e.sourceCapabilities?.firesTouchEvents) return
 
@@ -146,6 +155,9 @@ export function useActivator (
 
     if (openOnClick.value) {
       events.onClick = availableEvents.onClick
+    }
+    if (props.openOnTouch) {
+      events.onTouchstart = availableEvents.onTouchstart
     }
     if (props.openOnHover) {
       events.onMouseenter = availableEvents.onMouseenter


### PR DESCRIPTION
fixes #17640

**Note**: disabling touch for `open-on-hover` was a conscious decision [b86d05b](https://github.com/vuetifyjs/vuetify/commit/b86d05b), so we need additional prop

Alternatives:
- drop the guard from `b86d05b`, but let users opt-out with `open-on-hover="no-touch"`
- make `open-on-touch` computed, `true` when `open-on-hover` is `true`, letting people opt-out with `:open-on-touch="false"`

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>

      <div class="text-center">
        <v-menu open-on-hover open-on-touch>
          <template #activator="{ props }">
            <v-btn color="primary" v-bind="props"> Dropdown </v-btn>
          </template>

          <v-list>
            <v-list-item v-for="(item, index) in items" :key="index">
              <v-list-item-title>{{ item.title }}</v-list-item-title>
            </v-list-item>
          </v-list>
        </v-menu>
        <br />
        <br />
        <v-menu open-on-hover>
          <template #activator="{ props }">
            <v-text-field color="primary" v-bind="props" />
          </template>

          <v-list>
            <v-list-item v-for="(item, index) in items" :key="index">
              <v-list-item-title>{{ item.title }}</v-list-item-title>
            </v-list-item>
          </v-list>
        </v-menu>
      </div>

    </v-container>
  </v-app>
</template>

<script setup>
  const items = [
    { title: 'Click Me' },
    { title: 'Click Me' },
    { title: 'Click Me' },
    { title: 'Click Me 2' },
  ]
</script>
```
