### PR TITLE
fix(VDateInput): derive display format from date adapter locale

### DIFF
--- a/packages/vuetify/src/components/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/components/VDateInput/VDateInput.tsx
@@ -110,9 +110,6 @@ export const VDateInput = genericComponent<new <
   setup (props, { emit, slots }) {
     const { t } = useLocale()
     const adapter = useDate()
-    // Derive the input's display/parse format from the date adapter's locale —
-    // consistent with every other date component — rather than the i18n locale,
-    // which ignores a `date` adapter configured with a different locale.
     const adapterLocale = computed(() => adapter.locale)
     const { isValid, parseDate, formatDate, parserFormat } = useDateFormat(props, adapterLocale)
     const { mobile } = useDisplay(props)

--- a/packages/vuetify/src/components/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/components/VDateInput/VDateInput.tsx
@@ -108,9 +108,13 @@ export const VDateInput = genericComponent<new <
   },
 
   setup (props, { emit, slots }) {
-    const { t, current: currentLocale } = useLocale()
+    const { t } = useLocale()
     const adapter = useDate()
-    const { isValid, parseDate, formatDate, parserFormat } = useDateFormat(props, currentLocale)
+    // Derive the input's display/parse format from the date adapter's locale —
+    // consistent with every other date component — rather than the i18n locale,
+    // which ignores a `date` adapter configured with a different locale.
+    const adapterLocale = computed(() => adapter.locale)
+    const { isValid, parseDate, formatDate, parserFormat } = useDateFormat(props, adapterLocale)
     const { mobile } = useDisplay(props)
     const { InputIcon } = useInputIcon(props)
 


### PR DESCRIPTION
VDateInput inferred its display/parse format from the i18n locale (`useLocale().current`) instead of the configured date adapter's locale. Every other date component formats via the adapter, so an app whose `date` adapter used a different locale (e.g. Luxon `en-GB`) saw the picker honour en-GB while the input field still rendered en-US.

This routes `useDateFormat` through the adapter's locale, so the input is consistent with the rest of the date components. It is a no-op for the default setup, where the adapter locale already tracks the i18n locale.

Repro: https://github.com/johnleider/vdateinput-locale-repro
Workaround on current versions: `display-format="keyboardDate"`.