### PR TITLE
feat(VTimePicker): DOM events on buttons

### DIFF
--- a/packages/api-generator/src/locale/en/VTimePicker.json
+++ b/packages/api-generator/src/locale/en/VTimePicker.json
@@ -26,6 +26,10 @@
     "update:minute": "Emitted when user selects the minute.",
     "update:second": "Emitted when user selects the second.",
     "update:period": "Emitted when user clicks the AM/PM button.",
-    "update:viewMode": "Emitted when the view mode changes."
+    "update:viewMode": "Emitted when the view mode changes.",
+    "<domevent>:hour": "Emitted when the specified DOM event occurs on hours.",
+    "<domevent>:minute": "Emitted when the specified DOM event occurs on minutes.",
+    "<domevent>:second": "Emitted when the specified DOM event occurs on seconds.",
+    "<domevent>:period": "Emitted when the specified DOM event occurs on the period button."
   }
 }

--- a/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePicker.tsx
@@ -20,6 +20,7 @@ import { createRange, genericComponent, omit, propsFactory, useRender } from '@/
 import type { PropType } from 'vue'
 import type { Period, VTimePickerViewMode } from './shared'
 import type { VPickerSlots } from '@/labs/VPicker/VPicker'
+import type { EventProp, GenericProps } from '@/util'
 
 type AllowFunction = (val: number) => boolean
 
@@ -64,7 +65,15 @@ export const makeVTimePickerProps = propsFactory({
   ...makeDensityProps(),
 }, 'VTimePicker')
 
-export const VTimePicker = genericComponent<VTimePickerSlots>()({
+export const VTimePicker = genericComponent<new (
+  props: {
+    [key: `on${Capitalize<string>}:hour`]: EventProp<[Event, { value: number | string | null }]>
+    [key: `on${Capitalize<string>}:minute`]: EventProp<[Event, { value: number | string | null }]>
+    [key: `on${Capitalize<string>}:second`]: EventProp<[Event, { value: number | string | null }]>
+    [key: `on${Capitalize<string>}:period`]: EventProp<[Event, { value: Period }]>
+  },
+  slots: VTimePickerSlots,
+) => GenericProps<typeof props, typeof slots>>()({
   name: 'VTimePicker',
 
   props: makeVTimePickerProps(),
@@ -78,7 +87,7 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
     'update:viewMode': (val: VTimePickerViewMode) => true,
   },
 
-  setup (props, { emit, slots }) {
+  setup (props, { emit, slots, attrs }) {
     const { t } = useLocale()
     const { densityClasses } = useDensity(props)
     const inputHour = ref(null as number | null)
@@ -301,11 +310,13 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
       }
 
       const emitChange = inputHour.value !== null && inputMinute.value !== null && (props.useSeconds ? inputSecond.value !== null : true)
-      if (viewMode.value === 'hour') {
-        viewMode.value = 'minute'
-      } else if (props.useSeconds && viewMode.value === 'minute') {
-        viewMode.value = 'second'
-      }
+      setTimeout(() => {
+        if (viewMode.value === 'hour') {
+          viewMode.value = 'minute'
+        } else if (props.useSeconds && viewMode.value === 'minute') {
+          viewMode.value = 'second'
+        }
+      }, 0)
 
       if (inputHour.value === lazyInputHour.value &&
         inputMinute.value === lazyInputMinute.value &&
@@ -348,6 +359,7 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
             header: () => (
               <VTimePickerControls
                 { ...timePickerControlsProps }
+                { ...attrs }
                 ampm={ isAmPm.value }
                 hour={ inputHour.value as number }
                 minute={ inputMinute.value as number }
@@ -365,6 +377,8 @@ export const VTimePicker = genericComponent<VTimePickerSlots>()({
             default: () => (
               <VTimePickerClock
                 { ...timePickerClockProps }
+                { ...attrs }
+                viewMode={ viewMode.value }
                 allowedValues={
                   viewMode.value === 'hour'
                     ? isAllowedHourCb.value

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerClock.tsx
@@ -179,8 +179,11 @@ export const VTimePickerClock = genericComponent()({
       update(value)
     }
 
-    function getValueByEvent (e: MouseEvent | TouchEvent) {
-      const { width, top, left } = clockRef.value?.getBoundingClientRect()
+    function getValueByEvent (e: Event) {
+      if (!(e instanceof MouseEvent) && !(e instanceof TouchEvent)) return undefined
+      if (!clockRef.value) return undefined
+
+      const { width, top, left } = clockRef.value.getBoundingClientRect()
       const { width: innerWidth }: DOMRect = innerClockRef.value?.getBoundingClientRect() ?? { width: 0 } as DOMRect
       const { clientX, clientY } = 'touches' in e ? e.touches[0] : e
       const center = { x: width / 2, y: -width / 2 }

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerClock.tsx
@@ -6,10 +6,11 @@ import { useBackgroundColor, useTextColor } from '@/composables/color'
 
 // Utilities
 import { computed, onScopeDispose, ref, watch } from 'vue'
-import { debounce, genericComponent, propsFactory, useRender } from '@/util'
+import { debounce, genericComponent, getPrefixedEventHandlers, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
+import type { VTimePickerViewMode } from './shared'
 interface Point {
   x: number
   y: number
@@ -47,6 +48,7 @@ export const makeVTimePickerClockProps = propsFactory({
   modelValue: {
     type: Number,
   },
+  viewMode: String as PropType<VTimePickerViewMode>,
 }, 'VTimePickerClock')
 
 export const VTimePickerClock = genericComponent()({
@@ -59,7 +61,7 @@ export const VTimePickerClock = genericComponent()({
     input: (val: number) => true,
   },
 
-  setup (props, { emit }) {
+  setup (props, { emit, attrs }) {
     const clockRef = ref<HTMLElement | null>(null)
     const innerClockRef = ref<HTMLElement | null>(null)
     const inputValue = ref<number | undefined>(undefined)
@@ -177,9 +179,7 @@ export const VTimePickerClock = genericComponent()({
       update(value)
     }
 
-    function onDragMove (e: MouseEvent | TouchEvent) {
-      e.preventDefault()
-      if ((!isDragging.value && e.type !== 'click') || !clockRef.value) return
+    function getValueByEvent (e: MouseEvent | TouchEvent) {
       const { width, top, left } = clockRef.value?.getBoundingClientRect()
       const { width: innerWidth }: DOMRect = innerClockRef.value?.getBoundingClientRect() ?? { width: 0 } as DOMRect
       const { clientX, clientY } = 'touches' in e ? e.touches[0] : e
@@ -192,10 +192,22 @@ export const VTimePickerClock = genericComponent()({
 
       for (let i = 0; i < checksCount; i++) {
         value = angleToValue(handAngle + i * degreesPerUnit.value, insideClick)
-        if (isAllowed(value)) return setMouseDownValue(value)
+        if (isAllowed(value)) return value
 
         value = angleToValue(handAngle - i * degreesPerUnit.value, insideClick)
-        if (isAllowed(value)) return setMouseDownValue(value)
+        if (isAllowed(value)) return value
+      }
+
+      return value
+    }
+
+    function onDragMove (e: MouseEvent | TouchEvent) {
+      e.preventDefault()
+      if ((!isDragging.value && e.type !== 'click') || !clockRef.value) return
+
+      const value = getValueByEvent(e)
+      if (value != null && isAllowed(value)) {
+        setMouseDownValue(value)
       }
     }
 
@@ -234,6 +246,8 @@ export const VTimePickerClock = genericComponent()({
     onScopeDispose(removeListeners)
 
     useRender(() => {
+      const events = getPrefixedEventHandlers(attrs, `:${props.viewMode}`, nativeEvent => getValueByEvent(nativeEvent))
+
       return (
         <div
           class={[
@@ -243,6 +257,7 @@ export const VTimePickerClock = genericComponent()({
               'v-time-picker-clock--readonly': props.readonly,
             },
           ]}
+          { ...events }
           onMousedown={ onMouseDown }
           onTouchstart={ onMouseDown }
           onWheel={ wheel }

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerControls.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerControls.tsx
@@ -12,7 +12,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 // Utilities
 import { ref, watch } from 'vue'
 import { convert12to24, convert24to12, extractInteger, incrementHour, incrementMinuteOrSecond, pad } from './util'
-import { clamp, genericComponent, propsFactory, useRender } from '@/util'
+import { clamp, genericComponent, getPrefixedEventHandlers, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType, Ref } from 'vue'
@@ -45,7 +45,7 @@ export const VTimePickerControls = genericComponent()({
     'update:second': (v: number) => true,
   },
 
-  setup (props, { emit, slots }) {
+  setup (props, { emit, slots, attrs }) {
     const { t } = useLocale()
 
     const transformHours = {
@@ -209,6 +209,8 @@ export const VTimePickerControls = genericComponent()({
     )
 
     useRender(() => {
+      const prefixEvents = (value: Period) => getPrefixedEventHandlers(attrs, ':period', () => value)
+
       return (
         <div class="v-time-picker-controls">
           <div
@@ -279,6 +281,7 @@ export const VTimePickerControls = genericComponent()({
                   disabled={ props.disabled }
                   text={ t('$vuetify.timePicker.am') }
                   variant={ props.disabled && props.period === 'am' ? 'elevated' : 'tonal' }
+                  { ...prefixEvents('am') }
                   onClick={ () => props.period !== 'am' ? emit('update:period', 'am') : null }
                 />
 
@@ -293,6 +296,7 @@ export const VTimePickerControls = genericComponent()({
                   disabled={ props.disabled }
                   text={ t('$vuetify.timePicker.pm') }
                   variant={ props.disabled && props.period === 'pm' ? 'elevated' : 'tonal' }
+                  { ...prefixEvents('pm') }
                   onClick={ () => props.period !== 'pm' ? emit('update:period', 'pm') : null }
                 />
               </div>

--- a/packages/vuetify/src/util/events.ts
+++ b/packages/vuetify/src/util/events.ts
@@ -7,11 +7,11 @@ export function getPrefixedEventHandlers<T extends `:${string}`> (
   attrs: Record<string, any>,
   suffix: T,
   getData: EventHandler
-): Record<`${string}${T}`, EventHandler> {
+): Record<`${string}`, EventHandler> {
   return Object.keys(attrs)
     .filter(key => isOn(key) && key.endsWith(suffix))
     .reduce((acc: any, key) => {
       acc[key.slice(0, -suffix.length)] = (event: Event) => callEvent(attrs[key], event, getData(event))
       return acc
-    }, {} as Record<`${string}${T}`, EventHandler>)
+    }, {} as Record<`${string}`, EventHandler>)
 }


### PR DESCRIPTION
fixes #20784

## Description
Emits all kinds of DOM events for hour, minute, second and period buttons

## Markup:
```vue
<template>
  <v-container>
    <v-time-picker
      v-model="model"
      use-seconds
      @click:hour="handleClickHour"
      @click:minute="handleClickMinute"
      @click:period="handleClickPeriod"
      @click:second="handleClickSecond"
    />
  </v-container>
</template>

<script setup>
  import { ref } from 'vue'

  const model = ref()

  const handleClickHour = (event, value) => {
    console.log('click:hour', event, value)
  }

  const handleClickMinute = (event, value) => {
    console.log('click:minute', event, value)
  }

  const handleClickPeriod = (event, value) => {
    console.log('click:period', event, value)
  }

  const handleClickSecond = (event, value) => {
    console.log('click:second', event, value)
  }
</script>

```
