### PR TITLE
fix(VTreeviewItem): add aria-label to toggle button

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -13,6 +13,7 @@ import { VProgressCircular } from '@/components/VProgressCircular'
 // Composables
 import { forwardRefs } from '@/composables/forwardRefs'
 import { IconValue } from '@/composables/icons'
+import { useLocale } from '@/composables/locale'
 
 // Utilities
 import { computed, inject, ref, toRaw } from 'vue'
@@ -31,6 +32,7 @@ export const makeVTreeviewItemProps = propsFactory({
   hasCustomPrepend: Boolean,
   indentLines: Array as PropType<IndentLineType[]>,
   toggleIcon: IconValue,
+  ariaExpanded: Boolean,
 
   ...makeVListItemProps({ slim: true }),
 }, 'VTreeviewItem')
@@ -50,6 +52,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
 
   setup (props, { slots, emit }) {
     const visibleIds = inject(VTreeviewSymbol, { visibleIds: ref() }).visibleIds
+    const { t } = useLocale()
 
     const vListItemRef = ref<VListItem>()
 
@@ -102,6 +105,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
             props.class,
           ]}
           role="treeitem"
+          aria-expanded={ props.ariaExpanded || undefined }
           ripple={ false }
           onClick={ activateGroupActivator }
         >
@@ -132,6 +136,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
                               icon={ props.toggleIcon }
                               loading={ props.loading }
                               variant="text"
+                              aria-label={ t(props.ariaExpanded ? '$vuetify.treeview.collapse' : '$vuetify.treeview.expand') }
                               onClick={ onClickAction }
                             >
                               {{

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -957,3 +957,26 @@ describe('VTreeview with loading', () => {
     expect(screen.getByText(/4.leaf/)).not.toBeVisible()
   })
 })
+
+// https://github.com/vuetifyjs/vuetify/issues/21585
+// https://github.com/vuetifyjs/vuetify/issues/22898
+describe('VTreeview accessibility', () => {
+  it('should have aria-label on toggle button that changes with open state', async () => {
+    const items = [
+      { id: 1, title: 'Parent', children: [{ id: 2, title: 'Child' }] },
+    ]
+
+    render(() => (
+      <VTreeview items={ items } itemValue="id" />
+    ))
+
+    const toggleBtn = screen.getByLabelText('Expand')
+    expect(toggleBtn).toBeVisible()
+
+    await userEvent.click(toggleBtn)
+    await expect.element(screen.getByLabelText('Collapse')).toBeVisible()
+
+    await userEvent.click(screen.getByLabelText('Collapse'))
+    await expect.element(screen.getByLabelText('Expand')).toBeVisible()
+  })
+})

--- a/packages/vuetify/src/locale/af.ts
+++ b/packages/vuetify/src/locale/af.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Volskerm',
     exitFullscreen: 'Verlaat volskerm',
   },
+  treeview: {
+    expand: 'Uitbrei',
+    collapse: 'Invou',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Kies kleur van die skerm af',

--- a/packages/vuetify/src/locale/ar.ts
+++ b/packages/vuetify/src/locale/ar.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'ملء الشاشة',
     exitFullscreen: 'الخروج من وضع ملء الشاشة',
   },
+  treeview: {
+    expand: 'توسيع',
+    collapse: 'طي',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'اختيار لون من الشاشة',

--- a/packages/vuetify/src/locale/az.ts
+++ b/packages/vuetify/src/locale/az.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Tam ekran',
     exitFullscreen: 'Tam ekrandan çıx',
   },
+  treeview: {
+    expand: 'Genişlət',
+    collapse: 'Yığ',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Ekrandan rəng seçin',

--- a/packages/vuetify/src/locale/bg.ts
+++ b/packages/vuetify/src/locale/bg.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Цял екран',
     exitFullscreen: 'Изход от цял екран',
   },
+  treeview: {
+    expand: 'Разгъни',
+    collapse: 'Свий',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Вземане на цвят от екрана',

--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Pantalla completa',
     exitFullscreen: 'Sortir de pantalla completa',
   },
+  treeview: {
+    expand: 'Expandir',
+    collapse: 'Replegar',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Seleccionar color de la pantalla',

--- a/packages/vuetify/src/locale/ckb.ts
+++ b/packages/vuetify/src/locale/ckb.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'پڕ بە شاشە',
     exitFullscreen: 'چوونە دەرەوە لە پڕ بە شاشە',
   },
+  treeview: {
+    expand: 'فراوانکردن',
+    collapse: 'داخستن',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'ڕەنگ لەسەر شاشە هەڵبژێرە',

--- a/packages/vuetify/src/locale/cs.ts
+++ b/packages/vuetify/src/locale/cs.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Celá obrazovka',
     exitFullscreen: 'Ukončit celou obrazovku',
   },
+  treeview: {
+    expand: 'Rozbalit',
+    collapse: 'Sbalit',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Vybrat barvu z obrazovky',

--- a/packages/vuetify/src/locale/da.ts
+++ b/packages/vuetify/src/locale/da.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Fuld skærm',
     exitFullscreen: 'Afslut fuld skærm',
   },
+  treeview: {
+    expand: 'Udvid',
+    collapse: 'Skjul',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Vælg farve fra skærmen',

--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Vollbild',
     exitFullscreen: 'Vollbild beenden',
   },
+  treeview: {
+    expand: 'Erweitern',
+    collapse: 'Zuklappen',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Farbe vom Bildschirm auswählen',

--- a/packages/vuetify/src/locale/el.ts
+++ b/packages/vuetify/src/locale/el.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Πλήρης οθόνη',
     exitFullscreen: 'Έξοδος από πλήρη οθόνη',
   },
+  treeview: {
+    expand: 'Ανάπτυξη',
+    collapse: 'Σύμπτυξη',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Επιλογή χρώματος από την οθόνη',

--- a/packages/vuetify/src/locale/en.ts
+++ b/packages/vuetify/src/locale/en.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Full screen',
     exitFullscreen: 'Exit full screen',
   },
+  treeview: {
+    expand: 'Expand',
+    collapse: 'Collapse',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Select color with eyedropper',

--- a/packages/vuetify/src/locale/es.ts
+++ b/packages/vuetify/src/locale/es.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Pantalla completa',
     exitFullscreen: 'Salir de pantalla completa',
   },
+  treeview: {
+    expand: 'Expandir',
+    collapse: 'Colapsar',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Seleccionar color de la pantalla',

--- a/packages/vuetify/src/locale/et.ts
+++ b/packages/vuetify/src/locale/et.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Täisekraan',
     exitFullscreen: 'Välju täisekraanilt',
   },
+  treeview: {
+    expand: 'Laienda',
+    collapse: 'Ahenda',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Võta värv ekraanilt',

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'تمام صفحه',
     exitFullscreen: 'خروج از تمام صفحه',
   },
+  treeview: {
+    expand: 'گسترش',
+    collapse: 'جمع کردن',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'انتخاب رنگ از صفحه',

--- a/packages/vuetify/src/locale/fi.ts
+++ b/packages/vuetify/src/locale/fi.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Koko näyttö',
     exitFullscreen: 'Poistu koko näytöstä',
   },
+  treeview: {
+    expand: 'Laajenna',
+    collapse: 'Supista',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Valitse väri näytöltä',

--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Plein écran',
     exitFullscreen: 'Quitter le plein écran',
   },
+  treeview: {
+    expand: 'Développer',
+    collapse: 'Réduire',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Sélectionner une couleur à l\'écran',

--- a/packages/vuetify/src/locale/he.ts
+++ b/packages/vuetify/src/locale/he.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'מסך מלא',
     exitFullscreen: 'צא ממסך מלא',
   },
+  treeview: {
+    expand: 'הרחב',
+    collapse: 'צמצם',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'בחר צבע מהמסך',

--- a/packages/vuetify/src/locale/hr.ts
+++ b/packages/vuetify/src/locale/hr.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Puni zaslon',
     exitFullscreen: 'Izađi iz punog zaslona',
   },
+  treeview: {
+    expand: 'Proširi',
+    collapse: 'Sažmi',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Odaberite boju sa zaslona',

--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Teljes képernyő',
     exitFullscreen: 'Kilépés a teljes képernyőből',
   },
+  treeview: {
+    expand: 'Kibontás',
+    collapse: 'Összecsukás',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Szín kiválasztása a képernyőről',

--- a/packages/vuetify/src/locale/id.ts
+++ b/packages/vuetify/src/locale/id.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Layar penuh',
     exitFullscreen: 'Keluar dari layar penuh',
   },
+  treeview: {
+    expand: 'Perluas',
+    collapse: 'Ciutkan',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Pilih warna dari layar',

--- a/packages/vuetify/src/locale/it.ts
+++ b/packages/vuetify/src/locale/it.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Schermo intero',
     exitFullscreen: 'Esci da schermo intero',
   },
+  treeview: {
+    expand: 'Espandi',
+    collapse: 'Collassa',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Seleziona il colore dallo schermo',

--- a/packages/vuetify/src/locale/ja.ts
+++ b/packages/vuetify/src/locale/ja.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: '全画面表示',
     exitFullscreen: '全画面表示を終了',
   },
+  treeview: {
+    expand: '展開',
+    collapse: '折りたたむ',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: '画面から色を選択',

--- a/packages/vuetify/src/locale/km.ts
+++ b/packages/vuetify/src/locale/km.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'ពេញអេក្រង់',
     exitFullscreen: 'ចេញពីអេក្រង់ពេ',
   },
+  treeview: {
+    expand: 'ពង្រីក',
+    collapse: 'បង្រួម',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'ជ្រើសរើសពណ៌ពីអេក្រង់',

--- a/packages/vuetify/src/locale/ko.ts
+++ b/packages/vuetify/src/locale/ko.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: '전체 화면',
     exitFullscreen: '전체 화면 종료',
   },
+  treeview: {
+    expand: '펼치기',
+    collapse: '접기',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: '화면에서 색상 선택',

--- a/packages/vuetify/src/locale/lt.ts
+++ b/packages/vuetify/src/locale/lt.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Visas ekranas',
     exitFullscreen: 'Išeiti iš viso ekrano',
   },
+  treeview: {
+    expand: 'Išskleisti',
+    collapse: 'Suskleisti',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Pasirinkite spalvą iš ekrano',

--- a/packages/vuetify/src/locale/lv.ts
+++ b/packages/vuetify/src/locale/lv.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Pilnekrāna režīms',
     exitFullscreen: 'Iziet no pilnekrāna režīma',
   },
+  treeview: {
+    expand: 'Izvērst',
+    collapse: 'Sakļaut',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Izvēlēties krāsu no ekrāna',

--- a/packages/vuetify/src/locale/nl.ts
+++ b/packages/vuetify/src/locale/nl.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Volledig scherm',
     exitFullscreen: 'Volledig scherm verlaten',
   },
+  treeview: {
+    expand: 'Uitvouwen',
+    collapse: 'Invouwen',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Kies een kleur van het scherm',

--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Fullskjerm',
     exitFullscreen: 'Avslutt fullskjerm',
   },
+  treeview: {
+    expand: 'Utvid',
+    collapse: 'Skjul',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Velg farge fra skjermen',

--- a/packages/vuetify/src/locale/pl.ts
+++ b/packages/vuetify/src/locale/pl.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Pełny ekran',
     exitFullscreen: 'Opuść pełny ekran',
   },
+  treeview: {
+    expand: 'Rozwiń',
+    collapse: 'Zwiń',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Pobierz kolor z ekranu',

--- a/packages/vuetify/src/locale/pt.ts
+++ b/packages/vuetify/src/locale/pt.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Tela cheia',
     exitFullscreen: 'Sair da tela cheia',
   },
+  treeview: {
+    expand: 'Expandir',
+    collapse: 'Recolher',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Selecionar cor da tela',

--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Ecran complet',
     exitFullscreen: 'Ieșire din ecran complet',
   },
+  treeview: {
+    expand: 'Extinde',
+    collapse: 'Restrânge',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Alege culoarea de pe ecran',

--- a/packages/vuetify/src/locale/ru.ts
+++ b/packages/vuetify/src/locale/ru.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Полноэкранный режим',
     exitFullscreen: 'Выйти из полноэкранного режима',
   },
+  treeview: {
+    expand: 'Развернуть',
+    collapse: 'Свернуть',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Выбрать цвет с экрана',

--- a/packages/vuetify/src/locale/sk.ts
+++ b/packages/vuetify/src/locale/sk.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Celá obrazovka',
     exitFullscreen: 'Opustiť celú obrazovku',
   },
+  treeview: {
+    expand: 'Rozbaliť',
+    collapse: 'Zbaliť',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Vybrať farbu z obrazovky',

--- a/packages/vuetify/src/locale/sl.ts
+++ b/packages/vuetify/src/locale/sl.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Celozaslonski način',
     exitFullscreen: 'Izhod iz celozaslonskega načina',
   },
+  treeview: {
+    expand: 'Razširi',
+    collapse: 'Skrči',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Izberi barvo z zaslona',

--- a/packages/vuetify/src/locale/sr-Cyrl.ts
+++ b/packages/vuetify/src/locale/sr-Cyrl.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Цео екран',
     exitFullscreen: 'Изађи из целог екрана',
   },
+  treeview: {
+    expand: 'Прошири',
+    collapse: 'Скупи',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Изаберите боју са екрана',

--- a/packages/vuetify/src/locale/sr-Latn.ts
+++ b/packages/vuetify/src/locale/sr-Latn.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Prikaz preko cijelog ekrana',
     exitFullscreen: 'Izađi iz prikaza preko cijelog ekrana',
   },
+  treeview: {
+    expand: 'Proširi',
+    collapse: 'Skupi',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Izaberite boju sa ekrana',

--- a/packages/vuetify/src/locale/sv.ts
+++ b/packages/vuetify/src/locale/sv.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Helskärm',
     exitFullscreen: 'Avsluta helskärm',
   },
+  treeview: {
+    expand: 'Expandera',
+    collapse: 'Komprimera',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Välj färg från skärmen',

--- a/packages/vuetify/src/locale/th.ts
+++ b/packages/vuetify/src/locale/th.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'เต็มหน้าจอ',
     exitFullscreen: 'ออกจากเต็มหน้าจอ',
   },
+  treeview: {
+    expand: 'ขยาย',
+    collapse: 'ยุบ',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'เลือกสีจากหน้าจอ',

--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Tam ekran',
     exitFullscreen: 'Tam ekrandan çık',
   },
+  treeview: {
+    expand: 'Genişlet',
+    collapse: 'Daralt',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Ekranda renk seç',

--- a/packages/vuetify/src/locale/uk.ts
+++ b/packages/vuetify/src/locale/uk.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'На весь екран',
     exitFullscreen: 'Вийти з повноекранного режиму',
   },
+  treeview: {
+    expand: 'Розгорнути',
+    collapse: 'Згорнути',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Вибрати колір з екрана',

--- a/packages/vuetify/src/locale/vi.ts
+++ b/packages/vuetify/src/locale/vi.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: 'Toàn màn hình',
     exitFullscreen: 'Thoát toàn màn hình',
   },
+  treeview: {
+    expand: 'Mở rộng',
+    collapse: 'Thu gọn',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: 'Chọn màu từ màn hình',

--- a/packages/vuetify/src/locale/zh-Hans.ts
+++ b/packages/vuetify/src/locale/zh-Hans.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: '全屏',
     exitFullscreen: '退出全屏',
   },
+  treeview: {
+    expand: '展开',
+    collapse: '收起',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: '从屏幕拾取颜色',

--- a/packages/vuetify/src/locale/zh-Hant.ts
+++ b/packages/vuetify/src/locale/zh-Hant.ts
@@ -185,6 +185,10 @@ export default {
     enterFullscreen: '全螢幕',
     exitFullscreen: '退出全螢幕',
   },
+  treeview: {
+    expand: '展開',
+    collapse: '收起',
+  },
   colorPicker: {
     ariaLabel: {
       eyedropper: '從螢幕上選取顏色',


### PR DESCRIPTION
## Description
  
Adds an accessible `aria-label` to the expand/collapse toggle `VBtn` in `VTreeviewItem` using the locale composable.
The label toggles between "Expand" and "Collapse" based on the current open state.
  
Adds corresponding `treeview.expand` and `treeview.collapse` locale entries for `en` and `it`.
  
fixes #21585, fixes #22898
  
## Example:
  
```vue
<template>
    <v-treeview
      :items="items"
      open-all
      item-value="id"
    />
</template>
  
<script setup>
  const items = [
    {
      id: 1,
      title: 'Root',
      children: [
        { id: 2, title: 'Child 1' },
        { id: 3, title: 'Child 2', children: [{ id: 4, title: 'Grandchild' }] },
      ],
    },
  ]
</script>

check with Accessibility Insights for Web, should display no issues.