### PR TITLE
fix(VInput): Use direction prop only where needed

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.tsx
@@ -22,7 +22,7 @@ import type { GenericProps } from '@/util'
 export type VCheckboxSlots = Omit<VInputSlots, 'default'> & VSelectionControlSlots
 
 export const makeVCheckboxProps = propsFactory({
-  ...makeVInputProps(),
+  ...omit(makeVInputProps(), ['direction']),
   ...omit(makeVCheckboxBtnProps(), ['inline']),
 }, 'VCheckbox')
 

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -23,6 +23,7 @@ import {
   filterInputAttrs,
   genericComponent,
   humanReadableFileSize,
+  omit,
   propsFactory,
   useRender,
   wrapInArray,
@@ -70,7 +71,7 @@ export const makeVFileInputProps = propsFactory({
     default: 22,
   },
 
-  ...makeVInputProps({ prependIcon: '$file' }),
+  ...omit(makeVInputProps({ prependIcon: '$file' }), ['direction']),
 
   modelValue: {
     type: [Array, Object] as PropType<File[] | File | null>,

--- a/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
+++ b/packages/vuetify/src/components/VRadioGroup/VRadioGroup.tsx
@@ -34,7 +34,7 @@ export const makeVRadioGroupProps = propsFactory({
     default: 'auto',
   },
 
-  ...makeVInputProps(),
+  ...omit(makeVInputProps(), ['direction']),
   ...omit(makeSelectionControlGroupProps(), ['multiple']),
 
   trueIcon: {

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -45,7 +45,7 @@ export const makeVTextFieldProps = propsFactory({
   modelModifiers: Object as PropType<Record<string, boolean>>,
 
   ...makeAutocompleteProps(),
-  ...makeVInputProps(),
+  ...omit(makeVInputProps(), ['direction']),
   ...makeVFieldProps(),
 }, 'VTextField')
 

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -21,7 +21,7 @@ import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
-import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, propsFactory, useRender } from '@/util'
+import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -56,7 +56,7 @@ export const makeVTextareaProps = propsFactory({
   modelModifiers: Object as PropType<Record<string, boolean>>,
 
   ...makeAutocompleteProps(),
-  ...makeVInputProps(),
+  ...omit(makeVInputProps(), ['direction']),
   ...makeVFieldProps(),
 }, 'VTextarea')
 


### PR DESCRIPTION
## Description
For components such as VTextField, autocomplete etc the `direction` prop is listed in the docs and all it does is break the UI

## Markup:
<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-sheet class="d-flex" height="200" width="200">
        <v-range-slider
          v-model="a"
          color="primary"
          direction="vertical"
        />

        <v-slider
          v-model="c"
          color="primary"
          direction="vertical"
        />

        <v-switch
          v-model="b"
          color="primary"
          direction="vertical"
        />
      </v-sheet>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const a = ref(true)
  const b = ref(true)
  const c = ref(true)
</script>


```
