### PR TITLE
feat(VDatePicker): highlight the selected date range

### DIFF
--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.sass
@@ -72,3 +72,32 @@
 
   .v-date-picker-month__day .v-date-picker-month__events
     bottom: $date-picker-event-date-bottom
+
+  .v-date-picker-month__day--hover-range
+    &::before
+      content: ''
+      position: absolute
+      top: 2px
+      bottom: 2px
+      left: calc($date-picker-month-column-gap / -2)
+      right: calc($date-picker-month-column-gap / -2)
+      background-color: rgba(var(--v-theme-primary), 0.12)
+      pointer-events: none
+
+  .v-date-picker-month__day--hover-range-start,
+  .v-date-picker-month__day--hover-range-end
+    .v-btn
+      background-color: rgb(var(--v-theme-primary))
+      color: rgb(var(--v-theme-on-primary))
+
+  .v-date-picker-month__day--hover-range-start
+    &::before
+      border-top-left-radius: 100%
+      border-bottom-left-radius: 100%
+      left: calc(var(--v-date-picker-month-day-diff) / 2)
+
+  .v-date-picker-month__day--hover-range-end
+    &::before
+      border-top-right-radius: 100%
+      border-bottom-right-radius: 100%
+      right: calc(var(--v-date-picker-month-day-diff) / 2)

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerMonth.tsx
@@ -88,6 +88,7 @@ export const VDatePickerMonth = genericComponent<new <TModel>(
 
     const rangeStart = shallowRef()
     const rangeStop = shallowRef()
+    const hoverDate = shallowRef<Date | null>(null)
     const isReverse = shallowRef(false)
 
     const transition = toRef(() => {
@@ -144,6 +145,36 @@ export const VDatePickerMonth = genericComponent<new <TModel>(
         rangeStop.value = undefined
         model.value = [rangeStart.value]
       }
+    }
+
+    const isHoverRangeActive = computed(() => props.multiple === 'range' && !!rangeStart.value && !rangeStop.value && !!hoverDate.value)
+
+    function isInHoverRange (date: Date): boolean {
+      if (!isHoverRangeActive.value) return false
+      const start = rangeStart.value
+      const hover = hoverDate.value
+      const isAfterHover = adapter.isAfter(hover, start)
+      const rangeMin = isAfterHover ? start : hover
+      const rangeMax = isAfterHover ? hover : start
+      return !adapter.isBefore(date, rangeMin) && !adapter.isAfter(date, rangeMax)
+    }
+
+    function isHoverRangeStart (date: Date): boolean {
+      if (!isHoverRangeActive.value) return false
+      const start = rangeStart.value
+      const hover = hoverDate.value
+      return adapter.isAfter(hover, start)
+        ? adapter.isSameDay(date, start)
+        : adapter.isSameDay(date, hover)
+    }
+
+    function isHoverRangeEnd (date: Date): boolean {
+      if (!isHoverRangeActive.value) return false
+      const start = rangeStart.value
+      const hover = hoverDate.value
+      return adapter.isAfter(hover, start)
+        ? adapter.isSameDay(date, hover)
+        : adapter.isSameDay(date, start)
     }
 
     function getDateAriaLabel (item: any) {
@@ -247,6 +278,7 @@ export const VDatePickerMonth = genericComponent<new <TModel>(
             ref={ daysRef }
             key={ daysInMonth.value[0].date?.toString() }
             class="v-date-picker-month__days"
+            onMouseleave={ props.multiple === 'range' ? () => { hoverDate.value = null } : undefined }
           >
             { !props.hideWeekdays && weekdayLabels.value.map(weekDay => (
               <div
@@ -293,9 +325,13 @@ export const VDatePickerMonth = genericComponent<new <TModel>(
                       'v-date-picker-month__day--selected': isSelected,
                       'v-date-picker-month__day--week-end': item.isWeekEnd,
                       'v-date-picker-month__day--week-start': item.isWeekStart,
+                      'v-date-picker-month__day--hover-range': isInHoverRange(item.date),
+                      'v-date-picker-month__day--hover-range-start': isHoverRangeStart(item.date),
+                      'v-date-picker-month__day--hover-range-end': isHoverRangeEnd(item.date),
                     },
                   ]}
                   data-v-date={ !item.isDisabled ? item.isoDate : undefined }
+                  onMouseenter={ props.multiple === 'range' ? () => { hoverDate.value = item.date } : undefined }
                 >
                   { (props.showAdjacentMonths || !item.isAdjacent) && (
                     slots.day?.(slotProps) ?? (

--- a/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDatePicker/__tests__/VDatePicker.spec.browser.tsx
@@ -8,6 +8,67 @@ import { commands } from 'vitest/browser'
 import { nextTick, ref } from 'vue'
 
 describe('VDatePicker', () => {
+  it('shows hover range preview after selecting start date', async () => {
+    const model = ref<unknown[]>([])
+    render(() => (
+      <VDatePicker v-model={ model.value } multiple="range" />
+    ))
+
+    // Select the 10th as start date
+    await userEvent.click(await screen.findByText(10))
+    await expect.poll(() => model.value).toHaveLength(1)
+
+    // Hover over the 15th
+    const day15 = await screen.findByText(15)
+    await userEvent.hover(day15)
+
+    // Days between 10 and 15 (inclusive) should have the hover-range class
+    const hoverRangeDays = document.querySelectorAll('.v-date-picker-month__day--hover-range')
+    expect(hoverRangeDays).toHaveLength(6) // 10, 11, 12, 13, 14, 15
+
+    // The start day should have the hover-range-start class
+    const hoverStart = document.querySelectorAll('.v-date-picker-month__day--hover-range-start')
+    expect(hoverStart).toHaveLength(1)
+
+    // The hovered day should have the hover-range-end class
+    const hoverEnd = document.querySelectorAll('.v-date-picker-month__day--hover-range-end')
+    expect(hoverEnd).toHaveLength(1)
+  })
+
+  it('clears hover range preview when mouse leaves the calendar', async () => {
+    const model = ref<unknown[]>([])
+    render(() => (
+      <VDatePicker v-model={ model.value } multiple="range" />
+    ))
+
+    // Select the 10th as start date
+    await userEvent.click(await screen.findByText(10))
+
+    // Hover over the 15th
+    await userEvent.hover(await screen.findByText(15))
+    expect(document.querySelectorAll('.v-date-picker-month__day--hover-range').length).toBeGreaterThan(0)
+
+    // Move mouse out of the days container
+    await userEvent.unhover(document.querySelector('.v-date-picker-month__days')!)
+    expect(document.querySelectorAll('.v-date-picker-month__day--hover-range')).toHaveLength(0)
+  })
+
+  it('does not show hover range preview when range is already complete', async () => {
+    const model = ref<unknown[]>([])
+    render(() => (
+      <VDatePicker v-model={ model.value } multiple="range" />
+    ))
+
+    // Select full range: 10th to 15th
+    await userEvent.click(await screen.findByText(10))
+    await userEvent.click(await screen.findByText(15))
+    await expect.poll(() => model.value).toHaveLength(2)
+
+    // Hover over another day — no hover-range class should appear
+    await userEvent.hover(await screen.findByText(20))
+    expect(document.querySelectorAll('.v-date-picker-month__day--hover-range')).toHaveLength(0)
+  })
+
   it('selects a range of dates', async () => {
     const model = ref<unknown[]>([])
     render(() => (


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
Add a preview of the selected date range when you hover over a date
resolves #19428

<img width="405" height="432" alt="Screenshot from 2026-04-23 16-46-47" src="https://github.com/user-attachments/assets/093d8e68-0d3d-4b9c-8cdb-3678599e88a9" />


## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-date-input
    v-model="dateRange"
    multiple="range"
  />
</template>

<script setup>
import { ref } from 'vue'
const dateRange = ref([])
</script>
```
