### PR TITLE
fix(VBtn): set explicit tabindex=0 to restore keyboard focus on Safari

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -228,7 +228,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
           ]}
           aria-busy={ props.loading ? true : undefined }
           disabled={ (isDisabled.value && Tag !== 'a') || undefined }
-          tabindex={ props.loading || props.readonly ? -1 : undefined }
+          tabindex={ props.loading || props.readonly ? -1 : 0 }
           onClick={ onClick }
           value={ valueAttr.value }
         >


### PR DESCRIPTION
## Description

Fixes #21905

Safari requires an explicit `tabindex` attribute on `<button>` elements to include them in sequential keyboard navigation. Without it, toolbar buttons (VBtn rendered inside VToolbar) are skipped when tabbing, making the toolbar inaccessible via keyboard on Safari.

## Root Cause

The VBtn component sets `tabindex` to `undefined` when the button is not loading or readonly. For `<button>` elements, this means the `tabindex` attribute is not rendered in the DOM. While Chrome and Firefox correctly handle this by defaulting to `tabindex="0"`, Safari requires the explicit attribute to include the button in the tab order.

## Fix

Changed `tabindex={ props.loading || props.readonly ? -1 : undefined }` to `tabindex={ props.loading || props.readonly ? -1 : 0 }`.

This is a safe change — for `<button>` elements, `tabindex="0"` is the default behavior. Making it explicit only fixes the Safari edge case without changing behavior on other browsers.

## Testing

- ✅ Icon buttons inside VToolbar (append/prepend/default slots) are keyboard-focusable on Safari
- ✅ Loading buttons still have `tabindex="-1"` (not focusable)
- ✅ Readonly buttons still have `tabindex="-1"` (not focusable)
- ✅ Disabled buttons still have `disabled` attribute (not focusable regardless of tabindex)
- ✅ Non-interactive non-button elements (VCard, VChip) unchanged