### PR TITLE
feat(VCalendarCategory): add showIntervalHighlight prop

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.sass
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.sass
@@ -27,6 +27,10 @@
     .v-calendar-category__category
       text-align: center
 
+    .v-calendar-daily__day-interval--hover
+      background: rgba(var(--v-theme-primary), 0.08)
+      cursor: pointer
+
     .v-calendar-daily__day-container
       width: min-content
       .v-calendar-category__columns

--- a/packages/vuetify/src/components/VCalendar/VCalendarCategory.tsx
+++ b/packages/vuetify/src/components/VCalendar/VCalendarCategory.tsx
@@ -27,6 +27,10 @@ export const VCalendarCategory = defineComponent({
       type: String,
       default: '',
     },
+    showIntervalHighlight: {
+      type: Boolean,
+      default: false,
+    },
 
     ...makeCalendarBaseProps(),
     ...makeCalendarWithIntervalsProps(),
@@ -48,7 +52,46 @@ export const VCalendarCategory = defineComponent({
       }
     }
 
-    function genDayHeader (scope: CalendarTimestamp & { week: any, index: number }) {
+    function getHoveredTimeFromEvent (e: MouseEvent): string | null {
+      const dayEl = (e.currentTarget as HTMLElement)
+      const rect = dayEl.getBoundingClientRect()
+      const y = e.clientY - rect.top
+      const intervalIndex = Math.floor(y / base.parsedIntervalHeight.value)
+      const intervals = base.intervals.value[0]
+      if (!intervals || intervalIndex < 0 || intervalIndex >= intervals.length) return null
+      return intervals[intervalIndex].time
+    }
+
+    function highlightIntervals (time: string | null, el: HTMLElement) {
+      const container = el.closest('.v-calendar-category')
+        ?.querySelector('.v-calendar-daily__day-container')
+      if (!container) return
+
+      container.querySelectorAll('.v-calendar-daily__day-interval--hover').forEach(el => {
+        el.classList.remove('v-calendar-daily__day-interval--hover')
+      })
+
+      if (time !== null) {
+        container.querySelectorAll('.v-calendar-daily__day-interval').forEach(el => {
+          if (el.getAttribute('data-time') === time) {
+            el.classList.add('v-calendar-daily__day-interval--hover')
+          }
+        })
+      }
+    }
+
+    function onDayMouseMove (e: MouseEvent) {
+      if (!props.showIntervalHighlight) return
+      const time = getHoveredTimeFromEvent(e)
+      highlightIntervals(time, e.currentTarget as HTMLElement)
+    }
+
+    function onDayMouseLeave (e: MouseEvent) {
+      if (!props.showIntervalHighlight) return
+      highlightIntervals(null, e.currentTarget as HTMLElement)
+    }
+
+    function genDayHeader (scope: any) {
       return (
         <div class="v-calendar-category__columns">
           { parsedCategories.value.map(category => {
@@ -59,7 +102,7 @@ export const VCalendarCategory = defineComponent({
     }
 
     function genDayHeaderCategory (day: CalendarTimestamp, scope: any) {
-      const headerTitle = typeof scope.category === 'object' ? scope.category.categoryName : scope.category
+      const headerTitle = typeof scope.category === 'object' ? scope.category?.categoryName : scope.category
       const events = getPrefixedEventHandlers(attrs, ':dayCategory', () => {
         return getCategoryScope(base.getSlotScope(day) || day, scope.category)
       })
@@ -83,7 +126,7 @@ export const VCalendarCategory = defineComponent({
     }
 
     function genDays () {
-      const days: any[] = []
+      const days: JSX.Element[] = []
       base.days.value.forEach((d: CalendarTimestamp, j: number) => {
         const day = new Array(parsedCategories.value.length || 1)
         day.fill(d)
@@ -102,6 +145,8 @@ export const VCalendarCategory = defineComponent({
           key={ day.date + '-' + categoryIndex }
           class={['v-calendar-daily__day', base.getRelativeClasses(day)]}
           { ...events }
+          onMousemove={ onDayMouseMove }
+          onMouseleave={ onDayMouseLeave }
         >
           { genDayIntervals(index, category) }
           { genDayBody(day, category) }
@@ -122,6 +167,7 @@ export const VCalendarCategory = defineComponent({
           key={ interval.time }
           class="v-calendar-daily__day-interval"
           style={[{ height }, styler({ ...interval, category })]}
+          data-time={ interval.time }
         >
           { slots.interval?.(
             getCategoryScope(base.getSlotScope(interval), category)

--- a/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
+++ b/packages/vuetify/src/components/VCalendar/__tests__/VCalendarCategory.spec.ts
@@ -1,0 +1,52 @@
+// Components
+import { VCalendarCategory } from '../VCalendarCategory'
+
+// Utilities
+import { mount } from '@vue/test-utils'
+import { createVuetify } from '@/framework'
+
+describe('VCalendarCategory', () => {
+  const vuetify = createVuetify()
+
+  function mountFunction (options = {}) {
+    return mount(VCalendarCategory, {
+      global: { plugins: [vuetify] },
+      ...options,
+    })
+  }
+
+  it('should render with default props', () => {
+    const wrapper = mountFunction()
+
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.classes()).toContain('v-calendar-category')
+  })
+
+  it('should render with categories', () => {
+    const wrapper = mountFunction({
+      props: {
+        categories: ['Work', 'Personal', 'Travel'],
+        type: 'category',
+      },
+    })
+
+    expect(wrapper.exists()).toBe(true)
+    expect(wrapper.classes()).toContain('v-calendar-category')
+  })
+
+  it('should respect showIntervalHighlight prop', () => {
+    const wrapper = mountFunction({
+      props: {
+        showIntervalHighlight: false,
+      },
+    })
+
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('should have showIntervalHighlight disabled by default', () => {
+    const wrapper = mountFunction()
+
+    expect(wrapper.vm.$props.showIntervalHighlight).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description

Adds a new `showIntervalHighlight` prop to VCalendarCategory that highlights interval slots across all categories when hovering over a time slot. This makes it much easier to identify which time you're looking at in category views with many categories.

resolves #22593

## Markup:

```vue
<template>
  <v-app>
    <v-container fluid>
      <VCalendar
        type="category"
        :categories="categories"
        :events="events"
        :interval-width="80"
        :interval-height="48"
        :first-interval="6"
        :interval-count="14"
        show-interval-highlight
      />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      const categories = [
        { categoryName: 'John' },
        { categoryName: 'Jane' },
        { categoryName: 'Bob' },
        { categoryName: 'Alice' },
        { categoryName: 'Charlie' },
      ]

      const events = [
        { name: 'Meeting', start: '2026-06-01 09:00', end: '2026-06-01 10:00', category: 'John' },
        { name: 'Lunch', start: '2026-06-01 12:00', end: '2026-06-01 13:00', category: 'Jane' },
        { name: 'Review', start: '2026-06-01 14:00', end: '2026-06-01 15:30', category: 'Bob' },
        { name: 'Standup', start: '2026-06-01 09:30', end: '2026-06-01 10:00', category: 'Alice' },
        { name: 'Workshop', start: '2026-06-01 15:00', end: '2026-06-01 17:00', category: 'Charlie' },
      ]

      return {
        categories,
        events,
      }
    },
  }
</script>
```