### PR TITLE
fix(VRangeSlider): prevent thumb movement when disabled mid-interaction

### DIFF
--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
@@ -87,29 +87,30 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
       onSliderTouchstart,
       position,
       trackContainerRef,
+      disabled,
       readonly,
     } = useSlider({
       props,
       steps,
       onSliderStart: () => {
-        if (props.disabled || props.readonly) {
+        if (disabled.value || readonly.value) {
           activeThumbRef.value?.blur()
           return
         }
         emit('start', model.value)
       },
       onSliderEnd: ({ value }) => {
-        if (props.disabled || props.readonly) {
+        if (disabled.value || readonly.value) {
           activeThumbRef.value?.blur()
-          return
-        }
+        } else {
+          const newValue: [number, number] =
+            activeThumbRef.value === startThumbRef.value?.$el
+              ? [value, model.value[1]]
+              : [model.value[0], value]
 
-        const newValue: [number, number] = activeThumbRef.value === startThumbRef.value?.$el
-          ? [value, model.value[1]]
-          : [model.value[0], value]
-
-        if (!props.strict && newValue[0] < newValue[1]) {
-          model.value = newValue
+          if (!props.strict && newValue[0] < newValue[1]) {
+            model.value = newValue
+          }
         }
 
         emit('end', model.value)
@@ -117,13 +118,14 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
       onSliderMove: ({ value }) => {
         const [start, stop] = model.value
 
-        if (props.disabled || props.readonly) {
+        if (disabled.value || readonly.value) {
           activeThumbRef.value?.blur()
           return
         }
 
         if (!props.strict && start === stop && start !== min.value) {
-          activeThumbRef.value = value > start ? stopThumbRef.value?.$el : startThumbRef.value?.$el
+          activeThumbRef.value =
+            value > start ? stopThumbRef.value?.$el : startThumbRef.value?.$el
           activeThumbRef.value?.focus()
         }
 

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -83,14 +83,24 @@ export const VSlider = genericComponent<VSliderSlots>()({
       props,
       steps,
       onSliderStart: () => {
-        emit('start', model.value)
+        if (!disabled.value && !readonly.value) {
+          emit('start', model.value)
+        }
       },
       onSliderEnd: ({ value }) => {
         const roundedValue = roundValue(value)
-        model.value = roundedValue
+
+        if (!disabled.value && !readonly.value) {
+          model.value = roundedValue
+        }
+
         emit('end', roundedValue)
       },
-      onSliderMove: ({ value }) => model.value = roundValue(value),
+      onSliderMove: ({ value }) => {
+        if (!disabled.value && !readonly.value) {
+          model.value = roundValue(value)
+        }
+      },
       getActiveThumb: () => thumbContainerRef.value?.$el,
     })
 

--- a/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
+++ b/packages/vuetify/src/components/VSlider/VSliderThumb.tsx
@@ -103,7 +103,7 @@ export const VSliderThumb = genericComponent<VSliderThumbSlots>()({
     })
 
     function parseKeydown (e: KeyboardEvent, value: number) {
-      if (props.noKeyboard) return
+      if (props.noKeyboard || disabled.value) return
       if (!relevantKeys.includes(e.key)) return
 
       e.preventDefault()


### PR DESCRIPTION

## Description
Fixes an issue where the `VRangeSlider` thumb could still move if `disabled` became `true` while the user was dragging it.


### Reproduction
1. Start dragging a thumb.
2. Programmatically set `disabled` to `true` before release.
3. Thumb continues to move despite being disabled.

### Fix
Added a check to stop tracking thumb movement when `disabled` state changes during interaction.

Closes #22248

```html
<template>
  <v-app>
    <v-container>
      {{ range }}
      <v-progress-circular v-if="isLoading" indeterminate />
      <v-range-slider
        v-model="range"
        :disabled="isLoading"
        :max="100"
        :min="0"
        :step="1"
        @end="log('end')"
        @start="log('start')"
        @update:model-value="debouncedMockFetch"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  function log (v) {
    console.log(v)
  }

  function debounce (func, wait, immediate) {
    let timeout
    return function () {
      const context = this; const args = arguments
      clearTimeout(timeout)
      if (immediate && !timeout) func.apply(context, args)
      timeout = setTimeout(function () {
        timeout = null
        if (!immediate) func.apply(context, args)
      }, wait)
    }
  }
  function delay (time) {
    return new Promise(resolve => setTimeout(resolve, time))
  }
  async function mockFetch () {
    isLoading.value = true
    await delay(2000)
    isLoading.value = false
  }

  const range = ref([20, 80])
  const isLoading = ref(false)
  const debouncedMockFetch = debounce(mockFetch, 2000)
</script>
```
