### PR TITLE
fix(VTooltip): correct pointer-events selector for non-interactive tooltips

### DIFF
--- a/packages/vuetify/src/components/VTooltip/VTooltip.sass
+++ b/packages/vuetify/src/components/VTooltip/VTooltip.sass
@@ -28,6 +28,5 @@
       transition-timing-function: settings.$accelerated-easing
       transition-duration: $tooltip-transition-leave-duration
 
-    &:not(.v-tooltip--interactive)
-      > .v-overlay__content
-        pointer-events: none
+  .v-tooltip:not(.v-tooltip--interactive) > .v-overlay__content
+    pointer-events: none


### PR DESCRIPTION
Fixes #22724.

## Problem

Non-interactive tooltips do not disappear on mouseover since v4.0.2. The tooltip always behaves as if `:interactive="true"`.

## Root Cause

In `VTooltip.sass`, the `pointer-events: none` rule for non-interactive tooltips used incorrect SASS nesting:

```sass
.v-tooltip > .v-overlay__content
  &:not(.v-tooltip--interactive)
    > .v-overlay__content
      pointer-events: none
```

The `&` resolves to `.v-overlay__content`, producing the CSS selector:

```css
.v-tooltip > .v-overlay__content:not(.v-tooltip--interactive) > .v-overlay__content
```

This **never matches** because:
1. `.v-tooltip--interactive` is applied to `.v-tooltip` (the root), not `.v-overlay__content`
2. `.v-overlay__content` does not contain a nested `.v-overlay__content`

## Fix

Move the rule out of the nested block so `:not()` targets `.v-tooltip`:

```sass
.v-tooltip:not(.v-tooltip--interactive) > .v-overlay__content
  pointer-events: none
```

This produces the correct CSS:

```css
.v-tooltip:not(.v-tooltip--interactive) > .v-overlay__content {
  pointer-events: none;
}
```

The rule sits in `tools.layer('overrides')`, which correctly overrides the `pointer-events: auto` from `VOverlay.sass` in `tools.layer('components')`.