### PR TITLE
fix(VHover): reconcile actual hover state when re-enabled

### DIFF
--- a/packages/docs/src/examples/v-hover/prop-disabled.vue
+++ b/packages/docs/src/examples/v-hover/prop-disabled.vue
@@ -1,22 +1,79 @@
 <template>
-  <v-row class="align-center justify-center">
-    <v-col cols="12">
-      <v-hover
-        v-slot="{ isHovering, props }"
-        disabled
-      >
-        <v-card
-          :elevation="isHovering ? 12 : 2"
-          class="mx-auto"
-          height="350"
-          max-width="350"
-          v-bind="props"
+  <v-container>
+    <v-hover
+      v-slot="{ isHovering, props: hoverProps }"
+      :disabled="pending"
+    >
+      <v-card v-bind="hoverProps" class="pa-4">
+        Quarterly report
+        <span v-if="pending"> (Generating…)</span>
+        <v-overlay
+          :model-value="isHovering"
+          class="d-flex pa-2 justify-end align-center"
+          contained
         >
-          <v-card-text class="my-4 text-center text-title-large">
-            Hover over me!
-          </v-card-text>
-        </v-card>
-      </v-hover>
-    </v-col>
-  </v-row>
+          <v-btn
+            :color="success ? 'success' : ''"
+            :loading="pending && !success"
+            :text="success ? 'Done!' : 'Generate'"
+            style="min-width: 120px"
+            @click="generate"
+          ></v-btn>
+        </v-overlay>
+      </v-card>
+    </v-hover>
+  </v-container>
 </template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const pending = ref(false)
+  const success = ref(false)
+
+  function generate () {
+    if (pending.value) return
+
+    pending.value = true
+
+    setTimeout(() => {
+      success.value = true
+
+      setTimeout(() => {
+        pending.value = false
+
+        setTimeout(() => {
+          success.value = false
+        }, 300) // small delay to keep final state for fade-out
+      }, 1200) // time to show "success" state
+    }, 2000) // simulated delay for the action processing
+  }
+</script>
+
+<script>
+  export default {
+    data: () => ({
+      pending: false,
+      success: false,
+    }),
+    methods: {
+      generate () {
+        if (this.pending) return
+
+        this.pending = true
+
+        setTimeout(() => {
+          this.success = true
+
+          setTimeout(() => {
+            this.pending = false
+
+            setTimeout(() => {
+              this.success = false
+            }, 300)
+          }, 1200)
+        }, 2000)
+      },
+    },
+  }
+</script>

--- a/packages/docs/src/pages/en/components/hover.md
+++ b/packages/docs/src/pages/en/components/hover.md
@@ -42,7 +42,7 @@ The `v-hover` component provides a simple interface for handling hover states fo
 
 #### Disabled
 
-The **disabled** prop disables the hover functionality.
+Use the **disabled** prop to pause hover tracking. When re-enabled, the value updates to reflect the cursor's current position.
 
 <ExamplesExample file="v-hover/prop-disabled" />
 

--- a/packages/vuetify/src/components/VHover/VHover.tsx
+++ b/packages/vuetify/src/components/VHover/VHover.tsx
@@ -3,6 +3,7 @@ import { makeDelayProps, useDelay } from '@/composables/delay'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
+import { shallowRef, watch } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 type VHoverSlots = {
@@ -33,7 +34,22 @@ export const VHover = genericComponent<VHoverSlots>()({
 
   setup (props, { slots }) {
     const isHovering = useProxiedModel(props, 'modelValue')
-    const { runOpenDelay, runCloseDelay } = useDelay(props, value => !props.disabled && (isHovering.value = value))
+
+    // track hover state regardless of disabled, so we can reconcile
+    const internal = shallowRef(false)
+    const { runOpenDelay, runCloseDelay } = useDelay(props, value => {
+      internal.value = value
+
+      if (!props.disabled) {
+        isHovering.value = value
+      }
+    })
+
+    watch(() => props.disabled, (val, old) => {
+      if (old && !val) {
+        isHovering.value = internal.value
+      }
+    })
 
     return () => slots.default?.({
       isHovering: isHovering.value,

--- a/packages/vuetify/src/components/VHover/__tests__/VHover.spec.browser.tsx
+++ b/packages/vuetify/src/components/VHover/__tests__/VHover.spec.browser.tsx
@@ -1,8 +1,8 @@
 import { VHover } from '../VHover'
 
 // Utilities
-import { ref } from 'vue'
 import { render, screen, userEvent, wait } from '@test'
+import { ref } from 'vue'
 
 describe('VHover', () => {
   it('should react on mouse events', async () => {

--- a/packages/vuetify/src/components/VHover/__tests__/VHover.spec.browser.tsx
+++ b/packages/vuetify/src/components/VHover/__tests__/VHover.spec.browser.tsx
@@ -1,6 +1,7 @@
 import { VHover } from '../VHover'
 
 // Utilities
+import { ref } from 'vue'
 import { render, screen, userEvent, wait } from '@test'
 
 describe('VHover', () => {
@@ -45,6 +46,34 @@ describe('VHover', () => {
     await expect.element(element).not.toHaveClass('bg-primary')
 
     await userEvent.unhover(element)
+    await expect.element(element).not.toHaveClass('bg-primary')
+  })
+
+  it('should reconcile hover state when re-enabled', async () => {
+    const disabled = ref(false)
+
+    render(() => (
+      <VHover disabled={ disabled.value }>
+        {{
+          default: ({ isHovering, props }) => (
+            <div { ...props } class={['hover-element', isHovering && 'bg-primary']}>foobar</div>
+          ),
+        }}
+      </VHover>
+    ))
+
+    const element = screen.getByCSS('.hover-element')
+
+    await userEvent.hover(element)
+    await expect.element(element).toHaveClass('bg-primary')
+
+    // Disable while hovered, then move cursor away while disabled — no events observed.
+    disabled.value = true
+    await userEvent.unhover(element)
+    expect(element).toHaveClass('bg-primary')
+
+    // Re-enabling should reconcile to the actual cursor position (not hovered).
+    disabled.value = false
     await expect.element(element).not.toHaveClass('bg-primary')
   })
 


### PR DESCRIPTION
fixes #22498

- keep track of actual hover state to serve correct `isHovering` when `disabled` changes to `false`

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-hover
        v-slot="{ isHovering, props: hoverProps }"
        :disabled="pending"
      >
        <v-card v-bind="hoverProps" class="pa-4">
          Some Information
          <span v-if="pending"> (Action Triggered)</span>
          <v-overlay
            :model-value="isHovering"
            class="d-flex pa-2 justify-end align-center"
            contained
          >
            <v-btn
              :color="success ? 'success' : ''"
              :loading="pending && !success"
              :text="success ? 'Done!' : 'Do Action'"
              style="min-width: 120px"
              @click="doSomething"
            />
          </v-overlay>
        </v-card>
      </v-hover>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const pending = ref(false)
  const success = ref(false)

  function doSomething () {
    if (pending.value) return

    pending.value = true

    setTimeout(() => {
      success.value = true

      setTimeout(() => {
        pending.value = false

        setTimeout(() => {
          success.value = false
        }, 300) // small delay to keep final state for fade-out
      }, 1200) // time to show "success" state
    }, 2000) // simulated delay for the action processing
  }
</script>
```
