### PR TITLE
feat(VImg): pass attributes to `<img>`

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -28,6 +28,7 @@ import {
 } from 'vue'
 import {
   convertToUnit,
+  filterInputAttrs,
   genericComponent,
   getCurrentInstance,
   propsFactory,
@@ -105,6 +106,8 @@ export const VImg = genericComponent<VImgSlots>()({
 
   directives: { vIntersect },
 
+  inheritAttrs: false,
+
   props: makeVImgProps(),
 
   emits: {
@@ -113,7 +116,7 @@ export const VImg = genericComponent<VImgSlots>()({
     error: (value: string | undefined) => true,
   },
 
-  setup (props, { emit, slots }) {
+  setup (props, { attrs, emit, slots }) {
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)
     const { roundedClasses } = useRounded(props)
     const vm = getCurrentInstance('VImg')
@@ -348,6 +351,8 @@ export const VImg = genericComponent<VImgSlots>()({
 
     useRender(() => {
       const responsiveProps = VResponsive.filterProps(props)
+      const [rootAttrs, imageAttrs] = filterInputAttrs(attrs)
+
       return (
         <VResponsive
           class={[
@@ -366,6 +371,7 @@ export const VImg = genericComponent<VImgSlots>()({
             props.style,
           ]}
           { ...responsiveProps }
+          { ...rootAttrs }
           aspectRatio={ aspectRatio.value }
           aria-label={ props.alt }
           role={ props.alt ? 'img' : undefined }
@@ -376,7 +382,7 @@ export const VImg = genericComponent<VImgSlots>()({
         >{{
           additional: () => (
             <>
-              <__image />
+              <__image { ...imageAttrs } />
               <__preloadImage />
               <__gradient />
               <__placeholder />


### PR DESCRIPTION
Pass attributes to `img` (similar to VTextarea and other input fields)
- ~~TODO: rename `filterInputAttrs` or duplicate as `filterImageAttrs` if there would be any differences~~
  - maybe later

resolves #18860
closes #18907

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-img
        ref="img"
        :width="300"
        aspect-ratio="16/9"
        fetchpriority="low"
        src="https://cdn.vuetifyjs.com/images/parallax/material.jpg"
        cover
      />
    </v-container>
  </v-app>
</template>
```
