### PR TITLE
fix(rules): type resolution for custom rules

### DIFF
--- a/packages/vuetify/src/labs/rules/rules.ts
+++ b/packages/vuetify/src/labs/rules/rules.ts
@@ -8,12 +8,10 @@ import type { ValidationProps, ValidationRule } from '@/composables/validation'
 
 export type ValidationRuleBuilderWithoutOptions = (err?: string) => ValidationRule
 export type ValidationRuleBuilderWithOptions<T> = (options: T, err?: string) => ValidationRule
-export type ValidationRuleBuilder =
-  | ValidationRuleBuilderWithoutOptions
-  | ValidationRuleBuilderWithOptions<any>
+export type CustomValidationRuleBuilder = (...args: any[]) => ValidationRule
 
 export interface RuleAliases {
-  [name: string]: ValidationRuleBuilder
+  [name: string]: CustomValidationRuleBuilder
   required: ValidationRuleBuilderWithoutOptions
   email: ValidationRuleBuilderWithoutOptions
   number: ValidationRuleBuilderWithoutOptions


### PR DESCRIPTION
fixes #22688

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-text-field :rules="usernameRules" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { useRules } from '@/labs/rules'

  const all = useRules()
  const usernameRules = [all.required(), all.pinCode()]
  // hover over to see the types. IDE might not highlight issues in Playground.vue
</script>
```
