### PR TITLE
fix(VColorPicker): Disable swatches

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/VColorPickerSwatches.sass
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerSwatches.sass
@@ -28,6 +28,10 @@
     background: $color-picker-checkerboard
     cursor: pointer
 
+    &--disabled
+      opacity: var(--v-disabled-opacity)
+      pointer-events: none
+
     > div
       display: flex
       align-items: center

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerSwatches.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerSwatches.tsx
@@ -69,6 +69,14 @@ export const VColorPickerSwatches = defineComponent({
   },
 
   setup (props, { emit }) {
+    function onSwatchClick (hsva: HSV) {
+      if (props.disabled || !hsva) {
+        return
+      }
+
+      emit('update:color', hsva)
+    }
+
     useRender(() => (
       <div
         class={[
@@ -90,8 +98,13 @@ export const VColorPickerSwatches = defineComponent({
 
                 return (
                   <div
-                    class="v-color-picker-swatches__color"
-                    onClick={ () => hsva && emit('update:color', hsva) }
+                    class={[
+                      'v-color-picker-swatches__color',
+                      {
+                        'v-color-picker-swatches__color--disabled': props.disabled,
+                      },
+                    ]}
+                    onClick={ () => onSwatchClick(hsva) }
                   >
                     <div style={{ background }}>
                       { props.color && deepEqual(props.color, hsva)


### PR DESCRIPTION
fixes #22471

## Description
Disable swatches when `disabled` prop is passed from VColorPicker

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-color-picker
        v-model="value"
        disabled
        show-swatches
      />

      {{ value }}
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref('#461818')
</script>

```
