### PR TITLE
docs: fix TailwindCSS guide snippets

### DIFF
--- a/packages/docs/src/pages/en/features/css-utilities/tailwindcss.md
+++ b/packages/docs/src/pages/en/features/css-utilities/tailwindcss.md
@@ -175,12 +175,11 @@ Create `tailwind.css` (in `src/styles/` for Vite or `assets/styles/` for Nuxt). 
 
 ```css { resource="tailwind.css" }
 @import "tailwindcss/theme" layer(tailwind-theme);
-@import "tailwindcss/preflight" layer(tailwind-reset);
 @import "tailwindcss/utilities" layer(tailwind-utilities);
 
 /* dark/light mode — Vuetify uses .v-theme--dark/.v-theme--light instead of .dark */
 @custom-variant light (&:where(.v-theme--light, .v-theme--light *));
-@custom-variant dark  (&:where(.v-theme--dark,  .v-theme--dark  *));
+@custom-variant dark (&:where(.v-theme--dark, .v-theme--dark *));
 
 @theme {
   --breakpoint-*: initial; /* reset Tailwind defaults */


### PR DESCRIPTION
## Description

This PR fixes two documentation issues in the TailwindCSS CSS utilities guide.

The guide currently says that Tailwind’s Preflight is skipped because Vuetify already ships its own reset, but the code snippet still imports it:

```css
@import "tailwindcss/preflight" layer(tailwind-reset);
```

This is contradictory and can cause Vuetify styling issues when TailwindCSS Preflight is enabled together with Vuetify's own reset/base styles.

This PR also fixes the `dark` `@custom-variant` snippet. The current snippet contains extra spacing:

```css
@custom-variant dark  (&:where(.v-theme--dark,  .v-theme--dark  *));
```

In TailwindCSS v4, copying this snippet can cause the following build error:

```txt
@custom-variant dark has no selector or body.
```

Updated snippet:

```css
@import "tailwindcss/theme" layer(tailwind-theme);
@import "tailwindcss/utilities" layer(tailwind-utilities);

@custom-variant light (&:where(.v-theme--light, .v-theme--light *));
@custom-variant dark (&:where(.v-theme--dark, .v-theme--dark *));
```

Fixes #22972
Fixes #22973
