### PR TITLE
fix(defaults): avoid parent config leaking into menu and dialog content

### DIFF
--- a/packages/vuetify/src/composables/__tests__/defaults.spec.ts
+++ b/packages/vuetify/src/composables/__tests__/defaults.spec.ts
@@ -95,4 +95,36 @@ describe('defaults', () => {
 
     expect(wrapper.find('[data-color]').attributes('data-color')).toBe('primary')
   })
+
+  it('drops an ancestor contextual default from reset content', () => {
+    const vuetify = createVuetify({
+      defaults: {
+        Probe: { color: 'global' },
+        Container: {
+          Probe: { color: 'contextual' },
+        },
+      },
+    })
+
+    const Probe = defineComponent({
+      name: 'Probe',
+      props: { color: String },
+      setup (props) {
+        const _props = useDefaults(props, 'Probe')
+        return () => h('div', { 'data-color': _props.color || 'red' })
+      },
+    })
+
+    const Container = defineComponent({
+      name: 'Container',
+      setup (props) {
+        useDefaults(props, 'Container')
+        return () => h(VDefaultsProvider, { root: 'VMenu' }, () => h(Probe))
+      },
+    })
+
+    const wrapper = mount(Container, { global: { plugins: [vuetify] } })
+
+    expect(wrapper.find('[data-color]').attributes('data-color')).toBe('global')
+  })
 })

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -16,6 +16,7 @@ export type DefaultsInstance = undefined | {
 export type DefaultsOptions = Partial<DefaultsInstance>
 
 export const DefaultsSymbol: InjectionKey<Ref<DefaultsInstance>> = Symbol.for('vuetify:defaults')
+export const RootDefaultsSymbol: InjectionKey<Ref<DefaultsInstance>> = Symbol.for('vuetify:defaults:root')
 
 export function createDefaults (options?: DefaultsInstance): Ref<DefaultsInstance> {
   return ref(options)
@@ -39,6 +40,7 @@ export function provideDefaults (
   }
 ) {
   const injectedDefaults = injectDefaults()
+  const injectedRoot = inject(RootDefaultsSymbol, null)
   const providedDefaults = ref(defaults)
 
   const newDefaults = computed(() => {
@@ -60,6 +62,10 @@ export function provideDefaults (
       const len = Number(reset || Infinity)
 
       const rootDefaults = typeof root === 'string' ? properties.prev?.[root] : undefined
+
+      if (root && injectedRoot?.value) {
+        properties = injectedRoot.value
+      }
 
       for (let i = 0; i <= len; i++) {
         if (!properties || !('prev' in properties)) {

--- a/packages/vuetify/src/framework.ts
+++ b/packages/vuetify/src/framework.ts
@@ -1,7 +1,7 @@
 // Composables
 import { createIcons } from './icons'
 import { createDate, DateAdapterSymbol, DateOptionsSymbol } from '@/composables/date/date'
-import { createDefaults, DefaultsSymbol } from '@/composables/defaults'
+import { createDefaults, DefaultsSymbol, RootDefaultsSymbol } from '@/composables/defaults'
 import { createDisplay, DisplaySymbol } from '@/composables/display'
 import { createGoTo, GoToSymbol } from '@/composables/goto'
 import { IconSymbol } from '@/composables/icons'
@@ -86,6 +86,7 @@ export function createVuetify (vuetify: VuetifyOptions = {}) {
       app.onUnmount(() => appScope.stop())
 
       app.provide(DefaultsSymbol, defaults)
+      app.provide(RootDefaultsSymbol, defaults)
       app.provide(DisplaySymbol, display)
       app.provide(ThemeSymbol, theme)
       app.provide(IconSymbol, icons)


### PR DESCRIPTION
fixes #18123

## Markup:

```js
// defaults.js
export default {
  VTextField: { variant: 'outlined' },
  VTable: {
    VTextField: { variant: 'solo' },
  },
}
```

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-sheet>
        <h2>With No VDefaultsProvider (Expected Code)</h2>
        <v-table>
          <tbody>
            <tr>
              <td>
                <v-text-field placeholder="plain" />
              </td>
              <td>
                <v-dialog>
                  <template #activator="{ props }">
                    <v-btn v-bind="props">Click</v-btn>
                  </template>
                  <v-card width="300">
                    <v-card-text>
                      <v-text-field placeholder="outlined" />
                    </v-card-text>
                  </v-card>
                </v-dialog>
              </td>
            </tr>
          </tbody>
        </v-table>

        <h2>With An Empty VDefaultsProvider (Workaround)</h2>
        <v-defaults-provider :defaults="{}">
          <v-table>
            <tbody>
              <tr>
                <td>
                  <v-text-field placeholder="plain" />
                </td>
                <td>
                  <v-dialog>
                    <template #activator="{ props }">
                      <v-btn v-bind="props">Click</v-btn>
                    </template>
                    <v-card width="300">
                      <v-card-text>
                        <v-text-field placeholder="outlined" />
                      </v-card-text>
                    </v-card>
                  </v-dialog>
                </td>
              </tr>
            </tbody>
          </v-table>
        </v-defaults-provider>
      </v-sheet>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const work = ref('it works')
  const notwork = ref('it doesnt work')

  const workItems = ref(['it', 'works', 'fine'])
  const notWorkItems = ref(['it', 'doesnt', 'work'])
</script>
```
