### PR TITLE
fix(VAutocomplete): populate input with selected item title on initial render

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -170,6 +170,12 @@ export const VAutocomplete = genericComponent<new <
 
     const selectedValues = computed(() => model.value.map(selection => selection.props.value))
 
+    watch(model, value => {
+      if (!isFocused.value && !props.multiple && !hasSelectionSlot.value) {
+        search.value = value.at(-1)?.props.title ?? ''
+      }
+    }, { immediate: true })
+
     const firstSelectableItem = computed(() => displayItems.value.find(x => x.type === 'item' && !x.props.disabled))
 
     const highlightFirst = computed(() => {


### PR DESCRIPTION
Fixes #22270

## Summary

`VAutocomplete` did not show the selected item's text in the input on initial render when a value was set via `v-model` or `:model-value`. The input only became populated after the user first focused the component.

## Root cause

`search` (the text shown in the underlying input) was initialized to `''` and was only updated to reflect the selected item's title inside the `watch(isFocused)` handler — which only fires on user interaction.

`VCombobox` already handles this correctly by initializing `_search` eagerly from the model value and watching `model` for external changes.

## Fix

Added a `watch(model, ..., { immediate: true })` in `VAutocomplete.tsx` that mirrors the `VCombobox` pattern:

```ts
watch(model, value => {
  if (!isFocused.value && !props.multiple && !hasSelectionSlot.value) {
    search.value = value.at(-1)?.props.title ?? ''
  }
}, { immediate: true })
```

Guards match the same conditions used in the focus watcher's focus-in branch:
- `!isFocused.value` — avoids overwriting the user's live typing  
- `!props.multiple` — multiple-select doesn't show a single title in the input  
- `!hasSelectionSlot.value` — chips/custom selection slots render separately