### PR TITLE
feat(VCombobox): add `trim-values` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VCombobox.json
+++ b/packages/api-generator/src/locale/en/VCombobox.json
@@ -7,6 +7,7 @@
     "closeOnInputClick": "Clicking the field while the menu is open closes it.",
     "itemChildren": "This property currently has **no effect**.",
     "delimiters": "Accepts an array of strings that will trigger a new tag when typing. Does not replace the normal Tab and Enter keys.",
+    "trimValues": "Trims leading and trailing whitespace from entered values, and discards entries that are empty once trimmed.",
     "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props."
   },
   "slots": {

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -126,7 +126,8 @@
       "closeOnInputClick": "4.2.0",
       "form": "4.2.0",
       "listProps": "3.5.0",
-      "menuElevation": "4.0.0"
+      "menuElevation": "4.0.0",
+      "trimValues": "4.2.0"
     },
     "slots": {
       "menu-header": "3.12.0",

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -80,6 +80,7 @@ export const makeVComboboxProps = propsFactory({
   },
   delimiters: Array as PropType<readonly string[]>,
   closeOnInputClick: Boolean,
+  trimValues: Boolean,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps({ hideNoData: true, returnObject: true }),
@@ -348,8 +349,13 @@ export const VCombobox = genericComponent<new <
       }
 
       if (e.key === 'Enter' && search.value) {
-        select(transformItem(props, search.value), true, true)
-        if (hasSelectionSlot.value) _search.value = ''
+        const value = props.trimValues ? search.value.trim() : search.value
+        if (!value) {
+          search.value = ''
+        } else {
+          select(transformItem(props, value), true, true)
+          if (hasSelectionSlot.value) _search.value = ''
+        }
       }
 
       if (['Backspace', 'Delete'].includes(e.key)) {
@@ -540,17 +546,27 @@ export const VCombobox = genericComponent<new <
       menu.value = false
 
       if (search.value) {
-        if (props.multiple) {
-          select(transformItem(props, search.value))
+        const value = props.trimValues ? search.value.trim() : search.value
+
+        if (!value) {
+          search.value = ''
           return
         }
 
-        if (!hasSelectionSlot.value) return
+        if (props.multiple) {
+          select(transformItem(props, value))
+          return
+        }
 
-        if (model.value.some(({ title }) => title === search.value)) {
+        if (!hasSelectionSlot.value) {
+          if (value !== search.value) select(transformItem(props, value))
+          return
+        }
+
+        if (model.value.some(({ title }) => title === value)) {
           _search.value = ''
         } else {
-          select(transformItem(props, search.value))
+          select(transformItem(props, value))
         }
       }
     })

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -1094,5 +1094,60 @@ describe('VCombobox', () => {
     })
   })
 
+  describe('trimValues', () => {
+    it('should discard whitespace-only values and trim committed values', async () => {
+      const model = ref([])
+      render(() => (
+        <>
+          <VCombobox v-model={ model.value } multiple trimValues />
+          <button type="button">dummy</button>
+        </>
+      ))
+
+      const input = screen.getByCSS('input')
+
+      await userEvent.click(input)
+      await userEvent.keyboard(' ')
+      await userEvent.tab()
+      await expect.poll(() => model.value).toEqual([])
+
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+      await expect.poll(() => document.activeElement).toBe(input)
+      await userEvent.keyboard('  {Enter}')
+      await expect.poll(() => model.value).toEqual([])
+
+      await userEvent.keyboard('a {Enter}')
+      await expect.poll(() => model.value).toEqual(['a'])
+
+      await userEvent.keyboard(' b b')
+      await userEvent.tab()
+      await expect.poll(() => model.value).toEqual(['a', 'b b'])
+    })
+
+    it('should trim single value on blur', async () => {
+      const model = ref()
+      render(() => (
+        <>
+          <VCombobox v-model={ model.value } trimValues />
+          <button type="button">dummy</button>
+        </>
+      ))
+
+      const input = screen.getByCSS('input')
+
+      await userEvent.click(input)
+      await userEvent.keyboard('  ')
+      await userEvent.tab()
+      await expect.poll(() => model.value).toBeNull()
+
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+      await expect.poll(() => document.activeElement).toBe(input)
+      await userEvent.keyboard(' a a ')
+      await userEvent.tab()
+      await expect.poll(() => model.value).toBe('a a')
+      await expect.poll(() => (input as HTMLInputElement).value).toBe('a a')
+    })
+  })
+
   showcase({ stories })
 })


### PR DESCRIPTION
fixes #14874

Could be a default in v5.0, depending on reception and feedback. Original issue did not attract too much attention.

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="500">
      <v-alert class="mb-4"><pre>{{ values }}</pre></v-alert>
      <v-combobox
        v-model="values"
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        label="Combobox"
        chips
        closable-chips
        multiple
        trim-values
      />
    </v-container>
  </v-app>
</template>

<script setup>
  import { shallowRef } from 'vue'

  const values = shallowRef([])
</script>
```
