### PR TITLE
fix(VFooter,VFab): include padding in measured layout height

### DIFF
--- a/packages/vuetify/src/components/VFab/VFab.tsx
+++ b/packages/vuetify/src/components/VFab/VFab.tsx
@@ -54,7 +54,7 @@ export const VFab = genericComponent()({
     const el = shallowRef<HTMLElement>()
     useResizeObserver(el, entries => {
       if (!entries.length) return
-      height.value = entries[0].contentRect.height
+      height.value = entries[0].target.clientHeight
     })
 
     const hasPosition = toRef(() => props.app || props.absolute)

--- a/packages/vuetify/src/components/VFooter/VFooter.tsx
+++ b/packages/vuetify/src/components/VFooter/VFooter.tsx
@@ -52,7 +52,7 @@ export const VFooter = genericComponent()({
     const el = shallowRef<HTMLElement>()
     useResizeObserver(el, entries => {
       if (!entries.length) return
-      autoHeight.value = entries[0].contentRect.height
+      autoHeight.value = entries[0].target.clientHeight
     })
     const height = computed(() => props.height === 'auto' ? autoHeight.value : parseInt(props.height, 10))
 

--- a/packages/vuetify/src/components/VFooter/__tests__/VFooter.spec.browser.tsx
+++ b/packages/vuetify/src/components/VFooter/__tests__/VFooter.spec.browser.tsx
@@ -1,0 +1,52 @@
+// Components
+import { VFooter } from '..'
+import { VLayout } from '@/components/VLayout'
+import { VMain } from '@/components/VMain'
+
+// Utilities
+import { commands, render, screen } from '@test'
+
+describe('VFooter', () => {
+  it('should reserve layout space equal to its rendered height', async () => {
+    render(() => (
+      <VLayout>
+        <VMain>Content</VMain>
+        <VFooter app>Footer</VFooter>
+      </VLayout>
+    ))
+
+    const footer = screen.getByCSS('.v-footer')
+    const main = screen.getByCSS('.v-main')
+
+    await commands.waitStable('.v-footer')
+
+    // Default $footer-padding is 8px 16px, so the content box is 16px shorter
+    // than the box the footer actually occupies. The layout must reserve the
+    // latter or the last 16px of VMain content renders underneath the footer.
+    const rendered = footer.getBoundingClientRect().height
+    const reserved = parseFloat(getComputedStyle(main).paddingBottom)
+
+    expect(rendered).toBeGreaterThan(0)
+    expect(reserved).toBe(rendered)
+  })
+
+  it('should reserve layout space including custom vertical padding', async () => {
+    render(() => (
+      <VLayout>
+        <VMain>Content</VMain>
+        <VFooter app style="padding-top: 40px; padding-bottom: 40px">Footer</VFooter>
+      </VLayout>
+    ))
+
+    const footer = screen.getByCSS('.v-footer')
+    const main = screen.getByCSS('.v-main')
+
+    await commands.waitStable('.v-footer')
+
+    const rendered = footer.getBoundingClientRect().height
+    const reserved = parseFloat(getComputedStyle(main).paddingBottom)
+
+    expect(rendered).toBeGreaterThan(80)
+    expect(reserved).toBe(rendered)
+  })
+})


### PR DESCRIPTION
## Description

`#22672` (`ec2fdbd83a`, `next` only) migrated the observer composables to `@vuetify/v0` and, in the process, changed how `VFooter` and `VFab` measure themselves:

```diff
- autoHeight.value = entries[0].target.clientHeight
+ autoHeight.value = entries[0].contentRect.height
```

`contentRect` is the **content box** — it excludes padding. `_variables.scss` sets `$footer-padding: 8px 16px` (and `$footer-border-width: 0`), so `autoHeight` under-reports the footer's occupied height by **16px**.

That value feeds `layoutSize` through `useLayoutItem`, which drives `--v-layout-bottom` and therefore `VMain`'s `padding-bottom`. The result: `<v-footer app>` reserves 16px too little, and the last 16px of `VMain` content renders underneath the footer. Default theme, no props required.

Measured in the new browser test on `next` before the fix:

```
AssertionError: expected 24 to be 40 // Object.is equality
```

40px rendered, 24px reserved — the 16px shortfall exactly.

## Fix

Read `entries[0].target.clientHeight` again.

**Why this accessor.** The options available against the pinned `@vuetify/v0@^0.2.1` are limited — its `ResizeObserverEntry` exposes only `contentRect` (always content-box) and `target`. Notably the `box: 'border-box'` option does *not* help: it changes which box triggers a notification, not what `contentRect` reports.

- `target.clientHeight` — content + padding, excludes border and scrollbar. Restores the pre-migration behaviour byte-for-byte, so `next` stops diverging from `master`/`dev` (both still use `clientHeight`). Not affected by CSS transforms.
- `getBoundingClientRect().height` — true border-box, but it is **scaled by CSS transforms**. `VFab` sits inside a `fab-transition` that scales it, so this accessor would feed transient scaled heights into the layout during the transition. Rejected.

`clientHeight` still under-reports by the border width if a consumer sets a non-zero `$footer-border-width`, but that is pre-existing behaviour on every branch, not part of this regression — fixing it is a separate change and shouldn't land as a silent behaviour delta on `next` only.

**Once `@vuetify/v0` 1.0.2 lands** (vuetifyjs/0#724, fixed by vuetifyjs/0#725, which adds `borderBoxSize`/`contentBoxSize` to the entry), the accessor becomes true border-box and transform-independent:

```ts
useResizeObserver(el, entries => {
  if (!entries.length) return
  autoHeight.value = entries[0].borderBoxSize[0].blockSize
}, { box: 'border-box' })
```

That is the eventual target; it is not reachable from the currently pinned range.

## VFab

Fixed in the same PR. It carries the identical `clientHeight` → `contentRect.height` swap and is **not** observably broken by default (`$button-border-width: 0`, and `VBtn`'s padding is inline-only, so content height == client height), but it diverges the moment a consumer applies vertical padding or a border to the FAB. Leaving one half of a two-line regression in place because the default theme happens to mask it means the next person to touch it re-derives the same analysis. Zero default behaviour change, and it restores parity with `master`/`dev`.

## Tests

`ec2fdbd83a` deleted both observer specs and added none, and `VFooter` had **no tests at all**. `VVirtualScroll.spec.browser.tsx` renders unpadded divs, so it passes vacuously against exactly this class of bug.

Added `packages/vuetify/src/components/VFooter/__tests__/VFooter.spec.browser.tsx` with two cases that assert the **layout consequence**, not the composable's return value — they compare `VMain`'s computed `padding-bottom` against the footer's real rendered height:

1. default padding — catches the shipped regression (24 vs 40)
2. custom 40px vertical padding — catches any future content-box regression at a larger, unambiguous magnitude (24 vs 104)

Both fail on `next` without the source change and pass with it.

## Verification

```
$ pnpm vitest run --project browser src/components/VFooter/__tests__/VFooter.spec.browser.tsx
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ pnpm vitest run --project browser src/components/VFab src/components/VLayout \
    src/components/VNavigationDrawer src/components/VAppBar \
    src/components/VBottomNavigation src/components/VFooter
 Test Files  5 passed (5)
      Tests  25 passed (25)

$ pnpm lint
[tsc] tsgo -p tsconfig.checks.json --noEmit --pretty exited with code 0
[eslint] eslint src -f codeframe --max-warnings 0 exited with code 0
```

## Base branch

`next`. `CONTRIBUTING.md` routes bug fixes to `master`, but that predates the `next` line and does not apply here: the regression exists **only** on `next` (`git branch -r --contains ec2fdbd83a` returns `next` and three unmerged `feat/v0-*` branches). `master` and `dev` still read `target.clientHeight` and are unaffected, so there is nothing to fix there.