### PR TITLE
fix(VSlider): pass aria- attributes to thumb element

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerPreview.tsx
@@ -100,7 +100,7 @@ export const VColorPickerPreview = defineComponent({
         <div class="v-color-picker-preview__sliders">
           <VSlider
             class="v-color-picker-preview__track v-color-picker-preview__hue"
-            name={ t('$vuetify.colorPicker.ariaLabel.hueSlider') }
+            aria-label={ t('$vuetify.colorPicker.ariaLabel.hueSlider') }
             modelValue={ props.color?.h }
             onUpdate:modelValue={ h => emit('update:color', { ...(props.color ?? nullColor), h }) }
             step={ 1 }
@@ -116,7 +116,7 @@ export const VColorPickerPreview = defineComponent({
           { !props.hideAlpha && (
             <VSlider
               class="v-color-picker-preview__track v-color-picker-preview__alpha"
-              name={ t('$vuetify.colorPicker.ariaLabel.alphaSlider') }
+              aria-label={ t('$vuetify.colorPicker.ariaLabel.alphaSlider') }
               modelValue={ props.color?.a ?? 1 }
               onUpdate:modelValue={ a => emit('update:color', { ...(props.color ?? nullColor), a }) }
               step={ 0.01 }

--- a/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
+++ b/packages/vuetify/src/components/VRangeSlider/VRangeSlider.tsx
@@ -16,7 +16,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref } from 'vue'
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType, WritableComputedRef } from 'vue'
@@ -37,6 +37,8 @@ export const makeVRangeSliderProps = propsFactory({
 export const VRangeSlider = genericComponent<VSliderSlots>()({
   name: 'VRangeSlider',
 
+  inheritAttrs: false,
+
   props: makeVRangeSliderProps(),
 
   emits: {
@@ -46,7 +48,7 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
     start: (value: [number, number]) => true,
   },
 
-  setup (props, { slots, emit }) {
+  setup (props, { slots, emit, attrs }) {
     const startThumbRef = ref<VSliderThumb>()
     const stopThumbRef = ref<VSliderThumb>()
     const inputRef = ref<VInput>()
@@ -144,6 +146,7 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
 
     useRender(() => {
       const inputProps = VInput.filterProps(props)
+      const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const hasPrepend = !!(props.label || slots.label || slots.prepend)
 
       return (
@@ -163,6 +166,7 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
           style={ props.style }
           ref={ inputRef }
           { ...inputProps }
+          { ...rootAttrs }
           focused={ isFocused.value }
         >
           {{
@@ -246,6 +250,7 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
                   max={ model.value[1] }
                   position={ trackStart.value }
                   ripple={ props.ripple }
+                  { ...inputAttrs }
                 >
                   {{ 'thumb-label': slots['thumb-label'] }}
                 </VSliderThumb>
@@ -282,6 +287,7 @@ export const VRangeSlider = genericComponent<VSliderSlots>()({
                   max={ max.value }
                   position={ trackStop.value }
                   ripple={ props.ripple }
+                  { ...inputAttrs }
                 >
                   {{ 'thumb-label': slots['thumb-label'] }}
                 </VSliderThumb>

--- a/packages/vuetify/src/components/VSlider/VSlider.tsx
+++ b/packages/vuetify/src/components/VSlider/VSlider.tsx
@@ -16,7 +16,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, ref } from 'vue'
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { VSliderThumbSlots } from './VSliderThumb'
@@ -41,6 +41,8 @@ export const makeVSliderProps = propsFactory({
 export const VSlider = genericComponent<VSliderSlots>()({
   name: 'VSlider',
 
+  inheritAttrs: false,
+
   props: makeVSliderProps(),
 
   emits: {
@@ -50,7 +52,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
     end: (value: number) => true,
   },
 
-  setup (props, { slots, emit }) {
+  setup (props, { slots, emit, attrs }) {
     const thumbContainerRef = ref<VSliderThumb>()
     const inputRef = ref<VInput>()
     const { rtlClasses } = useRtl()
@@ -109,6 +111,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
 
     useRender(() => {
       const inputProps = VInput.filterProps(props)
+      const [rootAttrs, inputAttrs] = filterInputAttrs(attrs)
       const hasPrepend = !!(props.label || slots.label || slots.prepend)
 
       return (
@@ -127,6 +130,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
           ]}
           style={ props.style }
           { ...inputProps }
+          { ...rootAttrs }
           focused={ isFocused.value }
         >
           {{
@@ -185,6 +189,7 @@ export const VSlider = genericComponent<VSliderSlots>()({
                   onBlur={ blur }
                   ripple={ props.ripple }
                   name={ props.name }
+                  { ...inputAttrs }
                 >
                   {{ 'thumb-label': slots['thumb-label'] }}
                 </VSliderThumb>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes #22432

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-color-picker />
    <v-range-slider aria-label="Range" />
  </v-app>
</template>
```
