### PR TITLE
fix(VOverlay): static location should snap to edges using CSS

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.sass
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.sass
@@ -41,7 +41,6 @@
     right: 0
     top: 0
 
-  // Modifier
   .v-overlay--absolute
     position: absolute
 
@@ -50,6 +49,20 @@
 
   .v-overlay--scroll-blocked
     padding-inline-end: var(--v-scrollbar-offset)
+
+@include tools.layer('overrides')
+  .v-overlay--justify-start
+    justify-content: flex-start
+  .v-overlay--justify-center
+    justify-content: center
+  .v-overlay--justify-end
+    justify-content: flex-end
+  .v-overlay--align-start
+    align-items: flex-start
+  .v-overlay--align-center
+    align-items: center
+  .v-overlay--align-end
+    align-items: flex-end
 
 @include tools.layer('trumps')
   .v-overlay-scroll-blocked

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -2,7 +2,7 @@
 import './VOverlay.sass'
 
 // Composables
-import { makeLocationStrategyProps, useLocationStrategies } from './locationStrategies'
+import { getStaticLocationClasses, makeLocationStrategyProps, useLocationStrategies } from './locationStrategies'
 import { makeScrollStrategyProps, useScrollStrategies } from './scrollStrategies'
 import { makeActivatorProps, useActivator } from './useActivator'
 import { useBackgroundColor } from '@/composables/color'
@@ -172,6 +172,11 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     })
     const { dimensionStyles } = useDimension(props)
     const isMounted = useHydration()
+    const staticLocationClasses = computed(() => {
+      return props.locationStrategy === 'static'
+        ? getStaticLocationClasses(props.location)
+        : undefined
+    })
     const { scopeId } = useScopeId()
 
     watch(() => props.disabled, v => {
@@ -364,6 +369,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                   'v-overlay--active': isActive.value,
                   'v-overlay--contained': props.contained,
                 },
+                staticLocationClasses.value,
                 themeClasses.value,
                 rtlClasses.value,
                 props.class,

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -48,7 +48,7 @@ const locationStrategies = {
 
 export interface StrategyProps {
   locationStrategy: keyof typeof locationStrategies | LocationStrategyFunction
-  location: Anchor
+  location?: Anchor
   origin: Anchor | 'auto' | 'overlap'
   offset?: number | string | number[]
   stickToTarget?: boolean
@@ -65,10 +65,7 @@ export const makeLocationStrategyProps = propsFactory({
     default: 'static',
     validator: (val: any) => typeof val === 'function' || val in locationStrategies,
   },
-  location: {
-    type: String as PropType<StrategyProps['location']>,
-    default: 'bottom',
-  },
+  location: String as PropType<StrategyProps['location']>,
   origin: {
     type: String as PropType<StrategyProps['origin']>,
     default: 'auto',
@@ -131,8 +128,9 @@ export function useLocationStrategies (
   }
 }
 
-export function getStaticLocationClasses (location: Anchor) {
-  // A bare side ("bottom") implies center on the other axis, matching `useLocation`.
+export function getStaticLocationClasses (location: Anchor | undefined) {
+  if (!location) return undefined
+
   const normalized = location.includes(' ') ? location : `${location} center`
 
   let justify = 'center'
@@ -227,7 +225,7 @@ function connectedLocationStrategy (data: LocationStrategyData, props: StrategyP
   }
 
   const { preferredAnchor, preferredOrigin } = destructComputed(() => {
-    const parsedAnchor = parseAnchor(props.location, data.isRtl.value)
+    const parsedAnchor = parseAnchor(props.location ?? 'bottom', data.isRtl.value)
     const parsedOrigin =
       props.origin === 'overlap' ? parsedAnchor
       : props.origin === 'auto' ? flipSide(parsedAnchor)

--- a/packages/vuetify/src/components/VOverlay/locationStrategies.ts
+++ b/packages/vuetify/src/components/VOverlay/locationStrategies.ts
@@ -48,7 +48,6 @@ const locationStrategies = {
 
 export interface StrategyProps {
   locationStrategy: keyof typeof locationStrategies | LocationStrategyFunction
-  contained?: boolean
   location: Anchor
   origin: Anchor | 'auto' | 'overlap'
   offset?: number | string | number[]
@@ -132,61 +131,42 @@ export function useLocationStrategies (
   }
 }
 
+export function getStaticLocationClasses (location: Anchor) {
+  // A bare side ("bottom") implies center on the other axis, matching `useLocation`.
+  const normalized = location.includes(' ') ? location : `${location} center`
+
+  let justify = 'center'
+  let align = 'center'
+  const inline: Record<string, string> = { left: 'start', start: 'start', right: 'end', end: 'end' }
+  const block: Record<string, string> = { top: 'start', bottom: 'end' }
+
+  for (const token of normalized.split(' ')) {
+    if (token in inline) justify = inline[token]
+    else if (token in block) align = block[token]
+  }
+
+  return {
+    [`v-overlay--justify-${justify}`]: true,
+    [`v-overlay--align-${align}`]: true,
+  }
+}
+
 function staticLocationStrategy (data: LocationStrategyData, props: StrategyProps, contentStyles: Ref<Record<string, string>>) {
-  if (props.contained) return
-
-  const target = ref<[x: number, y: number]>()
-  const connectedStyles = ref<Record<string, string>>({})
-
-  // reactive equivalent of `{ ...props, origin: 'auto' }`
-  const connectedProps = new Proxy(props, {
-    get: (target, key) => key === 'origin' ? 'auto' : Reflect.get(target, key),
-  })
-
-  const connected = connectedLocationStrategy(
-    { ...data, target },
-    connectedProps,
-    connectedStyles
-  )
-
+  // Positioning is handled by CSS flexbox alignment on the overlay root, keeping
+  // the content's insets `auto` so user utility classes (justify-*, align-*) compose.
+  // Here we only forward an explicit `origin` to `transform-origin` for the transition.
   function updateStyles () {
     if (props.origin !== 'auto' && props.origin !== 'overlap') {
       const { side, align } = parseAnchor(props.origin, data.isRtl.value)
-      contentStyles.value = { ...connectedStyles.value, transformOrigin: `${side} ${align}` }
+      contentStyles.value = { transformOrigin: `${side} ${align}` }
     } else {
-      contentStyles.value = connectedStyles.value
+      contentStyles.value = {}
     }
   }
 
-  watch(connectedStyles, updateStyles, { deep: true })
-  watch([() => props.origin, data.isRtl], updateStyles)
+  watch([() => props.origin, data.isRtl], updateStyles, { immediate: true })
 
-  function updateTarget () {
-    const viewportBox = new Box({
-      x: visualViewport?.offsetLeft ?? 0,
-      y: visualViewport?.offsetTop ?? 0,
-      width: visualViewport?.width ?? window.innerWidth,
-      height: visualViewport?.height ?? window.innerHeight,
-    })
-
-    const point = anchorToPoint(parseAnchor(props.location, data.isRtl.value), viewportBox)
-    target.value = [point.x, point.y]
-  }
-
-  function updateLocation () {
-    updateTarget()
-    connected.updateLocation()
-  }
-
-  watch(() => [props.location, data.isRtl.value], () => {
-    updateLocation()
-  })
-
-  nextTick(() => {
-    updateLocation()
-  })
-
-  return { updateLocation }
+  return { updateLocation: () => {} }
 }
 
 /** Resolve a CSS length the browser understands (calc(), min(), vw, …) to pixels */


### PR DESCRIPTION
- now it will also work with `contained`

fixes #22911

## Markup:

```vue
<template>
  <v-app theme="dark">
    <div class="guidelines">
      <div class="guideline guideline-v" />
      <div class="guideline guideline-h" />
    </div>
    <v-container max-width="800">
      <v-btn @click="open = true">Show</v-btn>
      <v-dialog
        v-model="open"
        :location="location"
        :origin="origin"
        :scrim="false"
        width="400"
        no-click-animation
        persistent
      >
        <v-card>
          <v-card-item class="bg-primary">Title</v-card-item>
          <v-card-text>
            <div class="pa-12">Hello world!</div>
          </v-card-text>
          <v-card-actions class="justify-end">
            <v-btn text="Close" @click="open = false" />
          </v-card-actions>
        </v-card>
      </v-dialog>

      <v-row class="mt-6">
        <v-col cols="12" sm="3">
          <h5 class="my-0">location</h5>

          <v-radio-group v-model="location" density="compact" hide-details>
            <div class="d-flex">
              <v-radio value="top left" />
              <v-radio value="top center" />
              <v-radio value="top right" />
            </div>

            <div class="d-flex">
              <v-radio value="left center" />
              <v-radio value="center center" />
              <v-radio value="right center" />
            </div>

            <div class="d-flex">
              <v-radio value="left bottom" />
              <v-radio value="bottom center" />
              <v-radio value="right bottom" />
            </div>
          </v-radio-group>

          <code>({{ location }})</code>
        </v-col>

        <v-col cols="12" sm="3">
          <h5 class="my-0">Origin</h5>

          <v-radio-group v-model="origin" density="compact" hide-details>
            <div class="d-flex">
              <v-radio disabled />
              <v-radio value="top left" />
              <v-radio value="top center" />
              <v-radio value="top right" />
              <v-radio disabled />
            </div>

            <div class="d-flex">
              <v-radio value="left top" />
              <v-radio disabled />
              <v-radio disabled />
              <v-radio disabled />
              <v-radio value="right top" />
            </div>

            <div class="d-flex">
              <v-radio value="left center" />
              <v-radio disabled />
              <v-radio value="center" />
              <v-radio disabled />
              <v-radio value="right center" />
            </div>

            <div class="d-flex">
              <v-radio value="left bottom" />
              <v-radio disabled />
              <v-radio disabled />
              <v-radio disabled />
              <v-radio value="right bottom" />
            </div>

            <div class="d-flex">
              <v-radio disabled />
              <v-radio value="bottom left" />
              <v-radio value="bottom center" />
              <v-radio value="bottom right" />
              <v-radio disabled />
            </div>
          </v-radio-group>

          <code>({{ origin }})</code>
        </v-col>

        <v-col cols="12" sm="6">
          <h5 class="my-0">contained VOverlay</h5>

          <v-sheet
            class="contained-box d-flex align-center justify-center text-medium-emphasis"
            color="surface-variant"
            height="320"
            rounded
          >
            contained area
            <v-overlay
              v-model="containedOpen"
              :location="location"
              :origin="origin"
              location-strategy="static"
              scrim="rgba(0,0,0,.2)"
              contained
              persistent
              no-click-animation
            >
              <v-card class="ma-4" color="primary" width="180">
                <v-card-item>VOverlay</v-card-item>
                <v-card-text>
                  <div>location: {{ location }}</div>
                  <div>origin: {{ origin }}</div>
                </v-card-text>
              </v-card>
            </v-overlay>
          </v-sheet>

          <v-btn class="mt-2" @click="containedOpen = !containedOpen">
            Toggle contained
          </v-btn>
        </v-col>
      </v-row>
    </v-container>

    <v-btn
      class="ma-auto"
      size="x-large"
      text="Open bottom sheet"
      @click="sheet = !sheet"
    />

    <v-bottom-sheet v-model="sheet" inset>
      <v-card class="text-center" height="200">
        <v-card-text>
          <v-btn
            text="Close"
            variant="text"
            @click="sheet = !sheet"
          />

          <br>
          <br>

          <div>
            This is a bottom sheet that is using the inset prop
          </div>
        </v-card-text>
      </v-card>
    </v-bottom-sheet>
  </v-app>
</template>

<script setup>
  import { ref, watch } from 'vue'
  const sheet = ref(false)
  const open = ref(false)
  const containedOpen = ref(true)
  const location = ref('center center')
  const origin = ref('left bottom')

  watch(origin, () => {
    open.value = false
    setTimeout(() => open.value = true, 300)
  })
</script>

<style scoped>
.guidelines {
  position: fixed;
  inset: 0;
  pointer-events: none;
}
.guideline {
  position: absolute;
  background: transparent;
}
.guideline-v {
  left: 50%;
  top: 0;
  bottom: 0;
  width: 0;
  border-left: 3px dashed red;
}
.guideline-h {
  top: 50%;
  left: 0;
  right: 0;
  height: 0;
  border-top: 3px dashed red;
}
.v-selection-control--disabled {
  opacity: .1;
}
.contained-box {
  position: relative;
  overflow: hidden;
}
</style>
```
