### PR TITLE
fix(VImg): don't poll for size when image ref is missing

### DIFF
--- a/packages/vuetify/src/components/VImg/VImg.tsx
+++ b/packages/vuetify/src/components/VImg/VImg.tsx
@@ -193,7 +193,7 @@ export const VImg = genericComponent<VImgSlots>()({
             if (!aspectRatio.value) pollForSize(image.value, null)
             if (state.value === 'loading') onLoad()
           } else {
-            if (!aspectRatio.value) pollForSize(image.value!)
+            if (!aspectRatio.value) pollForSize(image.value)
             getSrc()
           }
         })
@@ -204,7 +204,7 @@ export const VImg = genericComponent<VImgSlots>()({
       if (vm.isUnmounted) return
 
       getSrc()
-      pollForSize(image.value!)
+      pollForSize(image.value)
       state.value = 'loaded'
       emit('load', image.value?.currentSrc || normalisedSrc.value.src)
     }
@@ -227,10 +227,10 @@ export const VImg = genericComponent<VImgSlots>()({
       clearTimeout(timer)
     })
 
-    function pollForSize (img: HTMLImageElement, timeout: number | null = 100) {
+    function pollForSize (img: HTMLImageElement | undefined, timeout: number | null = 100) {
       const poll = () => {
         clearTimeout(timer)
-        if (vm.isUnmounted) return
+        if (vm.isUnmounted || !img) return
 
         const { naturalHeight: imgHeight, naturalWidth: imgWidth } = img
 


### PR DESCRIPTION
## Description

Resolves #23011.

The native `load` event can fire while `VImg` is kept alive by a leave transition (a fade between routes is the common case). At that point the `image` template ref is already cleared, but `vm.isUnmounted` is still `false`, so `onLoad` calls `pollForSize(image.value!)` and the destructuring throws:

```
TypeError: Cannot destructure property 'naturalHeight' of 'img' as it is undefined
```

The fix widens `pollForSize` to accept `undefined` and bails out early, which also removes the two non-null assertions at the call sites.

Confirmed against a real Nuxt 4 SSR app via an actual router-driven page transition: a CDP script navigating away while several card images were still loading threw one exception per in-flight image against the unpatched build (5 exceptions for 5 cards) and zero against a build with this guard applied. Console was otherwise clean, so this isn't a side effect of an unrelated error — see #23011 for the full trace.

A bare `v-if` + `Transition` toggle (see markup below) does not reliably reproduce this on its own — that kind of unmount clears the ref and removes the DOM node in the same tick, leaving no window for the race; the window only reliably opens with the extra scheduling from a router+Suspense-driven page transition.

No test added: `VImg` has no existing spec and the race needs a browser-mode test to reproduce honestly. Happy to add one if you want it.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn text="toggle" @click="toggle" />
      <v-fade-transition>
        <div v-if="show">
          <v-img
            v-for="n in 8"
            :key="n"
            :src="`https://picsum.photos/seed/${n}-${toggleCount}/3000/3000`"
            width="200"
          />
        </div>
      </v-fade-transition>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const show = ref(true)
  const toggleCount = ref(0)

  function toggle () {
    toggleCount.value++
    show.value = !show.value
  }
</script>
```
