### PR TITLE
docs(typography): add font-weight-semibold on main typography page

### DIFF
--- a/packages/docs/src/pages/en/styles/text-and-typography.md
+++ b/packages/docs/src/pages/en/styles/text-and-typography.md
@@ -55,8 +55,8 @@ Control text size, alignment, wrapping, overflow, transforms and more. By defaul
 | **text-decoration-underline** | text-decoration: underline; |
 | **text-decoration-line-through** | text-decoration: line-through; |
 | **font-weight-black** | font-weight: 900; |
-| **font-weight-semibold** | font-weight: 600; |
 | **font-weight-bold** | font-weight: 700; |
+| **font-weight-semibold** | font-weight: 600; |
 | **font-weight-medium** | font-weight: 500; |
 | **font-weight-regular** | font-weight: 400; |
 | **font-weight-light** | font-weight: 300; |


### PR DESCRIPTION
ref d608fe5

Porting of #20586

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
add font-weight-semibold on main docs page `styles/text-and-typography/#text-and-typography`
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
