### PR TITLE
feat(theme): Support alpha values in hexa theme colors

### DIFF
--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -251,7 +251,8 @@ function genCssVariables (theme: InternalThemeDefinition, prefix: string) {
   const variables: string[] = []
   for (const [key, value] of Object.entries(theme.colors)) {
     const rgb = parseColor(value)
-    variables.push(`--${prefix}theme-${key}: ${rgb.r},${rgb.g},${rgb.b}`)
+    const colorVariable = rgb.a ? `${rgb.r},${rgb.g},${rgb.b},${rgb.a}` : `${rgb.r},${rgb.g},${rgb.b}`
+    variables.push(`--${prefix}theme-${key}: ${colorVariable}`)
     if (!key.startsWith('on-')) {
       variables.push(`--${prefix}theme-${key}-overlay-multiplier: ${getLuma(value) > 0.18 ? lightOverlay : darkOverlay}`)
     }


### PR DESCRIPTION
Resolves #19961
Resolves #10299

## Description
Presently, when using hexa colors in the Vuetify themes configuration, the alpha channel values are discarded when creating CSS variables. This PR passes them through if present.

So a configuration of:

```js
export default createVuetify({
  theme: {
    themes: {
      light: {
        colors: {
          surface: '#EEEEEEAA',
        },
      },
    },
  },
})
```

generates the variable `--v-theme-surface: 238,238,238,0.66` which is compatible with the `rgb` CSS function. See [MDN rgba() -> comma-separated values](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/rgb#legacy_syntax_comma-separated_values)

## Markup:
Follow standard Vuetify dev setup

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-text-field label="Test" variant="outlined" />
    </v-container>
  </v-app>
</template>

<script>
export default {
  name: "Playground",
  setup() {
    return {
      //
    };
  },
};
</script>
```
