### PR TITLE
fix(VCalendar): add missing interval props

### DIFF
--- a/packages/vuetify/src/components/VCalendar/VCalendar.tsx
+++ b/packages/vuetify/src/components/VCalendar/VCalendar.tsx
@@ -11,6 +11,7 @@ import { VCalendarWeekly } from './VCalendarWeekly'
 // Composables
 import { makeCalendarBaseProps } from './composables/calendarBase'
 import { makeCalendarWithEventsProps, useCalendarWithEvents } from './composables/calendarWithEvents'
+import { makeCalendarWithIntervalsProps } from './composables/calendarWithIntervals'
 import { makeIntervalHighlightProps } from './composables/intervalHighlight'
 import { forwardRefs } from '@/composables/forwardRefs'
 
@@ -132,10 +133,6 @@ export const VCalendar = genericComponent<new (
     categoryText: {
       type: [String, Function] as PropType<string | CalendarCategoryTextFunction>,
     },
-    maxDays: {
-      type: Number,
-      default: 7,
-    },
     categoryHideDynamic: {
       type: Boolean,
     },
@@ -150,6 +147,7 @@ export const VCalendar = genericComponent<new (
     ...makeIntervalHighlightProps(),
     ...makeCalendarBaseProps(),
     ...makeCalendarWithEventsProps(),
+    ...makeCalendarWithIntervalsProps(),
   },
 
   setup (props, { slots, attrs, emit }) {


### PR DESCRIPTION
Fixes #22718

The interval props (`interval-minutes`, `interval-count`, etc.) already work on `VCalendar` since it renders `VCalendarDaily`/`VCalendarCategory`, but they were never declared on `VCalendar` itself, so they're missing from its API. This spreads `makeCalendarWithIntervalsProps()` the same way the child components already do — the descriptions are already in the locale file.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-calendar type="day" :interval-minutes="5" :interval-count="288" />
    </v-container>
  </v-app>
</template>
```
