### PR TITLE
fix(VInput): make all input icons unfocusable

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -288,6 +288,7 @@ export const VField = genericComponent<new <T>(
                 ? slots['prepend-inner'](slotProps.value)
                 : (props.prependInnerIcon && (
                   <InputIcon
+                    tabindex={ -1 }
                     key="prepend-icon"
                     name="prependInner"
                     color={ iconColor.value }
@@ -388,6 +389,7 @@ export const VField = genericComponent<new <T>(
                 ? slots['append-inner'](slotProps.value)
                 : (props.appendInnerIcon && (
                   <InputIcon
+                    tabindex={ -1 }
                     key="append-icon"
                     name="appendInner"
                     color={ iconColor.value }

--- a/packages/vuetify/src/components/VInput/VInput.tsx
+++ b/packages/vuetify/src/components/VInput/VInput.tsx
@@ -205,6 +205,7 @@ export const VInput = genericComponent<new <T>(
                 ? slots.prepend(slotProps.value)
                 : (props.prependIcon && (
                   <InputIcon
+                    tabindex={ -1 }
                     key="prepend-icon"
                     name="prepend"
                     color={ iconColor.value }
@@ -226,6 +227,7 @@ export const VInput = genericComponent<new <T>(
                 ? slots.append(slotProps.value)
                 : (props.appendIcon && (
                   <InputIcon
+                    tabindex={ -1 }
                     key="append-icon"
                     name="append"
                     color={ iconColor.value }


### PR DESCRIPTION
fixes #22333

## Description
Alternative 2 for https://github.com/vuetifyjs/vuetify/issues/22333
All input icons are unfocusable

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input label="Prepend Icon cannot be focused" prepend-icon="$vuetify" />
      <v-text-field label="Prepend Icon cannot be focused" prepend-icon="$vuetify" @click:prepend="() => {}" />
      <v-select label="Prepend Icon cannot be focused" prepend-icon="$vuetify" @click:prepend="() => {}" />
    </v-container>
  </v-app>
</template>

```
