### PR TITLE
feat(VAlert): add timeout prop to auto-dismiss alerts

### DIFF
--- a/packages/api-generator/src/locale/en/VAlert.json
+++ b/packages/api-generator/src/locale/en/VAlert.json
@@ -6,6 +6,7 @@
     "closable": "Adds a close icon that can hide the alert.",
     "closeIcon": "Change the default icon used for **closable** alerts.",
     "closeLabel": "Text used for *aria-label* on **closable** alerts. Can also be customized globally in [Internationalization](/customization/internationalization).",
+    "duration": "Time (in milliseconds) to wait until the alert is automatically dismissed. A value of `0` keeps the alert visible.",
     "height": "Sets the height for the component.",
     "maxHeight": "Sets the maximum height for the component.",
     "maxWidth": "Sets the maximum width for the component.",

--- a/packages/api-generator/src/locale/en/VAlert.json
+++ b/packages/api-generator/src/locale/en/VAlert.json
@@ -6,7 +6,6 @@
     "closable": "Adds a close icon that can hide the alert.",
     "closeIcon": "Change the default icon used for **closable** alerts.",
     "closeLabel": "Text used for *aria-label* on **closable** alerts. Can also be customized globally in [Internationalization](/customization/internationalization).",
-    "duration": "Time (in milliseconds) to wait until the alert is automatically dismissed. A value of `0` keeps the alert visible.",
     "height": "Sets the height for the component.",
     "maxHeight": "Sets the maximum height for the component.",
     "maxWidth": "Sets the maximum width for the component.",
@@ -15,6 +14,7 @@
     "modelValue": "Controls whether the component is visible or hidden.",
     "prominent": "Displays a larger vertically centered icon to draw more attention.",
     "tile": "Removes the component's border-radius.",
+    "timeout": "Time (in milliseconds) to wait until the alert is automatically dismissed. Use `-1` to keep the alert visible indefinitely. Changes to this property will reset the countdown.",
     "type": "Create a specialized alert that uses a contextual color and has a pre-defined icon.",
     "width": "Sets the width for the component."
   },

--- a/packages/docs/src/examples/v-alert/prop-timeout.vue
+++ b/packages/docs/src/examples/v-alert/prop-timeout.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <v-alert
+      v-model="alert"
+      :timeout="3000"
+      title="Auto-dismiss Alert"
+      type="success"
+      variant="tonal"
+      closable
+    >
+      This alert dismisses itself 3 seconds after it appears. The countdown pauses while you hover or focus it.
+    </v-alert>
+
+    <div
+      v-if="!alert"
+      class="text-center"
+    >
+      <v-btn @click="alert = true">
+        Reset
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const alert = ref(true)
+</script>
+
+<script>
+  export default {
+    data: () => ({
+      alert: true,
+    }),
+  }
+</script>

--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -137,6 +137,12 @@ The close icon automatically applies a default `aria-label` and is configurable 
   For more information on how to global modify your locale settings, navigate to the [Internationalization page](/features/internationalization).
 :::
 
+#### Timeout
+
+The **timeout** property automatically dismisses the alert after the specified time in milliseconds. Use `-1` (the default) to keep the alert visible indefinitely. The countdown pauses while the alert is hovered or focused, so it stays visible while being read or interacted with.
+
+<ExamplesExample file="v-alert/prop-timeout" />
+
 ## Additional Examples
 
 The following is a collection of `v-alert` examples that demonstrate how different the properties work in an application.

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -8,6 +8,7 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VIcon } from '@/components/VIcon'
 
 // Composables
+import { useAutoDismiss } from '@/composables/autoDismiss'
 import { useTextColor } from '@/composables/color'
 import { makeComponentProps } from '@/composables/component'
 import { makeDensityProps, useDensity } from '@/composables/density'
@@ -25,7 +26,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { onMounted, onScopeDispose, shallowRef, toRef, watch } from 'vue'
+import { toRef } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 // Types
@@ -57,9 +58,9 @@ export const makeVAlertProps = propsFactory({
     type: String,
     default: '$vuetify.close',
   },
-  duration: {
+  timeout: {
     type: [Number, String],
-    default: 0,
+    default: -1,
   },
   icon: {
     type: [Boolean, String, Function, Object] as PropType<false | IconValue>,
@@ -111,57 +112,13 @@ export const VAlert = genericComponent<VAlertSlots>()({
 
   setup (props, { emit, slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
-    const isHovering = shallowRef(false)
-    const isFocused = shallowRef(false)
 
-    let activeTimeout = -1
-    function startTimeout () {
-      window.clearTimeout(activeTimeout)
-      const duration = Number(props.duration)
-
-      if (!isActive.value || !duration || duration < 0 || isHovering.value || isFocused.value) return
-
-      activeTimeout = window.setTimeout(() => {
-        isActive.value = false
-      }, duration)
-    }
-
-    function clearTimeout () {
-      window.clearTimeout(activeTimeout)
-    }
-
-    function onPointerenter () {
-      isHovering.value = true
-      clearTimeout()
-    }
-
-    function onPointerleave () {
-      isHovering.value = false
-      startTimeout()
-    }
-
-    function onFocusin () {
-      isFocused.value = true
-      clearTimeout()
-    }
-
-    function onFocusout (e: FocusEvent) {
-      if (e.relatedTarget && (e.currentTarget as HTMLElement | null)?.contains(e.relatedTarget as Node)) return
-
-      isFocused.value = false
-      startTimeout()
-    }
-
-    watch(isActive, startTimeout)
-    watch(() => props.duration, startTimeout)
-
-    onMounted(() => {
-      if (isActive.value) startTimeout()
-    })
-
-    onScopeDispose(() => {
-      window.clearTimeout(activeTimeout)
-    })
+    const {
+      onPointerenter,
+      onPointerleave,
+      onFocusin,
+      onFocusout,
+    } = useAutoDismiss(isActive, () => Number(props.timeout))
 
     const icon = toRef(() => {
       if (props.icon === false) return undefined

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -25,7 +25,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { toRef } from 'vue'
+import { onMounted, onScopeDispose, shallowRef, toRef, watch } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 // Types
@@ -56,6 +56,10 @@ export const makeVAlertProps = propsFactory({
   closeLabel: {
     type: String,
     default: '$vuetify.close',
+  },
+  duration: {
+    type: [Number, String],
+    default: 0,
   },
   icon: {
     type: [Boolean, String, Function, Object] as PropType<false | IconValue>,
@@ -107,6 +111,58 @@ export const VAlert = genericComponent<VAlertSlots>()({
 
   setup (props, { emit, slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
+    const isHovering = shallowRef(false)
+    const isFocused = shallowRef(false)
+
+    let activeTimeout = -1
+    function startTimeout () {
+      window.clearTimeout(activeTimeout)
+      const duration = Number(props.duration)
+
+      if (!isActive.value || !duration || duration < 0 || isHovering.value || isFocused.value) return
+
+      activeTimeout = window.setTimeout(() => {
+        isActive.value = false
+      }, duration)
+    }
+
+    function clearTimeout () {
+      window.clearTimeout(activeTimeout)
+    }
+
+    function onPointerenter () {
+      isHovering.value = true
+      clearTimeout()
+    }
+
+    function onPointerleave () {
+      isHovering.value = false
+      startTimeout()
+    }
+
+    function onFocusin () {
+      isFocused.value = true
+      clearTimeout()
+    }
+
+    function onFocusout (e: FocusEvent) {
+      if (e.relatedTarget && (e.currentTarget as HTMLElement | null)?.contains(e.relatedTarget as Node)) return
+
+      isFocused.value = false
+      startTimeout()
+    }
+
+    watch(isActive, startTimeout)
+    watch(() => props.duration, startTimeout)
+
+    onMounted(() => {
+      if (isActive.value) startTimeout()
+    })
+
+    onScopeDispose(() => {
+      window.clearTimeout(activeTimeout)
+    })
+
     const icon = toRef(() => {
       if (props.icon === false) return undefined
       if (!props.type) return props.icon
@@ -179,6 +235,10 @@ export const VAlert = genericComponent<VAlertSlots>()({
             props.style,
           ]}
           role="alert"
+          onPointerenter={ onPointerenter }
+          onPointerleave={ onPointerleave }
+          onFocusin={ onFocusin }
+          onFocusout={ onFocusout }
         >
           { genOverlays(false, 'v-alert') }
 

--- a/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.browser.tsx
@@ -1,7 +1,7 @@
 import { VAlert } from '..'
 
 // Utilities
-import { render, screen, showcase } from '@test'
+import { render, screen, showcase, userEvent, wait } from '@test'
 
 const defaultColors = ['success', 'info', 'warning', 'error', 'invalid']
 
@@ -37,6 +37,54 @@ describe('VAlert', () => {
         // TODO: useless assert
         expect(alert).toHaveTextContent(defaultColors[idx])
       })
+    })
+  })
+
+  describe('duration', () => {
+    it('keeps the alert visible until the duration elapses, then dismisses it', async () => {
+      render(() => <VAlert text="auto dismiss" duration={ 300 } />)
+
+      await screen.findByCSS('.v-alert')
+
+      // should not be dismissed before the duration elapses
+      await wait(100)
+      expect(document.querySelector('.v-alert')).not.toBeNull()
+
+      // should be dismissed after the duration
+      await expect.poll(() => document.querySelector('.v-alert'), { timeout: 2000 }).toBeNull()
+    })
+
+    it('emits update:modelValue when auto-dismissed', async () => {
+      const onUpdate = vi.fn()
+
+      render(() => <VAlert text="auto dismiss" duration={ 150 } { ...{ 'onUpdate:modelValue': onUpdate } } />)
+
+      await expect.poll(() => onUpdate.mock.calls.length, { timeout: 2000 }).toBeGreaterThan(0)
+      expect(onUpdate).toHaveBeenLastCalledWith(false)
+    })
+
+    it('pauses the timer while hovered and resumes on leave', async () => {
+      render(() => <VAlert text="hover" duration={ 500 } />)
+
+      const alert = await screen.findByCSS('.v-alert')
+
+      await userEvent.hover(alert)
+      // stays visible past its duration while hovered
+      await wait(700)
+      expect(document.querySelector('.v-alert')).not.toBeNull()
+
+      // resumes and dismisses once the pointer leaves
+      await userEvent.unhover(alert)
+      await expect.poll(() => document.querySelector('.v-alert'), { timeout: 2000 }).toBeNull()
+    })
+
+    it('does not auto-dismiss by default', async () => {
+      render(() => <VAlert text="persistent" />)
+
+      await screen.findByCSS('.v-alert')
+      await wait(300)
+
+      expect(document.querySelector('.v-alert')).not.toBeNull()
     })
   })
 

--- a/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.browser.tsx
@@ -42,7 +42,9 @@ describe('VAlert', () => {
 
   describe('timeout', () => {
     it('keeps the alert visible until the timeout elapses, then dismisses it', async () => {
-      render(() => <VAlert text="auto dismiss" timeout={ 300 } />)
+      // Offset from the top-left corner so the resting headless-CI cursor doesn't
+      // hover the full-width alert and pause its auto-dismiss timer.
+      render(() => <div style={{ paddingTop: '200px' }}><VAlert text="auto dismiss" timeout={ 1000 } /></div>)
 
       await screen.findByCSS('.v-alert')
 
@@ -51,15 +53,19 @@ describe('VAlert', () => {
       expect(document.querySelector('.v-alert')).not.toBeNull()
 
       // should be dismissed after the timeout
-      await expect.poll(() => document.querySelector('.v-alert'), { timeout: 2000 }).toBeNull()
+      await expect.poll(() => document.querySelector('.v-alert'), { timeout: 5000 }).toBeNull()
     })
 
     it('emits update:modelValue when auto-dismissed', async () => {
       const onUpdate = vi.fn()
 
-      render(() => <VAlert text="auto dismiss" timeout={ 150 } { ...{ 'onUpdate:modelValue': onUpdate } } />)
+      render(() => (
+        <div style={{ paddingTop: '200px' }}>
+          <VAlert text="auto dismiss" timeout={ 150 } { ...{ 'onUpdate:modelValue': onUpdate } } />
+        </div>
+      ))
 
-      await expect.poll(() => onUpdate.mock.calls.length, { timeout: 2000 }).toBeGreaterThan(0)
+      await expect.poll(() => onUpdate.mock.calls.length, { timeout: 5000 }).toBeGreaterThan(0)
       expect(onUpdate).toHaveBeenLastCalledWith(false)
     })
 
@@ -75,7 +81,7 @@ describe('VAlert', () => {
 
       // resumes and dismisses once the pointer leaves
       await userEvent.unhover(alert)
-      await expect.poll(() => document.querySelector('.v-alert'), { timeout: 2000 }).toBeNull()
+      await expect.poll(() => document.querySelector('.v-alert'), { timeout: 5000 }).toBeNull()
     })
 
     it('does not auto-dismiss by default', async () => {

--- a/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAlert/__tests__/VAlert.spec.browser.tsx
@@ -40,36 +40,36 @@ describe('VAlert', () => {
     })
   })
 
-  describe('duration', () => {
-    it('keeps the alert visible until the duration elapses, then dismisses it', async () => {
-      render(() => <VAlert text="auto dismiss" duration={ 300 } />)
+  describe('timeout', () => {
+    it('keeps the alert visible until the timeout elapses, then dismisses it', async () => {
+      render(() => <VAlert text="auto dismiss" timeout={ 300 } />)
 
       await screen.findByCSS('.v-alert')
 
-      // should not be dismissed before the duration elapses
+      // should not be dismissed before the timeout elapses
       await wait(100)
       expect(document.querySelector('.v-alert')).not.toBeNull()
 
-      // should be dismissed after the duration
+      // should be dismissed after the timeout
       await expect.poll(() => document.querySelector('.v-alert'), { timeout: 2000 }).toBeNull()
     })
 
     it('emits update:modelValue when auto-dismissed', async () => {
       const onUpdate = vi.fn()
 
-      render(() => <VAlert text="auto dismiss" duration={ 150 } { ...{ 'onUpdate:modelValue': onUpdate } } />)
+      render(() => <VAlert text="auto dismiss" timeout={ 150 } { ...{ 'onUpdate:modelValue': onUpdate } } />)
 
       await expect.poll(() => onUpdate.mock.calls.length, { timeout: 2000 }).toBeGreaterThan(0)
       expect(onUpdate).toHaveBeenLastCalledWith(false)
     })
 
     it('pauses the timer while hovered and resumes on leave', async () => {
-      render(() => <VAlert text="hover" duration={ 500 } />)
+      render(() => <VAlert text="hover" timeout={ 500 } />)
 
       const alert = await screen.findByCSS('.v-alert')
 
       await userEvent.hover(alert)
-      // stays visible past its duration while hovered
+      // stays visible past its timeout while hovered
       await wait(700)
       expect(document.querySelector('.v-alert')).not.toBeNull()
 

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -13,6 +13,7 @@ import { useSnackbarItem } from '@/components/VSnackbarQueue/queue'
 
 // Composables
 import { useLayout } from '@/composables'
+import { useAutoDismiss } from '@/composables/autoDismiss'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { IconValue } from '@/composables/icons'
 import { VuetifyLayoutKey } from '@/composables/layout'
@@ -26,7 +27,7 @@ import { useToggleScope } from '@/composables/toggleScope'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { computed, inject, mergeProps, nextTick, onMounted, onScopeDispose, ref, shallowRef, watch, watchEffect } from 'vue'
+import { computed, inject, mergeProps, nextTick, onScopeDispose, ref, shallowRef, watchEffect } from 'vue'
 import { convertToUnit, genericComponent, noop, omit, propsFactory, refElement, useRender } from '@/util'
 
 // Types
@@ -147,8 +148,6 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
     let _lastOffset: string
 
     const timerRef = ref<VProgressLinear>()
-    const isHovering = shallowRef(false)
-    const isFocused = shallowRef(false)
     const startY = shallowRef(0)
     const mainStyles = ref()
     const hasLayout = inject(VuetifyLayoutKey, undefined)
@@ -161,60 +160,18 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
       })
     })
 
-    watch(isActive, startTimeout)
-    watch(() => props.timeout, startTimeout)
-
-    onMounted(() => {
-      if (isActive.value) startTimeout()
+    const {
+      isHovering,
+      isFocused,
+      onPointerenter,
+      onPointerleave,
+      onFocusin,
+      onFocusout,
+    } = useAutoDismiss(isActive, () => Number(props.timeout), {
+      getContentEl: () => overlay.value?.contentEl,
+      onClear: () => countdown.reset(),
+      onStart: () => nextTick(() => countdown.start(refElement(timerRef.value))),
     })
-
-    let activeTimeout = -1
-    function startTimeout () {
-      countdown.clear()
-      window.clearTimeout(activeTimeout)
-      const timeout = Number(props.timeout)
-
-      if (!isActive.value || timeout === -1) return
-
-      countdown.reset()
-
-      const element = refElement(timerRef.value)
-
-      nextTick(() => countdown.start(element))
-
-      activeTimeout = window.setTimeout(() => {
-        isActive.value = false
-      }, timeout)
-    }
-
-    function clearTimeout () {
-      countdown.reset()
-      window.clearTimeout(activeTimeout)
-    }
-
-    function onPointerenter () {
-      isHovering.value = true
-      clearTimeout()
-    }
-
-    function onPointerleave () {
-      isHovering.value = false
-      if (!isFocused.value) startTimeout()
-    }
-
-    function onFocusin () {
-      isFocused.value = true
-      clearTimeout()
-    }
-
-    function onFocusout (event: FocusEvent) {
-      const contentEl = overlay.value?.contentEl
-      if (contentEl?.contains(event.relatedTarget as Node)) {
-        return
-      }
-      isFocused.value = false
-      if (!isHovering.value) startTimeout()
-    }
 
     function onTouchstart (event: TouchEvent) {
       startY.value = event.touches[0].clientY

--- a/packages/vuetify/src/components/VSnackbar/__tests__/VSnackbar.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSnackbar/__tests__/VSnackbar.spec.browser.tsx
@@ -8,7 +8,7 @@ const CONTENT = '.v-snackbar .v-overlay__content'
 describe('VSnackbar', () => {
   describe('timeout', () => {
     it('auto-dismisses after the timeout elapses', async () => {
-      render(() => <VSnackbar modelValue timeout={ 300 } text="auto dismiss" />)
+      render(() => <VSnackbar modelValue timeout={ 1000 } text="auto dismiss" />)
 
       await expect.poll(() => screen.queryByCSS(CONTENT)).toBeVisible()
 
@@ -17,7 +17,7 @@ describe('VSnackbar', () => {
       expect(screen.queryByCSS(CONTENT)).toBeVisible()
 
       // should be dismissed after the timeout
-      await expect.poll(() => screen.queryByCSS(CONTENT), { timeout: 2000 }).toBeNull()
+      await expect.poll(() => screen.queryByCSS(CONTENT), { timeout: 5000 }).toBeNull()
     })
 
     it('pauses the timer while hovered and resumes on leave', async () => {
@@ -32,7 +32,7 @@ describe('VSnackbar', () => {
 
       // resumes and dismisses once the pointer leaves
       await userEvent.unhover(content)
-      await expect.poll(() => screen.queryByCSS(CONTENT), { timeout: 2000 }).toBeNull()
+      await expect.poll(() => screen.queryByCSS(CONTENT), { timeout: 5000 }).toBeNull()
     })
 
     it('stays open indefinitely when timeout is -1', async () => {

--- a/packages/vuetify/src/components/VSnackbar/__tests__/VSnackbar.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSnackbar/__tests__/VSnackbar.spec.browser.tsx
@@ -1,0 +1,47 @@
+import { VSnackbar } from '..'
+
+// Utilities
+import { render, screen, userEvent, wait } from '@test'
+
+const CONTENT = '.v-snackbar .v-overlay__content'
+
+describe('VSnackbar', () => {
+  describe('timeout', () => {
+    it('auto-dismisses after the timeout elapses', async () => {
+      render(() => <VSnackbar modelValue timeout={ 300 } text="auto dismiss" />)
+
+      await expect.poll(() => screen.queryByCSS(CONTENT)).toBeVisible()
+
+      // should still be visible shortly before the timeout elapses
+      await wait(100)
+      expect(screen.queryByCSS(CONTENT)).toBeVisible()
+
+      // should be dismissed after the timeout
+      await expect.poll(() => screen.queryByCSS(CONTENT), { timeout: 2000 }).toBeNull()
+    })
+
+    it('pauses the timer while hovered and resumes on leave', async () => {
+      render(() => <VSnackbar modelValue timeout={ 500 } text="hover" />)
+
+      const content = await screen.findByCSS(CONTENT)
+
+      await userEvent.hover(content)
+      // stays visible past its timeout while hovered
+      await wait(700)
+      expect(screen.queryByCSS(CONTENT)).toBeVisible()
+
+      // resumes and dismisses once the pointer leaves
+      await userEvent.unhover(content)
+      await expect.poll(() => screen.queryByCSS(CONTENT), { timeout: 2000 }).toBeNull()
+    })
+
+    it('stays open indefinitely when timeout is -1', async () => {
+      render(() => <VSnackbar modelValue timeout={ -1 } text="persistent" />)
+
+      await expect.poll(() => screen.queryByCSS(CONTENT)).toBeVisible()
+      await wait(300)
+
+      expect(screen.queryByCSS(CONTENT)).toBeVisible()
+    })
+  })
+})

--- a/packages/vuetify/src/composables/autoDismiss.ts
+++ b/packages/vuetify/src/composables/autoDismiss.ts
@@ -1,0 +1,94 @@
+// Utilities
+import { onMounted, onScopeDispose, shallowRef, watch } from 'vue'
+
+// Types
+import type { Ref } from 'vue'
+
+export interface AutoDismissOptions {
+  /** Called when the timeout (re)starts */
+  onStart?: () => void
+  /** Called when the pending timeout is cleared */
+  onClear?: () => void
+  /** Element scoping the focusout containment check, defaults to the event's currentTarget */
+  getContentEl?: () => HTMLElement | null | undefined
+}
+
+/**
+ * Toggles `isActive` off after `timeout` ms, pausing while hovered or focused.
+ * A negative `timeout` never dismisses. Shared by VSnackbar and VAlert.
+ */
+export function useAutoDismiss (
+  isActive: Ref<boolean>,
+  timeout: () => number,
+  options: AutoDismissOptions = {},
+) {
+  const isHovering = shallowRef(false)
+  const isFocused = shallowRef(false)
+
+  let activeTimeout = -1
+
+  function startTimeout () {
+    options.onClear?.()
+    window.clearTimeout(activeTimeout)
+
+    const value = timeout()
+
+    if (!isActive.value || value < 0 || isHovering.value || isFocused.value) return
+
+    options.onStart?.()
+
+    activeTimeout = window.setTimeout(() => {
+      isActive.value = false
+    }, value)
+  }
+
+  function clearTimeout () {
+    options.onClear?.()
+    window.clearTimeout(activeTimeout)
+  }
+
+  function onPointerenter () {
+    isHovering.value = true
+    clearTimeout()
+  }
+
+  function onPointerleave () {
+    isHovering.value = false
+    if (!isFocused.value) startTimeout()
+  }
+
+  function onFocusin () {
+    isFocused.value = true
+    clearTimeout()
+  }
+
+  function onFocusout (e: FocusEvent) {
+    const contentEl = options.getContentEl?.() ?? (e.currentTarget as HTMLElement | null)
+    if (contentEl?.contains(e.relatedTarget as Node)) return
+
+    isFocused.value = false
+    if (!isHovering.value) startTimeout()
+  }
+
+  watch(isActive, startTimeout)
+  watch(timeout, startTimeout)
+
+  onMounted(() => {
+    if (isActive.value) startTimeout()
+  })
+
+  onScopeDispose(() => {
+    window.clearTimeout(activeTimeout)
+  })
+
+  return {
+    isHovering,
+    isFocused,
+    startTimeout,
+    clearTimeout,
+    onPointerenter,
+    onPointerleave,
+    onFocusin,
+    onFocusout,
+  }
+}


### PR DESCRIPTION
## Description

Adds a `timeout` prop to `VAlert` that automatically dismisses the alert after a given time in milliseconds, matching `VSnackbar`'s `timeout`. Currently developers have to wire up their own `setTimeout` to hide an alert after a delay.

- `timeout` accepts a number (or numeric string) of milliseconds.
- `-1` (the default) keeps the alert visible indefinitely, so existing alerts are unaffected. `0` dismisses immediately and `> 0` dismisses after the given delay, matching `VSnackbar`'s semantics.
- The timer pauses while the alert is hovered or focused, so it doesn't vanish while someone is reading it or reaching for the close button / a link in a slot. It restarts when the alert becomes visible again or when `timeout` changes, and is cleared on manual close and on unmount.

The auto-dismiss timeout and pause-on-hover/focus handling is shared with `VSnackbar` through a new `useAutoDismiss` composable, so the two components stay consistent and the hover/focus pause logic that used to live only in `VSnackbar` is no longer duplicated. Pausing while hovered or focused also satisfies WCAG 2.2.1 (Timing Adjustable). `VSnackbar` keeps driving its visual countdown timer through the composable's `onStart`/`onClear` hooks, so its behavior is unchanged.

Unit tests cover auto-dismiss, the pause-on-hover case, and the persistent default. The API description and a docs example have been added.

resolves #20409

> #22952 addresses the same issue. This PR was opened first and also covers the requested shared composable, the hover/focus pause, and tests for both `VSnackbar` and `VAlert`. Happy to consolidate into whichever the team prefers.

## Markup:

```vue
<template>
  <v-btn @click="visible = true">Show alert</v-btn>
  <v-alert
    v-model="visible"
    :timeout="3000"
    closable
    type="success"
    text="I will dismiss myself after 3 seconds"
  />
</template>

<script setup>
  import { shallowRef } from 'vue'

  const visible = shallowRef(true)
</script>
```
