### PR TITLE
fix(VListItemAction): adjust inline margins for non-default density

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.sass
+++ b/packages/vuetify/src/components/VList/VListItem.sass
@@ -289,6 +289,18 @@
     &--nav
       padding-inline: $list-nav-padding
 
+    @at-root
+      @each $density, $margin in $list-item-action-margin-density
+        .v-list-item--density-#{$density}
+          .v-list-item-action
+            &--start
+              margin-inline-end: $margin
+              margin-inline-start: -$margin
+
+            &--end
+              margin-inline-start: $margin
+              margin-inline-end: -$margin
+
   .v-list-item__underlay
     position: absolute
 

--- a/packages/vuetify/src/components/VList/_variables.scss
+++ b/packages/vuetify/src/components/VList/_variables.scss
@@ -63,6 +63,14 @@ $list-item-slim-avatar-spacer-width: 4px !default;
 $list-item-action-margin-end: 8px !default;
 $list-item-action-margin-start: 8px !default;
 
+// Action margins adjusted per density level to keep the selection-control icon
+// visually aligned with the list item's inline padding.
+// Values match (selection-control-size - icon-size) / 2 for each density level:
+//   default: (40px - 24px) / 2 = 8px
+//   comfortable: (36px - 24px) / 2 = 6px
+//   compact: (28px - 24px) / 2 = 2px
+$list-item-action-margin-density: ('default': 8px, 'comfortable': 6px, 'compact': 2px) !default;
+
 $list-item-icon-margin-end: 32px !default;
 $list-item-icon-margin-start: 32px !default;
 


### PR DESCRIPTION
## Summary

Closes #22686 

When `VList` has `density="comfortable"` or `density="compact"`, the `VCheckboxBtn` (and other `VSelectionControl`-based components) inside a `VListItemAction` become smaller. However, `VListItemAction` had fixed inline margins that were calculated for the default 40 px selection-control size, causing visual misalignment with `VListSubheader` text.

## Root cause

The icon inside `VSelectionControl` is always 24 px. To keep the icon visually aligned with the list's inline padding, the start margin of `VListItemAction--start` must equal `(selection-control-size - 24px) / 2`:

| Density | Control size | Required margin |
|---|---|---|
| default | 40 px | 8 px |
| comfortable | 36 px | 6 px |
| compact | 28 px | 2 px |

## Changes

- **`packages/vuetify/src/components/VList/_variables.scss`** — adds a new `$list-item-action-margin-density` map with the per-density margin values (overridable via user SASS variables).
- **`packages/vuetify/src/components/VList/VListItem.sass`** — iterates the map at `@at-root` to emit `.v-list-item--density-*` rules that override the default action margins.

The `default` entry in the new map reproduces the existing 8 px margins, so there is no visual change at default density.