### PR TITLE
feat(VPagination, VDataTableFooter): ability to hide last page

### DIFF
--- a/packages/api-generator/src/locale/en/VPagination.json
+++ b/packages/api-generator/src/locale/en/VPagination.json
@@ -14,7 +14,7 @@
     "pageAriaLabel": "Label for each page button.",
     "prevIcon": "The icon to use for the prev button.",
     "previousAriaLabel": "Label for the previous button.",
-    "showFirstLastPage": "Show buttons for going to first and last page.",
+    "showFirstLastPage": "Show buttons for going to first and last page. Since v4.1.0 it accepts `'only-first'`, to only the first page button.",
     "start": "Specify the starting page.",
     "totalVisible": "Specify the total visible pagination numbers."
   },

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -133,6 +133,7 @@
       "headerProps": "3.5.0",
       "initialSortOrder": "3.11.0",
       "pageBy": "3.12.0",
+      "showFirstLastPage": "4.1.0",
       "sortIcon": "3.12.0"
     },
     "slots": {
@@ -147,6 +148,7 @@
       "groupExpandIcon": "3.10.0",
       "initialSortOrder": "3.11.0",
       "pageBy": "3.12.0",
+      "showFirstLastPage": "4.1.0",
       "sortIcon": "3.12.0"
     },
     "slots": {

--- a/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
@@ -72,7 +72,9 @@ export const makeVDataTableFooterProps = propsFactory({
   },
   showCurrentPage: Boolean,
 
-  ...pick(makeVPaginationProps(), ['showFirstLastPage']),
+  ...pick(makeVPaginationProps({
+    showFirstLastPage: true,
+  }), ['showFirstLastPage']),
 }, 'VDataTableFooter')
 
 export const VDataTableFooter = genericComponent<{ prepend: never }>()({

--- a/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
@@ -70,6 +70,18 @@ export const makeVDataTableFooterProps = propsFactory({
     ]),
   },
   showCurrentPage: Boolean,
+  showFirstPage: {
+    type: Boolean,
+    default: false,
+  },
+  showLastPage: {
+    type: Boolean,
+    default: false,
+  },
+  showFirstLastPage: {
+    type: Boolean,
+    default: true,
+  },
 }, 'VDataTableFooter')
 
 export const VDataTableFooter = genericComponent<{ prepend: never }>()({
@@ -137,6 +149,8 @@ export const VDataTableFooter = genericComponent<{ prepend: never }>()({
               nextAriaLabel={ props.nextPageLabel }
               previousAriaLabel={ props.prevPageLabel }
               rounded
+              showFirstPage
+              showLastPage
               showFirstLastPage
               totalVisible={ props.showCurrentPage ? 1 : 0 }
               variant="plain"

--- a/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
@@ -12,10 +12,11 @@ import { useLocale } from '@/composables/locale'
 
 // Utilities
 import { computed } from 'vue'
-import { genericComponent, omit, propsFactory, useRender } from '@/util'
+import { genericComponent, omit, pick, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType } from 'vue'
+import { makeVPaginationProps } from '../VPagination/VPagination'
 
 export const makeVDataTableFooterProps = propsFactory({
   color: String,
@@ -70,18 +71,8 @@ export const makeVDataTableFooterProps = propsFactory({
     ]),
   },
   showCurrentPage: Boolean,
-  showFirstPage: {
-    type: Boolean,
-    default: false,
-  },
-  showLastPage: {
-    type: Boolean,
-    default: false,
-  },
-  showFirstLastPage: {
-    type: Boolean,
-    default: true,
-  },
+
+  ...pick(makeVPaginationProps(), ['showFirstLastPage']),
 }, 'VDataTableFooter')
 
 export const VDataTableFooter = genericComponent<{ prepend: never }>()({
@@ -149,8 +140,6 @@ export const VDataTableFooter = genericComponent<{ prepend: never }>()({
               nextAriaLabel={ props.nextPageLabel }
               previousAriaLabel={ props.prevPageLabel }
               rounded
-              showFirstPage
-              showLastPage
               showFirstLastPage
               totalVisible={ props.showCurrentPage ? 1 : 0 }
               variant="plain"

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -343,12 +343,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
       >
         <ul class="v-pagination__list">
           {[true, 'only-first'].includes(props.showFirstLastPage) && (
-            <li
-              key="first"
-              class="v-pagination__first"
-              data-test="v-pagination-first"
-              data-testid="v-pagination-first"
-            >
+            <li key="first" class="v-pagination__first" data-test="v-pagination-first">
               { slots.first ? slots.first(controls.value.first!) : (
                 <VBtn _as="VPaginationBtn" { ...controls.value.first } />
               )}
@@ -389,12 +384,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
           </li>
 
           { props.showFirstLastPage === true && (
-            <li
-              key="last"
-              class="v-pagination__last"
-              data-test="v-pagination-last"
-              data-testid="v-pagination-last"
-            >
+            <li key="last" class="v-pagination__last" data-test="v-pagination-last">
               { slots.last ? slots.last(controls.value.last!) : (
                 <VBtn _as="VPaginationBtn" { ...controls.value.last } />
               )}

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -117,7 +117,18 @@ export const makeVPaginationProps = propsFactory({
     type: String,
     default: '...',
   },
-  showFirstLastPage: Boolean,
+  showFirstPage: {
+    type: Boolean,
+    default: false,
+  },
+  showLastPage: {
+    type: Boolean,
+    default: false,
+  },
+  showFirstLastPage: {
+    type: Boolean,
+    default: true,
+  },
 
   ...makeBorderProps(),
   ...makeComponentProps(),
@@ -278,7 +289,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
       const nextDisabled = !!props.disabled || page.value >= start.value + length.value - 1
 
       return {
-        first: props.showFirstLastPage ? {
+        first: (props.showFirstPage || props.showFirstLastPage) ? {
           icon: isRtl.value ? props.lastIcon : props.firstIcon,
           onClick: (e: Event) => setValue(e, start.value, 'first'),
           disabled: prevDisabled,
@@ -299,7 +310,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
           'aria-label': t(props.nextAriaLabel),
           'aria-disabled': nextDisabled,
         },
-        last: props.showFirstLastPage ? {
+        last: (props.showLastPage || props.showFirstLastPage) ? {
           icon: isRtl.value ? props.firstIcon : props.lastIcon,
           onClick: (e: Event) => setValue(e, start.value + length.value - 1, 'last'),
           disabled: nextDisabled,
@@ -339,8 +350,13 @@ export const VPagination = genericComponent<VPaginationSlots>()({
         data-test="v-pagination-root"
       >
         <ul class="v-pagination__list">
-          { props.showFirstLastPage && (
-            <li key="first" class="v-pagination__first" data-test="v-pagination-first">
+          { (props.showFirstPage || props.showFirstLastPage) && (
+            <li
+              key="first"
+              class="v-pagination__first"
+              data-test="v-pagination-first"
+              data-testid="v-pagination-first"
+            >
               { slots.first ? slots.first(controls.value.first!) : (
                 <VBtn _as="VPaginationBtn" { ...controls.value.first } />
               )}
@@ -380,11 +396,12 @@ export const VPagination = genericComponent<VPaginationSlots>()({
             )}
           </li>
 
-          { props.showFirstLastPage && (
+          { (props.showLastPage || props.showFirstLastPage) && (
             <li
               key="last"
               class="v-pagination__last"
               data-test="v-pagination-last"
+              data-testid="v-pagination-last"
             >
               { slots.last ? slots.last(controls.value.last!) : (
                 <VBtn _as="VPaginationBtn" { ...controls.value.last } />

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -27,7 +27,7 @@ import { computed, nextTick, shallowRef, toRef } from 'vue'
 import { createRange, genericComponent, keyValues, propsFactory, useRender } from '@/util'
 
 // Types
-import type { ComponentPublicInstance } from 'vue'
+import type { ComponentPublicInstance, PropType } from 'vue'
 
 type ItemSlot = {
   isActive: boolean
@@ -117,17 +117,9 @@ export const makeVPaginationProps = propsFactory({
     type: String,
     default: '...',
   },
-  showFirstPage: {
-    type: Boolean,
-    default: false,
-  },
-  showLastPage: {
-    type: Boolean,
-    default: false,
-  },
   showFirstLastPage: {
-    type: Boolean,
-    default: true,
+    type: [Boolean, String] as PropType<boolean | 'only-first'>,
+    default: false,
   },
 
   ...makeBorderProps(),
@@ -289,7 +281,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
       const nextDisabled = !!props.disabled || page.value >= start.value + length.value - 1
 
       return {
-        first: (props.showFirstPage || props.showFirstLastPage) ? {
+        first: [true, 'only-first'].includes(props.showFirstLastPage) ? {
           icon: isRtl.value ? props.lastIcon : props.firstIcon,
           onClick: (e: Event) => setValue(e, start.value, 'first'),
           disabled: prevDisabled,
@@ -310,7 +302,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
           'aria-label': t(props.nextAriaLabel),
           'aria-disabled': nextDisabled,
         },
-        last: (props.showLastPage || props.showFirstLastPage) ? {
+        last: props.showFirstLastPage === true ? {
           icon: isRtl.value ? props.firstIcon : props.lastIcon,
           onClick: (e: Event) => setValue(e, start.value + length.value - 1, 'last'),
           disabled: nextDisabled,
@@ -350,7 +342,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
         data-test="v-pagination-root"
       >
         <ul class="v-pagination__list">
-          { (props.showFirstPage || props.showFirstLastPage) && (
+          {[true, 'only-first'].includes(props.showFirstLastPage) && (
             <li
               key="first"
               class="v-pagination__first"
@@ -396,7 +388,7 @@ export const VPagination = genericComponent<VPaginationSlots>()({
             )}
           </li>
 
-          { (props.showLastPage || props.showFirstLastPage) && (
+          { props.showFirstLastPage === true && (
             <li
               key="last"
               class="v-pagination__last"

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
@@ -23,15 +23,6 @@ describe('VPagination', () => {
     expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(3)
   })
 
-  it('should render with first and last page buttons', () => {
-    render(() => (
-      <VPagination length="3" />
-    ))
-
-    expect(page.getByTestId('v-pagination-first')).toBeInTheDocument()
-    expect(page.getByTestId('v-pagination-last')).toBeInTheDocument()
-  })
-
   it('should render without first and last page buttons', () => {
     render(() => (
       <VPagination showFirstLastPage={ false } length="3" />
@@ -43,7 +34,7 @@ describe('VPagination', () => {
 
   it('should render without last page button', () => {
     render(() => (
-      <VPagination showFirstLastPage={ false } showFirstPage showlength="3" />
+      <VPagination showFirstLastPage="only-first" showlength="3" />
     ))
 
     expect(page.getByTestId('v-pagination-first')).toBeInTheDocument()

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
@@ -23,6 +23,33 @@ describe('VPagination', () => {
     expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(3)
   })
 
+  it('should render with first and last page buttons', () => {
+    render(() => (
+      <VPagination length="3" />
+    ))
+
+    expect(page.getByTestId('v-pagination-first')).toBeInTheDocument()
+    expect(page.getByTestId('v-pagination-last')).toBeInTheDocument()
+  })
+
+  it('should render without first and last page buttons', () => {
+    render(() => (
+      <VPagination showFirstLastPage={ false } length="3" />
+    ))
+
+    expect(page.getByTestId('v-pagination-first')).not.toBeInTheDocument()
+    expect(page.getByTestId('v-pagination-last')).not.toBeInTheDocument()
+  })
+
+  it('should render without last page button', () => {
+    render(() => (
+      <VPagination showFirstLastPage={ false } showFirstPage showlength="3" />
+    ))
+
+    expect(page.getByTestId('v-pagination-first')).toBeInTheDocument()
+    expect(page.getByTestId('v-pagination-last')).not.toBeInTheDocument()
+  })
+
   it('should react to mouse navigation', async () => {
     render(() => (
       <VPagination length="3" />

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
@@ -28,8 +28,8 @@ describe('VPagination', () => {
       <VPagination showFirstLastPage={ false } length="3" />
     ))
 
-    expect(page.getByTestId('v-pagination-first')).not.toBeInTheDocument()
-    expect(page.getByTestId('v-pagination-last')).not.toBeInTheDocument()
+    expect(screen.queryByCSS('[data-test="v-pagination-first"]')).not.toBeInTheDocument()
+    expect(screen.queryByCSS('[data-test="v-pagination-last"]')).not.toBeInTheDocument()
   })
 
   it('should render without last page button', () => {
@@ -37,8 +37,8 @@ describe('VPagination', () => {
       <VPagination showFirstLastPage="only-first" showlength="3" />
     ))
 
-    expect(page.getByTestId('v-pagination-first')).toBeInTheDocument()
-    expect(page.getByTestId('v-pagination-last')).not.toBeInTheDocument()
+    expect(screen.queryByCSS('[data-test="v-pagination-first"]')).toBeInTheDocument()
+    expect(screen.queryByCSS('[data-test="v-pagination-last"]')).not.toBeInTheDocument()
   })
 
   it('should react to mouse navigation', async () => {

--- a/packages/vuetify/vitest.config.ts
+++ b/packages/vuetify/vitest.config.ts
@@ -51,7 +51,7 @@ export default defineConfig(configEnv => {
         'process.env.TEST_TDD_ONLY': process.env.TEST_TDD_ONLY,
       },
       test: {
-        watch: true,
+        watch: false,
         slowTestThreshold: Infinity,
         setupFiles: ['../test/setup/to-have-been-warned.ts'],
         reporters: process.env.GITHUB_ACTIONS
@@ -104,8 +104,8 @@ export default defineConfig(configEnv => {
                     ].filter(v => v != null),
                   },
                 }),
-                ui: true,
-                headless: false, //! process.env.TEST_BAIL,
+                ui: false,
+                headless: !process.env.TEST_BAIL,
                 screenshotDirectory: '../test/__screenshots__',
                 commands,
                 instances: [{

--- a/packages/vuetify/vitest.config.ts
+++ b/packages/vuetify/vitest.config.ts
@@ -51,7 +51,7 @@ export default defineConfig(configEnv => {
         'process.env.TEST_TDD_ONLY': process.env.TEST_TDD_ONLY,
       },
       test: {
-        watch: false,
+        watch: true,
         slowTestThreshold: Infinity,
         setupFiles: ['../test/setup/to-have-been-warned.ts'],
         reporters: process.env.GITHUB_ACTIONS
@@ -104,8 +104,8 @@ export default defineConfig(configEnv => {
                     ].filter(v => v != null),
                   },
                 }),
-                ui: false,
-                headless: !process.env.TEST_BAIL,
+                ui: true,
+                headless: false, //! process.env.TEST_BAIL,
                 screenshotDirectory: '../test/__screenshots__',
                 commands,
                 instances: [{


### PR DESCRIPTION
## Description

Sometimes we don't know the last page.

- extend the existing `show-first-last-page` prop to enable showing only first page button without the last page button
- adds `show-first-last-page` to VDataTable

## Markup:

<details>
<summary>Playground</summary>

```vue
<template>
  <v-app>
    <div>
      <v-text-field v-model="search" label="Search" variant="outlined" />
    </div>

    <h1>header rowspan/colspan</h1>
    <v-data-table
      :headers="complex"
      :items="items"
      show-first-last-page="only-first"
    >
      <template #header.header>
        foo
      </template>
    </v-data-table>
  </v-app>
</template>

<script lang="ts">
  import { defineComponent } from 'vue'

  const serverItems = Array(1000).fill(0).map((_, i) => ({ id: i, name: `Name ${i}`, one: i, two: Math.random() > 0.5 ? 'foo' : 'bar', three: Math.random() > 0.5 ? 'hello' : 'world', four: i }))

  const items = Array(20).fill(0).map((_, i) => ({ id: i, name: `Name ${i}`, one: i, two: Math.random() > 0.5 ? 'foo' : 'bar', three: Math.random() > 0.5 ? 'hello' : 'world', four: i }))

  const groupItems = [
    { id: 1, name: 'Name 1', two: 'foo', three: 'hello' },
    { id: 2, name: 'Name 2', two: 'foo', three: 'world' },
    { id: 3, name: 'Name 3', two: 'foo', three: 'hello' },
    { id: 4, name: 'Name 4', two: 'bar', three: 'world' },
    { id: 5, name: 'Name 5', two: 'bar', three: 'world' },
    { id: 6, name: 'Name 6', two: 'bar', three: 'hello' },
  ]

  const srcs = {
    1: 'https://cdn.vuetifyjs.com/images/lists/1.jpg',
    2: 'https://cdn.vuetifyjs.com/images/lists/2.jpg',
    3: 'https://cdn.vuetifyjs.com/images/lists/3.jpg',
    4: 'https://cdn.vuetifyjs.com/images/lists/4.jpg',
    5: 'https://cdn.vuetifyjs.com/images/lists/5.jpg',
  }

  export default defineComponent({
    data: () => ({
      people: [
        { name: 'Sandra Adams', group: 'Group 1', avatar: srcs[1] },
        { name: 'Ali Connors', group: 'Group 1', avatar: srcs[2] },
        { name: 'Trevor Hansen', group: 'Group 1', avatar: srcs[3] },
        { name: 'Tucker Smith', group: 'Group 1', avatar: srcs[2] },
        { name: 'Britta Holt', group: 'Group 2', avatar: srcs[4] },
        { name: 'Jane Smith ', group: 'Group 2', avatar: srcs[5] },
        { name: 'John Smith', group: 'Group 2', avatar: srcs[1] },
        { name: 'Sandra Williams', group: 'Group 2', avatar: srcs[3] },
      ],
      groupItems,
      serverItems,
      simple: [
        {
          title: 'Name',
          id: 'name',
        },
        {
          title: 'Two',
          id: 'two',
        },
        {
          title: 'Three',
          id: 'three',
        },
        {
          title: 'Four',
          id: 'four',
          align: 'end',
        },
      ],
      test: [
        [
          {
            title: 'Group 1',
            colspan: 1,
            width: 200,
            fixed: true,
          },
          {
            title: 'Group 2',
            colspan: 1,
            fixed: true,
          },
          {
            title: 'Group 3',
            colspan: 2,
          },
        ],
        [
          {
            title: 'A',
            id: 'one',
            fixed: true,
            width: 200,
          },
          {
            title: 'B',
            id: 'two',
            fixed: true,
            width: 200,
          },
          {
            title: 'C',
            id: 'three',
            width: 200,
          },
          {
            title: 'D',
            id: 'four',
            width: 200,
          },
        ],
      ],
      complex: [
        [
          {
            id: 'data-table-select',
            rowspan: 3,
            fixed: true,
            width: 48,
          },
          {
            title: 'Name',
            id: 'name',
            rowspan: 3,
            fixed: true,
            width: 200,
          },
          {
            title: 'Header',
            colspan: 4,
            id: 'header',
          },
        ],
        [
          {
            title: 'Section',
            colspan: 2,
          },
          {
            title: 'Section',
            colspan: 2,
          },
        ],
        [
          {
            title: 'One',
            id: 'one',
            width: 200,
            fixed: true,
          },
          {
            title: 'Two',
            id: 'two',
            width: 200,
          },
          {
            title: 'Three',
            id: 'three',
          },
          {
            title: 'Four',
            id: 'four',
          },
        ],
      ],
      search: '',
      // headers: [
      //   {
      //     id: 'end',
      //     name: 'Two rows',
      //     maxWidth: '2fr',
      //   },
      //   {
      //     id: 'one',
      //     name: 'One',
      //   },
      //   {
      //     id: 'two',
      //     name: 'Two',
      //   },
      // ],
      items,
      remoteItems: serverItems.slice(0, 10),
      timeout: null as any,
      loading: false,
    }),
    methods: {
      getItems ({ startIndex, stopIndex }: any) {
        this.loading = true
        clearTimeout(this.timeout)
        this.timeout = setTimeout(() => {
          this.remoteItems = serverItems.slice(startIndex, stopIndex)
          this.loading = false
        }, 1000)
      },
    },
  })
</script>
```

</details>
