### PR TITLE
fix(VDataTableVirtual): avoid scroll glitches with expanded rows

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -51,6 +51,9 @@ export type VDataTableVirtualSlots<T> = VDataTableRowsSlots<T> & VDataTableHeade
   item: {
     itemRef: TemplateRef
   }
+  'expanded-row': {
+    itemRef: TemplateRef
+  }
 }
 
 export const makeVDataTableVirtualProps = propsFactory({
@@ -120,7 +123,11 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
       sortRawFunctions,
     })
     const { flatItems } = useGroupedItems(sortedItems, groupBy, opened, () => !!slots['group-summary'])
-
+    const virtualItems = computed(() =>
+      props.showExpand
+        ? flatItems.value.flatMap(item => [item, { type: 'placeholder' }])
+        : flatItems.value
+    )
     const allItems = computed(() => extractRows(flatItems.value))
 
     const { isSelected, select, selectAll, toggleSelect, someSelected, allSelected } = provideSelection(props, {
@@ -140,8 +147,13 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
       handleScrollend,
       calculateVisibleItems,
       scrollToIndex,
-    } = useVirtual(props, flatItems)
-    const displayItems = computed(() => computedItems.value.map(item => item.raw))
+    } = useVirtual(props, virtualItems)
+
+    const displayItems = computed(() =>
+      computedItems.value
+        .filter(item => (item as any).raw.type !== 'placeholder')
+        .map(item => item.raw)
+    )
 
     useOptions({
       sortBy,
@@ -240,7 +252,9 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
                             <VVirtualScrollItem
                               key={ itemSlotProps.internalItem.index }
                               renderless
-                              onUpdate:height={ height => handleItemResize(itemSlotProps.internalItem.index, height) }
+                              onUpdate:height={ height =>
+                                handleItemResize(itemSlotProps.internalItem.index * (props.showExpand ? 2 : 1), height)
+                              }
                             >
                               { ({ itemRef }) => (
                                 slots.item?.({ ...itemSlotProps, itemRef }) ?? (
@@ -253,6 +267,15 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
                                   />
                                 )
                               )}
+                            </VVirtualScrollItem>
+                          ),
+                          'expanded-row': slotProps => (
+                            <VVirtualScrollItem
+                              key={ `${slotProps.internalItem.index}-expanded` }
+                              renderless
+                              onUpdate:height={ height => handleItemResize(slotProps.internalItem.index * 2 + 1, height) }
+                            >
+                              { ({ itemRef }) => slots['expanded-row']?.({ ...slotProps, itemRef }) }
                             </VVirtualScrollItem>
                           ),
                         }}

--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -75,7 +75,7 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
     return !!(containerRef.value && markerRef.value && viewportHeight.value && itemHeight.value)
   })
 
-  let sizes = Array.from<number | null>({ length: items.value.length })
+  let sizes = Array.from({ length: items.value.length }, () => 0.001)
   let offsets = Array.from<number>({ length: items.value.length })
   const updateTime = shallowRef(0)
   let targetScrollIndex = -1
@@ -257,7 +257,7 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   })
 
   watch(items, () => {
-    sizes = Array.from({ length: items.value.length })
+    sizes = Array.from({ length: items.value.length }, () => 0.001)
     offsets = Array.from({ length: items.value.length })
     updateOffsets.immediate()
     calculateVisibleItems()


### PR DESCRIPTION
## Description

fixes #20457

TODO:
- [ ] discussion around PoC approach
- [ ] are we missing some code that would reset `sizes[index]` when collapsed?
- [ ] minor cleanup

## Markup:

```vue
<template>
  <v-app>
    <v-data-table-virtual
      :headers="headers"
      :items="items"
      height="400"
      item-value="id"
      show-expand
    >
      <template #expanded-row="{ itemRef }">
        <tr :ref="itemRef">
          <td :colspan="headers.length + 1">
            <div v-for="subItem in subItems" :key="subItem.id">
              {{ subItem.name }}
            </div>
          </td>
        </tr>
      </template>
    </v-data-table-virtual>
  </v-app>
</template>

<script setup>
  const subItems = Array.from({ length: 20 })
    .map((_, index) => ({
      id: index + 1,
      name: `ID ${index + 1}`,
    }))

  const items = [
    ...Array.from({ length: 200 }, (_, index) => ({
      id: index + 1,
      name: `Version ${index + 1}`,
      status: 'Active',
      date: '2024-03-20',
    })),
  ]

  const headers = [
    { title: 'Name', key: 'name' },
    { title: 'Status', key: 'status' },
    { title: 'Date', key: 'date' },
  ]
</script>
```
