### PR TITLE
feat(VTreeview): add aria-label and aria-expanded to expand/collapse buttons

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewGroup.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewGroup.tsx
@@ -30,6 +30,7 @@ export const VTreeviewGroup = genericComponent<VListGroupSlots>()({
         prependIcon: undefined,
         appendIcon: undefined,
         toggleIcon: toggleIcon.value,
+        isOpen: vListGroupRef.value?.isOpen ?? false,
       },
     }))
 

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -31,6 +31,7 @@ export const makeVTreeviewItemProps = propsFactory({
   hasCustomPrepend: Boolean,
   indentLines: Array as PropType<IndentLineType[]>,
   toggleIcon: IconValue,
+  isOpen: Boolean,
 
   ...makeVListItemProps({ slim: true }),
 }, 'VTreeviewItem')
@@ -73,6 +74,11 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
         vListItemRef.value?.activate(!vListItemRef.value?.isActivated, e)
       }
     }
+
+    const toggleAriaLabel = computed(() => {
+      const title = props.title ?? ''
+      return props.isOpen ? `Collapse ${title}` : `Expand ${title}`
+    })
 
     function onClickAction (e: PointerEvent) {
       e.preventDefault()
@@ -132,6 +138,8 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
                               icon={ props.toggleIcon }
                               loading={ props.loading }
                               variant="text"
+                              aria-label={ toggleAriaLabel.value }
+                              aria-expanded={ props.isOpen }
                               onClick={ onClickAction }
                             >
                               {{


### PR DESCRIPTION
## Description
Adds accessibility attributes to the expand/collapse buttons in VTreeview. Screen readers will now announce "Expand [item]" / "Collapse [item]" instead of just "Button".

Fixes #21585

### Motivation
Currently, screen readers announce the expand/collapse buttons in VTreeview simply as "Button" without any context about what the button does. This makes the treeview inaccessible for users relying on assistive technologies.

### Changes
- Added `isOpen` prop to `VTreeviewItem` to receive the open state from parent
- `VTreeviewGroup` now passes its `isOpen` state to `VTreeviewItem` via defaults
- Added `aria-label` ("Expand [title]" / "Collapse [title]") to the toggle button
- Added `aria-expanded` attribute to indicate the current state

### Before
```html
<button>▶</button>  <!-- Screen reader: "Button" -->
```

### After
```html
<button aria-label="Expand Red" aria-expanded="false">▶</button>
<!-- Screen reader: "Expand Red, collapsed" -->
```