### PR TITLE
feat(VMain): add disableTransition prop to suppress layout-shift (#22948)

### DIFF
--- a/packages/vuetify/src/components/VMain/VMain.tsx
+++ b/packages/vuetify/src/components/VMain/VMain.tsx
@@ -13,6 +13,7 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 
 export const makeVMainProps = propsFactory({
   scrollable: Boolean,
+  disableTransition: Boolean,
 
   ...makeComponentProps(),
   ...makeDimensionProps(),
@@ -40,6 +41,7 @@ export const VMain = genericComponent()({
           mainStyles.value,
           ssrBootStyles.value,
           dimensionStyles.value,
+          props.disableTransition ? { transition: 'none' } : undefined,
           props.style,
         ]}
       >


### PR DESCRIPTION
Fixes #22948

Adds a `disableTransition` boolean prop to `v-main` that suppresses the CSS transition on padding changes.

This is useful when views use different `v-app-bar` configurations (varying heights or extension slots), causing a visual glitch on route transitions as the main content area adjusts.

**Usage:**
```vue
<v-main disable-transition>
  <router-view />
</v-main>
```

**What changed:**
- Added `disableTransition: Boolean` prop to `makeVMainProps`
- When `true`, inlines `transition: none` style on the root element (overrides the SASS variable)