### PR TITLE
chore(ci): bump setup-action pin to node24 build

### DIFF
--- a/.github/actions/nightly-release/action.yml
+++ b/.github/actions/nightly-release/action.yml
@@ -32,7 +32,7 @@ runs:
         repository: ${{ inputs.checkout-repo }}
         ref: ${{ inputs.checkout-ref }}
         fetch-depth: 0
-    - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+    - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
     - run: >-
         node -e "
           const json = require('./lerna.json');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
       - run: pnpm build vuetify
       - uses: actions/upload-artifact@v4
         with:
@@ -53,7 +53,7 @@ jobs:
         with:
           name: vuetify-dist
           path: packages/vuetify
-      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
       - run: pnpm run $SCOPES lint
         env:
           SCOPES: ${{ matrix.scopes }}
@@ -69,7 +69,7 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('./pnpm-lock.yaml') }}
-      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
       - run: pnpm exec playwright install chromium
       - run: pnpm run test
         working-directory: ./packages/vuetify
@@ -97,7 +97,7 @@ jobs:
         with:
           name: vuetify-dist
           path: packages/vuetify
-      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
       - run: pnpm build api
       - run: npm install -g npm@latest
       - name: NPM Release
@@ -125,7 +125,7 @@ jobs:
         with:
           name: vuetify-dist
           path: packages/vuetify
-      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
       - uses: ./.github/actions/download-locales
       - run: pnpm build api
       - run: pnpm build docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,7 +115,7 @@ jobs:
               echo "Last commit was more than 24 hours ago, skipping tests"
               exit 1
           fi
-      - uses: vuetifyjs/setup-action@fb6949e3ee1041636b7fa9eef3c7694ff31840b8 # master
+      - uses: vuetifyjs/setup-action@cb5ac088588387e65433a762de90c0b06d878677 # master
       - run: pnpm exec playwright install chromium
       - run: pnpm vizzly run "pnpm test:browser"
         working-directory: ./packages/vuetify


### PR DESCRIPTION
`vuetifyjs/setup-action@fb6949e` is a composite action wrapping `pnpm/action-setup@v4` + `actions/setup-node@v4` — both run the deprecated **node20** runtime, triggering GitHub's node20 deprecation warning across CI (`Run vuetifyjs/setup-action@…` steps in ci/nightly/nightly-release).

Bumps the pin to `cb5ac08`, which updates those nested actions to `v6` (node24). The inputs setup-action passes (`cache: pnpm`, `node-version-file: .nvmrc`) are unchanged across majors.