### PR TITLE
fix(VMenu): keep open when selecting and `open-delay="0"`

### DIFF
--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -135,7 +135,7 @@ export function useActivator (
       isFocused = false
       e.stopPropagation()
 
-      runCloseDelay()
+      runCloseDelay({ minDelay: 1 })
     },
   }
 
@@ -178,7 +178,7 @@ export function useActivator (
       }
       events.onFocusout = () => {
         isFocused = false
-        runCloseDelay()
+        runCloseDelay({ minDelay: 1 })
       }
     }
 

--- a/packages/vuetify/src/composables/delay.ts
+++ b/packages/vuetify/src/composables/delay.ts
@@ -16,10 +16,13 @@ export const makeDelayProps = propsFactory({
 export function useDelay (props: DelayProps, cb?: (value: boolean) => void) {
   let clearDelay: (() => void) = () => {}
 
-  function runDelay (isOpening: boolean) {
+  function runDelay (isOpening: boolean, options?: { minDelay: number }) {
     clearDelay?.()
 
-    const delay = Number(isOpening ? props.openDelay : props.closeDelay)
+    const delay = Math.max(
+      options?.minDelay ?? 0,
+      Number(isOpening ? props.openDelay : props.closeDelay)
+    )
 
     return new Promise(resolve => {
       clearDelay = defer(delay, () => {
@@ -33,8 +36,8 @@ export function useDelay (props: DelayProps, cb?: (value: boolean) => void) {
     return runDelay(true)
   }
 
-  function runCloseDelay () {
-    return runDelay(false)
+  function runCloseDelay (options?: { minDelay: number }) {
+    return runDelay(false, options)
   }
 
   return {


### PR DESCRIPTION
- forces minimal **1ms** delay for `blur` and `focusout`

fixes #21591

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-alert class="mb-4">
        Note: focus with <v-kbd>TAB</v-kbd> then use arrows
        <v-kbd>↑</v-kbd>/<v-kbd>↓</v-kbd> to select an item
      </v-alert>
      <v-menu
        close-delay="0"
        open-delay="0"
        transition="slide-x-transition"
        open-on-hover
      >
        <template #activator="{ props }">
          <v-btn v-bind="props">Test</v-btn>
        </template>
        <v-list :items="items" />
      </v-menu>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = ['Item 1', 'Item 2', 'Item 3']
</script>
```
