### PR TITLE
fix(VTreeview): open nodes when searching

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -183,8 +183,8 @@ export const VTreeview = genericComponent<new <T, O, A, S, M>(
             },
             props.style,
           ]}
-          opened={ opened.value }
-          onUpdate:opened={ (val: unknown[]) => { opened.value = val } }
+          opened={[...opened.value]}
+          onUpdate:opened={ val => { opened.value = val } }
           v-model:activated={ activated.value }
           v-model:selected={ selected.value }
         >

--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -183,8 +183,7 @@ export const VTreeview = genericComponent<new <T, O, A, S, M>(
             },
             props.style,
           ]}
-          opened={[...opened.value]}
-          onUpdate:opened={ val => { opened.value = val } }
+          v-model:opened={ opened.value }
           v-model:activated={ activated.value }
           v-model:selected={ selected.value }
         >

--- a/packages/vuetify/src/components/VTreeview/VTreeview.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeview.tsx
@@ -4,6 +4,7 @@ import { makeVListProps, useListItems, VList } from '@/components/VList/VList'
 import { VListItem } from '@/components/VList/VListItem'
 
 // Composables
+import { useOpened } from './open'
 import { useLocale } from '@/composables'
 import { provideDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
@@ -17,7 +18,6 @@ import { genericComponent, isBoolean, omit, propsFactory, useRender } from '@/ut
 import type { PropType } from 'vue'
 import { VTreeviewSymbol } from './shared'
 import type { VTreeviewChildrenSlots } from './VTreeviewChildren'
-import type { InternalListItem } from '@/components/VList/VList'
 import type { ListItem } from '@/composables/list-items'
 import type { GenericProps, IndentLinesVariant } from '@/util'
 
@@ -106,10 +106,11 @@ export const VTreeview = genericComponent<new <T, O, A, S, M>(
 
     const vListRef = ref<VList>()
 
-    const opened = computed(() => props.openAll ? openAll(items.value) : props.opened)
     const flatItems = computed(() => flatten(items.value))
     const search = toRef(() => props.search)
     const { filteredItems } = useFilter(props, flatItems, search)
+    const opened = useOpened(props, items, filteredItems, () => vListRef.value?.getPath)
+
     const visibleIds = computed(() => {
       if (!search.value) return null
       const getPath = vListRef.value?.getPath
@@ -133,22 +134,6 @@ export const VTreeview = genericComponent<new <T, O, A, S, M>(
         queue.push(...((vListRef.value?.children.get(child) ?? []).slice()))
       }
       return arr
-    }
-
-    function openAll (items: InternalListItem<any>[]) {
-      let ids: any[] = []
-
-      for (const i of items) {
-        if (!i.children) continue
-
-        ids.push(props.returnObject ? toRaw(i.raw) : i.value)
-
-        if (i.children) {
-          ids = ids.concat(openAll(i.children))
-        }
-      }
-
-      return ids
     }
 
     provide(VTreeviewSymbol, { visibleIds })
@@ -199,6 +184,7 @@ export const VTreeview = genericComponent<new <T, O, A, S, M>(
             props.style,
           ]}
           opened={ opened.value }
+          onUpdate:opened={ (val: unknown[]) => { opened.value = val } }
           v-model:activated={ activated.value }
           v-model:selected={ selected.value }
         >

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -755,6 +755,123 @@ describe.each([
         expect(screen.getByText(/Andrew/)).not.toBeVisible()
         expect(screen.getByText(/Administrators/)).not.toBeVisible()
       })
+
+      it('should expand collapsed parents of matched items', async () => {
+        const search = shallowRef('')
+        render(() => (
+          <VTreeview
+            search={ search.value }
+            items={ items }
+            itemValue="id"
+            returnObject
+            itemsRegistration={ itemsRegistration }
+          />
+        ))
+
+        await nextTick()
+
+        search.value = 'John'
+        await nextTick()
+        expect(screen.getByText(/Vuetify/)).toBeVisible()
+        expect(screen.getByText(/Core/)).toBeVisible()
+        expect(screen.getByText(/John/)).toBeVisible()
+      })
+
+      it('should allow manually collapsing a branch while search is active', async () => {
+        const search = shallowRef('')
+        render(() => (
+          <VTreeview
+            search={ search.value }
+            items={ items }
+            itemValue="id"
+            returnObject
+            itemsRegistration={ itemsRegistration }
+          />
+        ))
+
+        await nextTick()
+        search.value = 'John'
+        await nextTick()
+        expect(screen.getByText(/John/)).toBeVisible()
+
+        await userEvent.click(screen.getByText(/Core/).parentElement!.previousElementSibling!)
+        // eslint-disable-next-line @vitest/no-conditional-in-test
+        if (itemsRegistration === 'render') {
+          // eslint-disable-next-line @vitest/no-conditional-expect
+          await expect.poll(() => screen.queryByText(/John/)).not.toBeVisible()
+        } else {
+          // eslint-disable-next-line @vitest/no-conditional-expect
+          await expect.poll(() => screen.queryByText(/John/)).toBeNull()
+        }
+      })
+
+      it('should keep user-opened branches when search is cleared', async () => {
+        const opened = shallowRef<any[]>([])
+        const search = shallowRef('')
+        render(() => (
+          <VTreeview
+            v-model:opened={ opened.value }
+            search={ search.value }
+            items={ items }
+            itemValue="id"
+            itemsRegistration={ itemsRegistration }
+          />
+        ))
+
+        await nextTick()
+        search.value = 'John'
+        await waitIdle()
+        expect(opened.value).toContain(2) // search opened John's parent "Core team"
+        expect(opened.value).not.toContain(201) // never open the matched leaf itself
+
+        // user opens an unrelated branch while searching
+        opened.value = [...opened.value, 3]
+        await waitIdle()
+
+        search.value = ''
+        await waitIdle()
+        expect(opened.value).toContain(3) // user's branch survives
+        expect(opened.value).not.toContain(2) // search's expansion is undone
+      })
+
+      it('should keep ancestors of a branch opened inside a search match', async () => {
+        const nested = [{
+          id: 1,
+          title: 'Root',
+          children: [
+            {
+              id: 2,
+              title: 'Core team',
+              children: [
+                { id: 21, title: 'Managers', children: [{ id: 211, title: 'Alice' }] },
+              ],
+            },
+          ],
+        }]
+        const opened = shallowRef<any[]>([1])
+        const search = shallowRef('')
+        render(() => (
+          <VTreeview
+            v-model:opened={ opened.value }
+            search={ search.value }
+            items={ nested }
+            itemValue="id"
+            itemsRegistration={ itemsRegistration }
+          />
+        ))
+
+        await nextTick()
+        search.value = 'core' // reveals & opens "Core team"
+        await waitIdle()
+
+        opened.value = [...opened.value, 21]
+        await waitIdle()
+
+        search.value = ''
+        await waitIdle()
+        expect(opened.value).toEqual(expect.arrayContaining([1, 2, 21])) // whole chain kept
+        expect(screen.getByText(/Alice/)).toBeVisible()
+      })
     })
   })
 

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -892,6 +892,34 @@ describe.each([
     })
   })
 
+  it('should not re-open collapsed groups when an item is mutated with open-all', async () => {
+    const data = reactive<any[]>([
+      { id: 1, title: 'Qux', children: [{ id: 11, title: 'Quid' }] },
+      { id: 2, title: 'Mop', children: [{ id: 21, title: 'Moon' }] },
+    ])
+    const opened = shallowRef<any[]>([])
+    render(() => (
+      <VTreeview
+        v-model:opened={ opened.value }
+        openAll
+        items={ data }
+        itemValue="id"
+        itemsRegistration={ itemsRegistration }
+      />
+    ))
+
+    await waitIdle()
+    expect(opened.value).toEqual(expect.arrayContaining([1, 2]))
+
+    await userEvent.click(screen.getByText('Mop').parentElement!.previousElementSibling!)
+    await waitIdle()
+    expect(opened.value).not.toContain(2)
+
+    data[0].children![0].disabled = true
+    await waitIdle()
+    expect(opened.value).not.toContain(2) // mutation must not re-open Mop
+  })
+
   // https://github.com/vuetifyjs/vuetify/issues/20830
   it('should return correct isOpen state in prepend slot', async () => {
     render(() => (

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -815,18 +815,20 @@ describe.each([
             items={ items }
             itemValue="id"
             itemsRegistration={ itemsRegistration }
+            openOnClick
           />
         ))
 
         await nextTick()
-        search.value = 'John'
-        await waitIdle()
-        expect(opened.value).toContain(2) // search opened John's parent "Core team"
-        expect(opened.value).not.toContain(201) // never open the matched leaf itself
+        search.value = 'Human'
+        await expect.poll(() => opened.value).toContain(1)
 
-        // user opens an unrelated branch while searching
-        opened.value = [...opened.value, 3]
+        // user opens an unrelated branch
+        await userEvent.click(screen.getByText(/Administrators/))
         await waitIdle()
+
+        search.value = 'John'
+        await expect.poll(() => opened.value).toContain(2)
 
         search.value = ''
         await waitIdle()
@@ -857,6 +859,7 @@ describe.each([
             items={ nested }
             itemValue="id"
             itemsRegistration={ itemsRegistration }
+            openOnClick
           />
         ))
 
@@ -864,7 +867,7 @@ describe.each([
         search.value = 'core' // reveals & opens "Core team"
         await waitIdle()
 
-        opened.value = [...opened.value, 21]
+        await userEvent.click(screen.getByText(/Managers/))
         await waitIdle()
 
         search.value = ''

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -795,6 +795,8 @@ describe.each([
         expect(screen.getByText(/John/)).toBeVisible()
 
         await userEvent.click(screen.getByText(/Core/).parentElement!.previousElementSibling!)
+        // registration changes are propagated with a 100ms throttle
+        await wait(300)
         // eslint-disable-next-line @vitest/no-conditional-in-test
         if (itemsRegistration === 'render') {
           // eslint-disable-next-line @vitest/no-conditional-expect
@@ -803,6 +805,48 @@ describe.each([
           // eslint-disable-next-line @vitest/no-conditional-expect
           await expect.poll(() => screen.queryByText(/John/)).toBeNull()
         }
+
+        search.value = 'Andrew'
+        await expect.poll(() => screen.queryByText(/Andrew/)).toBeVisible()
+      })
+
+      it('should reveal matches added to items while search is active', async () => {
+        const liveItems = reactive([
+          {
+            id: 1,
+            title: 'Vuetify Human Resources',
+            children: [
+              { id: 2, title: 'Core team', children: [{ id: 201, title: 'John' }] },
+              { id: 3, title: 'Administrators', children: [{ id: 301, title: 'Mike' }] },
+            ],
+          },
+        ])
+        const search = shallowRef('')
+        render(() => (
+          <VTreeview
+            search={ search.value }
+            items={ liveItems }
+            itemValue="id"
+            itemsRegistration={ itemsRegistration }
+          />
+        ))
+
+        await nextTick()
+        search.value = 'John'
+        await expect.poll(() => screen.queryByText(/John/)).toBeVisible()
+
+        liveItems[0].children[1].children.push({ id: 302, title: 'Johnson' })
+        await expect.poll(() => screen.queryByText(/Johnson/)).toBeVisible()
+
+        // a branch the user collapsed stays closed until the search changes
+        await userEvent.click(screen.getByText(/Core/).parentElement!.previousElementSibling!)
+        await wait(300)
+        liveItems[0].children[0].children.push({ id: 202, title: 'Johnny' })
+        await wait(300)
+        expect(screen.queryByText(/Johnny/)?.checkVisibility()).toBeFalsy()
+
+        search.value = 'Johnny'
+        await expect.poll(() => screen.queryByText(/Johnny/)).toBeVisible()
       })
 
       it('should keep user-opened branches when search is cleared', async () => {

--- a/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTreeview/__tests__/VTreeview.spec.browser.tsx
@@ -798,7 +798,7 @@ describe.each([
         // eslint-disable-next-line @vitest/no-conditional-in-test
         if (itemsRegistration === 'render') {
           // eslint-disable-next-line @vitest/no-conditional-expect
-          await expect.poll(() => screen.queryByText(/John/)).not.toBeVisible()
+          await expect.poll(() => screen.queryByText(/John/), { timeout: 3000 }).not.toBeVisible()
         } else {
           // eslint-disable-next-line @vitest/no-conditional-expect
           await expect.poll(() => screen.queryByText(/John/)).toBeNull()

--- a/packages/vuetify/src/components/VTreeview/open.ts
+++ b/packages/vuetify/src/components/VTreeview/open.ts
@@ -1,0 +1,84 @@
+// Composables
+import { useProxiedModel } from '@/composables/proxiedModel'
+
+// Utilities
+import { computed, toRaw, watch } from 'vue'
+
+// Types
+import type { Ref } from 'vue'
+import type { ListItem } from '@/composables/list-items'
+
+type GetPath = (id: unknown) => unknown[]
+
+interface OpenProps {
+  opened: unknown[]
+  openAll: boolean
+  returnObject: boolean
+  search: string | undefined
+}
+
+export function useOpened (
+  props: OpenProps,
+  items: Ref<ListItem[]>,
+  filteredItems: Ref<ListItem[]>,
+  getPath: () => GetPath | undefined,
+) {
+  const opened = useProxiedModel(
+    props,
+    'opened',
+    props.opened,
+    (v): unknown[] => Array.isArray(v) ? v : [],
+  )
+
+  const idOf = (item: ListItem) => props.returnObject ? toRaw(item.raw) : item.props.value
+
+  function everyGroupId (items: ListItem[]): unknown[] {
+    return items.flatMap(item => item.children
+      ? [idOf(item), ...everyGroupId(item.children)]
+      : []
+    )
+  }
+
+  watch([() => props.openAll, items], ([openAll]) => {
+    if (openAll) opened.value = everyGroupId(items.value)
+  }, { immediate: true })
+
+  const revealedBySearch = new Set<unknown>()
+
+  const groupsRevealingMatches = computed<unknown[]>(() => {
+    const getPathTo = getPath()
+    if (!props.search || !getPathTo) return []
+    return [...new Set(
+      filteredItems.value.flatMap(item => {
+        const branch = getPathTo(idOf(item))
+        return item.children ? branch : branch.slice(0, -1)
+      }).map(toRaw)
+    )]
+  })
+
+  watch(groupsRevealingMatches, groups => {
+    const open = new Set(opened.value.map(toRaw))
+    const toOpen = groups.filter(id => !open.has(id))
+    if (!toOpen.length) return
+    toOpen.forEach(id => revealedBySearch.add(id))
+    opened.value = [...opened.value, ...toOpen]
+  })
+
+  watch(() => !!props.search, searching => {
+    if (searching || !revealedBySearch.size) return
+    const getPathTo = getPath()
+    const stillNeeded = new Set(
+      opened.value
+        .map(toRaw)
+        .filter(id => !revealedBySearch.has(id))
+        .flatMap(id => (getPathTo?.(id) ?? [id]).map(toRaw))
+    )
+    opened.value = opened.value.filter(id => {
+      const raw = toRaw(id)
+      return !revealedBySearch.has(raw) || stillNeeded.has(raw)
+    })
+    revealedBySearch.clear()
+  })
+
+  return opened
+}

--- a/packages/vuetify/src/components/VTreeview/open.ts
+++ b/packages/vuetify/src/components/VTreeview/open.ts
@@ -7,11 +7,13 @@ import { computed, toRaw, watch } from 'vue'
 // Types
 import type { Ref } from 'vue'
 import type { ListItem } from '@/composables/list-items'
+import type { EventProp } from '@/util'
 
 type GetPath = (id: unknown) => unknown[]
 
 interface OpenProps {
   opened: unknown[]
+  'onUpdate:opened': EventProp | undefined
   openAll: boolean
   returnObject: boolean
   search: string | undefined
@@ -39,8 +41,20 @@ export function useOpened (
     )
   }
 
-  watch([() => props.openAll, items], ([openAll]) => {
-    if (openAll) opened.value = everyGroupId(items.value)
+  const allGroupIds = computed(() => props.openAll ? everyGroupId(items.value).map(toRaw) : [])
+
+  watch(allGroupIds, (ids, previous = []) => {
+    const open = new Set(opened.value.map(toRaw))
+    const stillAllGroups = new Set(ids)
+
+    const toOpen = ids.filter(id => !previous.includes(id) && !open.has(id))
+    const toClose = previous.filter(id => !stillAllGroups.has(id) && open.has(id))
+    if (!toOpen.length && !toClose.length) return
+
+    toOpen.forEach(id => open.add(id))
+    toClose.forEach(id => open.delete(id))
+
+    opened.value = [...open]
   }, { immediate: true })
 
   const revealedBySearch = new Set<unknown>()

--- a/packages/vuetify/src/components/VTreeview/open.ts
+++ b/packages/vuetify/src/components/VTreeview/open.ts
@@ -33,6 +33,7 @@ export function useOpened (
   )
 
   const revealedBySearch = new Set<unknown>()
+  const collapsedByUser = new Set<unknown>()
 
   function idOf (item: ListItem) {
     return props.returnObject ? toRaw(item.raw) : item.props.value
@@ -78,9 +79,16 @@ export function useOpened (
     return [...new Set(groups.map(toRaw))]
   })
 
+  watch(opened, val => {
+    const open = new Set(val.map(toRaw))
+    revealedBySearch.forEach(id => open.has(id) || collapsedByUser.add(id))
+  })
+
+  watch(() => props.search, () => collapsedByUser.clear())
+
   watch(groupsRevealingMatches, groups => {
     const open = new Set(opened.value.map(toRaw))
-    const toOpen = groups.filter(id => !open.has(id))
+    const toOpen = groups.filter(id => !open.has(id) && !collapsedByUser.has(id))
 
     if (!toOpen.length) return
 

--- a/packages/vuetify/src/components/VTreeview/open.ts
+++ b/packages/vuetify/src/components/VTreeview/open.ts
@@ -2,10 +2,10 @@
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, toRaw, watch } from 'vue'
+import { computed, toRaw, toValue, watch } from 'vue'
 
 // Types
-import type { Ref } from 'vue'
+import type { MaybeRefOrGetter, Ref } from 'vue'
 import type { ListItem } from '@/composables/list-items'
 import type { EventProp } from '@/util'
 
@@ -23,7 +23,7 @@ export function useOpened (
   props: OpenProps,
   items: Ref<ListItem[]>,
   filteredItems: Ref<ListItem[]>,
-  getPath: () => GetPath | undefined,
+  getPath: MaybeRefOrGetter<GetPath | undefined>,
 ) {
   const opened = useProxiedModel(
     props,
@@ -32,7 +32,11 @@ export function useOpened (
     (v): unknown[] => Array.isArray(v) ? v : [],
   )
 
-  const idOf = (item: ListItem) => props.returnObject ? toRaw(item.raw) : item.props.value
+  const revealedBySearch = new Set<unknown>()
+
+  function idOf (item: ListItem) {
+    return props.returnObject ? toRaw(item.raw) : item.props.value
+  }
 
   function everyGroupId (items: ListItem[]): unknown[] {
     return items.flatMap(item => item.children
@@ -41,14 +45,17 @@ export function useOpened (
     )
   }
 
-  const allGroupIds = computed(() => props.openAll ? everyGroupId(items.value).map(toRaw) : [])
+  const allGroupIds = computed(() => {
+    return props.openAll ? everyGroupId(items.value).map(toRaw) : []
+  })
 
   watch(allGroupIds, (ids, previous = []) => {
     const open = new Set(opened.value.map(toRaw))
-    const stillAllGroups = new Set(ids)
+    const all = new Set(ids)
 
     const toOpen = ids.filter(id => !previous.includes(id) && !open.has(id))
-    const toClose = previous.filter(id => !stillAllGroups.has(id) && open.has(id))
+    const toClose = previous.filter(id => !all.has(id) && open.has(id))
+
     if (!toOpen.length && !toClose.length) return
 
     toOpen.forEach(id => open.add(id))
@@ -57,40 +64,48 @@ export function useOpened (
     opened.value = [...open]
   }, { immediate: true })
 
-  const revealedBySearch = new Set<unknown>()
-
   const groupsRevealingMatches = computed<unknown[]>(() => {
-    const getPathTo = getPath()
+    const getPathTo = toValue(getPath)
+
     if (!props.search || !getPathTo) return []
-    return [...new Set(
-      filteredItems.value.flatMap(item => {
+
+    const groups = filteredItems.value
+      .flatMap(item => {
         const branch = getPathTo(idOf(item))
         return item.children ? branch : branch.slice(0, -1)
-      }).map(toRaw)
-    )]
+      })
+
+    return [...new Set(groups.map(toRaw))]
   })
 
   watch(groupsRevealingMatches, groups => {
     const open = new Set(opened.value.map(toRaw))
     const toOpen = groups.filter(id => !open.has(id))
+
     if (!toOpen.length) return
+
     toOpen.forEach(id => revealedBySearch.add(id))
+
     opened.value = [...opened.value, ...toOpen]
   })
 
-  watch(() => !!props.search, searching => {
-    if (searching || !revealedBySearch.size) return
-    const getPathTo = getPath()
+  watch(() => !props.search, cleared => {
+    if (!cleared || !revealedBySearch.size) return
+
+    const getPathTo = toValue(getPath)
+
     const stillNeeded = new Set(
       opened.value
         .map(toRaw)
         .filter(id => !revealedBySearch.has(id))
-        .flatMap(id => (getPathTo?.(id) ?? [id]).map(toRaw))
+        .flatMap(id => (getPathTo?.(id) ?? [id]))
+        .map(toRaw)
     )
-    opened.value = opened.value.filter(id => {
-      const raw = toRaw(id)
-      return !revealedBySearch.has(raw) || stillNeeded.has(raw)
-    })
+
+    opened.value = opened.value
+      .map(toRaw)
+      .filter(val => !revealedBySearch.has(val) || stillNeeded.has(val))
+
     revealedBySearch.clear()
   })
 

--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -174,6 +174,17 @@ export const useNested = (
     v => [...v.values()],
   )
 
+  // opening multiple nodes in a sync loop cannot wait for the proxied model to catch up
+  let batch: Set<unknown> | null = null
+  function currentOpened () {
+    if (!batch) queueMicrotask(() => { batch = null })
+    return batch ?? opened.value
+  }
+  function setOpened (value: Set<unknown>) {
+    batch = value
+    opened.value = value
+  }
+
   const activeStrategy = computed(() => {
     if (isFunction(props.activeStrategy)) return props.activeStrategy(props.mandatory)
     if (isObject(props.activeStrategy)) return props.activeStrategy
@@ -401,25 +412,25 @@ export const useNested = (
         const newOpened = openStrategy.value.open({
           id,
           value,
-          opened: new Set(opened.value),
+          opened: new Set(currentOpened()),
           children: children.value,
           parents: parents.value,
           event,
         })
 
-        newOpened && (opened.value = newOpened)
+        newOpened && setOpened(newOpened)
       },
       openOnSelect: (id, value, event) => {
         const newOpened = openStrategy.value.select({
           id,
           value,
           selected: new Map(selected.value),
-          opened: new Set(opened.value),
+          opened: new Set(currentOpened()),
           children: children.value,
           parents: parents.value,
           event,
         })
-        newOpened && (opened.value = newOpened)
+        newOpened && setOpened(newOpened)
       },
       select: (id, value, event) => {
         vm.emit('click:select', { id, value, path: getPath(id), event })


### PR DESCRIPTION
fixes #22035
fixes #22392

- open nodes when searching
  - collapse only what was temporarily opened
  - accept expand/collapse (`opened` changes) mid-search
- prevent re-opening nodes after irrelevant small changes to `items`
- accept collapsing when `open-all` and `v-model:opened`

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-card class="mx-auto" max-width="500">
      <v-sheet class="pa-4" color="surface-variant">
        <v-text-field
          v-model="search"
          clear-icon="mdi-close-circle-outline"
          label="Search Company Directory"
          variant="solo"
          clearable
          flat
          hide-details
        />

        <v-checkbox-btn
          v-model="caseSensitive"
          label="Case sensitive search"
        />
      </v-sheet>

      <v-treeview
        v-model:opened="open"
        :custom-filter="filter"
        :items="items"
        :search="search"
        item-value="id"
        open-all
        open-on-click
      >
        <template #prepend="{ item }">
          <v-icon
            v-if="item.children"
            :icon="`mdi-${item.id === 1 ? 'home-variant' : 'folder-network'}`"
          />
        </template>
      </v-treeview>
    </v-card>
    <pre>{{ open }}</pre>
  </v-app>
</template>

<script setup>
  import { onMounted, ref, shallowRef } from 'vue'

  const items = ref([
    {
      id: 1,
      title: 'Vuetify Human Resources',
      children: [
        {
          id: 2,
          title: 'Core team',
          children: [
            {
              id: 20001,
              title: 'John',
              children: [
                {
                  id: 30001,
                  title: 'TEST 1',
                },
                {
                  id: 30002,
                  title: 'TEST 2',
                },
              ],
            },
            {
              id: 202,
              title: 'Kael',
            },
            {
              id: 203,
              title: 'Nekosaur',
            },
            {
              id: 204,
              title: 'Jacek',
            },
            {
              id: 205,
              title: 'Andrew',
            },
          ],
        },
        {
          id: 3,
          title: 'Administrators',
          children: [
            {
              id: 301,
              title: 'Blaine',
            },
            {
              id: 302,
              title: 'Yuchao',
            },
          ],
        },
        {
          id: 4,
          title: 'Contributors',
          children: [
            {
              id: 401,
              title: 'Phlow',
            },
            {
              id: 402,
              title: 'Brandon',
            },
            {
              id: 403,
              title: 'Sean',
            },
          ],
        },
      ],
    },
  ])

  const open = shallowRef([1])
  const search = shallowRef(null)
  const caseSensitive = shallowRef(false)

  function filter (value, search, item) {
    return caseSensitive.value ? value.indexOf(search) > -1 : value.toLowerCase().indexOf(search.toLowerCase()) > -1
  }

  onMounted(() => {
    setTimeout(() => {
      items.value[0].children[1].children.push({ id: 30003, title: 'TEST 2', children: [{ id: 30004, title: 'Child 2.1' }] })
    }, 3000)
  })
</script>
```