### PR TITLE
fix(VSelect/VAutocomplete/VCombobox): keep menu open when scrolling

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -17,6 +17,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 import { VVirtualScroll } from '@/components/VVirtualScroll'
 
 // Composables
+import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
 import { useTextColor } from '@/composables/color'
 import { highlightResult, makeFilterProps, useFilter } from '@/composables/filter'
@@ -199,6 +200,11 @@ export const VAutocomplete = genericComponent<new <
     const headerRef = ref<HTMLElement>()
     const footerRef = ref<HTMLElement>()
     const listEvents = useScrolling(listRef, vTextFieldRef)
+    const repairOrphanedFocus = useFocusRepair(
+      menu,
+      () => vMenuRef.value?.contentEl,
+      () => vTextFieldRef.value?.controlRef,
+    )
     const { onTabKeydown } = useFocusGroups({
       groups: [
         { type: 'element' as const, contentRef: headerRef },
@@ -361,6 +367,7 @@ export const VAutocomplete = genericComponent<new <
     function onFocusout (e: FocusEvent) {
       listHasFocus.value = false
       if (!vTextFieldRef.value?.$el.contains(e.relatedTarget as Node)) {
+        if (repairOrphanedFocus(e)) return
         isFocused.value = false
       }
     }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -200,6 +200,64 @@ describe('VAutocomplete', () => {
     expect(menu.value).toBe(true)
   })
 
+  it('should keep menu open and repair focus when the focused item is removed', async () => {
+    const menu = ref(false)
+    render(() => (
+      <VAutocomplete
+        v-model:menu={ menu.value }
+        items={ Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`) }
+      />
+    ))
+
+    const input = screen.getByCSS('input')
+    await userEvent.click(input)
+    await waitIdle()
+    expect(menu.value).toBe(true)
+
+    // Arrow-navigation (navigationStrategy="focus") puts real DOM focus on an item.
+    const option = screen.getAllByRole('option')[0]
+    option.focus()
+    await waitIdle()
+    expect(document.activeElement).toBe(option)
+
+    // Recycling/reload removes the focused node from the DOM (what VVirtualScroll
+    // or an async items reload does); focus falls to <body> and the menu closes.
+    option.remove()
+    await waitIdle()
+    await wait(300)
+
+    // Repaired: focus returns into the menu content and the menu stays open.
+    expect(menu.value).toBe(true)
+    expect(screen.getByRole('listbox').contains(document.activeElement)).toBe(true)
+  })
+
+  it('should return focus to the field when a reload leaves no item to focus', async () => {
+    const items = ref(Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`))
+    const menu = ref(false)
+    render(() => (
+      <VAutocomplete v-model:menu={ menu.value } items={ items.value } />
+    ))
+
+    const input = screen.getByCSS('input')
+    await userEvent.click(input)
+    await waitIdle()
+    expect(menu.value).toBe(true)
+
+    const option = screen.getAllByRole('option')[0]
+    option.focus()
+    await waitIdle()
+    expect(document.activeElement).toBe(option)
+
+    // Reload into no-data: the focused item is gone and nothing in the menu is
+    // focusable, so focus should fall back to the text field.
+    items.value = []
+    await waitIdle()
+    await wait(300)
+
+    expect(menu.value).toBe(true)
+    expect(document.activeElement).toBe(input)
+  })
+
   it('should close only first chip', async () => {
     const items = ['Item 1', 'Item 2', 'Item 3', 'Item 4']
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -18,6 +18,7 @@ import { makeVTextFieldProps } from '@/components/VTextField/VTextField'
 import { VVirtualScroll } from '@/components/VVirtualScroll'
 
 // Composables
+import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
 import { useTextColor } from '@/composables/color'
 import { highlightResult, makeFilterProps, useFilter } from '@/composables/filter'
@@ -255,6 +256,11 @@ export const VCombobox = genericComponent<new <
     const headerRef = ref<HTMLElement>()
     const footerRef = ref<HTMLElement>()
     const listEvents = useScrolling(listRef, vTextFieldRef)
+    const repairOrphanedFocus = useFocusRepair(
+      menu,
+      () => vMenuRef.value?.contentEl,
+      () => vTextFieldRef.value?.controlRef,
+    )
     const { onTabKeydown } = useFocusGroups({
       groups: [
         { type: 'element' as const, contentRef: headerRef },
@@ -468,6 +474,7 @@ export const VCombobox = genericComponent<new <
     function onFocusout (e: FocusEvent) {
       listHasFocus.value = false
       if (!vTextFieldRef.value?.$el.contains(e.relatedTarget as Node)) {
+        if (repairOrphanedFocus(e)) return
         isFocused.value = false
       }
     }

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -3,7 +3,7 @@ import { VCombobox } from '../VCombobox'
 import { VForm } from '@/components/VForm'
 
 // Utilities
-import { render, screen, showcase, userEvent, waitAnimationFrame, waitIdle } from '@test'
+import { render, screen, showcase, userEvent, wait, waitAnimationFrame, waitIdle } from '@test'
 import { commands } from 'vitest/browser'
 import { cloneVNode, ref } from 'vue'
 
@@ -889,6 +889,36 @@ describe('VCombobox', () => {
       await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
       expect(screen.getByTestId('header-btn')).toHaveFocus()
     })
+  })
+
+  it('should keep menu open and repair focus when the focused item is removed', async () => {
+    const menu = ref(false)
+    render(() => (
+      <VCombobox
+        v-model:menu={ menu.value }
+        items={ Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`) }
+      />
+    ))
+
+    const input = screen.getByCSS('input')
+    await userEvent.click(input)
+    await waitIdle()
+    expect(menu.value).toBe(true)
+
+    const option = screen.getAllByRole('option')[0]
+    option.focus()
+    await waitIdle()
+    expect(document.activeElement).toBe(option)
+
+    // The focused option is removed (virtual-scroll recycle or async items reload);
+    // focus falls to <body> and the menu would close.
+    option.remove()
+    await waitIdle()
+    await wait(300)
+
+    // Repaired: focus returns into the menu content and the menu stays open.
+    expect(menu.value).toBe(true)
+    expect(screen.getByRole('listbox').contains(document.activeElement)).toBe(true)
   })
 
   showcase({ stories })

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -17,6 +17,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 import { VVirtualScroll } from '@/components/VVirtualScroll'
 
 // Composables
+import { useFocusRepair } from './useFocusRepair'
 import { useScrolling } from './useScrolling'
 import { useFocusGroups } from '../../composables/focusGroups'
 import { useAutocomplete } from '@/composables/autocomplete'
@@ -222,6 +223,11 @@ export const VSelect = genericComponent<new <
 
     const listRef = ref<VList>()
     const listEvents = useScrolling(listRef, vTextFieldRef)
+    const repairOrphanedFocus = useFocusRepair(
+      menu,
+      () => vMenuRef.value?.contentEl,
+      () => vTextFieldRef.value?.controlRef,
+    )
     const { onTabKeydown } = useFocusGroups({
       groups: [
         { type: 'element' as const, contentRef: headerRef },
@@ -408,6 +414,7 @@ export const VSelect = genericComponent<new <
         !vTextFieldRef.value?.$el.contains(e.relatedTarget as Node) &&
         !(e.currentTarget as HTMLElement).contains(e.relatedTarget as Node)
       ) {
+        if (repairOrphanedFocus(e)) return
         isFocused.value = false
       }
     }

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -1028,5 +1028,29 @@ describe('VSelect', () => {
     expect(screen.getByCSS('.v-select .v-field')).not.toHaveClass('v-field--focused')
   })
 
+  it('should keep menu open and repair focus when the focused item is removed', async () => {
+    const menu = ref(false)
+    render(() => (
+      <VSelect
+        v-model:menu={ menu.value }
+        items={ Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`) }
+      />
+    ))
+
+    await userEvent.click(screen.getByCSS('.v-select'))
+    await commands.waitStable('.v-list')
+    await waitFor(() => expect(screen.getAllByRole('option').at(0)).toHaveFocus(), { timeout: 3000 })
+    expect(menu.value).toBe(true)
+
+    // The focused option is removed (virtual-scroll recycle or async items reload);
+    // focus falls to <body> and the menu would close.
+    screen.getAllByRole('option')[0].remove()
+    await wait(300)
+
+    // Repaired: focus returns into the menu content and the menu stays open.
+    expect(menu.value).toBe(true)
+    expect(screen.getByRole('listbox').contains(document.activeElement)).toBe(true)
+  })
+
   showcase({ stories })
 })

--- a/packages/vuetify/src/components/VSelect/useFocusRepair.ts
+++ b/packages/vuetify/src/components/VSelect/useFocusRepair.ts
@@ -1,0 +1,24 @@
+// Utilities
+import { focusableChildren } from '@/util'
+
+// Types
+import type { Ref } from 'vue'
+
+export function useFocusRepair (
+  active: Ref<boolean>,
+  content: () => HTMLElement | undefined,
+  fallback: () => HTMLElement | undefined,
+) {
+  return function repairOrphanedFocus (e: FocusEvent): boolean {
+    if (!e.relatedTarget && document.activeElement === document.body && active.value) {
+      requestAnimationFrame(() => {
+        if (!active.value) return
+        const el = content()
+        const target = (el && focusableChildren(el)[0]) ?? fallback()
+        target?.focus({ preventScroll: true })
+      })
+      return true
+    }
+    return false
+  }
+}


### PR DESCRIPTION
When list virtualization kicks in (narrow screen, or 100+ items), the focused item is removed from the DOM which triggers focusout/blur and closes the menu unexpectedly.

When the list is being synchronized with backend API and changes the items without user interaction - also closes the menu.

Fix scope:

- keep menu open when when the focused item is removed
- return focus back to the menu
	- to the first focusable element within menu content
	- fallback to the activator field

fixes #22850

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-autocomplete
        v-model:menu="menu"
        :items="items"
        :menu-props="{ transition: false }"
        label="Try scrolling the dropdown"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { computed, shallowRef, watch } from 'vue'

  const menu = shallowRef(false)

  const init = shallowRef(0)
  const items = computed(() => Array.from({ length: 100 }, (_, i) => `Item ${init.value + i + 1}`))

  watch(menu, v => {
    if (v) {
      setTimeout(() => init.value += 10, 2000)
    }
  })
</script>
```
