### PR TITLE
feat: split buffer and indeterminate

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
@@ -90,9 +90,7 @@
     .long, .short
       bottom: 0
       height: inherit
-      left: 0
       position: absolute
-      right: auto
       top: 0
       width: auto
 
@@ -103,6 +101,24 @@
     .short
       left: var(--v-progress-indeterminate-short-left)
       right: var(--v-progress-indeterminate-short-right)
+
+    > .v-progress-linear__background
+      height: 100%
+      border-radius: inherit
+      transition: none
+
+      &:nth-child(1)
+        left: 0
+        width: clamp(0%, calc(var(--v-progress-indeterminate-long-left) - var(--v-progress-chunk-gap)), 100%)
+
+      &:nth-child(2)
+        left: clamp(0%, calc(100% - var(--v-progress-indeterminate-long-right) + var(--v-progress-chunk-gap)), 100%)
+        width: clamp(0%, calc(var(--v-progress-indeterminate-short-left) - var(--v-progress-chunk-gap)), 100%)
+
+      &:nth-child(3)
+        right: 0
+        left: unset
+        width: clamp(0%, calc(var(--v-progress-indeterminate-short-right) - var(--v-progress-chunk-gap)), 100%)
 
   .v-progress-linear__split
     height: inherit
@@ -132,9 +148,21 @@
     .v-progress-linear__indeterminate
       animation-name: indeterminate-rtl
 
-      .long, .short
-        left: auto
-        right: 0
+      > .v-progress-linear__background
+        &:nth-child(1)
+          left: unset
+          right: 0
+          width: clamp(0%, calc(var(--v-progress-indeterminate-long-right) - var(--v-progress-chunk-gap)), 100%)
+
+        &:nth-child(2)
+          left: unset
+          right: clamp(0%, calc(100% - var(--v-progress-indeterminate-long-left) + var(--v-progress-chunk-gap)), 100%)
+          width: clamp(0%, calc(var(--v-progress-indeterminate-short-right) - var(--v-progress-chunk-gap)), 100%)
+
+        &:nth-child(3)
+          right: unset
+          left: 0
+          width: clamp(0%, calc(var(--v-progress-indeterminate-short-left) - var(--v-progress-chunk-gap)), 100%)
 
     .v-progress-linear__stream
       right: auto
@@ -171,25 +199,6 @@
 
     .v-progress-linear__stream
       animation-play-state: running
-
-  .v-progress-linear__indeterminate
-    > .v-progress-linear__background
-      height: 100%
-      border-radius: inherit
-      transition: none
-
-      &:nth-child(1)
-        left: 0
-        width: clamp(0%, calc(var(--v-progress-indeterminate-long-left) - var(--v-progress-chunk-gap)), 100%)
-
-      &:nth-child(2)
-        left: clamp(0%, calc(100% - var(--v-progress-indeterminate-long-right) + var(--v-progress-chunk-gap)), 100%)
-        width: clamp(0%, calc(var(--v-progress-indeterminate-short-left) - var(--v-progress-chunk-gap)), 100%)
-
-      &:nth-child(3)
-        right: 0
-        left: unset
-        width: clamp(0%, calc(var(--v-progress-indeterminate-short-right) - var(--v-progress-chunk-gap)), 100%)
 
   .v-progress-linear--rounded-bar
     .v-progress-linear__determinate,

--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
@@ -107,8 +107,13 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
 
     const containerWidth = shallowRef(0)
     const { hasChunks, splitStyles, chunksMaskStyles, snapValueToChunk } = useChunks(
-      props, containerWidth, normalizedValue, normalizedBuffer, height,
-      () => !!props.rounded
+      props,
+      containerWidth,
+      normalizedValue,
+      normalizedBuffer,
+      height,
+      () => !!props.rounded,
+      isReversed
     )
     useToggleScope(hasChunks, () => {
       const { resizeRef } = useResizeObserver(entries => containerWidth.value = entries[0].contentRect.width)
@@ -252,7 +257,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
                 <>
                   { renderBackgroundBar() }
                   { renderBackgroundBar() }
-                  { renderBackgroundBar()}
+                  { renderBackgroundBar() }
                 </>
               )}
               {['long', 'short'].map(bar => (

--- a/packages/vuetify/src/components/VProgressLinear/chunks.ts
+++ b/packages/vuetify/src/components/VProgressLinear/chunks.ts
@@ -34,6 +34,7 @@ export function useChunks (
   bufferValue: MaybeRefOrGetter<number>,
   height: MaybeRefOrGetter<number>,
   rounded: MaybeRefOrGetter<boolean>,
+  reversed: MaybeRefOrGetter<boolean>,
 ) {
   const isSplit = toRef(() => props.chunkCount === 'split')
   const hasChunks = toRef(() => !isSplit.value && (!!props.chunkCount || !!props.chunkWidth))
@@ -71,8 +72,10 @@ export function useChunks (
 
     const h = toValue(height)
     const isRounded = toValue(rounded)
+    const isReversed = toValue(reversed)
     const halfGap = convertToUnit(chunkGap.value / 2)
     const r = isRounded ? convertToUnit(h / 2) : undefined
+    const pos = isReversed ? 'right' : 'left'
 
     const val = toValue(value)
     if (val <= 0 || val >= 100) return undefined
@@ -88,12 +91,12 @@ export function useChunks (
         borderRadius: r,
       },
       buffer: hasBuffer ? {
-        left: `calc(${split} + ${halfGap})`,
+        [pos]: `calc(${split} + ${halfGap})`,
         width: `calc(${bufSplit} - ${split} - ${convertToUnit(chunkGap.value)})`,
         borderRadius: r,
       } : undefined,
       background: {
-        left: `calc(${hasBuffer ? bufSplit : split} + ${halfGap})`,
+        [pos]: `calc(${hasBuffer ? bufSplit : split} + ${halfGap})`,
         width: `calc(100% - ${hasBuffer ? bufSplit : split} - ${halfGap})`,
         borderRadius: r,
       },


### PR DESCRIPTION
experiment for #22662 introducing "split" to align with MD3
- supports buffer chunk
- for `indeterminate` replaces background with 3 chunks floating next to "short" and "long"

We can either take changes for buffer only or both. TBD

```vue
<template>
  <v-app theme="dark">
    <v-container class="pa-md-12" max-width="1600" fluid>
      <v-card class="py-5 px-6 mb-6" rounded="lg">
        <div class="d-flex flex-column ga-3">
          <div class="d-flex align-start">
            <v-scroll-y-transition mode="out-in">
              <div :key="progressValue" class="text-h2">
                {{ progressValue }}<span class="text-h4">%</span>
              </div>
            </v-scroll-y-transition>
            <v-btn-toggle
              v-model="group"
              class="ml-auto border"
              density="compact"
              max-width="200"
              variant="solo-filled"
              flat
              hide-details
              mandatory
              single-line
            >
              <v-btn text="Transactions" />
              <v-btn text="Fees" />
            </v-btn-toggle>
          </div>
          <div class="mb-1">
            <v-progress-linear
              :buffer-value="bufferValue"
              :model-value="progressValue"
              buffer-opacity=".5"
              chunk-count="split"
              chunk-gap="6"
              color="blue"
              height="18"
              rounded
            />
          </div>
          <div class="mb-1">
            <v-progress-linear
              :model-value="progressValue"
              chunk-count="split"
              chunk-gap="6"
              color="blue"
              height="18"
              indeterminate
              rounded
              rounded-bar
            />
          </div>
        </div>
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup>
  import { shallowRef, toRef } from 'vue'

  const group = shallowRef(0)
  const progressValue = toRef(() => [78, 35][group.value])
  const bufferValue = toRef(() => [90, 55][group.value])
</script>
```
