### PR TITLE
docs: replace 'variant' to 'control-variant' in v-date-picker code sample

### DIFF
--- a/packages/docs/src/examples/v-date-picker/usage.vue
+++ b/packages/docs/src/examples/v-date-picker/usage.vue
@@ -8,7 +8,6 @@
     <v-date-picker
       v-bind="props"
       v-model="date"
-      :control-variant="variant"
       class="mx-auto"
     ></v-date-picker>
 
@@ -27,11 +26,11 @@
   // const hideActions = ref(false)
   const adjacent = ref(false)
 
-  const variant = toRef(() => model.value !== 'default' ? model.value : undefined)
+  const controlVariant = toRef(() => model.value !== 'default' ? model.value : undefined)
 
   const props = computed(() => {
     return {
-      variant: variant.value,
+      'control-variant': controlVariant.value,
       // 'hide-actions': hideActions.value || undefined,
       'show-adjacent-months': adjacent.value || undefined,
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description

Fixed incorrect property name in the DatePicker documentation page. The correct property name is 'control-variant' instead of 'variant'. 

### Current Docs

<img width="967" height="738" alt="image" src="https://github.com/user-attachments/assets/ea0aceff-eb3d-4f6b-8119-61217f47bbd2" />

### Fixed Docs

<img width="818" height="723" alt="image" src="https://github.com/user-attachments/assets/fa95b968-d621-4637-b8ff-37ddece8f7a1" />

<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
