### PR TITLE
fix(VMenu): avoid aria-owns for menu activators

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -169,7 +169,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
         'aria-haspopup': 'menu',
         'aria-expanded': String(isActive.value),
         'aria-controls': id.value,
-        'aria-owns': id.value,
+        'data-v-overlay-activator': id.value,
         onKeydown: onActivatorKeydown,
       }, props.activatorProps)
     )

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -12,6 +12,22 @@ import { commands, render, screen, userEvent, wait } from '@test'
 import { ref } from 'vue'
 
 describe('VMenu', () => {
+  it('should associate the activator with the menu using aria-controls', () => {
+    render(() => (
+      <VMenu>
+        {{
+          activator: ({ props }: any) => <VBtn { ...props } data-testid="activator">Menu</VBtn>,
+          default: () => <VListItem title="Item" />,
+        }}
+      </VMenu>
+    ))
+
+    const activator = screen.getByTestId('activator')
+
+    expect(activator.getAttribute('aria-controls')).toMatch(/^v-menu-v-\d+$/)
+    expect(activator).not.toHaveAttribute('aria-owns')
+  })
+
   describe('open-on-focus with template activator', () => {
     beforeEach(() => commands.setFocusEmulationDisabled())
 

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -226,7 +226,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         if (el === contentEl.value) return true
         visited.add(el)
         const ownerId = el.closest('.v-overlay')?.id
-        current = ownerId ? document.querySelector(`[aria-owns~="${CSS.escape(ownerId)}"]`) : null
+        current = ownerId ? document.querySelector(`[data-v-overlay-activator="${CSS.escape(ownerId)}"]`) : null
       }
       return false
     }


### PR DESCRIPTION
## Description

Fixes #22540.

`VMenu` activators now use `aria-controls` without also exposing `aria-owns`, which prevents Safari VoiceOver from dropping the accessible labels of menu items. Nested-overlay ownership tracking still works through a private `data-v-overlay-activator` attribute, preserving focus restoration for nested menus.

A browser regression test verifies that menu activators retain `aria-controls` and no longer receive `aria-owns`.

Validation:

- `pnpm --filter vuetify test:browser src/components/VMenu/__tests__/VMenu.spec.browser.tsx --run` — 17 passed
- Targeted ESLint for the three changed files — passed
- `pnpm --filter vuetify exec tsgo -p tsconfig.checks.json --noEmit --pretty` — passed

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-menu>
        <template #activator="{ props }">
          <v-btn v-bind="props">Open menu</v-btn>
        </template>

        <v-list>
          <v-list-item title="Click me" />
        </v-list>
      </v-menu>
    </v-container>
  </v-app>
</template>
```
