### PR TITLE
fix(v-tooltip): prevent showing empty tooltip

### DIFF
--- a/packages/vuetify/src/directives/tooltip/index.ts
+++ b/packages/vuetify/src/directives/tooltip/index.ts
@@ -4,6 +4,9 @@ import { VTooltip } from '@/components/VTooltip'
 // Composables
 import { useDirectiveComponent } from '@/composables/directiveComponent'
 
+// Utilities
+import { isObject } from '@/util'
+
 // Types
 import type { DirectiveBinding } from 'vue'
 import type { Anchor } from '@/util'


### PR DESCRIPTION
## Description
Fixes #22345 

Disables activator when `value === null` or `value === false`, undefined is intentional, but at least this will give users a way to not show the tooltip conditionally

```vue
<template>
  <v-app>
    <v-container>
      <v-btn text="button with undefined tooltip" v-tooltip />
      <br>
      <v-btn text="button with null tooltip" v-tooltip="nullTooltip" />
      <br>
      <v-btn text="button with false tooltip" v-tooltip="false" @click="handleClick" />
      <br>
      <v-btn text="button without tooltip" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const nullTooltip = ref(null)

  function handleClick () {
    nullTooltip.value = 'Changed'
  }
</script>

```
