### PR TITLE
fix(VFileUpload): keep compact dropzone clickable when multiple files allowed

### DIFF
--- a/packages/vuetify/src/labs/VFileUpload/VFileUploadDropzone.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUploadDropzone.tsx
@@ -181,7 +181,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
           class={[
             'v-file-upload-dropzone',
             {
-              'v-file-upload-dropzone--clickable': !hasBrowse && !hasFiles,
+              'v-file-upload-dropzone--clickable': !hasBrowse && (!hasFiles || props.multiple),
               'v-file-upload-dropzone--disabled': disabled,
               'v-file-upload-dropzone--dragging': isDragging.value,
               'v-file-upload-dropzone--has-files': hasFiles,
@@ -195,7 +195,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
           onDragleave={ onDragleave }
           onDragover={ onDragover }
           onDrop={ onDrop }
-          onClick={ !hasBrowse && !hasFiles ? onClickBrowse : undefined }
+          onClick={ !hasBrowse && (!hasFiles || props.multiple) ? onClickBrowse : undefined }
         >
           { slots.default?.({
             isDragging: isDragging.value,


### PR DESCRIPTION
## Description

When `density` is not `'default'` (e.g. `compact` or `comfortable`), the browse button is hidden (`hasBrowse` is `false`) and clicking the dropzone itself opens the file picker. Previously the click handler was removed once any file was added (`!hasBrowse && !hasFiles`), making it impossible to select additional files via click after the first selection.

Fixes #22737

## Changes

- In `VFileUploadDropzone.tsx`, changed the condition for `v-file-upload-dropzone--clickable` and the `onClick` handler from `!hasBrowse && !hasFiles` to `!hasBrowse && (!hasFiles || props.multiple)`
- When `multiple` is `true`, the dropzone stays clickable after files are added so users can keep adding files
- When `multiple` is `false` (single-file mode), existing behavior is preserved: clicking is disabled once a file is selected (the file must be removed first)

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)