### PR TITLE
fix(VImg): don't poll for size when image ref is missing

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -193,7 +193,7 @@ export const VImg = genericComponent<VImgSlots>()({
             if (!aspectRatio.value) pollForSize(image.value, null)
             if (state.value === 'loading') onLoad()
           } else {
-            if (!aspectRatio.value) pollForSize(image.value!)
+            if (!aspectRatio.value) pollForSize(image.value)
             getSrc()
           }
         })
@@ -204,7 +204,7 @@ export const VImg = genericComponent<VImgSlots>()({
       if (vm.isUnmounted) return
 
       getSrc()
-      pollForSize(image.value!)
+      pollForSize(image.value)
       state.value = 'loaded'
       emit('load', image.value?.currentSrc || normalisedSrc.value.src)
     }
@@ -227,10 +227,10 @@ export const VImg = genericComponent<VImgSlots>()({
       clearTimeout(timer)
     })
 
-    function pollForSize (img: HTMLImageElement, timeout: number | null = 100) {
+    function pollForSize (img: HTMLImageElement | undefined, timeout: number | null = 100) {
       const poll = () => {
         clearTimeout(timer)
-        if (vm.isUnmounted) return
+        if (vm.isUnmounted || !img) return
 
         const { naturalHeight: imgHeight, naturalWidth: imgWidth } = img
 


### PR DESCRIPTION
## Description

The native `load` event can fire while `VImg` is kept alive by a leave transition (a fade between routes is the common case). At that point the `image` template ref is already cleared, but `vm.isUnmounted` is still `false`, so `onLoad` calls `pollForSize(image.value!)` and the destructuring throws:

```
TypeError: Cannot destructure property 'naturalHeight' of 'img' as it is undefined
```

In a Nuxt app this reproduces every time you navigate away from a page with several `v-img` cards before their images finish loading — one uncaught error per in-flight image.

The fix widens `pollForSize` to accept `undefined` and bails out early, which also removes the two non-null assertions at the call sites.

No test added: `VImg` has no existing spec and the race (load event landing during a leave transition) needs a browser-mode test to reproduce honestly. Happy to add one if you want it.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn text="toggle" @click="show = !show" />

      <v-fade-transition>
        <div v-if="show">
          <v-img
            v-for="n in 8"
            :key="n"
            :src="`https://picsum.photos/seed/${n}/1600/900`"
            width="200"
          />
        </div>
      </v-fade-transition>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const show = ref(true)
</script>
```

Throttle the network (e.g. Fast 4G), then click toggle while the images are still loading — each in-flight image throws once the leave transition starts.
