### PR TITLE
fix(VAutocomplete): respect noAutoScroll prop when opening menu (#22920)

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -460,7 +460,7 @@ export const VAutocomplete = genericComponent<new <
         const index = displayItems.value.findIndex(
           item => model.value.some(s => item.value === s.value)
         )
-        IN_BROWSER && window.requestAnimationFrame(() => {
+        IN_BROWSER && !props.noAutoScroll && window.requestAnimationFrame(() => {
           index >= 0 && vVirtualScrollRef.value?.scrollToIndex(index)
         })
       }


### PR DESCRIPTION
Fixes #22920

VAutocomplete inherited the `no-auto-scroll` prop from `makeSelectProps` but the `watch(menu)` handler that calls `scrollToIndex` was missing the `!props.noAutoScroll` guard that VSelect already has (#21254).

One-line fix: add the same guard to VAutocomplete's menu watcher.