### PR TITLE
fix(VListItem): attach click listener conditionally

### DIFF
--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -27,7 +27,7 @@ import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant
 import vRipple from '@/directives/ripple'
 
 // Utilities
-import { computed, nextTick, onBeforeMount, ref, toDisplayString, toRef, watch } from 'vue'
+import { computed, nextTick, onBeforeMount, onMounted, ref, toDisplayString, toRef, watch } from 'vue'
 import { convertToUnit, deprecate, EventProp, genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
@@ -198,6 +198,11 @@ export const VListItem = genericComponent<VListItemSlots>()({
         nextTick(() => handleActiveLink())
       }
     })
+    onMounted(() => {
+      if (props.activeColor) {
+        deprecate('active-color', ['color', 'base-color'])
+      }
+    })
     function handleActiveLink () {
       if (parent.value != null) {
         root.open(parent.value, true)
@@ -274,10 +279,6 @@ export const VListItem = genericComponent<VListItemSlots>()({
 
       list?.updateHasPrepend(hasPrepend)
 
-      if (props.activeColor) {
-        deprecate('active-color', ['color', 'base-color'])
-      }
-
       return (
         <Tag
           { ...link.linkProps }
@@ -316,7 +317,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
           tabindex={ props.tabindex ?? (isClickable.value ? (list ? -2 : 0) : undefined) }
           aria-selected={ ariaSelected.value }
           role={ role.value }
-          onClick={ onClick }
+          onClick={ isClickable.value && onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && rippleOptions.value }
         >


### PR DESCRIPTION
fixes #22854
- add conditional check to `onClick` prop assignment 
- move `active-color` deprecation check to `onMounted` to reduce `useRender` complexity

This does not address the VList 'clickable' issue, but I think this is a good compromise between reducing the number of elements NVDA detects as clickable while retaining focus semantics for VList.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
