### PR TITLE
feat(icons): add more iconsets based on UnoCSS

### DIFF
--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -16,7 +16,7 @@ features:
 
 # Icon Fonts
 
-Out of the box, Vuetify supports 4 popular icon font libraries—[Material Design Icons](https://pictogrammers.com/library/mdi/), [Material Icons](https://fonts.google.com/icons), [Font Awesome 4](https://fontawesome.com/v4.7.0/) and [Font Awesome 5](https://fontawesome.com/).
+Out of the box, Vuetify supports many popular icon libraries—[Material Design Icons](https://pictogrammers.com/library/mdi/), [Material Icons](https://fonts.google.com/icons), [Font Awesome](https://fontawesome.com/), [Phosphor](https://phosphoricons.com/), [Lucide](https://lucide.dev/), [Tabler](https://tabler.io/icons), [Remix Icon](https://remixicon.com/), [BoxIcons](https://boxicons.com/), and [Carbon](https://carbondesignsystem.com/elements/icons/library/).
 
 <PageFeatures />
 
@@ -203,37 +203,48 @@ Use this tool to search for any Material Design Icons and copy them to your clip
 
 <DocIconList />
 
-#### MDI - UnoCSS
+#### UnoCSS icon sets
 
-You can use Vuetify's MDI icon set with [UnoCSS Preset Icon](https://unocss.dev/presets/icons) by installing the `@unocss/preset-icons` package, all your icons will be tree-shaken and only the icons you use will be included in your final CSS bundle.
+Vuetify provides pre-configured icon sets that work with [UnoCSS Preset Icons](https://unocss.dev/presets/icons). All icons are tree-shaken so only the icons you use are included in your final CSS bundle.
 
-You need to install `unocss` and `@iconify-json/mdi` dev dependencies first:
+| Icon library | Iconify package | Vuetify import | Default set name |
+|---|---|---|---|
+| [Material Design Icons](https://pictogrammers.com/library/mdi/) | `@iconify-json/mdi` | `vuetify/iconsets/mdi-unocss` | `mdi` |
+| [Font Awesome 6](https://fontawesome.com/) | `@iconify-json/fa6-solid`<br>`@iconify-json/fa6-regular` | `vuetify/iconsets/fa6` | `fa6` |
+| [Phosphor](https://phosphoricons.com/) | `@iconify-json/ph` | `vuetify/iconsets/ph` | `ph` |
+| [Lucide](https://lucide.dev/) | `@iconify-json/lucide` | `vuetify/iconsets/lucide` | `lucide` |
+| [Tabler](https://tabler.io/icons) | `@iconify-json/tabler` | `vuetify/iconsets/tabler` | `tabler` |
+| [Remix Icon](https://remixicon.com/) | `@iconify-json/ri` | `vuetify/iconsets/ri` | `ri` |
+| [BoxIcons](https://boxicons.com/) | `@iconify-json/bx` | `vuetify/iconsets/bx` | `bx` |
+| [Carbon](https://carbondesignsystem.com/elements/icons/library/) | `@iconify-json/carbon` | `vuetify/iconsets/carbon` | `carbon` |
+
+Install `unocss` and the Iconify package for your chosen library:
 
 ::: tabs
 
 ```bash [pnpm]
-pnpm add unocss @iconify-json/mdi -D
+pnpm add unocss @iconify-json/ph -D
 ```
 
 ```bash [yarn]
-yarn add unocss @iconify-json/mdi -D
+yarn add unocss @iconify-json/ph -D
 ```
 
 ```bash [npm]
-npm install unocss @iconify-json/mdi -D
+npm install unocss @iconify-json/ph -D
 ```
 
 ```bash [bun]
-bun add unocss @iconify-json/mdi -D
+bun add unocss @iconify-json/ph -D
 ```
 
 :::
 
-then, configure UnoCSS in your project adding the preset (read the [UnoCSS integration section](https://unocss.dev/integrations/) for further details).
+Then configure UnoCSS in your project (read the [UnoCSS integration section](https://unocss.dev/integrations/) for further details).
 
 ::: warning
 
-Don't change the default prefix `i-` of UnoCSS preset-icons, Vuetify's MDI icon set relies on it.
+Don't change the default prefix `i-` of UnoCSS preset-icons, Vuetify icon sets rely on it.
 
 :::
 
@@ -247,18 +258,18 @@ export default defineConfig({
 })
 ```
 
-To register the icon set, use the following code:
+Register the icon set in your Vuetify configuration. The following example uses Phosphor, but you can substitute any set from the table above:
 
 ```js { resource="src/plugins/vuetify.js" }
 import { createVuetify } from 'vuetify'
-import { aliases, mdi } from 'vuetify/iconsets/mdi-unocss'
+import { aliases, ph } from 'vuetify/iconsets/ph'
 
 export default createVuetify({
   icons: {
-    defaultSet: 'mdi',
+    defaultSet: 'ph',
     aliases,
     sets: {
-      mdi,
+      ph,
     },
   },
 })

--- a/packages/vuetify/src/iconsets/bx.ts
+++ b/packages/vuetify/src/iconsets/bx.ts
@@ -1,0 +1,83 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+import { aliases as mdiAliases } from './mdi-svg'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-bx:chevron-up',
+  complete: 'i-bx:check',
+  cancel: 'i-bx:x-circle',
+  close: 'i-bx:x',
+  delete: 'i-bx:x-circle', // delete (e.g. v-chip close)
+  clear: 'i-bx:x-circle',
+  success: 'i-bx:check-circle',
+  info: 'i-bx:info-circle',
+  warning: 'i-bx:error-circle',
+  error: 'i-bx:x-circle',
+  prev: 'i-bx:chevron-left',
+  next: 'i-bx:chevron-right',
+  checkboxOn: 'i-bx:checkbox-checked',
+  checkboxOff: 'i-bx:checkbox',
+  checkboxIndeterminate: 'i-bx:checkbox-minus',
+  delimiter: 'i-bx:bxs-circle', // for carousel
+  sortAsc: 'i-bx:sort-up',
+  sortDesc: 'i-bx:sort-down',
+  expand: 'i-bx:chevron-down',
+  menu: 'i-bx:menu',
+  subgroup: 'i-bx:caret-down',
+  dropdown: 'i-bx:caret-down',
+  radioOn: 'i-bx:radio-circle-marked',
+  radioOff: 'i-bx:radio-circle',
+  edit: 'i-bx:pencil',
+  ratingEmpty: 'i-bx:star',
+  ratingFull: 'i-bx:bxs-star',
+  ratingHalf: 'i-bx:bxs-star-half',
+  loading: 'i-bx:refresh',
+  first: 'i-bx:first-page',
+  last: 'i-bx:last-page',
+  unfold: 'i-bx:expand-vertical',
+  file: 'i-bx:paperclip',
+  plus: 'i-bx:plus',
+  minus: 'i-bx:minus',
+  calendar: 'i-bx:calendar',
+  treeviewCollapse: 'i-bx:chevron-down',
+  treeviewExpand: 'i-bx:chevron-right',
+  tableGroupExpand: 'i-bx:chevron-right',
+  tableGroupCollapse: 'i-bx:chevron-down',
+  eyeDropper: 'i-bx:bxs-eyedropper',
+  upload: 'i-bx:cloud-upload',
+  color: 'i-bx:palette',
+  command: 'i-bx:command',
+  ctrl: 'i-bx:chevron-up',
+  space: 'i-bx:space-bar',
+  shift: 'i-bx:up-arrow-alt',
+  alt: mdiAliases.alt,
+  enter: mdiAliases.enter,
+  arrowup: 'i-bx:up-arrow-alt',
+  arrowdown: 'i-bx:down-arrow-alt',
+  arrowleft: 'i-bx:left-arrow-alt',
+  arrowright: 'i-bx:right-arrow-alt',
+  backspace: 'i-bx:undo',
+  play: 'i-bx:play',
+  pause: 'i-bx:pause',
+  fullscreen: 'i-bx:fullscreen',
+  fullscreenExit: 'i-bx:exit-fullscreen',
+  volumeHigh: 'i-bx:volume-full',
+  volumeMedium: 'i-bx:volume',
+  volumeLow: 'i-bx:volume-low',
+  volumeOff: 'i-bx:volume-mute',
+  search: 'i-bx:search',
+}
+
+const bx: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'bx' }),
+}
+
+export { aliases, bx }

--- a/packages/vuetify/src/iconsets/carbon.ts
+++ b/packages/vuetify/src/iconsets/carbon.ts
@@ -1,0 +1,83 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+import { aliases as mdiAliases } from './mdi-svg'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-carbon:chevron-up',
+  complete: 'i-carbon:checkmark',
+  cancel: 'i-carbon:close-filled',
+  close: 'i-carbon:close',
+  delete: 'i-carbon:close-filled', // delete (e.g. v-chip close)
+  clear: 'i-carbon:close-filled',
+  success: 'i-carbon:checkmark-filled',
+  info: 'i-carbon:information',
+  warning: 'i-carbon:warning',
+  error: 'i-carbon:misuse',
+  prev: 'i-carbon:chevron-left',
+  next: 'i-carbon:chevron-right',
+  checkboxOn: 'i-carbon:checkbox-checked',
+  checkboxOff: 'i-carbon:checkbox',
+  checkboxIndeterminate: 'i-carbon:checkbox-indeterminate',
+  delimiter: 'i-carbon:circle-filled', // for carousel
+  sortAsc: 'i-carbon:arrow-up',
+  sortDesc: 'i-carbon:arrow-down',
+  expand: 'i-carbon:chevron-down',
+  menu: 'i-carbon:menu',
+  subgroup: 'i-carbon:caret-down',
+  dropdown: 'i-carbon:caret-down',
+  radioOn: 'i-carbon:radio-button-checked',
+  radioOff: 'i-carbon:radio-button',
+  edit: 'i-carbon:edit',
+  ratingEmpty: 'i-carbon:star',
+  ratingFull: 'i-carbon:star-filled',
+  ratingHalf: 'i-carbon:star-half',
+  loading: 'i-carbon:renew',
+  first: 'i-carbon:page-first',
+  last: 'i-carbon:page-last',
+  unfold: mdiAliases.unfold,
+  file: 'i-carbon:attachment',
+  plus: 'i-carbon:add',
+  minus: 'i-carbon:subtract',
+  calendar: 'i-carbon:calendar',
+  treeviewCollapse: 'i-carbon:chevron-down',
+  treeviewExpand: 'i-carbon:chevron-right',
+  tableGroupExpand: 'i-carbon:chevron-right',
+  tableGroupCollapse: 'i-carbon:chevron-down',
+  eyeDropper: mdiAliases.eyeDropper,
+  upload: 'i-carbon:cloud-upload',
+  color: 'i-carbon:color-palette',
+  command: 'i-carbon:mac-command',
+  ctrl: mdiAliases.ctrl,
+  space: mdiAliases.space,
+  shift: 'i-carbon:mac-shift',
+  alt: 'i-carbon:mac-option',
+  enter: 'i-carbon:return',
+  arrowup: 'i-carbon:arrow-up',
+  arrowdown: 'i-carbon:arrow-down',
+  arrowleft: 'i-carbon:arrow-left',
+  arrowright: 'i-carbon:arrow-right',
+  backspace: 'i-carbon:undo',
+  play: 'i-carbon:play',
+  pause: 'i-carbon:pause',
+  fullscreen: 'i-carbon:maximize',
+  fullscreenExit: 'i-carbon:minimize',
+  volumeHigh: 'i-carbon:volume-up',
+  volumeMedium: 'i-carbon:volume-down',
+  volumeLow: 'i-carbon:volume-down',
+  volumeOff: 'i-carbon:volume-mute',
+  search: 'i-carbon:search',
+}
+
+const carbon: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'carbon' }),
+}
+
+export { aliases, carbon }

--- a/packages/vuetify/src/iconsets/fa6.ts
+++ b/packages/vuetify/src/iconsets/fa6.ts
@@ -1,0 +1,83 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+import { aliases as mdiAliases } from './mdi-svg'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-fa6-solid:chevron-up',
+  complete: 'i-fa6-solid:check',
+  cancel: 'i-fa6-solid:circle-xmark',
+  close: 'i-fa6-solid:xmark',
+  delete: 'i-fa6-solid:circle-xmark', // delete (e.g. v-chip close)
+  clear: 'i-fa6-solid:circle-xmark',
+  success: 'i-fa6-solid:circle-check',
+  info: 'i-fa6-solid:circle-info',
+  warning: 'i-fa6-solid:triangle-exclamation',
+  error: 'i-fa6-solid:circle-xmark',
+  prev: 'i-fa6-solid:chevron-left',
+  next: 'i-fa6-solid:chevron-right',
+  checkboxOn: 'i-fa6-solid:square-check',
+  checkboxOff: 'i-fa6-regular:square',
+  checkboxIndeterminate: 'i-fa6-solid:square-minus',
+  delimiter: 'i-fa6-solid:circle', // for carousel
+  sortAsc: 'i-fa6-solid:arrow-up',
+  sortDesc: 'i-fa6-solid:arrow-down',
+  expand: 'i-fa6-solid:chevron-down',
+  menu: 'i-fa6-solid:bars',
+  subgroup: 'i-fa6-solid:caret-down',
+  dropdown: 'i-fa6-solid:caret-down',
+  radioOn: 'i-fa6-regular:circle-dot',
+  radioOff: 'i-fa6-regular:circle',
+  edit: 'i-fa6-solid:pencil',
+  ratingEmpty: 'i-fa6-regular:star',
+  ratingFull: 'i-fa6-solid:star',
+  ratingHalf: 'i-fa6-solid:star-half-stroke',
+  loading: 'i-fa6-solid:arrows-rotate',
+  first: 'i-fa6-solid:angles-left',
+  last: 'i-fa6-solid:angles-right',
+  unfold: 'i-fa6-solid:up-down',
+  file: 'i-fa6-solid:paperclip',
+  plus: 'i-fa6-solid:plus',
+  minus: 'i-fa6-solid:minus',
+  calendar: 'i-fa6-regular:calendar',
+  treeviewCollapse: 'i-fa6-solid:caret-down',
+  treeviewExpand: 'i-fa6-solid:caret-right',
+  tableGroupExpand: 'i-fa6-solid:chevron-right',
+  tableGroupCollapse: 'i-fa6-solid:chevron-down',
+  eyeDropper: 'i-fa6-solid:eye-dropper',
+  upload: 'i-fa6-solid:cloud-arrow-up',
+  color: 'i-fa6-solid:palette',
+  command: mdiAliases.command,
+  ctrl: mdiAliases.ctrl,
+  space: mdiAliases.space,
+  shift: 'i-fa6-solid:up-long',
+  alt: mdiAliases.alt,
+  enter: mdiAliases.enter,
+  arrowup: 'i-fa6-solid:arrow-up',
+  arrowdown: 'i-fa6-solid:arrow-down',
+  arrowleft: 'i-fa6-solid:arrow-left',
+  arrowright: 'i-fa6-solid:arrow-right',
+  backspace: 'i-fa6-solid:delete-left',
+  play: 'i-fa6-solid:play',
+  pause: 'i-fa6-solid:pause',
+  fullscreen: 'i-fa6-solid:maximize',
+  fullscreenExit: 'i-fa6-solid:minimize',
+  volumeHigh: 'i-fa6-solid:volume-high',
+  volumeMedium: 'i-fa6-solid:volume-low',
+  volumeLow: 'i-fa6-solid:volume-off',
+  volumeOff: 'i-fa6-solid:volume-xmark',
+  search: 'i-fa6-solid:magnifying-glass',
+}
+
+const fa6: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'fa6' }),
+}
+
+export { aliases, fa6 }

--- a/packages/vuetify/src/iconsets/lucide.ts
+++ b/packages/vuetify/src/iconsets/lucide.ts
@@ -1,0 +1,83 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+import { aliases as mdiAliases } from './mdi-svg'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-lucide:chevron-up',
+  complete: 'i-lucide:check',
+  cancel: 'i-lucide:circle-x',
+  close: 'i-lucide:x',
+  delete: 'i-lucide:circle-x', // delete (e.g. v-chip close)
+  clear: 'i-lucide:circle-x',
+  success: 'i-lucide:circle-check-big',
+  info: 'i-lucide:info',
+  warning: 'i-lucide:triangle-alert',
+  error: 'i-lucide:circle-x',
+  prev: 'i-lucide:chevron-left',
+  next: 'i-lucide:chevron-right',
+  checkboxOn: 'i-lucide:square-check',
+  checkboxOff: 'i-lucide:square',
+  checkboxIndeterminate: 'i-lucide:square-minus',
+  delimiter: mdiAliases.delimiter, // for carousel
+  sortAsc: 'i-lucide:arrow-up',
+  sortDesc: 'i-lucide:arrow-down',
+  expand: 'i-lucide:chevron-down',
+  menu: 'i-lucide:menu',
+  subgroup: 'i-lucide:chevron-down',
+  dropdown: 'i-lucide:chevron-down',
+  radioOn: 'i-lucide:circle-check',
+  radioOff: 'i-lucide:circle',
+  edit: 'i-lucide:pencil',
+  ratingEmpty: 'i-lucide:star',
+  ratingFull: 'i-lucide:star',
+  ratingHalf: 'i-lucide:star-half',
+  loading: 'i-lucide:refresh-cw',
+  first: 'i-lucide:chevrons-left',
+  last: 'i-lucide:chevrons-right',
+  unfold: 'i-lucide:unfold-vertical',
+  file: 'i-lucide:paperclip',
+  plus: 'i-lucide:plus',
+  minus: 'i-lucide:minus',
+  calendar: 'i-lucide:calendar',
+  treeviewCollapse: 'i-lucide:chevron-down',
+  treeviewExpand: 'i-lucide:chevron-right',
+  tableGroupExpand: 'i-lucide:chevron-right',
+  tableGroupCollapse: 'i-lucide:chevron-down',
+  eyeDropper: 'i-lucide:pipette',
+  upload: 'i-lucide:cloud-upload',
+  color: 'i-lucide:palette',
+  command: 'i-lucide:command',
+  ctrl: 'i-lucide:chevron-up',
+  space: 'i-lucide:space',
+  shift: 'i-lucide:arrow-big-up',
+  alt: 'i-lucide:option',
+  enter: 'i-lucide:corner-down-left',
+  arrowup: 'i-lucide:arrow-up',
+  arrowdown: 'i-lucide:arrow-down',
+  arrowleft: 'i-lucide:arrow-left',
+  arrowright: 'i-lucide:arrow-right',
+  backspace: 'i-lucide:delete',
+  play: 'i-lucide:play',
+  pause: 'i-lucide:pause',
+  fullscreen: 'i-lucide:maximize',
+  fullscreenExit: 'i-lucide:minimize',
+  volumeHigh: 'i-lucide:volume-2',
+  volumeMedium: 'i-lucide:volume-1',
+  volumeLow: 'i-lucide:volume',
+  volumeOff: 'i-lucide:volume-x',
+  search: 'i-lucide:search',
+}
+
+const lucide: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'lucide' }),
+}
+
+export { aliases, lucide }

--- a/packages/vuetify/src/iconsets/ph.ts
+++ b/packages/vuetify/src/iconsets/ph.ts
@@ -1,0 +1,83 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+import { aliases as mdiAliases } from './mdi-svg'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-ph:caret-up',
+  complete: 'i-ph:check',
+  cancel: 'i-ph:x-circle',
+  close: 'i-ph:x',
+  delete: 'i-ph:x-circle', // delete (e.g. v-chip close)
+  clear: 'i-ph:x-circle',
+  success: 'i-ph:check-circle',
+  info: 'i-ph:info',
+  warning: 'i-ph:warning',
+  error: 'i-ph:x-circle',
+  prev: 'i-ph:caret-left',
+  next: 'i-ph:caret-right',
+  checkboxOn: 'i-ph:check-square',
+  checkboxOff: 'i-ph:square',
+  checkboxIndeterminate: 'i-ph:minus-square',
+  delimiter: 'i-ph:circle-fill', // for carousel
+  sortAsc: 'i-ph:arrow-up',
+  sortDesc: 'i-ph:arrow-down',
+  expand: 'i-ph:caret-down',
+  menu: 'i-ph:list',
+  subgroup: 'i-ph:caret-down',
+  dropdown: 'i-ph:caret-down',
+  radioOn: 'i-ph:radio-button-fill',
+  radioOff: 'i-ph:circle',
+  edit: 'i-ph:pencil',
+  ratingEmpty: 'i-ph:star',
+  ratingFull: 'i-ph:star-fill',
+  ratingHalf: 'i-ph:star-half-fill',
+  loading: 'i-ph:arrows-clockwise',
+  first: 'i-ph:caret-double-left',
+  last: 'i-ph:caret-double-right',
+  unfold: 'i-ph:arrows-out-line-vertical',
+  file: 'i-ph:paperclip',
+  plus: 'i-ph:plus',
+  minus: 'i-ph:minus',
+  calendar: 'i-ph:calendar',
+  treeviewCollapse: 'i-ph:caret-down',
+  treeviewExpand: 'i-ph:caret-right',
+  tableGroupExpand: 'i-ph:caret-right',
+  tableGroupCollapse: 'i-ph:caret-down',
+  eyeDropper: 'i-ph:eyedropper',
+  upload: 'i-ph:cloud-arrow-up',
+  color: 'i-ph:palette',
+  command: 'i-ph:command',
+  ctrl: 'i-ph:control',
+  space: mdiAliases.space,
+  shift: 'i-ph:arrow-fat-up',
+  alt: 'i-ph:option',
+  enter: 'i-ph:key-return',
+  arrowup: 'i-ph:arrow-up',
+  arrowdown: 'i-ph:arrow-down',
+  arrowleft: 'i-ph:arrow-left',
+  arrowright: 'i-ph:arrow-right',
+  backspace: 'i-ph:backspace',
+  play: 'i-ph:play',
+  pause: 'i-ph:pause',
+  fullscreen: 'i-ph:arrows-out-simple',
+  fullscreenExit: 'i-ph:arrows-in-simple',
+  volumeHigh: 'i-ph:speaker-high',
+  volumeMedium: 'i-ph:speaker-simple-high',
+  volumeLow: 'i-ph:speaker-low',
+  volumeOff: 'i-ph:speaker-x',
+  search: 'i-ph:magnifying-glass',
+}
+
+const ph: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'ph' }),
+}
+
+export { aliases, ph }

--- a/packages/vuetify/src/iconsets/ri.ts
+++ b/packages/vuetify/src/iconsets/ri.ts
@@ -1,0 +1,83 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+import { aliases as mdiAliases } from './mdi-svg'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-ri:arrow-up-s-line',
+  complete: 'i-ri:check-line',
+  cancel: 'i-ri:close-circle-line',
+  close: 'i-ri:close-line',
+  delete: 'i-ri:close-circle-line', // delete (e.g. v-chip close)
+  clear: 'i-ri:close-circle-line',
+  success: 'i-ri:checkbox-circle-line',
+  info: 'i-ri:information-line',
+  warning: 'i-ri:alert-line',
+  error: 'i-ri:error-warning-line',
+  prev: 'i-ri:arrow-left-s-line',
+  next: 'i-ri:arrow-right-s-line',
+  checkboxOn: 'i-ri:checkbox-fill',
+  checkboxOff: 'i-ri:checkbox-line',
+  checkboxIndeterminate: 'i-ri:checkbox-indeterminate-line',
+  delimiter: 'i-ri:checkbox-blank-circle-fill', // for carousel
+  sortAsc: 'i-ri:arrow-up-line',
+  sortDesc: 'i-ri:arrow-down-line',
+  expand: 'i-ri:arrow-down-s-line',
+  menu: 'i-ri:menu-line',
+  subgroup: 'i-ri:arrow-down-s-fill',
+  dropdown: 'i-ri:arrow-down-s-fill',
+  radioOn: 'i-ri:radio-button-fill',
+  radioOff: 'i-ri:radio-button-line',
+  edit: 'i-ri:pencil-line',
+  ratingEmpty: 'i-ri:star-line',
+  ratingFull: 'i-ri:star-fill',
+  ratingHalf: 'i-ri:star-half-line',
+  loading: 'i-ri:refresh-line',
+  first: 'i-ri:skip-back-line',
+  last: 'i-ri:skip-forward-line',
+  unfold: 'i-ri:expand-up-down-line',
+  file: 'i-ri:attachment-2',
+  plus: 'i-ri:add-line',
+  minus: 'i-ri:subtract-line',
+  calendar: 'i-ri:calendar-line',
+  treeviewCollapse: 'i-ri:arrow-down-s-line',
+  treeviewExpand: 'i-ri:arrow-right-s-line',
+  tableGroupExpand: 'i-ri:arrow-right-s-line',
+  tableGroupCollapse: 'i-ri:arrow-down-s-line',
+  eyeDropper: 'i-ri:dropper-line',
+  upload: 'i-ri:upload-cloud-line',
+  color: 'i-ri:palette-line',
+  command: 'i-ri:command-line',
+  ctrl: 'i-ri:arrow-up-s-line',
+  space: 'i-ri:space',
+  shift: 'i-ri:arrow-up-line',
+  alt: mdiAliases.alt,
+  enter: 'i-ri:corner-down-left-line',
+  arrowup: 'i-ri:arrow-up-line',
+  arrowdown: 'i-ri:arrow-down-line',
+  arrowleft: 'i-ri:arrow-left-line',
+  arrowright: 'i-ri:arrow-right-line',
+  backspace: 'i-ri:delete-back-2-line',
+  play: 'i-ri:play-line',
+  pause: 'i-ri:pause-line',
+  fullscreen: 'i-ri:fullscreen-line',
+  fullscreenExit: 'i-ri:fullscreen-exit-line',
+  volumeHigh: 'i-ri:volume-up-line',
+  volumeMedium: 'i-ri:volume-down-line',
+  volumeLow: 'i-ri:volume-down-line',
+  volumeOff: 'i-ri:volume-mute-line',
+  search: 'i-ri:search-line',
+}
+
+const ri: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'ri' }),
+}
+
+export { aliases, ri }

--- a/packages/vuetify/src/iconsets/tabler.ts
+++ b/packages/vuetify/src/iconsets/tabler.ts
@@ -1,0 +1,81 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-tabler:chevron-up',
+  complete: 'i-tabler:check',
+  cancel: 'i-tabler:circle-x',
+  close: 'i-tabler:x',
+  delete: 'i-tabler:circle-x', // delete (e.g. v-chip close)
+  clear: 'i-tabler:circle-x',
+  success: 'i-tabler:circle-check',
+  info: 'i-tabler:info-circle',
+  warning: 'i-tabler:alert-circle',
+  error: 'i-tabler:circle-x',
+  prev: 'i-tabler:chevron-left',
+  next: 'i-tabler:chevron-right',
+  checkboxOn: 'i-tabler:square-check',
+  checkboxOff: 'i-tabler:square',
+  checkboxIndeterminate: 'i-tabler:square-minus',
+  delimiter: 'i-tabler:circle-filled', // for carousel
+  sortAsc: 'i-tabler:arrow-up',
+  sortDesc: 'i-tabler:arrow-down',
+  expand: 'i-tabler:chevron-down',
+  menu: 'i-tabler:menu-2',
+  subgroup: 'i-tabler:caret-down',
+  dropdown: 'i-tabler:caret-down',
+  radioOn: 'i-tabler:circle-check',
+  radioOff: 'i-tabler:circle',
+  edit: 'i-tabler:pencil',
+  ratingEmpty: 'i-tabler:star',
+  ratingFull: 'i-tabler:star-filled',
+  ratingHalf: 'i-tabler:star-half-filled',
+  loading: 'i-tabler:refresh',
+  first: 'i-tabler:chevrons-left',
+  last: 'i-tabler:chevrons-right',
+  unfold: 'i-tabler:arrows-vertical',
+  file: 'i-tabler:paperclip',
+  plus: 'i-tabler:plus',
+  minus: 'i-tabler:minus',
+  calendar: 'i-tabler:calendar',
+  treeviewCollapse: 'i-tabler:chevron-down',
+  treeviewExpand: 'i-tabler:chevron-right',
+  tableGroupExpand: 'i-tabler:chevron-right',
+  tableGroupCollapse: 'i-tabler:chevron-down',
+  eyeDropper: 'i-tabler:color-picker',
+  upload: 'i-tabler:cloud-upload',
+  color: 'i-tabler:palette',
+  command: 'i-tabler:command',
+  ctrl: 'i-tabler:arrow-back',
+  space: 'i-tabler:space',
+  shift: 'i-tabler:arrow-big-up',
+  alt: 'i-tabler:alt',
+  enter: 'i-tabler:corner-down-left',
+  arrowup: 'i-tabler:arrow-up',
+  arrowdown: 'i-tabler:arrow-down',
+  arrowleft: 'i-tabler:arrow-left',
+  arrowright: 'i-tabler:arrow-right',
+  backspace: 'i-tabler:backspace',
+  play: 'i-tabler:player-play',
+  pause: 'i-tabler:player-pause',
+  fullscreen: 'i-tabler:arrows-maximize',
+  fullscreenExit: 'i-tabler:arrows-minimize',
+  volumeHigh: 'i-tabler:volume',
+  volumeMedium: 'i-tabler:volume-2',
+  volumeLow: 'i-tabler:volume-3',
+  volumeOff: 'i-tabler:volume-off',
+  search: 'i-tabler:search',
+}
+
+const tabler: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'tabler' }),
+}
+
+export { aliases, tabler }


### PR DESCRIPTION
- aliases for UnoCSS-based icon sets for 7 additional libraries
  - Phosphor
  - Lucide
  - Tabler
  - Font Awesome 6
  - Carbon
  - BoxIcons
  - Remix Icon

Note: some aliases needed fallbacks to MDI-SVG

## PR verification

Instructions to run the last snippet as `dev/Playground.vue`

1. install dependencies

```bash
cd packages/vuetify
pnpm i -D unocss \
  @iconify-json/bx \
  @iconify-json/carbon \
  @iconify-json/fa6-solid \
  @iconify-json/fa6-regular \
  @iconify-json/lucide \
  @iconify-json/mdi \
  @iconify-json/ph \
  @iconify-json/ri \
  @iconify-json/tabler
```

2. add UnoCSS for dev Playground setup

```ts
// in dev/vuetify.js
import 'virtual:uno.css'
```

3. add `uno.config.ts`

```ts
import { defineConfig } from 'unocss'
import presetIcons from '@unocss/preset-icons'

export default defineConfig({
  presets: [presetIcons()],
})
```

4. add line in vite.config.ts

```ts
import UnoCSS from 'unocss/vite'
```

---

<details>
<summary><code>dev/Playground.vue</code> — icon set comparison table</summary>

```vue
<template>
  <v-app theme="dark">
    <v-main>
      <v-container max-width="900">
        <v-table density="compact" height="calc(100vh - 32px)" fixed-header>
          <thead>
            <tr>
              <th class="text-left">Alias</th>
              <th v-for="set in iconSets" :key="set.name" class="text-center">{{ set.name }}</th>
            </tr>
          </thead>
          <tbody>
            <tr v-for="alias in allAliases" :key="alias">
              <td><code>${{ alias }}</code></td>
              <td v-for="set in iconSets" :key="set.name" class="text-center">
                <v-tooltip v-if="set.aliases[alias]" location="bottom">
                  <template #activator="{ props }">
                    <v-icon v-bind="props" :icon="set.aliases[alias]" />
                  </template>
                  <code>${{ set.aliases[alias] }}</code>
                </v-tooltip>
                <span v-else class="text-disabled">—</span>
              </td>
            </tr>
          </tbody>
        </v-table>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { computed } from 'vue'
  import { aliases as mdiAliases } from '@/iconsets/mdi-svg'
  import { aliases as mdiUnoAliases } from '@/iconsets/mdi-unocss'
  import { aliases as phAliases } from '@/iconsets/ph'
  import { aliases as tablerAliases } from '@/iconsets/tabler'
  import { aliases as lucideAliases } from '@/iconsets/lucide'
  import { aliases as fa6Aliases } from '@/iconsets/fa6'
  import { aliases as carbonAliases } from '@/iconsets/carbon'
  import { aliases as bxAliases } from '@/iconsets/bx'
  import { aliases as riAliases } from '@/iconsets/ri'

  const iconSets = [
    { name: 'MDI (SVG)', aliases: mdiAliases },
    { name: 'MDI (UnoCSS)', aliases: mdiUnoAliases },
    { name: 'Phosphor', aliases: phAliases },
    { name: 'Tabler', aliases: tablerAliases },
    { name: 'Lucide', aliases: lucideAliases },
    { name: 'Font Awesome 6', aliases: fa6Aliases },
    { name: 'Carbon', aliases: carbonAliases },
    { name: 'Box Icons', aliases: bxAliases },
    { name: 'Remix Icons', aliases: riAliases },
  ]

  const allAliases = computed(() => {
    const keys = new Set()
    for (const set of iconSets) {
      for (const key of Object.keys(set.aliases)) {
        keys.add(key)
      }
    }
    return [...keys]
  })
</script>

<style>
.v-icon[class*='i-fa6-'] {
  width: 0.8em;
  height: 0.8em;
}

.v-table thead th:not(:first-child) {
  writing-mode: sideways-lr;
  height: 200px;
}
</style>
```

</details>