### PR TITLE
fix(VAutocomplete): don't trigger keydown listener during IME composition

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -38,6 +38,7 @@ import {
   ensureValidVNode,
   genericComponent,
   IN_BROWSER,
+  isComposingIgnoreKey,
   matchesSelector,
   noop,
   omit,
@@ -250,7 +251,7 @@ export const VAutocomplete = genericComponent<new <
 
     // eslint-disable-next-line complexity
     function onKeydown (e: KeyboardEvent) {
-      if (form.isReadonly.value) return
+      if (isComposingIgnoreKey(e) || form.isReadonly.value) return
 
       const selectionStart = vTextFieldRef.value?.selectionStart
       const length = model.value.length


### PR DESCRIPTION
## Description

`VAutocomplete`'s `onKeydown` runs its Enter/Arrow handling even while an IME composition is in progress. `VCombobox` already guards against this: #18423 added the `isComposingIgnoreKey` helper and used it at the top of `VCombobox`'s `onKeydown`, but the same guard was never added to `VAutocomplete`, whose `onKeydown` is otherwise the same handler.

`e.key` stays `'Enter'` while composing (the confirm keydown reports it as `Enter`, not the numeric `229` that older `keyCode` checks relied on), so pressing Enter to accept a candidate hits this branch:

- `e.preventDefault()` on `Enter` swallows the IME confirmation, and
- with `auto-select-first`, that same Enter selects the highlighted item using the still-unconfirmed search text.

It is easy to reproduce when filtering with a CJK IME (Japanese / Chinese / Korean): you type to narrow the list, press Enter to confirm the conversion, and instead the menu reacts and an item gets picked.

## Fix

Mirror `VCombobox` exactly by adding `isComposingIgnoreKey(e)` to the early return:

```ts
if (isComposingIgnoreKey(e) || form.isReadonly.value) return
```

`isComposingIgnoreKey` returns `true` only while `e.isComposing` and the key is one of the composition keys (`Enter`, the arrows, `Escape`, `Tab`, space), so for normal non-composing input this is a no-op and existing behavior is unchanged.

## Markup

The repro is IME-only, so it cannot be shown in static markup. Steps with any CJK IME:

```vue
<template>
  <v-autocomplete :items="['りんご', 'みかん', 'ぶどう']" auto-select-first />
</template>
```

1. Focus the field and start typing with a Japanese IME (e.g. `ringo`, which shows conversion candidates).
2. Press Enter to confirm the candidate.

Before: the confirm is swallowed and the highlighted item is selected mid-composition. After: Enter only confirms the IME candidate, and the list reacts on the next Enter.

#18423 added the same guard to `VCombobox` without an automated test since it is browser/IME behavior; happy to add one if you would prefer.
