### PR TITLE
chore: remove KaelWD and MajesticPotatoe from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [johnleider, KaelWD, MajesticPotatoe]
+github: [johnleider]
 open_collective: vuetify
 ko_fi: # Replace with a single Ko-fi username
 tidelift: npm/vuetify


### PR DESCRIPTION
Removes `KaelWD` and `MajesticPotatoe` from the `github:` sponsors list in `.github/FUNDING.yml`, leaving `johnleider`.