### PR TITLE
fix(VVirtualScroll): show more than 1 element when min height is `0`

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -149,14 +149,12 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   let lastScrollTime = 0
 
   watch(viewportHeight, (val, oldVal) => {
-    if (oldVal) {
-      calculateVisibleItems()
-      if (val < oldVal) {
-        requestAnimationFrame(() => {
-          scrollVelocity = 0
-          calculateVisibleItems()
-        })
-      }
+    calculateVisibleItems()
+    if (val < oldVal) {
+      requestAnimationFrame(() => {
+        scrollVelocity = 0
+        calculateVisibleItems()
+      })
     }
   })
 


### PR DESCRIPTION
context: It used to work before 3.4.0 ([#18392](https://github.com/vuetifyjs/vuetify/pull/18392)).

- when `height` or `min-height` are provided (with non-zero values) the `oldVal` is only `0` for the first run - which is irrelevant because it happens in the same frame as `watch(hasInitialRender, ..)` and gets canceled anyway.
- when `height` or `min-height` are not provided, the `if (oldVal)` gets `0` again external reload method resets `items` to empty array for a short moment. `watch(items, ..)` recalculates items and due to `0` height, puts just one into `computedItems`.

Alternatives:
- console warning when user did not provide `height` or `min-height`
- some additional conditions in the `if (oldVal && ...)`
- a new prop

[Playground](https://play.vuetifyjs.com/#eNqVU02PmzAQ/Ssj97BEC4Q02h6yJGrvPbanJAeXmGDVGMvYdCXk/96xvSSBPe2Jmec38+aL40h6Xa1/KJUPlpEdKQ1rlaCGHU4SoBwyqlQwg1N10lAumX6HAvjHSPheCV793Z+IVRcM/sl7k6xO5AC/gw8CAUjGkWP6PhdMXk3j3ArKdYjHdA8JJR34lRreyeyi6T+mQXRV8FFA82tjTgR2iumWSiYNgkZb5rFadMiT1xt0qzMkHrg2loqsr3QnBOxCNcgNX4xv6VvWMC+A4LYYmlkCTDENB75cWE2t8LzQUwpcXtibWwQEVd975kmLp/ljZrgR7IAjColcHoflnB/RkrXQeGTMC17P1nmnzydx3yY+fZj+tH58m+/fI/E8ZjroYlquDPTM2Hg9vFWdNjCCZjU4qHXXwhNe3FNcPObF+whrgL3nJEcP4xZZj8tO78Yn0fPq1St4s7ay8l3B44nCGJuLdzlQYRkWcDxjlIexgV+8ZZ01CXL3h4k+VYwHg/RN8U5HkU5DIhj2gnjxip/Sk9B4fr6JLQRzZfsmmcr2BUeKi4ZLYftSRBihch2Hi2MlLiXb/FteZFSohuYvxPubTf6VpDUVPUtnP3fEzv8BZ4s+Mw==)
