### PR TITLE
fix(VNumberInput): prevent input changes when readonly

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -240,6 +240,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
     }
 
     function onBeforeinput (e: InputEvent) {
+      if (controlsDisabled.value) return
       if (!e.data) return
       const inputElement = e.target as HTMLInputElement
       const { value: existingTxt, selectionStart, selectionEnd } = inputElement ?? {}

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -85,6 +85,25 @@ describe('VNumberInput', () => {
       expect(model.value).toBe(1)
     })
 
+    // https://github.com/vuetifyjs/vuetify/issues/22677
+    it('does not mutate model when typing non-digit chars while readonly', async () => {
+      const model = ref(42)
+
+      const { element } = render(() => (
+        <VNumberInput v-model={ model.value } readonly />
+      ))
+
+      await userEvent.click(element)
+      // Select all text and type a non-digit character
+      await userEvent.keyboard('{Control>}a{/Control}')
+      await userEvent.keyboard(' ')
+      expect(model.value).toBe(42)
+
+      // Type arbitrary non-digit chars
+      await userEvent.keyboard('abc')
+      expect(model.value).toBe(42)
+    })
+
     it('prevents mutation in readonly form', async () => {
       const model = ref(1)
 


### PR DESCRIPTION
## Description

When a user selects text in a readonly `VNumberInput` and types a non-digit character (e.g. a space or letter), the `onBeforeinput` handler would still fire. Inside that handler, when the typed character doesn't match the allowed pattern, the code calls:

```ts
e.preventDefault()
inputElement!.value = potentialNewNumber  // empty string when invalid chars replace all text
nextTick(() => inputText.value = potentialNewNumber)
```

This inadvertently sets `inputText` to an empty string, which the computed setter interprets as clearing the value (`model.value = null`), breaking the `readonly` contract.

## Fix

Add an early return at the top of `onBeforeinput` when `controlsDisabled` (readonly or disabled) is `true`. This is consistent with how `toggleUpDown`, `clampModel`, `formatInputValue`, and `trimDecimalZeros` already guard against mutations.

## Changes

- `VNumberInput.tsx`: add `if (controlsDisabled.value) return` guard to `onBeforeinput`
- `VNumberInput.spec.browser.tsx`: add regression test for typing non-digit chars while readonly

Fixes #22677