### PR TITLE
fix(VStepper): expose prevVariant/nextVariant props on VStepperActions

### DIFF
--- a/packages/api-generator/src/locale/en/VStepper.json
+++ b/packages/api-generator/src/locale/en/VStepper.json
@@ -3,7 +3,9 @@
     "completeIcon": "Icon to display when step is marked as completed.",
     "editIcon": "Icon to display when step is editable.",
     "errorIcon": "Icon to display when step has an error.",
-    "flat": "Removes the stepper's elevation."
+    "flat": "Removes the stepper's elevation.",
+    "nextVariant": "The variant style applied to the Next button.",
+    "prevVariant": "The variant style applied to the Prev button."
   },
   "exposed": {
     "next": "Move to the next step.",

--- a/packages/api-generator/src/locale/en/VStepperActions.json
+++ b/packages/api-generator/src/locale/en/VStepperActions.json
@@ -1,7 +1,9 @@
 {
   "props": {
     "nextText": "The text used for the Next button.",
-    "prevText": "The text used for the Prev button."
+    "nextVariant": "The variant style applied to the Next button.",
+    "prevText": "The text used for the Prev button.",
+    "prevVariant": "The variant style applied to the Prev button."
   },
   "events": {
     "click:next": "Event emitted when clicking the next button.",

--- a/packages/vuetify/src/components/VStepper/VStepper.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepper.tsx
@@ -84,7 +84,7 @@ export const makeVStepperProps = propsFactory({
     selectedClass: 'v-stepper-item--selected',
   }),
   ...makeVSheetProps(),
-  ...pick(makeVStepperActionsProps(), ['prevText', 'nextText']),
+  ...pick(makeVStepperActionsProps(), ['prevText', 'nextText', 'prevVariant', 'nextVariant']),
 }, 'VStepper')
 
 export const VStepper = genericComponent<new <TModel>(
@@ -105,7 +105,7 @@ export const VStepper = genericComponent<new <TModel>(
   setup (props, { slots }) {
     const { items: _items, next, prev, selected } = useGroup(props, VStepperSymbol)
     const { displayClasses, mobile } = useDisplay(props)
-    const { completeIcon, editIcon, errorIcon, color, editable, prevText, nextText } = toRefs(props)
+    const { completeIcon, editIcon, errorIcon, color, editable, prevText, nextText, prevVariant, nextVariant } = toRefs(props)
 
     const items = computed(() => props.items.map((item, index) => {
       const title = getPropertyFromItem(item, props.itemTitle, item)
@@ -152,6 +152,8 @@ export const VStepper = genericComponent<new <TModel>(
         disabled,
         prevText,
         nextText,
+        prevVariant,
+        nextVariant,
       },
     })
 

--- a/packages/vuetify/src/components/VStepper/VStepperActions.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperActions.tsx
@@ -4,13 +4,13 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvi
 
 // Composables
 import { useLocale } from '@/composables/locale'
-import type { Variant } from '@/composables/variant'
 
 // Utilities
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
+import type { Variant } from '@/composables/variant'
 
 export type VStepperActionsSlots = {
   prev: {

--- a/packages/vuetify/src/components/VStepper/VStepperActions.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperActions.tsx
@@ -4,6 +4,7 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvi
 
 // Composables
 import { useLocale } from '@/composables/locale'
+import type { Variant } from '@/composables/variant'
 
 // Utilities
 import { genericComponent, propsFactory, useRender } from '@/util'
@@ -33,6 +34,14 @@ export const makeVStepperActionsProps = propsFactory({
   nextText: {
     type: String,
     default: '$vuetify.stepper.next',
+  },
+  prevVariant: {
+    type: String as PropType<Variant>,
+    default: 'text',
+  },
+  nextVariant: {
+    type: String as PropType<Variant>,
+    default: 'tonal',
   },
 }, 'VStepperActions')
 
@@ -71,7 +80,7 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
               VBtn: {
                 disabled: ['prev', true].includes(props.disabled),
                 text: t(props.prevText),
-                variant: 'text',
+                variant: props.prevVariant,
               },
             }}
           >
@@ -86,7 +95,7 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
                 color: props.color,
                 disabled: ['next', true].includes(props.disabled),
                 text: t(props.nextText),
-                variant: 'tonal',
+                variant: props.nextVariant,
               },
             }}
           >


### PR DESCRIPTION
Fixes #21420

## Problem

`VStepperActions` hardcoded `variant: 'text'` for the Prev button and `variant: 'tonal'` for the Next button inside `VDefaultsProvider`. Because component-scoped defaults (from `VDefaultsProvider`) take priority over global defaults, these values overrode whatever the user configured in their global `VBtn` defaults — including `variant`, `rounded`, and `color`.

## Solution

Expose `prevVariant` and `nextVariant` props on `VStepperActions` (typed as `Variant`, defaulting to `'text'` and `'tonal'` to preserve the existing visual design). Use these props in the `VDefaultsProvider` instead of hardcoded strings.

Also pick these new props into `VStepper` and forward them via `provideDefaults` so they can be set directly on the stepper:

```html
<!-- Use custom variants for stepper action buttons -->
<v-stepper prev-variant="outlined" next-variant="elevated">
  ...
</v-stepper>

<!-- Or on v-stepper-actions directly -->
<v-stepper-actions prev-variant="outlined" next-variant="elevated" />
```

## Behaviour

- **Unchanged**: The default stepper still uses `text` (Prev) and `tonal` (Next) variants — no visual regression.
- **Fixed**: Props like `rounded`, `size`, `density` from global `VBtn` defaults that were *not* set by the stepper's `VDefaultsProvider` already worked; now users can also control `variant` at the stepper level.

## Changes
- `packages/vuetify/src/components/VStepper/VStepperActions.tsx` — add `prevVariant`/`nextVariant` props; use in `VDefaultsProvider`
- `packages/vuetify/src/components/VStepper/VStepper.tsx` — pick and forward the new props
- `packages/api-generator/src/locale/en/VStepperActions.json` — document new props
- `packages/api-generator/src/locale/en/VStepper.json` — document new props