### PR TITLE
fix(theme): support transparent hex color for CSS variables

### DIFF
--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -255,7 +255,7 @@ function genCssVariables (theme: InternalThemeDefinition, prefix: string) {
 
   for (const [key, value] of Object.entries(theme.variables)) {
     const color = typeof value === 'string' && value.startsWith('#') ? parseColor(value) : undefined
-    const rgb = color ? `${color.r}, ${color.g}, ${color.b}` : undefined
+    const rgb = color ? `${color.r}, ${color.g}, ${color.b}${color.a != null ? `, ${color.a}` : ''}` : undefined
     variables.push(`--${prefix}${key}: ${rgb ?? value}`)
   }
 

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -255,7 +255,7 @@ function genCssVariables (theme: InternalThemeDefinition, prefix: string) {
 
   for (const [key, value] of Object.entries(theme.variables)) {
     const color = typeof value === 'string' && value.startsWith('#') ? parseColor(value) : undefined
-    const rgb = color ? `${color.r}, ${color.g}, ${color.b}${color.a != null ? `, ${color.a}` : ''}` : undefined
+    const rgb = color ? `${color.r}, ${color.g}, ${color.b}` + (color.a == null ? '' : `, ${color.a}`) : undefined
     variables.push(`--${prefix}${key}: ${rgb ?? value}`)
   }
 


### PR DESCRIPTION
## Description

Fixes #22865

When a theme variable is defined as a hex color with alpha (e.g. `#FF000080`), the `genCssVariables` function was dropping the alpha channel:

```js
// before — alpha discarded
const rgb = color ? `${color.r}, ${color.g}, ${color.b}` : undefined
```

Theme *colors* already include alpha correctly (line 250). This one-line fix applies the same pattern to theme *variables*.

```js
// after
const rgb = color ? `${color.r}, ${color.g}, ${color.b}${color.a != null ? `, ${color.a}` : ''}` : undefined
```

## Markup:

```vue
<template>
  <v-app :theme="theme">
    <v-btn>test</v-btn>
  </v-app>
</template>

<script setup>
import { ref } from 'vue'
const theme = {
  dark: false,
  colors: { primary: '#FF0000' },
  variables: {
    'border-color': '#FF000080',
  },
}
</script>
```

Before: `--v-border-color: 255, 0, 0`
After: `--v-border-color: 255, 0, 0, 0.5019607843137255`