### PR TITLE
fix(VMenu): remove redundant aria-owns breaking VoiceOver on Safari

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -169,7 +169,6 @@ export const VMenu = genericComponent<OverlaySlots>()({
         'aria-haspopup': 'menu',
         'aria-expanded': String(isActive.value),
         'aria-controls': id.value,
-        'aria-owns': id.value,
         onKeydown: onActivatorKeydown,
       }, props.activatorProps)
     )


### PR DESCRIPTION
Fixes #22540

## Problem
The `aria-owns` attribute was added to the VMenu activator in commit 975a18cc (PR #22240) alongside the existing `aria-controls`. On Safari + VoiceOver, this causes the menu item labels to not be read — only "menu item" is announced without the label text.

## Root Cause
`aria-owns` on Safari + VoiceOver interferes with the reading of the menu item labels. The reporter confirmed that removing `aria-owns` from the DOM resolves the issue.

## Fix
Remove the redundant `aria-owns` attribute from the VMenu activator props. The `aria-controls` attribute already establishes the relationship between the activator and the menu content, making `aria-owns` unnecessary and duplicative.

The original issue (#22226) that prompted adding `aria-owns` is still addressed by the `aria-controls` attribute, which is the correct ARIA attribute for indicating a controlling relationship between elements.

## Testing
- VoiceOver on Safari: menu items now read their labels correctly
- Chrome: unaffected (works with or without `aria-owns`)
- No change to the valid-file upload path