### PR TITLE
fix(VCalendar): show border for outside date when calendar has event

### DIFF
--- a/packages/vuetify/src/components/VCalendar/composables/calendarWithEvents.sass
+++ b/packages/vuetify/src/components/VCalendar/composables/calendarWithEvents.sass
@@ -62,8 +62,5 @@
       white-space: nowrap
 
     &.v-calendar-events
-      .v-calendar-weekly__head-weekday
-        margin-right: -$calendar-line-width
       .v-calendar-weekly__day
         overflow: visible
-        margin-right: -$calendar-line-width

--- a/packages/vuetify/src/components/VCalendar/composables/calendarWithEvents.tsx
+++ b/packages/vuetify/src/components/VCalendar/composables/calendarWithEvents.tsx
@@ -326,7 +326,7 @@ export function useCalendarWithEvents (props: CalendarWithEventsProps, slots: an
       ],
       style: {
         height: `${eventHeight}px`,
-        width: `${width}%`,
+        width: `calc(${width}% + ${(width - WIDTH_START) / WIDTH_FULL}px)`,
         marginBottom: `${eventMarginBottom}px`,
       },
       'data-date': day.date,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #22516 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <p>
        Alright, looks fine, left and right borders on outside days
        <v-icon color="green">mdi-check</v-icon>
      </p>
      <v-calendar ref="calendar1" model-value="2026-01-01"> </v-calendar>

      <p>
        No left and right borders on outside days when the calendar has an
        event.
        <v-icon color="red">mdi-alert</v-icon>
      </p>
      <v-calendar ref="calendar2" model-value="2026-01-01" :events="events">
      </v-calendar>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from "vue";
  const now = new Date(2026, 0, 4);
  const end = new Date(2026, 0, 5);
  const end2 = new Date(2026, 0, 12);
  const start13 = new Date(2026, 0, 13);

  const end15 = new Date(2026, 0, 15);
  const events = [
    {
      name: "Event name",
      start: now,
      end: end2,
      color: "blue",
      timed: false,
    },
    {
      name: "Event name2",
      start: end,
      end: end2,
      color: "blue",
      timed: false,
    },
    {
      name: "Event name5x",
      start: start13,
      end: end15,
      color: "blue",
      timed: false,
    }
  ];
</script>
```
