### PR TITLE
feat(VMain): default transition prop to true

### DIFF
--- a/packages/vuetify/README.md
+++ b/packages/vuetify/README.md
@@ -17,7 +17,7 @@
     <img src="https://img.shields.io/npm/l/vuetify.svg" alt="License">
   </a>
   <a href="https://discord.gg/vuetify">
-    <img src="https://discordapp.com/api/guilds/340160225338195969/widget.png" alt="Chat">
+    <img src="https://img.shields.io/discord/1513968811047522396?label=Chat&logo=discord" alt="Chat">
   </a>
   <br>
   <a href="https://www.npmjs.com/package/vuetify">

--- a/packages/vuetify/README.md
+++ b/packages/vuetify/README.md
@@ -17,7 +17,7 @@
     <img src="https://img.shields.io/npm/l/vuetify.svg" alt="License">
   </a>
   <a href="https://discord.gg/vuetify">
-    <img src="https://img.shields.io/discord/1513968811047522396?label=Chat&logo=discord" alt="Chat">
+    <img src="https://discordapp.com/api/guilds/340160225338195969/widget.png" alt="Chat">
   </a>
   <br>
   <a href="https://www.npmjs.com/package/vuetify">

--- a/packages/vuetify/src/components/VMain/VMain.tsx
+++ b/packages/vuetify/src/components/VMain/VMain.tsx
@@ -13,6 +13,10 @@ import { genericComponent, propsFactory, useRender } from '@/util'
 
 export const makeVMainProps = propsFactory({
   scrollable: Boolean,
+  transition: {
+    type: Boolean,
+    default: true,
+  },
 
   ...makeComponentProps(),
   ...makeDimensionProps(),
@@ -38,7 +42,7 @@ export const VMain = genericComponent()({
         ]}
         style={[
           mainStyles.value,
-          ssrBootStyles.value,
+          props.transition ? ssrBootStyles.value : {},
           dimensionStyles.value,
           props.style,
         ]}

--- a/packages/vuetify/src/components/VMain/VMain.tsx
+++ b/packages/vuetify/src/components/VMain/VMain.tsx
@@ -42,7 +42,7 @@ export const VMain = genericComponent()({
         ]}
         style={[
           mainStyles.value,
-          props.transition ? ssrBootStyles.value : {},
+          props.transition ? ssrBootStyles.value : { transition: 'none' },
           dimensionStyles.value,
           props.style,
         ]}

--- a/packages/vuetify/src/components/VMain/__tests__/VMain.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMain/__tests__/VMain.spec.browser.tsx
@@ -1,0 +1,40 @@
+// Components
+import { VMain } from '../VMain'
+import { VLayout } from '@/components/VLayout'
+
+// Utilities
+import { render, screen, wait } from '@test'
+
+describe('VMain', () => {
+  it('should suppress transition immediately after mount when transition is true (default)', () => {
+    render(() => (
+      <VLayout>
+        <VMain />
+      </VLayout>
+    ))
+
+    expect(screen.getByCSS('.v-main').style.transition).toBe('none')
+  })
+
+  it('should stop suppressing transition once booted', async () => {
+    render(() => (
+      <VLayout>
+        <VMain />
+      </VLayout>
+    ))
+
+    await wait(100)
+
+    expect(screen.getByCSS('.v-main').style.transition).not.toBe('none')
+  })
+
+  it('should never suppress transition when transition is explicitly false', async () => {
+    render(() => (
+      <VLayout>
+        <VMain transition={ false } />
+      </VLayout>
+    ))
+
+    expect(screen.getByCSS('.v-main').style.transition).not.toBe('none')
+  })
+})

--- a/packages/vuetify/src/components/VMain/__tests__/VMain.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMain/__tests__/VMain.spec.browser.tsx
@@ -6,17 +6,17 @@ import { VLayout } from '@/components/VLayout'
 import { render, screen, wait } from '@test'
 
 describe('VMain', () => {
-  it('should suppress transition immediately after mount when transition is true (default)', () => {
+  it('should be true if transition if transition is set to true', () => {
     render(() => (
       <VLayout>
-        <VMain />
+        <VMain transition />
       </VLayout>
     ))
 
     expect(screen.getByCSS('.v-main').style.transition).toBe('none')
   })
 
-  it('should stop suppressing transition once booted', async () => {
+  it('should be true if transition is not set', async () => {
     render(() => (
       <VLayout>
         <VMain />
@@ -28,13 +28,13 @@ describe('VMain', () => {
     expect(screen.getByCSS('.v-main').style.transition).not.toBe('none')
   })
 
-  it('should never suppress transition when transition is explicitly false', async () => {
+  it('should be none if transition is set to false', async () => {
     render(() => (
       <VLayout>
         <VMain transition={ false } />
       </VLayout>
     ))
 
-    expect(screen.getByCSS('.v-main').style.transition).not.toBe('none')
+    expect(screen.getByCSS('.v-main').style.transition).toBe('none')
   })
 })


### PR DESCRIPTION
Hello, my first PR :)
## Description
Added a transition flag to vmain component, with default value of true to avoid breaking changes.

closes https://github.com/vuetifyjs/vuetify/issues/22948

```vue
<template>
  <v-app>
    <v-app-bar height="64" />
    <v-navigation-drawer v-model="drawer" width="240" />
    <v-main :transition="transition">
      <v-container>
        <v-switch v-model="transition" color="primary" label="transition prop" />
        <v-switch v-model="drawer" color="primary" label="toggle drawer" />
        <p>
          Toggle the drawer switch above. When <code>transition</code> is
          <strong>on</strong>, the content should slide/smoothly resize as
          the drawer opens and closes. When <code>transition</code> is
          <strong>off</strong>, it should snap instantly with no animation.
        </p>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const transition = ref(true)
  const drawer = ref(true)
</script>

```
