### PR TITLE
fix(VCalendar): Use scrollAreaRef from base in VCalendar Daily

### DIFF
--- a/packages/vuetify/src/labs/VCalendar/VCalendarDaily.tsx
+++ b/packages/vuetify/src/labs/VCalendar/VCalendarDaily.tsx
@@ -38,9 +38,7 @@ export const VCalendarDaily = defineComponent({
 
   setup (props, { slots, attrs }) {
     const scrollPush = ref(0)
-    const scrollArea = ref<HTMLElement>()
     const pane = ref<HTMLElement>()
-
     const base = useCalendarWithIntervals(props)
 
     function init () {
@@ -52,8 +50,8 @@ export const VCalendarDaily = defineComponent({
     }
 
     function getScrollPush (): number {
-      return scrollArea.value && pane.value
-        ? (scrollArea.value.offsetWidth - pane.value.offsetWidth)
+      return base.scrollAreaRef.value && pane.value
+        ? (base.scrollAreaRef.value.offsetWidth - pane.value.offsetWidth)
         : 0
     }
 
@@ -157,7 +155,7 @@ export const VCalendarDaily = defineComponent({
 
     function genScrollArea () {
       return (
-        <div ref={ scrollArea } class="v-calendar-daily__scroll-area">
+        <div ref={ base.scrollAreaRef } class="v-calendar-daily__scroll-area">
           { genPane() }
         </div>
       )
@@ -281,7 +279,6 @@ export const VCalendarDaily = defineComponent({
     return {
       ...base,
       scrollPush,
-      scrollArea,
       pane,
       init,
       onResize,


### PR DESCRIPTION
## Description
Fixes #22251
Also removes duplicate exposed scrollArea and scrollAreaRef in VCalendar Api. 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-row>
    <v-col>
      <v-sheet height="400" border>
        <v-calendar
          ref="calendar"
          :events="events"
          :model-value="today"
          :now="today"
          color="primary"
          type="week"
        />
        <v-btn @click="calendar.scrollToTime('08:00')">scroll to 8am</v-btn>
      </v-sheet>
    </v-col>
  </v-row>
</template>

<script setup lang="ts">
  import { onMounted, ref } from 'vue'

  const calendar = ref()

  const today = ref('2019-01-08')
  const events = [
    {
      name: 'Weekly Meeting',
      start: '2019-01-07 09:00',
      end: '2019-01-07 10:00',
    },
    {
      name: `Thomas' Birthday`,
      start: '2019-01-10',
    },
    {
      name: 'Mash Potatoes',
      start: '2019-01-09 12:30',
      end: '2019-01-09 15:30',
    },
  ]

  onMounted(() => {
    calendar.value.scrollToTime('08:00')
  })
</script>

```
