### PR TITLE
feat(VSwitch): add 'square' as new `inset` variant

### DIFF
--- a/packages/api-generator/src/locale/en/VSwitch.json
+++ b/packages/api-generator/src/locale/en/VSwitch.json
@@ -3,7 +3,7 @@
   "props": {
     "flat": "Display component without elevation. Default elevation for thumb is 4dp, `flat` resets it.",
     "indeterminate": "Sets an indeterminate state for the switch.",
-    "inset": "Enlarge the `v-switch` track to encompass the thumb.",
+    "inset": "Controls the track and thumb styling\n- **tonal** (or `true`) enlarges the track to encompass the thumb\n- **material** applies the Material Design 3 treatment: an outlined track that fills when on and a thumb that morphs between states\n- **square** is the **material** variant with less round corners.",
     "loading": "Displays circular progress bar. Can either be a String which specifies which color is applied to the progress bar (any material color or theme color - primary, secondary, success, info, warning, error) or a Boolean which uses the component color (set by color prop - if it's supported by the component) or the primary color.",
     "multiple": "Changes expected model to an array."
   },

--- a/packages/vuetify/src/components/VSwitch/VSwitch.sass
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.sass
@@ -151,6 +151,13 @@
         .v-icon
           opacity: .4
 
+  .v-switch--inset-square
+    .v-switch__track
+      border-radius: $switch-inset-square-track-radius
+
+    .v-switch__thumb
+      border-radius: $switch-inset-square-thumb-radius
+
   .v-switch
     $switch-thumb-transform: $switch-track-width * .5 - $switch-thumb-width * .5 + $switch-thumb-offset
 

--- a/packages/vuetify/src/components/VSwitch/VSwitch.tsx
+++ b/packages/vuetify/src/components/VSwitch/VSwitch.tsx
@@ -45,7 +45,7 @@ export type VSwitchSlots =
 
 export const makeVSwitchProps = propsFactory({
   inset: {
-    type: [Boolean, String] as PropType<boolean | 'tonal' | 'material'>,
+    type: [Boolean, String] as PropType<boolean | 'tonal' | 'material' | 'square'>,
     default: false,
   },
   flat: Boolean,
@@ -125,7 +125,8 @@ export const VSwitch = genericComponent<new <T>(
             'v-switch',
             { 'v-switch--flat': props.flat },
             { 'v-switch--inset': !!props.inset },
-            { 'v-switch--inset-material': props.inset === 'material' },
+            { 'v-switch--inset-material': isMaterial },
+            { 'v-switch--inset-square': props.inset === 'square' },
             { 'v-switch--indeterminate': indeterminate.value },
             loaderClasses.value,
             props.class,

--- a/packages/vuetify/src/components/VSwitch/_variables.scss
+++ b/packages/vuetify/src/components/VSwitch/_variables.scss
@@ -18,6 +18,9 @@ $switch-inset-track-width: 52px !default;
 $switch-inset-track-opacity: 1 !default;
 $switch-inset-border-width: 2px !default;
 
+$switch-inset-square-track-radius: 6px !default;
+$switch-inset-square-thumb-radius: 4px !default;
+
 $switch-inset-unselected-track-color: color-mix(in srgb, rgb(var(--v-theme-on-surface-variant)) 50%, #888) !default;
 $switch-inset-unselected-thumb-color: color-mix(in srgb, rgb(var(--v-theme-surface-variant)) 50%, #888) !default;
 $switch-inset-unselected-border-color: $switch-inset-unselected-thumb-color !default;


### PR DESCRIPTION
<img width="1574" height="805" alt="image" src="https://github.com/user-attachments/assets/e8c38e60-afc0-4db5-9d5a-5b1d85afc37e" />

## Markup:

```vue
<template>
  <v-app class="bg-surface">
    <v-defaults-provider :defaults="{ VSwitch: { inset, loading, hideDetails: true, density, trueIcon: icons ? '$complete' : undefined, falseIcon: icons ? '$close' : undefined } }">
      <v-container>
        <v-card min-height="360">
          <v-card-text class="d-flex">
            <div class="pa-2 flex-grow-1">
              <v-theme-provider theme="light">
                <v-sheet>
                  <v-row class="justify-center align-center py-12 border-md" gap="24">
                    <v-switch :model-value="false" />
                    <v-switch :model-value="true" />
                  </v-row>
                </v-sheet>
              </v-theme-provider>
              <v-theme-provider theme="dark">
                <v-sheet>
                  <v-row class="justify-center align-center py-12 border-md" gap="24">
                    <v-switch :model-value="false" />
                    <v-switch :model-value="true" />
                  </v-row>
                </v-sheet>
              </v-theme-provider>
            </div>
            <div class="pa-2 flex-grow-1">
              <v-theme-provider theme="light">
                <v-sheet>
                  <v-row class="justify-center align-center py-12 border-md" gap="24">
                    <v-switch :model-value="false" color="primary" />
                    <v-switch :model-value="true" color="primary" />
                  </v-row>
                </v-sheet>
              </v-theme-provider>
              <v-theme-provider theme="dark">
                <v-sheet>
                  <v-row class="justify-center align-center py-12 border-md" gap="24">
                    <v-switch :model-value="false" color="primary" />
                    <v-switch :model-value="true" color="primary" />
                  </v-row>
                </v-sheet>
              </v-theme-provider>
            </div>
            <div class="pa-2 flex-grow-1">
              <v-theme-provider theme="light">
                <v-sheet>
                  <v-row class="justify-center align-center py-12 border-md" gap="24">
                    <v-switch :model-value="false" color="primary" />
                    <v-switch :model-value="true" color="primary" />
                  </v-row>
                </v-sheet>
              </v-theme-provider>
              <v-theme-provider theme="dark">
                <v-sheet>
                  <v-row class="justify-center align-center py-12 border-md" gap="24">
                    <v-switch :model-value="false" color="primary" />
                    <v-switch :model-value="true" color="primary" />
                  </v-row>
                </v-sheet>
              </v-theme-provider>
            </div>
            <v-defaults-provider :defaults="{ VSwitch: { disabled: true } }">
              <div class="pa-2 flex-grow-1">
                <v-theme-provider theme="light">
                  <v-sheet>
                    <v-row class="justify-center align-center py-12 border-md" gap="24">
                      <v-switch :model-value="false" color="primary" />
                      <v-switch :model-value="true" color="primary" />
                    </v-row>
                  </v-sheet>
                </v-theme-provider>
                <v-theme-provider theme="dark">
                  <v-sheet>
                    <v-row class="justify-center align-center py-12 border-md" gap="24">
                      <v-switch :model-value="false" color="primary" />
                      <v-switch :model-value="true" color="primary" />
                    </v-row>
                  </v-sheet>
                </v-theme-provider>
              </div>
            </v-defaults-provider>
          </v-card-text>
        </v-card>
        <v-card class="mt-4">
          <v-card-text>
            <div class="pa-2 flex-grow-1">
              <v-row>
                <v-col v-for="[color, thumbColor] in colors" :key="color" cols="12" md="4" sm="6">
                  <div class="d-flex align-center ga-3">
                    <v-avatar :color="thumbColor ?? color" size="32" />
                    <v-switch
                      v-model="model"
                      :color="color"
                      :label="color"
                      :thumb-color="thumbColor"
                      :value="color"
                      hide-details
                    />
                  </div>
                </v-col>
              </v-row>
            </div>
          </v-card-text>
        </v-card>
      </v-container>
    </v-defaults-provider>
    <div class="d-flex flex-column ga-2 ma-3 position-absolute bottom-0 right-0">
      <v-btn
        class="align-self-end"
        icon="mdi-palette"
        variant="tonal"
      >
        <v-icon />
        <v-menu
          :close-on-content-click="false"
          activator="parent"
          offset="8"
        >
          <v-sheet
            class="d-flex flex-column ga-3 align-start pa-3 border"
            max-width="500"
            rounded="xl"
          >
            <v-btn
              :text="current.dark ? 'Dark' : 'Light'"
              prepend-icon="mdi-theme-light-dark"
              variant="tonal"
              rounded
              @click="$vuetify.theme.cycle()"
            />
            <span class="text-caption font-weight-medium">Primary</span>
            <v-item-group v-model="primaryColor" class="d-flex ga-2 flex-wrap" mandatory>
              <v-item
                v-for="[key, c] of swatchColors"
                :key="key"
                v-slot="{ isSelected, toggle }"
                :value="key"
              >
                <v-icon-btn
                  :color="c[current.dark ? 'lighten1' : 'darken1']"
                  :icon="isSelected ? '$complete' : ''"
                  @click="toggle"
                />
              </v-item>
            </v-item-group>
            <span class="text-caption font-weight-medium">Surface</span>
            <v-item-group v-model="surfaceColor" class="d-flex ga-2 flex-wrap" mandatory>
              <v-item
                v-for="[key, c] of Object.entries(surfaceColors)"
                :key="key"
                v-slot="{ isSelected, toggle }"
                :value="key"
              >
                <v-icon-btn
                  :color="c.base"
                  :icon="isSelected ? '$complete' : ''"
                  @click="toggle"
                />
              </v-item>
            </v-item-group>
          </v-sheet>
        </v-menu>
      </v-btn>
      <v-btn
        :text="`inset: ${inset || 'OFF'}`"
        variant="tonal"
        @click="inset = insets[(insets.indexOf(inset) + 1) % insets.length]"
      />
      <v-btn
        :text="`loading: ${loading ? 'ON' : 'OFF'}`"
        variant="tonal"
        @click="loading = !loading"
      />
      <v-btn
        :text="`density: ${density}`"
        variant="tonal"
        @click="density = densities[(densities.indexOf(density) + 1) % densities.length]"
      />
      <v-btn
        :text="`icons: ${icons ? 'ON' : 'OFF'}`"
        variant="tonal"
        @click="icons = !icons"
      />
    </div>
  </v-app>
</template>

<script setup>
  import { useTheme } from 'vuetify'
  import { ref, shallowRef, watch } from 'vue'
  import paletteColors from '../src/util/colors'

  const insets = [false, 'tonal', 'material', 'square']
  const inset = ref('square')

  const loading = ref(false)

  const densities = ['default', 'comfortable', 'compact']
  const density = ref('default')

  const icons = ref(true)

  const { themes, current, change } = useTheme()

  change('dark')

  const swatchColors = Object.entries(paletteColors).filter(([key]) => key !== 'shades')

  const primaryColor = shallowRef('deepPurple')
  watch(primaryColor, v => {
    themes.value.light.colors.primary = paletteColors[v].darken1
    themes.value.dark.colors.primary = paletteColors[v].lighten4
    themes.value.dark.colors['on-primary'] = paletteColors[v].darken3
  }, { immediate: true })

  const surfaceColors = {
    slate: { base: '#64748b', lighten: '#e2e8f0', darken: '#0f172a' },
    gray: { base: '#6b7280', lighten: '#e5e7eb', darken: '#111827' },
    zinc: { base: '#71717a', lighten: '#e4e4e7', darken: '#18181b' },
    neutral: { base: '#737373', lighten: '#e5e5e5', darken: '#171717' },
    stone: { base: '#78716c', lighten: '#e7e5e4', darken: '#1c1917' },
  }
  const surfaceColor = shallowRef('stone')
  watch(surfaceColor, v => {
    themes.value.light.colors.surface = surfaceColors[v].lighten
    themes.value.dark.colors.surface = surfaceColors[v].darken
  }, { immediate: true })

  // [color, thumbColor?]
  const colors = [
    ['red'],
    ['red-darken-3'],
    ['indigo'],
    ['indigo-darken-3'],
    ['orange-lighten-3', 'orange-darken-2'],
    ['orange-darken-3'],
    ['#64a'],
    ['#cf3'],
    ['success'],
    ['info'],
    ['warning'],
    ['error'],
  ]

  const model = ref(colors.map(([color]) => color))
</script>
```
