### PR TITLE
fix(VListItem/VChip/VDatePickerHeader): only attach click when interactive

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -233,7 +233,7 @@ export const VChip = genericComponent<VChipSlots>()({
           disabled={ props.disabled || undefined }
           draggable={ props.draggable }
           tabindex={ isClickable.value ? 0 : undefined }
-          onClick={ onClick }
+          onClick={ (isClickable.value || props.onClick || props.onClickOnce) && onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={[isClickable.value && props.ripple, null]}
         >

--- a/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.tsx
+++ b/packages/vuetify/src/components/VDatePicker/VDatePickerHeader.tsx
@@ -26,6 +26,7 @@ export const makeVDatePickerHeaderProps = propsFactory({
   header: String,
   transition: String,
   onClick: EventProp<[MouseEvent]>(),
+  onClickOnce: EventProp<[MouseEvent]>(),
 }, 'VDatePickerHeader')
 
 export const VDatePickerHeader = genericComponent<VDatePickerHeaderSlots>()({
@@ -58,12 +59,12 @@ export const VDatePickerHeader = genericComponent<VDatePickerHeaderSlots>()({
           class={[
             'v-date-picker-header',
             {
-              'v-date-picker-header--clickable': !!props.onClick,
+              'v-date-picker-header--clickable': !!(props.onClick || props.onClickOnce),
             },
             backgroundColorClasses.value,
           ]}
           style={ backgroundColorStyles.value }
-          onClick={ onClick }
+          onClick={ (props.onClick || props.onClickOnce) && onClick }
         >
           { slots.prepend && (
             <div key="prepend" class="v-date-picker-header__prepend">

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -317,7 +317,7 @@ export const VListItem = genericComponent<VListItemSlots>()({
           tabindex={ props.tabindex ?? (isClickable.value ? (list ? -2 : 0) : undefined) }
           aria-selected={ ariaSelected.value }
           role={ role.value }
-          onClick={ onClick }
+          onClick={ (isClickable.value || props.onClick || props.onClickOnce) && onClick }
           onKeydown={ isClickable.value && !isLink.value && onKeyDown }
           v-ripple={ isClickable.value && rippleOptions.value }
         >

--- a/packages/vuetify/src/components/VList/VListItem.tsx
+++ b/packages/vuetify/src/components/VList/VListItem.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable complexity */
+
 // Styles
 import './VListItem.sass'
 


### PR DESCRIPTION
fixes #22854

- applies only to components that can realistically hold non-interactive content

```vue
<template>
  <v-app theme="dark">
    <v-app-bar title="#22854 click listener a11y" />

    <v-main>
      <v-container class="d-flex flex-column ga-8">
        <div>
          <div class="text-h6 mb-2">VListItem</div>
          <div class="text-caption mb-2">Static items must not get a click listener. @click / value / link must.</div>
          <v-list border>
            <v-list-subheader>static (no listener)</v-list-subheader>
            <v-list-item base-color="error" title="Static text only" />
            <v-list-item base-color="error">
              <v-list-item-title>Slot text only</v-list-item-title>
            </v-list-item>

            <v-list-subheader>@click (listener + handler)</v-list-subheader>
            <v-list-item title="@click only" @click="console.log('list-item @click')" />

            <v-list-subheader>built-in clickable</v-list-subheader>
            <v-list-item title="with value" value="a" />
            <v-list-item href="https://vuetifyjs.com" title="link" />
          </v-list>
          <v-list
            v-model:selected="selected"
            class="mt-4"
            border
            selectable
          >
            <v-list-subheader>selectable list</v-list-subheader>
            <v-list-item title="one" value="1" />
            <v-list-item title="two" value="2" />
          </v-list>
        </div>

        <div>
          <div class="text-h6 mb-2">VChip</div>
          <div class="text-caption mb-2">Static chip must not get a click listener. @click / link / group must.</div>
          <div class="d-flex flex-wrap ga-2">
            <v-chip color="error">static</v-chip>
            <v-chip @click="console.log('chip @click')">@click</v-chip>
            <v-chip href="https://vuetifyjs.com">link</v-chip>
            <v-chip-group v-model="chip" selected-class="text-primary">
              <v-chip value="a">group a</v-chip>
              <v-chip value="b">group b</v-chip>
            </v-chip-group>
          </div>
        </div>

        <div>
          <div class="text-h6 mb-2">VDatePickerHeader (via VDatePicker)</div>
          <div class="text-caption mb-2">
            Default month header: no listener.
            Year/month view: header clickable (back).
            Custom header below: @click.once must fire once.
          </div>
          <div class="d-flex ga-2">
            <v-date-picker v-model="date" />
            <v-date-picker v-model="date">
              <template #header>
                <v-date-picker-header
                  header="@click.once"
                  @click.once="console.log('header @click.once')"
                />
              </template>
            </v-date-picker>
          </div>
        </div>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const selected = ref([])
  const chip = ref()
  const date = ref(new Date())
</script>
```
