### PR TITLE
feat(VOverlay): noFlip location strategy prop

### DIFF
--- a/packages/api-generator/src/locale/en/VOverlay-location-strategies.json
+++ b/packages/api-generator/src/locale/en/VOverlay-location-strategies.json
@@ -3,6 +3,7 @@
     "locationStrategy": "A function used to specifies how the component should position relative to its activator.",
     "offset": "Increases distance from the target. When passed as a pair of numbers, the second value shifts anchor along the side and away from the target.",
     "stickToTarget": "Enables the overlay content to go off-screen when scrolling.",
-    "viewportMargin": "Sets custom viewport margin for the overlay content"
+    "viewportMargin": "Sets custom viewport margin for the overlay content",
+    "noFlip": "When using the \"connected\" location strategy, adjust the position when needed by shifting only, not flipping."
   }
 }

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -58,6 +58,7 @@ export interface StrategyProps {
   maxWidth?: number | string
   minHeight?: number | string
   minWidth?: number | string
+  noFlip?: boolean
 }
 
 export const makeLocationStrategyProps = propsFactory({
@@ -80,6 +81,7 @@ export const makeLocationStrategyProps = propsFactory({
     type: [Number, String],
     default: 12,
   },
+  noFlip: Boolean,
 }, 'VOverlay-location-strategies')
 
 export function useLocationStrategies (
@@ -430,7 +432,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       contentBox.y += _y
 
       // flip
-      {
+      if (!props.noFlip) {
         const axis = getAxis(placement.anchor)
         const hasOverflowX = overflows.x.before || overflows.x.after
         const hasOverflowY = overflows.y.before || overflows.y.after

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -60,6 +60,7 @@ export interface StrategyProps {
   maxWidth?: number | string
   minHeight?: number | string
   minWidth?: number | string
+  noFlip?: boolean
 }
 
 export const makeLocationStrategyProps = propsFactory({
@@ -79,6 +80,7 @@ export const makeLocationStrategyProps = propsFactory({
     type: [Number, String],
     default: 12,
   },
+  noFlip: Boolean,
 }, 'VOverlay-location-strategies')
 
 export function useLocationStrategies (
@@ -450,7 +452,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
       contentBox.y += _y
 
       // flip
-      {
+      if (!props.noFlip) {
         const axis = getAxis(placement.anchor)
         const hasOverflowX = overflows.x.before || overflows.x.after
         const hasOverflowY = overflows.y.before || overflows.y.after


### PR DESCRIPTION
## Description
resolves #22641

## Markup:
Here's a reproduction: https://play.vuetifyjs.com/playgrounds/lU44gg

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <div>
        <h1>Vmenu Position Tests</h1>
        <div class="vmenu-test-container">
          <div class="vmenu-test-container-inner">
            <v-checkbox
              v-model="noFlip"
              label="No Flip"
            />
            <v-btn
              class="target-btn"
              @click="clickTarget($event);"
            >Click</v-btn>
            <div>
              <v-menu
                v-model="showMenu"
                :target="menuTarget"
                :offset="-8"
                location-strategy="connected"
                location="start center"
                origin="end top"
                scroll-strategy="close"
                transition="fade-transition"
                :close-on-content-click="false"
                width="500"
                :no-flip="noFlip"
              >
                <v-sheet
                  rounded
                  elevation="1"
                  class="agd"
                  ref="sheet"
                >
                  <div class="noflip-demo__header">
                    <div class="noflip-demo__close"><v-btn
                        icon="$close"
                        variant="text"
                        size="x-small"
                        :ripple="false"
                        @click="close"
                        @keydown.enter="close"
                        aria-label="Close"
                      ></v-btn>
                    </div>
                  </div>
                  <div class="noflip-demo__controls">
                    <v-btn
                      class="noflip-demo__controls noflip-demo__controls--prev"
                      @click="tab = (tab + 3) % 4"
                      size="x-small"
                      variant="text"
                      :border="false"
                      aria-label="Previous"
                    >Prev</v-btn>
                    <v-btn
                      class="noflip-demo__controls noflip-demo__controls--next"
                      @click="tab = (tab + 1) % 4"
                      size="x-small"
                      variant="text"
                      :border="false"
                      aria-label="Next"
                    >Next</v-btn>
                  </div>
                  <v-window
                    v-model="tab"
                    class="noflip-demo__window"
                  >
                    <v-window-item
                      :value="0"
                      class="noflip-demo__window-item"
                    >
                      <v-responsive :aspect-ratio="10 / 2">
                        <h2>Item 0 (20%)</h2>
                        <p>Typically uses top right for origin.</p>
                      </v-responsive>
                    </v-window-item>
                    <v-window-item
                      :value="1"
                      class="noflip-demo__window-item"
                    >
                      <v-responsive :aspect-ratio="10 / 4">
                        <h2>Item 1 (40%)</h2>
                      </v-responsive>
                    </v-window-item>
                    <v-window-item
                      :value="2"
                      class="noflip-demo__window-item"
                    >
                      <v-responsive :aspect-ratio="10 / 8">
                        <h2>Item 2 (80%)</h2>
                        <p>Without noFlip, this one typically flips to use bottom right corner</p>
                      </v-responsive>
                    </v-window-item>
                    <v-window-item
                      :value="3"
                      class="noflip-demo__window-item"
                    >
                      <v-responsive :aspect-ratio="1">
                        <h2>Item 3 (100%)</h2>
                        <p>
                          Without noFlip, this one may or may not flip for different window heights.
                        </p>
                      </v-responsive>
                    </v-window-item>
                  </v-window>
                </v-sheet>
              </v-menu>
            </div>
          </div>
        </div>
      </div>
    </v-container>

  </v-app>
</template>

<script setup>
import { ref } from 'vue';
const showMenu = ref(false);
const menuTarget = ref(null);
const noFlip = ref(true);

async function clickTarget(event) {
  showMenu.value = true;
  menuTarget.value = event.target;
}

const tab = ref(0)

function close() {
  showMenu.value = false;
}

</script>

<style lang="scss">
.target-btn {
  position: absolute;
  top: 55%;
  left: 70%;
}
.noflip-demo {
  padding: 10px;
}

.noflip-demo__close {
  position: absolute;
  top: 5px;
  right: 5px;
}

.noflip-demo__window-item {
  width: 100%;
  display: flex;
  justify-content: center;
  align-items: center;
}
</style>

```
