### PR TITLE
feat(VSelectionControl): add description prop below label

### DIFF
--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -95,3 +95,17 @@
 
     .v-selection-control--focus-visible &::before
       opacity: calc(#{map.get(settings.$states, 'focus')} * var(--v-theme-overlay-multiplier))
+
+  .v-selection-control__label-wrapper
+    display: flex
+    flex-direction: column
+    justify-content: center
+    flex: 1
+
+  .v-label
+    display: block
+
+  .v-selection-control__description
+    font-size: $selection-control-description-font-size
+    color: $selection-control-description-color
+    line-height: 1.4

--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.tsx
@@ -52,12 +52,14 @@ export type VSelectionControlSlots = {
     backgroundColorStyles: Ref<CSSProperties>
   }
   label: { label: string | undefined, props: Record<string, unknown> }
+  description: { description: string | undefined }
   input: SelectionControlSlot
 }
 
 export const makeVSelectionControlProps = propsFactory({
   indeterminate: Boolean,
   label: String,
+  description: String,
   baseColor: String,
   trueValue: null,
   falseValue: null,
@@ -318,10 +320,23 @@ export const VSelectionControl = genericComponent<new <T>(
             </div>
           </div>
 
-          { label && (
-            <VLabel for={ id.value } onClick={ onClickLabel }>
-              { label }
-            </VLabel>
+          { (label || props.description || slots.description) && (
+            <div class="v-selection-control__label-wrapper">
+              { label && (
+                <VLabel key={ id.value } for={ id.value } onClick={ onClickLabel }>
+                  { label }
+                </VLabel>
+              )}
+
+              { (props.description || slots.description) && (
+                <div class="v-selection-control__description">
+                  { slots.description
+                    ? slots.description({ description: props.description })
+                    : props.description
+                  }
+                </div>
+              )}
+            </div>
           )}
         </div>
       )

--- a/packages/vuetify/src/components/VSelectionControl/_variables.scss
+++ b/packages/vuetify/src/components/VSelectionControl/_variables.scss
@@ -8,3 +8,5 @@ $selection-control-error-color: rgb(var(--v-theme-error)) !default;
 $selection-control-density: ('default': 0, 'comfortable': -1, 'compact': -3) !default;
 $selection-control-color: tools.theme-color('on-surface', var(--v-high-emphasis-opacity)) !default;
 $selection-control-size: 40px !default;
+$selection-control-description-font-size: 0.8125rem !default;
+$selection-control-description-color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity)) !default;


### PR DESCRIPTION
## Description
Adds a `description` prop and `#description` slot to `VSelectionControl`,
rendering text below the label with a font-size between label and hint.

Closes #21773

## Changes
- Added `description` prop to `makeVSelectionControlProps`
- Added `v-selection-control__label-wrapper` to stack label + description
- Added `v-selection-control__description` CSS class
- Added SASS variables: `$selection-control-description-font-size`,
  `$selection-control-description-color`
- Supports both prop and slot usage

## Playground
```vue
    <v-checkbox
        label="Accept terms and conditions"
        description="You must read and agree before proceeding"
        hint="View full terms at example.com"
        persistent-hint
    />

    <!-- Slot usage with custom markup -->
    <v-checkbox label="Subscribe to newsletter">
        <template #description>
            Weekly updates only. <a href="#">Unsubscribe anytime</a>
        </template>
    </v-checkbox>

    <!-- Without description — verify existing behaviour unchanged -->
    <v-checkbox label="No description here" />
```