### PR TITLE
feat(VFileInput,VFileUpload): unify dragging effect

### DIFF
--- a/packages/vuetify/src/components/VFileInput/VFileInput.sass
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.sass
@@ -37,17 +37,22 @@
       z-index: 0
 
     &--dragging
-      .v-field__overlay
-        background-color: rgb(var(--v-theme-primary))
-        opacity: .08
+      .v-field:not(.v-field--variant-outlined)
+        outline: 2px dashed rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity))
+        outline-offset: 2px
 
-      .v-field__outline
-        --v-field-border-opacity: 1
+      .v-field--variant-outlined
+        .v-field__outline
+          --v-field-border-opacity: var(--v-medium-emphasis-opacity)
+          --v-field-border-width: 2px
 
-        color: rgb(var(--v-theme-primary))
+          color: rgb(var(--v-theme-on-surface))
 
-      .v-field--variant-outlined .v-field__outline
-        --v-field-border-width: 2px
+        .v-field__outline__start,
+        .v-field__outline__notch::before,
+        .v-field__outline__notch::after,
+        .v-field__outline__end
+          border-style: dashed
 
       input[type="file"]
         z-index: 1

--- a/packages/vuetify/src/components/VFileInput/VFileInput.sass
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.sass
@@ -36,8 +36,21 @@
       width: 100%
       z-index: 0
 
-    &--dragging input[type="file"]
-      z-index: 1
+    &--dragging
+      .v-field__overlay
+        background-color: rgb(var(--v-theme-primary))
+        opacity: .08
+
+      .v-field__outline
+        --v-field-border-opacity: 1
+
+        color: rgb(var(--v-theme-primary))
+
+      .v-field--variant-outlined .v-field__outline
+        --v-field-border-width: 2px
+
+      input[type="file"]
+        z-index: 1
 
     input[inert]
       pointer-events: none // for Chromium < 102 / Firefox < 112 -- drop in v5

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -177,14 +177,21 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       const charsKeepOneSide = Math.floor((Number(props.truncateLength) - 1) / 2)
       return `${str.slice(0, charsKeepOneSide)}…${str.slice(str.length - charsKeepOneSide)}`
     }
+    function hasDraggedFiles (e: DragEvent) {
+      const types = [...e.dataTransfer?.types ?? []]
+      return types.includes('Files') || hasFilesOrFolders(e)
+    }
     function onDragover (e: DragEvent) {
-      if (props.disabled || props.readonly) return
+      if (props.disabled || props.readonly || !hasDraggedFiles(e)) return
       e.preventDefault()
       e.stopImmediatePropagation()
       isDragging.value = true
     }
     function onDragleave (e: DragEvent) {
       e.preventDefault()
+      isDragging.value = false
+    }
+    function onDragend () {
       isDragging.value = false
     }
     async function onDrop (e: DragEvent) {
@@ -314,6 +321,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                 focused={ isFocused.value }
                 details={ hasDetails.value }
                 error={ isValid.value === false }
+                onDragend={ onDragend }
                 onDragover={ onDragover }
                 onDrop={ onDrop }
               >

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -141,6 +141,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     ))
     const isPlainOrUnderlined = computed(() => ['plain', 'underlined'].includes(props.variant))
     const isDragging = shallowRef(false)
+    const dragCounter = shallowRef(0)
     const { handleDrop, hasFilesOrFolders } = useFileDrop()
 
     function onFocus () {
@@ -181,6 +182,13 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       const types = [...e.dataTransfer?.types ?? []]
       return types.includes('Files') || hasFilesOrFolders(e)
     }
+    function onDragenter (e: DragEvent) {
+      if (props.disabled || props.readonly || !hasDraggedFiles(e)) return
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      dragCounter.value++
+      isDragging.value = true
+    }
     function onDragover (e: DragEvent) {
       if (props.disabled || props.readonly || !hasDraggedFiles(e)) return
       e.preventDefault()
@@ -189,14 +197,17 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     }
     function onDragleave (e: DragEvent) {
       e.preventDefault()
-      isDragging.value = false
+      if (dragCounter.value > 0) dragCounter.value--
+      if (dragCounter.value === 0) isDragging.value = false
     }
     function onDragend () {
+      dragCounter.value = 0
       isDragging.value = false
     }
     async function onDrop (e: DragEvent) {
       e.preventDefault()
       e.stopImmediatePropagation()
+      dragCounter.value = 0
       isDragging.value = false
 
       if (!inputRef.value || props.disabled || props.readonly || !hasFilesOrFolders(e)) return
@@ -321,7 +332,9 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                 focused={ isFocused.value }
                 details={ hasDetails.value }
                 error={ isValid.value === false }
+                onDragenter={ onDragenter }
                 onDragend={ onDragend }
+                onDragleave={ onDragleave }
                 onDragover={ onDragover }
                 onDrop={ onDrop }
               >
@@ -348,7 +361,6 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                           onFocus()
                         }}
                         onChange={ onFileSelection }
-                        onDragleave={ onDragleave }
                         onFocus={ onFocus }
                         onBlur={ blur }
                         onPaste={ onPaste }

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.tsx
@@ -109,6 +109,18 @@ describe('VFileInput', () => {
 
     expect(input.classes()).not.toContain('v-file-input--dragging')
 
+    await field.trigger('dragenter', { dataTransfer })
+    expect(input.classes()).toContain('v-file-input--dragging')
+
+    await field.trigger('dragenter', { dataTransfer })
+    expect(input.classes()).toContain('v-file-input--dragging')
+
+    await field.trigger('dragleave')
+    expect(input.classes()).toContain('v-file-input--dragging')
+
+    await field.trigger('dragleave')
+    expect(input.classes()).not.toContain('v-file-input--dragging')
+
     await field.trigger('dragover', { dataTransfer })
     expect(input.classes()).toContain('v-file-input--dragging')
 

--- a/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.tsx
+++ b/packages/vuetify/src/components/VFileInput/__tests__/VFileInput.spec.tsx
@@ -6,6 +6,12 @@ import { createVuetify } from '@/framework'
 
 describe('VFileInput', () => {
   const vuetify = createVuetify()
+  const file = new File([''], 'test.txt')
+  const dataTransfer = {
+    files: [file],
+    items: [],
+    types: ['Files'],
+  }
 
   function mountFunction (component: any, options = {}) {
     return mount(component, {
@@ -94,5 +100,43 @@ describe('VFileInput', () => {
     expect(onClickPrepend).toHaveBeenCalledTimes(1)
     expect(onClickPrependInner).toHaveBeenCalledTimes(1)
     expect(onClickAppendInner).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies dragging class while files are dragged over the input', async () => {
+    const wrapper = mountFunction(<VFileInput />)
+    const input = wrapper.find('.v-file-input')
+    const field = wrapper.find('.v-field')
+
+    expect(input.classes()).not.toContain('v-file-input--dragging')
+
+    await field.trigger('dragover', { dataTransfer })
+    expect(input.classes()).toContain('v-file-input--dragging')
+
+    await field.trigger('dragend')
+    expect(input.classes()).not.toContain('v-file-input--dragging')
+  })
+
+  it('does not apply dragging class when disabled', async () => {
+    const wrapper = mountFunction(<VFileInput disabled />)
+    const input = wrapper.find('.v-file-input')
+
+    await wrapper.find('.v-field').trigger('dragover', { dataTransfer })
+
+    expect(input.classes()).not.toContain('v-file-input--dragging')
+  })
+
+  it('does not apply dragging class when dragged data does not contain files', async () => {
+    const wrapper = mountFunction(<VFileInput />)
+    const input = wrapper.find('.v-file-input')
+
+    await wrapper.find('.v-field').trigger('dragover', {
+      dataTransfer: {
+        files: [],
+        items: [],
+        types: ['text/plain'],
+      },
+    })
+
+    expect(input.classes()).not.toContain('v-file-input--dragging')
   })
 })


### PR DESCRIPTION
This improves drag-and-drop feedback in `v-file-input`.

resolves #20576

## Markup

```vue
<template>
  <v-sheet class="mb-8 pa-6" border rounded>
    <h2 class="text-h6 mb-4">
      VFileInput drag feedback test
    </h2>

    <v-row>
      <v-col v-for="variant in ['outlined', 'filled', 'solo', 'solo-inverted', 'solo-filled']" :key="variant" cols="12"
             md="6">
        <v-file-input
          :label="variant"
          :variant="variant"
          multiple
        />
      </v-col>
    </v-row>
  </v-sheet>
</template>
<script setup lang="ts">
</script>
