### PR TITLE
fix(VPagination): predictable length behavior in flex container

### DIFF
--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -193,6 +193,10 @@ export const VPagination = genericComponent<VPaginationSlots>()({
     const range = computed(() => {
       if (length.value <= 0 || isNaN(length.value) || length.value > Number.MAX_SAFE_INTEGER) return []
 
+      if (props.totalVisible == null && length.value < 3) {
+        return createRange(length.value, start.value)
+      }
+
       if (totalVisible.value <= 0) return []
       else if (totalVisible.value === 1) return [page.value]
 

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
@@ -3,7 +3,7 @@ import { VPagination } from '../VPagination'
 import { VLocaleProvider } from '@/components/VLocaleProvider'
 
 // Utilities
-import { page, render, screen, showcase, userEvent } from '@test'
+import { page, render, screen, showcase, userEvent, waitIdle } from '@test'
 import { ref } from 'vue'
 
 const stories = {
@@ -21,6 +21,30 @@ describe('VPagination', () => {
     ))
 
     expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(3)
+  })
+
+  it('should render all pages when length is less than 3 in a flexbox container', async () => {
+    render(() => (
+      <div class="d-flex">
+        <VPagination length="2" />
+      </div>
+    ))
+
+    await waitIdle() // resize-observer loop has to settle
+
+    expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(2)
+    expect(screen.getAllByCSS('.v-pagination__item .v-btn').at(0)).toHaveTextContent('1')
+    expect(screen.getAllByCSS('.v-pagination__item .v-btn').at(1)).toHaveTextContent('2')
+  })
+
+  it('should still honor an explicit total-visible when length is less than 3', () => {
+    render(() => (
+      <div class="d-flex">
+        <VPagination length="2" totalVisible="1" />
+      </div>
+    ))
+
+    expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(1)
   })
 
   it('should render without first and last page buttons', () => {


### PR DESCRIPTION
fixes #22907

- pagination with `length` below 3 should not require `total-visible` to show the items when placed in flex container

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-slider
        v-model="totalVisible"
        :max="10"
        :min="0"
        :step="1"
        class="px-4 pt-4"
        label="total-visible"
        thumb-label="always"
      />
      <pre>totalVisible: {{ totalVisible ?? 'null' }}</pre>

      <div class="d-flex pagination-container">
        <v-pagination v-model="page" :length="1" :total-visible="totalVisible" />
      </div>
      <div class="d-flex pagination-container">
        <v-pagination v-model="page" :length="2" :total-visible="totalVisible" />
      </div>
      <div class="d-flex pagination-container">
        <v-pagination v-model="page" :length="3" :total-visible="totalVisible" />
      </div>
      <div class="d-flex pagination-container">
        <v-pagination v-model="page" :length="4" :total-visible="totalVisible" />
      </div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const page = ref(1)
  const totalVisible = ref()
</script>

```
