### PR TITLE
fix(VOverlay): promote to GPU compositing layer to prevent flicker on WebKit

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -24,6 +24,12 @@
     right: 0
     will-change: transform
 
+    .v-btn__overlay,
+    .v-list-item__overlay,
+    .v-chip__overlay,
+    .v-field__overlay
+      will-change: opacity
+
   // Element
   .v-overlay__content
     outline: none

--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -22,6 +22,7 @@
     top: 0
     bottom: 0
     right: 0
+    transform: translateZ(0)
 
   // Element
   .v-overlay__content

--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -12,6 +12,24 @@
     top: 0
     display: contents
 
+  .v-overlay,
+  .v-list-item,
+  .v-chip,
+  .v-btn,
+  .v-field
+    will-change: transform
+
+  .v-overlay,
+  .v-list-item,
+  .v-chip,
+  .v-btn,
+  .v-field
+    .v-btn__overlay,
+    .v-list-item__overlay,
+    .v-chip__overlay,
+    .v-field__overlay
+      will-change: opacity
+
   .v-overlay
     --v-overlay-opacity: #{$overlay-opacity}
     border-radius: inherit
@@ -22,13 +40,6 @@
     top: 0
     bottom: 0
     right: 0
-    will-change: transform
-
-    .v-btn__overlay,
-    .v-list-item__overlay,
-    .v-chip__overlay,
-    .v-field__overlay
-      will-change: opacity
 
   // Element
   .v-overlay__content

--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -22,7 +22,7 @@
     top: 0
     bottom: 0
     right: 0
-    transform: translateZ(0)
+    will-change: transform
 
   // Element
   .v-overlay__content


### PR DESCRIPTION
## Description

When any `v-overlay`-based component (`v-dialog`, `v-menu`, etc.) is open, rapidly moving the cursor causes the overlay to flicker — for a single frame (~16ms) the content disappears and the page behind the overlay becomes visible.

[bug_proof.webm](https://github.com/user-attachments/assets/fbe3662b-945d-4058-85dd-127b411716eb)

Fixes the issue by adding `transform: translateZ(0)` to `.v-overlay`, which promotes it to a dedicated GPU compositing layer.

**Root cause:**

`.v-overlay__scrim` and `.v-overlay__content` are sibling elements with no GPU layer on their parent. During fast cursor movement, WebKit performs hit-testing on every `mousemove` event, which triggers compositing layer invalidation. Since neither child has its own GPU texture, the browser re-uploads them on each invalidation. During this re-upload, one child can be absent for exactly one frame — producing the visible flicker.

With `transform: translateZ(0)` on `.v-overlay`, both children share a single GPU texture. There is no inter-layer synchronization and no re-upload on cursor movement.

**Why this doesn't break `position: fixed` children:**

When a parent has `transform`, its `position: fixed` children are positioned relative to it instead of the viewport. This is safe here because `.v-overlay` itself is already `position: fixed` covering the full viewport (`top: 0; right: 0; bottom: 0; left: 0`), so `.v-overlay__scrim` still covers the full screen.

**Affected environments:** Linux (Tauri / WebKitGTK), potentially Safari on macOS/iOS. Chromium-based browsers are unaffected because their compositor promotes layers more aggressively by default.

## Markup:

```vue
<template>
  <v-app>
    <v-dialog max-width="400">
      <template #activator="{ props }">
        <v-btn v-bind="props">Open dialog</v-btn>
      </template>
      <v-card
        title="Flicker test"
        text="Open this dialog on WebKit (Linux/Tauri or Safari) and move your cursor rapidly. Without the fix, the dialog flickers for one frame on fast cursor movement."
      />
    </v-dialog>
  </v-app>
</template>
```



### My configuration where the issue is reproducible:

- OS: CachyOS x86_64
- CPU: Intel Core Ultra 9 185H (22 cores) @ 5.10 GHz
- GPU: Intel Arc Graphics (integrated) @ 2.35 GHz
- Laptop: Lenovo ThinkBook X IMH (model 21NW)
