### PR TITLE
feat(VDataTable): add filtered `itemsLength` to slot props

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.tsx
@@ -41,6 +41,7 @@ import type { GenericProps, SelectItemKey } from '@/util'
 export type VDataTableSlotProps<T> = {
   page: number
   itemsPerPage: number
+  itemsLength: number
   sortBy: UnwrapRef<ReturnType<typeof provideSort>['sortBy']>
   pageCount: number
   toggleSort: ReturnType<typeof provideSort>['toggleSort']
@@ -239,6 +240,7 @@ export const VDataTable = genericComponent<new <T extends readonly any[], V>(
     const slotProps = computed<VDataTableSlotProps<any>>(() => ({
       page: page.value,
       itemsPerPage: itemsPerPage.value,
+      itemsLength: filteredItems.value.length,
       sortBy: sortBy.value,
       pageCount: pageCount.value,
       toggleSort,

--- a/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableServer.tsx
@@ -131,6 +131,7 @@ export const VDataTableServer = genericComponent<new <T extends readonly any[], 
     const slotProps = computed<VDataTableSlotProps<any>>(() => ({
       page: page.value,
       itemsPerPage: itemsPerPage.value,
+      itemsLength: itemsLength.value,
       sortBy: sortBy.value,
       pageCount: pageCount.value,
       toggleSort,

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -179,6 +179,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
     })
 
     const slotProps = computed<VDataTableVirtualSlotProps<any>>(() => ({
+      itemsLength: allItems.value.length,
       sortBy: sortBy.value,
       toggleSort,
       someSelected: someSelected.value,


### PR DESCRIPTION
resolves #20496

- includes `itemsLength` in slot props - representing amount of items after filtering

This is the only real gap. Users won't be forced to create sub-components and wire them to pagination inject/provide data.

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-sheet elevation="1">
        <v-data-table
          v-model:items-per-page="itemsPerPage"
          v-model:page="page"
          :headers="headers"
          :items="items"
          :search="search"
        >
          <template #top>
            <div class="pa-1 d-flex">
              <v-text-field
                v-model="search"
                density="compact"
                label="Search"
                max-width="400"
                variant="outlined"
                hide-details
              />
            </div>
          </template>
          <template #bottom="{ itemsLength, pageCount }">
            <div class="v-data-table-footer">
              <div class="d-flex align-center ga-2">
                <span class="text-caption">Rows per page:</span>
                <v-select
                  v-model="itemsPerPage"
                  :items="[5, 10, 25, { title: 'All', value: -1 }]"
                  density="compact"
                  style="width: 96px"
                  variant="outlined"
                  hide-details
                />
              </div>

              <div class="v-data-table-footer__info">
                {{ pageRangeLabel(itemsLength, page, itemsPerPage) }}
              </div>

              <v-spacer />

              <v-pagination
                v-model="page"
                :length="pageCount"
                :total-visible="5"
                density="comfortable"
                variant="plain"
              />
            </div>
          </template>
        </v-data-table>
      </v-sheet>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import type { DataTableHeader } from '@/types'
  import { useLocale } from '@/composables'
  import { shallowRef } from 'vue'

  const { t } = useLocale()

  const page = shallowRef(1)
  const itemsPerPage = shallowRef(5)
  const search = shallowRef('')

  const headers = [
    { key: 'id', title: 'ID', width: 60, align: 'end' },
    { key: 'name', title: 'Product', minWidth: 160 },
    { key: 'unitPrice', title: 'Unit Price', width: 120, align: 'end' },
    { key: 'qty', title: 'Qty', width: 80, align: 'end' },
    { key: 'amount', title: 'Amount', width: 140, align: 'end' },
  ] satisfies DataTableHeader[]

  const items = Array.from({ length: 47 }, (_, i) => ({
    id: i + 1,
    name: `Item ${i + 1}`,
    unitPrice: `$${((i * 3 + 7) % 50 + 5).toFixed(2)}`,
    qty: (i % 8) + 1,
    amount: `$${((i * 11 + 19) % 200 + 10).toFixed(2)}`,
  }))

  function pageRangeLabel (itemsLength: number, page: number, itemsPerPage: number) {
    const start = !itemsLength ? 0 : 1 + itemsPerPage * (page - 1)
    const end = itemsPerPage === -1 ? itemsLength : Math.min(itemsPerPage * page, itemsLength)
    return t('$vuetify.dataFooter.pageText', start, end, itemsLength)
    // return `${start}-${end} of ${itemsLength}`
  }
</script>
```
