### PR TITLE
fix(VBtnToggle): remove forced opacity on buttons in toggle groups

### DIFF
--- a/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
+++ b/packages/vuetify/src/components/VBtnToggle/VBtnToggle.sass
@@ -9,6 +9,9 @@
       &.v-btn--variant-plain
         opacity: 1
 
+      // Remove default opacity for all buttons in toggle groups to prevent theme inconsistency
+      opacity: 1
+
 @include tools.layer('trumps')
   @media (forced-colors: active)
     .v-btn-toggle


### PR DESCRIPTION
## What

Remove forced opacity: 0.8 applied to buttons within .v-btn-toggle groups.

## Why

Fixes #22004

Buttons in .v-btn-toggle groups were receiving a default opacity of 0.8 which interfered with theme consistency and expected button appearance.

## How

Added opacity: 1 to buttons in toggle groups, ensuring they maintain their normal theme appearance without forced opacity values.

## Testing

- Verified the styling change is minimal and focused
- No other functionality affected