### PR TITLE
fix(VDataTable): make sorting information accessible

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -123,6 +123,28 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
         : props.sortDescIcon
     }
 
+    function getAriaSort (column: InternalDataTableHeader) {
+      if (!column.sortable || props.disableSort) return undefined
+
+      const item = sortBy.value.find(item => item.key === column.key)
+
+      if (!item) return undefined
+      return item.order === 'asc' ? 'ascending' : 'descending'
+    }
+
+    function getAriaLabel (column: InternalDataTableHeader) {
+      if (!column.sortable || props.disableSort) return column.title
+
+      const item = sortBy.value.find(item => item.key === column.key)
+        if (!item) {
+          return `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortNone')} ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
+        }
+
+      return item.order === 'asc'
+        ? `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortAscending')} ${t('$vuetify.dataTable.ariaLabel.activateDescending')}`
+        : `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortDescending')} ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
+    }
+
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)
 
     const { displayClasses, mobile } = useDisplay(props)
@@ -171,6 +193,8 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
             maxWidth: convertToUnit(column.maxWidth),
             ...getFixedStyles(column, y),
           }}
+          aria-sort={ getAriaSort(column) }
+          aria-label={ getAriaLabel(column) }
           colspan={ column.colspan }
           rowspan={ column.rowspan }
           fixed={ column.fixed }

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -138,12 +138,12 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
       const item = sortBy.value.find(item => item.key === column.key)
 
       if (!item) {
-        return `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortNone')} ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
+        return `${column.title}. ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
       }
 
       return item.order === 'asc'
-        ? `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortAscending')} ${t('$vuetify.dataTable.ariaLabel.activateDescending')}`
-        : `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortDescending')} ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
+        ? `${column.title}. ${t('$vuetify.dataTable.ariaLabel.activateDescending')}`
+        : `${column.title}. ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
     }
 
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -136,9 +136,10 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
       if (!column.sortable || props.disableSort) return column.title
 
       const item = sortBy.value.find(item => item.key === column.key)
-        if (!item) {
-          return `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortNone')} ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
-        }
+
+      if (!item) {
+        return `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortNone')} ${t('$vuetify.dataTable.ariaLabel.activateAscending')}`
+      }
 
       return item.order === 'asc'
         ? `${column.title}. ${t('$vuetify.dataTable.ariaLabel.sortAscending')} ${t('$vuetify.dataTable.ariaLabel.activateDescending')}`


### PR DESCRIPTION
## Description

Announces sorting information to screenreader by adding aria-sort attribute and aria-label to table header cells.

resolves #20974
resolves #13119 


## Markup:
```vue
<template>
  <v-app>
    <v-container>

      <v-data-table :items="itemsTable"/>

    </v-container>
  </v-app>
</template>

<script setup>

  const itemsTable = [
    { name: 'Frozen Yogurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 },
    { name: 'Ice cream sandwich', calories: 237, fat: 9.0, carbs: 37, protein: 4.3 },
    { name: 'Eclair', calories: 262, fat: 16.0, carbs: 23, protein: 6.0 },
    { name: 'Cupcake', calories: 305, fat: 3.7, carbs: 67, protein: 4.3 },
    { name: 'Gingerbread', calories: 356, fat: 16.0, carbs: 49, protein: 3.9 },
    { name: 'Jelly bean', calories: 375, fat: 0.0, carbs: 94, protein: 0.0 },
    { name: 'Lollipop', calories: 392, fat: 0.2, carbs: 98, protein: 0.0 },
    { name: 'Honeycomb', calories: 408, fat: 3.2, carbs: 87, protein: 6.5 },
    { name: 'Donut', calories: 452, fat: 25.0, carbs: 51, protein: 4.9 },
    { name: 'KitKat', calories: 518, fat: 26.0, carbs: 65, protein: 7.0 },
  ]
  
</script>

```
