### PR TITLE
fix(VTextField): forward title attribute to root element

### DIFF
--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -348,7 +348,7 @@ export function isComposingIgnoreKey (e: KeyboardEvent): boolean {
 export function filterInputAttrs (attrs: Record<string, unknown>) {
   const [events, props] = pickWithRest(attrs, [onRE])
   const inputEvents = omit(events, bubblingEvents)
-  const [rootAttrs, inputAttrs] = pickWithRest(props, ['class', 'style', 'id', 'inert', /^data-/])
+  const [rootAttrs, inputAttrs] = pickWithRest(props, ['class', 'style', 'id', 'title', 'inert', /^data-/])
   Object.assign(rootAttrs, events)
   Object.assign(inputAttrs, inputEvents)
   return [rootAttrs, inputAttrs]


### PR DESCRIPTION
## Summary

The `title` HTML attribute was being routed to the `<input>` element via `inputAttrs` in `filterInputAttrs`. For VSelect, the actual `<input>` is hidden, so the title tooltip never appears on hover.

This fix adds `title` to the `rootAttrs` pick list in `filterInputAttrs`, so it gets applied to the root element where it can function as a native browser tooltip.

## Playground Markup

```vue
<template>
  <v-app>
    <v-container style="max-width: 400px">
      <v-select
        label="Select a fruit"
        title="Hover over me to see this tooltip"
        :items="["Apple", "Banana", "Cherry"]"
      ></v-select>
      
      <v-text-field
        label="Text field"
        title="This also has a title tooltip"
        model-value="Hello"
      ></v-text-field>
    </v-container>
  </v-app>
</template>

<script setup>
</script>
```

## Testing

1. Open the playground above
2. Hover over the VSelect component (not the dropdown, the closed state)
3. A native browser tooltip should appear saying "Hover over me to see this tooltip"
4. Hover over the VTextField - tooltip should also appear
5. Before fix: no tooltip appeared on VSelect

Fixes #22730