### PR TITLE
feat(VExpansionPanels): add hover prop to disable overlay effect

### DIFF
--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanel.sass
@@ -154,8 +154,17 @@
 
     @include tools.states('.v-expansion-panel-title__overlay', false)
 
+    &:hover
+      > .v-expansion-panel-title__overlay
+        opacity: calc(#{$expansion-panel-title-hover-overlay} * var(--v-theme-overlay-multiplier))
+
     &--focusable.v-expansion-panel-title--active
       @include tools.active-states('.v-expansion-panel-title__overlay')
+
+    &--no-hover
+      &:hover
+        > .v-expansion-panel-title__overlay
+          opacity: 0
 
   .v-expansion-panel-title__overlay
     background-color: currentColor

--- a/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelTitle.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/VExpansionPanelTitle.tsx
@@ -51,6 +51,10 @@ export const makeVExpansionPanelTitleProps = propsFactory({
     default: false,
   },
   readonly: Boolean,
+  hover: {
+    type: Boolean,
+    default: true,
+  },
 
   ...makeComponentProps(),
   ...makeDimensionProps(),
@@ -89,6 +93,7 @@ export const VExpansionPanelTitle = genericComponent<VExpansionPanelTitleSlots>(
             'v-expansion-panel-title--active': expansionPanel.isSelected.value,
             'v-expansion-panel-title--focusable': props.focusable,
             'v-expansion-panel-title--static': props.static,
+            'v-expansion-panel-title--no-hover': !props.hover,
           },
           backgroundColorClasses.value,
           props.class,

--- a/packages/vuetify/src/components/VExpansionPanel/__tests__/VExpansionPanels.spec.browser.tsx
+++ b/packages/vuetify/src/components/VExpansionPanel/__tests__/VExpansionPanels.spec.browser.tsx
@@ -27,6 +27,11 @@ const stories = {
       <VExpansionPanel hideActions title="Header" text="Content" />
     </VExpansionPanels>
   ),
+  'Without hover effect': (
+    <VExpansionPanels>
+      <VExpansionPanel hover={ false } title="Header" text="Content" />
+    </VExpansionPanels>
+  ),
   'With title & text props': (
     <VExpansionPanels>
       {['Header 1', 'Header 2'].map((title, i) => (
@@ -77,6 +82,26 @@ describe('VExpansionPanels', () => {
 
     expect(screen.getAllByCSS('.v-expansion-panel-title')[1]).toHaveClass('v-expansion-panel-title--active')
     expect(model.value).toBe('foo')
+  })
+
+  it('applies no-hover class when hover prop is false', () => {
+    render(() => (
+      <VExpansionPanels>
+        <VExpansionPanel hover={ false } title="Header" text="Content" />
+      </VExpansionPanels>
+    ))
+
+    expect(screen.getByCSS('.v-expansion-panel-title')).toHaveClass('v-expansion-panel-title--no-hover')
+  })
+
+  it('does not apply no-hover class by default', () => {
+    render(() => (
+      <VExpansionPanels>
+        <VExpansionPanel title="Header" text="Content" />
+      </VExpansionPanels>
+    ))
+
+    expect(screen.getByCSS('.v-expansion-panel-title')).not.toHaveClass('v-expansion-panel-title--no-hover')
   })
 
   showcase({ stories })

--- a/packages/vuetify/src/components/VExpansionPanel/_variables.scss
+++ b/packages/vuetify/src/components/VExpansionPanel/_variables.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '../../styles/settings';
 @use '../../styles/tools';
 
@@ -20,6 +21,7 @@ $expansion-panel-active-title-min-height: 64px !default;
 $expansion-panel-title-font-size: 0.9375rem !default;
 $expansion-panel-title-min-height: 48px !default;
 $expansion-panel-title-padding: 16px 24px !default;
+$expansion-panel-title-hover-overlay: map.get(settings.$states, 'hover') !default;
 
 // VExpansionPanelText
 $expansion-panel-text-padding: 8px 24px 16px !default;


### PR DESCRIPTION
Resolves #21615

  Adds `hover` boolean prop to `VExpansionPanelTitle` (and `VExpansionPanel` via prop spreading) to disable the hover overlay effect without relying on custom CSS.

  Changes:
  - `VExpansionPanelTitle.tsx` — `hover` prop (default `true`); toggles `v-expansion-panel-title--no-hover` class
  - `VExpansionPanel.sass` — `.v-expansion-panel-title--no-hover` sets overlay opacity to `0`; `$expansion-panel-title-hover-overlay` rule for global SASS override
  - `_variables.scss` — `$expansion-panel-title-hover-overlay` variable (defaults to existing hover opacity)
  - `VExpansionPanels.spec.browser.tsx` — 2 tests + showcase story

  Backwards compatible. Default `hover=true` preserves existing behaviour.

  Markup section:
   ```vue
  <template>
    <v-app>
      <v-container style="max-width: 600px">
        <p class="mb-2">Default (hover enabled)</p>
        <v-expansion-panels>
          <v-expansion-panel title="With hover" text="Hover to see overlay effect." />
        </v-expansion-panels>

        <p class="mt-6 mb-2">hover=false (overlay disabled)</p>
        <v-expansion-panels>
          <v-expansion-panel :hover="false" title="Without hover" text="No overlay on hover." />
        </v-expansion-panels>
      </v-container>
    </v-app>
  </template>

  <script>
    export default {
      name: 'Playground',
      setup () {
        return {}
      },
    }
  </script>
  ```