### PR TITLE
feat(VField): add clearFocusable prop for keyboard accessibility

### DIFF
--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -56,6 +56,7 @@ export const makeVFieldProps = propsFactory({
   appendInnerIcon: IconValue,
   bgColor: String,
   clearable: Boolean,
+  clearFocusable: Boolean,
   clearIcon: {
     type: IconValue,
     default: '$clear',
@@ -380,7 +381,7 @@ export const VField = genericComponent<new <T>(
                       onFocus: focus,
                       onBlur: blur,
                       onClick: props['onClick:clear'],
-                      tabindex: -1,
+                      tabindex: props.clearFocusable ? 0 : -1,
                     },
                   })
                   : (
@@ -388,7 +389,7 @@ export const VField = genericComponent<new <T>(
                       name="clear"
                       onFocus={ focus }
                       onBlur={ blur }
-                      tabindex={ -1 }
+                      tabindex={ props.clearFocusable ? 0 : -1 }
                     />
                   )}
                 </VDefaultsProvider>

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -343,7 +343,11 @@ export const VSelect = genericComponent<new <
     }
     function onAfterLeave () {
       if (isFocused.value) {
-        vTextFieldRef.value?.focus()
+        // Don't steal focus if it's already on the clear button or another element within the field
+        const fieldEl = vTextFieldRef.value?.$el
+        if (fieldEl && !fieldEl.contains(document.activeElement)) {
+          vTextFieldRef.value?.focus()
+        }
       }
     }
     function onFocusin (e: FocusEvent) {

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -872,6 +872,58 @@ describe('VSelect', () => {
     })
   })
 
+  describe('clearFocusable', () => {
+    it('should have tabindex="-1" on clear button by default', async () => {
+      render(() => (
+        <VSelect
+          clearable
+          items={['Item 1', 'Item 2']}
+          modelValue="Item 1"
+        />
+      ))
+
+      const clearBtn = screen.getByCSS('.v-field__clearable .v-icon')
+      expect(clearBtn).toHaveAttribute('tabindex', '-1')
+    })
+
+    it('should have tabindex="0" on clear button when clearFocusable is true', async () => {
+      render(() => (
+        <VSelect
+          clearable
+          clearFocusable
+          items={['Item 1', 'Item 2']}
+          modelValue="Item 1"
+        />
+      ))
+
+      const clearBtn = screen.getByCSS('.v-field__clearable .v-icon')
+      expect(clearBtn).toHaveAttribute('tabindex', '0')
+    })
+
+    it('should clear selection when pressing Enter on focused clear button', async () => {
+      const selectedItem = ref('Item 1')
+
+      const { element } = render(() => (
+        <VSelect
+          clearable
+          clearFocusable
+          v-model={ selectedItem.value }
+          items={['Item 1', 'Item 2']}
+        />
+      ))
+
+      // Focus the select
+      await userEvent.click(element)
+      // Close menu and tab to clear button
+      await userEvent.keyboard('{Escape}')
+      await userEvent.keyboard('{Tab}')
+      // Press Enter to clear
+      await userEvent.keyboard('{Enter}')
+
+      expect(selectedItem.value).toBeNull()
+    })
+  })
+
   describe('native form submission', () => {
     const items = [
       { title: 'Item 1', value: 1 },

--- a/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.tsx
+++ b/packages/vuetify/src/components/VTextField/__tests__/VTextField.spec.tsx
@@ -96,6 +96,49 @@ describe('VTextField', () => {
     expect(onClickAppendInner).toHaveBeenCalledTimes(1)
   })
 
+  describe('clearFocusable', () => {
+    it('should have tabindex="-1" on clear button by default', () => {
+      const wrapper = mountFunction(
+        <VTextField
+          clearable
+          modelValue="test"
+        />
+      )
+
+      const clearBtn = wrapper.find('.v-field__clearable .v-icon')
+      expect(clearBtn.exists()).toBe(true)
+      expect(clearBtn.attributes('tabindex')).toBe('-1')
+    })
+
+    it('should have tabindex="0" on clear button when clearFocusable is true', () => {
+      const wrapper = mountFunction(
+        <VTextField
+          clearable
+          clearFocusable
+          modelValue="test"
+        />
+      )
+
+      const clearBtn = wrapper.find('.v-field__clearable .v-icon')
+      expect(clearBtn.exists()).toBe(true)
+      expect(clearBtn.attributes('tabindex')).toBe('0')
+    })
+
+    it('should have tabindex="-1" on clear button when clearFocusable is false', () => {
+      const wrapper = mountFunction(
+        <VTextField
+          clearable
+          clearFocusable={ false }
+          modelValue="test"
+        />
+      )
+
+      const clearBtn = wrapper.find('.v-field__clearable .v-icon')
+      expect(clearBtn.exists()).toBe(true)
+      expect(clearBtn.attributes('tabindex')).toBe('-1')
+    })
+  })
+
   describe('hide-details behavior', () => {
     it('should not have aria-describedby when hide-details is true', () => {
       const wrapper = mountFunction(


### PR DESCRIPTION
## Summary                                                                                                                                                                          
  - Adds `clearFocusable` prop to VField, VTextField, and VSelect                                                                                                                     
  - When enabled, the clear button becomes focusable via Tab navigation (tabindex="0")                                                                                                
  - Fixes VSelect focus management to prevent stealing focus from the clear button when menu closes                                                                                   
  - Maintains backwards compatibility (default behavior unchanged)                                                                                                                    
                                                                                                                                                                                      
  ## Motivation                                                                                                                                                                       
  WCAG 2.1.1 requires all interactive elements to be keyboard accessible. While the Backspace shortcut works (#22435), having a focusable clear button improves discoverability for keyboard users.                                                                                                                                                                     
                                                                                                                                                                                      
  ## Usage                                                                                                                                                                            
```vue                                                                                                                                                                      
      <v-select clearable clear-focusable />                                                                                                                                          
      <v-text-field clearable clear-focusable />                                                                                                                                      
```                                                                                                                                                                            
  ## Test plan                                                                                                                                                                        
  - [x] Unit tests for clearFocusable prop (VTextField)                                                                                                                               
  - [x] Browser tests for clearFocusable prop (VSelect)                                                                                                                               
  - [x] Manual keyboard navigation testing                                                                                                                                            
  - [x] Verify Enter/Space activates clear when focused                                                                                                                               
                                           
**Live demo:** https://stellular-douhua-118b69.netlify.app/                                                                                            
  (External demo to keep the PR clean and avoid modifying the Playground) 
                                                                                                                                           
Refs #18482, #22422 

**Transparency note:** This PR was developed with the assistance of Claude Code (AI). I am a software development expert at OCSIN (État de Genève) and I have personally reviewed, tested, and validated all changes before submission.