### PR TITLE
fix(VAutocomplete): fix scroll jump  #22531

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -436,9 +436,11 @@ export const VAutocomplete = genericComponent<new <
         const index = displayItems.value.findIndex(
           item => model.value.some(s => item.value === s.value)
         )
-        IN_BROWSER && window.requestAnimationFrame(() => {
-          index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
-        })
+        if (index >= 0 && IN_BROWSER) {
+          window.requestAnimationFrame(() => {
+            vVirtualScrollRef.value?.scrollToIndex(index)
+          })
+        }
       }
       if (val) _searchLock.value = null
     })

--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -117,27 +117,16 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   })
 
   function handleItemResize (index: number, height: number) {
-  const prevHeight = sizes[index]
-  const prevMinHeight = itemHeight.value
+    const prevHeight = sizes[index]
+    const prevMinHeight = itemHeight.value
 
-  itemHeight.value = prevMinHeight ? itemHeight.value : height
+    itemHeight.value = prevMinHeight ? itemHeight.value : height
 
-  if (prevHeight !== height || prevMinHeight !== itemHeight.value) {
-    sizes[index] = height
-    updateOffsets()
-
-    // After offsets recalculate, restore scroll position
-    if (lastScrollTop > 0 && containerRef.value) {
-      const newOffset = calculateOffset(targetScrollIndex >= 0 ? targetScrollIndex : calculateIndex(lastScrollTop))
-      nextTick(() => {
-        if (containerRef.value && newOffset > 0) {
-          containerRef.value.scrollTop = newOffset
-          lastScrollTop = newOffset
-        }
-      })
+    if (prevHeight !== height || prevMinHeight !== itemHeight.value) {
+      sizes[index] = height
+      updateOffsets()
     }
   }
-}
 
   function calculateOffset (index: number) {
     index = clamp(index, 0, items.value.length)
@@ -243,20 +232,20 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
   }
 
   function scrollToIndex (index: number) {
-  const offset = calculateOffset(index)
+    const offset = calculateOffset(index)
 
-  if (!containerRef.value || (index && !offset)) {
-    targetScrollIndex = index
-  } else {
-    containerRef.value.scrollTop = offset
-    lastScrollTop = offset
-    scrollVelocity = 0
-    lastScrollTime = performance.now()
-    targetScrollIndex = -1
-    cancelAnimationFrame(raf)
-    _calculateVisibleItems()
+    if (!containerRef.value || (index && !offset)) {
+      targetScrollIndex = index
+    } else {
+      containerRef.value.scrollTop = offset
+      lastScrollTop = offset
+      scrollVelocity = 0
+      lastScrollTime = performance.now()
+      targetScrollIndex = -1
+      cancelAnimationFrame(raf)
+      _calculateVisibleItems()
+    }
   }
-}
 
   const computedItems = computed(() => {
     return items.value.slice(first.value, last.value).map((item, index) => {


### PR DESCRIPTION
fixes #22531

The problem was that itemHeight dropped from 48px to 8.6px after render. That broke the offsets and made the scroll jump to the wrong place.
I fixed it by keeping the first measured itemHeight and not letting it change after that.

## Changes
virtual.ts: prevent itemHeight from shrinking after initial measurement
virtual.ts: Reset scrollVelocity to 0 on first scroll after long pause
VAutocomplete.tsx: Fixed scroll timing when menu opens


## Steps to reproduce fix
1. Create autocomplete with 500 items
2. Set initial value to Item 100
3. Open menu - should show Item 100
4. Scroll down - should scroll smoothly without jumping