### PR TITLE
fix(VDateInput): make prepend-icon unfocusable

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -1,6 +1,7 @@
 // Components
 import { makeVConfirmEditProps, VConfirmEdit } from '@/components/VConfirmEdit/VConfirmEdit'
 import { makeVDatePickerProps, VDatePicker } from '@/components/VDatePicker/VDatePicker'
+import { useInputIcon } from '@/components/VInput/InputIcon'
 import { VMenu } from '@/components/VMenu/VMenu'
 import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextField'
 
@@ -109,6 +110,7 @@ export const VDateInput = genericComponent<new <
     const adapter = useDate()
     const { isValid, parseDate, formatDate, parserFormat } = useDateFormat(props, currentLocale)
     const { mobile } = useDisplay(props)
+    const { InputIcon } = useInputIcon(props)
 
     const { clampDate, isInAllowedRange } = useCalendarRange(props)
 
@@ -288,7 +290,6 @@ export const VDateInput = genericComponent<new <
           onBlur={ onBlur }
           validationValue={ model.value }
           onClick:control={ isInteractive.value ? onClick : undefined }
-          onClick:prepend={ isInteractive.value ? onClick : undefined }
           onUpdate:modelValue={ onUpdateDisplayModel }
           onUpdate:focused={ event => isFocused.value = event }
         >
@@ -350,6 +351,18 @@ export const VDateInput = genericComponent<new <
 
                 { slots.default?.() }
               </>
+            ),
+            prepend: prependSlotProps => (
+              slots.prepend
+                ? slots.prepend(prependSlotProps)
+                : (props.prependIcon && (
+                  <InputIcon
+                    key="prepend-icon"
+                    name="prepend"
+                    tabindex={ -1 }
+                    onClick={ isInteractive.value ? onClick : undefined }
+                  />
+                ))
             ),
           }}
         </VTextField>


### PR DESCRIPTION
fixes #22333

## Description
Alternative 1 for https://github.com/vuetifyjs/vuetify/issues/22333
Only the prepend icon of VDatePicker is unfocusable

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input label="Prepend Icon cannot be focused" prepend-icon="$vuetify" />
      <v-text-field label="Prepend Icon can be focused" prepend-icon="$vuetify" @click:prepend="() => {}" />
      <v-select label="Prepend Icon can be focused" prepend-icon="$vuetify" @click:prepend="() => {}" />
    </v-container>
  </v-app>
</template>
```
