### PR TITLE
fix: CSS zoom causes coordinate mismatch (VColorPicker, ripple, VCalendar)

### DIFF
--- a/packages/vuetify/src/components/VCalendar/composables/calendarWithIntervals.ts
+++ b/packages/vuetify/src/components/VCalendar/composables/calendarWithIntervals.ts
@@ -16,6 +16,7 @@ import {
   validateTime,
 } from '../util/timestamp'
 import { propsFactory } from '@/util'
+import { Box, getTargetBox } from '@/util/box'
 
 // Types
 import type { PropType, StyleValue } from 'vue'
@@ -165,13 +166,14 @@ export function useCalendarWithIntervals (props: CalendarWithIntervalsProps) {
 
   function getTimestampAtEvent (e: Event, day: CalendarTimestamp): CalendarTimestamp {
     const timestamp: CalendarTimestamp = copyTimestamp(day)
-    const bounds = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    const bounds = new Box(e.currentTarget as HTMLElement)
     const baseMinutes: number = firstMinute.value
     const touchEvent: TouchEvent = e as TouchEvent
     const mouseEvent: MouseEvent = e as MouseEvent
     const touches: TouchList = touchEvent.changedTouches || touchEvent.touches
-    const clientY: number = touches && touches[0] ? touches[0].clientY : mouseEvent.clientY
-    const addIntervals: number = (clientY - bounds.top) / parsedIntervalHeight.value
+    const target = touches && touches[0] ? touches[0] : mouseEvent
+    const point = getTargetBox([target.clientX, target.clientY])
+    const addIntervals: number = (point.y - bounds.top) / parsedIntervalHeight.value
     const addMinutes: number = Math.floor(addIntervals * parsedIntervalMinutes.value)
     const minutes: number = baseMinutes + addMinutes
 

--- a/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.tsx
+++ b/packages/vuetify/src/components/VColorPicker/VColorPickerCanvas.tsx
@@ -8,10 +8,12 @@ import { useResizeObserver } from '@/composables/resizeObserver'
 // Utilities
 import { computed, onMounted, ref, shallowRef, toRef, watch } from 'vue'
 import { clamp, convertToUnit, defineComponent, getEventCoordinates, propsFactory, useRender } from '@/util'
+import { getTargetBox } from '@/util/box'
 
 // Types
 import type { PropType } from 'vue'
 import type { HSV } from '@/util'
+import type { Box } from '@/util/box'
 
 export const makeVColorPickerCanvasProps = propsFactory({
   color: {
@@ -91,7 +93,7 @@ export const VColorPickerCanvas = defineComponent({
       canvasHeight.value = Math.round(height)
     })
 
-    function updateDotPosition (x: number, y: number, rect: DOMRect) {
+    function updateDotPosition (x: number, y: number, rect: Box) {
       const { left, top, width, height } = rect
       dotPosition.value = {
         x: clamp(x - left, 0, width),
@@ -121,8 +123,9 @@ export const VColorPickerCanvas = defineComponent({
       isInteracting.value = true
 
       const coords = getEventCoordinates(e)
+      const point = getTargetBox([coords.clientX, coords.clientY])
 
-      updateDotPosition(coords.clientX, coords.clientY, canvasRef.value.getBoundingClientRect())
+      updateDotPosition(point.x, point.y, getTargetBox(canvasRef.value))
     }
 
     function handleMouseUp () {

--- a/packages/vuetify/src/directives/ripple/index.ts
+++ b/packages/vuetify/src/directives/ripple/index.ts
@@ -3,6 +3,7 @@ import './VRipple.sass'
 
 // Utilities
 import { isObject } from '@/util'
+import { Box, getTargetBox } from '@/util/box'
 
 // Types
 import type { DirectiveBinding } from 'vue'
@@ -53,11 +54,12 @@ const calculate = (
   let localY = 0
 
   if (!isKeyboardEvent(e)) {
-    const offset = el.getBoundingClientRect()
+    const offset = new Box(el)
     const target = isTouchEvent(e) ? e.touches[e.touches.length - 1] : e
+    const point = getTargetBox([target.clientX, target.clientY])
 
-    localX = target.clientX - offset.left
-    localY = target.clientY - offset.top
+    localX = point.x - offset.left
+    localY = point.y - offset.top
   }
 
   let radius = 0


### PR DESCRIPTION
fixes #22761

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

When CSS `zoom` is applied, coordinates returned by `getBoundingClientRect()` and
those from `clientX`/`clientY` use different scales, causing click/touch position
calculations to be off.

The `Box` class and `getTargetBox()` utility in `@/util/box` account for
`document.body.currentCSSZoom` and apply the necessary scale correction.
This PR replaces raw `getBoundingClientRect()` calls in the affected components
with these utilities to resolve the mismatch under CSS zoom.

## Changes

- **VColorPickerCanvas**: Replace `getBoundingClientRect()` with `Box` / `getTargetBox()`
  so dot position updates correctly under zoom
- **ripple directive**: Replace `getBoundingClientRect()` with `Box` and normalize
  `clientX`/`clientY` through `getTargetBox()` so the ripple origin matches the
  actual click point
- **VCalendar (calendarWithIntervals)**: Route touch/mouse event coordinates through
  `getTargetBox()` so interval click timestamps are accurate under zoom

## Tests

- `pnpm test colorpicker ripple calendar` passed
- applied `zoom: 0.75` (and 0.5, 1.25, 1.5) in the following Playground.vue and confirmed all three components behave correctly under CSS zoom
- applied `zoom: 1.0` and confirmed the components behave as before

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script setup lang="ts">
  import { ref, watch, onMounted } from "vue";

  const zoom = ref(0.75);
  const color = ref("#4caf50");
  const calendarDate = ref("2026-03-25");
  const intervalInfo = ref("Click interval area");

  const applyZoom = (z: number) => {
    document.documentElement.style.zoom = String(z);
  };

  onMounted(() => applyZoom(zoom.value));
  watch(zoom, applyZoom);

  const onClickInterval = (e, ts) => {
    if(ts){
      intervalInfo.value = ts.time;
    }else{
      intervalInfo.value = "no data";
    }
  };
</script>

<template>
  <v-app>
    <v-main>
      <v-container style="max-width: 1000px; padding-top: 24px">
        <h2>CSS zoom repro</h2>
        <p>Set page zoom, then test each component interaction.</p>

        <v-slider
          v-model="zoom"
          :min="0.5"
          :max="1.5"
          :step="0.25"
          thumb-label
          label="Page zoom"
        />

        <v-row class="mt-2">
          <v-col cols="12" md="6">
            <v-card class="pa-4" variant="outlined">
              <h3>VColorPicker</h3>
              <v-color-picker
                v-model="color"
                mode="rgb"
                hide-inputs
                hide-mode-switch
              />
            </v-card>
          </v-col>
        </v-row>

        <v-row class="mt-2">
          <v-col cols="12" md="6">
            <v-card class="pa-4" variant="outlined">
              <h3>Ripple</h3>
              <v-btn color="primary" size="x-large" block height="400px">
                Click me (ripple origin)
              </v-btn>
            </v-card>
          </v-col>

          <v-col cols="12" md="6">
            <v-card class="pa-4" variant="outlined">
              <h3>VCalendar interval click</h3>
              <v-calendar
                v-model="calendarDate"
                type="day"
                :interval-height="64"
                style="height: 360px; border: 1px solid #ccc"
                @click:interval="onClickInterval"
              />
              <pre>{{ intervalInfo }}</pre>
            </v-card>
          </v-col>
        </v-row>
      </v-container>
    </v-main>
  </v-app>
</template>

```
