### PR TITLE
feat(VDataTable): `loading` prop to accept object with `side`

### DIFF
--- a/packages/api-generator/src/locale/en/VDataTable.json
+++ b/packages/api-generator/src/locale/en/VDataTable.json
@@ -38,6 +38,7 @@
     "item.data-table-select": "Slot to replace the default `v-checkbox-btn` used when selecting rows.",
     "item.data-table-expand": "Slot to replace the default `v-icon` used when expanding rows.",
     "item.<name>": "Slot to customize a specific column.",
+    "loader": "Slot to replace the default `v-progress-linear` shown when `loading` is set.",
     "loading": "Defines content for when `loading` is true and no items are provided.",
     "tbody": "Slot to replace the default table `<tbody>`.",
     "thead": "Slot to replace the default table `<thead>`.",

--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -13,6 +13,7 @@ import { makeDataTableExpandProps, provideExpanded } from './composables/expand'
 import { createGroupBy, makeDataTableGroupProps, provideGroupBy, useGroupedItems, useOpenAllGroups } from './composables/group'
 import { createHeaders, makeDataTableHeaderProps } from './composables/headers'
 import { makeDataTableItemsProps, useDataTableItems } from './composables/items'
+import { useLoadingConfig } from './composables/loading'
 import { useOptions } from './composables/options'
 import {
   createPagination,
@@ -25,6 +26,7 @@ import { makeDataTableSelectProps, provideSelection } from './composables/select
 import { createSort, makeDataTableSortProps, provideSort, useSortedItems } from './composables/sort'
 import { provideDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
+import { LoaderSlot } from '@/composables/loader'
 
 // Utilities
 import { computed, toRef, toRefs, toValue } from 'vue'
@@ -219,6 +221,8 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
 
     const { isExpanded, toggleExpand } = provideExpanded(props)
 
+    const loadingConfig = useLoadingConfig(() => props.loading, () => props.color)
+
     useOptions({
       page,
       itemsPerPage,
@@ -311,6 +315,20 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
                       />
                     )}
                     { slots['body.append']?.(slotProps.value) }
+                    { loadingConfig.active.value && ['end', 'both'].includes(loadingConfig.side.value) && (
+                      <tr class="v-data-table-progress v-data-table-progress--bottom">
+                        <th colspan={ columns.value.length }>
+                          <LoaderSlot
+                            name="v-data-table-progress"
+                            absolute
+                            active
+                            color={ loadingConfig.color.value }
+                            indeterminate
+                            v-slots={{ default: slots.loader }}
+                          />
+                        </th>
+                      </tr>
+                    )}
                   </tbody>
                 )}
                 { slots.tbody?.(slotProps.value) }

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -7,6 +7,7 @@ import { VSelect } from '@/components/VSelect'
 
 // Composables
 import { useHeaders } from './composables/headers'
+import { useLoadingConfig } from './composables/loading'
 import { useSelection } from './composables/select'
 import { useSort } from './composables/sort'
 import { useBackgroundColor } from '@/composables/color'
@@ -138,6 +139,8 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
     const { backgroundColorClasses, backgroundColorStyles } = useBackgroundColor(() => props.color)
 
     const { displayClasses, mobile } = useDisplay(props)
+
+    const loadingConfig = useLoadingConfig(() => props.loading, () => props.color)
 
     const slotProps = computed(() => ({
       headers: headers.value,
@@ -366,16 +369,14 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
               </tr>
             ))}
 
-          { props.loading && (
+          { loadingConfig.active.value && ['start', 'both'].includes(loadingConfig.side.value) && (
             <tr class="v-data-table-progress">
               <th colspan={ columns.value.length }>
                 <LoaderSlot
                   name="v-data-table-progress"
                   absolute
                   active
-                  color={ typeof props.loading === 'boolean' || props.loading === 'true'
-                    ? props.color
-                    : props.loading }
+                  color={ loadingConfig.color.value }
                   indeterminate
                   v-slots={{ default: slots.loader }}
                 />

--- a/packages/vuetify/src/components/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRows.tsx
@@ -17,7 +17,7 @@ import { genericComponent, getPrefixedEventHandlers, pick, propsFactory, useRend
 // Types
 import type { PropType } from 'vue'
 import type { Group, GroupSummary } from './composables/group'
-import type { CellProps, DataTableItem, GroupHeaderSlot, GroupSummarySlot, ItemSlot, RowProps } from './types'
+import type { CellProps, DataTableItem, DataTableLoading, GroupHeaderSlot, GroupSummarySlot, ItemSlot, RowProps } from './types'
 import type { VDataTableGroupHeaderRowSlots } from './VDataTableGroupHeaderRow'
 import type { VDataTableRowSlots } from './VDataTableRow'
 import type { GenericProps } from '@/util'
@@ -33,7 +33,7 @@ export type VDataTableRowsSlots<T> = VDataTableGroupHeaderRowSlots & VDataTableR
 
 export const makeVDataTableRowsProps = propsFactory({
   color: String,
-  loading: [Boolean, String],
+  loading: [Boolean, String, Object] as PropType<DataTableLoading>,
   loadingText: {
     type: String,
     default: '$vuetify.dataIterator.loadingText',

--- a/packages/vuetify/src/components/VDataTable/composables/loading.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/loading.ts
@@ -1,0 +1,30 @@
+// Utilities
+import { computed } from 'vue'
+
+// Types
+import type { DataTableLoading, DataTableLoadingSide } from '../types'
+
+export function useLoadingConfig (
+  loading: () => DataTableLoading | undefined,
+  fallbackColor: () => string | undefined,
+) {
+  const active = computed(() => {
+    const v = loading()
+    return v != null && v !== false && v !== 'false'
+  })
+
+  const side = computed<DataTableLoadingSide>(() => {
+    const v = loading()
+    if (typeof v === 'object' && v !== null && v.side) return v.side
+    return 'start'
+  })
+
+  const color = computed(() => {
+    const v = loading()
+    if (typeof v === 'object' && v !== null && v.color) return v.color
+    if (typeof v === 'string' && v !== 'true') return v
+    return fallbackColor()
+  })
+
+  return { active, side, color }
+}

--- a/packages/vuetify/src/components/VDataTable/types.ts
+++ b/packages/vuetify/src/components/VDataTable/types.ts
@@ -7,6 +7,12 @@ import type { SelectItemKey } from '@/util'
 
 export type DataTableCompareFunction<T = any> = (a: T, b: T) => number | null
 
+export type DataTableLoadingSide = 'start' | 'end' | 'both'
+export type DataTableLoading =
+  | boolean
+  | string
+  | { side?: DataTableLoadingSide, color?: string }
+
 export type DataTableHeader<T = Record<string, any>> = {
   key?: 'data-table-group' | 'data-table-select' | 'data-table-expand' | (string & {})
   value?: SelectItemKey<T>


### PR DESCRIPTION
resolves #9655

- `loading` prop now accepts object `{ side, color }`
- pretty self-explanatory, skipping docs for now

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-sheet elevation="1">
        <v-data-table
          :headers="headers"
          :items="items"
          :items-per-page="-1"
          :loading="loading && { side: 'end', color: 'red' }"
          height="300"
          hide-default-footer
          show-select
        >
          <template #tfoot="{ columns }">
            <tr v-if="!reachedEnd" v-intersect="v => v && loadMore()">
              <td :colspan="columns.length" />
            </tr>
          </template>
        </v-data-table>
      </v-sheet>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref, shallowRef } from 'vue'

  const items = ref(
    Array.from({ length: 15 }, (_, v) => ({ id: v + 1, title: `item: ${v + 1}` }))
  )

  const headers = [
    { value: 'id', title: 'id' },
    { value: 'title', title: 'title' },
  ]

  const reachedEnd = shallowRef(false)
  const loading = shallowRef(false)

  async function api () {
    return new Promise(resolve => {
      let lastId = items.value.at(-1)?.id ?? 0
      setTimeout(() => {
        resolve({
          data: Array.from({ length: 10 }, () => ({ id: ++lastId, title: `item: ${lastId}` })),
          hasMore: lastId < 50,
        })
      }, 1000)
    })
  }

  async function loadMore () {
    if (loading.value || reachedEnd.value) return

    loading.value = true
    try {
      const { data, hasMore } = await api()
      items.value.push(...data)
      reachedEnd.value = !hasMore
    } finally {
      loading.value = false
    }
  }
</script>
```
