### PR TITLE
fix(VList): resolve keyboard navigation inside an open Shadow DOM

### DIFF
--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -39,6 +39,7 @@ import {
   convertToUnit,
   focusableChildren,
   genericComponent,
+  getActiveElement,
   getCurrentInstance,
   getScrollParent,
   IN_BROWSER,
@@ -238,7 +239,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
       if (contentEl.value?._clickOutside?.lastMousedownWasOutside) return
 
-      const activeEl = document.activeElement
+      const activeEl = getActiveElement()
       const focusWasInOverlay =
         ((!activeEl || activeEl === document.body) && openedWithActivatorFocus) ||
         activeEl === el ||
@@ -260,7 +261,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
     watch(isActive, val => {
       if (val) {
-        const activeEl = document.activeElement
+        const activeEl = getActiveElement()
         const el = activatorEl.value
         openedWithActivatorFocus = !!el && (activeEl === el || el.contains(activeEl))
       } else {
@@ -284,12 +285,12 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
     function onKeydown (e: KeyboardEvent) {
       if (e.key === 'Escape' && globalTop.value) {
-        if (!contentEl.value?.contains(document.activeElement)) {
+        if (!contentEl.value?.contains(getActiveElement())) {
           emit('keydown', e)
         }
         if (!props.persistent) {
           isActive.value = false
-          if (contentEl.value?.contains(document.activeElement)) {
+          if (contentEl.value?.contains(getActiveElement())) {
             activatorEl.value?.focus()
           }
         } else animateClick()

--- a/packages/vuetify/src/composables/focusTrap.ts
+++ b/packages/vuetify/src/composables/focusTrap.ts
@@ -1,6 +1,6 @@
 // Utilities
 import { onScopeDispose, toRef, toValue, watch } from 'vue'
-import { focusableChildren, IN_BROWSER, propsFactory } from '@/util'
+import { focusableChildren, getActiveElement, IN_BROWSER, propsFactory } from '@/util'
 
 // Types
 import type { Ref } from 'vue'
@@ -35,7 +35,7 @@ function lastActiveTrap (): HTMLElement | undefined {
 }
 
 function onKeydown (e: KeyboardEvent) {
-  const activeElement = document.activeElement as HTMLElement | null
+  const activeElement = getActiveElement() as HTMLElement | null
   if (e.key !== 'Tab' || !activeElement) return
 
   const parentTraps = Array.from(registry.values())

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -656,10 +656,6 @@ export function focusableChildren (el: Element, filterByTabIndex = true) {
     )
 }
 
-// `document.activeElement` returns the shadow *host*, not the focused element
-// inside an open shadow root. Walk down through open shadow roots so focus and
-// keyboard navigation resolve the real focused element — fixes VMenu / VList /
-// VSelect keyboard nav when rendered inside a custom element / shadow DOM.
 export function getActiveElement (): Element | null {
   let active = document.activeElement
   while (active?.shadowRoot?.activeElement) {

--- a/packages/vuetify/src/util/helpers.ts
+++ b/packages/vuetify/src/util/helpers.ts
@@ -656,9 +656,21 @@ export function focusableChildren (el: Element, filterByTabIndex = true) {
     )
 }
 
+// `document.activeElement` returns the shadow *host*, not the focused element
+// inside an open shadow root. Walk down through open shadow roots so focus and
+// keyboard navigation resolve the real focused element — fixes VMenu / VList /
+// VSelect keyboard nav when rendered inside a custom element / shadow DOM.
+export function getActiveElement (): Element | null {
+  let active = document.activeElement
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement
+  }
+  return active
+}
+
 export function getNextElement (elements: HTMLElement[], location?: 'next' | 'prev', condition?: (el: HTMLElement) => boolean) {
   let _el
-  let idx = elements.indexOf(document.activeElement as HTMLElement)
+  let idx = elements.indexOf(getActiveElement() as HTMLElement)
   const inc = location === 'next' ? 1 : -1
   do {
     idx += inc
@@ -675,7 +687,8 @@ export function focusChild (
   const focusable = focusableChildren(el)
 
   if (location == null) {
-    if (el === document.activeElement || !el.contains(document.activeElement)) {
+    const active = getActiveElement()
+    if (el === active || !el.contains(active)) {
       focusable[0]?.focus(options)
     }
   } else if (location === 'first') {


### PR DESCRIPTION
## Problem
VMenu / VList / VSelect keyboard navigation (ArrowUp/Down) breaks when the component renders inside a custom element with an **open Shadow DOM** (`defineCustomElement`). `document.activeElement` returns the shadow **host**, not the focused descendant — so `getNextElement`'s `elements.indexOf(document.activeElement)` returns `-1` and navigation can't advance. Tab behavior is inconsistent for the same reason.

Reported with a repro by @jdalk; root cause confirmed against a live repro (`document.activeElement` === the host, the focused button lives at `host.shadowRoot.activeElement`).

## Fix
Add a shadow-piercing `getActiveElement()` to `util/helpers.ts` that walks `document.activeElement` down through open shadow roots, and use it in `getNextElement` + `focusChild`. Light-DOM behavior is unchanged (nothing to walk). **Open** shadow roots only — closed roots can't be traversed (platform limit).

## v3 patch
The identical bug exists in v3 (`util/helpers.ts` is the same). A ready-to-apply v3 patch + `patch-package` instructions: **https://bin.vuetifyjs.com/bins/Ya05xQ**

## Scope / follow-ups
- Fixes the reported arrow-nav (`getNextElement`) + the `focusChild` containment check.
- For *complete* shadow-DOM focus coverage, the same `getActiveElement()` should also replace raw `document.activeElement` reads in `focusTrap.ts`, `VOverlay` (`ownsFocus`), `useActivator`, `VSelect/useFocusRepair`, and `hotkey` — follow-up.
- **Test:** the jsdom unit env doesn't reliably reproduce shadow-DOM focus retargeting, so a browser-based shadow-DOM nav spec (mirroring `click-outside-shadow-dom.spec.ts`) is the right home for a regression test — recommended follow-up.