### PR TITLE
chore(VDateInput): provide specific classes

### DIFF
--- a/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/labs/VDateInput/VDateInput.tsx
@@ -277,7 +277,7 @@ export const VDateInput = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
-          class={ props.class }
+          class={['v-date-input', props.class]}
           style={ props.style }
           modelValue={ display.value }
           inputmode={ inputmode.value }

--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -217,7 +217,7 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
           { ...textFieldProps }
           v-model={ model.value }
           ref={ vTextFieldRef }
-          class={ props.class }
+          class={['v-mask-input', props.class]}
           style={ props.style }
           validationValue={ validationValue.value }
           onCut={ onCut }


### PR DESCRIPTION
fixes #22334

## Description
Add a class to distinguish date inputs, mask inputs from general text fields

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-input />
      <v-mask-input />
      <v-color-input />
      <v-file-input />
      <v-text-field />
      <v-select />
    </v-container>
  </v-app>
</template>

```
