### PR TITLE
fix(VAutocomplete): keyboard navigation with virtual scroll items

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -34,6 +34,7 @@ import {
   checkPrintable,
   deepEqual,
   ensureValidVNode,
+  focusableChildren,
   genericComponent,
   IN_BROWSER,
   matchesSelector,
@@ -231,9 +232,43 @@ export const VAutocomplete = genericComponent<new <
       }
       menu.value = !menu.value
     }
+    const listItemIndex = shallowRef(-1)
+
     function onMenuKeydown (e: KeyboardEvent) {
       if (e.key === 'Tab') {
         onTabKeydown(e)
+      }
+
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        const count = displayItems.value.length
+        if (!count) return
+
+        const direction = e.key === 'ArrowDown' ? 1 : -1
+        let nextIndex = listItemIndex.value + direction
+
+        // Wrap around
+        if (nextIndex < 0) nextIndex = count - 1
+        if (nextIndex >= count) nextIndex = 0
+
+        listItemIndex.value = nextIndex
+        vVirtualScrollRef.value?.scrollToIndex(nextIndex)
+
+        // Wait for scroll to settle, then focus the item
+        nextTick(() => {
+          const listEl = listRef.value?.$el as HTMLElement | undefined
+          if (!listEl) return
+
+          const item = displayItems.value[nextIndex]
+          if (!item) return
+
+          // Find the list item by aria-posinset which we set during render
+          const listItem = listEl.querySelector(`[aria-posinset="${nextIndex + 1}"]`) as HTMLElement | null
+          if (listItem) listItem.focus()
+        })
+
+        return
       }
 
       if (listRef.value?.$el.contains(e.target) && (checkPrintable(e) || e.key === 'Backspace')) {
@@ -435,6 +470,7 @@ export const VAutocomplete = genericComponent<new <
     })
 
     watch(menu, val => {
+      listItemIndex.value = -1
       if (!props.hideSelected && val && model.value.length && isPristine.value) {
         const index = displayItems.value.findIndex(
           item => model.value.some(s => item.value === s.value)


### PR DESCRIPTION
## Summary

When using VAutocomplete with many items (e.g., 100+), keyboard navigation with ArrowUp/ArrowDown only works through the currently visible items in the virtual scroll. This is because VList's `focusChild` function filters out non-rendered DOM elements via `offsetParent` check, so items outside the viewport are not navigable.

This fix intercepts ArrowUp/ArrowDown keydown events in the menu handler, tracks the current virtual list index, uses `VVirtualScroll.scrollToIndex()` to scroll to the target item, and then focuses it.

## Playground Markup

```vue
<template>
  <v-app>
    <v-container style="max-width: 400px">
      <v-autocomplete
        label="Select an item"
        :items="items"
        density="comfortable"
      ></v-autocomplete>
    </v-container>
  </v-app>
</template>

<script setup>
  const items = Array.from({ length: 100 }, (_, i) => `Item ${i + 1}`)
</script>
```

## Testing

1. Open the playground above
2. Click on the autocomplete to open the dropdown
3. Press ArrowDown repeatedly - should navigate through ALL 100 items, scrolling as needed
4. Press ArrowUp at the first item - should wrap to the last item
5. Press ArrowDown at the last item - should wrap to the first item
6. Expected: smooth navigation through all items with proper scroll behavior
7. Before fix: navigation would only cycle through visible items (~10-15)

Fixes #22770