### PR TITLE
fix(VSelect): pass listProps density to VCheckboxBtn in multiple

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -321,7 +321,6 @@ export const VListItem = genericComponent<VListItemSlots>()({
               ) : (
                 <VDefaultsProvider
                   key="prepend-defaults"
-                  disabled={ !hasPrependMedia }
                   defaults={{
                     VAvatar: {
                       density: props.density,
@@ -333,6 +332,9 @@ export const VListItem = genericComponent<VListItemSlots>()({
                     },
                     VListItemAction: {
                       start: true,
+                    },
+                    VCheckboxBtn: {
+                      density: props.density,
                     },
                   }}
                 >
@@ -383,7 +385,6 @@ export const VListItem = genericComponent<VListItemSlots>()({
               ) : (
                 <VDefaultsProvider
                   key="append-defaults"
-                  disabled={ !hasAppendMedia }
                   defaults={{
                     VAvatar: {
                       density: props.density,
@@ -395,6 +396,9 @@ export const VListItem = genericComponent<VListItemSlots>()({
                     },
                     VListItemAction: {
                       end: true,
+                    },
+                    VCheckboxBtn: {
+                      density: props.density,
                     },
                   }}
                 >


### PR DESCRIPTION
## Summary
- Pass `listProps.density` to VCheckboxBtn when rendering multiple select items
- Fixes VSelect, VAutocomplete, and VCombobox which all share the same pattern
- Follows precedent from VTreeviewChildren

fixes #22525

## Problem
Global defaults for `listProps.density` were not applied to VCheckboxBtn when using the `multiple` prop. The checkboxes rendered with default density while VListItem used compact density, causing visual inconsistency.

## Playground for testing
```vue
<template>
  <v-app>
    <v-container>
      <v-defaults-provider
        :defaults="{
          VSelect: { listProps: { density: 'compact' } },
          VAutocomplete: { listProps: { density: 'compact' } },
          VCombobox: { listProps: { density: 'compact' } },
        }"
      >
        <v-row>
          <v-col cols="4">
            <v-select :items="['A','B','C']" label="Single" />
          </v-col>
          <v-col cols="4">
            <v-select :items="['A','B','C']" label="Multiple" multiple />
          </v-col>
        </v-row>
      </v-defaults-provider>
    </v-container>
  </v-app>
</template>
```