### PR TITLE
feat(VSkeletonLoader): add chip-group type

### DIFF
--- a/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.tsx
+++ b/packages/vuetify/src/components/VSkeletonLoader/VSkeletonLoader.tsx
@@ -28,6 +28,7 @@ export const rootTypes = {
   card: 'image, heading',
   'card-avatar': 'image, list-item-avatar',
   chip: 'chip',
+  'chip-group': 'chip@4',
   'date-picker': 'list-item, heading, divider, date-picker-options, date-picker-days, actions',
   'date-picker-options': 'text, avatar@2',
   'date-picker-days': 'avatar@28',


### PR DESCRIPTION
Closes #20695

Adds a `chip-group` type to `VSkeletonLoader` that renders 4 chip-shaped skeleton bones in a row, mimicking the appearance of a `v-chip-group`.

**Before:** Users had to compose their own chip skeletons using `type="chip@4"` manually.

**After:** `<v-skeleton-loader type="chip-group" />` provides a convenient shorthand.

The new type follows the same pattern as existing composed types like `paragraph` (`text@3`) and `sentences` (`text@2`).