### PR TITLE
fix(VSelect): prevent blur from firing when focus moves to dropdown (#22828)

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -150,9 +150,11 @@ export const VSelect = genericComponent<new <
     'update:modelValue': (value: any) => true,
     'update:menu': (ue: boolean) => true,
     'update:search': (value: string) => true,
+    'blur': (e: FocusEvent) => true,
+    'focus': (e: FocusEvent) => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { emit, slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const vMenuRef = ref<VMenu>()
@@ -417,8 +419,14 @@ export const VSelect = genericComponent<new <
       ) {
         if (repairOrphanedFocus(e)) return
         isFocused.value = false
+        emit('blur', e)
       }
     }
+
+    watch(isFocused, (val, old) => {
+      if (val && !old) emit('focus', new FocusEvent('focus'))
+      else if (!val && old && !menu.value) emit('blur', new FocusEvent('blur'))
+    })
     function onModelUpdate (v: any) {
       if (v == null) model.value = []
       else if (matchesSelector(vTextFieldRef.value, ':autofill') || matchesSelector(vTextFieldRef.value, ':-webkit-autofill')) {

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -150,8 +150,8 @@ export const VSelect = genericComponent<new <
     'update:modelValue': (value: any) => true,
     'update:menu': (ue: boolean) => true,
     'update:search': (value: string) => true,
-    'blur': (e: FocusEvent) => true,
-    'focus': (e: FocusEvent) => true,
+    blur: (e: FocusEvent) => true,
+    focus: (e: FocusEvent) => true,
   },
 
   setup (props, { emit, slots }) {


### PR DESCRIPTION
Fixes #22828

## Root cause

When VSelect opens, DOM focus moves from the `<input>` to the dropdown list (via `onAfterEnter`). The `<input>`'s native `blur` event fires at this point, and since VSelect doesn't declare `blur` in its `emits`, the `@blur` attribute falls through as a native DOM listener on the underlying input — causing it to fire prematurely.

## Fix

Add `blur` and `focus` to VSelect's `emits`, making `@blur` a **component event** (not a native DOM fallthrough). VSelect now emits them at the correct semantic times:

- **`@blur`** emits when focus truly leaves the entire widget (when `onFocusout` fires on the dropdown sheet, or when `isFocused` goes false while the menu is already closed)
- **`@focus`** emits when `isFocused` transitions from false → true

This matches the expected behaviour: `@blur` fires only when the user leaves the select entirely, not when focus shifts from the input to the dropdown list.