### PR TITLE
docs(VAppBar): document that v-app-bar must be inside v-app

### DIFF
--- a/packages/docs/src/pages/en/components/app-bars.md
+++ b/packages/docs/src/pages/en/components/app-bars.md
@@ -32,6 +32,27 @@ The `v-app-bar` component is used for application-wide actions and information.
 
 <ExamplesUsage name="v-app-bar" />
 
+::: warning
+
+`v-app-bar` relies on Vuetify's layout injection system and **must** be a direct or indirect child of `v-app`. Without `v-app` as an ancestor you will see a runtime error:
+
+```
+injection "Symbol(vuetify:layout)" not found
+```
+
+Always wrap your layout components in `v-app`:
+
+```html
+<v-app>
+  <v-app-bar title="My Application"></v-app-bar>
+  <v-main>
+    <!-- page content -->
+  </v-main>
+</v-app>
+```
+
+:::
+
 <PromotedEntry />
 
 ## API

--- a/packages/docs/src/pages/en/components/app-bars.md
+++ b/packages/docs/src/pages/en/components/app-bars.md
@@ -36,7 +36,7 @@ The `v-app-bar` component is used for application-wide actions and information.
 
 `v-app-bar` relies on Vuetify's layout injection system and **must** be a direct or indirect child of `v-app`. Without `v-app` as an ancestor you will see a runtime error:
 
-```
+```text
 injection "Symbol(vuetify:layout)" not found
 ```
 


### PR DESCRIPTION
## Summary

- Adds a `::: warning` callout to the App bars documentation page, placed directly after the Usage example
- Explains that `v-app-bar` depends on Vuetify's layout injection system and **must** be a descendant of `v-app`
- Reproduces the cryptic `injection "Symbol(vuetify:layout)" not found` error message users encounter so it is easy to search for
- Provides a minimal correct HTML structure (`<v-app><v-app-bar>…</v-app-bar><v-main>…</v-main></v-app>`) as a copy-paste guide

Closes #22855

## Test plan

- [ ] Open the docs page `/components/app-bars/` locally (`pnpm dev` in `packages/docs`) and confirm the warning callout renders correctly after the Usage example
- [ ] Verify the fenced code blocks inside the callout display as expected