### PR TITLE
feat(styles): CSS variables for fonts

### DIFF
--- a/packages/vuetify/src/styles/settings/_variables.scss
+++ b/packages/vuetify/src/styles/settings/_variables.scss
@@ -17,7 +17,7 @@ $misc: map-deep-merge(
   $misc
 );
 
-$body-font-family: 'Roboto', sans-serif !default;
+$body-font-family: var(--v-font-body, 'Roboto', sans-serif) !default;
 $font-size-root: 1rem !default;
 $line-height-root: 1.5 !default;
 $border-color-root: rgba(var(--v-border-color), var(--v-border-opacity)) !default;
@@ -199,7 +199,7 @@ $font-weights: map-deep-merge(
   $font-weights
 );
 
-$heading-font-family: $body-font-family !default;
+$heading-font-family: var(--v-font-heading, #{$body-font-family}) !default;
 
 $typography: () !default;
 $typography: map-deep-merge(


### PR DESCRIPTION
Utility of no-Sass approach based on loading style entry points (introduced by #22396) is limited. It is true, users give up on customization, but we can still make it possible to set the typeface, they could set using theme variables.

```scss
$body-font-family: var(--v-font-body, 'Roboto', sans-serif) !default;
$heading-font-family: var(--v-font-heading, #{$body-font-family}) !default;
```

```ts
export default createVuetify({
 theme: {
    defaultTheme: 'light',
    themes: {
      light: { // variables of default theme are "inherited" by every other theme
        variables: {
          'font-heading': '"Bricolage Grotesque", sans-serif',
          'font-body': 'Sen, sans-serif',
        },
      },
    },
  },
})
```