### PR TITLE
docs(api): fix `VThemeProvider` descriptions

### DIFF
--- a/packages/api-generator/src/locale/en/VThemeProvider.json
+++ b/packages/api-generator/src/locale/en/VThemeProvider.json
@@ -1,7 +1,6 @@
 {
   "props": {
-    "root": "Use the current value of `$vuetify.theme.dark` as opposed to the provided one.",
-    "withBackground": "Use the current value of `$vuetify.theme.dark` as opposed to the provided one."
+    "withBackground": "Wraps its children in an element and applies the current theme's background color to it."
   },
   "slots": {
     "default": "All child components will have their theme overridden. Must have exactly one root element."


### PR DESCRIPTION
## Description
Fix `VThemeProvider` API descriptions. Fixes #22265.