### PR TITLE
feat(VDatePicker): support readonly

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -42,10 +42,7 @@ export const makeVDatePickerMonthProps = propsFactory({
   hideWeekdays: Boolean,
   multiple: [Boolean, Number, String] as PropType<boolean | 'range' | number | (string & {})>,
   showWeek: Boolean,
-  readonly: {
-    type: Boolean,
-    defauly: false,
-  },
+  readonly: Boolean,
   transition: {
     type: String,
     default: 'picker-transition',


### PR DESCRIPTION
fixes #22282

## Description
Adds support for `readonly` for VDatePicker

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-checkbox v-model="readonly" label="Readonly" />
      <v-date-picker
        v-model="dates"
        :readonly="readonly"
        multiple="range"
        hide-header
        hide-title
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  const dates = ref(['2025-12-01', '2025-12-02', '2025-12-03'])
  const readonly = ref(true)
</script>

```
