### PR TITLE
fix(VColorPicker): avoid undefined alpha in rgb/hsl output

### DIFF
--- a/packages/vuetify/src/components/VColorPicker/util/index.ts
+++ b/packages/vuetify/src/components/VColorPicker/util/index.ts
@@ -24,7 +24,6 @@ function stripAlpha (color: any, stripAlpha: boolean) {
 
 export function extractColor (color: HSV, input: any) {
   if (input == null || typeof input === 'string') {
-  if (input == null || typeof input === 'string') {
     const hasA = typeof color.a === 'number' && color.a < 1
     if (input?.startsWith('rgb(')) {
       const { r, g, b, a } = HSVtoRGB(color)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Fixes an issue where `VColorPicker` (and `VColorInput`) generated invalid CSS color values when initialized with `rgb()` or `hsl()` strings that do not include an alpha channel.

When such values were used (e.g. `rgb(102, 187, 106)`), selecting a new color resulted in output like `rgb(... / undefined)`, which is not valid CSS. This happened because the alpha channel was appended even when the alpha value was `undefined`.

This change ensures that the alpha channel is only included in the generated color string when a valid alpha value is present.

Fixes #22567


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-color-input
        v-model="color"
        color-pip
        pip-variant="outlined"
        hide-actions
        show-swatches
        label="Color input"
      />

      <v-btn class="mt-4" @click="color = '#0000ff'">
        Set to #0000ff
      </v-btn>

      <v-btn class="mt-2" @click="color = 'rgb(102, 187, 106)'">
        Set to rgb(102, 187, 106)
      </v-btn>

      <div class="mt-4">
        <strong>Current value:</strong> {{ color }}
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'

const color = ref('#ff0000')
</script>
```

