### PR TITLE
feat(VSelect/VAutocomplete/VCombobox): allow persistent menu

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -20,6 +20,7 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
+import { useSelectionMenu } from '../VSelect/useSelectionMenu'
 import { useTextColor } from '@/composables/color'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -186,15 +187,7 @@ export const VAutocomplete = genericComponent<new <
       (props.hideNoData && !displayItems.value.length) ||
       form.isReadonly.value || form.isDisabled.value
     ))
-    const _menu = useProxiedModel(props, 'menu')
-    const menu = computed({
-      get: () => _menu.value,
-      set: v => {
-        if (_menu.value && !v && vMenuRef.value?.ΨopenChildren.size) return
-        if (v && menuDisabled.value) return
-        _menu.value = v
-      },
-    })
+    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled })
 
     const { menuId, ariaExpanded, ariaControls } = useMenuActivator(props, menu)
 
@@ -422,7 +415,7 @@ export const VAutocomplete = genericComponent<new <
 
         // watch for search watcher to trigger
         nextTick(() => {
-          menu.value = false
+          closeOnSelect()
           isPristine.value = true
         })
       }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -21,6 +21,7 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
+import { useSelectionMenu } from '../VSelect/useSelectionMenu'
 import { useTextColor } from '@/composables/color'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -210,15 +211,7 @@ export const VCombobox = genericComponent<new <
       (props.hideNoData && !displayItems.value.length) ||
       form.isReadonly.value || form.isDisabled.value
     ))
-    const _menu = useProxiedModel(props, 'menu')
-    const menu = computed({
-      get: () => _menu.value,
-      set: v => {
-        if (_menu.value && !v && vMenuRef.value?.ΨopenChildren.size) return
-        if (v && menuDisabled.value) return
-        _menu.value = v
-      },
-    })
+    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled })
 
     const { menuId, ariaExpanded, ariaControls } = useMenuActivator(props, menu)
 
@@ -447,7 +440,7 @@ export const VCombobox = genericComponent<new <
 
         // watch for search watcher to trigger
         nextTick(() => {
-          menu.value = keepMenu
+          if (!keepMenu) closeOnSelect()
           isPristine.value = true
         })
       }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -20,6 +20,7 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from './useFocusRepair'
 import { useScrolling } from './useScrolling'
+import { useSelectionMenu } from './useSelectionMenu'
 import { useFocusGroups } from '../../composables/focusGroups'
 import { useAutocomplete } from '@/composables/autocomplete'
 import { makeFilterProps, useFilter } from '@/composables/filter'
@@ -200,15 +201,7 @@ export const VSelect = genericComponent<new <
       (props.hideNoData && !displayItems.value.length) ||
       form.isReadonly.value || form.isDisabled.value
     ))
-    const _menu = useProxiedModel(props, 'menu')
-    const menu = computed({
-      get: () => _menu.value,
-      set: v => {
-        if (_menu.value && !v && vMenuRef.value?.ΨopenChildren.size) return
-        if (v && menuDisabled.value) return
-        _menu.value = v
-      },
-    })
+    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled })
 
     const { menuId, ariaExpanded, ariaControls } = useMenuActivator(props, menu)
 
@@ -365,9 +358,7 @@ export const VSelect = genericComponent<new <
         const add = set !== false
         model.value = add ? [item] : []
 
-        nextTick(() => {
-          menu.value = false
-        })
+        nextTick(() => closeOnSelect())
       }
     }
     function onBlur (e: FocusEvent) {

--- a/packages/vuetify/src/components/VSelect/useSelectionMenu.ts
+++ b/packages/vuetify/src/components/VSelect/useSelectionMenu.ts
@@ -1,0 +1,42 @@
+// Composables
+import { useProxiedModel } from '@/composables/proxiedModel'
+
+// Utilities
+import { computed, toValue } from 'vue'
+
+// Types
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { VMenu } from '@/components/VMenu'
+
+export interface SelectionMenuProps {
+  menu: boolean
+  'onUpdate:menu': ((value: boolean) => void) | undefined
+  menuProps: VMenu['$props'] | undefined
+  multiple: boolean
+}
+
+export function useSelectionMenu (
+  props: SelectionMenuProps,
+  options: {
+    vMenuRef: Ref<VMenu | undefined>
+    menuDisabled: MaybeRefOrGetter<boolean>
+  },
+) {
+  const _menu = useProxiedModel(props, 'menu')
+  const menu = computed({
+    get: () => _menu.value,
+    set: v => {
+      if (_menu.value && !v && options.vMenuRef.value?.ΨopenChildren.size) return
+      if (!v && props.menuProps?.persistent) return
+      if (v && toValue(options.menuDisabled)) return
+      _menu.value = v
+    },
+  })
+
+  function closeOnSelect () {
+    if (props.multiple || props.menuProps?.closeOnContentClick === false) return
+    menu.value = false
+  }
+
+  return { menu, closeOnSelect }
+}


### PR DESCRIPTION
- allows keeping menu open when `multiple` is false

closes #20590

```vue
<template>
  <v-app theme="dark">
    <v-container width="300">
      <v-combobox
        :items="colors"
        variant="solo"
        _multiple
        density="compact"
        autocomplete="off"
        chips
        closable-chips
        :menu-props="{ offset: 8, closeOnContentClick: false }"
        :list-props="{ density: 'compact', class: 'pa-1 pt-0 border rounded-lg' }"
      >
        <template v-slot:item="{ props }">
          <v-list-item v-bind="props" min-height="32" class="mt-1 rounded">
            <template #append="{ isSelected }">
              <v-checkbox-btn
                class="my-n2 mr-n3"
                style="zoom: 0.8125"
                true-icon="$complete"
                false-icon=""
                :model-value="isSelected"
                @click.prevent
                tabindex="-1"
              />
            </template>
          </v-list-item>
        </template>
      </v-combobox>
    </v-container>
  </v-app>
</template>

<script setup>
  const colors = ['green', 'purple', 'indigo', 'cyan', 'teal', 'orange']
</script>
```
