### PR TITLE
feat(VCarousel): add stopOnHover prop to pause cycling on hover

### DIFF
--- a/packages/api-generator/src/locale/en/VCarousel.json
+++ b/packages/api-generator/src/locale/en/VCarousel.json
@@ -10,6 +10,7 @@
     "nextIcon": "The displayed icon for forcing pagination to the next item.",
     "prevIcon": "The displayed icon for forcing pagination to the previous item.",
     "progress": "Displays a carousel progress bar. Requires the **cycle** prop and **interval**.",
+    "stopOnHover": "Pauses the cycle when the cursor is hovering over the carousel. Requires the **cycle** prop.",
     "showArrows": "Displays arrows for next/previous navigation.",
     "verticalArrows": "Displays the navigation arrows vertically instead of horizontally.",
     "verticalDelimiters": "Displays carousel delimiters vertically."

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -13,7 +13,7 @@ import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { nextTick, onMounted, ref, watch } from 'vue'
+import { nextTick, onMounted, ref, shallowRef, watch } from 'vue'
 import { convertToUnit, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -41,6 +41,7 @@ export const makeVCarouselProps = propsFactory({
     validator: (value: string | number) => Number(value) > 0,
   },
   progress: [Boolean, String],
+  stopOnHover: Boolean,
   verticalDelimiters: [Boolean, String] as PropType<boolean | 'left' | 'right'>,
 
   ...makeVWindowProps({
@@ -82,6 +83,8 @@ export const VCarousel = genericComponent<new <T>(
     const windowRef = ref<VWindow>()
 
     let slideTimeout = -1
+    const isHovered = shallowRef(false)
+
     watch(model, restartTimeout)
     watch(() => props.interval, restartTimeout)
     watch(() => props.cycle, val => {
@@ -92,7 +95,7 @@ export const VCarousel = genericComponent<new <T>(
     onMounted(startTimeout)
 
     function startTimeout () {
-      if (!props.cycle || !windowRef.value) return
+      if (!props.cycle || !windowRef.value || isHovered.value) return
 
       slideTimeout = window.setTimeout(
         windowRef.value.group.next,
@@ -103,6 +106,20 @@ export const VCarousel = genericComponent<new <T>(
     function restartTimeout () {
       window.clearTimeout(slideTimeout)
       window.requestAnimationFrame(startTimeout)
+    }
+
+    function onMouseenter () {
+      if (props.stopOnHover) {
+        isHovered.value = true
+        window.clearTimeout(slideTimeout)
+      }
+    }
+
+    function onMouseleave () {
+      if (props.stopOnHover) {
+        isHovered.value = false
+        restartTimeout()
+      }
     }
 
     function onDelimiterKeyDown (e: KeyboardEvent, group: GroupProvide) {
@@ -145,6 +162,8 @@ export const VCarousel = genericComponent<new <T>(
             { height: convertToUnit(props.height) },
             props.style,
           ]}
+          onMouseenter={ onMouseenter }
+          onMouseleave={ onMouseleave }
         >
           {{
             default: slots.default,

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -108,19 +108,11 @@ export const VCarousel = genericComponent<new <T>(
       window.requestAnimationFrame(startTimeout)
     }
 
-    function onMouseenter () {
-      if (props.stopOnHover) {
-        isHovered.value = true
-        window.clearTimeout(slideTimeout)
-      }
-    }
-
-    function onMouseleave () {
-      if (props.stopOnHover) {
-        isHovered.value = false
-        restartTimeout()
-      }
-    }
+    watch(isHovered, val => {
+      if (!props.stopOnHover) return
+      if (val) window.clearTimeout(slideTimeout)
+      else restartTimeout()
+    })
 
     function onDelimiterKeyDown (e: KeyboardEvent, group: GroupProvide) {
       if (
@@ -162,8 +154,8 @@ export const VCarousel = genericComponent<new <T>(
             { height: convertToUnit(props.height) },
             props.style,
           ]}
-          onMouseenter={ onMouseenter }
-          onMouseleave={ onMouseleave }
+          onMouseenter={ () => isHovered.value = true }
+          onMouseleave={ () => isHovered.value = false }
         >
           {{
             default: slots.default,


### PR DESCRIPTION
Fixes #10544

Adds a `stop-on-hover` prop to `VCarousel`. When set alongside `cycle`, the auto-cycling pauses while the user hovers over the carousel and resumes when they move away.

The implementation adds an `isHovered` ref and `onMouseenter`/`onMouseleave` handlers on the root `VWindow`. The handlers are no-ops unless `stopOnHover` is true, so there's no runtime cost for the default case. The `startTimeout` guard also checks `isHovered.value` so a programmatic restart (e.g. slide change) won't queue the next tick while hovering.

Usage:
```vue
<v-carousel cycle :interval="3000" stop-on-hover>
  <v-carousel-item v-for="item in items" :key="item.src" :src="item.src" />
</v-carousel>
```