### PR TITLE
fix(VNumberInput): prevent stepper hover overflow when rounded"

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.sass
@@ -22,6 +22,7 @@
       overflow: hidden
       border-start-start-radius: inherit
       border-end-start-radius: inherit
+
       > .v-icon
         margin-inline-end: 4px
 
@@ -29,9 +30,14 @@
       > .v-number-input__control + .v-icon
         margin-inline: 8px 0
 
+      .v-divider--vertical
+        margin-inline: -1px 0
+
     .v-field__append-inner:has(.v-number-input__control)
+      overflow: hidden
       border-start-end-radius: inherit
       border-end-end-radius: inherit
+
       > .v-icon
         margin-inline-start: 4px
 
@@ -39,10 +45,8 @@
       > .v-icon:has(+ .v-number-input__control)
         margin-inline: 0 8px
 
-      > .v-number-input__control
-        overflow: hidden
-        border-start-end-radius: inherit
-        border-end-end-radius: inherit
+      .v-divider--vertical
+        margin-inline: 0 -1px
 
     .v-field__clearable:has(+ .v-field__append-inner > hr:first-child)
       margin-inline-end: 8px


### PR DESCRIPTION
Fixes #22489

When using a rounded `VNumberInput`, the stepper hover background could
overflow the rounded edge. This change clips the hover overlay at the
control level while preserving the vertical divider and existing layout
behavior.

The same issue occurred when using `control-variant="stacked"` as well as when using the the `reverse` prop

## Markup:

```vue
<template>
  <v-defaults-provider :defaults="{ VBtn: { color: 'primary', variant: 'flat' }, VNumberInput: { appendInnerIcon: 'mdi-cow', prependInnerIcon: 'mdi-cow' } }">
    <v-container>
      <v-number-input variant="outlined" rounded />
      <v-number-input control-variant="stacked" variant="outlined" rounded />
      <v-number-input control-variant="split" variant="outlined" rounded />
      <v-number-input reverse variant="outlined" rounded />
      <v-number-input reverse control-variant="stacked" variant="outlined" rounded />
      <v-number-input reverse control-variant="split" variant="outlined" rounded />
    </v-container>
  </v-defaults-provider>
</template>
```