### PR TITLE
fix(VSnackbar): prevent blocking browser back navigation

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -112,6 +112,7 @@ export const makeVSnackbarProps = propsFactory({
     'offset',
     'retainFocus',
     'captureFocus',
+    'closeOnBack',
     'disableInitialFocus',
     'scrim',
     'scrollStrategy',


### PR DESCRIPTION
## Summary

Fixes VSnackbar blocking Vue Router navigation (browser back/forward buttons, `router.go()`, etc.) while the snackbar is visible.

## Root Cause

VSnackbar inherits `closeOnBack` from VOverlay with a default value of `true`. This registers a `router.beforeEach()` guard that blocks all navigation until the Promise resolves. Since snackbar is a non-blocking notification, it should never intercept browser navigation.

## Changes

Added `closeOnBack` to the omit list in `makeVSnackbarProps` so VSnackbar always passes `closeOnBack=false` to VOverlay.

## Playground Markup

```vue
<template>
  <v-app>
    <v-container>
      <v-btn @click="page = 2">Go to page 2</v-btn>
      <v-btn @click="snackbar = true">Show snackbar</v-btn>
      <p>Current page: {{ page }}</p>
      <v-snackbar v-model="snackbar">
        This is a snackbar notification
        <template #actions>
          <v-btn variant="text" @click="snackbar = false">Close</v-btn>
        </template>
      </v-snackbar>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
  import { useRouter } from 'vue-router'

  const router = useRouter()
  const snackbar = ref(false)
  const page = ref(1)

  router.afterEach(() => {
    page.value = router.currentRoute.value.path
  })
</script>
```

## Testing Steps

1. Open the playground link above
2. Click "Go to page 2" to navigate
3. Click "Show snackbar" to display the snackbar
4. Press browser back button while snackbar is visible
5. **Before fix:** navigation is blocked by the snackbar's `closeOnBack` guard
6. **After fix:** browser navigates back normally while snackbar remains visible

Fixes #18283