### PR TITLE
fix(VDateInput): min/max with built-in adapter

### DIFF
--- a/packages/vuetify/dev/vuetify/date.js
+++ b/packages/vuetify/dev/vuetify/date.js
@@ -10,7 +10,7 @@ import { StringDateAdapter } from '@/composables/date/adapters/string'
 
 export default {
   // adapter: DateFnsAdapter,
-  adapter: StringDateAdapter,
+  // adapter: StringDateAdapter,
   formats: {
     // dayOfMonth: date => date.getDate(),
   },

--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -12,6 +12,7 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { makeVPickerProps, VPicker } from '@/labs/VPicker/VPicker'
 
 // Composables
+import { useCalendarRange } from '@/composables/calendar'
 import { useDate } from '@/composables/date'
 import { daysDiff } from '@/composables/date/date'
 import { useLocale, useRtl } from '@/composables/locale'
@@ -124,27 +125,13 @@ export const VDatePicker = genericComponent<new <
     const viewMode = useProxiedModel(props, 'viewMode')
     // const inputMode = useProxiedModel(props, 'inputMode')
 
-    const minDate = computed(() => {
-      const date = adapter.date(props.min)
-
-      return props.min && adapter.isValid(date) ? date : null
-    })
-    const maxDate = computed(() => {
-      const date = adapter.date(props.max)
-
-      return props.max && adapter.isValid(date) ? date : null
-    })
+    const { minDate, maxDate, clampDate } = useCalendarRange(props)
 
     const internal = computed(() => {
       const today = adapter.date()
-      let value = today
-      if (model.value?.[0]) {
-        value = adapter.date(model.value[0])
-      } else if (minDate.value && adapter.isBefore(today, minDate.value)) {
-        value = minDate.value
-      } else if (maxDate.value && adapter.isAfter(today, maxDate.value)) {
-        value = maxDate.value
-      }
+      const value = model.value?.[0]
+        ? adapter.date(model.value[0])
+        : clampDate(today)
 
       return value && adapter.isValid(value) ? value : today
     })

--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -5,6 +5,7 @@ import { VMenu } from '@/components/VMenu/VMenu'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
 
 // Composables
+import { useCalendarRange } from '@/composables/calendar'
 import { useDate } from '@/composables/date'
 import { createDateRange } from '@/composables/date/date'
 import { makeDateFormatProps, useDateFormat } from '@/composables/dateFormat'
@@ -110,15 +111,7 @@ export const VDateInput = genericComponent<new <
     const { isValid, parseDate, formatDate, parserFormat } = useDateFormat(props, currentLocale)
     const { mobile } = useDisplay(props)
 
-    const clamp = (date: unknown) => {
-      if (props.max && adapter.isAfter(date, props.max)) {
-        return props.max
-      }
-      if (props.min && adapter.isBefore(date, props.min)) {
-        return props.min
-      }
-      return date
-    }
+    const { clampDate, isInAllowedRange } = useCalendarRange(props)
 
     const emptyModelValue = () => props.multiple ? [] : null
 
@@ -246,16 +239,21 @@ export const VDateInput = genericComponent<new <
         model.value = emptyModelValue()
       } else if (!props.multiple) {
         if (isValid(value)) {
-          model.value = clamp(parseDate(value))
+          model.value = clampDate(parseDate(value))
         }
       } else {
         const parts = value.trim().split(/\D+-\D+|[^\d\-/.]+/)
         if (parts.every(isValid)) {
           if (props.multiple === 'range') {
-            const [start, stop] = parts.map(parseDate).map(clamp).toSorted((a, b) => adapter.isAfter(a, b) ? 1 : -1)
+            const [start, stop] = parts
+              .map(parseDate)
+              .map(clampDate)
+              .toSorted((a, b) => adapter.isAfter(a, b) ? 1 : -1)
             model.value = createDateRange(adapter, start, stop)
           } else {
-            model.value = parts.map(parseDate).map(clamp)
+            model.value = parts
+              .map(parseDate)
+              .filter(isInAllowedRange)
           }
         }
       }


### PR DESCRIPTION
- added missing `adapter.date(...)` around `props.min` and `props.max`
- extracted into reusable composable
- changed to avoid clamping `multiple` (non-range) - it is confusing to when input field says 2 selected, but the picker shows only one day

fixes #22291

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-alert>
        paste: <v-code>09/09/2025</v-code> or <v-code>01/02/2026</v-code>
      </v-alert>
      <v-date-input label="Date input" max="2025-11-11" />
    </v-container>
    <v-container>
      <v-alert>
        paste: <v-code>09/09/2025</v-code> or <v-code>11/01/2025, 11/08/2025, 11/15/2025</v-code>
      </v-alert>
      <v-date-input label="Date input" max="2025-11-11" multiple />
    </v-container>
    <v-container>
      <v-alert>
        paste: <v-code>09/09/2025</v-code> or <v-code>11/07/2025 - 11/14/2025</v-code>
      </v-alert>
      <v-date-input label="Date input" max="2025-11-11" multiple="range" />
    </v-container>
  </v-app>
</template>
```
