### PR TITLE
fix(VStepper): make step items clickable when non-linear prop is set

### DIFF
--- a/packages/vuetify/src/components/VStepper/VStepper.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepper.tsx
@@ -105,7 +105,7 @@ export const VStepper = genericComponent<new <TModel>(
   setup (props, { slots }) {
     const { items: _items, next, prev, selected } = useGroup(props, VStepperSymbol)
     const { displayClasses, mobile } = useDisplay(props)
-    const { completeIcon, editIcon, errorIcon, color, editable, prevText, nextText } = toRefs(props)
+    const { completeIcon, editIcon, errorIcon, color, editable, nonLinear, prevText, nextText } = toRefs(props)
 
     const items = computed(() => props.items.map((item, index) => {
       const title = getPropertyFromItem(item, props.itemTitle, item)
@@ -141,6 +141,7 @@ export const VStepper = genericComponent<new <TModel>(
     provideDefaults({
       VStepperItem: {
         editable,
+        nonLinear,
         errorIcon,
         completeIcon,
         editIcon,

--- a/packages/vuetify/src/components/VStepper/VStepperItem.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperItem.tsx
@@ -52,6 +52,7 @@ export const makeStepperItemProps = propsFactory({
     default: '$complete',
   },
   editable: Boolean,
+  nonLinear: Boolean,
   editIcon: {
     type: IconValue,
     default: '$edit',
@@ -92,7 +93,7 @@ export const VStepperItem = genericComponent<VStepperItemSlots>()({
     const group = useGroupItem(props, VStepperSymbol, true)
     const step = computed(() => group?.value.value ?? props.value)
     const isValid = computed(() => props.rules.every(handler => handler() === true))
-    const isClickable = computed(() => !props.disabled && props.editable)
+    const isClickable = computed(() => !props.disabled && (props.editable || props.nonLinear))
     const canEdit = computed(() => !props.disabled && props.editable)
     const hasError = computed(() => props.error || !isValid.value)
     const hasCompleted = computed(() => props.complete || (props.rules.length > 0 && isValid.value))
@@ -141,10 +142,10 @@ export const VStepperItem = genericComponent<VStepperItemSlots>()({
             },
             group?.selectedClass.value,
           ]}
-          disabled={ !props.editable }
+          disabled={ !isClickable.value }
           type="button"
           v-ripple={[
-            props.editable && props.ripple,
+            isClickable.value && props.ripple,
             null,
             null,
           ]}


### PR DESCRIPTION
Fixes #19275

## Root cause

`VStepper` provides defaults to `VStepperItem` (editable, icons, etc.) but never provided `nonLinear`. As a result, in `VStepperItem`, `isClickable` was computed as `!props.disabled && props.editable` — meaning the `nonLinear` prop had no effect on step navigation.

## Fix

- In `VStepper.tsx`: include `nonLinear` in the `provideDefaults` for `VStepperItem`
- In `VStepperItem.tsx`: add `nonLinear` prop and update `isClickable` to `!disabled && (editable || nonLinear)`
- The `disabled` attribute and ripple on the button now use `isClickable` so non-linear steppers properly enable clicking without requiring `editable`

`editable` and `nonLinear` remain independent: `editable` also shows the edit icon on the active step, `nonLinear` only enables click navigation.