### PR TITLE
fix(v-intersect): re-mount on prop updates

### DIFF
--- a/packages/vuetify/src/directives/intersect/index.ts
+++ b/packages/vuetify/src/directives/intersect/index.ts
@@ -74,6 +74,10 @@ function unmounted (el: HTMLElement, binding: ObserveDirectiveBinding) {
 export const Intersect = {
   mounted,
   unmounted,
+  updated: (el: HTMLElement, binding: ObserveDirectiveBinding) => {
+    unmounted(el, binding)
+    mounted(el, binding)
+  },
 }
 
 export default Intersect


### PR DESCRIPTION
fixes #22554

```diff
export const Intersect = {
  mounted,
  unmounted,
+  updated: (el: HTMLElement, binding: ObserveDirectiveBinding) => {
+    unmounted(el, binding)
+    mounted(el, binding)
+  },
}
```