### PR TITLE
fix(VSelect): pass title attribute to root element

### DIFF
--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -348,7 +348,7 @@ export function isComposingIgnoreKey (e: KeyboardEvent): boolean {
 export function filterInputAttrs (attrs: Record<string, unknown>) {
   const [events, props] = pickWithRest(attrs, [onRE])
   const inputEvents = omit(events, bubblingEvents)
-  const [rootAttrs, inputAttrs] = pickWithRest(props, ['class', 'style', 'id', 'inert', /^data-/])
+  const [rootAttrs, inputAttrs] = pickWithRest(props, ['class', 'style', 'id', 'title', 'inert', /^data-/])
   Object.assign(rootAttrs, events)
   Object.assign(inputAttrs, inputEvents)
   return [rootAttrs, inputAttrs]


### PR DESCRIPTION
## Summary

Fixes #22730

The HTML `title` attribute was not being forwarded to the root element on `v-select` (and other input-based components), so tooltip-on-hover via `<v-select title="foo">` had no effect.

**Root cause**: `filterInputAttrs` in `src/util/helpers.ts` splits fallthrough attributes into two groups:
- `rootAttrs` → applied to the component's root element (`class`, `style`, `id`, `inert`, `data-*`, event listeners)
- `inputAttrs` → applied to the inner `<input>` element

`title` was not in the root list, so it landed on the inner `<input>` which is hidden/inert in `v-select` and not visible to the user.

**Fix**: Add `'title'` to the list of attributes forwarded to the root element in `filterInputAttrs`.

This single-line change fixes `title` for all components that use `filterInputAttrs`:
- `v-select`
- `v-text-field`
- `v-textarea`
- `v-slider` / `v-range-slider`
- `v-otp-input`
- `v-selection-control` (checkbox, radio, switch)
- `v-file-upload`
- `v-radio-group`
- `v-img`

## Test plan

- [ ] Add `title="foo"` to a `v-select` and verify the browser tooltip appears on hover over the control
- [ ] Verify the same works on `v-text-field`, `v-textarea`, `v-slider`
- [ ] Existing tests pass: `pnpm test`