### PR TITLE
fix(VOverlay): always return focus to activator on Escape key

### DIFF
--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -3,7 +3,7 @@ import { VMenu } from '..'
 import { VList, VListItem } from '@/components/VList'
 
 // Utilities
-import { render, screen, userEvent } from '@test'
+import { render, screen, userEvent, waitFor } from '@test'
 
 describe('VMenu', () => {
   it('returns focus to activator on Escape', async () => {
@@ -29,8 +29,8 @@ describe('VMenu', () => {
     // Press Escape to close
     await userEvent.keyboard('{Escape}')
 
-    // Menu should be closed
-    expect(item1).not.toBeVisible()
+    // Menu should be closed (wait for animation/transition to complete)
+    await waitFor(() => expect(item1).not.toBeVisible())
 
     // Focus should have returned to the activator button
     expect(document.activeElement).toBe(activator)

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -1,6 +1,6 @@
 // Components
-import { VList, VListItem } from '@/components/VList'
 import { VMenu } from '..'
+import { VList, VListItem } from '@/components/VList'
 
 // Utilities
 import { render, screen, userEvent } from '@test'
@@ -9,8 +9,8 @@ describe('VMenu', () => {
   it('returns focus to activator on Escape', async () => {
     render(() => (
       <div>
-        <button data-test="activator">Open menu</button>
-        <VMenu activator="[data-test='activator']">
+        <button data-testid="activator">Open menu</button>
+        <VMenu activator="[data-testid='activator']">
           <VList>
             <VListItem title="Item 1" />
             <VListItem title="Item 2" />

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -3,7 +3,8 @@ import { VMenu } from '..'
 import { VList, VListItem } from '@/components/VList'
 
 // Utilities
-import { render, screen, userEvent, waitFor } from '@test'
+import { render, screen, userEvent } from '@test'
+import { waitFor } from '@testing-library/vue'
 
 describe('VMenu', () => {
   it('returns focus to activator on Escape', async () => {

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -1,0 +1,38 @@
+// Components
+import { VList, VListItem } from '@/components/VList'
+import { VMenu } from '..'
+
+// Utilities
+import { render, screen, userEvent } from '@test'
+
+describe('VMenu', () => {
+  it('returns focus to activator on Escape', async () => {
+    render(() => (
+      <div>
+        <button data-test="activator">Open menu</button>
+        <VMenu activator="[data-test='activator']">
+          <VList>
+            <VListItem title="Item 1" />
+            <VListItem title="Item 2" />
+          </VList>
+        </VMenu>
+      </div>
+    ))
+
+    const activator = screen.getByTestId('activator')
+    await userEvent.click(activator)
+
+    // Menu should be open
+    const item1 = screen.getByText('Item 1')
+    expect(item1).toBeVisible()
+
+    // Press Escape to close
+    await userEvent.keyboard('{Escape}')
+
+    // Menu should be closed
+    expect(item1).not.toBeVisible()
+
+    // Focus should have returned to the activator button
+    expect(document.activeElement).toBe(activator)
+  })
+})

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -229,9 +229,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         }
         if (!props.persistent) {
           isActive.value = false
-          if (contentEl.value?.contains(document.activeElement)) {
-            activatorEl.value?.focus()
-          }
+          activatorEl.value?.focus()
         } else animateClick()
       }
     }


### PR DESCRIPTION
Fixes #22560

## Problem

Keyboard focus was lost after closing a `v-menu` (or any overlay) with the Escape key in certain scenarios:

- Menu opened by clicking a button but focus was not yet captured inside the content (e.g. before the user tabbed in)
- Coordinate-based menus where the activator element is not keyboard-focusable

**Root cause:** The focus-return logic in `VOverlay.onKeydown` was gated behind a check that the active element was *inside* the overlay content at the time Escape was pressed:

```ts
// Before
if (contentEl.value?.contains(document.activeElement)) {
  activatorEl.value?.focus()
}
```

When focus was outside the content (e.g. still on the page body), the activator was never re-focused.

## Fix

Remove the conditional so focus always returns to the activator when Escape closes an overlay:

```ts
// After
activatorEl.value?.focus()
```

If the activator is not focusable (e.g. a plain `<div>` used for coordinate-based menus), the `focus()` call is a silent no-op — same behaviour as before for those cases. For button-based activators this ensures focus is reliably returned.

Also adds a browser test covering this scenario.