### PR TITLE
feat(VAvatarGroup): add strictLimit prop to make limit include overflow avatar

### DIFF
--- a/packages/api-generator/src/locale/en/VAvatarGroup.json
+++ b/packages/api-generator/src/locale/en/VAvatarGroup.json
@@ -4,10 +4,11 @@
     "gap": "Sets the overlap gap between avatars. Negative values cause avatars to overlap.",
     "hoverable": "Enables a hover animation on child avatars.",
     "itemProps": "Props object that will be applied to each item component. `true` will treat the original object as raw props and pass it directly to the component.",
-    "limit": "Limits the number of visible avatars. Remaining items are represented by an overflow indicator.",
+    "limit": "Limits the number of items rendered into avatars. Remaining items are represented by an additional overflow indicator.",
     "overflowText": "Custom text to display in the overflow avatar. Defaults to `+N` where N is the number of hidden items.",
     "reverse": "Reverses the stacking order of the avatars.",
     "size": "Sets the size of all child avatars.",
+    "strictLimit": "Enforces the limit as the maximum total number of rendered avatars, including the overflow indicator.",
     "vertical": "Stacks avatars vertically instead of horizontally."
   },
   "slots": {

--- a/packages/docs/src/pages/en/components/avatar-groups.md
+++ b/packages/docs/src/pages/en/components/avatar-groups.md
@@ -70,7 +70,7 @@ Use the **size** prop to control avatar dimensions and the **gap** prop to adjus
 
 #### Limit
 
-Use the **limit** prop to restrict the number of visible avatars. Overflow is indicated with a "+N" avatar.
+Use the **limit** prop to restrict the number of items rendered into avatars. Overflow is indicated with an additional "+N" avatar.
 
 <ExamplesExample file="v-avatar-group/prop-limit" />
 

--- a/packages/vuetify/src/labs/VAvatarGroup/VAvatarGroup.tsx
+++ b/packages/vuetify/src/labs/VAvatarGroup/VAvatarGroup.tsx
@@ -43,6 +43,7 @@ export const makeVAvatarGroupProps = propsFactory({
   overflowText: String,
   reverse: Boolean,
   size: [Number, String],
+  strictLimit: Boolean,
   vertical: Boolean,
 
   ...makeComponentProps(),
@@ -57,8 +58,12 @@ export const VAvatarGroup = genericComponent<VAvatarGroupSlots>()({
   setup (props, { slots }) {
     const items = computed(() => {
       const visibleItems = props.limit
-        ? props.items.slice(0, props.limit)
-        : props.items
+          ? (props.strictLimit
+              ? (props.items.length > props.limit
+                  ? props.items.slice(0, props.limit - 1)
+                  : props.items)
+              : props.items.slice(0, props.limit))
+          : props.items
 
       const orderedItems = props.reverse
         ? visibleItems.toReversed()
@@ -77,7 +82,12 @@ export const VAvatarGroup = genericComponent<VAvatarGroupSlots>()({
       })
     })
 
-    const overflow = computed(() => props.limit ? Math.max(props.items.length - props.limit, 0) : 0)
+    const overflow = computed(() => {
+      if (!props.limit) return 0
+      return props.strictLimit && props.items.length > props.limit
+          ? Math.max(props.items.length - (props.limit - 1), 0)
+          : Math.max(props.items.length - props.limit, 0)
+    })
     const overflowText = computed(() => props.overflowText ?? (overflow.value ? `+${overflow.value}` : ''))
 
     const overflowItem = () => (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Added a prop to enforce the limit as the max total number of avatars actually rendered (including the overflow indicator) while preserving current limit logic rendering the overflow indicator additionally to the limit.

resolves #22702

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
    <v-app>
        <v-container class="d-flex flex-column gr-4">
            <h3>Example using limit of "4"</h3>
            <h4>Without strict (renders 5 avatars, of which the last is useless containing "+1")</h4>
            <div class="d-flex align-center gc-4">
                <v-avatar-group
                    border="md surface opacity-100"
                    :items="items"
                    :limit="4"
                />
            </div>
            <h4>With strict (renders 4 avatars)</h4>
            <div class="d-flex align-center gc-4">
                <v-avatar-group
                    border="md surface opacity-100"
                    :items="items"
                    :limit="4"
                    strict-limit
                />
            </div>
        </v-container>
    </v-app>
</template>

<script setup>
import { VAvatarGroup } from '../src/labs/VAvatarGroup'
const items = [
    { image: 'https://vuetifyjs.b-cdn.net/docs/images/one/snips/avatars/3.jpg' },
    { image: 'https://vuetifyjs.b-cdn.net/docs/images/one/snips/avatars/4.jpg' },
    { icon: 'mdi-account', color: 'info' },
    { text: 'JD', color: 'primary' },
    { icon: 'mdi-account', color: 'success' },
]
</script>
```
