### PR TITLE
fix(VAutocomplete,VCombobox,VSelect): improvements for native form submissions

### DIFF
--- a/packages/api-generator/src/locale/en/Select.json
+++ b/packages/api-generator/src/locale/en/Select.json
@@ -3,6 +3,7 @@
     "closeText": "Text set to the inputs `aria-label` and `title` when input menu is closed.",
     "chips": "Changes display of selections to chips.",
     "closableChips": "Enables the [closable](/api/v-chip/#props-closable) prop on all [v-chip](/components/chips/) components.",
+    "form": "The id of the `<form>` element to associate the hidden input used for native form submission with.",
     "hideSelected": "Do not display in the select menu items that are already selected.",
     "itemColor": "Sets color of selected items.",
     "listProps": "Pass props through to the `v-list` component. Accepts an object with anything from [v-list](/api/v-list/#props) props, camelCase keys are recommended.",

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -16,6 +16,7 @@
       "autocomplete": "3.10.0",
       "autoSelectFirst": "3.3.0",
       "clearOnSelect": "3.5.0",
+      "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0"
     },
@@ -112,6 +113,7 @@
       "alwaysFilter": "3.10.4",
       "autocomplete": "3.10.0",
       "clearOnSelect": "3.5.0",
+      "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0"
     },
@@ -432,6 +434,7 @@
   "VSelect": {
     "props": {
       "autocomplete": "3.10.0",
+      "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0",
       "noAutoScroll": "3.9.0"

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -123,7 +123,7 @@ export const VAutocomplete = genericComponent<new <
     'update:menu': (value: boolean) => true,
   },
 
-  setup (props, { attrs, slots }) {
+  setup (props, { slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const isFocused = shallowRef(false)
@@ -501,7 +501,7 @@ export const VAutocomplete = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
-          name={ undefined }
+          form=""
           v-model={ search.value }
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
@@ -540,7 +540,7 @@ export const VAutocomplete = genericComponent<new <
                     type="hidden"
                     name={ props.name }
                     value={ value }
-                    form={ attrs.form as string }
+                    form={ props.form }
                   />
                 ))}
 

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -20,6 +20,7 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
+import { useAutocomplete } from '@/composables/autocomplete'
 import { useTextColor } from '@/composables/color'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -174,6 +175,8 @@ export const VAutocomplete = genericComponent<new <
         ? ''
         : String(model.value.at(-1)?.props.title ?? '')
     })
+
+    const autocomplete = useAutocomplete(props)
 
     const selectedValues = computed(() => model.value.map(selection => selection.props.value))
 
@@ -501,6 +504,7 @@ export const VAutocomplete = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
+          name={ undefined }
           v-model={ search.value }
           onUpdate:modelValue={ onUpdateModelValue }
           v-model:focused={ isFocused.value }
@@ -533,6 +537,20 @@ export const VAutocomplete = genericComponent<new <
             ...slots,
             default: ({ id }) => (
               <>
+                <select
+                  hidden
+                  multiple={ props.multiple }
+                  name={ autocomplete.fieldName.value }
+                >
+                  { items.value.map(item => (
+                    <option
+                      key={ item.value }
+                      value={ item.value }
+                      selected={ selectedValues.value.includes(item.value) }
+                    />
+                  ))}
+                </select>
+
                 <VMenu
                   id={ menuId.value }
                   ref={ vMenuRef }

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -169,6 +169,12 @@ export const VAutocomplete = genericComponent<new <
     const hasChips = computed(() => !!(props.chips || slots.chip))
     const hasSelectionSlot = computed(() => hasChips.value || !!slots.selection)
 
+    const selectedTitle = computed(() => {
+      return (props.multiple || hasSelectionSlot.value)
+        ? ''
+        : String(model.value.at(-1)?.props.title ?? '')
+    })
+
     const selectedValues = computed(() => model.value.map(selection => selection.props.value))
 
     const firstSelectableItem = computed(() => displayItems.value.find(x => x.type === 'item' && !x.props.disabled))
@@ -393,8 +399,6 @@ export const VAutocomplete = genericComponent<new <
       }
     }
 
-    const isSelecting = shallowRef(false)
-
     /** @param set - null means toggle */
     function select (item: ListItem | undefined, set: boolean | null = true) {
       if (!item || item.props.disabled) return
@@ -432,24 +436,26 @@ export const VAutocomplete = genericComponent<new <
       if (val === oldVal) return
 
       if (val) {
-        isSelecting.value = true
-        search.value = (props.multiple || hasSelectionSlot.value) ? '' : String(model.value.at(-1)?.props.title ?? '')
         isPristine.value = true
-
-        nextTick(() => isSelecting.value = false)
       } else {
         if (!props.multiple && search.value == null) model.value = []
         menu.value = false
         if (!isPristine.value && search.value) {
           _searchLock.value = search.value
         }
-        search.value = ''
+        search.value = selectedTitle.value
+        isPristine.value = true
         selectionIndex.value = -1
       }
     })
 
+    watch(selectedTitle, val => {
+      if (isFocused.value) return
+      search.value = val
+    }, { immediate: true })
+
     watch(search, val => {
-      if (!isFocused.value || isSelecting.value) return
+      if (!isFocused.value) return
 
       if (val) menu.value = true
 

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -124,7 +124,7 @@ export const VAutocomplete = genericComponent<new <
     'update:menu': (value: boolean) => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { attrs, slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const isFocused = shallowRef(false)
@@ -541,6 +541,7 @@ export const VAutocomplete = genericComponent<new <
                   hidden
                   multiple={ props.multiple }
                   name={ autocomplete.fieldName.value }
+                  form={ attrs.form as string }
                 >
                   { items.value.map(item => (
                     <option

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -20,7 +20,6 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
-import { useAutocomplete } from '@/composables/autocomplete'
 import { useTextColor } from '@/composables/color'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -175,8 +174,6 @@ export const VAutocomplete = genericComponent<new <
         ? ''
         : String(model.value.at(-1)?.props.title ?? '')
     })
-
-    const autocomplete = useAutocomplete(props)
 
     const selectedValues = computed(() => model.value.map(selection => selection.props.value))
 
@@ -537,20 +534,15 @@ export const VAutocomplete = genericComponent<new <
             ...slots,
             default: ({ id }) => (
               <>
-                <select
-                  hidden
-                  multiple={ props.multiple }
-                  name={ autocomplete.fieldName.value }
-                  form={ attrs.form as string }
-                >
-                  { items.value.map(item => (
-                    <option
-                      key={ item.value }
-                      value={ item.value }
-                      selected={ selectedValues.value.includes(item.value) }
-                    />
-                  ))}
-                </select>
+                { selectedValues.value.map((value, i) => (
+                  <input
+                    key={ i }
+                    type="hidden"
+                    name={ props.name }
+                    value={ value }
+                    form={ attrs.form as string }
+                  />
+                ))}
 
                 <VMenu
                   id={ menuId.value }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -154,7 +154,8 @@ describe('VAutocomplete', () => {
     await userEvent.tab()
     await waitAnimationFrame()
     await userEvent.type(input, 'Colo')
-    expect(await screen.findAllByRole('option')).toHaveLength(1)
+    const filtered = await screen.findAllByRole('option')
+    expect(filtered).toHaveLength(1)
 
     screen.getByTestId('before').focus()
     await waitAnimationFrame()
@@ -162,7 +163,8 @@ describe('VAutocomplete', () => {
 
     await userEvent.click(input)
     await waitIdle()
-    expect(await screen.findAllByRole('option')).toHaveLength(items.length)
+    const reopened = await screen.findAllByRole('option')
+    expect(reopened).toHaveLength(items.length)
   })
 
   it('should not return focus to the input on click-outside', async () => {
@@ -1047,6 +1049,55 @@ describe('VAutocomplete', () => {
       // Shift+Tab back to header
       await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
       expect(screen.getByTestId('header-btn')).toHaveFocus()
+    })
+  })
+
+  describe('native form submission', () => {
+    const objectItems = [
+      { title: 'Item 1', value: 1 },
+      { title: 'Item 2', value: 2 },
+      { title: 'Item 3', value: 3 },
+    ]
+
+    it('should include selected value in form data for single selection', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VAutocomplete name="field" items={ objectItems } modelValue={ objectItems[0] } />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(submittedData!.get('field')).toBe('1')
+    })
+
+    it('should include selected values in form data for multiple selection', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VAutocomplete multiple name="field" items={ objectItems } modelValue={[objectItems[0], objectItems[1]]} />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      const values = submittedData!.getAll('field')
+      expect(values).toEqual(['1', '2'])
     })
   })
 

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -1099,6 +1099,29 @@ describe('VAutocomplete', () => {
       const values = submittedData!.getAll('field')
       expect(values).toEqual(['1', '2'])
     })
+
+    it('should associate with a form outside its tree via the form attribute', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <>
+          <form
+            id="outer"
+            onSubmit={ e => {
+              e.preventDefault()
+              submittedData = new FormData(e.target as HTMLFormElement)
+            }}
+          >
+            <button type="submit">Submit</button>
+          </form>
+          <VAutocomplete form="outer" name="field" items={ objectItems } modelValue={ objectItems[0] } />
+        </>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(submittedData!.get('field')).toBe('1')
+    })
   })
 
   showcase({ stories })

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -95,6 +95,76 @@ describe('VAutocomplete', () => {
     expect(fieldARoot).not.toHaveClass('v-input--focused')
   })
 
+  it('should select input text on keyboard focus but not on click', async () => {
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VAutocomplete items={ items } modelValue="California" />
+      </>
+    ))
+
+    const input = screen.getByCSS('input') as HTMLInputElement
+
+    screen.getByTestId('before').focus()
+    await userEvent.tab()
+    await waitAnimationFrame()
+    expect([input.selectionStart, input.selectionEnd]).toEqual([0, 'California'.length])
+
+    await userEvent.tab({ shift: true })
+    await waitAnimationFrame()
+
+    await userEvent.click(input)
+    await waitAnimationFrame()
+    expect(input.selectionStart).toBe(input.selectionEnd)
+  })
+
+  it('should keep the selected title in the input when blurred', async () => {
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VAutocomplete items={ items } modelValue="California" />
+      </>
+    ))
+
+    const input = screen.getByCSS('input') as HTMLInputElement
+    expect(input.value).toBe('California')
+
+    await userEvent.click(input)
+    await waitIdle()
+    await userEvent.type(input, 'xyz')
+    expect(input.value).not.toBe('California')
+
+    screen.getByTestId('before').focus()
+    await waitAnimationFrame()
+    expect(input.value).toBe('California')
+  })
+
+  it('should show the full list when reopened after an abandoned search', async () => {
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VAutocomplete items={ items } modelValue="California" />
+      </>
+    ))
+
+    const input = screen.getByCSS('input') as HTMLInputElement
+
+    // keyboard focus selects the title, so typing replaces it without clearing the model
+    screen.getByTestId('before').focus()
+    await userEvent.tab()
+    await waitAnimationFrame()
+    await userEvent.type(input, 'Colo')
+    expect(await screen.findAllByRole('option')).toHaveLength(1)
+
+    screen.getByTestId('before').focus()
+    await waitAnimationFrame()
+    expect(input.value).toBe('California')
+
+    await userEvent.click(input)
+    await waitIdle()
+    expect(await screen.findAllByRole('option')).toHaveLength(items.length)
+  })
+
   it('should not return focus to the input on click-outside', async () => {
     const menu = ref(false)
     render(() => (

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -103,7 +103,7 @@ describe('VAutocomplete', () => {
       </>
     ))
 
-    const input = screen.getByCSS('input') as HTMLInputElement
+    const input = screen.getByCSS('input[type="text"]') as HTMLInputElement
 
     screen.getByTestId('before').focus()
     await userEvent.tab()
@@ -126,7 +126,7 @@ describe('VAutocomplete', () => {
       </>
     ))
 
-    const input = screen.getByCSS('input') as HTMLInputElement
+    const input = screen.getByCSS('input[type="text"]') as HTMLInputElement
     expect(input.value).toBe('California')
 
     await userEvent.click(input)
@@ -147,7 +147,7 @@ describe('VAutocomplete', () => {
       </>
     ))
 
-    const input = screen.getByCSS('input') as HTMLInputElement
+    const input = screen.getByCSS('input[type="text"]') as HTMLInputElement
 
     // keyboard focus selects the title, so typing replaces it without clearing the model
     screen.getByTestId('before').focus()
@@ -259,7 +259,7 @@ describe('VAutocomplete', () => {
       </VAutocomplete>
     ))
 
-    const input = screen.getByCSS('input')
+    const input = screen.getByCSS('input[type="text"]')
     await userEvent.click(input)
     await waitIdle()
     expect(menu.value).toBe(true)
@@ -281,7 +281,7 @@ describe('VAutocomplete', () => {
       />
     ))
 
-    const input = screen.getByCSS('input')
+    const input = screen.getByCSS('input[type="text"]')
     await userEvent.click(input)
     await waitIdle()
     expect(menu.value).toBe(true)
@@ -310,7 +310,7 @@ describe('VAutocomplete', () => {
       <VAutocomplete v-model:menu={ menu.value } items={ items.value } />
     ))
 
-    const input = screen.getByCSS('input')
+    const input = screen.getByCSS('input[type="text"]')
     await userEvent.click(input)
     await waitIdle()
     expect(menu.value).toBe(true)
@@ -531,9 +531,9 @@ describe('VAutocomplete', () => {
     const activeItems = await findAllByRole(menu, 'option', { selected: true })
     expect(activeItems).toHaveLength(2)
 
-    expect(document.activeElement).toBe(within(container).getByCSS('input'))
+    expect(document.activeElement).toBe(within(container).getByCSS('input[type="text"]'))
 
-    const input = within(container).getByCSS('input')
+    const input = within(container).getByCSS('input[type="text"]')
     expect(input).toHaveValue('')
   })
 
@@ -555,7 +555,7 @@ describe('VAutocomplete', () => {
     expect(screen.queryAllByRole('listbox')).toHaveLength(0)
     expect(element).not.toHaveClass('v-select--active-menu')
 
-    screen.getByCSS('input').focus()
+    screen.getByCSS('input[type="text"]').focus()
     await userEvent.keyboard('{ArrowDown}')
 
     expect(screen.queryAllByRole('listbox')).toHaveLength(0)
@@ -583,7 +583,7 @@ describe('VAutocomplete', () => {
     expect(screen.queryAllByRole('listbox')).toHaveLength(0)
     expect(element).not.toHaveClass('v-select--active-menu')
 
-    screen.getByCSS('input').focus()
+    screen.getByCSS('input[type="text"]').focus()
     await userEvent.keyboard('{ArrowDown}')
 
     expect(screen.queryAllByRole('listbox')).toHaveLength(0)
@@ -743,7 +743,7 @@ describe('VAutocomplete', () => {
       props: { placeholder: 'Placeholder' },
     })
 
-    const input = getByCSS('input')
+    const input = getByCSS('input[type="text"]')
     expect(input).toHaveAttribute('placeholder', 'Placeholder')
 
     await rerender({ label: 'Label' })
@@ -781,7 +781,7 @@ describe('VAutocomplete', () => {
 
     await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}c')
 
-    expect(document.activeElement).toBe(within(element).getByCSS('input'))
+    expect(document.activeElement).toBe(within(element).getByCSS('input[type="text"]'))
   })
 
   it('should not open menu when closing a chip', async () => {
@@ -959,7 +959,7 @@ describe('VAutocomplete', () => {
     ))
 
     await userEvent.click(element)
-    const input = getByCSS('input')
+    const input = getByCSS('input[type="text"]')
     expect(input).toHaveValue('')
 
     // Blur input with a custom search input value
@@ -1098,6 +1098,26 @@ describe('VAutocomplete', () => {
 
       const values = submittedData!.getAll('field')
       expect(values).toEqual(['1', '2'])
+    })
+
+    it('should not submit any value when nothing is selected', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VAutocomplete name="field" items={ objectItems } />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(submittedData!.has('field')).toBe(false)
     })
 
     it('should associate with a form outside its tree via the form attribute', async () => {

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -128,7 +128,7 @@ export const VCombobox = genericComponent<new <
     'update:menu': (value: boolean) => true,
   },
 
-  setup (props, { attrs, emit, slots }) {
+  setup (props, { emit, slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const isFocused = shallowRef(false)
@@ -558,7 +558,7 @@ export const VCombobox = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
-          name={ undefined }
+          form=""
           v-model={ search.value }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
@@ -596,7 +596,7 @@ export const VCombobox = genericComponent<new <
                     type="hidden"
                     name={ props.name }
                     value={ value }
-                    form={ attrs.form as string }
+                    form={ props.form }
                   />
                 ))}
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -21,6 +21,7 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
+import { useAutocomplete } from '@/composables/autocomplete'
 import { useTextColor } from '@/composables/color'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -240,7 +241,15 @@ export const VCombobox = genericComponent<new <
       }
     })
 
+    const autocomplete = useAutocomplete(props)
+
     const selectedValues = computed(() => model.value.map(selection => selection.value))
+
+    // freeform entries aren't in `items`, so add them as options or the form drops them
+    const formItems = computed(() => {
+      const extra = selectedValues.value.filter(v => !items.value.some(item => item.value === v))
+      return [...items.value.map(item => item.value), ...extra]
+    })
 
     const firstSelectableItem = computed(() => displayItems.value.find(x => x.type === 'item' && !x.props.disabled))
 
@@ -558,6 +567,7 @@ export const VCombobox = genericComponent<new <
         <VTextField
           ref={ vTextFieldRef }
           { ...textFieldProps }
+          name={ undefined }
           v-model={ search.value }
           v-model:focused={ isFocused.value }
           validationValue={ model.externalValue }
@@ -589,6 +599,20 @@ export const VCombobox = genericComponent<new <
             ...slots,
             default: ({ id }) => (
               <>
+                <select
+                  hidden
+                  multiple={ props.multiple }
+                  name={ autocomplete.fieldName.value }
+                >
+                  { formItems.value.map(value => (
+                    <option
+                      key={ value }
+                      value={ value }
+                      selected={ selectedValues.value.includes(value) }
+                    />
+                  ))}
+                </select>
+
                 <VMenu
                   id={ menuId.value }
                   ref={ vMenuRef }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -21,7 +21,6 @@ import { VHighlight } from '@/labs/VHighlight'
 // Composables
 import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
-import { useAutocomplete } from '@/composables/autocomplete'
 import { useTextColor } from '@/composables/color'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
@@ -241,15 +240,7 @@ export const VCombobox = genericComponent<new <
       }
     })
 
-    const autocomplete = useAutocomplete(props)
-
     const selectedValues = computed(() => model.value.map(selection => selection.value))
-
-    // freeform entries aren't in `items`, so add them as options or the form drops them
-    const formItems = computed(() => {
-      const extra = selectedValues.value.filter(v => !items.value.some(item => item.value === v))
-      return [...items.value.map(item => item.value), ...extra]
-    })
 
     const firstSelectableItem = computed(() => displayItems.value.find(x => x.type === 'item' && !x.props.disabled))
 
@@ -599,20 +590,15 @@ export const VCombobox = genericComponent<new <
             ...slots,
             default: ({ id }) => (
               <>
-                <select
-                  hidden
-                  multiple={ props.multiple }
-                  name={ autocomplete.fieldName.value }
-                  form={ attrs.form as string }
-                >
-                  { formItems.value.map(value => (
-                    <option
-                      key={ value }
-                      value={ value }
-                      selected={ selectedValues.value.includes(value) }
-                    />
-                  ))}
-                </select>
+                { selectedValues.value.map((value, i) => (
+                  <input
+                    key={ i }
+                    type="hidden"
+                    name={ props.name }
+                    value={ value }
+                    form={ attrs.form as string }
+                  />
+                ))}
 
                 <VMenu
                   id={ menuId.value }

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -129,7 +129,7 @@ export const VCombobox = genericComponent<new <
     'update:menu': (value: boolean) => true,
   },
 
-  setup (props, { emit, slots }) {
+  setup (props, { attrs, emit, slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const isFocused = shallowRef(false)
@@ -603,6 +603,7 @@ export const VCombobox = genericComponent<new <
                   hidden
                   multiple={ props.multiple }
                   name={ autocomplete.fieldName.value }
+                  form={ attrs.form as string }
                 >
                   { formItems.value.map(value => (
                     <option

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -97,7 +97,7 @@ describe('VCombobox', () => {
       await userEvent.click((await screen.findAllByRole('option'))[0])
       expect(model.value).toStrictEqual(items[0])
       await expect.poll(() => search.value).toBe(items[0].title)
-      expect(screen.getByCSS('input')).toHaveValue(items[0].title)
+      expect(screen.getByCSS('input[type="text"]')).toHaveValue(items[0].title)
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent(items[0].title)
 
       await userEvent.click(element)
@@ -105,7 +105,7 @@ describe('VCombobox', () => {
       await userEvent.keyboard('Item 2')
       expect(model.value).toBe('Item 2')
       expect(search.value).toBe('Item 2')
-      expect(screen.getByCSS('input')).toHaveValue('Item 2')
+      expect(screen.getByCSS('input[type="text"]')).toHaveValue('Item 2')
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent('Item 2')
 
       await userEvent.click(element)
@@ -113,7 +113,7 @@ describe('VCombobox', () => {
       await userEvent.keyboard('item3')
       expect(model.value).toBe('item3')
       expect(search.value).toBe('item3')
-      expect(screen.getByCSS('input')).toHaveValue('item3')
+      expect(screen.getByCSS('input[type="text"]')).toHaveValue('item3')
       expect(screen.getByCSS('.v-combobox__selection')).toHaveTextContent('item3')
     })
 
@@ -140,7 +140,7 @@ describe('VCombobox', () => {
         />
       ))
 
-      const input = screen.getByCSS('input')
+      const input = screen.getByCSS('input[type="text"]')
 
       await userEvent.click(element)
       await commands.waitStable('.v-list')
@@ -259,7 +259,7 @@ describe('VCombobox', () => {
         />
       ))
 
-      const input = screen.getByCSS('input')
+      const input = screen.getByCSS('input[type="text"]')
 
       await userEvent.click(element)
 
@@ -312,7 +312,7 @@ describe('VCombobox', () => {
         />
       ))
 
-      const input = screen.getByCSS('input')
+      const input = screen.getByCSS('input[type="text"]')
 
       await userEvent.click(element)
 
@@ -481,7 +481,7 @@ describe('VCombobox', () => {
 
     await userEvent.click(screen.getAllByRole('option')[0])
 
-    await expect.poll(() => screen.getByCSS('input')).toHaveValue('0')
+    await expect.poll(() => screen.getByCSS('input[type="text"]')).toHaveValue('0')
   })
 
   it('should conditionally show placeholder', async () => {
@@ -489,7 +489,7 @@ describe('VCombobox', () => {
       props: { placeholder: 'Placeholder' },
     })
 
-    const input = screen.getByCSS('input')
+    const input = screen.getByCSS('input[type="text"]')
     await expect.element(input).toHaveAttribute('placeholder', 'Placeholder')
 
     await rerender({ label: 'Label' })
@@ -708,7 +708,7 @@ describe('VCombobox', () => {
     ))
 
     await userEvent.click(element)
-    const input = getByCSS('input')
+    const input = getByCSS('input[type="text"]')
     expect(input).toHaveValue('')
 
     // Blur input with a custom search input value
@@ -905,7 +905,7 @@ describe('VCombobox', () => {
       />
     ))
 
-    const input = screen.getByCSS('input')
+    const input = screen.getByCSS('input[type="text"]')
     await userEvent.click(input)
     await waitIdle()
     expect(menu.value).toBe(true)

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -926,5 +926,74 @@ describe('VCombobox', () => {
     expect(screen.getByRole('listbox').contains(document.activeElement)).toBe(true)
   })
 
+  describe('native form submission', () => {
+    const objectItems = [
+      { title: 'Item 1', value: 1 },
+      { title: 'Item 2', value: 2 },
+      { title: 'Item 3', value: 3 },
+    ]
+
+    it('should include selected value in form data for single selection', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VCombobox name="field" items={ objectItems } modelValue={ objectItems[0] } />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(submittedData!.get('field')).toBe('1')
+    })
+
+    it('should include selected values in form data for multiple selection', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VCombobox multiple name="field" items={ objectItems } modelValue={[objectItems[0], objectItems[1]]} />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      const values = submittedData!.getAll('field')
+      expect(values).toEqual(['1', '2'])
+    })
+
+    it('should include freeform values not present in items', async () => {
+      let submittedData: FormData | null = null
+
+      render(() => (
+        <form
+          onSubmit={ e => {
+            e.preventDefault()
+            submittedData = new FormData(e.target as HTMLFormElement)
+          }}
+        >
+          <VCombobox name="field" items={ items } modelValue="Narnia" />
+          <button type="submit">Submit</button>
+        </form>
+      ))
+
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(submittedData!.get('field')).toBe('Narnia')
+    })
+  })
+
   showcase({ stories })
 })

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -21,7 +21,6 @@ import { VHighlight } from '@/labs/VHighlight'
 import { useFocusRepair } from './useFocusRepair'
 import { useScrolling } from './useScrolling'
 import { useFocusGroups } from '../../composables/focusGroups'
-import { useAutocomplete } from '@/composables/autocomplete'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
@@ -178,7 +177,6 @@ export const VSelect = genericComponent<new <
         : model.value.length
     })
     const form = useForm(props)
-    const autocomplete = useAutocomplete(props)
     const selectedValues = computed(() => model.value.map(selection => selection.value))
     const isFocused = shallowRef(false)
     const closableChips = toRef(() => props.closableChips && !form.isReadonly.value && !form.isDisabled.value)
@@ -506,20 +504,15 @@ export const VSelect = genericComponent<new <
             ...slots,
             default: ({ id }) => (
               <>
-                <select
-                  hidden
-                  multiple={ props.multiple }
-                  name={ autocomplete.fieldName.value }
-                  form={ attrs.form as string }
-                >
-                  { items.value.map(item => (
-                    <option
-                      key={ item.value }
-                      value={ item.value }
-                      selected={ selectedValues.value.includes(item.value) }
-                    />
-                  ))}
-                </select>
+                { selectedValues.value.map((value, i) => (
+                  <input
+                    key={ i }
+                    type="hidden"
+                    name={ props.name }
+                    value={ value }
+                    form={ attrs.form as string }
+                  />
+                ))}
 
                 <VMenu
                   id={ menuId.value }

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -69,6 +69,7 @@ export const makeSelectProps = propsFactory({
   chips: Boolean,
   closableChips: Boolean,
   eager: Boolean,
+  form: String,
   hideNoData: Boolean,
   hideSelected: Boolean,
   listProps: {
@@ -151,7 +152,7 @@ export const VSelect = genericComponent<new <
     'update:search': (value: string) => true,
   },
 
-  setup (props, { attrs, slots }) {
+  setup (props, { slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const vMenuRef = ref<VMenu>()
@@ -510,7 +511,7 @@ export const VSelect = genericComponent<new <
                     type="hidden"
                     name={ props.name }
                     value={ value }
-                    form={ attrs.form as string }
+                    form={ props.form }
                   />
                 ))}
 

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -152,7 +152,7 @@ export const VSelect = genericComponent<new <
     'update:search': (value: string) => true,
   },
 
-  setup (props, { slots }) {
+  setup (props, { attrs, slots }) {
     const { t } = useLocale()
     const vTextFieldRef = ref<VTextField>()
     const vMenuRef = ref<VMenu>()
@@ -510,6 +510,7 @@ export const VSelect = genericComponent<new <
                   hidden
                   multiple={ props.multiple }
                   name={ autocomplete.fieldName.value }
+                  form={ attrs.form as string }
                 >
                   { items.value.map(item => (
                     <option

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -384,7 +384,7 @@ describe('VSelect', () => {
       props: { placeholder: 'Placeholder' },
     })
 
-    const input = screen.getByCSS('input')
+    const input = screen.getByCSS('input[type="text"]')
     await expect.element(input).toHaveAttribute('placeholder', 'Placeholder')
 
     await rerender({ label: 'Label' })


### PR DESCRIPTION
- VAutocomplete: do not clear `search` on blur - for "auto-select on focus" consistency
- VAutocomplete, VCombobox: hidden input for native form submissions
- VSelect: use hidden inputs instead of `<select>`  (aligns with v0, better for SSR, same behavior)
- VSelect, VAutocomplete, VCombobox: the `form` attribute should land on `<input hidden>`s
- adds explicit `form` prop to make it possible to send `form=""` and detach the text input field with mangled name for autocomplete suppression

fixes #21938
fixes #22270

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="900">
      <h2 class="text-h5 mb-4">Auto-select text on focus</h2>
      <v-alert class="mb-6" variant="outlined">
        <pre>
- [TAB] focus: selecting text always
- direct click / programatic focus / label click:
  - selecting text relies on browser heuristics
  - hold [TAB] for 3s to cycle through all fields, then click to try
- direct double click: selecting (native behavior)</pre>
      </v-alert>
      <v-row class="justify-center">
        <v-col cols="12" md="6">
          <label for="field1">VAutocomplete</label>
          <v-autocomplete id="field1" v-model="autocompleteValue" :items="simpleItems" />

          <label for="field2">VCombobox</label>
          <v-combobox id="field2" v-model="comboboxValue" :items="simpleItems" />

          <label for="field3">VTextField</label>
          <v-text-field id="field3" v-model="textFieldValue" />

          <label for="field4">Native text input</label>
          <input id="field4" v-model="nativeTextValue" type="text">

          <label for="field5">Native date input</label>
          <input id="field5" v-model="dateValue" type="date">

          <label for="field6">VDateInput</label>
          <v-date-input id="field6" v-model="dateInputValue" />

          <label for="field7">VMaskInput</label>
          <v-mask-input id="field7" v-model="maskValue" mask="(###) ###-####" />

          <label for="field8">VColorInput</label>
          <v-color-input id="field8" v-model="colorValue" />
        </v-col>
      </v-row>

      <v-divider class="my-8" />

      <v-btn color="primary" text="Focus next" @click="cycle()" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const simpleItems = [
    'California',
    'Colorado',
    'Florida',
    'Georgia',
    'Texas',
    'Wyoming',
  ]

  const autocompleteValue = ref('California')
  const comboboxValue = ref('Colorado')
  const textFieldValue = ref('Florida')
  const nativeTextValue = ref('Georgia')
  const dateValue = ref('2026-07-21')
  const dateInputValue = ref(new Date('2026-07-21'))
  const maskValue = ref('5551234567')
  const colorValue = ref('#1976D2')

  let index = 0
  const ids = ['field1', 'field2', 'field3', 'field4', 'field5', 'field6', 'field7', 'field8']
  function cycle () {
    document.getElementById(ids[index++ % ids.length])?.focus()
  }
</script>

<style scoped>
  label {
    display: block;
    margin-block: 16px 4px;
    font-size: 0.8rem;
    font-weight: 600;
  }

  input[type="text"],
  input[type="date"] {
    display: block;
    width: 100%;
    padding: 8px 12px;
    border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
    border-radius: 4px;
  }
</style>
```
