### PR TITLE
fix(SSR): avoid errors when rendering with latest Vue

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/hold.ts
+++ b/packages/vuetify/src/components/VNumberInput/hold.ts
@@ -1,5 +1,6 @@
 // Utilities
 import { onScopeDispose } from 'vue'
+import { IN_BROWSER } from '@/util'
 
 const HOLD_REPEAT = 50
 const HOLD_DELAY = 500
@@ -21,6 +22,7 @@ export function useHold ({ toggleUpDown }: { toggleUpDown: (increment: boolean) 
   }
 
   function holdStop () {
+    if (!IN_BROWSER) return
     window.clearTimeout(timeout)
     window.clearInterval(interval)
     window.removeEventListener('pointerup', holdStop)

--- a/packages/vuetify/src/components/VSlider/slider.ts
+++ b/packages/vuetify/src/components/VSlider/slider.ts
@@ -7,7 +7,7 @@ import { makeRoundedProps } from '@/composables/rounded'
 
 // Utilities
 import { computed, nextTick, onScopeDispose, provide, ref, shallowRef, toRef } from 'vue'
-import { clamp, createRange, getDecimals, propsFactory } from '@/util'
+import { clamp, createRange, getDecimals, IN_BROWSER, propsFactory } from '@/util'
 
 // Types
 import type { ExtractPropTypes, InjectionKey, PropType, Ref } from 'vue'
@@ -316,6 +316,7 @@ export const useSlider = ({
   }
 
   onScopeDispose(() => {
+    if (!IN_BROWSER) return
     window.removeEventListener('touchmove', onMouseMove)
     window.removeEventListener('mousemove', onMouseMove)
     window.removeEventListener('mouseup', onSliderMouseUp)

--- a/packages/vuetify/src/components/VTimePicker/VTimePickerClock.tsx
+++ b/packages/vuetify/src/components/VTimePicker/VTimePickerClock.tsx
@@ -6,7 +6,7 @@ import { useBackgroundColor, useTextColor } from '@/composables/color'
 
 // Utilities
 import { computed, onScopeDispose, ref, watch } from 'vue'
-import { debounce, genericComponent, propsFactory, useRender } from '@/util'
+import { debounce, genericComponent, IN_BROWSER, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -225,6 +225,7 @@ export const VTimePickerClock = genericComponent()({
     }
 
     function removeListeners () {
+      if (!IN_BROWSER) return
       window.removeEventListener('mousemove', onDragMove)
       window.removeEventListener('touchmove', onDragMove)
       window.removeEventListener('mouseup', onMouseUp)

--- a/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
+++ b/packages/vuetify/src/components/VVirtualScroll/VVirtualScroll.tsx
@@ -17,6 +17,7 @@ import {
   genericComponent,
   getCurrentInstance,
   getScrollParent,
+  IN_BROWSER,
   propsFactory,
   useRender,
 } from '@/util'
@@ -76,6 +77,8 @@ export const VVirtualScroll = genericComponent<new <T, Renderless extends boolea
     useToggleScope(() => props.renderless, () => {
       function handleListeners (add = false) {
         const method = add ? 'addEventListener' : 'removeEventListener'
+
+        if (!IN_BROWSER) return
 
         if (containerRef.value === document.documentElement) {
           document[method]('scroll', handleScroll, { passive: true })

--- a/packages/vuetify/src/composables/focusTrap.ts
+++ b/packages/vuetify/src/composables/focusTrap.ts
@@ -190,6 +190,7 @@ export function useFocusTrap (
 
   onScopeDispose(() => {
     registry.delete(trapId)
+    if (!IN_BROWSER) return
     clearTimeout(focusTrapSuppressionTimeout)
     document.removeEventListener('pointerdown', onPointerdown)
     document.removeEventListener('focusin', captureOnFocus)


### PR DESCRIPTION
fixes #22762

steps to verify:

1. scaffold new project with Nuxt (Vite project needs more manual work to setup SSR, and it behaves the same anyway)
2. run it locally
3. inject code below into HelloWorld.vue

```html
<v-select :items="[1,2,3]" />
<v-number-input />
<v-time-picker />
<v-slider v-model="sliderValue" />
<v-virtual-scroll renderless :height="300" :items="Array.from({ length: 999 }, (_, i) => i)">
  <template v-slot:default="{ item }">Item {{ item }}</template>
</v-virtual-scroll>
```

```ts
const sliderValue = shallowRef(10)
useHotkey('shift+right', () => sliderValue.value++)
useHotkey('shift+left', () => sliderValue.value--)
```

Note: tested without changes to `hotkey.ts` and it does not break