### PR TITLE
fix(VSelect): prevent brief error state when clicking a menu item

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -368,6 +368,10 @@ export const VSelect = genericComponent<new <
       if (!vTextFieldRef.value?.$el.contains(target)) {
         menu.value = false
       }
+      const menuContent = vMenuRef.value?.contentEl
+      if (menuContent?.contains(e.relatedTarget as Node)) {
+        isFocused.value = true
+      }
     }
     function getSelectedIndex () {
       return displayItems.value.findIndex(


### PR DESCRIPTION
## Description

When the VSelect input loses focus as a user clicks an option in the dropdown menu, `onBlur` fires before the new model value has been propagated back from the parent. Because the menu content is rendered in a teleport outside the textfield's DOM element, the existing `isFocused` guard in `onFocusout` does not catch this case. Blur-triggered validation therefore runs with the old (potentially invalid) value and briefly shows an error state before the selection completes.

**VAutocomplete already handles this** — its `onBlur` checks whether focus moved into the menu content and keeps `isFocused=true` in that case. This PR applies the same guard to VSelect.

Fixes #22742

## Changes

Added two lines to VSelect's `onBlur` handler, following the same pattern already used in `VAutocomplete`:

```ts
const menuContent = vMenuRef.value?.contentEl
if (menuContent?.contains(e.relatedTarget as Node)) {
  isFocused.value = true
}
```

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)