### PR TITLE
fix(V-switch): fix deadspace

### DIFF
--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -81,13 +81,22 @@
       height: $switch-inset-thumb-height
       width: $switch-inset-thumb-width
       transform: scale(calc($switch-inset-thumb-off-height / $switch-inset-thumb-height))
+      transition: $switch-thumb-transition, .2s translate settings.$standard-easing
+      @include tools.ltr()
+        translate: -#{($switch-inset-track-width - $switch-inset-track-height) * .5}
+      @include tools.rtl()
+        translate: #{($switch-inset-track-width - $switch-inset-track-height) * .5}
 
       &--filled
         transform: none
 
     .v-switch--inset .v-selection-control--dirty &
       transform: none
-      transition: .15s .05s transform settings.$decelerated-easing
+      transition: .15s .05s transform settings.$decelerated-easing, .2s translate settings.$standard-easing
+      @include tools.ltr()
+        translate: #{($switch-inset-track-width - $switch-inset-track-height) * .5}
+      @include tools.rtl()
+        translate: -#{($switch-inset-track-width - $switch-inset-track-height) * .5}
 
   .v-switch
     $switch-thumb-transform: $switch-track-width * .5 - $switch-thumb-width * .5 + $switch-thumb-offset
@@ -127,6 +136,15 @@
     &.v-switch--inset
       .v-selection-control__wrapper
         width: auto
+
+      .v-selection-control__input
+        left: 0
+        width: 100%
+        transform: none
+
+      .v-selection-control--dirty
+        .v-selection-control__input
+          transform: none
 
     &.v-input--vertical
       .v-label


### PR DESCRIPTION
fixes #22864 


```
<template>
  <v-app>
    <v-switch
      v-model="model"
      :label="`Switch: ${model.toString()}`"
      class="ml-4"
      hide-details
      inset
    />
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const model = ref(true)
</script>
```
