### PR TITLE
docs: add /.well-known/security.txt

### DIFF
--- a/packages/docs/public/.well-known/security.txt
+++ b/packages/docs/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/vuetifyjs/vuetify/security/advisories/new
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://vuetifyjs.com/.well-known/security.txt
+Policy: https://github.com/vuetifyjs/vuetify/blob/master/SECURITY.md

--- a/packages/docs/public/.well-known/security.txt
+++ b/packages/docs/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: https://github.com/vuetifyjs/vuetify/security/advisories/new
+Contact: mailto:security@vuetifyjs.com
 Expires: 2027-07-14T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://vuetifyjs.com/.well-known/security.txt


### PR DESCRIPTION
## What
Add `/.well-known/security.txt` under `packages/docs/public/` so vuetifyjs.com serves one.

## Why
`https://vuetifyjs.com/.well-known/security.txt` currently falls through to the SPA (no real file). [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) makes `/.well-known/security.txt` the standard, machine-discoverable place a researcher looks first to find how to report a security issue. The file points `Contact` at your existing GitHub Security Advisory intake and `Policy` at SECURITY.md, with a future `Expires` per §2.5.5. Files in `packages/docs/public/` are served verbatim, so it will resolve at the well-known path.

I used AI assistance to identify this and draft the file; I verified the RFC reference and the live behaviour myself.