### PR TITLE
feat(VTreeview): add aria-expanded and aria-label to toggle buttons

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewGroup.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewGroup.tsx
@@ -25,11 +25,14 @@ export const VTreeviewGroup = genericComponent<VListGroupSlots>()({
     const vListGroupRef = ref<VListGroup>()
     const toggleIcon = computed(() => vListGroupRef.value?.isOpen ? props.collapseIcon : props.expandIcon)
 
+    const isGroupOpen = computed(() => !!vListGroupRef.value?.isOpen)
+
     const activatorDefaults = computed(() => ({
       VTreeviewItem: {
         prependIcon: undefined,
         appendIcon: undefined,
         toggleIcon: toggleIcon.value,
+        toggleExpanded: isGroupOpen.value,
       },
     }))
 

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -31,6 +31,7 @@ export const makeVTreeviewItemProps = propsFactory({
   hasCustomPrepend: Boolean,
   indentLines: Array as PropType<IndentLineType[]>,
   toggleIcon: IconValue,
+  toggleExpanded: Boolean,
 
   ...makeVListItemProps({ slim: true }),
 }, 'VTreeviewItem')
@@ -132,6 +133,8 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
                               icon={ props.toggleIcon }
                               loading={ props.loading }
                               variant="text"
+                              aria-expanded={ props.toggleExpanded }
+                              aria-label={ props.toggleExpanded ? 'Collapse' : 'Expand' }
                               onClick={ onClickAction }
                             >
                               {{
@@ -153,6 +156,8 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
                                   icon: props.toggleIcon,
                                   variant: 'text',
                                   loading: props.loading,
+                                  'aria-expanded': props.toggleExpanded,
+                                  'aria-label': props.toggleExpanded ? 'Collapse' : 'Expand',
                                 },
                                 VProgressCircular: {
                                   indeterminate: 'disable-shrink',


### PR DESCRIPTION
## Problem

The expand/collapse buttons in VTreeview nodes are announced by screen readers as just "Button" without any context about what they do (#21585).

## Solution

Added `aria-expanded` and `aria-label` attributes to the toggle buttons in VTreeviewItem. The `aria-expanded` reflects the current open/closed state, and `aria-label` provides "Expand" or "Collapse" text.

The expanded state is passed from VTreeviewGroup (which already tracks `isOpen`) to VTreeviewItem via a new `toggleExpanded` prop, following the existing defaults injection pattern.

Fixes #21585