### PR TITLE
fix(VDataTableVirtual): correct item selection when shift-clicking

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -248,7 +248,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
                                     { ...itemSlotProps.props }
                                     ref={ itemRef }
                                     key={ itemSlotProps.internalItem.index }
-                                    index={ itemSlotProps.internalItem.index }
+                                    index={ itemSlotProps.index }
                                     v-slots={ slots }
                                   />
                                 )


### PR DESCRIPTION
### Summary
Fixes an issue where `VDataTableVirtual` selected the wrong range of items when holding **Shift** while the table was sorted by a specific column.

### Fix

Used the actual index based on the item position in the array and not the index in the item itself

```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-card>
          <v-data-table-virtual
            v-model="selected"
            :headers="headers"
            :items="items"
            :sort-by="[{ key: 'name', order: 'asc' }]"
            item-value="id"
            show-select
            height="400"
          />
          <v-card-text> <b>Selected IDs:</b> {{ selected }} </v-card-text>
        </v-card>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'


  const selected = ref([])

  const headers = [
    { title: 'ID', value: 'id', width: '100px' },
    { title: 'Name', value: 'name' },
  ]

  // A simple dataset
  const items = Array.from({ length: 100 }, (_, i) => ({
    id: i + 1, // Unique ID
    name: `User ${i + 1}`,
  }))
</script>
```
Closes #22220