### PR TITLE
Fix typo in installation.md

### DIFF
--- a/packages/docs/src/pages/en/getting-started/installation.md
+++ b/packages/docs/src/pages/en/getting-started/installation.md
@@ -160,7 +160,7 @@ export default defineNuxtConfig({
     plugins: [
       // @ts-expect-error
       vuetify({ autoImport: true }),
-    ]
+    ],
     vue: {
       template: {
         transformAssetUrls,


### PR DESCRIPTION
Missed comma

Missed comma generates "',' expected.ts(1005)" error.

## Description

It solves configuration issues when manually installing Vuetify on Next 3.

