### PR TITLE
feat(VCombobox): create new items when pasting with line breaks

### DIFF
--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -165,8 +165,7 @@ export const VCombobox = genericComponent<new <
         }
 
         if (val && props.multiple && props.delimiters?.length) {
-          const signsToMatch = props.delimiters.map(escapeForRegex).join('|')
-          const values = val.split(new RegExp(`(?:${signsToMatch})+`))
+          const values = splitByDelimiters(val)
           if (values.length > 1) {
             selectMultiple(values)
             _search.value = ''
@@ -360,7 +359,7 @@ export const VCombobox = genericComponent<new <
     }
     function onPaste (e: ClipboardEvent) {
       const clipboardText = e?.clipboardData?.getData('Text') ?? ''
-      const values = clipboardText.split('\n').filter(item => item.trim() !== '')
+      const values = splitByDelimiters(clipboardText)
 
       if (values.length > 1 && props.multiple) {
         e.preventDefault()
@@ -412,6 +411,11 @@ export const VCombobox = genericComponent<new <
           isPristine.value = true
         })
       }
+    }
+    function splitByDelimiters (val: string) {
+      const effectiveDelimiters = ['\n', ...props.delimiters ?? []]
+      const signsToMatch = effectiveDelimiters.map(escapeForRegex).join('|')
+      return val.split(new RegExp(`(?:${signsToMatch})+`))
     }
     async function selectMultiple (values: string[]) {
       for (let value of values) {

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -808,11 +808,12 @@ describe('VCombobox', () => {
       <VCombobox
         v-model={ model.value }
         multiple
+        delimiters={[',']}
       />
     ))
 
     await userEvent.tab()
-    navigator.clipboard.writeText('foo\nbar')
+    navigator.clipboard.writeText('foo,\nbar')
     await userEvent.paste()
     expect(model.value).toEqual(['foo', 'bar'])
   })


### PR DESCRIPTION
fixes #10813

## Description
When pasting content with newlines (like a column from excel or an html table), they are converted to spaces.
With this feature, pasting column data would automatically create items for each row.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      {{ comboboxModel }}
      <v-combobox
        v-model="comboboxModel"
        :delimiters="[',']"
        :items="items"
        chips
        multiple
      />
    </v-container>
  </v-app>
</template>
<script setup>
  import { ref } from 'vue'

  const comboboxModel = ref([])
  const items = [
    'Item 1',
    'Item 2',
    'Item 3',
  ]

  /*
  try pasting
    Item 1,
    Item 2,
    Item 3,
  or
    Item 4, Item 5,
    Item 6, Item 7
  */
</script>
```
