### PR TITLE
fix(VDataTable): selecting group should respect selectable prop

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableGroupHeaderRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableGroupHeaderRow.tsx
@@ -83,13 +83,15 @@ export const VDataTableGroupHeaderRow = genericComponent<VDataTableGroupHeaderRo
               </VDataTableColumn>
             )
           } else if (column.key === 'data-table-select') {
-            const modelValue = isSelected(rows.value)
-            const indeterminate = isSomeSelected(rows.value) && !modelValue
-            const selectGroup = (v: boolean) => select(rows.value, v)
+            const selectableRows = rows.value.filter(x => x.selectable)
+            const modelValue = selectableRows.length > 0 && isSelected(selectableRows)
+            const indeterminate = isSomeSelected(selectableRows) && !modelValue
+            const selectGroup = (v: boolean) => select(selectableRows, v)
             return slots['data-table-select']?.({ props: { modelValue, indeterminate, 'onUpdate:modelValue': selectGroup } }) ?? (
               <VDataTableColumn class="v-data-table__td--select-row" noPadding>
                 <VCheckboxBtn
                   density={ props.density }
+                  disabled={ selectableRows.length === 0 }
                   modelValue={ modelValue }
                   indeterminate={ indeterminate }
                   onUpdate:modelValue={ selectGroup }


### PR DESCRIPTION
fixes #22409

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="700">
      <v-data-table
        v-model="selected"
        :group-by="groupBy"
        :headers="headers"
        :item-selectable="v => v.selectable"
        :items="items"
        item-value="id"
        show-select
      />

      <v-card class="mt-4">
        <v-card-title>Selected Items</v-card-title>
        <v-card-text>
          <pre>{{ selected }}</pre>
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const headers = [
    { title: 'Name', key: 'name' },
    { title: 'Category', key: 'category' },
    { title: 'Selectable', key: 'selectable' },
  ]

  const items = [
    { id: 1, name: 'Item 1', category: 'Group A', selectable: true },
    { id: 2, name: 'Item 2', category: 'Group A', selectable: false },
    { id: 3, name: 'Item 3', category: 'Group A', selectable: true },
    { id: 4, name: 'Item 4', category: 'Group B', selectable: true },
    { id: 5, name: 'Item 5', category: 'Group B', selectable: false },
    { id: 6, name: 'Item 6', category: 'Group C', selectable: false },
    { id: 7, name: 'Item 7', category: 'Group C', selectable: false },
  ]

  const groupBy = [{ key: 'category' }]
  const selected = ref([])
</script>

<style>
.v-selection-control--disabled {
    color: red;
}
</style>
```
