### PR TITLE
feat(VDataTableVirtual): expose containerRef for scroll container access

### DIFF
--- a/packages/api-generator/src/locale/en/VDataTableVirtual.json
+++ b/packages/api-generator/src/locale/en/VDataTableVirtual.json
@@ -37,6 +37,7 @@
     "update:sortBy": "Emits when the **sortBy** prop is updated."
   },
   "exposed": {
-    "calculateVisibleItems": "Trigger updating the currently rendered items based on scroll position."
+    "calculateVisibleItems": "Trigger updating the currently rendered items based on scroll position.",
+    "containerRef": "Reference to the internal scroll container element (`.v-table__wrapper`). Use this to attach `IntersectionObserver`, scroll listeners, or implement infinite scroll without relying on internal class names."
   }
 }

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -290,6 +290,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
     return {
       calculateVisibleItems,
       scrollToIndex,
+      containerRef,
     }
   },
 })


### PR DESCRIPTION
## Description

Resolves #22647

`VDataTableVirtual` manages its own internal scroll container (`.v-table__wrapper`), but the element was not accessible through any public API. This made implementing reliable infinite scroll or custom scroll detection unnecessarily brittle — users had to reach into internals via `querySelector('.v-table__wrapper')` which can break at any time.

This PR exposes `containerRef` in the component's public API (alongside the existing `calculateVisibleItems` and `scrollToIndex`).

### Usage

```vue
<template>
  <v-data-table-virtual ref="table" :items="items" :headers="headers" height="400">
    <template #tfoot>
      <div ref="sentinel" />
    </template>
  </v-data-table-virtual>
</template>

<script setup>
const table = ref()
const sentinel = ref()

onMounted(() => {
  const observer = new IntersectionObserver(([entry]) => {
    if (entry.isIntersecting) loadMore()
  }, { root: table.value.containerRef })

  observer.observe(sentinel.value)
})
</script>
```

## Changes

- Exposed `containerRef` in `VDataTableVirtual`'s return value (matches how `VVirtualScroll` already works)
- Added API doc entry in `VDataTableVirtual.json`
