### PR TITLE
docs: add v-app requirement note to v-app-bar

### DIFF
--- a/packages/docs/src/pages/en/components/app-bars.md
+++ b/packages/docs/src/pages/en/components/app-bars.md
@@ -34,6 +34,10 @@ The `v-app-bar` component is used for application-wide actions and information.
 
 <PromotedEntry />
 
+::: warning
+  The `v-app-bar` must be used inside a `v-app` component. Without it, you will get an `injection "Symbol(vuetify:layout)" not found` error. See [v-app](/components/application/) for more information.
+:::
+
 ## API
 
 | Component | Description |


### PR DESCRIPTION
## Description
Adds a warning note to the v-app-bar documentation that the component must be used inside a `v-app` component.

Fixes #22855

### Motivation
Users frequently encounter the `injection "Symbol(vuetify:layout)" not found` error when using `v-app-bar` without wrapping it in `v-app`. The current documentation does not mention this requirement, forcing users to search for solutions externally.

### Changes
- Added a warning callout in the Usage section explaining that `v-app-bar` must be inside `v-app`
- Included the specific error message users will see
- Linked to the v-app component documentation