### PR TITLE
fix(VCheckboxBtn): restore full opacity for indeterminate state icon

### DIFF
--- a/packages/vuetify/src/components/VCheckbox/VCheckbox.sass
+++ b/packages/vuetify/src/components/VCheckbox/VCheckbox.sass
@@ -10,3 +10,7 @@
 
     .v-selection-control
       min-height: var(--v-input-control-height)
+
+  .v-checkbox-btn--indeterminate
+    .v-selection-control__input > .v-icon
+      opacity: 1

--- a/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx
@@ -72,6 +72,7 @@ export const VCheckboxBtn = genericComponent<new <T>(
           v-model={ model.value }
           class={[
             'v-checkbox-btn',
+            { 'v-checkbox-btn--indeterminate': indeterminate.value },
             props.class,
           ]}
           style={ props.style }


### PR DESCRIPTION
## Description

When a `VCheckboxBtn` (and by extension `VCheckbox`) is in the **indeterminate** state, the checkbox icon was rendered with reduced opacity (`var(--v-medium-emphasis-opacity)`, typically ~0.6), making it appear as if the checkbox is disabled.

This happens because `v-selection-control--dirty` (which sets icon opacity to 1) is only applied when `model.value` is truthy. In indeterminate state, the model value is `false` (unchecked), so the icon remains at medium-emphasis opacity.

## Changes

- Added `v-checkbox-btn--indeterminate` CSS class to the `VSelectionControl` wrapper in `VCheckboxBtn` when the checkbox is in indeterminate state.
- Added a CSS rule in `VCheckbox.sass` to set `opacity: 1` for the icon when this class is present.

## Before / After

| Before | After |
|--------|-------|
| Indeterminate icon shown at ~60% opacity (looks disabled) | Indeterminate icon shown at 100% opacity (matches Material Design) |

Fixes #22039