### PR TITLE
feat(VVideo): add `hide-progress-bar` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VVideoControls.json
+++ b/packages/api-generator/src/locale/en/VVideoControls.json
@@ -5,6 +5,7 @@
     "trackColor": "Passed to the main slider `color` prop.",
     "playing": "Applies correct icon of the default play button.",
     "hidePlay": "Hides default play button.",
+    "hideSeek": "Hides default seek slider.",
     "hideVolume": "Hides default volume control.",
     "hideFullscreen": "Hides default fullscreen button.",
     "fullscreen": "Applies correct icon on the default fullscreen button.",

--- a/packages/api-generator/src/locale/en/VVideoControls.json
+++ b/packages/api-generator/src/locale/en/VVideoControls.json
@@ -5,7 +5,7 @@
     "trackColor": "Passed to the main slider `color` prop.",
     "playing": "Applies correct icon of the default play button.",
     "hidePlay": "Hides default play button.",
-    "hideSeek": "Hides default seek slider.",
+    "hideSeekbar": "Hides default seek bar",
     "hideVolume": "Hides default volume control.",
     "hideFullscreen": "Hides default fullscreen button.",
     "fullscreen": "Applies correct icon on the default fullscreen button.",

--- a/packages/api-generator/src/locale/en/VVideoControls.json
+++ b/packages/api-generator/src/locale/en/VVideoControls.json
@@ -5,7 +5,7 @@
     "trackColor": "Passed to the main slider `color` prop.",
     "playing": "Applies correct icon of the default play button.",
     "hidePlay": "Hides default play button.",
-    "hideSeekbar": "Hides default seek bar",
+    "hideProgressBar": "Hides default progress bar.",
     "hideVolume": "Hides default volume control.",
     "hideFullscreen": "Hides default fullscreen button.",
     "fullscreen": "Applies correct icon on the default fullscreen button.",

--- a/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
+++ b/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
@@ -55,6 +55,7 @@ export const makeVVideoControlsProps = propsFactory({
   hidePlay: Boolean,
   hideVolume: Boolean,
   hideFullscreen: Boolean,
+  hideSeek: Boolean,
   fullscreen: Boolean,
   floating: Boolean,
   splitTime: Boolean,
@@ -281,20 +282,25 @@ export const VVideoControls = genericComponent<VVideoControlsSlots>()({
                         )
                         : ''
                     }
-                    <VSlider
-                      modelValue={ props.progress }
-                      noKeyboard
-                      color={ trackColor.value ?? 'surface-variant' }
-                      trackColor={ props.variant === 'tube' ? 'white' : undefined }
-                      class="v-video__track"
-                      thumbLabel="always"
-                      aria-label={ labels.value.seek }
-                      onUpdate:modelValue={ skipTo }
-                    >
-                      {{
-                        'thumb-label': () => currentTime.value.elapsed,
-                      }}
-                    </VSlider>
+                    { props.hideSeek
+                      ? <VSpacer />
+                      : (
+                          <VSlider
+                            modelValue={ props.progress }
+                            noKeyboard
+                            color={ trackColor.value ?? 'surface-variant' }
+                            trackColor={ props.variant === 'tube' ? 'white' : undefined }
+                            class="v-video__track"
+                            thumbLabel="always"
+                            aria-label={ labels.value.seek }
+                            onUpdate:modelValue={ skipTo }
+                          >
+                            {{
+                              'thumb-label': () => currentTime.value.elapsed,
+                            }}
+                          </VSlider>
+                        )
+                    }
                     { props.variant === 'tube' && <VSpacer /> }
                     { props.splitTime
                       ? (

--- a/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
+++ b/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
@@ -55,7 +55,7 @@ export const makeVVideoControlsProps = propsFactory({
   hidePlay: Boolean,
   hideVolume: Boolean,
   hideFullscreen: Boolean,
-  hideSeek: Boolean,
+  hideSeekbar: Boolean,
   fullscreen: Boolean,
   floating: Boolean,
   splitTime: Boolean,
@@ -282,7 +282,7 @@ export const VVideoControls = genericComponent<VVideoControlsSlots>()({
                         )
                         : ''
                     }
-                    { props.hideSeek
+                    { props.hideSeekbar
                       ? <VSpacer />
                       : (
                           <VSlider

--- a/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
+++ b/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
@@ -299,7 +299,7 @@ export const VVideoControls = genericComponent<VVideoControlsSlots>()({
                               'thumb-label': () => currentTime.value.elapsed,
                             }}
                           </VSlider>
-                        )
+                      )
                     }
                     { props.variant === 'tube' && <VSpacer /> }
                     { props.splitTime

--- a/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
+++ b/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
@@ -55,7 +55,7 @@ export const makeVVideoControlsProps = propsFactory({
   hidePlay: Boolean,
   hideVolume: Boolean,
   hideFullscreen: Boolean,
-  hideSeekbar: Boolean,
+  hideProgressBar: { type: Boolean, default: true },
   fullscreen: Boolean,
   floating: Boolean,
   splitTime: Boolean,
@@ -282,7 +282,7 @@ export const VVideoControls = genericComponent<VVideoControlsSlots>()({
                         )
                         : ''
                     }
-                    { props.hideSeekbar
+                    { props.hideProgressBar
                       ? <VSpacer />
                       : (
                           <VSlider


### PR DESCRIPTION
Resolves #22633 

Added an extra prop called `hide-progress-bar` that allows us to hide the seek bar without having to use the `controls` slot

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-video
        aspect-ratio="16/9"
        image="https://cdn.jsek.work/cdn/vt-sunflowers.jpg"
        hide-progress-bar
        src="https://cdn.jsek.work/cdn/vt-sunflowers.mp4"
      />
    </v-container>
  </v-app>
</template>
```
