### PR TITLE
fix(VTable): apply $table-header-font-size to th elements

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -112,6 +112,7 @@
             > th
               height: var(--v-table-header-height)
               font-weight: $table-header-font-weight
+              font-size: $table-header-font-size
               user-select: none
               text-align: start
 

--- a/packages/vuetify/src/components/VTable/_variables.scss
+++ b/packages/vuetify/src/components/VTable/_variables.scss
@@ -9,7 +9,7 @@ $table-color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity)) !d
 $table-density: ('default': 0, 'comfortable': -2, 'compact': -4) !default;
 $table-header-height: 56px !default;
 $table-header-font-weight: 500 !default;
-$table-header-font-size: tools.map-deep-get(settings.$typography, 'caption', 'size') !default;
+$table-header-font-size: inherit !default;
 $table-font-size: tools.map-deep-get(settings.$typography, 'body-2', 'size') !default;
 $table-row-height: 52px !default;
 $table-row-font-size: tools.map-deep-get(settings.$typography, 'subtitle-2', 'size') !default;


### PR DESCRIPTION
## Summary

- `$table-header-font-size` was defined in `_variables.scss` but never referenced in `VTable.sass`, so overriding it via `settings.scss` had no effect
- Added `font-size: $table-header-font-size` to the `> th` selector, right next to the existing `font-weight: $table-header-font-weight`

Fixes #21002