### PR TITLE
docs: fix incorrect URL for Vuetify Create in README

### DIFF
--- a/packages/vuetify/README.md
+++ b/packages/vuetify/README.md
@@ -211,7 +211,7 @@ Vuetify supports all **modern browsers**, including Safari 13+ (using [polyfills
     </tr>
     <tr>
       <td>
-        <a href="https://bin.vuetifyjs.com/">
+        <a href="https://github.com/vuetifyjs/create-vuetify">
           🫧&nbsp;Vuetify&nbsp;Create
         </a>
       </td>


### PR DESCRIPTION
- Changed link from bin.vuetifyjs.com to github.com/vuetifyjs/create-vuetify
- Vuetify Create was pointing to the wrong resource (Vuetify Bin)
- Fixes duplicate URL issue in Resources table