### PR TITLE
fix(VAutocomplete): use hidden select for native form submissions

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -18,6 +18,7 @@ import { VVirtualScroll } from '@/components/VVirtualScroll'
 
 // Composables
 import { useScrolling } from '../VSelect/useScrolling'
+import { useAutocomplete } from '@/composables/autocomplete'
 import { useTextColor } from '@/composables/color'
 import { highlightResult, makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -150,6 +151,7 @@ export const VAutocomplete = genericComponent<new <
         : model.value.length
     })
     const form = useForm(props)
+    const autocomplete = useAutocomplete(props)
     const { filteredItems, getMatches } = useFilter(
       props,
       items,
@@ -474,6 +476,7 @@ export const VAutocomplete = genericComponent<new <
           ref={ vTextFieldRef }
           { ...textFieldProps }
           v-model={ search.value }
+          name={ undefined }
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
@@ -505,6 +508,20 @@ export const VAutocomplete = genericComponent<new <
             ...slots,
             default: ({ id }) => (
               <>
+                <select
+                  hidden
+                  multiple={ props.multiple }
+                  name={ autocomplete.fieldName.value }
+                >
+                  { items.value.map(item => (
+                    <option
+                      key={ item.value }
+                      value={ item.value }
+                      selected={ selectedValues.value.includes(item.value) }
+                    />
+                  ))}
+                </select>
+
                 <VMenu
                   id={ menuId.value }
                   ref={ vMenuRef }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -768,5 +768,69 @@ describe('VAutocomplete', () => {
     })
   })
 
+  describe('native form submission', () => {
+    const items = [
+      { title: 'Item 1', value: 1 },
+      { title: 'Item 2', value: 2 },
+      { title: 'Item 3', value: 3 },
+    ]
+
+    it('should include selected value in form data for single selection', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VAutocomplete
+            name="autocomplete"
+            items={ items }
+            modelValue={ items[0] }
+          />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' })
+      await userEvent.click(submitButton)
+
+      expect(submittedData).not.toBeNull()
+      expect(submittedData!.get('autocomplete')).toBe('1')
+    })
+
+    it('should include selected values in form data for multiple selection', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VAutocomplete
+            multiple
+            name="autocomplete"
+            items={ items }
+            modelValue={[items[0], items[1]]}
+          />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' })
+      await userEvent.click(submitButton)
+
+      expect(submittedData).not.toBeNull()
+      const values = submittedData!.getAll('autocomplete')
+      expect(values).toHaveLength(2)
+      expect(values).toContain('1')
+      expect(values).toContain('2')
+    })
+  })
+
   showcase({ stories })
 })


### PR DESCRIPTION
## Description

Apply the same fix pattern from VSelect (#22330) to VAutocomplete. When using `v-model` or `:model-value`, the component's input value was empty until user interaction, breaking native form submission and Cypress tests.

### Root Cause

VAutocomplete uses a real `<input>` for its search field, but the input's value is only populated when the component is focused (`isFocused` watcher sets `search.value`). This means native form submission always submits an empty string.

### Fix

Mirror the VSelect fix from #22330:
1. Import and call `useAutocomplete(props)` — reuses the existing composable created in #22330
2. Pass `name={undefined}` to `<VTextField>` — excludes the visible text input from form submission
3. Render a hidden `<select>` with `<option>` elements driven by `items` and `selectedValues` — this is what native form submission reads

### Tests Added

- Single selection: verifies `FormData` contains the selected value
- Multiple selection: verifies `FormData` contains all selected values

### Related

- Fixes #22270
- Follows the same pattern as #22330 (VSelect)
- As suggested by @J-Sek in #22270 comment

### AI Disclosure

This contribution used AI assistance (Claude Code) for codebase exploration and implementation.