### PR TITLE
fix(useDelay): NaN issue closing the VMenu immediately

### DIFF
--- a/packages/vuetify/src/composables/delay.ts
+++ b/packages/vuetify/src/composables/delay.ts
@@ -19,12 +19,11 @@ export function useDelay (props: DelayProps, cb?: (value: boolean) => void) {
   function runDelay (isOpening: boolean, options?: { minDelay: number }) {
     clearDelay?.()
 
-    const delay = isOpening ? props.openDelay : props.closeDelay
+    const rawDelay = isOpening ? props.openDelay : props.closeDelay;
+    const parsedDelay = Number(rawDelay);
+    const safeDelay = Number.isFinite(parsedDelay) ? parsedDelay : 0;
 
-    const normalizedDelay = Math.max(
-      options?.minDelay ?? 0,
-      Number(delay ?? 0)
-    )
+    const normalizedDelay = Math.max(options?.minDelay ?? 0, safeDelay);
 
     return new Promise(resolve => {
       clearDelay = defer(normalizedDelay, () => {


### PR DESCRIPTION
- resolves #22759
- Root cause:
  - NormalizedDelay was still vulnerable to invalid values outputting NaN
  - Passing undefined or no value caused the delay to be 0 which closed the menu immediately

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
