### PR TITLE
fix(VDataTable): fix typing on the align attribute (replace center with middle)

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableColumn.tsx
@@ -6,7 +6,7 @@ import type { PropType } from 'vue'
 
 export const VDataTableColumn = defineFunctionalComponent({
   align: {
-    type: String as PropType<'start' | 'center' | 'end'>,
+    type: String as PropType<'start' | 'middle' | 'end'>,
     default: 'start',
   },
   fixed: {

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -13,7 +13,7 @@ export type DataTableHeader<T = Record<string, any>> = {
   title?: string
 
   fixed?: boolean | 'start' | 'end'
-  align?: 'start' | 'end' | 'center'
+  align?: 'start' | 'end' | 'middle'
 
   width?: number | string
   minWidth?: number | string


### PR DESCRIPTION
## Description

This patch fixes the TypeScript typing of the `align` prop on the `VDataTableColumn` component in Vuetify. The previously allowed value `'center'` has been replaced with `'middle'` in the prop’s union type (`'start' | 'middle' | 'end'`), aligning the type definition with the actual, supported alignment values used by the component.

The change improves type safety and developer experience by preventing invalid or misleading alignment values in TypeScript, while ensuring consistency between the component’s API and its internal alignment behavior.
