### PR TITLE
fix(VDataTable): respect disableSort prop for mobile display mode

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTable.sass
+++ b/packages/vuetify/src/components/VDataTable/VDataTable.sass
@@ -127,6 +127,13 @@
     display: flex
     align-items: center
 
+    > .v-data-table-header__select-all
+      margin-inline: $data-table-header-select-all-margin-inline
+      flex-grow: 0
+
+      &:only-child
+        margin-inline-start: auto
+
   .v-data-table-header__sort-icon
     margin-inline: $data-table-header-sort-icon-margin-inline
 

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -282,51 +282,55 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
           { ...props.headerProps }
         >
           <div class="v-data-table-header__content">
-            <VSelect
-              v-model={ sortingChips.value }
-              chips
-              color={ props.color }
-              class="v-data-table__td-sort-select"
-              clearable
-              density="default"
-              items={ sortableColumns.value }
-              label={ t('$vuetify.dataTable.sortBy') }
-              multiple={ props.multiSort }
-              variant="underlined"
-              returnObject
-              onClick:clear={ () => sortBy.value = [] }
-            >
-              {{
-                append: showSelectColumn ? () => (
-                  <VCheckboxBtn
-                    color={ props.color }
-                    density="compact"
-                    modelValue={ allSelected.value }
-                    indeterminate={ someSelected.value && !allSelected.value }
-                    onUpdate:modelValue={ () => selectAll(!allSelected.value) }
-                  />
-                ) : undefined,
-                chip: ({ item }) => (
-                  <VChip
-                    onClick={ item.raw.sortable ? () => toggleSort(item.raw, undefined, true) : undefined }
-                    onMousedown={ (e: MouseEvent) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                    }}
-                  >
-                    { item.title }
-                    <VIcon
-                      class={[
-                        'v-data-table__td-sort-icon',
-                        isSorted(item.raw) && 'v-data-table__td-sort-icon-active',
-                      ]}
-                      icon={ getSortIcon(item.raw) }
-                      size="small"
-                    />
-                  </VChip>
-                ),
-              }}
-            </VSelect>
+            { sortableColumns.value.length > 0 && (
+              <VSelect
+                key="header-sort-select"
+                v-model={ sortingChips.value }
+                chips
+                color={ props.color }
+                class="v-data-table__td-sort-select"
+                clearable
+                density="default"
+                items={ sortableColumns.value }
+                label={ t('$vuetify.dataTable.sortBy') }
+                multiple={ props.multiSort }
+                variant="underlined"
+                returnObject
+                onClick:clear={ () => sortBy.value = [] }
+              >
+                {{
+                  chip: ({ item }) => (
+                    <VChip
+                      onClick={ item.raw.sortable ? () => toggleSort(item.raw, undefined, true) : undefined }
+                      onMousedown={ (e: MouseEvent) => {
+                        e.preventDefault()
+                        e.stopPropagation()
+                      }}
+                    >
+                      { item.title }
+                      <VIcon
+                        class={[
+                          'v-data-table__td-sort-icon',
+                          isSorted(item.raw) && 'v-data-table__td-sort-icon-active',
+                        ]}
+                        icon={ getSortIcon(item.raw) }
+                        size="small"
+                      />
+                    </VChip>
+                  ),
+                }}
+              </VSelect>
+            )}
+            { showSelectColumn && (
+                <VCheckboxBtn
+                  class="v-data-table-header__select-all"
+                  color={ props.color }
+                  density="compact"
+                  modelValue={ allSelected.value }
+                  indeterminate={ someSelected.value && !allSelected.value }
+                  onUpdate:modelValue={ () => selectAll(!allSelected.value) }
+                />
+            )}
           </div>
         </VDataTableColumn>
       )

--- a/packages/vuetify/src/components/VDataTable/_variables.scss
+++ b/packages/vuetify/src/components/VDataTable/_variables.scss
@@ -6,6 +6,7 @@ $data-table-header-sort-badge-color: rgba(var(--v-border-color), var(--v-border-
 $data-table-header-sort-icon-default-opacity: .0 !default;
 $data-table-header-sort-icon-hover-opacity: .5 !default;
 $data-table-header-sort-icon-margin-inline: 0px !default;
+$data-table-header-select-all-margin-inline: 16px -4px !default;
 
 $data-table-loading-opacity: var(--v-disabled-opacity) !default;
 


### PR DESCRIPTION
## Description
fixes #22998

1. Prevents the VSelect "Sort by" from rendering in the mobile header under either of the following conditions:
    - When the `disable-sort` prop is active.
    - When all columns have `sortable: false` configured.
2. Moves the "Select all" VCheckboxBtn into a standalone input component (from VSelect "Sort by" append slot).

inspired by commit c0bdb9c

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-data-table
        disable-sort
        :headers="headers"
        :items="desserts"
        mobile
        show-select
      ></v-data-table>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    data() {
      return {
        headers: [
          {
            title: 'Dessert (100g serving)',
            align: 'start',
            key: 'name',
          },
          { title: 'Calories', key: 'calories' },
          { title: 'Fat (g)', key: 'fat' },
          { title: 'Carbs (g)', key: 'carbs' },
          { title: 'Protein (g)', key: 'protein' },
          { title: 'Iron (%)', key: 'iron' },
        ],
        desserts: [
          {
            name: 'Frozen Yogurt',
            calories: 200,
            fat: 6.0,
            carbs: 24,
            protein: 4.0,
            iron: '1%',
          },
          {
            name: 'Ice cream sandwich',
            calories: 200,
            fat: 9.0,
            carbs: 37,
            protein: 4.3,
            iron: '1%',
          },
          {
            name: 'Eclair',
            calories: 300,
            fat: 16.0,
            carbs: 23,
            protein: 6.0,
            iron: '7%',
          },
          {
            name: 'Cupcake',
            calories: 300,
            fat: 3.7,
            carbs: 67,
            protein: 4.3,
            iron: '8%',
          },
          {
            name: 'Gingerbread',
            calories: 400,
            fat: 16.0,
            carbs: 49,
            protein: 3.9,
            iron: '16%',
          },
          {
            name: 'Jelly bean',
            calories: 400,
            fat: 0.0,
            carbs: 94,
            protein: 0.0,
            iron: '0%',
          },
          {
            name: 'Lollipop',
            calories: 400,
            fat: 0.2,
            carbs: 98,
            protein: 0,
            iron: '2%',
          },
          {
            name: 'Honeycomb',
            calories: 400,
            fat: 3.2,
            carbs: 87,
            protein: 6.5,
            iron: '45%',
          },
          {
            name: 'Donut',
            calories: 500,
            fat: 25.0,
            carbs: 51,
            protein: 4.9,
            iron: '22%',
          },
          {
            name: 'KitKat',
            calories: 500,
            fat: 26.0,
            carbs: 65,
            protein: 7,
            iron: '6%',
          },
        ],
      }
    },
  }
</script>
```
