### PR TITLE
fix(VCounter): inherit color (aligns with VMessages)

### DIFF
--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -152,6 +152,17 @@ The **$field-clearable-margin** SASS variable has been removed and replaced with
 +   $field-gap: 8px,
 ```
 
+### VCounter (hint under VTextField, VTextarea and VFieldInput)
+
+The **$counter-color** and `color` was replaced in favor of opacity. If you modified this value, move it to target CSS class directly:
+
+```diff { resource="styles/styles.scss"}
+.v-counter {
+  opacity: 1;
+  color: /* your $counter-color */;
+}
+```
+
 ### VSelect/VCombobox/VAutocomplete
 
 #### `item` in slots has been renamed to `internalItem`

--- a/packages/vuetify/src/components/VCounter/VCounter.sass
+++ b/packages/vuetify/src/components/VCounter/VCounter.sass
@@ -4,7 +4,7 @@
 
 @include tools.layer('components')
   .v-counter
-    color: $counter-color
+    opacity: var(--v-medium-emphasis-opacity)
     flex: $counter-flex
     font-size: $counter-font-size
     transition-duration: $counter-transition-duration

--- a/packages/vuetify/src/components/VCounter/_variables.scss
+++ b/packages/vuetify/src/components/VCounter/_variables.scss
@@ -1,5 +1,4 @@
 // VCounter
-$counter-color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity)) !default;
 $counter-flex: 0 1 auto !default;
 $counter-font-size: 12px !default;
 $counter-line-height: $counter-font-size !default;


### PR DESCRIPTION
- use opacity instead of color

[Playground](https://play.vuetifyjs.com/#eNqlVc1u2zAMfhXWGJYEqJ0mbXcIkm4DhgG77FBgA4amB0VmaqGy5Emym6LNu4/yfxqvHbAcYukjxY+kSOrmKbCGTz9nWVTkGCyCpcM0k8zh1VoBLIvQJojOrwG4ZNau1kG6C1nuNGQs/ACpC2fzdVBpoMSCOaEVaXXog4hdQsj52VkDcS21ISgzImXmsYJLypJ0q00KBrek4ZfroBaVQoc7F24FyrgBAYow1TFK0lcsxYbF/xZc58qhJ5u19KXA5BJ9OP7EtV/3pZJtSnPfX5hLhHIE/7Bo/DnQBjBMmZB9pQyNFdahcqHXHxTUbnUyg79zYbANakoxt1FvzOGe7oVyzXumuwzUkn6ogm7Vh1p+B5NwU8DqCk5OCnh+htE30gNhW59Gt0O58Vp9/NUIipAnyO83ejfkcyt727dfOoc0tw7YnUEEqkOulRMqx5NhN79oeKQzpfrH1/y9Wk47L/u+x6Joiz8OtxJ34P/oDmWeql51lnFunOpaxYUX66Atd5tzjpZuADZS83v4xKXg9yQomBQxdd2BLYCfDdzZJxeJoOfdW5xojDbHjAYt9fUh3bXH4KvvuP8gfGBGCXX3F8o6JJoRg+Q98YALzZ4upBkWJPMjohpXtCnnFe2W094ko63lRmReQFNql2njIMYty6WDp8oSsbIFjCe+1sY1BuCbfAGj0WkfKKfFAm56ldyvUD8zDrqnPVwrjgt4/x6KSKK6cwksVzA7m3RHy+reIIHAE2YYpzlh/aQhVtsZu21XVccvQOVStmDZ6wdOVm0967tTQfNj6PwYuhiibtplAVsmLdb4fkKLapmiS3RMjrQpZfZRcWgq3me8FfmHQVHwT5UY9rAC9sCEA5cIG72jJ8FG/rqj5vh40i9MsaXceskEmETjxiNfzP4uSnREypXivg2gLMoXTrwkK3U80+DhrmT/xUynfWyw+u598bblGuxPg/PoMppfBn4xm0Xz4LTK9cHTXWG3fwAOjkxB)

<img width="337" height="226" alt="image" src="https://github.com/user-attachments/assets/b20808d3-8126-4183-b116-707e657706c7" />
