### PR TITLE
fix(VSelect): fix screenreader navigation to select options

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -341,12 +341,23 @@ export const VSelect = genericComponent<new <
         item => model.value.some(s => (props.valueComparator || deepEqual)(s.value, item.value))
       )
     }
+    function getSelectedFocusableIndex () {
+      if (!model.value.length) return -1
+      const comparator = props.valueComparator || deepEqual
+      let focusableIndex = 0
+      for (const item of displayItems.value) {
+        const isSelected = model.value.some(s => comparator(s.value, item.value))
+        if (isSelected) return item.props.disabled ? -1 : focusableIndex
+        if (!item.props.disabled) focusableIndex++
+      }
+      return -1
+    }
     function onAfterEnter () {
       if (props.eager) {
         vVirtualScrollRef.value?.calculateVisibleItems()
       }
       if (listRef.value) {
-        const index = getSelectedIndex()
+        const index = getSelectedFocusableIndex()
         listRef.value.focus(index >= 0 ? index : 'first')
       }
     }


### PR DESCRIPTION
fixes #22226

## Description
When VSelect menu is opened, the selected item or first item in the list is focused so that screen-readers can navigate through the options. 

- [x] tested on IOS screenreader
- [x] tested on Android Talkback

## Markup:
<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>

      <v-select
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        label="Select"
      />
      <div>hello there</div>
      <v-btn>click me</v-btn>
    </v-container>
  </v-app>
</template>

```
