### PR TITLE
docs(VStepper): clarify non-linear only affects step opacity

### DIFF
--- a/packages/api-generator/src/locale/en/Stepper.json
+++ b/packages/api-generator/src/locale/en/Stepper.json
@@ -1,7 +1,7 @@
 {
   "props": {
     "altLabels": "Places the labels beneath the step.",
-    "editable": "Marks step as editable.",
+    "editable": "Marks step as editable, allowing the user to navigate to it by clicking.",
     "hideActions": "Hide actions bar (prev and next buttons).",
     "itemProps": "Props object that will be applied to each item component. `true` will treat the original object as raw props and pass it directly to the component.",
     "itemTitle": "Property on supplied `items` that contains its title.",
@@ -9,7 +9,7 @@
     "mobile": "Forces the stepper into a mobile state, removing labels from stepper items.",
     "nextText": "The text used for the Next button.",
     "prevText": "The text used for the Prev button.",
-    "nonLinear": "Allow user to jump to any step."
+    "nonLinear": "Displays unvisited steps with increased opacity to indicate that they can be completed in any order. Purely visual; combine with the **editable** prop on steps to let users select them directly."
   },
   "slots": {
     "[`header-item.${string}`]": "Slot for customizing header items when using the [items](/api/v-stepper/#props-items) prop.",

--- a/packages/api-generator/src/locale/en/StepperItem.json
+++ b/packages/api-generator/src/locale/en/StepperItem.json
@@ -2,7 +2,7 @@
   "props": {
     "complete": "Marks step as complete.",
     "completeIcon": "Icon to display when step is marked as completed.",
-    "editable": "Marks step as editable.",
+    "editable": "Marks step as editable, allowing the user to navigate to it by clicking.",
     "editIcon": "Icon to display when step is editable.",
     "errorIcon": "Icon to display when step has an error.",
     "error": "Puts the stepper item in a manual error state.",

--- a/packages/docs/src/pages/en/components/steppers.md
+++ b/packages/docs/src/pages/en/components/steppers.md
@@ -94,7 +94,7 @@ Steppers also have an alternative label style which places the title under the s
 
 #### Linear steppers
 
-Linear steppers will always move a user through your defined path.
+Steppers are linear by default, de-emphasizing unvisited steps and guiding users through your defined path with the prev and next actions. Note that the component has no internal logic enforcing this progression: steps simply cannot be selected directly unless they are marked as **editable**.
 
 <ExamplesExample file="v-stepper/misc-linear" />
 
@@ -142,6 +142,6 @@ The error state can also be applied to the alternative label style.
 
 #### Non linear
 
-Non-linear steppers allow the user to move through your process in whatever way they choose.
+The **non-linear** prop signals that steps can be completed in any order by displaying unvisited steps with increased opacity. The prop is purely visual: to actually let users jump between steps by clicking, each step must also be marked as **editable**, as in the example below.
 
 <ExamplesExample file="v-stepper/prop-non-linear" />

--- a/packages/docs/src/pages/en/components/vertical-steppers.md
+++ b/packages/docs/src/pages/en/components/vertical-steppers.md
@@ -45,7 +45,7 @@ The `v-stepper-vertical` is the vertical variant of the [v-stepper](/components/
 
 #### Non linear
 
-Non-linear stepper allow the user to navigate freely – skip to a desired section without forcing clicks on the action buttons within, provided **editable** prop is also present. When combined with `:mandatory="false"`, allowes to collapse the section as well.
+Non-linear steppers allow the user to navigate freely – skip to a desired section without forcing clicks on the action buttons within, provided the **editable** prop is also present. When combined with `:mandatory="false"`, the section can be collapsed as well.
 
 <ExamplesExample file="v-stepper-vertical/prop-non-linear" />
 


### PR DESCRIPTION
## Description

`non-linear` was documented as "Allow user to jump to any step", but the prop has no navigation logic — it only renders unvisited step items with increased opacity (`VStepperItem.sass` under `.v-stepper--non-linear`). Steps only become selectable when marked `editable` (`isClickable` in `VStepperItem.tsx`).

This updates the prop descriptions and the Linear/Non-linear docs sections to describe the actual behavior, following maintainer guidance in #19275 and the resolution of #22957 ("in v4 we only need docs change").

Also includes small grammar fixes in the matching vertical-steppers section.

fixes #19275
