### PR TITLE
fix(defaults): keep nested root defaults through teleport reset

### DIFF
--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -68,6 +68,32 @@ This is used internally by some components already:
 
 [v-defaults-provider](/components/defaults-providers/) can be used to set defaults for components within a specific scope.
 
+## Defaults for menu and dialog content
+
+Components like `<v-menu>` and `<v-dialog>` open their content in a popup. That content starts from your **global** defaults rather than inheriting from the place in your template where you wrote it, so a menu looks the same no matter where you put it.
+
+To add defaults to that popup content, nest them under the component's own key (`VMenu` or `VDialog`), **not** `VOverlay`:
+
+```js { resource="src/plugins/vuetify.js" }
+createVuetify({
+  defaults: {
+    VSelect: {
+      VMenu: { // not VOverlay
+        VList: { bgColor: 'primary' },
+      },
+    },
+  },
+})
+```
+
+This applies to the components that open a menu or dialog. Everything else follows the normal [contextual defaults](#contextual-defaults) rules:
+
+| Component | How to set defaults for its content |
+| - | - |
+| `<v-menu>`, `<v-select>`, `<v-autocomplete>`, `<v-combobox>`, `<v-speed-dial>` | Nest under the `VMenu` |
+| `<v-dialog>`, `<v-bottom-sheet>` | Nest under the `VDialog` |
+| `<v-overlay>`, `<v-tooltip>`, `<v-snackbar>` | configuration inherited normally |
+
 ## Global class and styles
 
 Define global classes and styles for all [built-in](/components/all/) components; including [virtual](/features/aliasing/#virtual-component-defaults) ones. This provides an immense amount of utility when building your application's design system and it reduces the amount of duplicated code in your templates.

--- a/packages/vuetify/src/composables/__tests__/defaults.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/defaults.spec.ts
@@ -74,7 +74,7 @@ describe('defaults', () => {
       props: { color: String },
       setup (props) {
         const _props = useDefaults(props, 'Probe')
-        return () => h('div', { 'data-color': _props.color })
+        return () => h('div', { 'data-color': _props.color || 'red' })
       },
     })
 

--- a/packages/vuetify/src/composables/__tests__/defaults.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/defaults.spec.ts
@@ -1,8 +1,13 @@
 // Components
 import { VBtn } from '@/components/VBtn'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
+
+// Composables
+import { useDefaults } from '@/composables/defaults'
 
 // Utilities
 import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
 import { createVuetify } from '@/framework'
 
 describe('defaults', () => {
@@ -51,5 +56,47 @@ describe('defaults', () => {
     expect(wrapper.attributes('style')).toContain('color: red;')
     expect(wrapper.attributes('style')).toContain('background: blue;')
     expect(wrapper.attributes('style')).toContain('caret-color: blue;')
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/23009
+  // A `root` reset (as VMenu does for teleported content) must keep the nested
+  // defaults the owning component flattened into the immediate context, even
+  // when an ancestor provideDefaults links a `prev` chain to the global root.
+  it.each([false, true])('keeps nested root defaults under a provideDefaults ancestor (ancestor: %s)', hasAncestor => {
+    const vuetify = createVuetify({
+      defaults: {
+        Owner: {
+          VMenu: {
+            Probe: { color: 'primary' },
+          },
+        },
+      },
+    })
+
+    const Probe = defineComponent({
+      name: 'Probe',
+      props: { color: String },
+      setup (props) {
+        const _props = useDefaults(props, 'Probe')
+        return () => h('div', { 'data-color': _props.color })
+      },
+    })
+
+    const Owner = defineComponent({
+      name: 'Owner',
+      setup (props) {
+        useDefaults(props, 'Owner')
+        return () => h(VDefaultsProvider, { root: 'VMenu' }, () => h(Probe))
+      },
+    })
+
+    const wrapper = mount(
+      hasAncestor
+        ? defineComponent(() => () => h(VDefaultsProvider, { defaults: { Unrelated: { foo: 'bar' } } }, () => h(Owner)))
+        : Owner,
+      { global: { plugins: [vuetify] } },
+    )
+
+    expect(wrapper.find('[data-color]').attributes('data-color')).toBe('primary')
   })
 })

--- a/packages/vuetify/src/composables/__tests__/defaults.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/defaults.spec.ts
@@ -58,10 +58,6 @@ describe('defaults', () => {
     expect(wrapper.attributes('style')).toContain('caret-color: blue;')
   })
 
-  // https://github.com/vuetifyjs/vuetify/issues/23009
-  // A `root` reset (as VMenu does for teleported content) must keep the nested
-  // defaults the owning component flattened into the immediate context, even
-  // when an ancestor provideDefaults links a `prev` chain to the global root.
   it.each([false, true])('keeps nested root defaults under a provideDefaults ancestor (ancestor: %s)', hasAncestor => {
     const vuetify = createVuetify({
       defaults: {

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -59,9 +59,6 @@ export function provideDefaults (
     if (reset || root) {
       const len = Number(reset || Infinity)
 
-      // The owning component flattens its nested `root` defaults (e.g. VSelect's
-      // VMenu config) into the immediate context, so grab them before walking
-      // `prev` — an intermediate provideDefaults ancestor pushes them out of reach.
       const rootDefaults = typeof root === 'string' ? properties.prev?.[root] : undefined
 
       for (let i = 0; i <= len; i++) {

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -59,6 +59,11 @@ export function provideDefaults (
     if (reset || root) {
       const len = Number(reset || Infinity)
 
+      // The owning component flattens its nested `root` defaults (e.g. VSelect's
+      // VMenu config) into the immediate context, so grab them before walking
+      // `prev` — an intermediate provideDefaults ancestor pushes them out of reach.
+      const rootDefaults = typeof root === 'string' ? properties.prev?.[root] : undefined
+
       for (let i = 0; i <= len; i++) {
         if (!properties || !('prev' in properties)) {
           break
@@ -67,8 +72,8 @@ export function provideDefaults (
         properties = properties.prev
       }
 
-      if (properties && typeof root === 'string' && root in properties) {
-        properties = mergeDeep(mergeDeep(properties, { prev: properties }), properties[root])
+      if (properties && rootDefaults) {
+        properties = mergeDeep(mergeDeep(properties, { prev: properties }), rootDefaults)
       }
 
       return properties


### PR DESCRIPTION
- make VMenu/VDialog-keyed nested defaults work under any provideDefaults ancestor
- does not change how non-reset-root keys are shed

fixes #23009
fixes #22506 (although `VOverlay` needs to be replaced with `VMenu` in the reproduction example)
fixes #21814

## Markup:

```js
// defaults.js
export default {

  VSelect: {
    menuProps: {
      contentClass: 'rounded-lg overflow-hidden border',
      transition: false,
    },
    VOverlay: {
      VList: {
        variant: 'plain',
        class: 'rounded-lg px-1 py-0 bg-green elevation-0',
        VListItem: {
          class: 'px-3 py-1 my opacity-80 hover-bg rounded',
          activeClass: 'bg-primary opacity-100',
          minHeight: 0,
          variant: 'plain',
        },
      },
    },
    rounded: 'lg',
    variant: 'outlined',
    density: 'compact',
    menuIcon: 'mdi-chevron-down',
  },
}
```

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-select :items="['it', 'works', 'fine']" />

      <h4>inside a v-expansion-panels</h4>
      <v-expansion-panels>
        <v-select :items="['it', 'works', 'fine']" />
      </v-expansion-panels>

      <h4>inside a v-expansion-panel</h4>
      <v-expansion-panels>
        <v-expansion-panel>
          <v-select :items="['it', 'works', 'fine']" />
        </v-expansion-panel>
      </v-expansion-panels>

      <h4>inside a v-expansion-panel-text</h4>
      <v-expansion-panels>
        <v-expansion-panel>
          <v-expansion-panel-title>click to expand</v-expansion-panel-title>
          <v-expansion-panel-text>
            <v-select :items="['it', 'works', 'fine']" />
          </v-expansion-panel-text>
        </v-expansion-panel>
      </v-expansion-panels>
    </v-container>
  </v-app>
</template>
```