### PR TITLE
fix(VAutocomplete, VSelect): keep menu open when scrollbar interaction blurs focus to body

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -357,6 +357,13 @@ export const VAutocomplete = genericComponent<new <
     function onFocusout (e: FocusEvent) {
       listHasFocus.value = false
       if (!vTextFieldRef.value?.$el.contains(e.relatedTarget as Node)) {
+        if (
+          menu.value &&
+          e.relatedTarget == null &&
+          vMenuRef.value?.contentEl?.matches(':hover')
+        ) {
+          return
+        }
         isFocused.value = false
       }
     }
@@ -475,7 +482,13 @@ export const VAutocomplete = genericComponent<new <
           { ...textFieldProps }
           v-model={ search.value }
           onUpdate:modelValue={ onUpdateModelValue }
-          v-model:focused={ isFocused.value }
+          focused={ isFocused.value }
+          onUpdate:focused={ (val: boolean) => {
+            if (!val && menu.value && vMenuRef.value?.contentEl?.matches(':hover')) {
+              return
+            }
+            isFocused.value = val
+          }}
           validationValue={ model.externalValue }
           counterValue={ counterValue.value }
           dirty={ isDirty }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -485,6 +485,27 @@ describe('VAutocomplete', () => {
     expect(input).not.toHaveAttribute('placeholder')
   })
 
+  it('should keep menu open when scrollbar interaction blurs focus while hovering menu', async () => {
+    const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`)
+    const { element } = render(() => <VAutocomplete items={ items } />)
+
+    const input = within(element).getByCSS('input') as HTMLInputElement
+    await userEvent.click(input)
+
+    const listbox = await screen.findByRole('listbox')
+    await expect.element(listbox).toBeVisible()
+
+    // Move mouse over menu content (mimics scrollbar drag where cursor stays on menu)
+    await userEvent.hover(listbox)
+
+    // Browser fires focusout with relatedTarget=null when scrollbar is dragged.
+    // With the menu hovered, the fix should keep the menu open.
+    input.dispatchEvent(new FocusEvent('focusout', { relatedTarget: null, bubbles: true }))
+    await waitIdle()
+
+    await expect.element(screen.queryByRole('listbox')!).toBeVisible()
+  })
+
   it('should keep TextField focused while selecting items from open menu', async () => {
     const { element } = render(() => (
       <VAutocomplete

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -464,6 +464,13 @@ export const VCombobox = genericComponent<new <
     function onFocusout (e: FocusEvent) {
       listHasFocus.value = false
       if (!vTextFieldRef.value?.$el.contains(e.relatedTarget as Node)) {
+        if (
+          menu.value &&
+          e.relatedTarget == null &&
+          vMenuRef.value?.contentEl?.matches(':hover')
+        ) {
+          return
+        }
         isFocused.value = false
       }
     }

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -891,5 +891,23 @@ describe('VCombobox', () => {
     })
   })
 
+  it('should keep menu open when scrollbar interaction blurs focus while hovering menu', async () => {
+    const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`)
+    const { element } = render(() => <VCombobox items={ items } />)
+
+    await userEvent.click(element)
+
+    const listbox = await screen.findByRole('listbox')
+    await expect.element(listbox).toBeVisible()
+
+    await userEvent.hover(listbox)
+
+    const input = element.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(new FocusEvent('focusout', { relatedTarget: null, bubbles: true }))
+    await waitIdle()
+
+    await expect.element(screen.queryByRole('listbox')!).toBeVisible()
+  })
+
   showcase({ stories })
 })

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -408,6 +408,13 @@ export const VSelect = genericComponent<new <
         !vTextFieldRef.value?.$el.contains(e.relatedTarget as Node) &&
         !(e.currentTarget as HTMLElement).contains(e.relatedTarget as Node)
       ) {
+        if (
+          menu.value &&
+          e.relatedTarget == null &&
+          vMenuRef.value?.contentEl?.matches(':hover')
+        ) {
+          return
+        }
         isFocused.value = false
       }
     }
@@ -469,7 +476,13 @@ export const VSelect = genericComponent<new <
           modelValue={ model.value.map(v => v.props.title).join(', ') }
           name={ undefined }
           onUpdate:modelValue={ onModelUpdate }
-          v-model:focused={ isFocused.value }
+          focused={ isFocused.value }
+          onUpdate:focused={ (val: boolean) => {
+            if (!val && menu.value && vMenuRef.value?.contentEl?.matches(':hover')) {
+              return
+            }
+            isFocused.value = val
+          }}
           validationValue={ model.externalValue }
           counterValue={ counterValue.value }
           dirty={ isDirty }

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -1028,5 +1028,23 @@ describe('VSelect', () => {
     expect(screen.getByCSS('.v-select .v-field')).not.toHaveClass('v-field--focused')
   })
 
+  it('should keep menu open when scrollbar interaction blurs focus while hovering menu', async () => {
+    const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`)
+    const { element } = render(() => <VSelect items={ items } />)
+
+    await userEvent.click(element)
+
+    const listbox = await screen.findByRole('listbox')
+    await expect.element(listbox).toBeVisible()
+
+    await userEvent.hover(listbox)
+
+    const input = element.querySelector('input') as HTMLInputElement
+    input.dispatchEvent(new FocusEvent('focusout', { relatedTarget: null, bubbles: true }))
+    await wait(50)
+
+    await expect.element(screen.queryByRole('listbox')!).toBeVisible()
+  })
+
   showcase({ stories })
 })


### PR DESCRIPTION
## Description

fixes #22850

When users scroll the dropdown list of `v-autocomplete` or `v-select` by dragging the scrollbar (especially with `menuProps: { transition: false }`), the dropdown closes unexpectedly mid-scroll.

**Root cause**: Dragging the scrollbar blurs the input's focus to `<body>` because the scrollbar itself isn't a focusable element. `relatedTarget` is `null` and `document.activeElement` falls back to `<body>`. The existing logic in `onFocusout` and the implicit `update:focused` handler then sets `isFocused = false`, which triggers the watcher that closes the menu.

**Fix**: In both `onFocusout` and the `update:focused` callback, detect this scrollbar-induced blur (`relatedTarget == null` and `document.activeElement === document.body`) while the menu is open, and skip setting `isFocused` to `false`.

Affected components: `VAutocomplete`, `VSelect`.

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-autocomplete :items="items" :menu-props="{ transition: false }" label="Try scrolling the dropdown" />
    </v-container>
  </v-app>
</template>

<script setup>
const items = Array.from({ length: 100 }, (_, i) => `Item ${i + 1}`)
</script>
```

**Steps to reproduce**:
1. Open the autocomplete to show the dropdown.
2. Click and drag the dropdown's scrollbar.
3. Before this fix: the dropdown closes mid-scroll.
4. After this fix: the dropdown stays open while scrolling.
