### PR TITLE
docs(css-reset): formatting of 'ress'

### DIFF
--- a/packages/docs/src/pages/en/styles/css-reset.md
+++ b/packages/docs/src/pages/en/styles/css-reset.md
@@ -19,7 +19,7 @@ Opinionated base styles for Vuetify projects.
 
 ## Bootstrapping
 
-ress is a modern CSS reset that applies a solid base for stylesheets. It is built on top of [normalize.css](https://github.com/necolas/normalize.css) and adds new features such as specifying `font-family: monospace` for `<code>` elements, removing all `outlines` from elements when hovering, and much much more. Additional information can be found on the [ress GitHub repository](https://github.com/filipelinhares/ress).
+`ress` is a modern CSS reset that applies a solid base for stylesheets. It is built on top of [normalize.css](https://github.com/necolas/normalize.css) and adds new features such as specifying `font-family: monospace` for `<code>` elements, removing all `outlines` from elements when hovering, and much much more. Additional information can be found on the [ress GitHub repository](https://github.com/filipelinhares/ress).
 
 ::: warning
   The Vuetify style reset is applied globally and affects default elements such as `button` and `input`. This also includes anything located outside of the [v-app](/components/application) component.


### PR DESCRIPTION
It was not clear to me that `ress` was the name of the CSS Reset package, with the highlight it will be easier to identify as a separate concept.
