### PR TITLE
feat(VTooltip): `target="cursor"` should work for hoverable tooltips

### DIFF
--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -126,6 +126,7 @@ export function useActivator (
     },
     onMouseleave: (e: MouseEvent) => {
       isHovered = false
+      if (props.target === 'cursor') isFocused = false
       runCloseDelay()
     },
     onFocus: (e: FocusEvent) => {

--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -116,7 +116,13 @@ export function useActivator (
     onMouseenter: (e: MouseEvent) => {
       isHovered = true
       activatorEl.value = (e.currentTarget || e.target) as HTMLElement
+      if (props.target === 'cursor') {
+        cursorTarget.value = [e.clientX, e.clientY]
+      }
       runOpenDelay()
+    },
+    onMousemove: (e: MouseEvent) => {
+      cursorTarget.value = [e.clientX, e.clientY]
     },
     onMouseleave: (e: MouseEvent) => {
       isHovered = false
@@ -148,6 +154,9 @@ export function useActivator (
     if (props.openOnHover) {
       events.onMouseenter = availableEvents.onMouseenter
       events.onMouseleave = availableEvents.onMouseleave
+      if (props.target === 'cursor' && !openOnClick.value) {
+        events.onMousemove = availableEvents.onMousemove
+      }
     }
     if (openOnFocus.value) {
       events.onFocus = availableEvents.onFocus


### PR DESCRIPTION
resolves #22161

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex justify-center ga-3">

      <v-tooltip target="cursor" open-on-hover>
        <template #activator="{ props: activatorProps }">
          <v-card
            v-bind="activatorProps"
            height="300"
            image="https://picsum.photos/600/300"
            tabindex="0"
            width="600"
          />
        </template>
        <span>I follow the cursor</span>
      </v-tooltip>

      <v-card
        height="300"
        image="https://picsum.photos/600/300"
        tabindex="0"
        width="600"
      >
        <v-tooltip activator="parent" target="cursor" open-on-hover>
          <span>I follow the cursor 2</span>
        </v-tooltip>
      </v-card>

    </v-container>
  </v-app>
</template>
```
