### PR TITLE
fix(VListItem): prevent navigation when disabled link is clicked

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -233,6 +233,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
     } satisfies ListItemSlot))
 
     function onClick (e: MouseEvent) {
+      if (props.disabled) e.preventDefault()
       emit('click', e)
       if (['INPUT', 'TEXTAREA'].includes((e.target as Element)?.tagName)) return
 

--- a/packages/vuetify/src/components/VList/__tests__/VListItem.spec.browser.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VListItem.spec.browser.tsx
@@ -1,0 +1,26 @@
+// Components
+import { VList, VListItem } from '..'
+
+// Utilities
+import { render, screen, userEvent } from '@test'
+
+describe('VListItem', () => {
+  // https://github.com/vuetifyjs/vuetify/issues/22172
+  it('should not navigate when disabled item with href is clicked', async () => {
+    render(() => (
+      <VList>
+        <VListItem href="/about" disabled title="Link">
+          {{
+            append: () => <span class="append-content">append</span>,
+          }}
+        </VListItem>
+      </VList>
+    ))
+
+    const item = screen.getByCSS('.v-list-item')
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    item.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/packages/vuetify/src/components/VList/__tests__/VListItem.spec.browser.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VListItem.spec.browser.tsx
@@ -2,7 +2,7 @@
 import { VList, VListItem } from '..'
 
 // Utilities
-import { render, screen, userEvent } from '@test'
+import { render, screen } from '@test'
 
 describe('VListItem', () => {
   // https://github.com/vuetifyjs/vuetify/issues/22172


### PR DESCRIPTION
Fixes #22172

When a `v-list-item` has `href` or `to` (renders as `<a>`) and is `disabled`, clicking content inside a slot (e.g. a badge in the `append` slot) still causes the browser to follow the link.

The root cause: the `onClick` handler returns early when `!isClickable.value` (which covers the disabled case), but native anchor click behaviour fires independently of our handler — `preventDefault()` was never called.

**Fix:** call `e.preventDefault()` at the start of `onClick` when `props.disabled` is true. This is the same pattern used by other Vuetify components (e.g. `VBtn`) to block navigation on disabled link elements.

Added a browser test verifying that clicking a disabled list item with `href` does not navigate (`event.defaultPrevented === true`).