### PR TITLE
fix(VStepperWindow/VTouch): only remove touchHandlers when   not null…

### DIFF
--- a/packages/vuetify/src/directives/touch/index.ts
+++ b/packages/vuetify/src/directives/touch/index.ts
@@ -139,11 +139,11 @@ function unmounted (el: HTMLElement, binding: TouchDirectiveBinding) {
   if (!target?._touchHandlers || uid === undefined) return
 
   const handlers = target._touchHandlers[uid]
-
-  keys(handlers).forEach(eventName => {
-    target.removeEventListener(eventName, handlers[eventName])
-  })
-
+  if (handlers) {
+    keys(handlers).forEach(eventName => {
+      target.removeEventListener(eventName, handlers[eventName])
+    })
+  }
   delete target._touchHandlers[uid]
 }
 

--- a/packages/vuetify/src/directives/touch/index.ts
+++ b/packages/vuetify/src/directives/touch/index.ts
@@ -139,12 +139,20 @@ function unmounted (el: HTMLElement, binding: TouchDirectiveBinding) {
   if (!target?._touchHandlers || uid === undefined) return
 
   const handlers = target._touchHandlers[uid]
-  if (handlers) {
-    keys(handlers).forEach(eventName => {
-      target.removeEventListener(eventName, handlers[eventName])
-    })
-  }
+
+  // guard against double teardown: e.g. router & suspence racing
+  if (!handlers) return
+
+  keys(handlers).forEach(eventName => {
+    target.removeEventListener(eventName, handlers[eventName])
+  })
+
   delete target._touchHandlers[uid]
+
+  if (!keys(target._touchHandlers).length) {
+    // only relevant if we keep `parent: boolean`
+    delete target._touchHandlers
+  }
 }
 
 export const Touch = {


### PR DESCRIPTION
## Description
VStepperWindow uses the VWindow component internally. VWindow always renders with the VTouch directive, even when touch is disabled (which it is in the VStepperWindow usage).

In my Application, due to a mixture of router-view, suspense and other side-effects, the unmounted hook is called **twice**. The first time, the handler is removed. For the second call the assignment `const handlers = target._touchHandlers[uid]` returns `null` which later, together with the `keys(handler)` call, causes the error `TypeError: Cannot convert undefined or null to object`

This has the potential to break VStepper usage (for me it already does).

The fix makes the unmounted lifecycle hook idempotent, so that it does not fail on subsequent runs, by guarding against the handlers being null/undefined.

## Markdown
Unfortunately I cannot reproduce the issue in the Playground.vue 
I tried many different combinations, but i cannot re-create it in this environment.