### PR TITLE
fix(VMaskInput): preserve value when pasting over a selection

### DIFF
--- a/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/VMaskInput.tsx
@@ -188,8 +188,9 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
     async function replaceSelection (inputElement: HTMLInputElement, pastedCharacters: string[]) {
       caretPosition.value = inputElement.selectionStart || 0
       for (let i = 0; i < pastedCharacters.length; i++) {
-        if (await replaceCharacter(caretPosition.value, pastedCharacters[i])) {
-          caretPosition.value++
+        const nextIndex = await replaceCharacter(caretPosition.value, pastedCharacters[i])
+        if (nextIndex !== -1) {
+          caretPosition.value = nextIndex
         }
       }
     }
@@ -207,9 +208,9 @@ export const VMaskInput = genericComponent<VMaskInputSlots>()({
       if (mask.isValid(newValue)) {
         model.value = newValue
         await nextTick()
-        return true
+        return targetIndex + 1
       }
-      return false
+      return -1
     }
 
     useRender(() => {

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -349,6 +349,21 @@ describe('VMaskInput', () => {
         expect(model.value).toBe(outputText)
         expect(input.selectionStart).toBe(outputCaret)
       })
+
+      it('should keep the value intact when copying and pasting a full selection', async () => {
+        const { input, model, insertCaretAt } = renderComponent({
+          defaultModel: '1234567890123456',
+          defaultMask: '####-####-####-####',
+        })
+
+        await insertCaretAt(0, input.value.length)
+        const lock = await commands.getLock()
+        await navigator.clipboard.writeText(input.value)
+        await userEvent.paste()
+        await commands.releaseLock(lock)
+
+        expect(model.value).toBe('1234-5678-9012-3456')
+      })
     })
   })
 })

--- a/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
+++ b/packages/vuetify/src/labs/VMaskInput/__tests__/VMaskInput.spec.browser.tsx
@@ -350,19 +350,28 @@ describe('VMaskInput', () => {
         expect(input.selectionStart).toBe(outputCaret)
       })
 
-      it('should keep the value intact when copying and pasting a full selection', async () => {
+      it('should reformat pasted value when replacing a full selection', async () => {
         const { input, model, insertCaretAt } = renderComponent({
-          defaultModel: '1234567890123456',
+          defaultModel: '',
           defaultMask: '####-####-####-####',
         })
 
-        await insertCaretAt(0, input.value.length)
-        const lock = await commands.getLock()
-        await navigator.clipboard.writeText(input.value)
-        await userEvent.paste()
-        await commands.releaseLock(lock)
+        const pasteOverAll = async (text: string) => {
+          await insertCaretAt(0, input.value.length)
+          const lock = await commands.getLock()
+          await navigator.clipboard.writeText(text)
+          await userEvent.paste()
+          await commands.releaseLock(lock)
+        }
 
+        await pasteOverAll('1234-5678-9012-3456')
         expect(model.value).toBe('1234-5678-9012-3456')
+
+        await pasteOverAll('98765432-reformat10987654')
+        expect(model.value).toBe('9876-5432-1098-7654')
+
+        await pasteOverAll('1111 / 2222 / 3333 / 4444')
+        expect(model.value).toBe('1111-2222-3333-4444')
       })
     })
   })


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
When pasting over a selection, `replaceSelection` advanced the caret by one per character, but `replaceCharacter` skips past delimiters before writing. With a mask like `####-####-####-####`, selecting all and pasting the value back overwrote characters at the wrong positions and corrupted the model. `replaceCharacter` now returns the index it wrote at so the caret continues after any skipped delimiter.

fixes #22831

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <v-app>
    <v-container>
      <v-mask-input v-model="model" mask="####-####-####-####" label="Card" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { shallowRef } from 'vue'

  const model = shallowRef('1234567890123456')
</script>
```
