### PR TITLE
feat(VAlert): add duration prop for auto-dismissal

### DIFF
--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -10,10 +10,10 @@
     <v-alert
       v-else
       v-model="visible"
-      type="info"
+      closable
       :duration="3000"
       text="This alert will automatically dismiss after 3 seconds."
-      closable
+      type="info"
     ></v-alert>
   </div>
 </template>

--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <v-btn
+      v-if="!visible"
+      @click="visible = true"
+    >
+      Show alert
+    </v-btn>
+
+    <v-alert
+      v-else
+      v-model="visible"
+      type="info"
+      closable
+      :duration="3000"
+      text="This alert will automatically dismiss after 3 seconds."
+    />
+  </div>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const visible = ref(true)
+</script>

--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -10,10 +10,10 @@
     <v-alert
       v-else
       v-model="visible"
-      closable
       :duration="3000"
       text="This alert will automatically dismiss after 3 seconds."
       type="info"
+      closable
     ></v-alert>
   </div>
 </template>

--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -11,10 +11,10 @@
       v-else
       v-model="visible"
       type="info"
-      closable
       :duration="3000"
       text="This alert will automatically dismiss after 3 seconds."
-    />
+      closable
+    ></v-alert>
   </div>
 </template>
 

--- a/packages/docs/src/examples/v-alert/prop-timeout.vue
+++ b/packages/docs/src/examples/v-alert/prop-timeout.vue
@@ -10,7 +10,7 @@
     <v-alert
       v-else
       v-model="visible"
-      :duration="3000"
+      :timeout="3000"
       text="This alert will automatically dismiss after 3 seconds."
       type="info"
       closable

--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -131,6 +131,12 @@ The **closable** prop adds a [v-icon](/components/icons) on the far right, after
 
 <ExamplesExample file="v-alert/prop-closable" />
 
+#### Duration
+
+The **duration** prop causes the alert to automatically dismiss itself after the specified number of milliseconds. Set to `-1` (the default) to disable auto-dismiss. Combine with **closable** to give users both auto-dismiss and manual control.
+
+<ExamplesExample file="v-alert/prop-duration" />
+
 The close icon automatically applies a default `aria-label` and is configurable by using the **close-label** prop or changing **close** value in your locale.
 
 ::: info

--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -135,7 +135,7 @@ The **closable** prop adds a [v-icon](/components/icons) on the far right, after
 
 The **duration** prop causes the alert to automatically dismiss itself after the specified number of milliseconds. Set to `-1` (the default) to disable auto-dismiss. Combine with **closable** to give users both auto-dismiss and manual control.
 
-<ExamplesExample file="v-alert/prop-duration" />
+<ExamplesExample file="v-alert/prop-timeout" />
 
 The close icon automatically applies a default `aria-label` and is configurable by using the **close-label** prop or changing **close** value in your locale.
 

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -25,7 +25,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { toRef } from 'vue'
+import { onMounted, onScopeDispose, toRef, watch } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 // Types
@@ -56,6 +56,10 @@ export const makeVAlertProps = propsFactory({
   closeLabel: {
     type: String,
     default: '$vuetify.close',
+  },
+  duration: {
+    type: [Number, String],
+    default: -1,
   },
   icon: {
     type: [Boolean, String, Function, Object] as PropType<false | IconValue>,
@@ -107,6 +111,28 @@ export const VAlert = genericComponent<VAlertSlots>()({
 
   setup (props, { emit, slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
+
+    let dismissTimer = -1
+    function clearDismissTimer () {
+      if (dismissTimer !== -1) {
+        window.clearTimeout(dismissTimer)
+        dismissTimer = -1
+      }
+    }
+    function scheduleDismiss () {
+      clearDismissTimer()
+      const ms = Number(props.duration)
+      if (ms > 0 && isActive.value) {
+        dismissTimer = window.setTimeout(() => {
+          isActive.value = false
+          dismissTimer = -1
+        }, ms)
+      }
+    }
+    onMounted(scheduleDismiss)
+    watch(() => [props.duration, isActive.value], scheduleDismiss)
+    onScopeDispose(clearDismissTimer)
+
     const icon = toRef(() => {
       if (props.icon === false) return undefined
       if (!props.type) return props.icon

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -22,10 +22,11 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { makeTagProps } from '@/composables/tag'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
+import { useTimeout } from '@/composables/timeout'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { onMounted, onScopeDispose, toRef, watch } from 'vue'
+import { onMounted, toRef, watch } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 // Types
@@ -57,7 +58,7 @@ export const makeVAlertProps = propsFactory({
     type: String,
     default: '$vuetify.close',
   },
-  duration: {
+  timeout: {
     type: [Number, String],
     default: -1,
   },
@@ -112,26 +113,16 @@ export const VAlert = genericComponent<VAlertSlots>()({
   setup (props, { emit, slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
 
-    let dismissTimer = -1
-    function clearDismissTimer () {
-      if (dismissTimer !== -1) {
-        window.clearTimeout(dismissTimer)
-        dismissTimer = -1
-      }
-    }
+    const { start: startTimeout, clear: clearTimeout } = useTimeout()
     function scheduleDismiss () {
-      clearDismissTimer()
-      const ms = Number(props.duration)
+      clearTimeout()
+      const ms = Number(props.timeout)
       if (ms > 0 && isActive.value) {
-        dismissTimer = window.setTimeout(() => {
-          isActive.value = false
-          dismissTimer = -1
-        }, ms)
+        startTimeout(ms, () => { isActive.value = false })
       }
     }
     onMounted(scheduleDismiss)
-    watch(() => [props.duration, isActive.value], scheduleDismiss)
-    onScopeDispose(clearDismissTimer)
+    watch(() => [props.timeout, isActive.value], scheduleDismiss)
 
     const icon = toRef(() => {
       if (props.icon === false) return undefined

--- a/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
+++ b/packages/vuetify/src/components/VSnackbar/VSnackbar.tsx
@@ -22,6 +22,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 import { makeRoundedProps, useRounded } from '@/composables/rounded'
 import { useScopeId } from '@/composables/scopeId'
 import { makeThemeProps, provideTheme } from '@/composables/theme'
+import { useTimeout } from '@/composables/timeout'
 import { useToggleScope } from '@/composables/toggleScope'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
@@ -168,10 +169,10 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
       if (isActive.value) startTimeout()
     })
 
-    let activeTimeout = -1
+    const { start: _startTimeout, clear: _clearTimeout } = useTimeout()
     function startTimeout () {
       countdown.clear()
-      window.clearTimeout(activeTimeout)
+      _clearTimeout()
       const timeout = Number(props.timeout)
 
       if (!isActive.value || timeout === -1) return
@@ -182,14 +183,12 @@ export const VSnackbar = genericComponent<VSnackbarSlots>()({
 
       nextTick(() => countdown.start(element))
 
-      activeTimeout = window.setTimeout(() => {
-        isActive.value = false
-      }, timeout)
+      _startTimeout(timeout, () => { isActive.value = false })
     }
 
     function clearTimeout () {
       countdown.reset()
-      window.clearTimeout(activeTimeout)
+      _clearTimeout()
     }
 
     function onPointerenter () {

--- a/packages/vuetify/src/composables/timeout.ts
+++ b/packages/vuetify/src/composables/timeout.ts
@@ -1,0 +1,25 @@
+// Utilities
+import { onScopeDispose } from 'vue'
+
+export function useTimeout () {
+  let timerId = -1
+
+  onScopeDispose(clear)
+
+  function start (ms: number, cb: () => void) {
+    clear()
+    if (ms > 0) {
+      timerId = window.setTimeout(() => {
+        timerId = -1
+        cb()
+      }, ms)
+    }
+  }
+
+  function clear () {
+    window.clearTimeout(timerId)
+    timerId = -1
+  }
+
+  return { start, clear }
+}


### PR DESCRIPTION
Fixes #20409

Adds a `duration` prop to `v-alert` that automatically dismisses the alert after the specified number of milliseconds (default: `-1` = disabled).

The timer is cleaned up on component destroy and restarts if `duration` or `modelValue` changes.