### PR TITLE
fix(VDatePicker): ISO-8601 compliant month string

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePicker.tsx
@@ -171,7 +171,7 @@ export const VDatePicker = genericComponent<new <
         : formattedDate
     })
 
-    const date = toRef(() => adapter.parseISO(`${year.value}-${month.value + 1}-01`))
+    const date = toRef(() => adapter.parseISO(`${year.value}-${String(month.value + 1).padStart(2, '0')}-01`))
     const monthYearText = toRef(() => adapter.format(date.value, 'monthAndYear'))
     const monthText = toRef(() => adapter.format(date.value, 'monthShort'))
     const yearText = toRef(() => adapter.format(date.value, 'year'))


### PR DESCRIPTION
## Description
fixes #22388 

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
