### PR TITLE
fix(VBtnToggle): remove semicolon from Sass

### DIFF
--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
@@ -24,7 +24,7 @@
 
       > .v-btn--active
         color: highlight !important
-        forced-color-adjust: preserve-parent-color;
+        forced-color-adjust: preserve-parent-color
 
         &:not(.v-btn--variant-text, .v-btn--variant-plain)
           background-color: highlight !important


### PR DESCRIPTION
fixes #22292

Removed an errant semicolon in VBtnToggle.sass which caused the application to have an error with older versions of the sass package. 

## Description
Removed an errant semicolon in VBtnToggle.sass.

## Markup:
Errors can be demonstrated in this repo: https://github.com/methompson/vuetify_vbtntoggle_bug
