### PR TITLE
docs(upgrade-guide): document CSS reset fallback for non-Sass setups

### DIFF
--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -128,6 +128,23 @@ Restoring most of the previous reset styles would be heavy-handed, but will get 
 }
 ```
 
+#### Applying without a build step
+
+The snippets above are plain CSS and require no Sass toolchain — drop them into any stylesheet, or inline them as a `<style>` block when using the CDN build with an importmap:
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@4/dist/vuetify.css">
+
+<style>
+  @layer vuetify-core.reset {
+    ul, ol, figure, details, summary { padding: 0; margin: 0; }
+    h1, h2, h3, h4, h5, h6, p { margin: 0; }
+  }
+</style>
+```
+
+Place the `<style>` block after Vuetify's stylesheet so the layer order declared in `vuetify.css` takes effect first; subsequent `@layer vuetify-core.reset { … }` rules append to the existing layer and won't override component styles.
+
 ### Layers
 
 Cascade layers are now being used everywhere. If you have other styles that are not using `@layer` they will now always take priority over vuetify.

--- a/packages/docs/src/pages/en/getting-started/upgrade-guide.md
+++ b/packages/docs/src/pages/en/getting-started/upgrade-guide.md
@@ -130,7 +130,7 @@ Restoring most of the previous reset styles would be heavy-handed, but will get 
 
 #### Applying without a build step
 
-The snippets above are plain CSS and require no Sass toolchain — drop them into any stylesheet, or inline them as a `<style>` block when using the CDN build with an importmap:
+The snippets above are plain CSS and do not require Sass compiler — drop them into any stylesheet, or inline them within `<style>` block when using the CDN build:
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@4/dist/vuetify.css">
@@ -143,7 +143,7 @@ The snippets above are plain CSS and require no Sass toolchain — drop them int
 </style>
 ```
 
-Place the `<style>` block after Vuetify's stylesheet so the layer order declared in `vuetify.css` takes effect first; subsequent `@layer vuetify-core.reset { … }` rules append to the existing layer and won't override component styles.
+Place the `<style>` block after Vuetify's stylesheet so the layer order declared in `vuetify.css` takes effect first. Subsequent `@layer vuetify-core.reset { … }` rules append to the existing layer and won't override component styles.
 
 ### Layers
 


### PR DESCRIPTION
## Summary

- Adds a small subsection under **Styles → CSS reset** clarifying that the existing `@layer vuetify-core.reset { … }` snippets are plain CSS and work without a Sass toolchain.
- Includes an inline `<style>` example for users on the CDN build / importmap setup, where importing CSS through a bundler isn't an option.
- Notes the placement requirement (`<style>` block after `vuetify.css`) so the layer order declared in `vuetify.css` is registered first.

The existing CSS reset section already covered the *what*; this addition covers the *where to put it* for users without Vite.