### PR TITLE
feat(icons): add Material Symbols iconset via UnoCSS

### DIFF
--- a/packages/docs/src/pages/en/features/icon-fonts.md
+++ b/packages/docs/src/pages/en/features/icon-fonts.md
@@ -16,7 +16,7 @@ features:
 
 # Icon Fonts
 
-Out of the box, Vuetify supports many popular icon libraries—[Material Design Icons](https://pictogrammers.com/library/mdi/), [Material Icons](https://fonts.google.com/icons), [Font Awesome](https://fontawesome.com/), [Phosphor](https://phosphoricons.com/), [Lucide](https://lucide.dev/), [Tabler](https://tabler.io/icons), [Remix Icon](https://remixicon.com/), [BoxIcons](https://boxicons.com/), and [Carbon](https://carbondesignsystem.com/elements/icons/library/).
+Out of the box, Vuetify supports many popular icon libraries - [Material Design Icons](https://pictogrammers.com/library/mdi/), [Font Awesome](https://fontawesome.com/), [Phosphor](https://phosphoricons.com/), [Lucide](https://lucide.dev/), [Tabler](https://tabler.io/icons), and more.
 
 <PageFeatures />
 
@@ -217,6 +217,7 @@ Vuetify provides pre-configured icon sets that work with [UnoCSS Preset Icons](h
 | [Remix Icon](https://remixicon.com/) | `@iconify-json/ri` | `vuetify/iconsets/ri` | `ri` |
 | [BoxIcons](https://boxicons.com/) | `@iconify-json/bx` | `vuetify/iconsets/bx` | `bx` |
 | [Carbon](https://carbondesignsystem.com/elements/icons/library/) | `@iconify-json/carbon` | `vuetify/iconsets/carbon` | `carbon` |
+| [Material Symbols](https://fonts.google.com/icons) | `@iconify-json/material-symbols` | `vuetify/iconsets/ms` | `ms` |
 
 Install `unocss` and the Iconify package for your chosen library:
 

--- a/packages/vuetify/src/iconsets/ms.ts
+++ b/packages/vuetify/src/iconsets/ms.ts
@@ -1,0 +1,81 @@
+// @unocss-include
+// Composables
+import { VClassIcon } from '@/composables/icons'
+
+// Utilities
+import { h } from 'vue'
+
+// Types
+import type { IconAliases, IconSet } from '@/composables/icons'
+
+const aliases: IconAliases = {
+  collapse: 'i-material-symbols:keyboard-arrow-up',
+  complete: 'i-material-symbols:check',
+  cancel: 'i-material-symbols:cancel',
+  close: 'i-material-symbols:close',
+  delete: 'i-material-symbols:cancel', // delete (e.g. v-chip close)
+  clear: 'i-material-symbols:cancel',
+  success: 'i-material-symbols:check-circle',
+  info: 'i-material-symbols:info',
+  warning: 'i-material-symbols:warning',
+  error: 'i-material-symbols:error',
+  prev: 'i-material-symbols:chevron-left',
+  next: 'i-material-symbols:chevron-right',
+  checkboxOn: 'i-material-symbols:check-box',
+  checkboxOff: 'i-material-symbols:check-box-outline-blank',
+  checkboxIndeterminate: 'i-material-symbols:indeterminate-check-box',
+  delimiter: 'i-material-symbols:circle', // for carousel
+  sortAsc: 'i-material-symbols:arrow-upward',
+  sortDesc: 'i-material-symbols:arrow-downward',
+  expand: 'i-material-symbols:keyboard-arrow-down',
+  menu: 'i-material-symbols:menu',
+  subgroup: 'i-material-symbols:arrow-drop-down',
+  dropdown: 'i-material-symbols:arrow-drop-down',
+  radioOn: 'i-material-symbols:radio-button-checked',
+  radioOff: 'i-material-symbols:radio-button-unchecked',
+  edit: 'i-material-symbols:edit',
+  ratingEmpty: 'i-material-symbols:star-outline',
+  ratingFull: 'i-material-symbols:star',
+  ratingHalf: 'i-material-symbols:star-half',
+  loading: 'i-material-symbols:cached',
+  first: 'i-material-symbols:first-page',
+  last: 'i-material-symbols:last-page',
+  unfold: 'i-material-symbols:unfold-more',
+  file: 'i-material-symbols:attach-file',
+  plus: 'i-material-symbols:add',
+  minus: 'i-material-symbols:remove',
+  calendar: 'i-material-symbols:calendar-today',
+  treeviewCollapse: 'i-material-symbols:arrow-drop-down',
+  treeviewExpand: 'i-material-symbols:arrow-right',
+  tableGroupExpand: 'i-material-symbols:chevron-right',
+  tableGroupCollapse: 'i-material-symbols:keyboard-arrow-down',
+  eyeDropper: 'i-material-symbols:colorize',
+  upload: 'i-material-symbols:upload',
+  color: 'i-material-symbols:palette',
+  command: 'i-material-symbols:keyboard-command-key',
+  ctrl: 'i-material-symbols:keyboard-control-key',
+  space: 'i-material-symbols:space-bar',
+  shift: 'i-material-symbols:shift',
+  alt: 'i-material-symbols:keyboard-option-key',
+  enter: 'i-material-symbols:keyboard-return',
+  arrowup: 'i-material-symbols:arrow-upward',
+  arrowdown: 'i-material-symbols:arrow-downward',
+  arrowleft: 'i-material-symbols:arrow-back',
+  arrowright: 'i-material-symbols:arrow-forward',
+  backspace: 'i-material-symbols:backspace-outline',
+  play: 'i-material-symbols:play-arrow',
+  pause: 'i-material-symbols:pause',
+  fullscreen: 'i-material-symbols:fullscreen',
+  fullscreenExit: 'i-material-symbols:fullscreen-exit',
+  volumeHigh: 'i-material-symbols:volume-up',
+  volumeMedium: 'i-material-symbols:volume-down',
+  volumeLow: 'i-material-symbols:volume-mute',
+  volumeOff: 'i-material-symbols:volume-off',
+  search: 'i-material-symbols:search',
+}
+
+const ms: IconSet = {
+  component: (props: any) => h(VClassIcon, { ...props, class: 'ms' }),
+}
+
+export { aliases, ms }


### PR DESCRIPTION
resolves #20053

- adds aliases for UnoCSS-based icon set Material Symbols
- tradeoff: avoids bloating the app with ~400kB font files, but does not allow changing width and opsz
- note: replacement icon for missing `cloud_upload`

## PR verification

Instructions to run the last snippet as `dev/Playground.vue`

1. install dependencies

```bash
cd packages/vuetify
pnpm i -D unocss @iconify-json/material-symbols
```

2. add UnoCSS for dev Playground setup

```ts
// in dev/vuetify.js
import 'virtual:uno.css'
```

3. add `uno.config.ts`

```ts
import { defineConfig } from 'unocss'
import presetIcons from '@unocss/preset-icons'

export default defineConfig({
  presets: [presetIcons()],
})
```

4. add line in vite.config.ts

```ts
import UnoCSS from 'unocss/vite'
```

---

<details>
<summary><code>dev/Playground.vue</code> — icon set comparison table</summary>

```vue
<template>
  <v-app theme="dark">
    <v-main>
      <v-container max-width="400">
        <v-table density="compact" height="calc(100vh - 32px)" fixed-header>
          <thead>
            <tr>
              <th class="text-left">Alias</th>
              <th v-for="set in iconSets" :key="set.name" class="text-center">{{ set.name }}</th>
            </tr>
          </thead>
          <tbody>
            <tr v-for="alias in allAliases" :key="alias">
              <td><code>${{ alias }}</code></td>
              <td v-for="set in iconSets" :key="set.name" class="text-center">
                <v-tooltip v-if="set.aliases[alias]" location="bottom">
                  <template #activator="{ props }">
                    <v-icon v-bind="props" :icon="set.aliases[alias]" />
                  </template>
                  <code>{{ set.aliases[alias] }}</code>
                </v-tooltip>
                <span v-else class="text-disabled">—</span>
              </td>
            </tr>
          </tbody>
        </v-table>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { computed } from 'vue'
  import { aliases as mdiAliases } from '@/iconsets/mdi-svg'
  import { aliases as msAliases } from '@/iconsets/ms'

  const iconSets = [
    { name: 'MDI (SVG)', aliases: mdiAliases },
    { name: 'Material Symbols', aliases: msAliases },
  ]

  const allAliases = computed(() => {
    const keys = new Set()
    for (const set of iconSets) {
      for (const key of Object.keys(set.aliases)) {
        keys.add(key)
      }
    }
    return [...keys]
  })
</script>

<style>
.v-table thead th:not(:first-child) {
  writing-mode: sideways-lr;
  height: 200px;
}
</style>
```

</details>