### PR TITLE
fix(VCard): accept height when used within a dialog

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.tsx
+++ b/packages/vuetify/src/components/VCard/VCard.tsx
@@ -31,7 +31,7 @@ import vRipple from '@/directives/ripple'
 
 // Utilities
 import { shallowRef, watch } from 'vue'
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -165,6 +165,9 @@ export const VCard = genericComponent<VCardSlots>()({
             colorStyles.value,
             dimensionStyles.value,
             locationStyles.value,
+            {
+              '--v-card-height': convertToUnit(props.height),
+            },
             props.style,
           ]}
           onClick={ isClickable && link.navigate }

--- a/packages/vuetify/src/components/VDialog/VDialog.sass
+++ b/packages/vuetify/src/components/VDialog/VDialog.sass
@@ -24,7 +24,7 @@
           --v-scrollbar-offset: 0px
           border-radius: $dialog-border-radius
           overflow-y: auto
-          flex: 1 1 100%
+          flex: 1 1 var(--v-card-height, 100%)
 
           @include tools.elevation($dialog-elevation)
 
@@ -82,7 +82,7 @@
       &,
       > .v-card
         display: flex
-        flex: 1 1 100%
+        flex: 1 1 var(--v-card-height, 100%)
         flex-direction: column
 
       > .v-card > .v-card-text


### PR DESCRIPTION
fixes #20979

```vue
<template>
  <v-app>
    <v-container>
      <v-dialog max-width="500">
        <template #activator="{ props: activatorProps }">
          <v-btn
            v-bind="activatorProps"
            color="surface-variant"
            text="Open Dialog"
            variant="flat"
          />
        </template>

        <template #default="{ isActive }">
          <v-card height="800" title="Dialog">
            <v-card-text>
              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
              eiusmod tempor incididunt ut labore et dolore magna aliqua.
            </v-card-text>

            <v-card-actions>
              <v-spacer />

              <v-btn
                text="Close Dialog"
                @click="isActive.value = false"
              />
            </v-card-actions>
          </v-card>
        </template>
      </v-dialog>
    </v-container>
  </v-app>
</template>
```
