### PR TITLE
fix(a11y): skip aria-labelledby when no label element exists

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -543,7 +543,7 @@ export const VAutocomplete = genericComponent<new <
                         tabindex="-1"
                         selectable={ !!displayItems.value.length }
                         aria-live="polite"
-                        aria-labelledby={ `${id.value}-label` }
+                        aria-labelledby={ (props.label || slots.label) ? `${id.value}-label` : undefined }
                         aria-multiselectable={ props.multiple }
                         color={ props.itemColor ?? props.color }
                         { ...listEvents }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -606,7 +606,7 @@ export const VCombobox = genericComponent<new <
                         onFocusout={ onFocusout }
                         tabindex="-1"
                         aria-live="polite"
-                        aria-labelledby={ `${id.value}-label` }
+                        aria-labelledby={ (props.label || slots.label) ? `${id.value}-label` : undefined }
                         aria-multiselectable={ props.multiple }
                         color={ props.itemColor ?? props.color }
                         { ...listEvents }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -546,7 +546,7 @@ export const VSelect = genericComponent<new <
                         tabindex="-1"
                         selectable={ !!displayItems.value.length }
                         aria-live="polite"
-                        aria-labelledby={ `${id.value}-label` }
+                        aria-labelledby={ (props.label || slots.label) ? `${id.value}-label` : undefined }
                         aria-multiselectable={ props.multiple }
                         color={ props.itemColor ?? props.color }
                         { ...listEvents }

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -246,7 +246,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                         type={ props.type }
                         onFocus={ focus }
                         onBlur={ blur }
-                        aria-labelledby={ `${id.value}-label` }
+                        aria-labelledby={ (props.label || slots.label) ? `${id.value}-label` : undefined }
                         { ...slotProps }
                         { ...inputAttrs }
                       />

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -340,7 +340,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
                         autocomplete={ autocomplete.fieldAutocomplete.value }
                         onFocus={ onFocus }
                         onBlur={ blur }
-                        aria-labelledby={ `${id.value}-label` }
+                        aria-labelledby={ (props.label || slots.label) ? `${id.value}-label` : undefined }
                         { ...slotProps }
                         { ...inputAttrs }
                       />


### PR DESCRIPTION
Fixes #22550

## Problem

When VTextField, VTextarea, VSelect, VAutocomplete, or VCombobox are used without a `label` prop (relying on `aria-label` instead), `aria-labelledby` was still emitted pointing to `${id}-label` — an element ID that doesn't exist in the DOM.

This is an accessibility violation. WCAG requires that `aria-labelledby` references a real element ID. Screen readers may ignore the working `aria-label` when a broken `aria-labelledby` is present (browsers prefer `aria-labelledby` over `aria-label`).

Practical example: `VDataTableFooter` uses `VSelect` with only `aria-label` (no `label` prop), causing the "Items per page" combobox to have a broken ARIA reference that WAVE and browser DevTools flag.

## Fix

Conditionally emit `aria-labelledby` only when `props.label` or `slots.label` is provided — i.e. when a corresponding label element will actually be rendered with that ID.

## Files changed

- `VTextField.tsx` — input element `aria-labelledby`
- `VTextarea.tsx` — textarea element `aria-labelledby`
- `VSelect.tsx` — listbox dropdown `aria-labelledby`
- `VAutocomplete.tsx` — listbox dropdown `aria-labelledby`
- `VCombobox.tsx` — listbox dropdown `aria-labelledby`