### PR TITLE
fix(VDatePicker): should accept controls height customization

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerControls.sass
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerControls.sass
@@ -10,7 +10,6 @@
     font-size: .875rem
     height: $date-picker-controls-height
     padding: $date-picker-controls-padding
-    flex: 1
 
     .v-btn
       text-transform: none


### PR DESCRIPTION
fixes #22478

## Description
The control-height property of VDatePickerControls was not working.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-date-picker control-height="100" />
    </v-container>
  </v-app>
</template>
```
