### PR TITLE
test(hotkey): add coverage for alternate (/) key combinations

### DIFF
--- a/packages/vuetify/src/composables/hotkey/__tests__/hotkey.spec.ts
+++ b/packages/vuetify/src/composables/hotkey/__tests__/hotkey.spec.ts
@@ -688,4 +688,83 @@ describe('hotkey.ts', () => {
     document.body.removeChild(input)
     stop()
   })
+
+  // -----------------------------------------------------------------------
+  // Alternate (/) separator — fixes #22712
+  // -----------------------------------------------------------------------
+  describe('alternate (/) combinations', () => {
+    it.each([
+      // Each alternative should independently trigger the callback
+      ['1/2', '1', {}],
+      ['1/2', '2', {}],
+      ['up/down', 'ArrowUp', {}],
+      ['up/down', 'ArrowDown', {}],
+      ['ctrl+a/ctrl+b', 'a', { ctrlKey: true }],
+      ['ctrl+a/ctrl+b', 'b', { ctrlKey: true }],
+      ['shift+tab/tab', 'Tab', { shiftKey: true }],
+      ['shift+tab/tab', 'Tab', {}],
+    ])('fires for %s when key %s pressed', (combo, key, extraProps) => {
+      const cb = vi.fn()
+      const stop = useHotkey(combo, cb)
+
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          metaKey: false,
+          key,
+          ...extraProps,
+        })
+      )
+
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      stop()
+    })
+
+    it('fires once per matching keypress (not twice)', () => {
+      const cb = vi.fn()
+      const stop = useHotkey('a/b', cb)
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }))
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }))
+
+      // Each key press counts independently — two presses → two fires
+      expect(cb).toHaveBeenCalledTimes(2)
+
+      stop()
+    })
+
+    it('does not fire for an unrelated key', () => {
+      const cb = vi.fn()
+      const stop = useHotkey('a/b', cb)
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
+
+      expect(cb).not.toHaveBeenCalled()
+
+      stop()
+    })
+
+    it('works when alternate is embedded in a sequence', () => {
+      // 'a/b-c' means "(a OR b), then c"
+      const cb = vi.fn()
+      const stop = useHotkey('a/b-c', cb)
+
+      // First part via 'a', then 'c'
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }))
+      expect(cb).toHaveBeenCalledTimes(0) // Not yet — waiting for 'c'
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
+      expect(cb).toHaveBeenCalledTimes(1)
+
+      // First part via 'b', then 'c'
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }))
+      expect(cb).toHaveBeenCalledTimes(1) // Not yet
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
+      expect(cb).toHaveBeenCalledTimes(2)
+
+      stop()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #22712

The `useHotkey` composable parses the `/` character as an **alternate** separator (e.g. `'up/down'` means "fire on ArrowUp **or** ArrowDown"), yet the test suite had **zero coverage** for this code path.

## What was reported

In #22712, a user found that pressing the **first** key of an alternate combination (`'1'` in `'1/2'`) did not trigger the callback, while pressing the last key (`'2'`) did work.

## What these tests cover

| Test | What it checks |
|------|---------------|
| each alternative triggers callback independently | `'1/2'` → '1' fires; `'1/2'` → '2' fires |
| arrow key alternates | `'up/down'` → ArrowUp and ArrowDown each fire |
| modifier + key alternates | `'ctrl+a/ctrl+b'` fires for each combo |
| shift variations | `'shift+tab/tab'` fires for both shifted and unshifted Tab |
| unrelated key ignored | pressing 'c' on hotkey `'a/b'` does nothing |
| alternate inside sequence | `'a/b-c'` means (a OR b), then c — tests both entry points |

If the alternate matching logic is broken for the first element (as #22712 describes), the `'1/2' → '1'` and similar tests will surface the regression.