### PR TITLE
fix(VTimePicker): make invalid values accessible by screenreader

### DIFF
--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
@@ -175,6 +175,25 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
       }
     })
 
+    const isHourInvalid = computed((): boolean => {
+      return inputHour.value !== null &&
+        isAllowedHourCb.value &&
+        !isAllowedHourCb.value(inputHour.value)
+    })
+
+    const isMinuteInvalid = computed((): boolean => {
+      return inputMinute.value !== null &&
+        isAllowedMinuteCb.value &&
+        !isAllowedMinuteCb.value(inputMinute.value)
+    })
+
+    const isSecondInvalid = computed((): boolean => {
+      return props.useSeconds &&
+        inputSecond.value !== null &&
+        isAllowedSecondCb.value &&
+        !isAllowedSecondCb.value(inputSecond.value)
+    })
+
     const isAmPm = computed((): boolean => {
       return props.format === 'ampm'
     })
@@ -354,6 +373,9 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
                 period={ period.value }
                 second={ inputSecond.value as number }
                 viewMode={ viewMode.value }
+                hourInvalid={ isHourInvalid.value }
+                minuteInvalid={ isMinuteInvalid.value }
+                secondInvalid={ isSecondInvalid.value }
                 onUpdate:hour={ (val: number) => inputHour.value = val }
                 onUpdate:minute={ (val: number) => inputMinute.value = val }
                 onUpdate:period={ (val: Period) => setPeriod(val) }

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerControls.sass
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerControls.sass
@@ -1,6 +1,7 @@
 @use 'sass:map'
 @use '../../styles/tools'
 @use '../../styles/settings'
+@use '../../styles/utilities'
 @use './variables' as *
 
 @include tools.layer('components')

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerControls.tsx
@@ -25,6 +25,9 @@ export const makeVTimePickerControlsProps = propsFactory({
   hour: [Number, String] as PropType<number | string | null>,
   minute: [Number, String] as PropType<number | string | null>,
   second: [Number, String] as PropType<number | string | null>,
+  hourInvalid: Boolean,
+  minuteInvalid: Boolean,
+  secondInvalid: Boolean,
   period: String as PropType<Period>,
   readonly: Boolean,
   useSeconds: Boolean,
@@ -224,12 +227,24 @@ export const VTimePickerControls = genericComponent()({
               color={ props.color }
               disabled={ props.disabled }
               label={ t('$vuetify.timePicker.hour') }
+              aria-invalid={ props.hourInvalid ? 'true' : undefined }
+              aria-describedby={ props.hourInvalid ? 'v-time-picker-hour-error' : undefined }
               modelValue={ hour.value }
               onUpdate:modelValue={ v => hour.value = v }
               onKeydown={ onHourFieldKeydown }
               onBeforeinput={ hourInputFilter }
               onFocus={ () => emit('update:viewMode', 'hour') }
             />
+
+            { props.hourInvalid && (
+              <span
+                id="v-time-picker-hour-error"
+                key="hoursError"
+                class="v-sr-only"
+              >
+                This value is not allowed.
+              </span>
+            )}
 
             <span class="v-time-picker-controls__time__separator">:</span>
 
@@ -239,6 +254,8 @@ export const VTimePickerControls = genericComponent()({
               color={ props.color }
               disabled={ props.disabled }
               label={ t('$vuetify.timePicker.minute') }
+              aria-invalid={ props.minuteInvalid ? 'true' : undefined }
+              aria-describedby={ props.minuteInvalid ? 'v-time-picker-minute-error' : undefined }
               modelValue={ minute.value }
               onUpdate:modelValue={ v => minute.value = v }
               onKeydown={ onMinuteFieldKeydown }
@@ -246,24 +263,49 @@ export const VTimePickerControls = genericComponent()({
               onFocus={ () => emit('update:viewMode', 'minute') }
             />
 
+            { props.minuteInvalid && (
+              <span
+                id="v-time-picker-minute-error"
+                key="minutesError"
+                class="v-sr-only"
+              >
+                This value is not allowed.
+              </span>
+            )}
+
             { props.useSeconds && (
               <span key="secondsDivider" class="v-time-picker-controls__time__separator">:</span>
             )}
 
             { props.useSeconds && (
-              <VTimePickerField
-                key="secondsVal"
-                ref={ secondInputRef }
-                active={ props.viewMode === 'second' }
-                color={ props.color }
-                disabled={ props.disabled }
-                label={ t('$vuetify.timePicker.second') }
-                modelValue={ second.value }
-                onUpdate:modelValue={ v => second.value = v }
-                onKeydown={ onSecondFieldKeydown }
-                onBeforeinput={ secondInputFilter }
-                onFocus={ () => emit('update:viewMode', 'second') }
-              />
+              <>
+                <VTimePickerField
+                  key="secondsVal"
+                  ref={ secondInputRef }
+                  active={ props.viewMode === 'second' }
+                  color={ props.color }
+                  disabled={ props.disabled }
+                  label={ t('$vuetify.timePicker.second') }
+                  aria-invalid={ props.secondInvalid ? 'true' : undefined }
+                  aria-describedby={ props.secondInvalid ? 'v-time-picker-second-error' : undefined }
+                  modelValue={ second.value }
+                  onUpdate:modelValue={ v => second.value = v }
+                  onKeydown={ onSecondFieldKeydown }
+                  onBeforeinput={ secondInputFilter }
+                  onFocus={ () => emit('update:viewMode', 'second') }
+                />
+
+                { props.secondInvalid && (
+                  // TODO: i18n
+                  <span
+                    id="v-time-picker-second-error"
+                    key="secondsError"
+                    class="v-sr-only"
+                  >
+                    This value is not allowed
+                  </span>
+                )}
+              </>
             )}
 
             { props.ampm && (


### PR DESCRIPTION
## Description

Makes information about allowed values accessible by screenreader by adding aria-invalid for disabled hour/minute/second values.

resolves #21885


## Markup:
```vue
<template>
  <v-app>
    <v-container>

      <v-time-picker :allowed-hours="allowedTime" />
     
    </v-container>
  </v-app>
</template>

<script setup>

  const allowedTime = [5, 6, 7, 8, 9, 10, 11, 12]
 
</script>
```
