### PR TITLE
fix(VPagination): render small page ranges when total visible is zero

### DIFF
--- a/packages/docs/src/pages/en/about/incidents/2026-06-nyven-infostealer.md
+++ b/packages/docs/src/pages/en/about/incidents/2026-06-nyven-infostealer.md
@@ -1,7 +1,7 @@
 ---
 meta:
-  nav: Infostealer & Discord takeover (June 2026)
-  title: 'Incident report: infostealer compromise and Discord account takeover (June 2026)'
+  nav: Discord takeover (June 2026)
+  title: Incident report: Compromise and Discord account takeover (June 2026)
   description: Report on the June 2026 security incident in which a maintainer's personal machine was compromised by an infostealer and the Vuetify Discord support account was taken over. No Vuetify packages, source, releases, or user data were affected.
   keywords: vuetify security incident, infostealer, discord account takeover, extortion, incident report, nyven
 related:
@@ -10,7 +10,7 @@ related:
   - /introduction/long-term-support/
 ---
 
-# Incident report: infostealer compromise and Discord account takeover
+# Incident report June 2026
 
 This page documents the June 2026 security incident affecting Vuetify's Discord support account.
 

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -193,6 +193,9 @@ export const VPagination = genericComponent<VPaginationSlots>()({
     const range = computed(() => {
       if (length.value <= 0 || isNaN(length.value) || length.value > Number.MAX_SAFE_INTEGER) return []
 
+      // Always show all pages when length < 3 — no truncation needed
+      if (length.value < 3) return createRange(length.value, start.value)
+
       if (totalVisible.value <= 0) return []
       else if (totalVisible.value === 1) return [page.value]
 


### PR DESCRIPTION
## Description

Fixes VPagination rendering an empty range when the computed `totalVisible` value is `0` and `length` is `1` or `2`.

Previously, if `totalVisible` resolved to `0`, the range immediately returned an empty array. This caused valid small pagination ranges to render as an empty pagination component.

This change allows small page ranges to still render when `length <= 2`, while preserving the existing behavior for larger ranges.

Fixes #22907