### PR TITLE
fix(VTreeview): add aria-label to expand/collapse toggle buttons

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewChildren.tsx
@@ -217,6 +217,7 @@ export const VTreeviewChildren = genericComponent<new <T extends InternalListIte
                 ...activatorProps,
                 value: treeItemProps?.value,
                 ariaExpanded: isOpen,
+                expanded: isOpen,
                 onToggleExpand: [() => checkChildren(item), activatorProps.onClick] as any,
                 onClick: props.disabled || treeItemProps.disabled
                   ? undefined

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -11,9 +11,9 @@ import { makeVListItemProps, VListItem } from '@/components/VList/VListItem'
 import { VProgressCircular } from '@/components/VProgressCircular'
 
 // Composables
+import { useLocale } from '@/composables'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { IconValue } from '@/composables/icons'
-import { useLocale } from '@/composables'
 
 // Utilities
 import { computed, inject, ref, toRaw } from 'vue'

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -13,6 +13,7 @@ import { VProgressCircular } from '@/components/VProgressCircular'
 // Composables
 import { forwardRefs } from '@/composables/forwardRefs'
 import { IconValue } from '@/composables/icons'
+import { useLocale } from '@/composables'
 
 // Utilities
 import { computed, inject, ref, toRaw } from 'vue'
@@ -31,6 +32,10 @@ export const makeVTreeviewItemProps = propsFactory({
   hasCustomPrepend: Boolean,
   indentLines: Array as PropType<IndentLineType[]>,
   toggleIcon: IconValue,
+  expanded: {
+    type: Boolean,
+    default: undefined,
+  },
 
   ...makeVListItemProps({ slim: true }),
 }, 'VTreeviewItem')
@@ -49,6 +54,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
   },
 
   setup (props, { slots, emit }) {
+    const { t } = useLocale()
     const visibleIds = inject(VTreeviewSymbol, { visibleIds: ref() }).visibleIds
 
     const vListItemRef = ref<VListItem>()
@@ -132,6 +138,11 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
                               icon={ props.toggleIcon }
                               loading={ props.loading }
                               variant="text"
+                              aria-label={
+                                props.expanded
+                                  ? t('$vuetify.treeview.collapse', String(props.title))
+                                  : t('$vuetify.treeview.expand', String(props.title))
+                              }
                               onClick={ onClickAction }
                             >
                               {{

--- a/packages/vuetify/src/locale/af.ts
+++ b/packages/vuetify/src/locale/af.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Verander kleurformaat',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ar.ts
+++ b/packages/vuetify/src/locale/ar.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'تغيير تنسيق اللون',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/az.ts
+++ b/packages/vuetify/src/locale/az.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Rəng formatını dəyişdirin',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/bg.ts
+++ b/packages/vuetify/src/locale/bg.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Промяна на цветовия формат',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ca.ts
+++ b/packages/vuetify/src/locale/ca.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Canviar format de color',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ckb.ts
+++ b/packages/vuetify/src/locale/ckb.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'گۆڕینی فۆرماتی ڕەنگ',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/cs.ts
+++ b/packages/vuetify/src/locale/cs.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Změnit formát barvy',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/da.ts
+++ b/packages/vuetify/src/locale/da.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Skift farveformat',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/de.ts
+++ b/packages/vuetify/src/locale/de.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Farbformat ändern',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/el.ts
+++ b/packages/vuetify/src/locale/el.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Αλλαγή μορφής χρώματος',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/en.ts
+++ b/packages/vuetify/src/locale/en.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Change color format',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/es.ts
+++ b/packages/vuetify/src/locale/es.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Cambiar formato de color',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/et.ts
+++ b/packages/vuetify/src/locale/et.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Muuda värvi formaati',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/fa.ts
+++ b/packages/vuetify/src/locale/fa.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'تغییر فرمت رنگ',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/fi.ts
+++ b/packages/vuetify/src/locale/fi.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Vaihda värimuotoa',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/fr.ts
+++ b/packages/vuetify/src/locale/fr.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Changer le format de couleur',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/he.ts
+++ b/packages/vuetify/src/locale/he.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'שנה פורמט צבע',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/hr.ts
+++ b/packages/vuetify/src/locale/hr.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Promijeni format boje',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/hu.ts
+++ b/packages/vuetify/src/locale/hu.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Színformátum módosítása',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/id.ts
+++ b/packages/vuetify/src/locale/id.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Ubah format warna',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/it.ts
+++ b/packages/vuetify/src/locale/it.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Cambia formato colore',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ja.ts
+++ b/packages/vuetify/src/locale/ja.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'カラーフォーマットを変更',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/km.ts
+++ b/packages/vuetify/src/locale/km.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'ប្ដូរទម្រង់ពណ៌',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ko.ts
+++ b/packages/vuetify/src/locale/ko.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: '색상 형식 변경',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/lt.ts
+++ b/packages/vuetify/src/locale/lt.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Keisti spalvos formatą',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/lv.ts
+++ b/packages/vuetify/src/locale/lv.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Mainīt krāsas formātu',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/nl.ts
+++ b/packages/vuetify/src/locale/nl.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Wijzig kleurformaat',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/no.ts
+++ b/packages/vuetify/src/locale/no.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Endre fargeformat',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/pl.ts
+++ b/packages/vuetify/src/locale/pl.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Zmień format koloru',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/pt.ts
+++ b/packages/vuetify/src/locale/pt.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Alterar formato da cor',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ro.ts
+++ b/packages/vuetify/src/locale/ro.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Schimbă formatul culorii',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/ru.ts
+++ b/packages/vuetify/src/locale/ru.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Изменить формат цвета',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/sk.ts
+++ b/packages/vuetify/src/locale/sk.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Zmeniť formát farby',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/sl.ts
+++ b/packages/vuetify/src/locale/sl.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Spremeni format barve',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/sr-Cyrl.ts
+++ b/packages/vuetify/src/locale/sr-Cyrl.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Промени формат боје',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/sr-Latn.ts
+++ b/packages/vuetify/src/locale/sr-Latn.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Promeni format boje',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/sv.ts
+++ b/packages/vuetify/src/locale/sv.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Ändra färgformat',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/th.ts
+++ b/packages/vuetify/src/locale/th.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'เปลี่ยนรูปแบบสี',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/tr.ts
+++ b/packages/vuetify/src/locale/tr.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Renk biçimini değiştir',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/uk.ts
+++ b/packages/vuetify/src/locale/uk.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Змінити формат кольору',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/vi.ts
+++ b/packages/vuetify/src/locale/vi.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: 'Thay đổi định dạng màu',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/zh-Hans.ts
+++ b/packages/vuetify/src/locale/zh-Hans.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: '更改颜色格式',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }

--- a/packages/vuetify/src/locale/zh-Hant.ts
+++ b/packages/vuetify/src/locale/zh-Hant.ts
@@ -202,4 +202,8 @@ export default {
       changeFormat: '變更顏色格式',
     },
   },
+  treeview: {
+    expand: 'Expand {0}',
+    collapse: 'Collapse {0}',
+  },
 }


### PR DESCRIPTION
Fixes #21585

## Problem

Screen readers announce VTreeview expand/collapse toggle buttons as just "Button" with no context about which node they control or what action they perform.

## Solution

- Added `expanded` prop to `VTreeviewItem` to track the open/collapsed state of a tree node
- Added `useLocale` to `VTreeviewItem` and set `aria-label` on the toggle `VBtn` using i18n keys
- Added `treeview.expand` and `treeview.collapse` locale keys to `en.ts` with `{0}` placeholder for the node title
- Pass `expanded: isOpen` from the `VTreeviewChildren` activator slot into `listItemProps`

With this change, screen readers will announce something like **"Expand Fruits"** or **"Collapse Fruits"** instead of just **"Button"**.