### PR TITLE
fix(VTreeview): resolve search with load-children and return-object

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -125,12 +125,12 @@ export const VTreeview = genericComponent<new <T, O, A, S, M>(
 
     function getChildren (id: unknown) {
       const arr: unknown[] = []
-      const queue = ((vListRef.value?.children.get(id) ?? []).slice())
+      const queue = ((vListRef.value?.children.get(toRaw(id)) ?? []).slice())
       while (queue.length) {
         const child = queue.shift()
         if (!child) continue
         arr.push(child)
-        queue.push(...((vListRef.value?.children.get(child) ?? []).slice()))
+        queue.push(...((vListRef.value?.children.get(toRaw(child)) ?? []).slice()))
       }
       return arr
     }


### PR DESCRIPTION
## Description

Fixes #22533

When `return-object` is enabled on VTreeview, the internal `getChildren()` helper used during search directly passed the item reference (which may be a reactive proxy) to `vListRef.children.get()`. However, the VList children map is built by `useNested`'s `updateInternalMaps()`, which stores de-proxied keys via `toRaw()` when `returnObject` is true.

This reference mismatch caused `getChildren()` to return an empty array for items loaded via `loadChildren`, making their children invisible during search even though the tree was correctly expanded.

### Root Cause

In `VTreeview.tsx` `getChildren()` (line 126), the map lookup used the raw `id` parameter directly. But `useNested`'s `updateInternalMaps()` applies `toRaw()` to item references when building the children map keys (when `returnObject` is true). When items originate from a reactive data source, the reference in `filteredItems` is the reactive proxy while the map key is the de-proxied version.

### Fix

Apply `toRaw()` to the lookup keys in both `getChildren()` calls (initial lookup and recursive child lookup), matching the same de-proxying that `updateInternalMaps()` applies when building the map.

### Changes

- `packages/vuetify/src/components/VTreeview/VTreeview.tsx`: +2 -2 lines

## Markup

```vue
<template>
  <v-treeview
    :items="items"
    :load-children="loadChildren"
    return-object
    search="Dir1"
    open-all
  />
</template>
```
