### PR TITLE
fix(VDataTable): sort icon persists after removing sort via click

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -71,7 +71,7 @@
                   opacity: 0
 
                 &:hover,
-                &:focus
+                &:focus-visible
                   .v-data-table-header__sort-icon
                     opacity: 0.5
 


### PR DESCRIPTION
Fixes #22558

When you click a column header to cycle through sort states (asc → desc → none), the sort icon stays visible after sorting is removed — even after your mouse leaves the header.

The root cause is that clicking the `th` gives it `:focus`, and `:focus` sticks around until you click somewhere else on the page. The CSS rule that shows the sort icon at `opacity: 0.5` on `:focus` keeps it visible even though sorting is gone and the mouse is no longer hovering.

The fix is just swapping `:focus` for `:focus-visible` on the unsorted icon rule. `:focus-visible` only fires for keyboard navigation (Tab), not mouse clicks, so:
- **Mouse users**: icon hides immediately after click-to-unsort
- **Keyboard users**: icon still shows when they Tab to a sortable column (accessibility preserved)

One-liner in `VDataTable.sass`.