### PR TITLE
feat(VCardTitle): add truncate prop to allow title text wrapping

### DIFF
--- a/packages/vuetify/src/components/VCard/VCard.sass
+++ b/packages/vuetify/src/components/VCard/VCard.sass
@@ -127,6 +127,17 @@
 
     @include card-line-height-densities($card-title-densities)
 
+    &--truncate
+      overflow: $card-title-overflow
+      text-overflow: $card-title-text-overflow
+      white-space: $card-title-white-space
+
+    &--wrap
+      overflow: visible
+      text-overflow: clip
+      white-space: normal
+      word-break: break-word
+
     .v-card-item &
       padding: $card-title-header-padding
 

--- a/packages/vuetify/src/components/VCard/VCardTitle.ts
+++ b/packages/vuetify/src/components/VCard/VCardTitle.ts
@@ -1,6 +1,0 @@
-// Utilities
-import { createSimpleFunctional } from '@/util'
-
-export const VCardTitle = createSimpleFunctional('v-card-title')
-
-export type VCardTitle = InstanceType<typeof VCardTitle>

--- a/packages/vuetify/src/components/VCard/VCardTitle.tsx
+++ b/packages/vuetify/src/components/VCard/VCardTitle.tsx
@@ -1,0 +1,46 @@
+// Composables
+import { makeComponentProps } from '@/composables/component'
+import { makeTagProps } from '@/composables/tag'
+
+// Utilities
+import { genericComponent, propsFactory, useRender } from '@/util'
+
+export const makeVCardTitleProps = propsFactory({
+  truncate: {
+    type: Boolean,
+    default: true,
+  },
+
+  ...makeComponentProps(),
+  ...makeTagProps({ tag: 'div' }),
+}, 'VCardTitle')
+
+export type VCardTitle = InstanceType<typeof VCardTitle>
+
+export const VCardTitle = genericComponent()({
+  name: 'VCardTitle',
+
+  props: makeVCardTitleProps(),
+
+  setup (props, { slots }) {
+    useRender(() => {
+      return (
+        <props.tag
+          class={[
+            'v-card-title',
+            {
+              'v-card-title--truncate': props.truncate,
+              'v-card-title--wrap': !props.truncate,
+            },
+            props.class,
+          ]}
+          style={ props.style }
+        >
+          { slots.default?.() }
+        </props.tag>
+      )
+    })
+
+    return {}
+  },
+})


### PR DESCRIPTION
## Description

`VCardTitle` currently uses `white-space: nowrap` by default, causing long titles to be truncated with ellipsis instead of wrapping to multiple lines. This does not match expected card behavior for long titles.

## Changes

- Converted `VCardTitle` from `createSimpleFunctional` to a full component with a `truncate` prop
- Added `.v-card-title--truncate` and `.v-card-title--wrap` CSS modifier classes
- `truncate` prop defaults to `true` (preserving current behavior - **non-breaking**)
- Users can set `:truncate="false"` to allow wrapping

## Test Plan

- [x] TypeScript check passes (`tsgo --noEmit`)
- [x] Backward compatible - default behavior unchanged
- [ ] Manual: verify with VCardTitle containing long text

Closes #19966