### PR TITLE
fix(focusTrap): guard onScopeDispose document listeners with IN_BROWSER

### DIFF
--- a/packages/vuetify/src/composables/focusTrap.ts
+++ b/packages/vuetify/src/composables/focusTrap.ts
@@ -191,12 +191,15 @@ export function useFocusTrap (
   onScopeDispose(() => {
     registry.delete(trapId)
     clearTimeout(focusTrapSuppressionTimeout)
-    document.removeEventListener('pointerdown', onPointerdown)
-    document.removeEventListener('focusin', captureOnFocus)
-    document.removeEventListener('keydown', captureOnKeydown)
 
-    if (--subscribers < 1) {
-      document.removeEventListener('keydown', onKeydown)
+    if (IN_BROWSER) {
+      document.removeEventListener('pointerdown', onPointerdown)
+      document.removeEventListener('focusin', captureOnFocus)
+      document.removeEventListener('keydown', captureOnKeydown)
+
+      if (--subscribers < 1) {
+        document.removeEventListener('keydown', onKeydown)
+      }
     }
   })
 }


### PR DESCRIPTION
## Description

Fixes an SSR crash when any component using `useFocusTrap` (e.g. `v-dialog`, `v-menu` with `retainFocus`) is rendered server-side.

## Root Cause

The `onScopeDispose` callback calls `document.removeEventListener` directly without checking `IN_BROWSER`. On the server, `document` is `undefined`, so this crashes with:

```
Error: Cannot read properties of undefined (reading 'removeEventListener')
  at onScopeDispose (focusTrap.js:...)
```

The setup block already wraps all `document` access in `if (IN_BROWSER) { ... }` — the `onScopeDispose` teardown was simply missing the same guard.

## Fix

Wrap the `document.removeEventListener` calls in `onScopeDispose` with the same `IN_BROWSER` check used in the setup block. The `registry.delete` and `clearTimeout` calls are safe in SSR and remain outside the guard.

Fixes #22762