### PR TITLE
fix(VProgressLinear): guard opacity against undefined props to prevent NaN in SSR

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.tsx
@@ -185,7 +185,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
               ...textColorStyles.value,
               [isReversed.value ? 'left' : 'right']: convertToUnit(-height.value),
               borderTop: `${convertToUnit(height.value / 2)} dotted`,
-              opacity: parseFloat(props.bufferOpacity!),
+              opacity: props.bufferOpacity != null ? parseFloat(props.bufferOpacity) : undefined,
               top: `calc(50% - ${convertToUnit(height.value / 4)})`,
               width: convertToUnit(100 - normalizedBuffer.value, '%'),
               '--v-progress-linear-stream-to': convertToUnit(height.value * (isReversed.value ? 1 : -1)),
@@ -201,7 +201,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
           style={[
             backgroundColorStyles.value,
             {
-              opacity: parseFloat(props.bgOpacity!),
+              opacity: props.bgOpacity != null ? parseFloat(props.bgOpacity) : undefined,
               width: props.stream ? 0 : undefined,
             },
           ]}
@@ -215,7 +215,7 @@ export const VProgressLinear = genericComponent<VProgressLinearSlots>()({
           style={[
             bufferColorStyles.value,
             {
-              opacity: parseFloat(props.bufferOpacity!),
+              opacity: props.bufferOpacity != null ? parseFloat(props.bufferOpacity) : undefined,
               width: convertToUnit(bufferWidth.value, '%'),
             },
           ]}


### PR DESCRIPTION
Fixes #22876

When `bgOpacity` or `bufferOpacity` props are unset, `parseFloat(undefined)` evaluates to `NaN`. In CSR the DOM silently rejects it, but in SSR Vue serializes `NaN` (which has `typeof === "number"`) as `opacity:NaN;` in the HTML — invalid CSS that fails W3C validation.

Added null checks so the inline opacity is only set when the prop is explicitly provided. When unset, the CSS variable fallback (`opacity: var(--v-border-opacity)`) applies as intended.