### PR TITLE
fix(VSelect): match autofill against item values

### DIFF
--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -337,7 +337,8 @@ export const VAutocomplete = genericComponent<new <
 
     function onChange (e: Event) {
       if (matchesSelector(vTextFieldRef.value, ':autofill') || matchesSelector(vTextFieldRef.value, ':-webkit-autofill')) {
-        const item = items.value.find(item => item.title === (e.target as HTMLInputElement).value)
+        const value = (e.target as HTMLInputElement).value
+        const item = items.value.find(item => item.title === value || item.value === value)
         if (item) {
           select(item)
         }

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -46,6 +46,25 @@ const stories = Object.fromEntries(Object.entries({
 )]))
 
 describe('VAutocomplete', () => {
+  it('should match autofilled text against item values', async () => {
+    const model = ref()
+
+    render(() => (
+      <VAutocomplete
+        v-model={ model.value }
+        items={[{ title: 'California', value: 'CA' }]}
+      />
+    ))
+
+    const input = screen.getByCSS('input')
+    vi.spyOn(input, 'matches').mockImplementation(selector => selector === ':autofill')
+
+    await userEvent.fill(input, 'CA')
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expect(model.value).toBe('CA')
+  })
+
   it('should clear focused state after interacting with content and moving to sibling field', async () => {
     const menuA = ref(false)
     const menuB = ref(false)

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -448,7 +448,7 @@ export const VSelect = genericComponent<new <
     function onModelUpdate (v: any) {
       if (v == null) model.value = []
       else if (matchesSelector(vTextFieldRef.value, ':autofill') || matchesSelector(vTextFieldRef.value, ':-webkit-autofill')) {
-        const item = items.value.find(item => item.title === v)
+        const item = items.value.find(item => item.title === v || item.value === v)
         if (item) {
           select(item)
         }

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -48,6 +48,24 @@ const stories = Object.fromEntries(Object.entries({
 )]))
 
 describe('VSelect', () => {
+  it('should match autofilled text against item values', async () => {
+    const model = ref()
+
+    render(() => (
+      <VSelect
+        v-model={ model.value }
+        items={[{ title: 'California', value: 'CA' }]}
+      />
+    ))
+
+    const input = screen.getByCSS('input')
+    vi.spyOn(input, 'matches').mockImplementation(selector => selector === ':autofill')
+
+    await userEvent.fill(input, 'CA')
+
+    expect(model.value).toBe('CA')
+  })
+
   it('should toggle menu with dropdown icon', async () => {
     const { element } = render(() => (
       <VSelect items={['Item #1', 'Item #2']} />


### PR DESCRIPTION
## Description

Fixes #20560.

Browser address autofill commonly writes short state or country codes such as `CA` or `US`. VSelect and VAutocomplete previously compared autofilled text only with each item's title, so those values were ignored when the visible labels were `California` or `United States`.

This keeps the existing title matching behavior and also checks the item value in the autofill-only paths. Focused browser tests cover both components.

Verification:

- `pnpm --filter vuetify test:browser --run src/components/VSelect/__tests__/VSelect.spec.browser.tsx src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx` (90 passed)
- `pnpm --filter vuetify lint`
- `git diff --check`

## Markup:

```vue
<script setup>
const states = [
  { title: 'California', value: 'CA' },
  { title: 'New York', value: 'NY' },
]

const countries = [
  { title: 'United States', value: 'US' },
  { title: 'Canada', value: 'CA' },
]
</script>

<template>
  <v-container>
    <v-form autocomplete="on">
      <v-text-field
        autocomplete="name"
        label="Name"
        name="name"
      />

      <v-select
        autocomplete="address-level1"
        :items="states"
        label="State"
        name="state"
      />

      <v-autocomplete
        autocomplete="country"
        :items="countries"
        label="Country"
        name="country"
      />
    </v-form>
  </v-container>
</template>
```
