### PR TITLE
fix(VVideoControls): import VVideo.sass to ensure styles are bundled with tree shaking

### DIFF
--- a/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
+++ b/packages/vuetify/src/labs/VVideo/VVideoControls.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable complexity */
 
+// Styles
+import './VVideo.sass'
+
 // Components
 import { VVideoVolume } from './VVideoVolume'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvider'

--- a/packages/vuetify/src/labs/VVideo/VVideoVolume.tsx
+++ b/packages/vuetify/src/labs/VVideo/VVideoVolume.tsx
@@ -1,3 +1,6 @@
+// Styles
+import './VVideo.sass'
+
 // Components
 import { VIcon } from '@/components/VIcon/VIcon'
 import { VMenu } from '@/components/VMenu/VMenu'


### PR DESCRIPTION
## What does this PR do?

Fixes #22529

When `VVideoControls` (or `VVideoVolume`) is used in an app **without** importing `VVideo`, production builds with tree shaking skip the `VVideo.sass` stylesheet — because only `VVideo.tsx` imported it. The result is unstyled controls in production (`vite build` + `vite preview`) while dev mode works fine (Vite doesn't tree-shake in dev).

## Fix

Add `import './VVideo.sass'` to the top of both `VVideoControls.tsx` and `VVideoVolume.tsx`. This is the same pattern used throughout Vuetify (e.g. every component that needs styles imports its own `.sass` file directly). Adding the import to both ensures styles are included whenever any of the three VVideo sub-components is used standalone.