### PR TITLE
docs(VDataTable): note fixed-header requires height

### DIFF
--- a/packages/docs/src/pages/en/components/data-tables/basics.md
+++ b/packages/docs/src/pages/en/components/data-tables/basics.md
@@ -147,6 +147,16 @@ Using the **density** prop you are able to give your data tables an alternate st
 
 <ExamplesExample file="v-data-table/prop-dense" />
 
+#### Fixed header
+
+Use the **fixed-header** prop together with the **height** prop to fix the header to the top of the table while the rows scroll beneath it.
+
+::: warning
+
+The **fixed-header** prop has no effect on its own. You must also set the **height** prop (or otherwise constrain the table's height), otherwise the table has no internal scroll area and the header will not stay fixed.
+
+:::
+
 <!-- #### Footer props
 
 The `v-data-table` renders a default footer using the `v-data-footer` component. You can pass props to this component using **footer-props**.


### PR DESCRIPTION
## Description

The **fixed-header** prop on `VDataTable` has no visible effect unless a **height** is also set — without a constrained scroll container there is nothing for the header to stay fixed against. This is an easy point of confusion (see #20201), and the Data table docs never mentioned it, even though the base [VTable docs](https://vuetifyjs.com/en/components/tables/#fixed-header) already do.

This adds a **Fixed header** subsection under the Data table **Props** section that mirrors the existing VTable wording, plus a `::: warning` callout that makes the **height** requirement explicit.

Documentation-only change — no component or behavior changes.

resolves #20201