### PR TITLE
fix(VOverlay): force real scrollbar visibility to avoid shift

### DIFF
--- a/packages/vuetify/src/components/VAppBar/VAppBar.sass
+++ b/packages/vuetify/src/components/VAppBar/VAppBar.sass
@@ -10,6 +10,3 @@
 
       &:not(.v-toolbar--flat)
         @include tools.elevation($app-bar-elevation)
-
-    &:not(.v-toolbar--absolute)
-      padding-inline-end: var(--v-scrollbar-offset)

--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -21,7 +21,6 @@
 
         > .v-card,
         > .v-sheet
-          --v-scrollbar-offset: 0px
           border-radius: $dialog-border-radius
           overflow-y: auto
           flex: 1 1 100%
@@ -48,8 +47,6 @@
             justify-content: $dialog-card-actions-justify
 
   .v-dialog--fullscreen
-    --v-scrollbar-offset: 0px
-
     > .v-overlay__content
       border-radius: 0
       margin: 0

--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -49,11 +49,11 @@
     position: absolute
 
   .v-overlay--scroll-blocked
-    padding-inline-end: var(--v-scrollbar-offset)
+    scrollbar-gutter: stable
 
 @include tools.layer('trumps')
   .v-overlay-scroll-blocked
-    padding-inline-end: var(--v-scrollbar-offset)
+    scrollbar-gutter: stable
 
     &:not(html)
       overflow-y: hidden
@@ -64,6 +64,3 @@
       left: var(--v-body-scroll-x)
       width: 100%
       height: 100%
-
-    .v-navigation-drawer--right.v-navigation-drawer--active
-      margin-right: var(--v-scrollbar-offset)

--- a/packages/vuetify/src/components/VOverlay/scrollStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/scrollStrategies.ts
@@ -80,7 +80,6 @@ function blockScrollStrategy (data: ScrollStrategyData, props: StrategyProps) {
     ...getScrollParents(target, props.contained ? offsetParent : undefined),
     ...getScrollParents(data.contentEl.value, props.contained ? offsetParent : undefined),
   ])].filter(el => !el.classList.contains('v-overlay-scroll-blocked'))
-  const scrollbarWidth = window.innerWidth - document.documentElement.offsetWidth
 
   const scrollableParent = (el => hasScrollbar(el) && el)(offsetParent || document.documentElement)
   if (scrollableParent) {
@@ -90,11 +89,6 @@ function blockScrollStrategy (data: ScrollStrategyData, props: StrategyProps) {
   scrollElements.forEach((el, i) => {
     el.style.setProperty('--v-body-scroll-x', convertToUnit(-el.scrollLeft))
     el.style.setProperty('--v-body-scroll-y', convertToUnit(-el.scrollTop))
-
-    if (el !== document.documentElement || getComputedStyle(el).overflowY !== 'scroll') {
-      el.style.setProperty('--v-scrollbar-offset', convertToUnit(scrollbarWidth))
-    }
-
     el.classList.add('v-overlay-scroll-blocked')
   })
 
@@ -108,7 +102,6 @@ function blockScrollStrategy (data: ScrollStrategyData, props: StrategyProps) {
       el.style.scrollBehavior = 'auto'
       el.style.removeProperty('--v-body-scroll-x')
       el.style.removeProperty('--v-body-scroll-y')
-      el.style.removeProperty('--v-scrollbar-offset')
       el.classList.remove('v-overlay-scroll-blocked')
 
       el.scrollLeft = -x

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.sass
@@ -7,7 +7,7 @@
     justify-content: center
     z-index: $snackbar-z-index
     margin: $snackbar-wrapper-margin
-    margin-inline-end: calc(#{$snackbar-wrapper-margin} + var(--v-scrollbar-offset))
+    margin-inline-end: $snackbar-wrapper-margin
     padding: var(--v-layout-top) var(--v-layout-right) var(--v-layout-bottom) var(--v-layout-left)
 
     &:not(.v-snackbar--center):not(.v-snackbar--top)

--- a/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
+++ b/packages/vuetify/src/components/VSystemBar/VSystemBar.sass
@@ -29,4 +29,4 @@
       height: $system-bar-window-height
 
     &:not(.v-system-bar--absolute)
-      padding-inline-end: calc(var(--v-scrollbar-offset) + #{$system-bar-padding-x})
+      padding-inline-end: $system-bar-padding-x

--- a/packages/vuetify/src/styles/elements/_global.sass
+++ b/packages/vuetify/src/styles/elements/_global.sass
@@ -17,7 +17,6 @@
 
   :root
     --v-theme-overlay-multiplier: 1
-    --v-scrollbar-offset: 0px
 
   // iOS Safari hack to allow click events on body
   @supports (-webkit-touch-callout: none)


### PR DESCRIPTION
Noticable shift by ~1px:
- on docs [Dialogs](https://next.vuetifyjs.com/en/components/dialogs/#usage)
- with 150% scaling on the OS level

Also larger shift when using `<v-main scrollable>` (see example below)

Cause: `window.innerWidth - document.documentElement.offsetWidth` returns wrong value (verified on vanilla Chrome and Brave, on Linux) unless scaling is exactly 100%.

**Note**: `scrollbar-gutter` requires Safari 18.1 (we claim 16.4 is gonna be supported by v4)

```vue
<template>
  <v-app theme="dark">
    <v-main scrollable>
      <v-container>
        <v-dialog max-width="500" scroll-strategy="block">
          <template v-slot:activator="{ props: activatorProps }">
            <v-btn
              v-bind="activatorProps"
              color="surface-variant"
              text="Open Dialog"
              variant="flat"
            ></v-btn>
          </template>

          <v-card title="Dialog">
            <v-card-text>
              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
              eiusmod tempor incididunt ut labore et dolore magna aliqua.
            </v-card-text>
          </v-card>
        </v-dialog>
      </v-container>

      <v-img
        src="https://cdn.cosmicjs.com/68b46aa0-d4fe-11ee-9ce5-59949019255e-VUETIFY-ONE-3.png"
        width="200"
        height="300"
        class="position-absolute right-0"
      />

      <v-card width="200" height="200vh" />
    </v-main>
  </v-app>
</template>
```