### PR TITLE
docs: update HTTP to HTTPS for MIT license URLs in README

### DIFF
--- a/packages/vuetify/README.md
+++ b/packages/vuetify/README.md
@@ -65,7 +65,7 @@ For more information on how to get started, such as using Nuxt or Laravel, check
 
 ### 💖 Supporting Vuetify
 
-Vuetify is a [MIT licensed](http://opensource.org/licenses/MIT) project that is developed and maintained by the [Core Team](https://vuetifyjs.com/about/meet-the-team/). Sponsor Vuetify and receive some **awesome perks** and support Open Source Software at the same time! 🎉
+Vuetify is a [MIT licensed](https://opensource.org/licenses/MIT) project that is developed and maintained by the [Core Team](https://vuetifyjs.com/about/meet-the-team/). Sponsor Vuetify and receive some **awesome perks** and support Open Source Software at the same time! 🎉
 
 <ul>
   <li>
@@ -314,7 +314,7 @@ We also have a list of [help wanted](https://github.com/vuetifyjs/vuetify/labels
 
 ### 📑 License
 
-Vuetify is available under the [MIT](http://opensource.org/licenses/MIT) software license.
+Vuetify is available under the [MIT](https://opensource.org/licenses/MIT) software license.
 
 Copyright (c) 2016-present Vuetify, LLC
 


### PR DESCRIPTION
- Updated opensource.org URLs from HTTP to HTTPS
- Improves security by using secure protocol
- Affects 2 MIT license references in README

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
