### PR TITLE
fix(VAvatar): keep tonal background flush with the border

### DIFF
--- a/packages/vuetify/src/components/VAvatar/VAvatar.sass
+++ b/packages/vuetify/src/components/VAvatar/VAvatar.sass
@@ -26,6 +26,10 @@
     &--rounded
       @include tools.rounded($avatar-rounded-border-radius)
 
+    &--variant-tonal
+      .v-avatar__underlay
+        border-radius: 0
+
     &--start
       margin-inline-end: $avatar-margin-start
 

--- a/packages/vuetify/src/components/VAvatar/__tests__/VAvatar.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAvatar/__tests__/VAvatar.spec.browser.tsx
@@ -1,0 +1,17 @@
+import { VAvatar } from '../VAvatar'
+
+// Utilities
+import { render, screen } from '@test'
+
+describe('VAvatar', () => {
+  // https://github.com/vuetifyjs/vuetify/issues/22868
+  it('does not round the tonal underlay so it stays flush with the border', () => {
+    render(() => (
+      <VAvatar variant="tonal" border rounded />
+    ))
+
+    const underlay = screen.getByCSS('.v-avatar__underlay')
+
+    expect(getComputedStyle(underlay).borderRadius).toBe('0px')
+  })
+})


### PR DESCRIPTION
## Description

The tonal variant's `__underlay` uses `border-radius: inherit`, so once a border is added its rounded corners no longer follow the border's inner edge and a gap shows between the tinted background and the border. `.v-avatar` already clips with `overflow: hidden`, so dropping the underlay's radius lets it fill flush to the border, as suggested in the thread.

Fixes #22868

## Markup:

```vue
<template>
  <v-avatar variant="tonal" border rounded />
</template>
```
