### PR TITLE
feat(VRating): expose activeColor in item slot props

### DIFF
--- a/packages/vuetify/src/components/VRating/VRating.tsx
+++ b/packages/vuetify/src/components/VRating/VRating.tsx
@@ -29,6 +29,7 @@ type VRatingItemSlot = {
   isHovered: boolean
   icon: IconValue
   color?: string
+  activeColor?: string
   props: Record<string, unknown>
   rating: number
 }
@@ -117,7 +118,7 @@ export const VRating = genericComponent<VRatingSlots>()({
       const activeColor = props.activeColor ?? props.color
       const color = (isFilled || isHovered) ? activeColor : props.color
 
-      return { isFilled, isHovered, icon, color }
+      return { isFilled, isHovered, icon, color, activeColor }
     }))
 
     const eventState = computed(() => [0, ...increments.value].map(value => {


### PR DESCRIPTION
Fixes #22273

Currently only `color` is passed to the `#item` slot, even though `activeColor` is a distinct prop that gets resolved separately. This makes it hard to use `activeColor` for custom rendering without manually re-deriving it from props.

The `activeColor` is already computed in `itemState` — this just includes it in the returned object so it shows up in the slot payload alongside `color`.

Before:
```vue
<VRating>
  <template #item="{ color, props, isFilled }">
    <!-- activeColor not available here -->
  </template>
</VRating>
```

After:
```vue
<VRating active-color="red" color="grey">
  <template #item="{ color, activeColor, isFilled, props }">
    <VIcon :color="isFilled ? activeColor : color" v-bind="props" />
  </template>
</VRating>
```