### PR TITLE
fix(VDialog/VField/etc.): correct focus resolution in Shadow DOM

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -14,7 +14,7 @@ import { useScopeId } from '@/composables/scopeId'
 
 // Utilities
 import { mergeProps, nextTick, ref, watch } from 'vue'
-import { genericComponent, noop, omit, propsFactory, useRender } from '@/util'
+import { genericComponent, getActiveElement, noop, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { OverlaySlots } from '@/components/VOverlay/VOverlay'
@@ -57,7 +57,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
       if (
         (props.scrim || props.retainFocus) &&
         overlay.value?.contentEl &&
-        !overlay.value.contentEl.contains(document.activeElement)
+        !overlay.value.contentEl.contains(getActiveElement())
       ) {
         overlay.value.contentEl.focus({ preventScroll: true })
       }

--- a/packages/vuetify/src/components/VField/VField.tsx
+++ b/packages/vuetify/src/components/VField/VField.tsx
@@ -24,6 +24,7 @@ import {
   convertToUnit,
   EventProp,
   genericComponent,
+  getActiveElement,
   nullifyTransforms,
   PREFERS_REDUCED_MOTION,
   propsFactory,
@@ -238,7 +239,7 @@ export const VField = genericComponent<new <T>(
     })
 
     function onClick (e: MouseEvent) {
-      if (e.target !== document.activeElement) {
+      if (e.target !== getActiveElement()) {
         e.preventDefault()
       }
     }

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -22,6 +22,7 @@ import {
   callEvent,
   filterInputAttrs,
   genericComponent,
+  getActiveElement,
   humanReadableFileSize,
   omit,
   propsFactory,
@@ -137,7 +138,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
     const { handleDrop, hasFilesOrFolders } = useFileDrop()
 
     function onFocus () {
-      if (inputRef.value !== document.activeElement) {
+      if (inputRef.value !== getActiveElement()) {
         inputRef.value?.focus()
       }
 

--- a/packages/vuetify/src/components/VOverlay/useActivator.tsx
+++ b/packages/vuetify/src/components/VOverlay/useActivator.tsx
@@ -18,6 +18,7 @@ import {
 } from 'vue'
 import {
   bindProps,
+  getActiveElement,
   getCurrentInstance,
   IN_BROWSER,
   matchesSelector,
@@ -244,7 +245,7 @@ export function useActivator (
     if (val && (
       (props.openOnHover && !isHovered && (!openOnFocus.value || !isFocused)) ||
       (openOnFocus.value && !isFocused && (!props.openOnHover || !isHovered))
-    ) && !contentEl.value?.contains(document.activeElement)) {
+    ) && !contentEl.value?.contains(getActiveElement())) {
       runCloseDelay()
     }
   })

--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -18,7 +18,7 @@ import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { cloneVNode, computed, nextTick, ref, withDirectives } from 'vue'
-import { callEvent, filterInputAttrs, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { callEvent, filterInputAttrs, genericComponent, getActiveElement, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType, Ref } from 'vue'
@@ -114,7 +114,7 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
       if (!isFocused.value) focus()
 
       nextTick(() => {
-        if (inputRef.value !== document.activeElement) {
+        if (inputRef.value !== getActiveElement()) {
           inputRef.value?.focus()
         }
       })

--- a/packages/vuetify/src/components/VTextarea/VTextarea.tsx
+++ b/packages/vuetify/src/components/VTextarea/VTextarea.tsx
@@ -21,7 +21,17 @@ import vIntersect from '@/directives/intersect'
 
 // Utilities
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch, watchEffect } from 'vue'
-import { callEvent, clamp, convertToUnit, filterInputAttrs, genericComponent, omit, propsFactory, useRender } from '@/util'
+import {
+  callEvent,
+  clamp,
+  convertToUnit,
+  filterInputAttrs,
+  genericComponent,
+  getActiveElement,
+  omit,
+  propsFactory,
+  useRender,
+} from '@/util'
 
 // Types
 import type { PropType } from 'vue'
@@ -120,7 +130,7 @@ export const VTextarea = genericComponent<VTextareaSlots>()({
         autocomplete.update()
       }
 
-      if (textareaRef.value !== document.activeElement) {
+      if (textareaRef.value !== getActiveElement()) {
         textareaRef.value?.focus()
       }
 

--- a/packages/vuetify/src/composables/hotkey/hotkey.ts
+++ b/packages/vuetify/src/composables/hotkey/hotkey.ts
@@ -3,7 +3,7 @@ import { parseKeyCombination } from '@/composables/hotkey/hotkey-parsing'
 
 // Utilities
 import { onScopeDispose, toValue, watch } from 'vue'
-import { IN_BROWSER } from '@/util'
+import { getActiveElement, IN_BROWSER } from '@/util'
 
 // Types
 import type { Combo, Key, KeyCombination, Sequence } from '@/composables/hotkey/hotkey-parsing'
@@ -47,7 +47,7 @@ export function useHotkey (
   function isInputFocused () {
     if (toValue(inputs)) return false
 
-    const activeElement = document.activeElement as HTMLElement
+    const activeElement = getActiveElement() as HTMLElement
 
     return activeElement && (
       activeElement.tagName === 'INPUT' ||

--- a/packages/vuetify/src/labs/VCommandPalette/VCommandPalette.tsx
+++ b/packages/vuetify/src/labs/VCommandPalette/VCommandPalette.tsx
@@ -21,7 +21,7 @@ import { useProxiedModel } from '@/composables/proxiedModel'
 // Utilities
 import { computed, nextTick, onUnmounted, provide, ref, shallowRef, toRef, watch, watchEffect } from 'vue'
 import { isActionItem } from './types'
-import { convertToUnit, genericComponent, omit, propsFactory, useRender } from '@/util'
+import { convertToUnit, genericComponent, getActiveElement, omit, propsFactory, useRender } from '@/util'
 
 // Types
 import type { PropType, Ref } from 'vue'
@@ -250,7 +250,7 @@ export const VCommandPalette = genericComponent<VCommandPaletteSlots>()({
 
     watch(isOpen, (newValue, oldValue) => {
       if (newValue && !oldValue) {
-        previouslyFocusedElement.value = document.activeElement as HTMLElement | null
+        previouslyFocusedElement.value = getActiveElement() as HTMLElement | null
         searchQuery.value = ''
         navigation.reset()
 


### PR DESCRIPTION
follow-up after #23024

What is not covered:
- `useFocusRepair` - no change is required to keep it working

```vue
<template>
  <v-app :theme="theme.name.value">
    <v-btn
      icon="mdi-theme-light-dark"
      location="top right"
      position="fixed"
      style="z-index: 2000"
      @click="theme.cycle()"
    />
    <v-container>
      <h1 class="text-h5 mb-1">document.activeElement leftovers — Shadow DOM audit</h1>
      <p class="text-medium-emphasis mb-4">
        Each tab registers its own <code>&lt;vv-*&gt;</code> custom element (defineCustomElement)
        next to the same component in the document. Compare the two: a difference is the
        Shadow DOM <code>document.activeElement</code> bug.
      </p>

      <v-tabs v-model="tab" class="mb-4" show-arrows>
        <v-tab v-for="d in demos" :key="d.key" :value="d.key" :text="d.label" />
      </v-tabs>

      <v-window v-model="tab">
        <v-window-item v-for="d in demos" :key="d.key" :value="d.key">
          <v-alert :text="d.note" type="info" variant="tonal" class="mb-4" />
          <div class="mb-2">
            <span class="text-caption text-medium-emphasis">{{ d.files }}</span>
          </div>

          <main class="comparison">
            <section>
              <h2 class="text-subtitle-1 mb-2">Shadow DOM</h2>
              <div class="demo-box">
                <ShadowDemo :demo="tab" />
              </div>
            </section>
            <section>
              <h2 class="text-subtitle-1 mb-2">regular DOM</h2>
              <div class="demo-box">
                <component :is="d.component" />
              </div>
            </section>
          </main>
        </v-window-item>
      </v-window>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { defineComponent, defineCustomElement, h, onMounted, ref } from 'vue'
  import { VCombobox } from '@/components/VCombobox'
  import { VTextField } from '@/components/VTextField'
  import { VBtn } from '@/components/VBtn'
  import { VCard } from '@/components/VCard'
  import { VCheckbox } from '@/components/VCheckbox'
  import { VChip } from '@/components/VChip'
  import { VDialog } from '@/components/VDialog'
  import { VThemeProvider } from '@/components/VThemeProvider'
  import { VCommandPalette } from '@/labs/VCommandPalette'
  import { useHotkey } from '@/composables/hotkey'
  import { useTheme } from '@/composables/theme'
  import vuetify from './vuetify'

  // ── Representative repro per category ────────────────────────────────────
  const Refocus = defineComponent(() => {
    const model = ref('select this text then click back into the field')
    return () => h(VTextField, {
      label: 'onFocus re-calls .focus)',
      modelValue: model.value,
      clearable: true,
      'onUpdate:modelValue': (v: string) => (model.value = v),
      'onUpdate:focused': (v) => { console.log('VTextField.tsx:117', v) },
    }, {
      'append-inner': () => h(VBtn, { text: '?' }),
    })
  })

  const Containment = defineComponent(() => {
    const open = ref(false)
    return () => h('div', [
      h(VBtn, { color: 'primary', onClick: () => (open.value = true) }, () => 'open dialog'),
      h(VDialog, {
        modelValue: open.value,
        'onUpdate:modelValue': (v: boolean) => (open.value = v),
        width: 400,
        retainFocus: true,
      }, {
        // activator: ({ props }: any) => h(VBtn, { color: 'primary', ...props }, () => 'open dialog'),
        default: () => h(VCard, { title: 'retainFocus' }, () => [
          h(VTextField, { label: 'first' }),
          h(VTextField, { autofocus: true, label: 'middle — should keep focus on open' }),
          h(VTextField, { label: 'last' }),
        ]),
      }),
    ])
  })

  const Restore = defineComponent(() => {
    const open = ref(false)
    return () => h('div', [
      h(VBtn, { color: 'primary', onClick: () => (open.value = true) }, () => 'open palette, then Esc'),
      h(VCommandPalette, {
        modelValue: open.value,
        'onUpdate:modelValue': (v: boolean) => (open.value = v),
        items: [
          { title: 'Alpha', onClick: () => {} },
          { title: 'Bravo', onClick: () => {} },
          { title: 'Charlie', onClick: () => {} },
        ],
      }),
    ])
  })

  const Hotkey = defineComponent(() => {
    const count = ref(0)
    useHotkey('b', () => count.value++)
    return () => h('div', [
      h('div', { class: 'mb-2' }, `hotkey "b" fired: ${count.value}`),
      h(VTextField, { label: 'type the letter b — should NOT fire' }),
    ])
  })

  const FieldClick = defineComponent(() => {
    const model = ref(['Vue', 'Vuetify', 'Vite'])
    return () => h(VCombobox, {
      modelValue: model.value,
      'onUpdate:modelValue': (v: string[]) => (model.value = v),
      items: ['Vue', 'Vuetify', 'Vite', 'Pinia', 'Nuxt'],
      label: 'toggle a checkbox in the selection slot',
      multiple: true,
    }, {
      // stopPropagation keeps VField from stealing focus to the input, so the
      // checkbox itself becomes the focused element — the case cat 6 diverges on.
      selection: ({ item }: any) => h(VChip, {
        class: 'mr-1',
        onMousedown: (e: MouseEvent) => e.stopPropagation(),
      }, {
        prepend: () => h(VCheckbox, { hideDetails: true, density: 'compact' }),
        default: () => item.title,
      }),
    })
  })

  const demos = [
    {
      key: 'refocus',
      label: 'Re-focus guard',
      component: Refocus,
      files: 'VTextField.tsx:117, VTextarea.tsx:123, VFileInput.tsx:140',
      note: '...no difference before/after the change, but it is safeguard for the future',
    },
    {
      key: 'containment',
      label: 'Contains(focus)',
      component: Containment,
      files: 'VDialog.tsx:60 (also VOverlay/useActivator.tsx:247)',
      note: 'Open the dialog — the autofocused middle field must keep focus, not lose it to the wrapper.',
    },
    {
      key: 'restore',
      label: 'Focus restore',
      component: Restore,
      files: 'labs/VCommandPalette.tsx:253',
      note: 'Open the palette, press Esc — focus must return to the trigger button.',
    },
    {
      key: 'hotkey',
      label: 'Hotkey guard',
      component: Hotkey,
      files: 'composables/hotkey/hotkey.ts:50',
      note: 'Type "b" in the field — the hotkey must not fire while an input is focused.',
    },
    {
      key: 'fieldclick',
      label: 'Field click',
      component: FieldClick,
      files: 'VField.tsx:241',
      note: 'Toggle a checkbox in the field — the click must not be ignored.',
    },
  ]

  const theme = useTheme()
  const tab = ref('refocus')
  const tagFor = (key: string) => `vv-${key}`

  // Custom elements are isolated apps that default to the light theme; pass the
  // playground theme in as an attribute and apply it via a v-theme-provider.
  const ShadowDemo = defineComponent({
    props: { demo: String },
    setup: props => () => h(tagFor(props.demo!), { theme: theme.name.value }),
  })

  onMounted(() => {
    theme.change('dark')

    // ponytail: dev vite injects styles as <style> tags; the CDN repro fetched
    // built css instead. :root/html/body -> :host rewrite scopes them to the shadow.
    const css = Array.from(document.querySelectorAll('style'))
      .map(el => el.textContent ?? '')
      .join('\n')
      .replace(/:root/g, ':host')
      .replace(/\bhtml\b/g, ':host')
      .replace(/\bbody\b/g, ':host')

    for (const d of demos) {
      const name = tagFor(d.key)
      if (customElements.get(name)) continue
      const shadowApp = defineComponent({
        props: { theme: String },
        setup: props => () => h(VThemeProvider, { theme: props.theme, withBackground: true }, () => h(d.component)),
      })
      customElements.define(name, defineCustomElement(shadowApp, {
        styles: [css],
        configureApp: app => app.use(vuetify),
      }))
    }
  })
</script>

<style>
  .comparison {
    display: flex;
    gap: 24px;
  }
  .comparison section {
    flex: 1;
    min-width: 0;
  }
  .demo-box {
    border: 1px dashed rgba(255, 255, 255, 0.2);
    border-radius: 8px;
    padding: 24px;
    min-height: 120px;
  }
</style>
```
