### PR TITLE
fix(VProgressCircular): add `overflow: hidden` to avoid height changes

### DIFF
--- a/packages/vuetify/src/components/VProgressCircular/VProgressCircular.sass
+++ b/packages/vuetify/src/components/VProgressCircular/VProgressCircular.sass
@@ -9,6 +9,7 @@
     align-items: center
     display: inline-flex
     justify-content: center
+    overflow: hidden
     position: relative
     vertical-align: middle
 


### PR DESCRIPTION
fixes #22244; add overflow hidden to avoid transform height changes.

```vue
<script setup>
  import { ref } from 'vue'

  const indeterminate = ref(true)
</script>

<template>
  <v-app>
    <v-container>
      <v-switch v-model="indeterminate" label="Indeterminate" />
      <div class="border overflow-auto">
        <v-progress-circular :indeterminate />
      </div>
    </v-container>
  </v-app>
</template>
```