### PR TITLE
fix(VSelect): don't focus first item when menu opened via mouse click

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -185,6 +185,7 @@ export const VSelect = genericComponent<new <
     let keyboardLookupPrefix = ''
     let keyboardLookupIndex = 0
     let keyboardLookupLastTime: number
+    let openedByKeyboard = false
 
     const displayItems = computed(() => {
       const baseItems = search.value ? filteredItems.value : items.value
@@ -242,6 +243,7 @@ export const VSelect = genericComponent<new <
     function onMousedownControl () {
       if (menuDisabled.value) return
 
+      openedByKeyboard = false
       menu.value = !menu.value
     }
 
@@ -263,6 +265,7 @@ export const VSelect = genericComponent<new <
       }
 
       if (['Enter', 'ArrowDown', ' '].includes(e.key)) {
+        openedByKeyboard = true
         menu.value = true
       }
 
@@ -391,7 +394,11 @@ export const VSelect = genericComponent<new <
       }
       if (listRef.value && isFocused.value) {
         const index = getSelectedFocusableIndex()
-        listRef.value.focus(index >= 0 ? index : 'first')
+        if (index >= 0) {
+          listRef.value.focus(index)
+        } else if (openedByKeyboard) {
+          listRef.value.focus('first')
+        }
       }
     }
     function onAfterLeave () {


### PR DESCRIPTION
Fixes #22783

## Problem

Since v3.12.2, clicking a VSelect for the first time (no pre-selected value) causes the first list item to receive keyboard focus (:focus-visible highlight). This is a regression — v3.12.1 did not exhibit this behavior.

Root cause: `onAfterEnter` calls `listRef.value.focus('first')` when `getSelectedFocusableIndex()` returns `-1` (no selected item). This was intended for keyboard navigation but also fired on mouse-click-to-open.

## Fix

Track whether the menu was opened by keyboard or mouse using an `openedByKeyboard` flag:
- Set `openedByKeyboard = true` in `onKeydown` when Enter/ArrowDown/Space opens the menu
- Set `openedByKeyboard = false` in `onMousedownControl`
- In `onAfterEnter`, only call `focus('first')` when `openedByKeyboard` is true

When a value is already selected, the selected item is still focused regardless of how the menu was opened (unchanged behavior).