### PR TITLE
chore(ci): bump triage/close-action pins to node24

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository_owner == 'vuetifyjs'
     steps:
-      - uses: vuetifyjs/close-action@c0a4a544489ed6add12c6b899d18c8042db411a5 # master
+      - uses: vuetifyjs/close-action@7a2e1909290f2a1300ce5722068d7d1ce3b35629 # master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: vuetifyjs/triage-action@953df619fa87c3adea25eb49f988fdf9cb78bc00 # master
+      - uses: vuetifyjs/triage-action@1e4ff4fcdeecddee1dedab13ddd03d267ead0fba # master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           triageLabel: 'S: triage'


### PR DESCRIPTION
`vuetifyjs/triage-action` and `vuetifyjs/close-action` are JS actions that declared the deprecated **node20** runtime in their own `action.yml` — triggering the node20 deprecation warning on the issue-triage and close-issue workflows.

Both have been flipped to `node24` upstream (bundled `dist` unchanged), and these pins are bumped to the new commits:
- `triage-action` → `1e4ff4f`
- `close-action` → `7a2e190`