### PR TITLE
fix(VListItem): set role=listitem for link items in list context

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -164,7 +164,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
       props.index !== undefined &&
       list.trackingIndex.value === props.index
     )
-    const role = computed(() => list ? (isLink.value ? 'link' : isSelectable.value ? 'option' : 'listitem') : undefined)
+    const role = computed(() => list ? (isSelectable.value ? 'option' : 'listitem') : undefined)
     const ariaSelected = computed(() => {
       if (!isSelectable.value) return undefined
       return root.activatable.value ? isActivated.value

--- a/packages/vuetify/src/components/VList/__tests__/VList.spec.ts
+++ b/packages/vuetify/src/components/VList/__tests__/VList.spec.ts
@@ -1,5 +1,5 @@
 // Components
-import { VList } from '..'
+import { VList, VListItem } from '..'
 
 // Utilities
 import { mount } from '@vue/test-utils'
@@ -34,4 +34,10 @@ describe('VList', () => {
 
       expect(wrapper.attributes('role')).toBe(expected)
     })
+
+  it('should give link items role=listitem to satisfy ARIA requirements', async () => {
+    const wrapper = mount({ template: '<VList><VListItem href="/test">Link</VListItem></VList>' }, { global: { plugins: [vuetify], components: { VList, VListItem } } })
+    const item = wrapper.find('.v-list-item')
+    expect(item.attributes('role')).toBe('listitem')
+  })
 })

--- a/packages/vuetify/src/components/VList/__tests__/VList.spec.ts
+++ b/packages/vuetify/src/components/VList/__tests__/VList.spec.ts
@@ -36,7 +36,10 @@ describe('VList', () => {
     })
 
   it('should give link items role=listitem to satisfy ARIA requirements', async () => {
-    const wrapper = mount({ template: '<VList><VListItem href="/test">Link</VListItem></VList>' }, { global: { plugins: [vuetify], components: { VList, VListItem } } })
+    const wrapper = mount(
+      { template: '<VList><VListItem href="/test">Link</VListItem></VList>' },
+      { global: { plugins: [vuetify], components: { VList, VListItem } } }
+    )
     const item = wrapper.find('.v-list-item')
     expect(item.attributes('role')).toBe('listitem')
   })


### PR DESCRIPTION
## Summary

Fixes the WCAG 2.1 `aria-required-children` violation when using `v-list-item` with `to` or `href` inside a `v-list`.

## Problem

When a `VListItem` has a link (`to`/`href`), it renders as an `<a>` element and was previously given `role="link"`. However, the parent `VList` renders with `role="list"`, which requires its children to have `role="listitem"` (per the ARIA spec). Having `role="link"` children inside `role="list"` triggers the axe-core `aria-required-children` violation.

**Deque University rule:** [aria-required-children](https://dequeuniversity.com/rules/axe/4.11/aria-required-children)

## Solution

Remove the special case for link items in the `role` computation in `VListItem.tsx`:

**Before:**
```typescript
const role = computed(() => list ? (isLink.value ? 'link' : isSelectable.value ? 'option' : 'listitem') : undefined)
```

**After:**
```typescript
const role = computed(() => list ? (isSelectable.value ? 'option' : 'listitem') : undefined)
```

This ensures:
- Items in a non-selectable list → `role="listitem"` (regardless of link status)
- Items in a selectable list (listbox) → `role="option"` (unchanged)
- Items outside a list → no explicit role (native element semantics apply)

The link functionality (href navigation) is still provided by the `<a>` tag; only the ARIA announced role changes to comply with the spec.

## Test

Added a test case in `VList.spec.ts` that verifies link items inside a VList have `role="listitem"`.

Fixes #22611