### PR TITLE
docs: enforce SEO length limits on page meta title/description

### DIFF
--- a/packages/docs/.markdownlintrc
+++ b/packages/docs/.markdownlintrc
@@ -12,5 +12,9 @@
   "emphasis-style": false,
   "link-fragments": false,
   "descriptive-link-text": false,
-  "table-column-style": false
+  "table-column-style": false,
+  "meta-length": {
+    "title_max": 60,
+    "description_max": 160
+  }
 }

--- a/packages/docs/build/markdownlint-rules/meta-length.cjs
+++ b/packages/docs/build/markdownlint-rules/meta-length.cjs
@@ -1,0 +1,63 @@
+// Custom markdownlint rule: enforce SEO-friendly lengths for frontmatter
+// `meta.title` and `meta.description`. Parses with `front-matter` — the same
+// library the docs build uses (build/markdownBuilders.ts) — so the measured
+// length matches what actually ships in the rendered <title>/<meta> tags.
+'use strict'
+
+const fm = require('front-matter')
+
+const TITLE_MAX = 60
+const DESCRIPTION_MAX = 160
+
+function findKeyLine (frontMatterLines, key) {
+  // Frontmatter starts at file line 1, so array index + 1 is the line number.
+  // Scope the search to the `meta:` block to avoid matching a same-named
+  // top-level key.
+  let inMeta = false
+  for (let i = 0; i < frontMatterLines.length; i++) {
+    const line = frontMatterLines[i]
+    if (/^meta:\s*$/.test(line)) { inMeta = true; continue }
+    // A non-indented, non-fence line ends the meta block.
+    if (inMeta && /^\S/.test(line) && line !== '---') inMeta = false
+    if (inMeta && new RegExp(`^\\s+${key}:`).test(line)) return i + 1
+  }
+  return 1
+}
+
+module.exports = {
+  names: ['meta-length', 'frontmatter-meta-length'],
+  description: 'Frontmatter meta.title/meta.description exceed SEO length limits',
+  tags: ['frontmatter', 'seo'],
+  parser: 'none',
+  function: function metaLength (params, onError) {
+    const lines = params.frontMatterLines
+    if (!lines || !lines.length) return
+
+    let attributes
+    try {
+      attributes = fm(lines.join('\n')).attributes
+    } catch {
+      return
+    }
+
+    const meta = attributes && attributes.meta
+    if (!meta || typeof meta !== 'object') return
+
+    const titleMax = Number(params.config.title_max ?? TITLE_MAX)
+    const descriptionMax = Number(params.config.description_max ?? DESCRIPTION_MAX)
+
+    const checks = [
+      ['title', meta.title, titleMax],
+      ['description', meta.description, descriptionMax],
+    ]
+
+    for (const [key, value, max] of checks) {
+      if (typeof value !== 'string' || value.length <= max) continue
+      onError({
+        lineNumber: findKeyLine(lines, key),
+        detail: `meta.${key} is ${value.length} characters; keep it ${max} or fewer`,
+        context: `${value.slice(0, 50)}…`,
+      })
+    }
+  },
+}

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -17,8 +17,8 @@
     "preview-https": "HTTPS=true vite preview",
     "lint": "concurrently 'vue-tsc --noEmit --pretty' 'pnpm lint:md' 'jest --no-cache' -n 'tsc,md,eslint' --kill-others-on-fail -gr",
     "lint:fix": "pnpm fix:md && JEST_FIX=true jest --no-cache",
-    "lint:md": "markdownlint --config .markdownlintrc src/pages/en",
-    "fix:md": "markdownlint --config .markdownlintrc src/pages/en --fix"
+    "lint:md": "markdownlint --config .markdownlintrc --rules build/markdownlint-rules/meta-length.cjs src/pages/en",
+    "fix:md": "markdownlint --config .markdownlintrc --rules build/markdownlint-rules/meta-length.cjs src/pages/en --fix"
   },
   "dependencies": {
     "@cosmicjs/sdk": "^1.5.6",

--- a/packages/docs/src/pages/en/about/licensing.md
+++ b/packages/docs/src/pages/en/about/licensing.md
@@ -2,7 +2,7 @@
 meta:
   nav: Licensing
   title: Licensing
-  description: Explore the MIT License under which Vuetify is available, understand your freedoms for using, modifying, and distributing Vuetify, and learn about community contributions.
+  description: Vuetify is available under the MIT License — understand your freedoms to use, modify, and distribute it, and how community contributions are licensed.
   keywords: MIT License, open source, Vuetify license, free software
 related:
   - /introduction/why-vuetify/

--- a/packages/docs/src/pages/en/blog/announcing-vuetify0-alpha.md
+++ b/packages/docs/src/pages/en/blog/announcing-vuetify0-alpha.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: Announcing the Vuetify0 Alpha
-  description: The Vuetify0 alpha is here — a headless Vue framework with 46 components, 63 composables, first-class AI integration, and an adapter-based plugin system. 100% TypeScript, 0 styles, built for building UI libraries.
+  description: The Vuetify0 alpha is here — a headless Vue framework with 46 components, 63 composables, first-class AI integration, 100% TypeScript, and zero styles.
   keywords: Vuetify0 alpha, headless Vue, Vue component library, AI-native framework, TypeScript components, Vuetify MCP
 ---
 

--- a/packages/docs/src/pages/en/blog/announcing-vuetify0-beta.md
+++ b/packages/docs/src/pages/en/blog/announcing-vuetify0-beta.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: Announcing the Vuetify0 Beta
-  description: Vuetify0 has reached beta, freezing the public API. A summary of what changed since the alpha — 49 components, 68 composables, a headless drag-and-drop family, and the testing work leading to v1.
+  description: Vuetify0 hits beta and freezes its public API — 49 components, 68 composables, a headless drag-and-drop family, and the testing work leading to v1.
   keywords: Vuetify0 beta, headless Vue, API freeze, Vue drag and drop, createSortable, createKanban, TypeScript components, Vuetify0 v1
 ---
 

--- a/packages/docs/src/pages/en/blog/april-2026-update.md
+++ b/packages/docs/src/pages/en/blog/april-2026-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: April 2026 Update
-  description: April delivered the Vuetify0 v1.0.0 public alpha — 46 components and 63 composables of headless Vue primitives. The framework shipped 3 patch releases, MCP hit v0.7.0 with playground and link tools, and ESLint config landed 4 releases including ESLint 10 support.
+  description: April shipped the Vuetify0 v1.0.0 public alpha — 46 headless components, 63 composables — plus 3 Vuetify patches, MCP v0.7.0, and ESLint 10 support.
   keywords: Vuetify April 2026, Vuetify0 v1.0.0 alpha, VTooltip cursor, VVideo controls, VNumberInput grouping, MCP playground tools, useTheme reactive
 ---
 

--- a/packages/docs/src/pages/en/blog/august-2025-update.md
+++ b/packages/docs/src/pages/en/blog/august-2025-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: August 2025 Update
-  description: August marks a pivotal moment in Vuetify's evolution as we prepare to release the pre-alpha of Vuetify0 (v0), launch our redesigned issues page, and continue delivering powerful components and improvements.
+  description: August prepares the Vuetify0 pre-alpha, launches the redesigned issues page, and continues delivering powerful components and improvements.
   keywords: Vuetify August 2025, Vuetify0, v0 pre-alpha, VEditor, issues page redesign, theming webinar, performance optimization
 ---
 

--- a/packages/docs/src/pages/en/blog/december-2025-update.md
+++ b/packages/docs/src/pages/en/blog/december-2025-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: December 2025 Update
-  description: December delivered Vuetify 4.0.0-alpha.0 with CSS layers and theme improvements, five v3.11.x patch releases, the Vuetify CLI public release, PWA rollout across all ecosystem products, and significant Vuetify0 progress.
+  description: December shipped Vuetify 4.0.0-alpha.0 with CSS layers, five v3.11.x patches, the Vuetify CLI public release, ecosystem-wide PWA rollout, and v0 progress.
   keywords: Vuetify December 2025, v4.0.0-alpha.0, Vuetify CLI, PWA, CSS layers, Vuetify0, MCP
 ---
 

--- a/packages/docs/src/pages/en/blog/february-2026-update.md
+++ b/packages/docs/src/pages/en/blog/february-2026-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: February 2026 Update
-  description: February marks Vuetify's most significant milestone—the stable release of Vuetify 4.0.0 with CSS layers, MD3 design system, and unstyled component foundations. The CLI hits v1.0.0, VAvatarGroup ships, and Vuetify0 gains createDataTable and Breadcrumbs composables.
+  description: February ships stable Vuetify 4.0.0 — CSS layers, MD3, and unstyled foundations — plus CLI v1.0.0, VAvatarGroup, and new Vuetify0 composables.
   keywords: Vuetify February 2026, Vuetify 4.0.0 Revisionist, v4 stable, VAvatarGroup, CLI v1.0.0, Vuetify0, createDataTable
 ---
 

--- a/packages/docs/src/pages/en/blog/index.md
+++ b/packages/docs/src/pages/en/blog/index.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: Blog
-  description: The Vuetify blog is a place where we share the latest news, updates, and stories about Vuetify. Stay up to date with the latest developments in the Vuetify ecosystem.
+  description: The Vuetify blog shares the latest news, updates, and stories — stay up to date with developments across the Vuetify ecosystem.
   keywords: vuetify, blog, news, updates, stories, ecosystem
 ---
 

--- a/packages/docs/src/pages/en/blog/january-2026-update.md
+++ b/packages/docs/src/pages/en/blog/january-2026-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: January 2026 Update
-  description: January delivered Vuetify 4.0.0-beta.0, MD3 typography and elevation levels, VCommandPalette labs release, grid system overhaul, and Vuetify0 hitting v0.1.0 with 21 merged PRs including Tabs, Radio, and Checkbox components.
+  description: January shipped Vuetify 4.0.0-beta.0, MD3 typography and elevation, the VCommandPalette labs release, a grid overhaul, and Vuetify0 v0.1.0.
   keywords: Vuetify January 2026, v4.0.0-beta.0, VCommandPalette, MD3 typography, grid system, Vuetify0, CLI
 ---
 

--- a/packages/docs/src/pages/en/blog/july-2025-update.md
+++ b/packages/docs/src/pages/en/blog/july-2025-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: July 2025 Update
-  description: July delivered substantial progress on collaborative development, component enhancements, developer experience improvements, and ecosystem tools across the Vuetify ecosystem.
+  description: July delivered progress on collaborative development, component enhancements, developer-experience improvements, and ecosystem tools across Vuetify.
   keywords: Vuetify July 2025, Vuetify Migrations Webinar, Vuetify0, VCommandPalette, VEditor, Framework Czar, Vuetify Bin
 ---
 

--- a/packages/docs/src/pages/en/blog/june-2025-update.md
+++ b/packages/docs/src/pages/en/blog/june-2025-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: June 2025 Update
-  description: June delivered substantial progress on VHotkey component, VCommandPalette development, component stability improvements, and developer experience enhancements across the Vuetify ecosystem.
+  description: June delivered progress on the VHotkey component, VCommandPalette development, component stability, and developer-experience improvements across Vuetify.
   keywords: Vuetify June 2025, VHotkey, VCommandPalette, Vuetify 0, component stability, developer experience
 ---
 

--- a/packages/docs/src/pages/en/blog/march-2026-update.md
+++ b/packages/docs/src/pages/en/blog/march-2026-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: March 2026 Update
-  description: March delivered 7 Vuetify patch releases stabilizing v4, while Vuetify0 exploded with 427 commits reaching v0.2.0 with 7 new headless components. The Nuxt Module hit beta, the CLI shipped 10 releases, and ESLint gained v4 migration rules.
+  description: March shipped 7 Vuetify patches while Vuetify0 reached v0.2.0 with 7 new headless components, the Nuxt Module beta, 10 CLI releases, and ESLint v4 rules.
   keywords: Vuetify March 2026, Vuetify0 v0.2.0, VCommandPalette, VProgress, Nuxt Module beta, Vuetify CLI, ESLint v4 migration
 ---
 

--- a/packages/docs/src/pages/en/blog/november-2025-update.md
+++ b/packages/docs/src/pages/en/blog/november-2025-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: November 2025 Update
-  description: November delivered Vuetify v3.11.0 with VCalendar and VHotkey promoted from labs, new VTimePicker input variant, VDatePicker MD3 improvements, and significant CLI progress.
+  description: November shipped Vuetify v3.11.0 with VCalendar and VHotkey promoted from labs, a new VTimePicker input variant, VDatePicker MD3 work, and CLI progress.
   keywords: Vuetify November 2025, v3.11.0 Harbinger, VCalendar, VHotkey, VTimePicker, VDatePicker MD3
 ---
 

--- a/packages/docs/src/pages/en/blog/september-2025-update.md
+++ b/packages/docs/src/pages/en/blog/september-2025-update.md
@@ -2,7 +2,7 @@
 layout: blog
 meta:
   title: September 2025 Update
-  description: September marks significant progress as we assemble the building blocks for Vuetify's next phase. From revolutionary design-to-development workflows with our new Figma UI Kit to foundational v0 composables, September has been about connecting the pieces that will define the future of Vue development.
+  description: September assembles the building blocks for Vuetify's next phase — from the new Figma UI Kit and design-to-development workflows to foundational v0 composables.
   keywords: Vuetify September 2025, Figma UI Kit, Vuetify0
 ---
 

--- a/packages/docs/src/pages/en/components/confirm-edit.md
+++ b/packages/docs/src/pages/en/components/confirm-edit.md
@@ -2,7 +2,7 @@
 meta:
   nav: Confirm Edit
   title: Confirm Edit
-  description: The confirm edit component is used to allow the user to verify their changes before they are committed. This is useful when you want to prevent accidental changes or to allow the user to cancel their changes.
+  description: The confirm edit component lets users verify changes before they are committed — preventing accidental edits or letting them cancel before saving.
   keywords: v-confirm-edit, confirm edit, vuetify confirm edit, vuetify confirm edit component, vuetify confirm edit examples
 related:
   - /components/avatars/

--- a/packages/docs/src/pages/en/components/skeleton-loaders.md
+++ b/packages/docs/src/pages/en/components/skeleton-loaders.md
@@ -2,7 +2,7 @@
 meta:
   nav: Skeleton loaders
   title: Skeleton loader component
-  description:  The skeleton loader component provides a placeholder loading state for when content is being fetched from a server or loaded asynchronously. It can be used in a variety of contexts, including cards, lists, and tables.
+  description:  The skeleton loader component provides a placeholder loading state while content is fetched or loaded asynchronously — ideal for cards, lists, and tables.
   keywords: skeleton loaders, vuetify skeleton loader component, vue skeleton loader
 related:
   - /components/cards/

--- a/packages/docs/src/pages/en/components/snackbars.md
+++ b/packages/docs/src/pages/en/components/snackbars.md
@@ -2,7 +2,7 @@
 meta:
   nav: Snackbars
   title: Snackbar component
-  description: The snackbar component informs user of a process that your application has performed is will perform. It can be temporary and often contains actions. Timer will stop when user hovers over the snackbar.
+  description: The snackbar component informs users of a process your application has performed or will perform. It is often temporary and can contain actions.
   keywords: snackbars, vuetify snackbar component, vue snackbar component
 related:
   - /components/buttons/

--- a/packages/docs/src/pages/en/index.md
+++ b/packages/docs/src/pages/en/index.md
@@ -2,7 +2,7 @@
 layout: home
 meta:
   title: Vuetify — A Vue Component Framework
-  description: Vuetify is a no design skills required Open Source UI Component Framework for Vue. It provides you with all of the tools necessary to create beautiful content rich web applications.
+  description: Vuetify is a no-design-skills-required Open Source UI component framework for Vue with everything you need to build beautiful, content-rich web apps.
   keywords: vue, vue components, vue ui components, material design components, vuetify, component framework, component library
 ---
 

--- a/packages/docs/src/pages/en/sponsor.md
+++ b/packages/docs/src/pages/en/sponsor.md
@@ -3,7 +3,7 @@ layout: home
 meta:
   nav: Enterprise Sponsorship
   title: Enterprise Sponsorship
-  description: Direct support from the Vuetify team for companies running Vuetify in production. Private Discord, priority bug fixes, roadmap input, office hours, early access, and consulting hours.
+  description: Direct support from the Vuetify team for companies running Vuetify in production — private Discord, priority fixes, roadmap input, early access, and more.
   keywords: vuetify enterprise sponsorship, vuetify production support, priority support vuetify, sponsor vuetify
 ---
 


### PR DESCRIPTION
Adds a custom markdownlint rule (`meta-length`) that flags frontmatter `meta.title` over 60 characters and `meta.description` over 160 characters — the lengths search engines actually display before truncating. It parses frontmatter with `front-matter` (the same library the docs build uses), so the measured length matches what ships in the rendered `<title>`/`<meta>` tags.

The rule is wired into the existing `lint:md`/`fix:md` scripts via `--rules` and configured in `.markdownlintrc` (thresholds are config-driven, so adjusting a limit is a one-line change). No new dependencies.

Also shortens the 19 existing pages whose descriptions exceeded 160 characters (mostly blog monthly-updates plus a few component pages) so the rule passes clean. Titles were already all within range.