### PR TITLE
fix(VFileInput): expose controlRef for template ref access

### DIFF
--- a/packages/api-generator/src/locale/en/VFileInput.json
+++ b/packages/api-generator/src/locale/en/VFileInput.json
@@ -17,5 +17,8 @@
   "events": {
     "counter": "Creates counter for selected files length. Does not apply any validation.",
     "mousedown:control": "Event that is emitted when using mousedown on the main control area."
+  },
+  "exposed": {
+    "controlRef": "Reference to the underlying input element."
   }
 }

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -368,7 +368,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       )
     })
 
-    return forwardRefs({}, vInputRef, vFieldRef, inputRef)
+    return forwardRefs({ controlRef: inputRef }, vInputRef, vFieldRef, inputRef)
   },
 })
 


### PR DESCRIPTION
## Description

Fixes #22309

`VFileInput` uses the underlying `<input type="file">` element as its control ref (set via `ref={ val => inputRef.value = controlRef.value = val as HTMLInputElement }`), but `controlRef` was not explicitly forwarded in the component's `forwardRefs` call, making it unavailable when accessing the component via a template ref.

The fix adds `controlRef: inputRef` to the `forwardRefs` target object, following the same pattern already used in `VFileUpload` (labs). Also adds the `controlRef` exposed property description to the API locale JSON.

## Markup:

```vue
<template>
  <v-file-input ref="fileInput" label="Upload" />
  <v-btn @click="openPicker">Open picker</v-btn>
</template>

<script setup>
import { ref } from 'vue'

const fileInput = ref(null)

function openPicker() {
  // controlRef now accessible and typed as HTMLInputElement
  fileInput.value.controlRef.click()
}
</script>
```