### PR TITLE
fix: accept Vue 3.6 prereleases in the vue peer range

### DIFF
--- a/packages/vuetify/package.json
+++ b/packages/vuetify/package.json
@@ -212,7 +212,7 @@
   "peerDependencies": {
     "typescript": ">=4.7",
     "vite-plugin-vuetify": ">=2.1.0",
-    "vue": "^3.5.0",
+    "vue": "^3.5.0 || ^3.6.0-0",
     "webpack-plugin-vuetify": ">=3.1.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Description

`packages/vuetify` declares `peerDependencies.vue: "^3.5.0"`. Per semver, **a range with no prerelease comparator does not match prerelease versions**, so `vue@3.6.0-rc.2` (published, current) falls outside it and anyone on a Vue 3.6 release candidate hits `ERESOLVE` installing Vuetify.

Verified against the `semver@7.7.3` already in the repo rather than asserted from memory:

| version | `^3.5.0` (before) | `^3.5.0 \|\| ^3.6.0-0` (after) |
|---|---|---|
| `3.4.0` | ❌ | ❌ |
| `3.5.0` | ✅ | ✅ |
| `3.5.25` | ✅ | ✅ |
| `3.6.0-alpha.1` | ❌ | ✅ |
| `3.6.0-rc.2` | ❌ | ✅ |
| `3.6.0` | ✅ | ✅ |
| `3.7.0-alpha.1` | ❌ | ❌ |
| `3.7.1` | ✅ | ✅ |
| `4.0.0` | ❌ | ❌ |

Fuzzed across every `{2,3,4}.{0,4,5,6,7,9,99}.{0,1,25}` with and without `-alpha.1`/`-beta.3`/`-rc.2` suffixes, the delta between the two ranges is exactly three versions — all of them `3.6.0` prereleases. Nothing previously accepted is dropped, and Vue 4.x remains excluded.

Caret form was chosen over the `>=3.5.0 || >=3.6.0-0` shape used in vuetifyjs/0#720 because the `>=` variant **does** admit `vue@4.0.0`; the caret keeps the major bound intact. It also matches the existing style of this manifest.

This has a natural expiry — once 3.6.0 goes stable the original range covers it anyway.

Same defect and same fix as vuetifyjs/0#720.

## Markup:

N/A — manifest-only change, no source or template changes.
