### PR TITLE
fix(VAlert): border opacity should win over theme variables

### DIFF
--- a/packages/vuetify/src/components/VAlert/VAlert.sass
+++ b/packages/vuetify/src/components/VAlert/VAlert.sass
@@ -21,8 +21,6 @@
       grid-template-areas: "prepend content append close" "prepend content . ."
 
     &.v-alert--border
-      --v-border-opacity: #{$alert-border-opacity}
-
       &.v-alert--border-start
         padding-inline-start: $alert-padding + $alert-border-thin-width
 
@@ -51,7 +49,7 @@
     border-radius: inherit
     bottom: 0
     left: 0
-    opacity: var(--v-border-opacity)
+    opacity: $alert-border-opacity
     position: absolute
     pointer-events: none
     right: 0


### PR DESCRIPTION
Regression after introducing CSS layers. All of the borders in [the examples](https://vuetifyjs.com/en/components/alerts/#border-color) get 0.12 opacity instead of the one from Sass variable (expected 0.38 by default).

<img width="662" height="156" alt="image" src="https://github.com/user-attachments/assets/9e68b8d9-faa8-414f-b6eb-ff370f520b54" />