### PR TITLE
fix: Fix broken discord badge

### DIFF
--- a/packages/vuetify/README.md
+++ b/packages/vuetify/README.md
@@ -17,7 +17,7 @@
     <img src="https://img.shields.io/npm/l/vuetify.svg" alt="License">
   </a>
   <a href="https://discord.gg/vuetify">
-    <img src="https://discordapp.com/api/guilds/340160225338195969/widget.png" alt="Chat">
+    <img src="https://img.shields.io/discord/1513968811047522396?label=Chat&logo=discord" alt="Chat">
   </a>
   <br>
   <a href="https://www.npmjs.com/package/vuetify">


### PR DESCRIPTION
## Description

The **Chat** badge in the Vuetify README was rendering as a broken image. This PR fixes it.

## Root Cause

The badge pointed at Discord guild ID `340160225338195969`, which no longer exists (`Unknown Guild`). Because the server was gone, the Discord widget endpoint returned a `404`, so the badge showed a broken image.

## Changes

- Repointed the Chat badge to Vuetify's current Discord server (guild ID `1513968811047522396`, resolved from `discord.gg/vuetify`).
- Switched from the deprecated `discordapp.com/.../widget.png` endpoint to a `shields.io` badge, matching the other badges already used in the README.
- The badge now displays the live online member count (e.g. `Chat | 35 online`).

## Before / After

**Before:**

<div align="center" >

<img width="427" height="232" alt="image" src="https://github.com/user-attachments/assets/0f5d94d0-9a1a-4c7a-8790-340f6929f9c8" />

</div>

**After:**

<div align="center">

<img width="402" height="227" alt="image" src="https://github.com/user-attachments/assets/fb56fd02-e64d-4e60-a10e-26936d58f8f2" />


</div>
