### PR TITLE
fix(VField): correct baseline alignment

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -15,7 +15,6 @@
     letter-spacing: $field-letter-spacing
     max-width: $field-max-width
     border-radius: $field-border-radius
-    contain: layout
     flex: 1 0
     grid-area: control
     position: relative


### PR DESCRIPTION
fixes #22648

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-row class="align-baseline">
        <v-col>
          <div class="position-relative">
            Correct alignment <span class="guideline" />
          </div>
        </v-col>
        <v-col>
          <v-text-field v-model="msg" messages="Message" />
        </v-col>
        <v-col>
          <v-text-field v-model="msg" hide-details />
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const msg = ref('Hello World!')
</script>

<style>
  .guideline {
    position: absolute;
    bottom: 0;
    left: 0;
    right: -100vw;
    border-bottom: 1px dashed red;
  }
</style>
```
