### PR TITLE
fix(VTooltip): should be dismissable by default

### DIFF
--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -377,7 +377,8 @@
       "eager": "3.2.0",
       "interactive": "3.8.0",
       "stickToTarget": "3.10.0",
-      "viewportMargin": "3.11.0"
+      "viewportMargin": "3.11.0",
+      "persistent": "3.11.3"
     }
   },
   "VVirtualScroll": {

--- a/packages/vuetify/src/components/VTooltip/VTooltip.tsx
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.tsx
@@ -41,7 +41,6 @@ export const makeVTooltipProps = propsFactory({
     'retainFocus',
     'captureFocus',
     'disableInitialFocus',
-    'persistent',
   ]),
 }, 'VTooltip')
 
@@ -109,7 +108,6 @@ export const VTooltip = genericComponent<OverlaySlots>()({
           absolute
           location={ location.value }
           origin={ origin.value }
-          persistent
           role="tooltip"
           activatorProps={ activatorProps.value }
           _disableGlobalStack


### PR DESCRIPTION
- makes all tooltips dismissable with Escape key (aligned with v2)
- `persistent` prop is exposed in case anyone wants the tooltip to ignore Escape key

fixes #21501

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn v-tooltip="'Try to hide me with ESC'">Directive Tooltip</v-btn>
      &nbsp;
      <v-tooltip text="Try to hide me with ESC">
        <template #activator="{ props }">
          <v-btn v-bind="props">Component Tooltip</v-btn>
        </template>
      </v-tooltip>
    </v-container>
  </v-app>
</template>
```
