### PR TITLE
fix(VSlider): correct roundValue when min is not a multiple of step

### DIFF
--- a/packages/vuetify/src/components/VSlider/slider.ts
+++ b/packages/vuetify/src/components/VSlider/slider.ts
@@ -162,8 +162,8 @@ export const useSteps = (props: SliderProps) => {
     if (step.value <= 0) return value
 
     const clamped = clamp(value, min.value, max.value)
-    const offset = min.value % step.value
-    let newValue = Math.round((clamped - offset) / step.value) * step.value + offset
+    const stepsFromMin = Math.round((clamped - min.value) / step.value)
+    let newValue = min.value + stepsFromMin * step.value
 
     if (clamped > newValue && newValue + step.value > max.value) {
       newValue = max.value


### PR DESCRIPTION
## Summary

When `min` is not a multiple of `step` (e.g., `min=0.1`, `step=1`), the `roundValue` function in `useSteps` incorrectly computes `min % step` as an offset, causing floating point rounding errors. For example, a thumb at value 25 would display as 25.1 instead of 25.

The fix computes the number of steps from `min` and builds the rounded value from there, avoiding the offset-based approach entirely.

## Playground Markup

```vue
<template>
  <v-app>
    <v-container style="max-width: 400px">
      <p>With bug: thumb should show 25, not 25.1</p>
      <v-slider
        :min="0.1"
        :max="100"
        :step="1"
        thumb-label
        model-value="25"
      ></v-slider>
      
      <p class="mt-4">Another example: min=0.3, step=1, value=10</p>
      <v-slider
        :min="0.3"
        :max="50"
        :step="1"
        thumb-label
        model-value="10"
      ></v-slider>
    </v-container>
  </v-app>
</template>

<script setup>
</script>
```

## Testing

1. Open the playground above
2. Check the first slider thumb label - it should show **25** (not 25.1)
3. Click on the slider and drag - values should snap to integers (0.1, 1.1, 2.1, ... no, to 0, 1, 2...)
4. Check the second slider - thumb should show **10** (not 10.3)
5. Before fix: first slider showed 25.1, second showed 10.3

Fixes #22348