### PR TITLE
feat(VAutocomplete,VCombobox): add `close-on-input-click` prop

### DIFF
--- a/packages/api-generator/src/locale/en/VAutocomplete.json
+++ b/packages/api-generator/src/locale/en/VAutocomplete.json
@@ -3,6 +3,7 @@
   "props": {
     "autoSelectFirst": "When searching, will always highlight the first option and select it on blur. `exact` will only highlight and select exact matches.",
     "clearOnSelect": "Reset the search text when a selection is made while using the **multiple** prop.",
+    "closeOnInputClick": "Clicking the field while the menu is open closes it.",
     "itemChildren": "This property currently has **no effect**.",
     "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props.",
     "noFilter": "Do not apply filtering when searching. Useful when data is being filtered server side."

--- a/packages/api-generator/src/locale/en/VCombobox.json
+++ b/packages/api-generator/src/locale/en/VCombobox.json
@@ -4,6 +4,7 @@
     "alwaysFilter": "When enabled, dropdown list will always show items matching non-empty value within the field. Recommended when the list is meant to show suggestions rather than options to choose from. For optimal UX, should be combined with `:menu-icon=\"false\"` and `hide-selected`.",
     "autoSelectFirst": "When searching, will always highlight the first option and select it on blur. `exact` will only highlight and select exact matches.",
     "clearOnSelect": "Reset the search text when a selection is made while using the **multiple** prop.",
+    "closeOnInputClick": "Clicking the field while the menu is open closes it.",
     "itemChildren": "This property currently has **no effect**.",
     "delimiters": "Accepts an array of strings that will trigger a new tag when typing. Does not replace the normal Tab and Enter keys.",
     "items": "Can be an array of objects or strings. By default objects should have **title** and **value** properties, and can optionally have a **props** property containing any [VListItem props](/api/v-list-item/#props). Keys to use for these can be changed with the **item-title**, **item-value**, and **item-props** props."

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -16,6 +16,7 @@
       "autocomplete": "3.10.0",
       "autoSelectFirst": "3.3.0",
       "clearOnSelect": "3.5.0",
+      "closeOnInputClick": "4.2.0",
       "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0"
@@ -122,6 +123,7 @@
       "alwaysFilter": "3.10.4",
       "autocomplete": "3.10.0",
       "clearOnSelect": "3.5.0",
+      "closeOnInputClick": "4.2.0",
       "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0"

--- a/packages/docs/src/pages/en/blog/july-2026-update.md
+++ b/packages/docs/src/pages/en/blog/july-2026-update.md
@@ -265,7 +265,7 @@ The [v4.2.0 milestone](https://github.com/vuetifyjs/vuetify/milestone/90) is tar
 * **[VDatePicker](/components/date-pickers/)** — week selection ([#20867](https://github.com/vuetifyjs/vuetify/pull/20867))
 * **[VField](/components/text-fields/)** — a `border` prop ([#19819](https://github.com/vuetifyjs/vuetify/pull/19819))
 
-Opened in July and still open at the end of it: persistent menus for the select family ([#23008](https://github.com/vuetifyjs/vuetify/pull/23008)) and a `toggle-on-click` prop for VAutocomplete and VCombobox ([#23023](https://github.com/vuetifyjs/vuetify/pull/23023)).
+Opened in July and still open at the end of it: persistent menus for the select family ([#23008](https://github.com/vuetifyjs/vuetify/pull/23008)) and a `close-on-input-click` prop for VAutocomplete and VCombobox ([#23023](https://github.com/vuetifyjs/vuetify/pull/23023)).
 
 ---
 

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -74,6 +74,7 @@ export const makeVAutocompleteProps = propsFactory({
   },
   clearOnSelect: Boolean,
   search: String,
+  closeOnInputClick: Boolean,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps(),
@@ -239,7 +240,7 @@ export const VAutocomplete = genericComponent<new <
     function onMousedownControl () {
       if (menuDisabled.value) return
 
-      menu.value = true
+      menu.value = props.closeOnInputClick ? !menu.value : true
     }
     function onMousedownMenuIcon (e: MouseEvent) {
       if (menuDisabled.value) return

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -813,6 +813,18 @@ describe('VAutocomplete', () => {
     await expect.poll(() => screen.queryByRole('listbox')).toBeNull()
   })
 
+  it('should close menu on control click with close-on-input-click', async () => {
+    const { element } = render(() => (
+      <VAutocomplete items={['foo', 'bar']} closeOnInputClick />
+    ))
+
+    await userEvent.click(element)
+    await screen.findByRole('listbox')
+
+    await userEvent.click(element)
+    await expect.poll(() => screen.queryByRole('listbox')).toBeNull()
+  })
+
   describe('auto-select-first', () => {
     async function setup () {
       const selectedItems = ref()

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -79,6 +79,7 @@ export const makeVComboboxProps = propsFactory({
     default: true,
   },
   delimiters: Array as PropType<readonly string[]>,
+  closeOnInputClick: Boolean,
 
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps({ hideNoData: true, returnObject: true }),
@@ -293,7 +294,7 @@ export const VCombobox = genericComponent<new <
     function onMousedownControl () {
       if (menuDisabled.value) return
 
-      menu.value = true
+      menu.value = props.closeOnInputClick ? !menu.value : true
     }
     function onMousedownMenuIcon (e: MouseEvent) {
       if (menuDisabled.value) return


### PR DESCRIPTION
resolves #23021

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <v-autocomplete
        v-model="msg"
        :items="[1, 2, 3, 4, 6]"
        label="autocomplete"
        close-on-input-click
      />
      <v-combobox
        v-model="msg"
        :items="[1, 2, 3, 4, 6]"
        label="combobox"
        close-on-input-click
      />
      <v-select
        v-model="msg"
        :items="[1, 2, 3, 4, 6]"
        label="select"
        close-on-input-click
      />
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { ref } from 'vue'

  const msg = ref(1)
</script>
```
