### PR TITLE
fix(VTreeview): automatically expand filtered items' ancestors

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -113,7 +113,7 @@ export const VTreeview = genericComponent<new <T>(
       })
       const newOpened = new Set([
         ...opened.value,
-        ...filteredItemsAncestors
+        ...filteredItemsAncestors,
       ])
       if (opened.value.length !== newOpened.size) {
         emit('update:opened', [...newOpened])

--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -8,7 +8,7 @@ import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, provide, ref, toRaw, toRef } from 'vue'
+import { computed, provide, ref, toRaw, toRef, watch } from 'vue'
 import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
@@ -101,6 +101,23 @@ export const VTreeview = genericComponent<new <T>(
           ...getChildren(itemVal),
         ].map(toRaw)
       }))
+    })
+
+    watch(filteredItems, val => {
+      if (!search.value) return
+      const getPath = vListRef.value?.getPath
+      if (!getPath) return
+      const filteredItemsAncestors = val.flatMap(item => {
+        const itemVal = props.returnObject ? item.raw : item.props.value
+        return getPath(itemVal).slice(0, -1)
+      })
+      const newOpened = new Set([
+        ...opened.value,
+        ...filteredItemsAncestors
+      ])
+      if (opened.value.length !== newOpened.size) {
+        emit('update:opened', [...newOpened])
+      }
     })
 
     function getChildren (id: unknown) {


### PR DESCRIPTION
fixes #22035
When searching a VTreeView, automatically expands the ancestors of filtered items.
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
I used a watcher to watch when the filtered items change. I find the path of all filtered items and emit update:opened to include those so that they are opened in addition to the filtered items.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div>
    opened: {{ openedTitles }}
  </div>
  <v-card class="mx-auto" max-width="500">
    <v-sheet class="pa-4" color="surface-variant">
      <v-text-field v-model="search" clear-icon="mdi-close-circle-outline" label="Search Company Directory"
        variant="solo" clearable flat hide-details></v-text-field>

      <v-checkbox-btn v-model="caseSensitive" label="Case sensitive search"></v-checkbox-btn>
    </v-sheet>

    <v-treeview v-model:opened="open" :custom-filter="filter" :items="items" :search="search" item-value="id"
      open-on-click>
      <template v-slot:prepend="{ item }">
        <v-icon v-if="item.children" :icon="`mdi-${item.id === 1 ? 'home-variant' : 'folder-network'}`"></v-icon>
      </template>
    </v-treeview>
  </v-card>
</template>

<script setup>
import { shallowRef, computed } from 'vue'

const items = [
  {
    id: 1,
    title: 'Vuetify Human Resources',
    children: [
      {
        id: 2,
        title: 'Core team',
        children: [
          {
            id: 20001,
            title: 'John',
            children: [
              {
                id: 30001,
                title: 'TEST 1',
              },
              {
                id: 30002,
                title: 'TEST 2',
              },
            ],
          },
          {
            id: 202,
            title: 'Kael',
          },
          {
            id: 203,
            title: 'Nekosaur',
          },
          {
            id: 204,
            title: 'Jacek',
          },
          {
            id: 205,
            title: 'Andrew',
          },
        ],
      },
      {
        id: 3,
        title: 'Administrators',
        children: [
          {
            id: 301,
            title: 'Blaine',
          },
          {
            id: 302,
            title: 'Yuchao',
          },
        ],
      },
      {
        id: 4,
        title: 'Contributors',
        children: [
          {
            id: 401,
            title: 'Phlow',
          },
          {
            id: 402,
            title: 'Brandon',
          },
          {
            id: 403,
            title: 'Sean',
          },
        ],
      },
    ],
  },
]

const open = shallowRef([1, 2])
const search = shallowRef(null)
const caseSensitive = shallowRef(false)

function filter(value, search, item) {
  return caseSensitive.value ? value.indexOf(search) > -1 : value.toLowerCase().indexOf(search.toLowerCase()) > -1
}


function findById(items, id) {
  for (const item of items) {
    if (item.id === id) return item;

    if (item.children) {
      const found = findById(item.children, id);
      if (found) return found;
    }
  }

  return null;
}

const openedTitles = computed(() => {
  return open.value.map(id => findById(items, id)?.title ?? '??')
})

</script>
```
