### PR TITLE
fix(VTimePicker): enforce allowed values and range in inputs

### DIFF
--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.sass
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.sass
@@ -21,10 +21,6 @@
       transition-behavior: allow-discrete
       max-height: calc-size(max-content, size)
 
-    &--variant-dial
-      .v-time-picker-controls__field-label
-        opacity: 0
-
     &--variant-input
       .v-picker__body
         transform: scale(0)

--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
@@ -13,36 +13,25 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
 import { computed, onMounted, ref, toRef, watch } from 'vue'
+import { makeTimeValidationProps, useTimeValidation } from './useTimeValidation'
 import { convert12to24, convert24to12, pad } from './util'
-import { createRange, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
 import type { Period, VTimePickerViewMode } from './shared'
 import type { VPickerSlots } from '@/labs/VPicker/VPicker'
 
-type AllowFunction = (val: number) => boolean
-
-const rangeHours24 = createRange(24)
-const rangeHours12am = createRange(12)
-const rangeHours12pm = rangeHours12am.map(v => v + 12)
-const range60 = createRange(60)
-
 export type VTimePickerSlots = Omit<VPickerSlots, 'header'>
 
 type Variant = 'dial' | 'input'
 
 export const makeVTimePickerProps = propsFactory({
-  allowedHours: [Function, Array] as PropType<AllowFunction | number[]>,
-  allowedMinutes: [Function, Array] as PropType<AllowFunction | number[]>,
-  allowedSeconds: [Function, Array] as PropType<AllowFunction | number[]>,
   disabled: Boolean,
   format: {
     type: String as PropType<'ampm' | '24hr'>,
     default: 'ampm',
   },
-  max: String,
-  min: String,
   viewMode: {
     type: String as PropType<VTimePickerViewMode>,
     default: 'hour',
@@ -60,6 +49,7 @@ export const makeVTimePickerProps = propsFactory({
     type: String as PropType<Variant>,
     default: 'dial',
   },
+  ...makeTimeValidationProps(),
   ...omit(makeVPickerProps({ title: '$vuetify.timePicker.title' }), ['landscape']),
   ...makeDensityProps(),
 }, 'VTimePicker')
@@ -92,92 +82,15 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
     const controlsRef = ref<VTimePickerControls | null>(null)
     const clockRef = ref<VTimePickerClock | null>(null)
 
-    const isAllowedHourCb = computed((): AllowFunction => {
-      let cb: AllowFunction
-
-      if (props.allowedHours instanceof Array) {
-        cb = (val: number) => (props.allowedHours as number[]).includes(val)
-      } else {
-        cb = props.allowedHours as AllowFunction
-      }
-
-      if (!props.min && !props.max) return cb
-
-      const minHour = props.min ? Number(props.min.split(':')[0]) : 0
-      const maxHour = props.max ? Number(props.max.split(':')[0]) : 23
-
-      return (val: number) => {
-        return val >= Number(minHour) &&
-          val <= Number(maxHour) &&
-          (!cb || cb(val))
-      }
-    })
-
-    const isAllowedMinuteCb = computed((): AllowFunction => {
-      let cb: AllowFunction
-
-      const isHourAllowed = !isAllowedHourCb.value || inputHour.value === null || isAllowedHourCb.value(inputHour.value)
-      if (props.allowedMinutes instanceof Array) {
-        cb = (val: number) => (props.allowedMinutes as number[]).includes(val)
-      } else {
-        cb = props.allowedMinutes as AllowFunction
-      }
-
-      if (!props.min && !props.max) {
-        return isHourAllowed ? cb : () => false
-      }
-
-      const [minHour, minMinute] = props.min ? props.min.split(':').map(Number) : [0, 0]
-      const [maxHour, maxMinute] = props.max ? props.max.split(':').map(Number) : [23, 59]
-      const minTime = minHour * 60 + Number(minMinute)
-      const maxTime = maxHour * 60 + Number(maxMinute)
-
-      return (val: number) => {
-        const time = 60 * inputHour.value! + val
-        return time >= minTime &&
-          time <= maxTime &&
-          isHourAllowed &&
-          (!cb || cb(val))
-      }
-    })
-
-    const isAllowedSecondCb = computed((): AllowFunction => {
-      let cb: AllowFunction
-
-      const isHourAllowed = !isAllowedHourCb.value || inputHour.value === null || isAllowedHourCb.value(inputHour.value)
-      const isMinuteAllowed = isHourAllowed &&
-        (!isAllowedMinuteCb.value ||
-          inputMinute.value === null ||
-          isAllowedMinuteCb.value(inputMinute.value)
-        )
-
-      if (props.allowedSeconds instanceof Array) {
-        cb = (val: number) => (props.allowedSeconds as number[]).includes(val)
-      } else {
-        cb = props.allowedSeconds as AllowFunction
-      }
-
-      if (!props.min && !props.max) {
-        return isMinuteAllowed ? cb : () => false
-      }
-
-      const [minHour, minMinute, minSecond] = props.min ? props.min.split(':').map(Number) : [0, 0, 0]
-      const [maxHour, maxMinute, maxSecond] = props.max ? props.max.split(':').map(Number) : [23, 59, 59]
-      const minTime = minHour * 3600 + minMinute * 60 + Number(minSecond || 0)
-      const maxTime = maxHour * 3600 + maxMinute * 60 + Number(maxSecond || 0)
-
-      return (val: number) => {
-        const time = 3600 * inputHour.value! + 60 * inputMinute.value! + val
-        return time >= minTime &&
-          time <= maxTime &&
-          isMinuteAllowed &&
-          (!cb || cb(val))
-      }
-    })
-
     const isAmPm = computed((): boolean => {
       return props.format === 'ampm'
     })
+
+    const {
+      isAllowedHour,
+      isAllowedMinute,
+      isAllowedSecond,
+    } = useTimeValidation(props)
 
     const shouldClear = toRef(() => {
       return props.modelValue !== null &&
@@ -200,8 +113,6 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
     watch(inputHour, emitValue)
     watch(inputMinute, emitValue)
     watch(inputSecond, emitValue)
-
-    watch(() => props.period, val => setPeriod(val))
 
     watch(() => props.modelValue, val => setInputData(val))
 
@@ -244,35 +155,6 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
       }
 
       period.value = (inputHour.value == null || inputHour.value < 12) ? 'am' : 'pm'
-    }
-
-    function firstAllowed (type: VTimePickerViewMode, value: number) {
-      const allowedFn = type === 'hour' ? isAllowedHourCb.value : (type === 'minute' ? isAllowedMinuteCb.value : isAllowedSecondCb.value)
-      if (!allowedFn) return value
-
-      // TODO: clean up (Note from V2 code)
-      const range = type === 'minute'
-        ? range60
-        : (type === 'second'
-          ? range60
-          : (isAmPm.value
-            ? (value < 12
-              ? rangeHours12am
-              : rangeHours12pm)
-            : rangeHours24))
-      const first = range.find(v => allowedFn((v + value) % range.length + range[0]))
-      return ((first || 0) + value) % range.length + range[0]
-    }
-
-    function setPeriod (val: Period) {
-      period.value = val
-      if (inputHour.value != null) {
-        const newHour = inputHour.value! + (period.value === 'am' ? -12 : 12)
-        inputHour.value = firstAllowed('hour', newHour)
-      }
-      emit('update:period', val)
-      emitValue()
-      return true
     }
 
     function onInput (value: number) {
@@ -327,6 +209,12 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
       const timePickerControlsProps = VTimePickerControls.filterProps(props)
       const timePickerClockProps = VTimePickerClock.filterProps(omit(props, ['format', 'modelValue', 'min', 'max']))
 
+      const clockValidation = viewMode.value === 'hour'
+        ? isAllowedHour.value
+        : viewMode.value === 'minute'
+          ? (v: number) => isAllowedMinute.value(inputHour.value, v)
+          : (v: number) => isAllowedSecond.value(inputHour.value, inputMinute.value, v)
+
       return (
         <VPicker
           { ...pickerProps }
@@ -354,10 +242,11 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
                 period={ period.value }
                 second={ inputSecond.value as number }
                 viewMode={ viewMode.value }
+                inputHints={ props.variant === 'input' }
                 onUpdate:hour={ (val: number) => inputHour.value = val }
                 onUpdate:minute={ (val: number) => inputMinute.value = val }
-                onUpdate:period={ (val: Period) => setPeriod(val) }
                 onUpdate:second={ (val: number) => inputSecond.value = val }
+                onUpdate:period={ (val: Period) => period.value = val }
                 onUpdate:viewMode={ (value: VTimePickerViewMode) => (viewMode.value = value) }
                 ref={ controlsRef }
               />
@@ -365,13 +254,7 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
             default: () => (
               <VTimePickerClock
                 { ...timePickerClockProps }
-                allowedValues={
-                  viewMode.value === 'hour'
-                    ? isAllowedHourCb.value
-                    : (viewMode.value === 'minute'
-                      ? isAllowedMinuteCb.value
-                      : isAllowedSecondCb.value)
-                    }
+                allowedValues={ clockValidation }
                 double={ viewMode.value === 'hour' && !isAmPm.value }
                 format={ viewMode.value === 'hour'
                   ? (isAmPm.value ? convert24to12 : (val: number) => val)

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerControls.sass
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerControls.sass
@@ -1,6 +1,7 @@
 @use 'sass:map'
 @use '../../styles/tools'
 @use '../../styles/settings'
+@use '../../styles/utilities'
 @use './variables' as *
 
 @include tools.layer('components')
@@ -79,10 +80,17 @@
       &:focus::placeholder
         opacity: 0
 
-  .v-time-picker-controls__field-label
-    font-size: $time-picker-field-label-font-size
-    letter-spacing: $time-picker-field-label-letter-spacing
-    padding-top: 6px
+    &.v-input > .v-input__details
+      font-size: $time-picker-field-label-font-size
+      letter-spacing: $time-picker-field-label-letter-spacing
+      padding-inline: 0
+      white-space: normal
+
+      > .v-messages
+        opacity: 1
+
+    &.v-input--error .v-field__input
+      color: rgb(var(--v-theme-error))
 
   .v-time-picker-controls__ampm
     margin-left: 12px
@@ -115,7 +123,7 @@
 
   @at-root
     @include tools.density('v-time-picker', $time-picker-controls-field-density) using ($modifier)
-      .v-time-picker-controls__time__field
+      .v-time-picker-controls__time__field .v-input__control
         height: $time-picker-controls-field-height + $modifier
 
         .v-field
@@ -124,7 +132,7 @@
           .v-field__input
             min-height: $time-picker-controls-field-height + $modifier
 
-      &.v-time-picker--variant-input .v-time-picker-controls__time__field
+      &.v-time-picker--variant-input .v-time-picker-controls__time__field .v-input__control
         height: $time-picker-controls-input-field-height + $modifier
 
         .v-field

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerField.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerField.tsx
@@ -18,13 +18,13 @@ export const makeVTimePickerFieldProps = propsFactory({
   disabled: Boolean,
   label: String,
   modelValue: String as PropType<string | number | null>,
+  error: String,
+  showHint: Boolean,
   readonly: Boolean,
 }, 'VTimePickerField')
 
 export const VTimePickerField = genericComponent()({
   name: 'VTimePickerField',
-
-  inheritAttrs: false,
 
   props: makeVTimePickerFieldProps(),
 
@@ -32,7 +32,7 @@ export const VTimePickerField = genericComponent()({
     'update:modelValue': (v: string | null) => true,
   },
 
-  setup (props, { emit, attrs }) {
+  setup (props, { emit }) {
     const { textColorClasses, textColorStyles } = useTextColor(() => props.color)
 
     const vTextInputRef = ref<VTextField>()
@@ -50,31 +50,33 @@ export const VTimePickerField = genericComponent()({
 
     useRender(() => {
       return (
-        <div>
-          <VTextField
-            ref={ vTextInputRef }
-            _as="VTimePickerField"
-            autocomplete="off"
-            class={[
-              'v-time-picker-controls__time__field',
-              { 'v-time-picker-controls__time__field--active': props.active },
-              props.active ? textColorClasses.value : [],
-            ]}
-            style={ props.active ? textColorStyles.value : [] }
-            disabled={ props.disabled }
-            variant="solo-filled"
-            inputmode="numeric"
-            hideDetails
-            flat
-            modelValue={ props.modelValue ?? (isFocused.value ? '' : '--') }
-            onUpdate:modelValue={ v => emit('update:modelValue', v) }
-            onKeydown={ onKeydown }
-            onFocus={ () => isFocused.value = true }
-            onBlur={ () => isFocused.value = false }
-            { ...attrs }
-          />
-          <div class="v-time-picker-controls__field-label">{ props.label }</div>
-        </div>
+        <VTextField
+          ref={ vTextInputRef }
+          _as="VTimePickerField"
+          autocomplete="off"
+          class={[
+            'v-time-picker-controls__time__field',
+            { 'v-time-picker-controls__time__field--active': props.active },
+            props.active ? textColorClasses.value : [],
+          ]}
+          style={ props.active ? textColorStyles.value : [] }
+          disabled={ props.disabled }
+          variant="solo-filled"
+          inputmode="numeric"
+          hideDetails="auto"
+          aria-label={ props.label }
+          aria-invalid={ !!props.error }
+          aria-errormessage={ props.error }
+          error={ !!props.error }
+          hint={ props.showHint ? props.label : undefined }
+          persistentHint
+          flat
+          modelValue={ props.modelValue ?? (isFocused.value ? '' : '--') }
+          onUpdate:modelValue={ v => emit('update:modelValue', v) }
+          onKeydown={ onKeydown }
+          onFocus={ () => isFocused.value = true }
+          onBlur={ () => isFocused.value = false }
+        />
       )
     })
 

--- a/packages/vuetify/src/components/VTimePicker/useTimeValidation.ts
+++ b/packages/vuetify/src/components/VTimePicker/useTimeValidation.ts
@@ -1,0 +1,109 @@
+// Utilities
+import { computed } from 'vue'
+import { incrementHour, incrementMinuteOrSecond } from './util'
+import { propsFactory } from '@/util'
+
+// Types
+import type { PropType } from 'vue'
+import type { VTimePickerViewMode } from './shared'
+
+export type AllowFunction = (val: number) => boolean
+
+export const makeTimeValidationProps = propsFactory({
+  allowedHours: [Function, Array] as PropType<AllowFunction | number[]>,
+  allowedMinutes: [Function, Array] as PropType<AllowFunction | number[]>,
+  allowedSeconds: [Function, Array] as PropType<AllowFunction | number[]>,
+  max: String,
+  min: String,
+}, 'time-validation')
+
+export interface TimeValidationProps {
+  allowedHours?: AllowFunction | number[]
+  allowedMinutes?: AllowFunction | number[]
+  allowedSeconds?: AllowFunction | number[]
+  min?: string
+  max?: string
+}
+
+export function useTimeValidation (props: TimeValidationProps) {
+  const isAllowedHour = computed(() => {
+    const minHour = props.min ? Number(props.min.split(':')[0]) : 0
+    const maxHour = props.max ? Number(props.max.split(':')[0]) : 23
+
+    return (val: number) => {
+      if (val < minHour) return false
+      if (val > maxHour) return false
+      if (Array.isArray(props.allowedHours)) return props.allowedHours.includes(val)
+      if (typeof props.allowedHours === 'function') return props.allowedHours(val)
+      return true
+    }
+  })
+
+  const isAllowedMinute = computed(() => {
+    const [minHour, minMinute] = props.min ? props.min.split(':').map(Number) : [0, 0]
+    const [maxHour, maxMinute] = props.max ? props.max.split(':').map(Number) : [23, 59]
+    const minTime = minHour * 60 + minMinute
+    const maxTime = maxHour * 60 + maxMinute
+
+    return (hour24hr: number | null, val: number) => {
+      if (hour24hr !== null) {
+        const time = 60 * hour24hr + val
+        if (time < minTime) return false
+        if (time > maxTime) return false
+      }
+      if (Array.isArray(props.allowedMinutes)) return props.allowedMinutes.includes(val)
+      if (typeof props.allowedMinutes === 'function') return props.allowedMinutes(val)
+      return true
+    }
+  })
+
+  const isAllowedSecond = computed(() => {
+    const [minHour, minMinute, minSecond] = props.min ? props.min.split(':').map(Number) : [0, 0, 0]
+    const [maxHour, maxMinute, maxSecond] = props.max ? props.max.split(':').map(Number) : [23, 59, 59]
+    const minTime = minHour * 3600 + minMinute * 60 + (minSecond || 0)
+    const maxTime = maxHour * 3600 + maxMinute * 60 + (maxSecond || 0)
+
+    return (hour24hr: number | null, minute: number | null, val: number) => {
+      if (hour24hr !== null && minute !== null) {
+        const time = 3600 * hour24hr + 60 * minute + val
+        if (time < minTime) return false
+        if (time > maxTime) return false
+      }
+      if (Array.isArray(props.allowedSeconds)) return props.allowedSeconds.includes(val)
+      if (typeof props.allowedSeconds === 'function') return props.allowedSeconds(val)
+      return true
+    }
+  })
+
+  function findNextAllowed (
+    type: VTimePickerViewMode,
+    value: number,
+    increment: boolean,
+    currentHour: number | null = null,
+    currentMinute: number | null = null
+  ): number {
+    const isAllowed = type === 'hour'
+      ? isAllowedHour.value
+      : type === 'minute'
+        ? (v: number) => isAllowedMinute.value(currentHour, v)
+        : (v: number) => isAllowedSecond.value(currentHour, currentMinute, v)
+
+    const nextValue = type === 'hour'
+      ? (v: number) => incrementHour(v, increment, null).value
+      : (v: number) => incrementMinuteOrSecond(v, increment)
+
+    const limit = type === 'hour' ? 24 : 60
+    for (let i = 1; i <= limit; i++) {
+      value = nextValue(value)
+      if (isAllowed(value)) break
+    }
+    return value
+  }
+
+  return {
+    isAllowedHour,
+    isAllowedMinute,
+    isAllowedSecond,
+    findNextAllowed,
+  }
+}

--- a/packages/vuetify/src/locale/af.ts
+++ b/packages/vuetify/src/locale/af.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Uur',
     minute: 'Minute',
     second: 'Sekondes',
+    notAllowed: 'Waarde word nie toegelaat nie',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ar.ts
+++ b/packages/vuetify/src/locale/ar.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'ساعة',
     minute: 'دقائق',
     second: 'ثواني',
+    notAllowed: 'القيمة غير مسموح بها',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/az.ts
+++ b/packages/vuetify/src/locale/az.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Saat',
     minute: 'Dəqiqə',
     second: 'Saniyə',
+    notAllowed: 'Dəyərə icazə verilmir',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/bg.ts
+++ b/packages/vuetify/src/locale/bg.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Час',
     minute: 'Минути',
     second: 'Секунди',
+    notAllowed: 'Стойността не е разрешена',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Hora',
     minute: 'Minuts',
     second: 'Segons',
+    notAllowed: 'El valor no està permès',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ckb.ts
+++ b/packages/vuetify/src/locale/ckb.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'کاتژمێر',
     minute: 'خولەک',
     second: 'چرکە',
+    notAllowed: 'بەهاکە ڕێگەپێدراو نییە',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/cs.ts
+++ b/packages/vuetify/src/locale/cs.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Hodina',
     minute: 'Minuty',
     second: 'Sekundy',
+    notAllowed: 'Hodnota není povolena',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/da.ts
+++ b/packages/vuetify/src/locale/da.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Time',
     minute: 'Minutter',
     second: 'Sekunder',
+    notAllowed: 'Værdien er ikke tilladt',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Stunde',
     minute: 'Minuten',
     second: 'Sekunden',
+    notAllowed: 'Wert ist nicht erlaubt',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/el.ts
+++ b/packages/vuetify/src/locale/el.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Ώρα',
     minute: 'Λεπτά',
     second: 'Δευτερόλεπτα',
+    notAllowed: 'Η τιμή δεν επιτρέπεται',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/en.ts
+++ b/packages/vuetify/src/locale/en.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Hour',
     minute: 'Minute',
     second: 'Second',
+    notAllowed: 'Value is not allowed',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/es.ts
+++ b/packages/vuetify/src/locale/es.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Hora',
     minute: 'Minutos',
     second: 'Segundos',
+    notAllowed: 'El valor no está permitido',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/et.ts
+++ b/packages/vuetify/src/locale/et.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Tund',
     minute: 'Minut',
     second: 'Sekund',
+    notAllowed: 'Väärtus ei ole lubatud',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'ساعت',
     minute: 'دقیقه',
     second: 'ثانیه',
+    notAllowed: 'مقدار مجاز نیست',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/fi.ts
+++ b/packages/vuetify/src/locale/fi.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Tunti',
     minute: 'Minuutit',
     second: 'Sekunnit',
+    notAllowed: 'Arvo ei ole sallittu',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Heure',
     minute: 'Minute',
     second: 'Seconde',
+    notAllowed: 'La valeur n\'est pas autorisée',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/he.ts
+++ b/packages/vuetify/src/locale/he.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'שעה',
     minute: 'דקות',
     second: 'שניות',
+    notAllowed: 'הערך אינו מותר',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/hr.ts
+++ b/packages/vuetify/src/locale/hr.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Sat',
     minute: 'Minute',
     second: 'Sekunde',
+    notAllowed: 'Vrijednost nije dopuštena',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Óra',
     minute: 'Perc',
     second: 'Másodperc',
+    notAllowed: 'Az érték nem engedélyezett',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/id.ts
+++ b/packages/vuetify/src/locale/id.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Jam',
     minute: 'Menit',
     second: 'Detik',
+    notAllowed: 'Nilai tidak diizinkan',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/it.ts
+++ b/packages/vuetify/src/locale/it.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Ora',
     minute: 'Minuti',
     second: 'Secondi',
+    notAllowed: 'Il valore non è consentito',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ja.ts
+++ b/packages/vuetify/src/locale/ja.ts
@@ -91,6 +91,7 @@ export default {
     hour: '時',
     minute: '分',
     second: '秒',
+    notAllowed: '値は許可されていません',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/km.ts
+++ b/packages/vuetify/src/locale/km.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'ម៉ោង',
     minute: 'នាទី',
     second: 'វិនាទី',
+    notAllowed: 'តម្លៃមិនត្រូវបានអនុញ្ញាតទេ',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ko.ts
+++ b/packages/vuetify/src/locale/ko.ts
@@ -91,6 +91,7 @@ export default {
     hour: '시간',
     minute: '분',
     second: '초',
+    notAllowed: '값이 허용되지 않습니다',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/lt.ts
+++ b/packages/vuetify/src/locale/lt.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Valanda',
     minute: 'Minutės',
     second: 'Sekundės',
+    notAllowed: 'Reikšmė neleidžiama',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/lv.ts
+++ b/packages/vuetify/src/locale/lv.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Stunda',
     minute: 'Minūtes',
     second: 'Sekundes',
+    notAllowed: 'Vērtība nav atļauta',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/nl.ts
+++ b/packages/vuetify/src/locale/nl.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Uur',
     minute: 'Minuten',
     second: 'Seconden',
+    notAllowed: 'Waarde is niet toegestaan',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Time',
     minute: 'Minutter',
     second: 'Sekunder',
+    notAllowed: 'Verdien er ikke tillatt',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/pl.ts
+++ b/packages/vuetify/src/locale/pl.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Godzina',
     minute: 'Minuty',
     second: 'Sekudy',
+    notAllowed: 'Wartość jest niedozwolona',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/pt.ts
+++ b/packages/vuetify/src/locale/pt.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Hora',
     minute: 'Minuto',
     second: 'Segundos',
+    notAllowed: 'O valor não é permitido',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Oră',
     minute: 'Minute',
     second: 'Secunde',
+    notAllowed: 'Valoarea nu este permisă',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/ru.ts
+++ b/packages/vuetify/src/locale/ru.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Час',
     minute: 'Минуты',
     second: 'Секунды',
+    notAllowed: 'Значение не разрешено',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/sk.ts
+++ b/packages/vuetify/src/locale/sk.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Hodina',
     minute: 'Minúty',
     second: 'Sekundy',
+    notAllowed: 'Hodnota nie je povolená',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/sl.ts
+++ b/packages/vuetify/src/locale/sl.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Ura',
     minute: 'Minute',
     second: 'Sekunde',
+    notAllowed: 'Vrednost ni dovoljena',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/sr-Cyrl.ts
+++ b/packages/vuetify/src/locale/sr-Cyrl.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Сат',
     minute: 'Минути',
     second: 'Секунде',
+    notAllowed: 'Вредност није дозвољена',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/sr-Latn.ts
+++ b/packages/vuetify/src/locale/sr-Latn.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Sat',
     minute: 'Minute',
     second: 'Sekunde',
+    notAllowed: 'Vrednost nije dozvoljena',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/sv.ts
+++ b/packages/vuetify/src/locale/sv.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Timme',
     minute: 'Minuter',
     second: 'Sekunder',
+    notAllowed: 'Värdet är inte tillåtet',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/th.ts
+++ b/packages/vuetify/src/locale/th.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'ชั่วโมง',
     minute: 'นาที',
     second: 'วินาที',
+    notAllowed: 'ค่าไม่ได้รับอนุญาต',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Saat',
     minute: 'Dakika',
     second: 'Saniye',
+    notAllowed: 'Değere izin verilmiyor',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/uk.ts
+++ b/packages/vuetify/src/locale/uk.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Година',
     minute: 'Хвилини',
     second: 'Секунди',
+    notAllowed: 'Значення не дозволено',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/vi.ts
+++ b/packages/vuetify/src/locale/vi.ts
@@ -91,6 +91,7 @@ export default {
     hour: 'Giờ',
     minute: 'Phút',
     second: 'Giây',
+    notAllowed: 'Giá trị không được phép',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/zh-Hans.ts
+++ b/packages/vuetify/src/locale/zh-Hans.ts
@@ -91,6 +91,7 @@ export default {
     hour: '小时',
     minute: '分钟',
     second: '秒',
+    notAllowed: '值不允许',
   },
   pagination: {
     ariaLabel: {

--- a/packages/vuetify/src/locale/zh-Hant.ts
+++ b/packages/vuetify/src/locale/zh-Hant.ts
@@ -91,6 +91,7 @@ export default {
     hour: '小時',
     minute: '分鐘',
     second: '秒',
+    notAllowed: '值不允許',
   },
   pagination: {
     ariaLabel: {


### PR DESCRIPTION
`allowed-*` props and `min`/`max` currently apply only to the clock in "dial" variant. Follow-up after #21601

- skips over disallowed values when using up/down arrows
- colors inputs red when typing wrong value
- supplements aria attributes

> note: still emits values outside of range

closes #22576 (alternative PR)
resolves #22606

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-row class="justify-center">
      <v-col cols="auto">
        <v-container>
          <v-time-picker
            :allowed-hours="[5, 6, 7, 8, 9, 10, 11, 12]"
            elevation="3"
            variant="input"
            width="330"
          />
          <v-time-picker
            :allowed-hours="[8, 10, 12, 14]"
            :allowed-minutes="[0, 15, 30, 45]"
            elevation="3"
            variant="dial"
            width="330"
          />
        </v-container>
      </v-col>
      <v-col cols="auto">
        <v-container>
          <v-time-picker
            elevation="3"
            max="16:59"
            min="9:30"
            model-value="21:30"
            variant="input"
            width="330"
          />
          <v-time-picker
            elevation="3"
            max="16:59:59"
            min="9:30:30"
            model-value="9:29:00"
            variant="dial"
            width="330"
            use-seconds
          />
        </v-container>
      </v-col>
      <v-col cols="auto">
        <v-container>
          <v-time-picker
            :allowed-hours="(v) => v % 2 === 0"
            elevation="3"
            variant="input"
            width="330"
          />
          <v-time-picker
            :allowed-hours="(v) => v > 14 && v % 2 === 0"
            :allowed-minutes="(v) => v % 10 === 0"
            elevation="3"
            variant="dial"
            width="330"
          />
        </v-container>
      </v-col>
    </v-row>
  </v-app>
</template>
```
