### PR TITLE
fix(VProgressLinear): use independent opacity instead of --v-border-opacity

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/_variables.scss
+++ b/packages/vuetify/src/components/VProgressLinear/_variables.scss
@@ -4,7 +4,7 @@
 // VProgressLinear
 $progress-linear-background: currentColor !default;
 $progress-linear-background-background: $progress-linear-background !default;
-$progress-linear-background-opacity: var(--v-border-opacity) !default;
+$progress-linear-background-opacity: .12 !default;
 $progress-linear-border-radius: map.get(settings.$rounded, 'pill') !default;
 $progress-linear-stream-opacity: 0.3 !default;
 $progress-linear-stripe-background-size: 40px 40px !default;


### PR DESCRIPTION
## Description

The `--v-border-opacity` CSS variable is a global theme variable that controls border opacity across the entire application. Using it for VProgressLinear's background opacity means that changing `border-opacity` via utility classes or theme settings unexpectedly affects the progress bar's background appearance.

## Reproduction

1. Create a VProgressLinear component
2. Set `class="border-opacity-100"` on any ancestor element
3. Observe that the progress bar's background becomes fully opaque

## Fix

Replace `var(--v-border-opacity)` with a hardcoded `.12` opacity value (same as the default `--v-border-opacity` value) so the progress linear background is independent of the border opacity system.

## Related Issues

Fixes #23045