### PR TITLE
fix(VDialog): do not throw when unmounted while closing

### DIFF
--- a/packages/vuetify/src/components/VDialog/VDialog.tsx
+++ b/packages/vuetify/src/components/VDialog/VDialog.tsx
@@ -70,7 +70,7 @@ export const VDialog = genericComponent<OverlaySlots>()({
     watch(isActive, async val => {
       if (!val) {
         await nextTick()
-        overlay.value!.activatorEl?.focus({ preventScroll: true })
+        overlay.value?.activatorEl?.focus({ preventScroll: true })
       }
     })
 

--- a/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.browser.tsx
@@ -5,7 +5,7 @@ import { VTextField } from '@/components/VTextField'
 
 // Utilities
 import { commands, page, render, screen, userEvent, wait } from '@test'
-import { h, nextTick, ref } from 'vue'
+import { defineComponent, h, nextTick, onErrorCaptured, ref, watch } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 // Tests
@@ -49,6 +49,47 @@ describe('VDialog', () => {
     await expect.poll(() => model.value).toBeFalsy()
     await expect.poll(() => screen.queryByTestId('dialog')).toBeNull()
     await expect.poll(() => screen.queryByTestId('content')).toBeNull()
+  })
+
+  // https://github.com/vuetifyjs/vuetify/issues/23053
+  it('should not throw when unmounted while closing', async () => {
+    let error: unknown
+    const dialog = ref(false)
+    const selected = ref<{ name: string } | null>(null)
+
+    const Root = defineComponent({
+      setup () {
+        watch(selected, item => {
+          if (item) dialog.value = true
+        })
+        // Deselect after close unmounts the dialog inside the tick its close watcher awaits across.
+        watch(dialog, val => {
+          if (!val) selected.value = null
+        }, { flush: 'post' })
+
+        onErrorCaptured(err => {
+          error = err
+          return false
+        })
+
+        return () => selected.value && (
+          <VDialog v-model={ dialog.value } data-testid="dialog">
+            <div data-testid="content">Content</div>
+          </VDialog>
+        )
+      },
+    })
+
+    render(Root)
+
+    selected.value = { name: 'Item 1' }
+    await expect(screen.findByTestId('dialog')).resolves.toBeVisible()
+
+    dialog.value = false
+    await expect.poll(() => screen.queryByTestId('dialog')).toBeNull()
+    await wait()
+
+    expect(error).toBeUndefined()
   })
 
   it('should react to max-width changes', async () => {

--- a/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDialog/__tests__/VDialog.spec.browser.tsx
@@ -5,7 +5,7 @@ import { VTextField } from '@/components/VTextField'
 
 // Utilities
 import { commands, page, render, screen, userEvent, wait } from '@test'
-import { defineComponent, h, nextTick, onErrorCaptured, ref, watch } from 'vue'
+import { h, nextTick, ref } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 // Tests
@@ -49,47 +49,6 @@ describe('VDialog', () => {
     await expect.poll(() => model.value).toBeFalsy()
     await expect.poll(() => screen.queryByTestId('dialog')).toBeNull()
     await expect.poll(() => screen.queryByTestId('content')).toBeNull()
-  })
-
-  // https://github.com/vuetifyjs/vuetify/issues/23053
-  it('should not throw when unmounted while closing', async () => {
-    let error: unknown
-    const dialog = ref(false)
-    const selected = ref<{ name: string } | null>(null)
-
-    const Root = defineComponent({
-      setup () {
-        watch(selected, item => {
-          if (item) dialog.value = true
-        })
-        // Deselect after close unmounts the dialog inside the tick its close watcher awaits across.
-        watch(dialog, val => {
-          if (!val) selected.value = null
-        }, { flush: 'post' })
-
-        onErrorCaptured(err => {
-          error = err
-          return false
-        })
-
-        return () => selected.value && (
-          <VDialog v-model={ dialog.value } data-testid="dialog">
-            <div data-testid="content">Content</div>
-          </VDialog>
-        )
-      },
-    })
-
-    render(Root)
-
-    selected.value = { name: 'Item 1' }
-    await expect(screen.findByTestId('dialog')).resolves.toBeVisible()
-
-    dialog.value = false
-    await expect.poll(() => screen.queryByTestId('dialog')).toBeNull()
-    await wait()
-
-    expect(error).toBeUndefined()
   })
 
   it('should react to max-width changes', async () => {


### PR DESCRIPTION
## Description

After a dialog closes, VDialog waits a tick before returning focus to its activator. If the dialog is unmounted during that tick, for example when a `flush: 'post'` watcher clears the state a `v-if` depends on, `overlay.value` is already null and the non-null assertion throws `TypeError: Cannot read properties of null (reading 'activatorEl')`. Optional chaining makes the focus a no-op once the overlay is gone, matching the guarded `overlay.value?.contentEl` read a few lines above.

Fixes #23053

## Markup:

```vue
<template>
  <v-app>
    <v-main class="pa-8">
      <v-btn @click="selected = { name: 'Item 1' }">Edit item</v-btn>

      <!-- The dialog only exists while an item is selected -->
      <v-dialog v-if="selected" v-model="dialog" width="400">
        <v-card :title="selected.name">
          <v-card-text>Close this dialog to trigger the crash.</v-card-text>
          <v-card-actions>
            <v-btn @click="dialog = false">Save</v-btn>
          </v-card-actions>
        </v-card>
      </v-dialog>

      <v-alert v-if="error" type="error" class="mt-6" :text="error" />
    </v-main>
  </v-app>
</template>

<script setup>
  import { onErrorCaptured, ref, watch } from 'vue'

  const dialog = ref(false)
  const selected = ref(null)
  const error = ref('')

  watch(selected, item => {
    if (item) dialog.value = true
  })

  // Deselect once closed; the post-flush unmount is what triggers the error
  watch(dialog, val => {
    if (!val) selected.value = null
  }, { flush: 'post' })

  onErrorCaptured(err => {
    error.value = `${err.name}: ${err.message}`
    return false
  })
</script>
```
