### PR TITLE
fix(VList): correct styles for spacing with `nav` prop

### DIFF
--- a/packages/docs/src/components/app/drawer/PinnedItems.vue
+++ b/packages/docs/src/components/app/drawer/PinnedItems.vue
@@ -3,7 +3,7 @@
     v-if="one.isSubscriber && user.ecosystem.docs.pins.enabled"
     v-model:opened="opened"
     :items="pinned"
-    class="pb-0 mb-n2"
+    class="pb-0 mb-n1"
     nav
   >
     <template #item="{ props: itemProps }">
@@ -11,7 +11,6 @@
         <v-list-item
           :title="itemProps.title"
           :to="itemProps.to"
-          class="mb-1"
           v-bind="activatorProps"
           @click.prevent="onClickPin(itemProps.to)"
         >

--- a/packages/vuetify/src/components/VList/VList.sass
+++ b/packages/vuetify/src/components/VList/VList.sass
@@ -21,6 +21,12 @@
     &--nav
       padding-inline: $list-nav-padding
 
+      .v-list-item:not(:first-child),
+      .v-list-group:not(:first-child) > .v-list-item,
+      .v-list-group__items > .v-list-item,
+      .v-list-group__items > .v-list-group
+        margin-top: $list-item-nav-margin-top
+
     &--rounded
       @include tools.rounded($list-rounded-border-radius)
 

--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -274,10 +274,6 @@
     &--nav
       padding-inline: $list-nav-padding
 
-      .v-list &
-        &:not(:only-child)
-          margin-bottom: $list-item-nav-margin-top
-
   .v-list-item__underlay
     position: absolute
 


### PR DESCRIPTION
fixes #20895

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-card class="mx-auto" width="300">
      <v-list nav v-model:opened="open">
        <v-list-item border prepend-icon="mdi-home" title="Home"></v-list-item>

        <v-list-group value="Users">
          <template v-slot:activator="{ props }">
            <v-list-item
              border
              v-bind="props"
              prepend-icon="mdi-account-circle"
              title="Users"
            ></v-list-item>
          </template>

          <v-list-group value="Admin">
            <template v-slot:activator="{ props }">
              <v-list-item border v-bind="props" title="Admin"></v-list-item>
            </template>

            <v-list-item
              border
              v-for="([title, icon], i) in admins"
              :key="i"
              :prepend-icon="icon"
              :title="title"
              :value="title"
            ></v-list-item>
          </v-list-group>

          <v-list-group value="Actions">
            <template v-slot:activator="{ props }">
              <v-list-item border v-bind="props" title="Actions"></v-list-item>
            </template>

            <v-list-item
              border
              v-for="([title, icon], i) in cruds"
              :key="i"
              :prepend-icon="icon"
              :title="title"
              :value="title"
            ></v-list-item>
          </v-list-group>
        </v-list-group>
      </v-list>
    </v-card>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const open = ref(['Users'])

  const admins = [
    ['Management', 'mdi-account-multiple-outline'],
    // ['Settings', 'mdi-cog-outline'],
  ]
  const cruds = [
    ['Create', 'mdi-plus-outline'],
    ['Read', 'mdi-file-outline'],
    ['Update', 'mdi-update'],
    ['Delete', 'mdi-delete'],
  ]
</script>
```
