### PR TITLE
fix(VSelect): prevent blur event from misfiring when clicking menu item

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -365,6 +365,12 @@ export const VSelect = genericComponent<new <
     }
     function onBlur (e: FocusEvent) {
       const target = e.target as Element
+      // If the blur originates from the text field itself, close the menu.
+      // However, when the blur originates from within the menu (e.g., clicking an option),
+      // we must keep the menu open to avoid emitting @blur on the VSelect component.
+      if (vMenuRef.value?.$el.contains(target)) {
+        return
+      }
       if (!vTextFieldRef.value?.$el.contains(target)) {
         menu.value = false
       }


### PR DESCRIPTION
## Summary

Fix the `blur` event incorrectly firing on `VSelect` when the user clicks a menu item to make a selection.

## Problem

When a user clicks an option in the VSelect dropdown menu, focus temporarily moves from the text field to the menu element. The `onBlur` handler in `VSelect.tsx` only checks if the blurred target is within the text field element. Since the menu is a separate element, the blur handler closes the menu and emits the `blur` event — even though the user is actively interacting with the select component.

This causes issues for consumers who listen to `@blur` on VSelect to detect when the user truly leaves the component.

## Fix

Add an early return in the `onBlur` handler: if the blur target is within the menu element (`vMenuRef.value?.$el`), skip the menu-close logic. This prevents false blur events while preserving the real blur behavior when focus leaves the component entirely.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #22828