### PR TITLE
fix(types): add module declarations for vuetify/style imports

### DIFF
--- a/packages/vuetify/src/ambient.d.ts
+++ b/packages/vuetify/src/ambient.d.ts
@@ -1,2 +1,9 @@
 declare module '*.sass' {}
 declare module '*.scss' {}
+
+// Type declarations for side-effect style imports
+// Fixes: https://github.com/vuetifyjs/vuetify/issues/22766
+declare module 'vuetify/styles'
+declare module 'vuetify/styles/core'
+declare module 'vuetify/styles/colors'
+declare module 'vuetify/styles/utilities'


### PR DESCRIPTION
## Summary

Fixes TS2882 error when using side-effect imports like `import "vuetify/styles"` with TypeScript strict mode.

## Changes

- Added module declarations in `packages/vuetify/src/ambient.d.ts` for:
  - `vuetify/styles`
  - `vuetify/styles/core`
  - `vuetify/styles/colors`
  - `vuetify/styles/utilities`

These are side-effect imports that only load CSS, so the declarations are empty modules.

## Testing

- Verified the declarations follow the existing pattern in `ambient.d.ts` (which already declares `*.sass` and `*.scss` modules)
- The fix is minimal and non-breaking

Fixes #22766