### PR TITLE
fix(VAutocomplete): Respect menuProps persistent and closeOnContentClick

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -212,7 +212,7 @@ export const VAutocomplete = genericComponent<new <
         e.preventDefault()
         e.stopPropagation()
       }
-      menu.value = !menu.value
+      menu.value = !menu.value || !!props.menuProps?.persistent
     }
     function onListKeydown (e: KeyboardEvent) {
       if (checkPrintable(e) || e.key === 'Backspace') {
@@ -235,7 +235,7 @@ export const VAutocomplete = genericComponent<new <
       }
 
       if (['Escape'].includes(e.key)) {
-        menu.value = false
+        menu.value = !!props.menuProps?.persistent
       }
 
       if (
@@ -368,7 +368,7 @@ export const VAutocomplete = genericComponent<new <
 
         // watch for search watcher to trigger
         nextTick(() => {
-          menu.value = false
+          if (props.menuProps?.closeOnContentClick !== false) menu.value = !!props.menuProps?.persistent
           isPristine.value = true
         })
       }
@@ -385,7 +385,7 @@ export const VAutocomplete = genericComponent<new <
         nextTick(() => isSelecting.value = false)
       } else {
         if (!props.multiple && search.value == null) model.value = []
-        menu.value = false
+        menu.value = !!props.menuProps?.persistent
         if (!isPristine.value && search.value) {
           _searchLock.value = search.value
         }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -3,7 +3,7 @@ import { VAutocomplete } from '../VAutocomplete'
 import { VForm } from '@/components/VForm'
 
 // Utilities
-import { render, screen, showcase, userEvent, waitAnimationFrame, waitIdle, wait } from '@test'
+import { render, screen, showcase, userEvent, wait, waitAnimationFrame, waitIdle } from '@test'
 import { findAllByRole, queryAllByRole, within } from '@testing-library/vue'
 import { commands } from 'vitest/browser'
 import { cloneVNode, ref } from 'vue'
@@ -756,7 +756,7 @@ describe('VAutocomplete', () => {
 
       await userEvent.click(element)
       await commands.waitStable('.v-list')
-      expect(await screen.findByRole('listbox')).toBeVisible()
+      await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
       await userEvent.keyboard('{Escape}')
       await wait(150)
@@ -786,7 +786,7 @@ describe('VAutocomplete', () => {
       const autocomplete = element.querySelector('.v-autocomplete') as HTMLElement
       await userEvent.click(autocomplete)
       await commands.waitStable('.v-list')
-      expect(await screen.findByRole('listbox')).toBeVisible()
+      await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
       const otherInput = screen.getByTestId('other-input')
       await userEvent.click(otherInput, { force: true })

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -201,8 +201,8 @@ export const VCombobox = genericComponent<new <
     })
 
     const menuDisabled = computed(() => (
-      props.menuProps?.persistent ? false :
-        (props.hideNoData && !displayItems.value.length) ||
+      props.menuProps?.persistent ? false
+      : (props.hideNoData && !displayItems.value.length) ||
         form.isReadonly.value || form.isDisabled.value
     ))
     const _menu = useProxiedModel(props, 'menu')
@@ -415,7 +415,7 @@ export const VCombobox = genericComponent<new <
 
         // watch for search watcher to trigger
         nextTick(() => {
-          if (props.menuProps?.closeOnContentClick !== false) menu.value =  !!props.menuProps?.persistent || keepMenu
+          if (props.menuProps?.closeOnContentClick !== false) menu.value = !!props.menuProps?.persistent || keepMenu
           isPristine.value = true
         })
       }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -201,8 +201,9 @@ export const VCombobox = genericComponent<new <
     })
 
     const menuDisabled = computed(() => (
-      (props.hideNoData && !displayItems.value.length) ||
-      form.isReadonly.value || form.isDisabled.value
+      props.menuProps?.persistent ? false :
+        (props.hideNoData && !displayItems.value.length) ||
+        form.isReadonly.value || form.isDisabled.value
     ))
     const _menu = useProxiedModel(props, 'menu')
     const menu = computed({
@@ -269,7 +270,7 @@ export const VCombobox = genericComponent<new <
         e.preventDefault()
         e.stopPropagation()
       }
-      menu.value = !menu.value
+      menu.value = !menu.value || !!props.menuProps?.persistent
     }
     function onListKeydown (e: KeyboardEvent) {
       if (checkPrintable(e) || e.key === 'Backspace') {
@@ -292,7 +293,7 @@ export const VCombobox = genericComponent<new <
       }
 
       if (['Escape'].includes(e.key)) {
-        menu.value = false
+        menu.value = !!props.menuProps?.persistent
       }
 
       if (
@@ -414,7 +415,7 @@ export const VCombobox = genericComponent<new <
 
         // watch for search watcher to trigger
         nextTick(() => {
-          menu.value = keepMenu
+          if (props.menuProps?.closeOnContentClick !== false) menu.value =  !!props.menuProps?.persistent || keepMenu
           isPristine.value = true
         })
       }
@@ -447,7 +448,7 @@ export const VCombobox = genericComponent<new <
       if (val || val === oldVal) return
 
       selectionIndex.value = -1
-      menu.value = false
+      menu.value = !!props.menuProps?.persistent
 
       if (search.value) {
         if (props.multiple) {

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -3,7 +3,7 @@ import { VCombobox } from '../VCombobox'
 import { VForm } from '@/components/VForm'
 
 // Utilities
-import { render, screen, showcase, userEvent, waitAnimationFrame, waitIdle } from '@test'
+import { render, screen, showcase, userEvent, waitAnimationFrame, waitIdle, wait } from '@test'
 import { commands } from 'vitest/browser'
 import { cloneVNode, ref } from 'vue'
 
@@ -824,6 +824,101 @@ describe('VCombobox', () => {
     await userEvent.paste()
     await commands.releaseLock(lock)
     expect(model.value).toEqual(['foo', 'bar'])
+  })
+
+  describe('menuProps.closeOnContentClick', () => {
+    it.each([
+      { menuProps: { closeOnContentClick: false }, shouldClose: false },
+      { menuProps: { closeOnContentClick: true }, shouldClose: true },
+      { menuProps: undefined, shouldClose: true },
+    ])('should close=$shouldClose when menuProps=$menuProps', async ({ menuProps, shouldClose }) => {
+      const selectedItem = ref<string | null>(null)
+
+      const { element } = render(() => (
+        <VCombobox
+          v-model={ selectedItem.value }
+          items={['California', 'Colorado', 'Florida']}
+          menuProps={ menuProps }
+        />
+      ))
+
+      await userEvent.click(element)
+      await commands.waitStable('.v-list')
+
+      const listbox = await screen.findByRole('listbox')
+      expect(listbox).toBeVisible()
+
+      const options = await screen.findAllByRole('option')
+      await userEvent.click(options[0])
+
+      expect(selectedItem.value).toBe('California')
+      await wait(150)
+
+      if (shouldClose) {
+        await expect.poll(() => screen.queryByRole('listbox')).toBeNull()
+      } else {
+        await expect.element(screen.getByRole('listbox')).toBeVisible()
+      }
+    })
+  })
+
+  describe('menuProps.persistent', () => {
+    it.each([
+      { menuProps: { persistent: true }, shouldClose: false },
+      { menuProps: { persistent: false }, shouldClose: true },
+      { menuProps: undefined, shouldClose: true },
+    ])('should close=$shouldClose on Escape when menuProps=$menuProps', async ({ menuProps, shouldClose }) => {
+      const { element } = render(() => (
+        <VCombobox
+          items={['California', 'Colorado', 'Florida']}
+          menuProps={ menuProps }
+        />
+      ))
+
+      await userEvent.click(element)
+      await commands.waitStable('.v-list')
+      expect(await screen.findByRole('listbox')).toBeVisible()
+
+      await userEvent.keyboard('{Escape}')
+      await wait(150)
+
+      if (shouldClose) {
+        await expect.poll(() => screen.queryByRole('listbox')).toBeNull()
+      } else {
+        await expect.element(screen.getByRole('listbox')).toBeVisible()
+      }
+    })
+
+    it.each([
+      { menuProps: { persistent: true }, shouldClose: false },
+      { menuProps: { persistent: false }, shouldClose: true },
+      { menuProps: undefined, shouldClose: true },
+    ])('should close=$shouldClose on focus out when menuProps=$menuProps', async ({ menuProps, shouldClose }) => {
+      const { element } = render(() => (
+        <div>
+          <VCombobox
+            items={['California', 'Colorado', 'Florida']}
+            menuProps={ menuProps }
+          />
+          <input data-testid="other-input" />
+        </div>
+      ))
+
+      const combobox = element.querySelector('.v-combobox') as HTMLElement
+      await userEvent.click(combobox)
+      await commands.waitStable('.v-list')
+      expect(await screen.findByRole('listbox')).toBeVisible()
+
+      const otherInput = screen.getByTestId('other-input')
+      await userEvent.click(otherInput, { force: true })
+      await wait(150)
+
+      if (shouldClose) {
+        await expect.poll(() => screen.queryByRole('listbox')).toBeNull()
+      } else {
+        await expect.element(screen.getByRole('listbox')).toBeVisible()
+      }
+    })
   })
 
   showcase({ stories })

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -3,7 +3,7 @@ import { VCombobox } from '../VCombobox'
 import { VForm } from '@/components/VForm'
 
 // Utilities
-import { render, screen, showcase, userEvent, waitAnimationFrame, waitIdle, wait } from '@test'
+import { render, screen, showcase, userEvent, wait, waitAnimationFrame, waitIdle } from '@test'
 import { commands } from 'vitest/browser'
 import { cloneVNode, ref } from 'vue'
 
@@ -877,7 +877,7 @@ describe('VCombobox', () => {
 
       await userEvent.click(element)
       await commands.waitStable('.v-list')
-      expect(await screen.findByRole('listbox')).toBeVisible()
+      await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
       await userEvent.keyboard('{Escape}')
       await wait(150)
@@ -907,7 +907,7 @@ describe('VCombobox', () => {
       const combobox = element.querySelector('.v-combobox') as HTMLElement
       await userEvent.click(combobox)
       await commands.waitStable('.v-list')
-      expect(await screen.findByRole('listbox')).toBeVisible()
+      await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
       const otherInput = screen.getByTestId('other-input')
       await userEvent.click(otherInput, { force: true })

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -216,7 +216,7 @@ export const VSelect = genericComponent<new <
     function onMousedownControl () {
       if (menuDisabled.value) return
 
-      menu.value = !menu.value
+      menu.value = !menu.value || !!props.menuProps?.persistent
     }
     function onListKeydown (e: KeyboardEvent) {
       if (checkPrintable(e)) {
@@ -235,7 +235,7 @@ export const VSelect = genericComponent<new <
       }
 
       if (['Escape', 'Tab'].includes(e.key)) {
-        menu.value = false
+        menu.value = !!props.menuProps?.persistent
       }
 
       if (props.clearable && e.key === 'Backspace') {
@@ -327,13 +327,13 @@ export const VSelect = genericComponent<new <
         model.value = add ? [item] : []
 
         nextTick(() => {
-          menu.value = false
+          if (props.menuProps?.closeOnContentClick !== false) menu.value = !!props.menuProps?.persistent
         })
       }
     }
     function onBlur (e: FocusEvent) {
       if (!listRef.value?.$el.contains(e.relatedTarget as HTMLElement)) {
-        menu.value = false
+        menu.value = !!props.menuProps?.persistent
       }
     }
     function onAfterEnter () {

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -4,7 +4,7 @@ import { VForm } from '@/components/VForm'
 import { VListItem } from '@/components/VList'
 
 // Utilities
-import { commands, render, screen, showcase, userEvent, waitForClickable, wait } from '@test'
+import { commands, render, screen, showcase, userEvent, wait, waitForClickable } from '@test'
 import { getAllByRole } from '@testing-library/vue'
 import { cloneVNode, computed, nextTick, ref } from 'vue'
 
@@ -982,7 +982,7 @@ describe('VSelect', () => {
 
       await userEvent.click(element)
       await commands.waitStable('.v-list')
-      expect(await screen.findByRole('listbox')).toBeVisible()
+      await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
       await userEvent.keyboard('{Escape}')
       await wait(150)
@@ -1012,7 +1012,7 @@ describe('VSelect', () => {
       const select = element.querySelector('.v-select') as HTMLElement
       await userEvent.click(select)
       await commands.waitStable('.v-list')
-      expect(await screen.findByRole('listbox')).toBeVisible()
+      await expect(screen.findByRole('listbox')).resolves.toBeVisible()
 
       const otherInput = screen.getByTestId('other-input')
       await userEvent.click(otherInput, { force: true })


### PR DESCRIPTION
fixes #20590

## Description
Make VAutocomplete, VSelect and VCombobox respect menuProps - persistent and closeOnContentClick

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-switch v-model="isCloseOnContentClick" label="Close on content click" color="primary"></v-switch>
      <v-switch v-model="isPersistent" label="Persistent" color="primary"></v-switch>
      <v-switch v-if="isPersistent" v-model="isMenuOpen" label="Menu open" color="primary" class="ml-10"></v-switch>

      <v-autocomplete
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        label="Autocomplete"
        :menu-props="menuProps"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, computed } from 'vue';

  const isPersistent = ref(false);
  const isCloseOnContentClick = ref(true);
  const isMenuOpen = ref(true);

  const menuProps = computed(() => {
    const props = {
      persistent: isPersistent.value,
      closeOnContentClick: isCloseOnContentClick.value,
    }

    if (isPersistent.value) {
      props.modelValue = isMenuOpen.value;
    }

    return props;
  });
</script>

```
