### PR TITLE
feat(VDatePicker): add readonly prop

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerControls.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerControls.tsx
@@ -52,10 +52,6 @@ export const makeVDatePickerControlsProps = propsFactory({
     type: [Boolean, String, Array] as PropType<boolean | string | string[] | null>,
     default: null,
   },
-  readonly: {
-    type: Boolean,
-    defauly: null,
-  },
   nextIcon: {
     type: IconValue,
     default: '$next',


### PR DESCRIPTION
## Description
fixes #22282

```vue
<template>
  <v-app>
    <v-container>
      <strong>Read Only?</strong>
      <v-date-picker
        :show-adjacent-months="true"
        aria-readonly="true"
        class="pa-"
        elevation="0"
        multiple="range"
        hide-header
        hide-title
        readonly
      />
      <br>
      <strong>Disabled</strong>
      <v-date-picker
        :model-value="['2025-11-29', '2025-11-30', '2025-12-1']"
        :show-adjacent-months="true"
        aria-readonly="true"
        class="pa-"
        elevation="0"
        multiple="range"
        disabled
        hide-header
        hide-title
      />
    </v-container>
  </v-app>
</template>

<script setup>

</script>

```
