### PR TITLE
feat(VFileUpload): add allowPaste prop to support pasting files from clipboard

### DIFF
--- a/packages/api-generator/src/locale/en/VFileUpload.json
+++ b/packages/api-generator/src/locale/en/VFileUpload.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "allowPaste": "Enables pasting files directly into the dropzone via Ctrl+V / Cmd+V.",
     "browseText": "Text for the browse button.",
     "dividerText": "Text in the divider.",
     "hideBrowse": "Hides the browse button.",

--- a/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
+++ b/packages/vuetify/src/labs/VFileUpload/VFileUpload.tsx
@@ -62,6 +62,7 @@ export const makeVFileUploadProps = propsFactory({
     type: IconValue,
     default: '$upload',
   },
+  allowPaste: Boolean,
   clearable: Boolean,
   insetFileList: Boolean,
   hideBrowse: Boolean,
@@ -181,6 +182,14 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
       inputRef.value.value = ''
     }
 
+    function onPaste (e: ClipboardEvent) {
+      if (!props.allowPaste || props.disabled) return
+      const files = Array.from(e.clipboardData?.files ?? [])
+      if (!files.length) return
+      e.preventDefault()
+      selectAccepted(files)
+    }
+
     useRender(() => {
       const { modelValue: _, ...inputProps } = VInput.filterProps(props)
       const { modelValue: __, ...dropzoneProps } = VFileUploadDropzone.filterProps(props as any)
@@ -220,6 +229,7 @@ export const VFileUpload = genericComponent<VFileUploadSlots>()({
           focused={ isFocused.value }
           { ...rootAttrs }
           { ...inputProps }
+          onPaste={ props.allowPaste ? onPaste : undefined }
         >
           {{
             ...slots,


### PR DESCRIPTION
Fixes #22732

## Problem

There's no way to paste files (e.g. screenshots) directly into `VFileUpload`. Users have to paste into an image editor first, save the file, then drag-and-drop or browse for it.

## Solution

Added an `allowPaste` boolean prop. When enabled, a `paste` event handler intercepts `ClipboardEvent.clipboardData.files` and passes them through the existing `selectAccepted()` flow — same path used by drag-and-drop and file browse selection.

```vue
<v-file-upload allow-paste multiple />
```

Users can now Ctrl+V / Cmd+V anywhere on the page when the component is focused to add files.

## Implementation notes

- Uses the same `selectAccepted()` path as drag-drop → file type filtering and `rejected` events work as expected
- `allowPaste` defaults to `false` → fully backward-compatible
- Guard: no-op when `disabled` is set
- No paste handler is attached at all when `allowPaste` is false (no unnecessary event listener)