### PR TITLE
fix(select): fix screen reader reading out selected value twice

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -603,6 +603,7 @@ export const VAutocomplete = genericComponent<new <
                   return (
                     <div
                       key={ item.value }
+                      aria-hidden="true"
                       class={[
                         'v-autocomplete__selection',
                         index === selectionIndex.value && [

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -650,6 +650,7 @@ export const VCombobox = genericComponent<new <
                   return (
                     <div
                       key={ item.value }
+                      aria-hidden="true"
                       class={[
                         'v-combobox__selection',
                         index === selectionIndex.value && [

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -574,7 +574,7 @@ export const VSelect = genericComponent<new <
                   if (hasSlot && !slotContent) return undefined
 
                   return (
-                    <div key={ item.value } class="v-select__selection">
+                    <div key={ item.value } class="v-select__selection" aria-hidden="true">
                       { hasChips ? (
                         !slots.chip ? (
                           <VChip


### PR DESCRIPTION
related to #21097

## Description
Screen readers were reading out the selected value in VSelect, VAutocomplete and VCombobox twice. This will ensure they are read only once

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-form ref="form">
        <v-select v-model="selected" :items="selectItems" name="select" />

        <v-autocomplete v-model="selected" :items="selectItems" name="autocomplete" />

        <v-combobox v-model="selected" :items="selectItems" name="combobox" />
      </v-form>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selectItems = [
    { title: 'Item 1', value: 1 },
    { title: 'Item 2', value: 2 },
    { title: 'Item 3', value: 3 },
  ]
  const selected = ref(selectItems[0])
</script>

```
