### PR TITLE
fix(VMaskInput): accept escaped characters in mask

### DIFF
--- a/packages/vuetify/src/composables/mask/__tests__/mask.spec.ts
+++ b/packages/vuetify/src/composables/mask/__tests__/mask.spec.ts
@@ -1,5 +1,5 @@
 // Composables
-import { isMaskDelimiter, useMask } from '../mask'
+import { useMask } from '../mask'
 
 // Types
 import type { MaskProps } from '../mask'
@@ -55,13 +55,6 @@ describe('mask', () => {
   ])('unmask %#', (props, expected) => {
     const { unmask } = useMask(props as MaskProps)
     expect(unmask(props.modelValue)).toEqual(expected)
-  })
-
-  it.each([
-    ['a', false],
-    ['-', true],
-  ])('isMaskDelimiter', (input, expected) => {
-    expect(isMaskDelimiter(input)).toEqual(expected)
   })
 
   describe('The test method', () => {

--- a/packages/vuetify/src/composables/mask/mask.ts
+++ b/packages/vuetify/src/composables/mask/mask.ts
@@ -42,10 +42,6 @@ const presets: Record<string, string> = {
   'time-with-seconds': '##:##:##',
 }
 
-export function isMaskDelimiter (char: string): boolean {
-  return char ? defaultDelimiters.test(char) : false
-}
-
 const defaultTokens: Record<string, MaskItem> = {
   '#': {
     pattern: /[0-9]/,
@@ -132,6 +128,10 @@ export function useMask (props: MaskProps) {
       } else if (maskValidates(mchar, tchar)) {
         newText += convert(mchar, tchar)
         textIndex++
+      } else if (textIndex < trimmedText.length) {
+        // No match, try the next input character
+        textIndex++
+        continue
       } else {
         break
       }
@@ -146,9 +146,25 @@ export function useMask (props: MaskProps) {
 
     if (!mask.value.length || !text.length) return text
 
+    let result = ''
+    const unmaskMap = getUnmaskMap(text)
+    for (let i = 0; i < text.length; i++) {
+      if (!unmaskMap[i]) result += text[i]
+    }
+    return result
+  }
+
+  function isDelimiter (text: string, index: number): boolean {
+    if (!mask.value.length || !text.length) return false
+    return !!getUnmaskMap(text)[index]
+  }
+
+  function getUnmaskMap (text: string | null): boolean[] {
+    if (text == null || !mask.value.length || !text.length) return []
+
     let textIndex = 0
     let maskIndex = 0
-    let newText = ''
+    const result = Array.from({ length: text.length }, () => true)
 
     while (true) {
       const mchar = mask.value[maskIndex]
@@ -157,7 +173,7 @@ export function useMask (props: MaskProps) {
       if (tchar == null) break
 
       if (mchar == null) {
-        newText += tchar
+        result[textIndex] = false
         textIndex++
         continue
       }
@@ -173,7 +189,7 @@ export function useMask (props: MaskProps) {
 
       if (maskValidates(mchar, tchar)) {
         // masked char
-        newText += tchar
+        result[textIndex] = false
         textIndex++
         maskIndex++
         continue
@@ -189,7 +205,8 @@ export function useMask (props: MaskProps) {
       textIndex++
       maskIndex++
     }
-    return newText
+
+    return result
   }
 
   function isValid (text: string): boolean {
@@ -206,6 +223,7 @@ export function useMask (props: MaskProps) {
   }
 
   return {
+    isDelimiter,
     isValid,
     isComplete,
     mask: maskText,

--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -3,7 +3,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 
 // Composables
 import { forwardRefs } from '@/composables/forwardRefs'
-import { isMaskDelimiter, makeMaskProps, useMask } from '@/composables/mask'
+import { makeMaskProps, useMask } from '@/composables/mask'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
@@ -47,11 +47,9 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       val => props.mask ? mask.mask(mask.unmask(val)) : val,
       val => {
         if (props.mask) {
-          const valueWithoutDelimiters = val ? removeMaskDelimiters(val) : ''
-
           // E.g. mask is #-# and the input value is '2-23'
           // model-value should be enforced to '2-2'
-          const newMaskedValue = mask.mask(valueWithoutDelimiters)
+          const newMaskedValue = mask.mask(mask.unmask(val))
           const newUnmaskedValue = mask.unmask(newMaskedValue)
 
           const newCaretPosition = getNewCaretPosition({
@@ -71,10 +69,6 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
 
     const validationValue = toRef(() => returnMaskedValue.value ? model.value : mask.unmask(model.value))
 
-    function removeMaskDelimiters (val: string): string {
-      return val.split('').filter(ch => !isMaskDelimiter(ch)).join('')
-    }
-
     function getNewCaretPosition ({
       oldValue,
       newValue,
@@ -91,13 +85,13 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
 
       if (inputAction.value === 'Backspace') {
         newCaret = oldCaret - 1
-        while (newCaret > 0 && isMaskDelimiter(newValue[newCaret - 1])) newCaret--
+        while (newCaret > 0 && mask.isDelimiter(newValue, newCaret - 1)) newCaret--
       } else if (inputAction.value === 'Delete') {
         newCaret = oldCaret
       } else { // insertion
         newCaret = oldCaret + 1
-        while (isMaskDelimiter(newValue[newCaret])) newCaret++
-        if (isMaskDelimiter(newValue[oldCaret])) newCaret++
+        while (mask.isDelimiter(newValue, newCaret)) newCaret++
+        if (mask.isDelimiter(newValue, oldCaret)) newCaret++
       }
 
       return newCaret
@@ -135,7 +129,7 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       e.preventDefault()
 
       const inputElement = e.target as HTMLInputElement
-      const pastedString = removeMaskDelimiters(e.clipboardData?.getData('text') || '')
+      const pastedString = e.clipboardData?.getData('text') || ''
 
       if (!pastedString) return
 
@@ -194,8 +188,9 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
     async function replaceSelection (inputElement: HTMLInputElement, pastedCharacters: string[]) {
       caretPosition.value = inputElement.selectionStart || 0
       for (let i = 0; i < pastedCharacters.length; i++) {
-        await replaceCharacter(caretPosition.value, pastedCharacters[i])
-        caretPosition.value++
+        if (await replaceCharacter(caretPosition.value, pastedCharacters[i])) {
+          caretPosition.value++
+        }
       }
     }
 
@@ -203,10 +198,18 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       let targetIndex = index
 
       // Find next non-delimiter position
-      while (targetIndex < model.value.length && isMaskDelimiter(model.value[targetIndex])) targetIndex++
+      while (targetIndex < model.value.length && mask.isDelimiter(model.value, targetIndex)) {
+        targetIndex++
+      }
 
-      model.value = model.value.slice(0, targetIndex) + character + model.value.slice(targetIndex + 1)
-      await nextTick()
+      const newValue = model.value.slice(0, targetIndex) + character + model.value.slice(targetIndex + 1)
+
+      if (mask.isValid(newValue)) {
+        model.value = newValue
+        await nextTick()
+        return true
+      }
+      return false
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -89,6 +89,13 @@ describe('VMaskInput', () => {
         expect(input.selectionStart).toBe(input.value.length)
       })
 
+      it('should handle escaped characters', async () => {
+        const { input, model } = renderComponent({ defaultModel: '', defaultMask: '\\####' })
+        await userEvent.type(input, '123')
+        expect(model.value).toBe('#123')
+        expect(input.selectionStart).toBe(input.value.length)
+      })
+
       it.each([
         // when cursor before delimiter
         {


### PR DESCRIPTION
## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
#21925 used `isMaskDelimiter` which removes all special characters from the input string rather than only those that are actually part of the mask. This PR adds a new `mask.isDelimiter` function instead that returns true if the character at the provided index is a literal from the mask and false if it is a replaced placeholder.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div>
    <v-mask-input
      v-model="modelA"
      label="3 Numbers"
      mask="###"
      placeholder="###"
    />

    <v-mask-input
      v-model="modelB"
      label="# + 3 Numbers"
      mask="\####"
      placeholder="####"
    />
  </div>
</template>

<script setup>
  import { shallowRef } from 'vue'

  const modelA = shallowRef(null)
  const modelB = shallowRef(null)
</script>
```
