### PR TITLE
fix(VAutocomplete, VCombobox): skip subheader for `auto-select-first`

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 // Styles
 import './VAutocomplete.sass'
 
@@ -217,6 +216,7 @@ export const VAutocomplete = genericComponent<new <
         vTextFieldRef.value?.focus()
       }
     }
+    // eslint-disable-next-line complexity
     function onKeydown (e: KeyboardEvent) {
       if (form.isReadonly.value) return
 
@@ -507,7 +507,7 @@ export const VAutocomplete = genericComponent<new <
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,
                             key: item.value,
-                            active: (highlightFirst.value && item.value === firstSelectableItem.value?.value) ? true : undefined,
+                            active: (highlightFirst.value && item === firstSelectableItem.value) ? true : undefined,
                             onClick: () => select(item, null),
                           })
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -292,7 +292,8 @@ export const VCombobox = genericComponent<new <
         menu.value = false
       }
 
-      if (highlightFirst.value &&
+      if (
+        highlightFirst.value &&
         ['Enter', 'Tab'].includes(e.key) &&
         firstSelectableItem.value &&
         !model.value.some(({ value }) => value === firstSelectableItem.value!.value)
@@ -569,7 +570,7 @@ export const VCombobox = genericComponent<new <
                           const itemProps = mergeProps(item.props, {
                             ref: itemRef,
                             key: item.value,
-                            active: (highlightFirst.value && item.value === firstSelectableItem.value?.value) ? true : undefined,
+                            active: (highlightFirst.value && item === firstSelectableItem.value) ? true : undefined,
                             onClick: () => select(item, null),
                           })
 


### PR DESCRIPTION
fixes #22398

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="450">
      <v-autocomplete :items="items" label="v-autocomplete" auto-select-first />
      <v-combobox :items="items" label="v-combobox" auto-select-first />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    data: () => ({
      items: [
        { type: 'subheader', title: 'Group 1' },
        { title: 'Item 1.1', value: 11 },
        { title: 'Item 1.2', value: 12 },
        { title: 'Item 1.3', value: 13 },
        { title: 'Item 1.4', value: 14 },
        { type: 'divider', text: 'or' },
        { type: 'subheader', title: 'Group 2' },
        { title: 'Item 2.1', value: 21 },
        { title: 'Item 2.2', value: 22 },
        { title: 'Item 2.3', value: 23 },
      ],
    }),
  }
</script>
```
