### PR TITLE
fix(VAutocomplete): auto-select input text on focus

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -382,7 +382,10 @@ export const VAutocomplete = genericComponent<new <
         search.value = (props.multiple || hasSelectionSlot.value) ? '' : String(model.value.at(-1)?.props.title ?? '')
         isPristine.value = true
 
-        nextTick(() => isSelecting.value = false)
+        nextTick(() => {
+          isSelecting.value = false
+          vTextFieldRef.value?.select()
+        })
       } else {
         if (!props.multiple && search.value == null) model.value = []
         menu.value = false

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -444,23 +444,29 @@ export const VCombobox = genericComponent<new <
     }
 
     watch(isFocused, (val, oldVal) => {
-      if (val || val === oldVal) return
+      if (val === oldVal) return
 
-      selectionIndex.value = -1
-      menu.value = false
+      if (val) {
+        nextTick(() => {
+          vTextFieldRef.value?.select()
+        })
+      } else {
+        selectionIndex.value = -1
+        menu.value = false
 
-      if (search.value) {
-        if (props.multiple) {
-          select(transformItem(props, search.value))
-          return
-        }
+        if (search.value) {
+          if (props.multiple) {
+            select(transformItem(props, search.value))
+            return
+          }
 
-        if (!hasSelectionSlot.value) return
+          if (!hasSelectionSlot.value) return
 
-        if (model.value.some(({ title }) => title === search.value)) {
-          _search.value = ''
-        } else {
-          select(transformItem(props, search.value))
+          if (model.value.some(({ title }) => title === search.value)) {
+            _search.value = ''
+          } else {
+            select(transformItem(props, search.value))
+          }
         }
       }
     })


### PR DESCRIPTION
fixes #21938

## Description
Restore v2 behaviour where VAutocomplete and VCombobox input value would auto-select on focus

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-container>
    <h2 class="text-h5 mb-4">Auto-select text on focus demonstration</h2>
    <p class="text-body-2 mb-6 text-medium-emphasis">
      In single-select mode (without chips), clicking on the input selects the text for easy replacement.
      Try: select an item, then click on the input again - the text should be selected.
    </p>

    <v-row>
      <v-col cols="12" md="6">
        <h3 class="text-subtitle-1 font-weight-bold mb-2">✅ VAutocomplete - Single select</h3>
        <p class="text-caption text-medium-emphasis mb-2">Text IS selected on focus</p>
        <v-autocomplete
          v-model="autocompleteValue"
          :items="simpleItems"
          hint="Text should be selected when you click again"
          label="Click, select item, click again"
          persistent-hint
        />
      </v-col>

      <v-col cols="12" md="6">
        <h3 class="text-subtitle-1 font-weight-bold mb-2">✅ VCombobox - Single select</h3>
        <p class="text-caption text-medium-emphasis mb-2">Text IS selected on focus</p>
        <v-combobox
          v-model="comboboxValue"
          :items="simpleItems"
          hint="Text should be selected when you click again"
          label="Click, select item, click again"
          persistent-hint
        />
      </v-col>
    </v-row>

    <v-divider class="my-8" />

    <h3 class="text-h6 mb-4">Cases where text is NOT selected</h3>
    <p class="text-body-2 mb-6 text-medium-emphasis">
      When using chips, multiple mode, or selection slots, the input is typically empty
      so text selection doesn't apply.
    </p>

    <v-row>
      <v-col cols="12" md="6">
        <h3 class="text-subtitle-1 font-weight-bold mb-2">❌ VAutocomplete - Multiple</h3>
        <p class="text-caption text-medium-emphasis mb-2">Text NOT selected (input is empty)</p>
        <v-autocomplete
          v-model="autocompleteMultiple"
          :items="simpleItems"
          hint="Input is empty, selection shown separately"
          label="Multiple select mode"
          multiple
          persistent-hint
        />
      </v-col>

      <v-col cols="12" md="6">
        <h3 class="text-subtitle-1 font-weight-bold mb-2">❌ VAutocomplete - Chips</h3>
        <p class="text-caption text-medium-emphasis mb-2">Text NOT selected (uses chips)</p>
        <v-autocomplete
          v-model="autocompleteChips"
          :items="simpleItems"
          hint="Selection shown as chip, input is empty"
          label="Single select with chips"
          chips
          persistent-hint
        />
      </v-col>
    </v-row>

    <v-row class="mt-4">
      <v-col cols="12" md="6">
        <h3 class="text-subtitle-1 font-weight-bold mb-2">❌ VCombobox - Multiple + Chips</h3>
        <p class="text-caption text-medium-emphasis mb-2">Text NOT selected (multiple + chips)</p>
        <v-combobox
          v-model="comboboxMultipleChips"
          :items="simpleItems"
          hint="Selections shown as chips"
          label="Multiple with chips"
          chips
          closable-chips
          multiple
          persistent-hint
        />
      </v-col>

      <v-col cols="12" md="6">
        <h3 class="text-subtitle-1 font-weight-bold mb-2">✅ Tab navigation test</h3>
        <p class="text-caption text-medium-emphasis mb-2">Tab into this field to test</p>
        <v-text-field
          hint="Tab to the autocomplete below"
          label="Focus me first, then Tab"
          persistent-hint
        />
        <v-autocomplete
          v-model="tabTestValue"
          :items="simpleItems"
          class="mt-4"
          hint="Text should be selected when tabbing in"
          label="Tab into me"
          persistent-hint
        />
      </v-col>
    </v-row>

    <v-divider class="my-8" />

    <h3 class="text-h6 mb-4">Current values</h3>
    <v-row>
      <v-col cols="12">
        <pre class="text-caption bg-grey-lighten-4 pa-4 rounded">{{
          {
            autocompleteValue,
            comboboxValue,
            autocompleteMultiple,
            autocompleteChips,
            comboboxMultipleChips,
            tabTestValue,
          }
        }}</pre>
      </v-col>
    </v-row>
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'

  const simpleItems = [
    'California',
    'Colorado',
    'Florida',
    'Georgia',
    'Texas',
    'Wyoming',
  ]

  const autocompleteValue = ref('California')
  const comboboxValue = ref('Colorado')
  const autocompleteMultiple = ref(['Florida', 'Georgia'])
  const autocompleteChips = ref('Texas')
  const comboboxMultipleChips = ref(['Wyoming'])
  const tabTestValue = ref('California')
</script>

```
