### PR TITLE
fix(VTreeview): wire valueComparator into selection logic

### DIFF
--- a/packages/vuetify/src/components/VList/VList.tsx
+++ b/packages/vuetify/src/components/VList/VList.tsx
@@ -182,6 +182,7 @@ export const VList = genericComponent<new <S, A, O, T extends readonly any[]>(
       items,
       returnObject: toRef(() => props.returnObject),
       scrollToActive: toRef(() => props.navigationStrategy === 'track'),
+      valueComparator: toRef(() => props.valueComparator),
     })
 
     const lineClasses = toRef(() => props.lines ? `v-list--${props.lines}-line` : undefined)

--- a/packages/vuetify/src/components/VList/__tests__/VList.spec.browser.tsx
+++ b/packages/vuetify/src/components/VList/__tests__/VList.spec.browser.tsx
@@ -153,5 +153,67 @@ describe('VList', () => {
     expect(selectedItem.value).toEqual([items[1]])
   })
 
+  describe('value-comparator', () => {
+    it('should apply to initial selected', async () => {
+      const caseItems = [
+        {
+          title: 'Group A',
+          value: 'GROUP_A',
+          children: [
+            { title: 'Alpha', value: 'ALPHA' },
+            { title: 'Beta', value: 'BETA' },
+          ],
+        },
+        {
+          title: 'Group B',
+          value: 'GROUP_B',
+          children: [
+            { title: 'Gamma', value: 'GAMMA' },
+            { title: 'Delta', value: 'DELTA' },
+          ],
+        },
+      ]
+      const selected = ref<string[]>(['beta', 'delta'])
+
+      render(() => (
+        <VList
+          v-model:selected={ selected.value }
+          items={ caseItems }
+          opened={['GROUP_A', 'GROUP_B']}
+          selectStrategy="independent"
+          valueComparator={ (a: string, b: string) => a.toLowerCase() === b.toLowerCase() }
+        />
+      ))
+
+      expect(screen.getByText('Beta').closest('.v-list-item')).toHaveClass('v-list-item--active')
+      expect(screen.getByText('Delta').closest('.v-list-item')).toHaveClass('v-list-item--active')
+      expect(screen.getByText('Alpha').closest('.v-list-item')).not.toHaveClass('v-list-item--active')
+      expect(screen.getByText('Gamma').closest('.v-list-item')).not.toHaveClass('v-list-item--active')
+    })
+
+    it('should apply to initial activated', async () => {
+      const caseItems = [
+        { title: 'Alpha', value: 'ALPHA' },
+        { title: 'Beta', value: 'BETA' },
+        { title: 'Gamma', value: 'GAMMA' },
+      ]
+      const activated = ref<string[]>(['beta'])
+
+      render(() => (
+        <VList
+          v-model:activated={ activated.value }
+          items={ caseItems }
+          activatable
+          activeStrategy="independent"
+          valueComparator={ (a: string, b: string) => a.toLowerCase() === b.toLowerCase() }
+        />
+      ))
+
+      expect(screen.getByText('Beta').closest('.v-list-item')).toHaveClass('v-list-item--active')
+      expect(screen.getByText('Alpha').closest('.v-list-item')).not.toHaveClass('v-list-item--active')
+      expect(screen.getByText('Gamma').closest('.v-list-item')).not.toHaveClass('v-list-item--active')
+    })
+  })
+
   showcase({ stories })
 })

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -185,6 +185,35 @@ describe.each([
       await userEvent.click(screen.getByText(/Human Resources/))
       expect(onActivated).toHaveBeenCalledTimes(2)
     })
+
+    it('should apply value-comparator to initial activated', async () => {
+      const caseItems = [
+        {
+          title: 'Group A',
+          value: 'GROUP_A',
+          children: [
+            { title: 'Alpha', value: 'ALPHA' },
+            { title: 'Beta', value: 'BETA' },
+          ],
+        },
+      ]
+      const activated = ref<string[]>(['beta'])
+
+      render(() => (
+        <VTreeview
+          v-model:activated={ activated.value }
+          items={ caseItems }
+          activatable
+          openAll
+          activeStrategy="independent"
+          valueComparator={ (a: string, b: string) => a.toLowerCase() === b.toLowerCase() }
+          itemsRegistration={ itemsRegistration }
+        />
+      ))
+
+      expect(screen.getByText('Beta').closest('.v-list-item')).toHaveClass('v-list-item--active')
+      expect(screen.getByText('Alpha').closest('.v-list-item')).not.toHaveClass('v-list-item--active')
+    })
   })
 
   describe('select', () => {
@@ -302,6 +331,43 @@ describe.each([
       expect(selected.value).toStrictEqual([])
       await userEvent.click(screen.getByText(/Vuetify/).parentElement!.previousElementSibling!)
       expect(selected.value).toStrictEqual([4, 201, 202, 203, 204, 205, 301, 302])
+    })
+
+    it('should apply value-comparator to initial selected', async () => {
+      const caseItems = [
+        {
+          title: 'Group A',
+          value: 'GROUP_A',
+          children: [
+            { title: 'Alpha', value: 'ALPHA' },
+            { title: 'Beta', value: 'BETA' },
+          ],
+        },
+        {
+          title: 'Group B',
+          value: 'GROUP_B',
+          children: [
+            { title: 'Gamma', value: 'GAMMA' },
+            { title: 'Delta', value: 'DELTA' },
+          ],
+        },
+      ]
+      const selected = ref<string[]>(['beta', 'delta'])
+
+      render(() => (
+        <VTreeview
+          v-model:selected={ selected.value }
+          items={ caseItems }
+          selectable
+          openAll
+          selectStrategy="independent"
+          valueComparator={ (a: string, b: string) => a.toLowerCase() === b.toLowerCase() }
+          itemsRegistration={ itemsRegistration }
+        />
+      ))
+
+      const inputs = screen.getAllByCSS('.v-checkbox-btn input') as HTMLInputElement[]
+      expect(inputs.filter(el => el.checked)).toHaveLength(2)
     })
   })
 

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -40,7 +40,7 @@ import type { ActiveStrategy } from './activeStrategies'
 import type { OpenStrategy } from './openStrategies'
 import type { SelectStrategy } from './selectStrategies'
 import type { ListItem } from '@/composables/list-items'
-import type { EventProp } from '@/util'
+import type { EventProp, ValueComparator } from '@/util'
 
 export type ActiveStrategyProp =
   | 'single-leaf'
@@ -153,10 +153,12 @@ export const useNested = (
     items,
     returnObject,
     scrollToActive,
+    valueComparator,
   }: {
     items: Ref<ListItem[]>
     returnObject: MaybeRefOrGetter<boolean>
     scrollToActive: MaybeRefOrGetter<boolean>
+    valueComparator?: MaybeRefOrGetter<ValueComparator | undefined>
   },
 ) => {
   let isUnmounted = false
@@ -212,18 +214,49 @@ export const useNested = (
     }
   })
 
+  const flatItems = computed(() => {
+    const flat: ListItem[] = []
+    const stack = [...items.value]
+    while (stack.length) {
+      const item = stack.shift()!
+      flat.push(item)
+      if (item.children) stack.push(...item.children)
+    }
+    return flat
+  })
+
+  function resolveValue (value: unknown): unknown {
+    const comparator = toValue(valueComparator)
+    if (!comparator) return value
+    const _returnObject = toValue(returnObject)
+    for (const item of flatItems.value) {
+      const itemVal = _returnObject ? toRaw(item.raw) : item.value
+      if (comparator(value, itemVal)) return itemVal
+    }
+    return value
+  }
+
   const activated = useProxiedModel(
     props,
     'activated',
     props.activated,
-    v => activeStrategy.value.in(v, children.value, parents.value),
+    v => activeStrategy.value.in(
+      Array.isArray(v) ? v.map(resolveValue) : v,
+      children.value,
+      parents.value,
+    ),
     v => activeStrategy.value.out(v, children.value, parents.value),
   )
   const selected = useProxiedModel(
     props,
     'selected',
     props.selected,
-    v => selectStrategy.value.in(v, children.value, parents.value, disabled.value),
+    v => selectStrategy.value.in(
+      Array.isArray(v) ? v.map(resolveValue) : v,
+      children.value,
+      parents.value,
+      disabled.value,
+    ),
     v => selectStrategy.value.out(v, children.value, parents.value),
   )
 

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -218,7 +218,7 @@ export const useNested = (
     const flat: ListItem[] = []
     const stack = [...items.value]
     while (stack.length) {
-      const item = stack.shift()!
+      const item = stack.pop()!
       flat.push(item)
       if (item.children) stack.push(...item.children)
     }


### PR DESCRIPTION
## Description
Fixes #22013

The `valueComparator` prop existed in VList/VTreeview's props 
(inherited from `makeItemsProps()`) but was never wired into the 
actual selection logic in `useNested`.

## Root Cause
The `selectStrategy.in()` and `activeStrategy.in()` transforms that 
convert the external `selected`/`activated` arrays into the internal 
state Map never called the comparator, so custom equality checks 
were completely ignored.

## Fix
**nested.ts:**
- Added `valueComparator` as an optional option to `useNested`
- Added `flatItems` computed that flattens the entire item tree
- Added `resolveValue(value)` that uses `valueComparator` to find 
  the canonical item reference matching an incoming value
- Updated both `activated` and `selected` transforms to map incoming 
  values through `resolveValue`

**VList.tsx:**
- Passes `valueComparator: toRef(() => props.valueComparator)` 
  into the `useNested` call

Since VTreeview already spreads `VList.filterProps(props)` into 
`<VList>`, the prop flows through automatically:
VTreeview → VList → useNested → resolveValue

## How to Test
1. Create a VTreeview with a custom `valueComparator`
2. Select some items
3. Verify the comparator function is called (check console)

## Playground

```vue
<template>
  <v-app theme="dark">
    <v-container class="py-6" fluid>
      <v-row align="center" class="mb-4">
        <v-col cols="auto">
          <v-switch
            v-model="comparatorEnabled"
            color="primary"
            label="value-comparator"
            hide-details
            inset
          />
        </v-col>
        <v-col>
          <v-chip v-if="!comparatorEnabled" color="success" size="small" variant="tonal">
            exact refs — expecting Beta & Delta
          </v-chip>
          <v-chip v-else color="warning" size="small" variant="tonal">
            fresh refs — expecting Alpha & Gamma
          </v-chip>
        </v-col>
      </v-row>

      <v-row>
        <v-col cols="6">
          <v-card title="VList">
            <v-list
              v-model:opened="listOpened"
              v-model:selected="listSelected"
              :items="items"
              :value-comparator="comparatorEnabled ? byId : undefined"
              select-strategy="independent"
              selectable
            >
              <template #prepend="{ isSelected }">
                <v-checkbox-btn :model-value="isSelected" density="compact" />
              </template>
            </v-list>
            <v-divider />
            <v-card-text>
              <pre class="text-caption">{{ fmt(listSelected) }}</pre>
            </v-card-text>
          </v-card>
        </v-col>

        <v-col cols="6">
          <v-card title="VTreeview">
            <v-treeview
              v-model:selected="treeSelected"
              :items="items"
              :value-comparator="comparatorEnabled ? byId : undefined"
              select-strategy="independent"
              open-all
              selectable
            />
            <v-divider />
            <v-card-text>
              <pre class="text-caption">{{ fmt(treeSelected) }}</pre>
            </v-card-text>
          </v-card>
        </v-col>
      </v-row>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, watch } from 'vue'

  const items = [
    {
      title: 'Group A',
      value: { id: 10 },
      children: [
        { title: 'Alpha', value: { id: 1 } },
        { title: 'Beta', value: { id: 2 } },
      ],
    },
    {
      title: 'Group B',
      value: { id: 20 },
      children: [
        { title: 'Gamma', value: { id: 3 } },
        { title: 'Delta', value: { id: 4 } },
      ],
    },
  ]

  // exact same object refs as treeItems — pre-select Beta and Delta
  const exactRefs = [items[0].children[1].value, items[1].children[1].value]
  const freshRefs = () => [{ id: 1 }, { id: 3 }]

  const byId = (a, b) => a?.id === b?.id
  const fmt = v => JSON.stringify(v, null, 2)

  const comparatorEnabled = ref(false)
  const listOpened = ref([items[0].value, items[1].value])
  const listSelected = ref([...exactRefs])
  const treeSelected = ref([...exactRefs])

  watch(comparatorEnabled, v => {
    listSelected.value = v ? freshRefs() : [...exactRefs]
    treeSelected.value = v ? freshRefs() : [...exactRefs]
  })
</script>
```