### PR TITLE
fix(VMenu): custom overlays and tooltips should not prevent closing

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -111,10 +111,6 @@ export const VMenu = genericComponent<OverlaySlots>()({
         : parent?.unregister()
     }, { immediate: true })
 
-    function onClickOutside (e: MouseEvent) {
-      parent?.closeParents(e)
-    }
-
     function onKeydown (e: KeyboardEvent) {
       if (props.disabled) return
 
@@ -191,7 +187,6 @@ export const VMenu = genericComponent<OverlaySlots>()({
           absolute
           activatorProps={ activatorProps.value }
           location={ props.location ?? (props.submenu ? 'end' : 'bottom') }
-          onClick:outside={ onClickOutside }
           onKeydown={ onKeydown }
           { ...scopeId }
         >

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -578,5 +578,61 @@ describe('VMenu', () => {
       expect(screen.queryByTestId('l1-1')).toBeVisible()
       expect(screen.queryByTestId('l3-1')).toBeNull()
     })
+
+    // A non-menu overlay child (tooltip, plain overlay) doesn't participate in the
+    // menu close cascade, so an outside click used to leave the menu open.
+    it('should close the menu on outside click while a tooltip child is open', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="opener">
+            Open
+            <VMenu activator="parent" closeOnContentClick={ false }>
+              <VSheet class="pa-4" data-testid="menu-content">
+                <VBtn data-testid="tip-btn">
+                  Tip
+                  <VTooltip activator="parent" openOnHover={ false } openOnClick>Tooltip</VTooltip>
+                </VBtn>
+                <VBtn data-testid="other">Other</VBtn>
+              </VSheet>
+            </VMenu>
+          </VBtn>
+          <div data-testid="outside" style="position: fixed; bottom: 0; right: 0; width: 120px; height: 120px;">out</div>
+        </div>
+      ))
+
+      await userEvent.click(screen.getByTestId('opener'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeVisible()
+      await userEvent.click(screen.getByTestId('tip-btn'))
+      await expect.poll(() => screen.queryByText('Tooltip')).toBeVisible()
+
+      await userEvent.click(screen.getByTestId('outside'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeNull()
+    })
+
+    it('should keep the menu open when clicking inside it while a tooltip child is open', async () => {
+      render(() => (
+        <VBtn data-testid="opener">
+          Open
+          <VMenu activator="parent" closeOnContentClick={ false }>
+            <VSheet class="pa-4" data-testid="menu-content">
+              <VBtn data-testid="tip-btn">
+                Tip
+                <VTooltip activator="parent" openOnHover={ false } openOnClick>Tooltip</VTooltip>
+              </VBtn>
+              <VBtn data-testid="other">Other</VBtn>
+            </VSheet>
+          </VMenu>
+        </VBtn>
+      ))
+
+      await userEvent.click(screen.getByTestId('opener'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeVisible()
+      await userEvent.click(screen.getByTestId('tip-btn'))
+      await expect.poll(() => screen.queryByText('Tooltip')).toBeVisible()
+
+      await userEvent.click(screen.getByTestId('other'))
+      await wait(300)
+      expect(screen.queryByTestId('menu-content')).toBeVisible()
+    })
   })
 })

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -2,6 +2,7 @@
 import { VMenu } from '../VMenu'
 import { VAutocomplete } from '@/components/VAutocomplete'
 import { VBtn } from '@/components/VBtn'
+import { VDialog } from '@/components/VDialog'
 import { VList, VListItem, VListItemTitle } from '@/components/VList'
 import { VSheet } from '@/components/VSheet'
 import { VTextarea } from '@/components/VTextarea'
@@ -631,6 +632,34 @@ describe('VMenu', () => {
       await expect.poll(() => screen.queryByText('Tooltip')).toBeVisible()
 
       await userEvent.click(screen.getByTestId('other'))
+      await wait(300)
+      expect(screen.queryByTestId('menu-content')).toBeVisible()
+    })
+
+    it('should keep the menu open when dismissing a scrimmed child overlay', async () => {
+      render(() => (
+        <VBtn data-testid="opener">
+          Open
+          <VMenu activator="parent" closeOnContentClick={ false }>
+            <VSheet class="pa-4" data-testid="menu-content">
+              <VBtn data-testid="dialog-btn">
+                Dialog
+                <VDialog activator="parent" width="200">
+                  <VSheet class="pa-4" data-testid="dialog-content">Dialog</VSheet>
+                </VDialog>
+              </VBtn>
+            </VSheet>
+          </VMenu>
+        </VBtn>
+      ))
+
+      await userEvent.click(screen.getByTestId('opener'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeVisible()
+      await userEvent.click(screen.getByTestId('dialog-btn'))
+      await expect.poll(() => screen.queryByTestId('dialog-content')).toBeVisible()
+
+      await userEvent.click(document.querySelector('.v-overlay__scrim')!, { position: { x: 5, y: 5 } })
+      await expect.poll(() => screen.queryByTestId('dialog-content')).toBeNull()
       await wait(300)
       expect(screen.queryByTestId('menu-content')).toBeVisible()
     })

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -1,6 +1,9 @@
 // Styles
 import './VOverlay.sass'
 
+// Components
+import { VMenuSymbol } from '@/components/VMenu/shared'
+
 // Composables
 import { getStaticLocationClasses, makeLocationStrategyProps, useLocationStrategies } from './locationStrategies'
 import { makeScrollStrategyProps, useScrollStrategies } from './scrollStrategies'
@@ -27,6 +30,7 @@ import vClickOutside from '@/directives/click-outside'
 // Utilities
 import {
   computed,
+  inject,
   mergeProps,
   onBeforeUnmount,
   ref,
@@ -203,11 +207,16 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       updateLocation,
     })
 
+    const menuParent = inject(VMenuSymbol, null)
+    const isMenu = vm.parent?.type?.name === 'VMenu'
+
     function onClickOutside (e: MouseEvent) {
       emit('click:outside', e)
 
       if (!props.persistent) isActive.value = false
       else animateClick()
+
+      if (!isMenu) menuParent?.closeParents(e)
     }
 
     function closeConditional (e: Event) {

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -207,8 +207,8 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       updateLocation,
     })
 
-    const menuParent = inject(VMenuSymbol, null)
-    const isMenu = vm.parent?.type?.name === 'VMenu'
+    // self-reference or the closest ancestor
+    const menu = inject(VMenuSymbol, null)
 
     function onClickOutside (e: MouseEvent) {
       emit('click:outside', e)
@@ -216,7 +216,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       if (!props.persistent) isActive.value = false
       else animateClick()
 
-      if (!isMenu) menuParent?.closeParents(e)
+      if (!props.scrim) menu?.closeParents(e)
     }
 
     function closeConditional (e: Event) {


### PR DESCRIPTION
When menu content has a tooltip or custom connected overlay that does not close on hover-out, the menu requires subsequent click-outside to close - first click is "swallowed" by the tooltip/overlay. This is inconsistent with VMenu cascading close.

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container class="d-flex ga-3">
      <v-select
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :menu-props="{ id: '#1' }"
        label="Select"
      />

      <v-combobox
        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
        :menu-props="{ id: '#2' }"
        label="Combobox"
      />

      <v-menu id="#3" :close-on-content-click="false">
        <template #activator="{ props }">
          <v-btn v-bind="props">Menu with Autocomplete</v-btn>
        </template>
        <v-sheet class="d-flex flex-column ga-3 pa-4" style="width: 300px">
          <v-autocomplete
            :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
            :menu-props="{ id: '#3-1' }"
            label="Autocomplete"
          />
          <v-btn>
            Button with tooltip
            <v-tooltip id="#3-2" :open-on-hover="false" activator="parent" open-on-click>Tooltip</v-tooltip>
          </v-btn>
          <v-btn>
            Button with menu
            <v-menu id="#3-3" activator="parent">
              <v-card>Menu content</v-card>
            </v-menu>
          </v-btn>
          <v-btn>
            Button with overlay
            <v-overlay id="#3-3" :scrim="false" activator="parent" location="bottom" location-strategy="connected">
              <v-card>overlay content</v-card>
            </v-overlay>
          </v-btn>
        </v-sheet>
      </v-menu>
    </v-container>
  </v-app>
</template>
```
