### PR TITLE
fix(VDataTable): keep rows visible after hiding a column with a custom filter

### DIFF
--- a/packages/vuetify/src/components/VDataTable/composables/headers.ts
+++ b/packages/vuetify/src/components/VDataTable/composables/headers.ts
@@ -312,6 +312,10 @@ export function createHeaders (
 
     const flatHeaders = parsed.headers.flat(1)
 
+    sortFunctions.value = {}
+    sortRawFunctions.value = {}
+    filterFunctions.value = {}
+
     for (const header of flatHeaders) {
       if (!header.key) continue
 


### PR DESCRIPTION
Fixes #22863

## Root cause

In `useHeaders`'s `watchEffect`, `sortFunctions`, `sortRawFunctions`, and `filterFunctions` were built by **appending** entries on every run without clearing old ones. When a column is removed from the visible headers, its old filter function remained in the map.

This caused `filterItems` to see a stale `customFiltersLength` count (e.g., 2) while the actual items only matched 1 custom filter key → all rows failed the intersection check and the table went blank.

## Fix

Reset the three function maps at the top of the `watchEffect` body before re-populating them. This ensures removed headers no longer contribute stale filter/sort entries.