### PR TITLE
fix(VCheckbox): align indeterminate opacity and color with MD3

### DIFF
--- a/packages/api-generator/src/locale/en/VSelectionControl.json
+++ b/packages/api-generator/src/locale/en/VSelectionControl.json
@@ -1,6 +1,8 @@
 {
   "props": {
     "baseColor": "Sets the color of the input when it is not focused.",
+    "indeterminate": "Styles the control as an intermediate 'partially selected' state.",
+    "indeterminateIcon": "The icon used when the control is in the indeterminate state.",
     "value": "The value used when the component is selected in a group. If not provided, a unique ID will be used."
   },
   "slots": {

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -315,6 +315,12 @@
       "menu-footer": "3.12.0"
     }
   },
+  "VSelectionControl": {
+    "props": {
+      "indeterminate": "4.1.0",
+      "indeterminateIcon": "4.1.0"
+    }
+  },
   "VSlider": {
     "events": {
       "start": "3.2.0",

--- a/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx
+++ b/packages/vuetify/src/components/VCheckbox/VCheckboxBtn.tsx
@@ -2,11 +2,9 @@
 import { makeVSelectionControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
 
 // Composables
-import { IconValue } from '@/composables/icons'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { toRef } from 'vue'
 import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
@@ -14,15 +12,10 @@ import type { VSelectionControlSlots } from '@/components/VSelectionControl/VSel
 import type { GenericProps } from '@/util'
 
 export const makeVCheckboxBtnProps = propsFactory({
-  indeterminate: Boolean,
-  indeterminateIcon: {
-    type: IconValue,
-    default: '$checkboxIndeterminate',
-  },
-
   ...makeVSelectionControlProps({
     falseIcon: '$checkboxOff',
     trueIcon: '$checkboxOn',
+    indeterminateIcon: '$checkboxIndeterminate',
   }),
 }, 'VCheckboxBtn')
 
@@ -52,18 +45,6 @@ export const VCheckboxBtn = genericComponent<new <T>(
       }
     }
 
-    const falseIcon = toRef(() => {
-      return indeterminate.value
-        ? props.indeterminateIcon
-        : props.falseIcon
-    })
-
-    const trueIcon = toRef(() => {
-      return indeterminate.value
-        ? props.indeterminateIcon
-        : props.trueIcon
-    })
-
     useRender(() => {
       const controlProps = omit(VSelectionControl.filterProps(props), ['modelValue'])
       return (
@@ -77,8 +58,6 @@ export const VCheckboxBtn = genericComponent<new <T>(
           style={ props.style }
           type="checkbox"
           onUpdate:modelValue={ onChange }
-          falseIcon={ falseIcon.value }
-          trueIcon={ trueIcon.value }
           aria-checked={ indeterminate.value ? 'mixed' : undefined }
           v-slots={ slots }
         />

--- a/packages/vuetify/src/components/VRadio/VRadio.tsx
+++ b/packages/vuetify/src/components/VRadio/VRadio.tsx
@@ -2,16 +2,16 @@
 import { makeVSelectionControlProps, VSelectionControl } from '@/components/VSelectionControl/VSelectionControl'
 
 // Utilities
-import { genericComponent, propsFactory, useRender } from '@/util'
+import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { VSelectionControlSlots } from '@/components/VSelectionControl/VSelectionControl'
 
 export const makeVRadioProps = propsFactory({
-  ...makeVSelectionControlProps({
+  ...omit(makeVSelectionControlProps({
     falseIcon: '$radioOff',
     trueIcon: '$radioOn',
-  }),
+  }), ['indeterminate', 'indeterminateIcon']),
 }, 'VRadio')
 
 export const VRadio = genericComponent<VSelectionControlSlots>()({

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -84,6 +84,7 @@
 
     .v-selection-control--disabled &,
     .v-selection-control--dirty &,
+    .v-selection-control--indeterminate &,
     .v-selection-control--error &
       > .v-icon
         opacity: 1

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -56,6 +56,7 @@ export type VSelectionControlSlots = {
 }
 
 export const makeVSelectionControlProps = propsFactory({
+  indeterminate: Boolean,
   label: String,
   baseColor: String,
   trueValue: null,
@@ -112,19 +113,24 @@ export function useSelectionControl (
       }
     },
   })
+  const isActive = computed(() => model.value || props.indeterminate)
   const { textColorClasses, textColorStyles } = useTextColor(() => {
     if (props.error || props.disabled) return undefined
 
-    return model.value ? props.color : props.baseColor
+    return isActive.value ? props.color : props.baseColor
   })
   const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => {
     return (
-      model.value &&
+      isActive.value &&
       !props.error &&
       !props.disabled
     ) ? props.color : props.baseColor
   })
-  const icon = computed(() => model.value ? props.trueIcon : props.falseIcon)
+  const icon = computed(() => (
+    props.indeterminate ? props.indeterminateIcon
+    : model.value ? props.trueIcon
+    : props.falseIcon
+  ))
 
   return {
     group,
@@ -254,6 +260,7 @@ export const VSelectionControl = genericComponent<new <T>(
             'v-selection-control',
             {
               'v-selection-control--dirty': model.value,
+              'v-selection-control--indeterminate': props.indeterminate,
               'v-selection-control--disabled': props.disabled,
               'v-selection-control--error': props.error,
               'v-selection-control--focused': isFocused.value,

--- a/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
+++ b/packages/vuetify/src/components/VSelectionControlGroup/VSelectionControlGroup.tsx
@@ -38,6 +38,7 @@ export const makeSelectionControlGroupProps = propsFactory({
   inline: Boolean,
   falseIcon: IconValue,
   trueIcon: IconValue,
+  indeterminateIcon: IconValue,
   ripple: {
     type: [Boolean, Object] as PropType<RippleDirectiveBinding['value']>,
     default: true,

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -43,7 +43,6 @@ export type VSwitchSlots =
   }
 
 export const makeVSwitchProps = propsFactory({
-  indeterminate: Boolean,
   inset: Boolean,
   flat: Boolean,
   loading: {


### PR DESCRIPTION
fixes #22039

- aligns VCheckbox indeterminate state with MD3
- moves `indeterminate` and `indeterminateIcon` down to VSelectionControl

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-app-bar class="px-3">
      <v-color-input
        v-model="color"
        class="mx-3"
        density="compact"
        label="Color"
        style="max-width: 220px"
        hide-details
      />
      <v-spacer />
      <v-icon-btn
        icon="mdi-theme-light-dark"
        @click="$vuetify.theme.toggle()"
      />
    </v-app-bar>
    <v-main>
      <v-defaults-provider :defaults="{ VCheckbox: { color }, VCheckboxBtn: { color } }">
        <v-container>
          <h2 class="text-h5 mb-4">VCheckbox — prop states</h2>
          <v-container fluid>
            <v-row>
              <v-col cols="4">on</v-col>
              <v-col cols="4">off</v-col>
              <v-col cols="4">indeterminate</v-col>
            </v-row>
            <v-row>
              <v-col cols="4">
                <v-checkbox :model-value="true" />
              </v-col>
              <v-col cols="4">
                <v-checkbox :model-value="false" />
              </v-col>
              <v-col cols="4">
                <v-checkbox indeterminate />
              </v-col>
            </v-row>
            <v-row>
              <v-col cols="4">on disabled</v-col>
              <v-col cols="4">off disabled</v-col>
              <v-col cols="4">indeterminate disabled</v-col>
            </v-row>
            <v-row>
              <v-col cols="4">
                <v-checkbox :model-value="true" disabled />
              </v-col>
              <v-col cols="4">
                <v-checkbox :model-value="false" disabled />
              </v-col>
              <v-col cols="4">
                <v-checkbox disabled indeterminate />
              </v-col>
            </v-row>
          </v-container>

          <h2 class="text-h5 mt-8 mb-4">VDataTable — show-select (partial selection)</h2>
          <v-data-table
            v-model="selectedRows"
            :headers="headers"
            :items="desserts"
            item-value="name"
            show-select
          />

          <h2 class="text-h5 mt-8 mb-4">VTreeview — selectable</h2>
          <v-sheet border rounded>
            <v-container fluid>
              <v-treeview
                v-model:selected="selected"
                :items="items"
                :selected-color="color"
                item-value="id"
                select-strategy="classic"
                return-object
                selectable
              />
            </v-container>
          </v-sheet>
        </v-container>
      </v-defaults-provider>
    </v-main>
  </v-app>
</template>

<script setup lang="ts">
  import { ref, shallowRef } from 'vue'

  const color = ref('#1976D2')

  const headers = [
    { title: 'Dessert (100g serving)', align: 'start' as const, key: 'name' },
    { title: 'Calories', align: 'end' as const, key: 'calories' },
    { title: 'Fat (g)', align: 'end' as const, key: 'fat' },
    { title: 'Carbs (g)', align: 'end' as const, key: 'carbs' },
    { title: 'Protein (g)', align: 'end' as const, key: 'protein' },
    { title: 'Iron (%)', align: 'end' as const, key: 'iron' },
  ]
  const desserts = [
    { name: 'Frozen Yogurt', calories: 159, fat: 6, carbs: 24, protein: 4, iron: 1 },
    { name: 'Ice cream sandwich', calories: 237, fat: 9, carbs: 37, protein: 4.3, iron: 1 },
    { name: 'Eclair', calories: 262, fat: 16, carbs: 23, protein: 6, iron: 7 },
    { name: 'Cupcake', calories: 305, fat: 3.7, carbs: 67, protein: 4.3, iron: 8 },
    { name: 'Gingerbread', calories: 356, fat: 16, carbs: 49, protein: 3.9, iron: 16 },
    { name: 'Jelly bean', calories: 375, fat: 0, carbs: 94, protein: 0, iron: 0 },
    { name: 'Lollipop', calories: 392, fat: 0.2, carbs: 98, protein: 0, iron: 2 },
    { name: 'Honeycomb', calories: 408, fat: 3.2, carbs: 87, protein: 6.5, iron: 45 },
    { name: 'Donut', calories: 452, fat: 25, carbs: 51, protein: 4.9, iron: 22 },
    { name: 'KitKat', calories: 518, fat: 26, carbs: 65, protein: 7, iron: 6 },
  ]
  const selectedRows = ref<string[]>(['Frozen Yogurt', 'Eclair'])

  const selected = shallowRef<any[]>([{ id: 2, title: 'Child #1' }])
  const items = ref([
    {
      id: 1,
      title: 'Root',
      children: [
        { id: 2, title: 'Child #1' },
        { id: 3, title: 'Child #2' },
        {
          id: 4,
          title: 'Child #3',
          children: [
            { id: 5, title: 'Grandchild #1' },
            { id: 6, title: 'Grandchild #2' },
          ],
        },
      ],
    },
  ])
</script>
```
