### PR TITLE
chore(ci): bump coolify-action pin to node24 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           name: docs-dist
           path: packages/docs/dist
-      - uses: vuetifyjs/coolify-action@f24a3716773c4c238e67c4bf0319c410bafc52de # master
+      - uses: vuetifyjs/coolify-action@37a9c5a532f4c489e941d43edffd73fd2af00ec2 # master
         with:
           token: ${{ secrets.GITHUB_TOKEN  }}
           imageName: docs


### PR DESCRIPTION
The docs-deploy step pinned `vuetifyjs/coolify-action@f24a371`, whose nested `docker/login-action@v3`, `docker/metadata-action@v5`, and `docker/build-push-action@v6` all ran the deprecated **node20** runtime — triggering GitHub's node20 deprecation warning.

Bumps the pin to `37a9c5a`, which updates those nested actions to `v4`/`v6`/`v7` (node24). Inputs are unchanged.