### PR TITLE
fix(VCard): allow VCardTitle text to wrap instead of truncating

### DIFF
--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -10,10 +10,10 @@
     <v-alert
       v-else
       v-model="visible"
-      type="info"
+      closable
       :duration="3000"
       text="This alert will automatically dismiss after 3 seconds."
-      closable
+      type="info"
     ></v-alert>
   </div>
 </template>

--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <v-btn
+      v-if="!visible"
+      @click="visible = true"
+    >
+      Show alert
+    </v-btn>
+
+    <v-alert
+      v-else
+      v-model="visible"
+      type="info"
+      closable
+      :duration="3000"
+      text="This alert will automatically dismiss after 3 seconds."
+    />
+  </div>
+</template>
+
+<script setup>
+  import { ref } from 'vue'
+
+  const visible = ref(true)
+</script>

--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -10,10 +10,10 @@
     <v-alert
       v-else
       v-model="visible"
-      closable
       :duration="3000"
       text="This alert will automatically dismiss after 3 seconds."
       type="info"
+      closable
     ></v-alert>
   </div>
 </template>

--- a/packages/docs/src/examples/v-alert/prop-duration.vue
+++ b/packages/docs/src/examples/v-alert/prop-duration.vue
@@ -11,10 +11,10 @@
       v-else
       v-model="visible"
       type="info"
-      closable
       :duration="3000"
       text="This alert will automatically dismiss after 3 seconds."
-    />
+      closable
+    ></v-alert>
   </div>
 </template>
 

--- a/packages/docs/src/pages/en/components/alerts.md
+++ b/packages/docs/src/pages/en/components/alerts.md
@@ -131,6 +131,12 @@ The **closable** prop adds a [v-icon](/components/icons) on the far right, after
 
 <ExamplesExample file="v-alert/prop-closable" />
 
+#### Duration
+
+The **duration** prop causes the alert to automatically dismiss itself after the specified number of milliseconds. Set to `-1` (the default) to disable auto-dismiss. Combine with **closable** to give users both auto-dismiss and manual control.
+
+<ExamplesExample file="v-alert/prop-duration" />
+
 The close icon automatically applies a default `aria-label` and is configurable by using the **close-label** prop or changing **close** value in your locale.
 
 ::: info

--- a/packages/vuetify/src/components/VAlert/VAlert.tsx
+++ b/packages/vuetify/src/components/VAlert/VAlert.tsx
@@ -25,7 +25,7 @@ import { makeThemeProps, provideTheme } from '@/composables/theme'
 import { genOverlays, makeVariantProps, useVariant } from '@/composables/variant'
 
 // Utilities
-import { toRef } from 'vue'
+import { onMounted, onScopeDispose, toRef, watch } from 'vue'
 import { genericComponent, propsFactory } from '@/util'
 
 // Types
@@ -56,6 +56,10 @@ export const makeVAlertProps = propsFactory({
   closeLabel: {
     type: String,
     default: '$vuetify.close',
+  },
+  duration: {
+    type: [Number, String],
+    default: -1,
   },
   icon: {
     type: [Boolean, String, Function, Object] as PropType<false | IconValue>,
@@ -107,6 +111,28 @@ export const VAlert = genericComponent<VAlertSlots>()({
 
   setup (props, { emit, slots }) {
     const isActive = useProxiedModel(props, 'modelValue')
+
+    let dismissTimer = -1
+    function clearDismissTimer () {
+      if (dismissTimer !== -1) {
+        window.clearTimeout(dismissTimer)
+        dismissTimer = -1
+      }
+    }
+    function scheduleDismiss () {
+      clearDismissTimer()
+      const ms = Number(props.duration)
+      if (ms > 0 && isActive.value) {
+        dismissTimer = window.setTimeout(() => {
+          isActive.value = false
+          dismissTimer = -1
+        }, ms)
+      }
+    }
+    onMounted(scheduleDismiss)
+    watch(() => [props.duration, isActive.value], scheduleDismiss)
+    onScopeDispose(clearDismissTimer)
+
     const icon = toRef(() => {
       if (props.icon === false) return undefined
       if (!props.type) return props.icon

--- a/packages/vuetify/src/components/VCard/_variables.scss
+++ b/packages/vuetify/src/components/VCard/_variables.scss
@@ -49,11 +49,11 @@ $card-title-hyphens: auto !default;
 $card-title-letter-spacing: tools.map-deep-get(settings.$typography, 'title-large', 'letter-spacing') !default;
 $card-title-line-height: tools.map-deep-get(settings.$typography, 'title-large', 'line-height') !default;
 $card-title-overflow-wrap: normal !default;
-$card-title-overflow: hidden !default;
+$card-title-overflow: visible !default;
 $card-title-padding: .5rem 1rem !default;
-$card-title-text-overflow: ellipsis !default;
+$card-title-text-overflow: clip !default;
 $card-title-text-transform: none !default;
-$card-title-white-space: nowrap !default;
+$card-title-white-space: normal !default;
 $card-title-word-break: normal !default;
 $card-title-word-wrap: break-word !default;
 


### PR DESCRIPTION
Closes #19966

## Problem

`VCardTitle` was using `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;` by default, causing long titles to be silently truncated with an ellipsis. This does not match Material Design 3 guidelines, which show card titles that wrap to multiple lines.

## Fix

Changed the defaults for VCardTitle typography variables:
- `$card-title-white-space`: `nowrap` → `normal` (allows text to wrap)
- `$card-title-overflow`: `hidden` → `visible`
- `$card-title-text-overflow`: `ellipsis` → `clip`

Since these are SASS `!default` variables, users who prefer the old truncation behavior can still override them in their own SASS configuration.