### PR TITLE
fix(VMenu): submenu a11y/navigation improvements

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -109,7 +109,6 @@ export const VMenu = genericComponent<OverlaySlots>()({
           }
         }, 40)
       },
-      openOnHover: props.openOnHover,
       rootOpenedByHover: props.submenu && parent
         ? parent.rootOpenedByHover
         : () => overlay.value?.openedByHover ?? false,

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -119,6 +119,12 @@ export const VMenu = genericComponent<OverlaySlots>()({
       if (props.disabled) return
 
       if (e.key === 'Tab') {
+        if (props.submenu && !props.retainFocus) {
+          e.preventDefault()
+          isActive.value = false
+          overlay.value?.activatorEl?.focus()
+          return
+        }
         const nextElement = getNextElement(
           focusableChildren(overlay.value?.contentEl as Element, false),
           e.shiftKey ? 'prev' : 'next',

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -165,7 +165,23 @@ export const VMenu = genericComponent<OverlaySlots>()({
       ) {
         isActive.value = true
         e.preventDefault()
-        setTimeout(() => setTimeout(() => onActivatorKeydown(e)))
+        focusContentWhenReady(e)
+      }
+    }
+
+    // Re-dispatch the opening keystroke once the menu content has mounted and its
+    // items are focusable. A fixed delay races with content layout and only lands
+    // focus about half the time, so retry across frames until focus is inside.
+    function focusContentWhenReady (e: KeyboardEvent, attempt = 1) {
+      if (!isActive.value) return
+      const el = overlay.value?.contentEl
+      if (el?.contains(document.activeElement)) return
+      if (el && focusableChildren(el).length) {
+        onActivatorKeydown(e)
+        if (el.contains(document.activeElement)) return
+      }
+      if (attempt <= 10) {
+        requestAnimationFrame(() => focusContentWhenReady(e, attempt + 1))
       }
     }
 

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -83,13 +83,17 @@ export const VMenu = genericComponent<OverlaySlots>()({
     const overlay = ref<VOverlay>()
 
     const parent = inject(VMenuSymbol, null)
-    const openChildren = shallowRef(new Set<string>())
+    const openChildren = shallowRef(new Map<string, () => void>())
     provide(VMenuSymbol, {
-      register () {
-        openChildren.value.add(uid)
+      register (childUid, close) {
+        // Only one submenu open per level: close any already-open sibling first.
+        for (const [otherUid, closeOther] of [...openChildren.value]) {
+          if (otherUid !== childUid) closeOther()
+        }
+        openChildren.value.set(childUid, close)
       },
-      unregister () {
-        openChildren.value.delete(uid)
+      unregister (childUid) {
+        openChildren.value.delete(childUid)
       },
       closeParents (e) {
         const clickedOutside = !e || overlay.value?.contentEl?._clickOutside?.lastMousedownWasOutside
@@ -104,15 +108,26 @@ export const VMenu = genericComponent<OverlaySlots>()({
           }
         }, 40)
       },
+      openOnHover: props.openOnHover,
+      // Submenus inherit the chain root's hover-open state; a non-submenu menu reports its own,
+      // so hover-leave collapses a submenu tree only when its root menu was hover-opened.
+      rootOpenedByHover: props.submenu && parent
+        ? parent.rootOpenedByHover
+        : () => overlay.value?.openedByHover ?? false,
     })
 
-    onBeforeUnmount(() => parent?.unregister())
+    onBeforeUnmount(() => parent?.unregister(uid))
     onDeactivated(() => isActive.value = false)
 
     watch(isActive, val => {
-      val
-        ? parent?.register()
-        : parent?.unregister()
+      if (val) {
+        parent?.register(uid, () => { isActive.value = false })
+      } else {
+        parent?.unregister(uid)
+        // Closing a menu collapses its whole open subtree, so descendants don't
+        // linger hidden-but-active and reappear when this menu is reopened.
+        for (const [, closeChild] of [...openChildren.value]) closeChild()
+      }
     }, { immediate: true })
 
     function onKeydown (e: KeyboardEvent) {
@@ -210,6 +225,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
           { ...overlayProps }
           v-model={ isActive.value }
           absolute
+          _submenu={ props.submenu }
           activatorProps={ activatorProps.value }
           location={ props.location ?? (props.submenu ? 'end' : 'bottom') }
           onKeydown={ onKeydown }

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -31,6 +31,7 @@ import {
   focusableChildren,
   focusChild,
   genericComponent,
+  getActiveElement,
   getNextElement,
   omit,
   propsFactory,
@@ -109,8 +110,6 @@ export const VMenu = genericComponent<OverlaySlots>()({
         }, 40)
       },
       openOnHover: props.openOnHover,
-      // Submenus inherit the chain root's hover-open state; a non-submenu menu reports its own,
-      // so hover-leave collapses a submenu tree only when its root menu was hover-opened.
       rootOpenedByHover: props.submenu && parent
         ? parent.rootOpenedByHover
         : () => overlay.value?.openedByHover ?? false,
@@ -124,8 +123,8 @@ export const VMenu = genericComponent<OverlaySlots>()({
         parent?.register(uid, () => { isActive.value = false })
       } else {
         parent?.unregister(uid)
-        // Closing a menu collapses its whole open subtree, so descendants don't
-        // linger hidden-but-active and reappear when this menu is reopened.
+
+        // close a submenu branch
         for (const [, closeChild] of [...openChildren.value]) closeChild()
       }
     }, { immediate: true })
@@ -184,16 +183,13 @@ export const VMenu = genericComponent<OverlaySlots>()({
       }
     }
 
-    // Re-dispatch the opening keystroke once the menu content has mounted and its
-    // items are focusable. A fixed delay races with content layout and only lands
-    // focus about half the time, so retry across frames until focus is inside.
     function focusContentWhenReady (e: KeyboardEvent, attempt = 1) {
       if (!isActive.value) return
       const el = overlay.value?.contentEl
-      if (el?.contains(document.activeElement)) return
+      if (el?.contains(getActiveElement())) return
       if (el && focusableChildren(el).length) {
         onActivatorKeydown(e)
-        if (el.contains(document.activeElement)) return
+        if (el.contains(getActiveElement())) return
       }
       if (attempt <= 10) {
         requestAnimationFrame(() => focusContentWhenReady(e, attempt + 1))

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -129,6 +129,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
         }
       } else if (props.submenu && e.key === (isRtl.value ? 'ArrowRight' : 'ArrowLeft')) {
         isActive.value = false
+        overlay.value?.activatorEl?.focus()
       }
     }
 
@@ -145,6 +146,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
         } else if (props.submenu) {
           if (e.key === (isRtl.value ? 'ArrowRight' : 'ArrowLeft')) {
             isActive.value = false
+            overlay.value?.activatorEl?.focus()
           } else if (e.key === (isRtl.value ? 'ArrowLeft' : 'ArrowRight')) {
             e.preventDefault()
             focusChild(el, 'first')

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -781,5 +781,101 @@ describe('VMenu', () => {
       await expect.poll(() => screen.queryByTestId('l1-item-1')).toBeNull()
       expect(document.activeElement).toBe(screen.getByTestId('after'))
     })
+
+    it('should keep focus inside the menu tree when Tab/Shift+Tab is pressed in a submenu', async () => {
+      render(() => (
+        <div>
+          <button data-testid="before">before</button>
+          <VBtn data-testid="top-btn">
+            Open
+            <VMenu activator="parent">
+              <VList>
+                <VListItem data-testid="l1-item-1" link>L1-1</VListItem>
+                <VListItem data-testid="l1-item-2" link>
+                  <span>L1-2</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="l2-item-1" link>L2-1</VListItem>
+                      <VListItem data-testid="l2-item-2" link>L2-2</VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+          <button data-testid="after">after</button>
+        </div>
+      ))
+
+      screen.getByTestId('before').focus()
+
+      await userEvent.keyboard('{Tab}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('top-btn'))
+
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l1-item-1'))
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l1-item-2'))
+      await userEvent.keyboard('{ArrowRight}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l2-item-1'))
+
+      await userEvent.keyboard('{Tab}')
+      await expect.poll(() => screen.queryByTestId('l2-item-1')).toBeNull()
+      expect(screen.queryByTestId('l1-item-1')).toBeVisible()
+      expect(document.activeElement).toBe(screen.getByTestId('l1-item-2'))
+
+      await userEvent.keyboard('{ArrowRight}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l2-item-1'))
+
+      await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+      await expect.poll(() => screen.queryByTestId('l2-item-1')).toBeNull()
+      expect(screen.queryByTestId('l1-item-1')).toBeVisible()
+      expect(document.activeElement).toBe(screen.getByTestId('l1-item-2'))
+    })
+
+    // Animations widen the gap between content mount and item layout, which is
+    // exactly when the open keystroke used to drop focus, so run with real motion.
+    describe('with animations', () => {
+      beforeEach(() => commands.setReduceMotionDisabled())
+      afterEach(() => commands.setReduceMotionEnabled())
+
+      it('should focus the first submenu item with a single ArrowRight press', async () => {
+        render(() => (
+          <div>
+            <button data-testid="before">before</button>
+            <VBtn data-testid="top-btn">
+              Open
+              <VMenu activator="parent">
+                <VList>
+                  <VListItem data-testid="l1-item-1" link>L1-1</VListItem>
+                  <VListItem data-testid="l1-item-2" link>
+                    <span>L1-2</span>
+                    <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                      <VList>
+                        <VListItem data-testid="l2-item-1" link>L2-1</VListItem>
+                        <VListItem data-testid="l2-item-2" link>L2-2</VListItem>
+                      </VList>
+                    </VMenu>
+                  </VListItem>
+                </VList>
+              </VMenu>
+            </VBtn>
+          </div>
+        ))
+
+        screen.getByTestId('top-btn').focus()
+
+        // Each open is a single keypress — no retry. Polling waits for the
+        // deferred focus to land, but never re-presses the key.
+        await userEvent.keyboard('{ArrowDown}')
+        await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l1-item-1'))
+
+        await userEvent.keyboard('{ArrowDown}')
+        await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l1-item-2'))
+
+        await userEvent.keyboard('{ArrowRight}')
+        await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l2-item-1'))
+      })
+    })
   })
 })

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -346,6 +346,94 @@ describe('VMenu', () => {
 
     afterEach(() => commands.setReduceMotionEnabled())
 
+    it('should keep submenus open on mouse-leave when the root menu was not hover-opened', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="top-btn">
+            Open
+            <VMenu activator="parent">
+              <VList>
+                <VListItem data-testid="l1-item" link>
+                  <span>L1</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="l2-item" link>L2</VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+          <div data-testid="outside" style="height: 40px;">outside</div>
+        </div>
+      ))
+
+      // root opened by click → the whole chain is sticky against hover-leave
+      await userEvent.click(screen.getByTestId('top-btn'))
+      await expect.poll(() => screen.queryByTestId('l1-item')).toBeVisible()
+
+      // hover-opened submenu, then leave entirely → stays open
+      await userEvent.hover(screen.getByTestId('l1-item'))
+      await expect.poll(() => screen.queryByTestId('l2-item')).toBeVisible()
+      await userEvent.hover(screen.getByTestId('outside'))
+      await wait(600)
+      expect(screen.queryByTestId('l2-item')).toBeVisible()
+
+      // keyboard-opened submenu, then leave → also stays open
+      screen.getByTestId('l1-item').focus()
+      await userEvent.keyboard('{ArrowRight}')
+      await expect.poll(() => screen.queryByTestId('l2-item')).toBeVisible()
+      await userEvent.hover(screen.getByTestId('outside'))
+      await wait(600)
+
+      expect(screen.queryByTestId('l2-item')).toBeVisible()
+    })
+
+    it('should collapse the whole chain when the cursor leaves a hover-opened root menu', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="top-btn" openOnHover>
+            Open
+            <VMenu activator="parent" openOnHover>
+              <VList>
+                <VListItem data-testid="l1-item" link>
+                  <span>L1</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="l2-item" link>
+                        <span>L2</span>
+                        <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                          <VList>
+                            <VListItem data-testid="l3-item" link>L3</VListItem>
+                          </VList>
+                        </VMenu>
+                      </VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+          <div data-testid="outside" style="height: 200px;">outside</div>
+        </div>
+      ))
+
+      // hover the whole chain open
+      await userEvent.hover(screen.getByTestId('top-btn'))
+      await expect.poll(() => screen.queryByTestId('l1-item')).toBeVisible()
+      await userEvent.hover(screen.getByTestId('l1-item'))
+      await expect.poll(() => screen.queryByTestId('l2-item')).toBeVisible()
+      await userEvent.hover(screen.getByTestId('l2-item'))
+      await expect.poll(() => screen.queryByTestId('l3-item')).toBeVisible()
+
+      // cursor leaves everything → the entire tree collapses (root was hover-opened)
+      await userEvent.hover(screen.getByTestId('outside'))
+
+      await expect.poll(() => screen.queryByTestId('l3-item'), { timeout: 2500 }).toBeNull()
+      await expect.poll(() => screen.queryByTestId('l2-item'), { timeout: 2500 }).toBeNull()
+      await expect.poll(() => screen.queryByTestId('l1-item'), { timeout: 2500 }).toBeNull()
+    })
+
     it('should return focus to the top-level activator after clicking the deepest item', async () => {
       render(() => (
         <div>
@@ -390,6 +478,39 @@ describe('VMenu', () => {
       await expect.poll(() => screen.queryByTestId('l1-item')).toBeNull()
 
       expect(document.activeElement).toBe(topBtn)
+    })
+
+    // The hover-leave verdict only follows the menu chain for actual submenus. A tooltip
+    // (or any non-submenu overlay) nested in a click-opened menu must still close on its own.
+    it('should close a tooltip nested in a click-opened menu when the mouse leaves', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="top-btn">
+            Open
+            <VMenu activator="parent">
+              <VList>
+                <VListItem data-testid="item" link>
+                  <span>Item</span>
+                  <VTooltip activator="parent" openOnHover>
+                    <span data-testid="tip">tip</span>
+                  </VTooltip>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+          <div data-testid="outside" style="height: 40px;">outside</div>
+        </div>
+      ))
+
+      await userEvent.click(screen.getByTestId('top-btn'))
+      await expect.poll(() => screen.queryByTestId('item')).toBeVisible()
+
+      await userEvent.hover(screen.getByTestId('item'))
+      await expect.poll(() => screen.queryByTestId('tip')).toBeVisible()
+
+      // VTooltip is eager, so its content stays mounted — assert it hides, not unmounts
+      await userEvent.hover(screen.getByTestId('outside'))
+      await expect.poll(() => screen.queryByTestId('tip')).not.toBeVisible()
     })
 
     it('should keep the parent menu open when parts of inner content hide on click', async () => {
@@ -713,6 +834,126 @@ describe('VMenu', () => {
     })
   })
 
+  describe('one submenu open per level', () => {
+    beforeEach(() => commands.setReduceMotionDisabled())
+
+    afterEach(() => commands.setReduceMotionEnabled())
+
+    function renderSiblings () {
+      return render(() => (
+        <div>
+          <VBtn data-testid="top-btn">
+            Open
+            <VMenu activator="parent">
+              <VList>
+                <VListItem data-testid="a-item" link>
+                  <span>A</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="a-sub" link>A-1</VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+                <VListItem data-testid="b-item" link>
+                  <span>B</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="b-sub" link>B-1</VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+        </div>
+      ))
+    }
+
+    it('should close a hover-opened submenu when a sibling submenu opens on hover', async () => {
+      renderSiblings()
+
+      await userEvent.click(screen.getByTestId('top-btn'))
+      await expect.poll(() => screen.queryByTestId('a-item')).toBeVisible()
+
+      await userEvent.hover(screen.getByTestId('a-item'))
+      await expect.poll(() => screen.queryByTestId('a-sub')).toBeVisible()
+
+      await userEvent.hover(screen.getByTestId('b-item'))
+      await expect.poll(() => screen.queryByTestId('b-sub')).toBeVisible()
+
+      // only one submenu should remain open at this level
+      await expect.poll(() => screen.queryByTestId('a-sub')).toBeNull()
+    })
+
+    it('should close a keyboard-opened submenu when a sibling submenu opens on hover', async () => {
+      renderSiblings()
+
+      await userEvent.click(screen.getByTestId('top-btn'))
+      await expect.poll(() => screen.queryByTestId('a-item')).toBeVisible()
+
+      screen.getByTestId('a-item').focus()
+      await userEvent.keyboard('{ArrowRight}')
+      await expect.poll(() => screen.queryByTestId('a-sub')).toBeVisible()
+
+      await userEvent.hover(screen.getByTestId('b-item'))
+      await expect.poll(() => screen.queryByTestId('b-sub')).toBeVisible()
+
+      await expect.poll(() => screen.queryByTestId('a-sub')).toBeNull()
+    })
+
+    it('should close a submenu and its open descendants when a sibling opens', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="top-btn">
+            Open
+            <VMenu activator="parent">
+              <VList>
+                <VListItem data-testid="a-item" link>
+                  <span>A</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="a-sub" link>
+                        <span>A-1</span>
+                        <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                          <VList>
+                            <VListItem data-testid="a-sub-sub" link>A-1-a</VListItem>
+                          </VList>
+                        </VMenu>
+                      </VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+                <VListItem data-testid="b-item" link>
+                  <span>B</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="b-sub" link>B-1</VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+        </div>
+      ))
+
+      await userEvent.click(screen.getByTestId('top-btn'))
+      await expect.poll(() => screen.queryByTestId('a-item')).toBeVisible()
+
+      await userEvent.hover(screen.getByTestId('a-item'))
+      await expect.poll(() => screen.queryByTestId('a-sub')).toBeVisible()
+      await userEvent.hover(screen.getByTestId('a-sub'))
+      await expect.poll(() => screen.queryByTestId('a-sub-sub')).toBeVisible()
+
+      // switching to sibling B should collapse A and its whole open subtree
+      await userEvent.hover(screen.getByTestId('b-item'))
+      await expect.poll(() => screen.queryByTestId('b-sub')).toBeVisible()
+
+      await expect.poll(() => screen.queryByTestId('a-sub')).toBeNull()
+      expect(screen.queryByTestId('a-sub-sub')).toBeNull()
+    })
+  })
+
   describe('submenu keyboard navigation', () => {
     it('should close submenus one level at a time with ArrowLeft and keep focus inside', async () => {
       render(() => (
@@ -837,6 +1078,7 @@ describe('VMenu', () => {
     // exactly when the open keystroke used to drop focus, so run with real motion.
     describe('with animations', () => {
       beforeEach(() => commands.setReduceMotionDisabled())
+
       afterEach(() => commands.setReduceMotionEnabled())
 
       it('should focus the first submenu item with a single ArrowRight press', async () => {

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -712,4 +712,74 @@ describe('VMenu', () => {
       expect(screen.queryByTestId('menu-content')).toBeVisible()
     })
   })
+
+  describe('submenu keyboard navigation', () => {
+    it('should close submenus one level at a time with ArrowLeft and keep focus inside', async () => {
+      render(() => (
+        <div>
+          <button data-testid="before">before</button>
+          <VBtn data-testid="top-btn">
+            Open
+            <VMenu activator="parent">
+              <VList>
+                <VListItem data-testid="l1-item-1" link>L1-1</VListItem>
+                <VListItem data-testid="l1-item-2" link>
+                  <span>L1-2</span>
+                  <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                    <VList>
+                      <VListItem data-testid="l2-item-1" link>L2-1</VListItem>
+                      <VListItem data-testid="l2-item-2" link>
+                        <span>L2-2</span>
+                        <VMenu openOnFocus={ false } activator="parent" openOnHover submenu>
+                          <VList>
+                            <VListItem data-testid="l3-item-1" link>L3-1</VListItem>
+                            <VListItem data-testid="l3-item-2" link>L3-2</VListItem>
+                          </VList>
+                        </VMenu>
+                      </VListItem>
+                    </VList>
+                  </VMenu>
+                </VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+          <button data-testid="after">after</button>
+        </div>
+      ))
+
+      screen.getByTestId('before').focus()
+
+      await userEvent.keyboard('{Tab}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('top-btn'))
+
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l1-item-1'))
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l1-item-2'))
+
+      await userEvent.keyboard('{ArrowRight}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l2-item-1'))
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l2-item-2'))
+
+      await userEvent.keyboard('{ArrowRight}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l3-item-1'))
+
+      await userEvent.keyboard('{ArrowLeft}')
+      await expect.poll(() => screen.queryByTestId('l3-item-1')).toBeNull()
+      expect(screen.queryByTestId('l2-item-1')).toBeVisible()
+      expect(document.activeElement).toBe(screen.getByTestId('l2-item-2'))
+
+      await userEvent.keyboard('{ArrowDown}')
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId('l2-item-1'))
+      await userEvent.keyboard('{ArrowLeft}')
+      await expect.poll(() => screen.queryByTestId('l2-item-1')).toBeNull()
+      expect(screen.queryByTestId('l1-item-1')).toBeVisible()
+      expect(document.activeElement).toBe(screen.getByTestId('l1-item-2'))
+
+      await userEvent.keyboard('{Tab}')
+      await expect.poll(() => screen.queryByTestId('l1-item-1')).toBeNull()
+      expect(document.activeElement).toBe(screen.getByTestId('after'))
+    })
+  })
 })

--- a/packages/vuetify/src/components/VMenu/shared.ts
+++ b/packages/vuetify/src/components/VMenu/shared.ts
@@ -2,8 +2,10 @@
 import type { InjectionKey } from 'vue'
 
 interface MenuProvide {
-  register (): void
-  unregister (): void
+  openOnHover: boolean
+  rootOpenedByHover: () => boolean
+  register (uid: string, close: () => void): void
+  unregister (uid: string): void
   closeParents (e?: MouseEvent): void
 }
 

--- a/packages/vuetify/src/components/VMenu/shared.ts
+++ b/packages/vuetify/src/components/VMenu/shared.ts
@@ -2,7 +2,6 @@
 import type { InjectionKey } from 'vue'
 
 interface MenuProvide {
-  openOnHover: boolean
   rootOpenedByHover: () => boolean
   register (uid: string, close: () => void): void
   unregister (uid: string): void

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -289,11 +289,13 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         const activeEl = getActiveElement()
         const el = activatorEl.value
         openedWithActivatorFocus = !!el && (activeEl === el || el.contains(activeEl))
+        contentEl.value?.removeAttribute('inert')
         // eager reuses contentEl, so the mousedown that opened us would linger until the next one
         if (contentEl.value?._clickOutside) {
           contentEl.value._clickOutside.lastMousedownWasOutside = false
         }
       } else {
+        if (contentEl.value) contentEl.value.inert = true
         returnFocusToActivator()
       }
     }, { flush: 'post' })

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -135,6 +135,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
   props: {
     _disableGlobalStack: Boolean,
+    _submenu: Boolean,
 
     ...omit(makeVOverlayProps(), ['disableInitialFocus']),
   },
@@ -172,7 +173,8 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       activatorEvents,
       contentEvents,
       scrimEvents,
-    } = useActivator(props, { isActive, isTop: localTop, contentEl })
+      openedByHover,
+    } = useActivator(props, { isActive, isTop: localTop, contentEl, isSubmenu: props._submenu })
     const { teleportTarget } = useTeleport(() => {
       const target = props.attach || props.contained
       if (target) return target
@@ -259,8 +261,12 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     function returnFocusToActivator () {
       const el = activatorEl.value
       if (!el || !el.isConnected) return
-      // Skip submenus; the outermost close in the cascade will restore focus.
-      if (el.closest('.v-overlay__content')) return
+      // In a full cascade, the parent overlay's content is also inert (closing),
+      // so let the outermost close handle focus restoration.
+      // If the parent is still active (e.g. only this submenu closes via hover-out),
+      // we must restore focus ourselves so it doesn't fall to document.body.
+      const parentContent = el.closest<HTMLElement>('.v-overlay__content')
+      if (parentContent?.inert) return
 
       if (contentEl.value?._clickOutside?.lastMousedownWasOutside) return
 
@@ -479,6 +485,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       globalTop,
       localTop,
       updateLocation,
+      openedByHover,
     }
   },
 })

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -261,9 +261,8 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     function returnFocusToActivator () {
       const el = activatorEl.value
       if (!el || !el.isConnected) return
-
-      const parentContent = el.closest<HTMLElement>('.v-overlay__content')
-      if (parentContent?.inert) return
+      // Skip submenus; the outermost close in the cascade will restore focus.
+      if (el.closest('.v-overlay__content')) return
 
       if (contentEl.value?._clickOutside?.lastMousedownWasOutside) return
 
@@ -292,7 +291,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         const activeEl = getActiveElement()
         const el = activatorEl.value
         openedWithActivatorFocus = !!el && (activeEl === el || el.contains(activeEl))
-        contentEl.value?.removeAttribute('inert')
+        if (contentEl.value) contentEl.value.inert = false
         // eager reuses contentEl, so the mousedown that opened us would linger until the next one
         if (contentEl.value?._clickOutside) {
           contentEl.value._clickOutside.lastMousedownWasOutside = false

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -261,10 +261,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     function returnFocusToActivator () {
       const el = activatorEl.value
       if (!el || !el.isConnected) return
-      // In a full cascade, the parent overlay's content is also inert (closing),
-      // so let the outermost close handle focus restoration.
-      // If the parent is still active (e.g. only this submenu closes via hover-out),
-      // we must restore focus ourselves so it doesn't fall to document.body.
+
       const parentContent = el.closest<HTMLElement>('.v-overlay__content')
       if (parentContent?.inert) return
 

--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -90,14 +90,10 @@ export function useActivator (
   let isHovered = false
   let isFocused = false
   let firstEnter = true
-  // True only when this overlay was last opened by the hover delay (not keyboard/click/focus).
   const openedByHover = ref(false)
-  // Set synchronously inside the delay callback before mutating isActive; consumed by the next watcher tick.
   let delayCallbackFiredOpen = false
 
-  // Hover-leave should collapse the whole structure only when the ROOT of the chain was hover-opened.
-  // A submenu inherits the root's verdict via VMenuSymbol; everything else (tooltips, root or
-  // standalone menus) decides on its own hover-open state, even when nested in a menu's content.
+  // mouseleave should collapse the whole structure only when the ROOT of the chain was hover-opened
   const rootOpenedByHover = () => isSubmenu
     ? (parentMenu?.rootOpenedByHover?.() ?? openedByHover.value)
     : openedByHover.value
@@ -327,7 +323,17 @@ export function useActivator (
     scope?.stop()
   })
 
-  return { activatorEl, activatorRef, target, targetEl, targetRef, activatorEvents, contentEvents, scrimEvents, openedByHover }
+  return {
+    activatorEl,
+    activatorRef,
+    target,
+    targetEl,
+    targetRef,
+    activatorEvents,
+    contentEvents,
+    scrimEvents,
+    openedByHover,
+  }
 }
 
 function _useActivator (

--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -93,10 +93,8 @@ export function useActivator (
   const openedByHover = ref(false)
   let delayCallbackFiredOpen = false
 
-  // mouseleave should collapse the whole structure only when the ROOT of the chain was hover-opened
-  const rootOpenedByHover = () => isSubmenu
-    ? (parentMenu?.rootOpenedByHover?.() ?? openedByHover.value)
-    : openedByHover.value
+  // a submenu chain collapses on mouseleave only when its root was hover-opened
+  const shouldCloseOnLeave = () => !isSubmenu || (parentMenu?.rootOpenedByHover?.() ?? openedByHover.value)
 
   const openOnFocus = computed(() => props.openOnFocus || (props.openOnFocus == null && props.openOnHover))
   const openOnClick = computed(() => props.openOnClick || (props.openOnClick == null && !props.openOnHover && !openOnFocus.value))
@@ -159,7 +157,7 @@ export function useActivator (
     onMouseleave: (e: MouseEvent) => {
       isHovered = false
       if (props.target === 'cursor') isFocused = false
-      if (rootOpenedByHover()) runCloseDelay()
+      if (shouldCloseOnLeave()) runCloseDelay()
     },
     onFocus: (e: FocusEvent) => {
       if (reopenLock) return
@@ -214,7 +212,7 @@ export function useActivator (
       }
       events.onMouseleave = () => {
         isHovered = false
-        if (rootOpenedByHover()) runCloseDelay()
+        if (shouldCloseOnLeave()) runCloseDelay()
       }
     }
 
@@ -257,7 +255,7 @@ export function useActivator (
       }
       events.onMouseleave = () => {
         isHovered = false
-        if (rootOpenedByHover()) runCloseDelay()
+        if (shouldCloseOnLeave()) runCloseDelay()
       }
     }
 
@@ -267,7 +265,7 @@ export function useActivator (
   watch(isTop, val => {
     if (
       val &&
-      rootOpenedByHover() &&
+      shouldCloseOnLeave() &&
       (
         (props.openOnHover && !isHovered && (!openOnFocus.value || !isFocused)) ||
         (openOnFocus.value && !isFocused && (!props.openOnHover || !isHovered))

--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -75,18 +75,32 @@ export const makeActivatorProps = propsFactory({
 
 export function useActivator (
   props: ActivatorProps,
-  { isActive, isTop, contentEl }: {
+  { isActive, isTop, contentEl, isSubmenu = false }: {
     isActive: Ref<boolean>
     isTop: Ref<boolean>
     contentEl: Ref<HTMLElement | undefined>
+    isSubmenu?: boolean
   }
 ) {
   const vm = getCurrentInstance('useActivator')
   const activatorEl = ref<HTMLElement>()
 
+  const parentMenu = inject(VMenuSymbol, null)
+
   let isHovered = false
   let isFocused = false
   let firstEnter = true
+  // True only when this overlay was last opened by the hover delay (not keyboard/click/focus).
+  const openedByHover = ref(false)
+  // Set synchronously inside the delay callback before mutating isActive; consumed by the next watcher tick.
+  let delayCallbackFiredOpen = false
+
+  // Hover-leave should collapse the whole structure only when the ROOT of the chain was hover-opened.
+  // A submenu inherits the root's verdict via VMenuSymbol; everything else (tooltips, root or
+  // standalone menus) decides on its own hover-open state, even when nested in a menu's content.
+  const rootOpenedByHover = () => isSubmenu
+    ? (parentMenu?.rootOpenedByHover?.() ?? openedByHover.value)
+    : openedByHover.value
 
   const openOnFocus = computed(() => props.openOnFocus || (props.openOnFocus == null && props.openOnHover))
   const openOnClick = computed(() => props.openOnClick || (props.openOnClick == null && !props.openOnHover && !openOnFocus.value))
@@ -100,6 +114,10 @@ export function useActivator (
     ) {
       if (isActive.value !== value) {
         firstEnter = true
+        if (value) {
+          delayCallbackFiredOpen = true
+          openedByHover.value = isHovered && props.openOnHover
+        }
       }
       isActive.value = value
     }
@@ -107,9 +125,17 @@ export function useActivator (
 
   let reopenLock = false
   watch(isActive, v => {
-    if (v) return
-    reopenLock = true
-    setTimeout(() => reopenLock = false, 50)
+    if (!v) {
+      reopenLock = true
+      setTimeout(() => reopenLock = false, 50)
+      openedByHover.value = false
+      delayCallbackFiredOpen = false
+      return
+    }
+    if (!delayCallbackFiredOpen) {
+      openedByHover.value = false
+    }
+    delayCallbackFiredOpen = false
   })
 
   const cursorTarget = ref<[x: number, y: number]>()
@@ -137,7 +163,7 @@ export function useActivator (
     onMouseleave: (e: MouseEvent) => {
       isHovered = false
       if (props.target === 'cursor') isFocused = false
-      runCloseDelay()
+      if (rootOpenedByHover()) runCloseDelay()
     },
     onFocus: (e: FocusEvent) => {
       if (reopenLock) return
@@ -192,7 +218,7 @@ export function useActivator (
       }
       events.onMouseleave = () => {
         isHovered = false
-        runCloseDelay()
+        if (rootOpenedByHover()) runCloseDelay()
       }
     }
 
@@ -235,7 +261,7 @@ export function useActivator (
       }
       events.onMouseleave = () => {
         isHovered = false
-        runCloseDelay()
+        if (rootOpenedByHover()) runCloseDelay()
       }
     }
 
@@ -243,10 +269,15 @@ export function useActivator (
   })
 
   watch(isTop, val => {
-    if (val && (
-      (props.openOnHover && !isHovered && (!openOnFocus.value || !isFocused)) ||
-      (openOnFocus.value && !isFocused && (!props.openOnHover || !isHovered))
-    ) && !contentEl.value?.contains(getActiveElement())) {
+    if (
+      val &&
+      rootOpenedByHover() &&
+      (
+        (props.openOnHover && !isHovered && (!openOnFocus.value || !isFocused)) ||
+        (openOnFocus.value && !isFocused && (!props.openOnHover || !isHovered))
+      ) &&
+      !contentEl.value?.contains(getActiveElement())
+    ) {
       runCloseDelay()
     }
   })
@@ -296,7 +327,7 @@ export function useActivator (
     scope?.stop()
   })
 
-  return { activatorEl, activatorRef, target, targetEl, targetRef, activatorEvents, contentEvents, scrimEvents }
+  return { activatorEl, activatorRef, target, targetEl, targetRef, activatorEvents, contentEvents, scrimEvents, openedByHover }
 }
 
 function _useActivator (


### PR DESCRIPTION
Makes nested submenus behave predictably under mixed keyboard + mouse use, instead of collapsing the whole tree to `document.body` on an incidental hover-out.

## Behavior

- `mouseleave` should not close the submenu unless the *root* menu opened with hover (aligns with other frameworks)
- one submenu open per level when mixing hover and keyboard interactions
- more reliable keyboard navigation
  - ArrowLeft steps back one level and keeps focus inside
  - Tab/Shift+Tab closes one level
  - opening a submenu lands focus on its first item
- closed overlay content now gets `inert` to avoid focus hijacking

## Notes

- `useActivator` gains an `isSubmenu` flag (plumbed via an internal `_submenu` prop on `VOverlay`) so the hover-chain logic applies only to actual submenus
- `VMenuSymbol` now tracks open children by id + close handle, enabling per-level replacement and subtree collapse

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="500">
      <button>before</button>
      <v-btn color="primary">
        Open menu
        <v-menu :close-on-content-click="false" activator="parent" open-on-hover>
          <v-list>
            <v-list-item v-for="i in 3" :key="i" link>
              <v-list-item-title>Item {{ i }}</v-list-item-title>
              <template #append>
                <v-icon icon="mdi-menu-right" size="x-small" />
              </template>

              <v-menu :close-on-content-click="false" :open-on-focus="false" activator="parent" open-on-hover submenu>
                <v-list>
                  <v-list-item v-for="j in 3" :key="j" link>
                    <v-list-item-title>Item {{ i }} - {{ j }}</v-list-item-title>
                    <template #append>
                      <v-icon icon="mdi-menu-right" size="x-small" />
                    </template>

                    <v-menu :open-on-focus="false" activator="parent" open-on-hover submenu>
                      <v-list>
                        <v-list-item
                          v-for="k in 3"
                          :key="k"
                          link
                          @click="clicked = `Item ${i} - ${j} - ${k}`"
                        >
                          <v-list-item-title>Item {{ i }} - {{ j }} - {{ k }}</v-list-item-title>
                        </v-list-item>
                      </v-list>
                    </v-menu>
                  </v-list-item>
                </v-list>
              </v-menu>
            </v-list-item>
          </v-list>
        </v-menu>
      </v-btn>
      <button>after</button>

      <pre class="mt-4">clicked: {{ clicked }}</pre>

      <v-divider class="my-6" />

      <v-btn color="primary">
        Pick a color
        <v-menu :close-on-content-click="false" activator="parent" open-on-hover>
          <v-list>
            <v-list-item
              v-for="palette in palettes"
              :key="palette.title"
              :prepend-icon="palette.icon"
              :title="palette.title"
              link
            >
              <template #append>
                <v-icon icon="mdi-menu-right" size="x-small" />
              </template>

              <v-menu :close-on-content-click="false" :open-on-focus="false" activator="parent" open-on-hover submenu>
                <v-list>
                  <v-list-item
                    v-for="group in palette.groups"
                    :key="group.title"
                    :title="group.title"
                    link
                  >
                    <template #append>
                      <v-icon icon="mdi-menu-right" size="x-small" />
                    </template>

                    <v-menu :open-on-focus="false" activator="parent" open-on-hover submenu>
                      <v-list>
                        <v-list-item
                          v-for="[shade, hex] in group.shades"
                          :key="shade"
                          :subtitle="hex"
                          :title="shade"
                          link
                          @click="picked = hex"
                        >
                          <template #prepend>
                            <v-avatar :color="hex" size="24" />
                          </template>
                        </v-list-item>
                      </v-list>
                    </v-menu>
                  </v-list-item>
                </v-list>
              </v-menu>
            </v-list-item>
          </v-list>
        </v-menu>
      </v-btn>

      <pre class="mt-4">picked: <v-avatar :color="picked" size="16" /> {{ picked }}</pre>
    </v-container>
  </v-app>
</template>

<script setup>
  import { shallowRef } from 'vue'
  import colors from '@/util/colors'

  const clicked = shallowRef('')
  const picked = shallowRef('')

  const tailwind = {
    red: { 200: '#fecaca', 400: '#f87171', 600: '#dc2626', 800: '#991b1b' },
    green: { 200: '#bbf7d0', 400: '#4ade80', 600: '#16a34a', 800: '#166534' },
    blue: { 200: '#bfdbfe', 400: '#60a5fa', 600: '#2563eb', 800: '#1e40af' },
  }

  function groups (source) {
    return ['red', 'green', 'blue'].map(name => ({
      title: name,
      shades: Object.entries(source[name]).filter(([shade]) => !shade.startsWith('accent')),
    }))
  }

  const palettes = [
    { title: 'Material', icon: 'mdi-material-design', groups: groups(colors) },
    { title: 'Tailwind', icon: 'mdi-tailwind', groups: groups(tailwind) },
  ]
</script>
```
