### PR TITLE
docs(themes): remove UI Lib themes section

### DIFF
--- a/packages/docs/src/pages/en/resources/themes.md
+++ b/packages/docs/src/pages/en/resources/themes.md
@@ -39,16 +39,6 @@ The following themes are created and maintained by Vuetify. They are available f
 
 <br>
 
-## UI Lib
-
-UI Lib is a collection of free and premium themes built on top of Vuetify.
-
-<DocThemeVendor name="UI Lib" />
-
----
-
-<br>
-
 ## WrapPixel
 
 Create web apps and products using WrapPixel's product ready Vue Admin Templates, UI Kits, Themes, Templates and Dashboards.


### PR DESCRIPTION
## Description

UI Lib is no longer an active theme vendor, so this removes its section from the themes page.