### PR TITLE
fix(theme): provideTheme current should use computedThemes

### DIFF
--- a/packages/vuetify/src/composables/__tests__/theme.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/theme.spec.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @vitest/no-commented-out-tests */
 // Composables
-import { createTheme } from '../theme'
+import { createTheme, provideTheme, ThemeSymbol } from '../theme'
 
 // Utilities
-import { createApp } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createApp, defineComponent, h, provide } from 'vue'
 
 // Types
 import type { App } from 'vue'
@@ -145,6 +146,45 @@ describe('createTheme', () => {
 
     expect(theme.computedThemes.value.light.colors).toHaveProperty('color2-darken-1')
     expect(theme.computedThemes.value.light.colors).toHaveProperty('color2-lighten-1')
+  })
+
+  it('should carry generated variations into a nested provideTheme current', () => {
+    const theme = createTheme({
+      defaultTheme: 'light',
+      themes: {
+        light: {
+          colors: { color2: '#1697f6' },
+        },
+      },
+      variations: {
+        colors: ['color2'],
+        lighten: 1,
+        darken: 1,
+      },
+    })
+
+    let nested: ReturnType<typeof provideTheme> | undefined
+
+    const ChildComponent = defineComponent({
+      setup () {
+        nested = provideTheme({ theme: undefined })
+        return () => h('div')
+      },
+    })
+
+    const ParentComponent = defineComponent({
+      setup () {
+        provide(ThemeSymbol, theme)
+        return () => h(ChildComponent)
+      },
+    })
+
+    mount(ParentComponent)
+
+    expect(nested?.current.value).toStrictEqual(theme.computedThemes.value.light)
+    expect(nested?.current.value.colors).toHaveProperty('color2-darken-1')
+    expect(nested?.current.value.colors).toHaveProperty('color2-lighten-1')
+    expect(nested?.current.value.colors).toHaveProperty('on-color2')
   })
 
   it('should allow for customization of the stylesheet id', () => {

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -652,7 +652,7 @@ export function provideTheme (props: { theme?: string }) {
   if (!theme) throw new Error('Could not find Vuetify theme injection')
 
   const name = toRef(() => props.theme ?? theme.name.value)
-  const current = toRef(() => theme.themes.value[name.value])
+  const current = toRef(() => theme.computedThemes.value[name.value])
 
   const themeClasses = toRef(() => theme.isDisabled ? undefined : `${theme.prefix}theme--${name.value}`)
 


### PR DESCRIPTION
`provideTheme()` built its `current` ref from the raw, unprocessed `theme.themes` instead of `theme.computedThemes`, silently dropping color variations, generated on-colors, and dark/light default merging for any component nested under a themed component. Since every component using `makeThemeProps()` calls `provideTheme()` regardless of whether a `theme` prop override is actually set, this affects almost any non-trivial component tree. `theme.global.current` was unaffected, since it's captured once at the root and passed through unchanged on every re-provide — which is why the bug looked like a scoping issue rather than a data-processing one.

One-line fix: `provideTheme()`'s `current` now reads `theme.computedThemes.value[name.value]` instead of `theme.themes.value[name.value]` — `computedThemes` was already available on the injected theme object, just unused for this ref.

Added a regression test asserting a nested/re-provided theme's `current` carries variations and on-colors through correctly.

Closes #22986
https://github.com/vuetifyjs/vuetify/issues/22986