### PR TITLE
fix(VAutocomplete): do not emit update:search on blur-triggered reset

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -120,7 +120,7 @@ export const VAutocomplete = genericComponent<new <
     'update:menu': (value: boolean) => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { emit, slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const isFocused = shallowRef(false)
@@ -133,7 +133,13 @@ export const VAutocomplete = genericComponent<new <
     const { items, transformIn, transformOut } = useItems(props)
     const { textColorClasses, textColorStyles } = useTextColor(() => vTextFieldRef.value?.color)
     const { InputIcon } = useInputIcon(props)
-    const search = useProxiedModel(props, 'search', '')
+    const _search = shallowRef<string>(props.search ?? '')
+    const search = computed<string>({
+      get: () => _search.value,
+      set: (val: string | null) => {
+        _search.value = val ?? ''
+      },
+    })
     const model = useProxiedModel(
       props,
       'modelValue',
@@ -424,6 +430,16 @@ export const VAutocomplete = genericComponent<new <
         search.value = ''
         selectionIndex.value = -1
       }
+    })
+
+    watch(_search, val => {
+      if (!isFocused.value || isSelecting.value) return
+
+      emit('update:search', val)
+    })
+
+    watch(() => props.search, val => {
+      _search.value = val ?? ''
     })
 
     watch(search, val => {


### PR DESCRIPTION
fixes #22767

## Problem

When using `v-model:search` to power remote data fetching, selecting an item and clicking outside triggers a spurious `update:search` event with `''`. This reloads the items list with an empty query, removing the selected item from the list and breaking the displayed value.

## Root Cause

`search` was declared as `useProxiedModel(props, 'search', '')`, which automatically emits `update:search` whenever `search.value` changes. The `isFocused` watcher unconditionally sets `search.value = ''` on blur, triggering the emit even though no user input occurred.

## Fix

Replace `useProxiedModel` for `search` with a private `_search` shallowRef + computed accessor. Only emit `update:search` when `isFocused` is true (matching the existing guard already used for menu/isPristine management). External prop changes are synced via a dedicated `watch(() => props.search)` watcher.