### PR TITLE
fix(VSnackbarQueue): avoid stale z-index

### DIFF
--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -336,7 +336,6 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
           noClickAnimation
           scrim={ false }
           scrollStrategy="none"
-          _disableGlobalStack
           onTouchstartPassive={ onTouchstart }
           onTouchend={ onTouchend }
           onAfterLeave={ onAfterLeave }


### PR DESCRIPTION
prompted by failed attempt to fix queue in #22790

Snackbars appear on top anyway, do not react to Esc key thanks to persistent, do not block router navigation ([`143ceaa`](https://github.com/vuetifyjs/vuetify/commit/143ceaa)), so it seems `_disableGlobalStack` does not really change much anymore.

Reproduction of stale z-index:

1. open dialog
2. push snackbar from dialog (green)
3. close dialog
4. push snackbar from the page (blue or red)

<img width="661" height="144" alt="image" src="https://github.com/user-attachments/assets/3bb124c1-3084-41d8-a089-644e9baf64c3" />

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex flex-column ga-5 align-center justify-center fill-height">
      <div class="d-flex ga-2">
        <v-btn color="info" @click="addMessage('info')">Info</v-btn>
        <v-btn color="error" @click="addMessage('error')">Error</v-btn>
      </div>

      <v-btn variant="outlined">
        Open Dialog
        <v-dialog activator="parent" max-width="500">
          <v-card class="border" title="Dialog">
            <v-card-text>Click outside to close</v-card-text>
            <v-card-actions>
              <v-spacer />
              <v-btn color="success" variant="flat" @click="addMessage('success')">Post Success</v-btn>
            </v-card-actions>
          </v-card>
        </v-dialog>
      </v-btn>

      <v-snackbar-queue
        v-model="messages"
        :total-visible="50"
        closable
        collapsed
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const messages = ref([])
  let messageCount = 0

  function addMessage (color) {
    messages.value.push({ text: `Message #${++messageCount}`, color })
  }
</script>
```
