### PR TITLE
feat(nested): mark individual nodes as detached (for selection)

### DIFF
--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -209,6 +209,7 @@
   "VListItem": {
     "props": {
       "baseColor": "3.3.0",
+      "detached": "3.12.0",
       "prependGap": "3.11.0",
       "slim": "3.4.0"
     }
@@ -362,6 +363,7 @@
   },
   "VTreeviewItem": {
     "props": {
+      "detached": "3.12.0",
       "hideActions": "3.9.0",
       "indentLines": "3.9.0"
     },

--- a/packages/vuetify/src/components/VList/VListGroup.tsx
+++ b/packages/vuetify/src/components/VList/VListGroup.tsx
@@ -39,6 +39,7 @@ export const makeVListGroupProps = propsFactory({
     type: IconValue,
     default: '$collapse',
   },
+  detached: Boolean,
   disabled: Boolean,
   expandIcon: {
     type: IconValue,
@@ -62,7 +63,12 @@ export const VListGroup = genericComponent<VListGroupSlots>()({
   props: makeVListGroupProps(),
 
   setup (props, { slots }) {
-    const { isOpen, open, id: _id } = useNestedItem(() => props.value, () => props.disabled, true)
+    const { isOpen, open, id: _id } = useNestedItem(
+      () => props.value,
+      () => props.disabled,
+      () => props.detached,
+      true
+    )
     const id = computed(() => `v-list-group--id-${String(props.rawId ?? _id.value)}`)
     const list = useList()
     const { isBooted } = useSsrBoot()

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -75,6 +75,7 @@ export const makeVListItemProps = propsFactory({
   appendAvatar: String,
   appendIcon: IconValue,
   baseColor: String,
+  detached: Boolean,
   disabled: Boolean,
   lines: [Boolean, String] as PropType<'one' | 'two' | 'three' | false>,
   link: {
@@ -145,14 +146,23 @@ export const VListItem = genericComponent<VListItemSlots>()({
       openOnSelect,
       scrollToActive,
       id: uid,
-    } = useNestedItem(id, () => props.disabled, false)
+    } = useNestedItem(
+      id,
+      () => props.disabled,
+      () => props.detached,
+      false
+    )
     const list = useList()
     const isActive = computed(() =>
       props.active !== false &&
       (props.active || link.isActive?.value || (root.activatable.value ? isActivated.value : isSelected.value))
     )
     const isLink = toRef(() => props.link !== false && link.isLink.value)
-    const isSelectable = computed(() => (!!list && (root.selectable.value || root.activatable.value || props.value != null)))
+    const isSelectable = computed(() => (
+      !!list &&
+      !props.detached &&
+      (root.selectable.value || root.activatable.value || props.value != null))
+    )
     const isClickable = computed(() =>
       !props.disabled &&
       props.link !== false &&

--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -157,7 +157,10 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
           : undefined,
         prepend: slotProps => (
           <>
-            { props.selectable && (!children || (children && !['leaf', 'single-leaf'].includes(props.selectStrategy as string))) && (
+            { props.selectable &&
+              !item.props.detached &&
+              (!children || (children && !['leaf', 'single-leaf'].includes(props.selectStrategy as string))) &&
+            (
               <VListItemAction start>
                 <VCheckboxBtn
                   key={ item.value }

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -54,6 +54,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
     const vListItemRef = ref<VListItem>()
 
     const isActivatableGroupActivator = computed(() =>
+      !props.detached &&
       (vListItemRef.value?.root.activatable.value) &&
       vListItemRef.value?.isGroupActivator
     )


### PR DESCRIPTION
resolves #11813

- so far it works for leafs
- [ ] should work for nodes
  - skip through detached nodes when building parents/children mapping
  - rebuild mapping when node changes state 
- [ ] test with all selection strategies

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex ga-8 justify-center flex-wrap" fluid>
      <v-sheet width="400">
        <v-treeview
          v-model:selected="selected"
          :items="items"
          item-title="name"
          item-value="id"
          select-strategy="classic"
          item-props
          open-all
          selectable
        >
          <template #append="{ item }">
            <v-switch v-model="item.detached" hide-details />
          </template>
        </v-treeview>
        <pre>{{ selected }}</pre>
      </v-sheet>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref([])

  const items = ref([{
    id: 999,
    name: 'root',
    children: [
      {
        id: 1,
        name: 'item 1',
        detached: true,
        children: [
          { id: 11, name: 'Test 1', detached: true },
          { id: 12, name: 'Test 2' },
        ],
      },
      { id: 2, name: 'item 2' },
      { id: 3, name: 'item 3', detached: true },
      { id: 4, name: 'item 4', detached: true },
      { id: 5, name: 'item 5' },
    ],
  }])
</script>
```
