### PR TITLE
fix(VDataTable): respect disableSort prop for sortable header

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -163,6 +163,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
       const noPadding = column.key === 'data-table-select' || column.key === 'data-table-expand'
       const isEmpty = column.key === 'data-table-group' && column.width === 0 && !column.title
       const headerProps = mergeProps(props.headerProps ?? {}, column.headerProps ?? {})
+      const isSortable = column.sortable && !props.disableSort
 
       return (
         <VDataTableColumn
@@ -170,7 +171,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           align={ column.align }
           class={[
             {
-              'v-data-table__th--sortable': column.sortable && !props.disableSort,
+              'v-data-table__th--sortable': isSortable,
               'v-data-table__th--sorted': isSorted(column),
               'v-data-table__th--fixed': column.fixed,
             },
@@ -190,9 +191,9 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           firstFixedEnd={ column.firstFixedEnd }
           noPadding={ noPadding }
           empty={ isEmpty }
-          tabindex={ column.sortable ? 0 : undefined }
-          onClick={ column.sortable ? (event: PointerEvent) => toggleSort(column, event) : undefined }
-          onKeydown={ column.sortable ? (event: KeyboardEvent) => handleEnterKeyPress(event, column) : undefined }
+          tabindex={ isSortable ? 0 : undefined }
+          onClick={ isSortable ? (event: PointerEvent) => toggleSort(column, event) : undefined }
+          onKeydown={ isSortable ? (event: KeyboardEvent) => handleEnterKeyPress(event, column) : undefined }
           { ...headerProps }
         >
           {{


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #22523 

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-data-table
    :headers="headers"
    :items="items"
    item-key="name"
    disable-sort
    hide-default-footer
    @update:sort-by="(v) => sortBy = v"
  />

  <div class="mt-8">Sort by: {{ sortBy }}</div>
</template>

<script setup>
  import { ref } from 'vue';

  const sortBy = ref(null);

  const headers = [
    {
      title: 'Pyramid',
      value: 'name',
      sortable: true,
    },
    {
      title: 'Location',
      value: 'location',
      sortable: true,
    },
    {
      title: 'Construction Date',
      value: 'constructionDate',
      sortable: true,
    },
  ]

  const items = [
    {
      name: 'Great Pyramid of Giza',
      location: 'Egypt',
      height: '146.6',
      base: '230.4',
      volume: '2583285',
      constructionDate: 'c. 2580–2560 BC',
    },
    {
      name: 'Pyramid of Khafre',
      location: 'Egypt',
      height: '136.4',
      base: '215.3',
      volume: '1477485',
      constructionDate: 'c. 2570 BC',
    },
    {
      name: 'Red Pyramid',
      location: 'Egypt',
      height: '104',
      base: '220',
      volume: '1602895',
      constructionDate: 'c. 2590 BC',
    },
    {
      name: 'Bent Pyramid',
      location: 'Egypt',
      height: '101.1',
      base: '188.6',
      volume: '1200690',
      constructionDate: 'c. 2600 BC',
    },
    {
      name: 'Pyramid of the Sun',
      location: 'Mexico',
      height: '65',
      base: '225',
      volume: '1237097',
      constructionDate: 'c. 200 CE',
    },
  ]
</script>
```
