### PR TITLE
fix(VMaskInput): prevent copy/paste corruption with masked values

### DIFF
--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -133,7 +133,11 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
 
       if (!pastedString) return
 
-      const pastedCharacters = [...pastedString]
+      // Strip mask delimiters from pasted text to prevent character
+      // misalignment when pasting masked values (e.g. copy/paste
+      // "1234-5678-9012-3456" into the same field).
+      const unmaskedPaste = mask.unmask(pastedString)
+      const pastedCharacters = [...(unmaskedPaste ?? pastedString)]
 
       const hasSelection = inputElement.selectionStart !== inputElement.selectionEnd
 


### PR DESCRIPTION
## Summary

Fix corrupted values when copy-pasting within a VMaskInput field that uses delimiters (e.g. `####-####-####-####`).

## Problem

When a user selects all content, copies it (Ctrl+C), then pastes it back (Ctrl+V), the pasted text includes mask delimiters like `-`. The `replaceSelection()` function processes these delimiters as regular characters. Each delimiter fails `mask.isValid()`, so `replaceCharacter()` returns `false` without advancing the caret. This causes subsequent characters to be placed at wrong positions, corrupting the value.

Example with mask `####-####-####-####`:
- Copy: `12345678-901234-5678`
- After paste: `12345678-90111-12345678-01111` (corrupted)

## Root Cause

`onPaste()` passes `pastedString` directly to `replaceSelection()` without stripping mask delimiters. When pasted text contains delimiters that align with the mask pattern, the character-by-character replacement logic breaks.

## Fix

Call `mask.unmask()` on the pasted string before processing. This strips mask delimiters and keeps only the actual data characters (e.g. `1234567890123456789012345678`), which are then correctly placed by `replaceSelection()`.

The `?? pastedString` fallback ensures the paste still works when no mask is configured.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #22831