### PR TITLE
fix(VDateInput): don't scroll the page when opening 'years' view

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerYears.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerYears.tsx
@@ -95,11 +95,11 @@ export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
       model.value = model.value ?? adapter.getYear(adapter.date())
     })
 
-    const yearsRef = templateRef()
+    const containerRef = templateRef()
     const yearRef = templateRef()
 
     function focusSelectedYear () {
-      const container = yearsRef.el
+      const container = containerRef.el
       const target = yearRef.el
       if (!container || !target) return
 
@@ -124,7 +124,7 @@ export const VDatePickerYears = genericComponent<VDatePickerYearsSlots>()({
     useRender(() => (
       <div
         class="v-date-picker-years"
-        ref={ yearsRef }
+        ref={ containerRef }
         v-intersect={[{
           handler: focusSelectedYear,
         }, null, ['once']]}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #22581 
In a page with big height, when opening a `VDateInput` and clicking on the _years_ selection, the main page would scroll down (apparently to the place where the current year, that is scrolled into view, is located).

I've removed the `scrollIntoView` behaviour and instead, added `yearsRef` for the years container, and calculate the scrollTop based on both yearsRef and yearRef.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container class="py-8" height="140vh">
      <v-card class="mx-auto" max-width="520" title="User info">
        <v-card-text>
          <v-form>
            <v-text-field
              v-model="form.firstName"
              autocomplete="given-name"
              label="First name"
            />

            <v-text-field
              v-model="form.lastName"
              autocomplete="family-name"
              label="Last name"
            />

            <v-text-field
              v-model="form.address"
              autocomplete="street-address"
              label="Address"
            />

            <v-date-input
              v-model="form.dateOfBirth"
              :picker-props="{ max: maxDate }"
              label="Date of birth"
              clearable
            />
          </v-form>
        </v-card-text>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
import { reactive } from "vue";

const maxDate = new Date();

const form = reactive({
  firstName: "",
  lastName: "",
  address: "",
  dateOfBirth: null,
});
</script>

```
