### PR TITLE
fix(VField): fix outlined label misalignment for small rounded variants

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -397,8 +397,10 @@
 
         @at-root
           #{selector.append('.v-field--rounded', &)},
-          #{selector.append('[class^="rounded-"]', &)},
-          #{selector.append('[class*=" rounded-"]', &)}
+          #{selector.append('[class*="rounded-xl"]', &)},
+          #{selector.append('[class*="rounded-pill"]', &)},
+          #{selector.append('[class*="rounded-circle"]', &)},
+          #{selector.append('[class*="rounded-shaped"]', &)}
             flex-basis: calc(var(--v-input-control-height) / 2 + 2px)
 
         @at-root #{selector.append('.v-field--reverse', &)}
@@ -416,8 +418,10 @@
 
         @at-root
           #{selector.append('.v-field--rounded', &)},
-          #{selector.append('[class^="rounded-"]', &)},
-          #{selector.append('[class*=" rounded-"]', &)}
+          #{selector.append('[class*="rounded-xl"]', &)},
+          #{selector.append('[class*="rounded-pill"]', &)},
+          #{selector.append('[class*="rounded-circle"]', &)},
+          #{selector.append('[class*="rounded-shaped"]', &)}
             max-width: calc(100% - var(--v-input-control-height))
 
         &::before,


### PR DESCRIPTION
## Description

Fixes #21486

The `__start` and `__notch` elements of the VField outlined variant were applying an
oversized `flex-basis` and reduced `max-width` to **all** elements with a `rounded-*`
class (via broad attribute selectors `[class^="rounded-"]` and `[class*=" rounded-"]`).

This caused the floating label to be misaligned when using small rounding values such as
`rounded-sm`, `rounded`, or `rounded-lg`, because the label start gap was sized for a
fully-circular border when the actual arc is small.

The extra space (`calc(var(--v-input-control-height) / 2 + 2px)`) is only needed when the
border-radius is large enough to form a significant arc. The generic `rounded-*` selectors
are replaced with explicit selectors targeting only the large rounding variants:
`rounded-xl`, `rounded-pill`, `rounded-circle`, and `rounded-shaped`.

## Markup:

```vue
<template>
  <v-container>
    <v-row dense>
      <v-col>
        <v-text-field label="rounded-sm" rounded="sm" variant="outlined" />
      </v-col>
      <v-col>
        <v-text-field label="rounded-lg" rounded="lg" variant="outlined" />
      </v-col>
      <v-col>
        <v-text-field label="rounded-xl" rounded="xl" variant="outlined" />
      </v-col>
      <v-col>
        <v-text-field label="rounded-pill" rounded="pill" variant="outlined" />
      </v-col>
    </v-row>
  </v-container>
</template>
```