### PR TITLE
fix(VAvatar): update background variable to use RGB format

### DIFF
--- a/packages/vuetify/src/components/VAvatar/_variables.scss
+++ b/packages/vuetify/src/components/VAvatar/_variables.scss
@@ -4,7 +4,7 @@
 @use "../../styles/tools/functions";
 
 // Defaults
-$avatar-background: var(--v-theme-surface) !default;
+$avatar-background: rgb(var(--v-theme-surface)) !default;
 $avatar-border-radius: map.get(variables.$rounded, 'circle') !default;
 $avatar-border-color: settings.$border-color-root !default;
 $avatar-border-radius: map.get(settings.$rounded, 0) !default;


### PR DESCRIPTION
## Description
- **What**: Set the default `$avatar-background` to `rgb(var(--v-theme-surface))`.
- **Why**: Aligns `VAvatar` with Vuetify’s RGB theme variable format for consistency with other components and base styles.
- **Impact**: No breaking changes; standardizes the variable format.
- **Files**: `packages/vuetify/src/components/VAvatar/_variables.scss`

## Markup:
---
```vue
<template>
  <VContainer class="bg-success">
    <VAvatar variant="elevated">JJ</VAvatar>
    <VAvatar variant="flat">JJ</VAvatar>
  </VContainer>
</template>
```
