### PR TITLE
fix(Touch directive): prevent memory leak when parent: true and element is detached

### DIFF
--- a/packages/vuetify/src/directives/touch/index.ts
+++ b/packages/vuetify/src/directives/touch/index.ts
@@ -116,7 +116,7 @@ function createHandlers (value: TouchHandlers = {}): TouchStoredHandlers {
 
 function mounted (el: HTMLElement, binding: TouchDirectiveBinding) {
   const value = binding.value
-  const target = value?.parent ? el.parentElement : el
+  const target = (value?.parent ? el.parentElement : el)!
   const options = value?.options ?? { passive: true }
   const uid = binding.instance?.$.uid // TODO: use custom uid generator
 
@@ -130,10 +130,18 @@ function mounted (el: HTMLElement, binding: TouchDirectiveBinding) {
   keys(handlers).forEach(eventName => {
     target.addEventListener(eventName, handlers[eventName], options)
   })
+
+  // Store references for cleanup in unmounted — element may be
+  // detached from the DOM by then (e.g. when parent: true), making
+  // el.parentElement unreachable.
+  el._touchTarget = target
+  el._touchOptions = options
 }
 
 function unmounted (el: HTMLElement, binding: TouchDirectiveBinding) {
-  const target = binding.value?.parent ? el.parentElement : el
+  // Use the stored target reference so cleanup works even when the
+  // element is no longer attached to the DOM (parent: true case).
+  const target = el._touchTarget ?? (binding.value?.parent ? el.parentElement : el)
   const uid = binding.instance?.$.uid
 
   if (!target?._touchHandlers || uid === undefined) return
@@ -143,8 +151,10 @@ function unmounted (el: HTMLElement, binding: TouchDirectiveBinding) {
   // guard against double teardown: e.g. router & suspence racing
   if (!handlers) return
 
+  const options = el._touchOptions ?? binding.value?.options
+
   keys(handlers).forEach(eventName => {
-    target.removeEventListener(eventName, handlers[eventName])
+    target.removeEventListener(eventName, handlers[eventName], options)
   })
 
   delete target._touchHandlers[uid]
@@ -153,6 +163,9 @@ function unmounted (el: HTMLElement, binding: TouchDirectiveBinding) {
     // only relevant if we keep `parent: boolean`
     delete target._touchHandlers
   }
+
+  delete el._touchTarget
+  delete el._touchOptions
 }
 
 export const Touch = {

--- a/packages/vuetify/src/globals.d.ts
+++ b/packages/vuetify/src/globals.d.ts
@@ -49,6 +49,8 @@ declare global {
     _touchHandlers?: {
       [_uid: number]: TouchStoredHandlers
     }
+    _touchTarget?: HTMLElement | null
+    _touchOptions?: AddEventListenerOptions
     _transitionInitialStyles?: {
       position: string
       top: string


### PR DESCRIPTION
## Description

When the `Touch` directive is used with `parent: true`, the `unmounted` hook attempts to find the target via `el.parentElement`. However, by the time `unmounted` fires, the element may already be detached from the DOM, making `parentElement` `null`. This causes the cleanup of event listeners and `_touchHandlers` to be skipped entirely, leaking memory.

## Root Cause

In `packages/vuetify/src/directives/touch/index.ts`, the `unmounted` function re-derives the target element from the DOM:

```typescript
const target = binding.value?.parent ? el.parentElement : el
```

When `parent: true` and the element is detached (e.g. inside a `v-if`/router transition), `el.parentElement` returns `null`, so no cleanup runs.

## Fix

1. **Store the target reference** on the directive element during `mounted` so it's available in `unmounted` regardless of DOM attachment state.
2. **Store the `addEventListener` options** alongside the target and pass them to `removeEventListener` for correct matching when custom options (e.g. `capture: true`) are used.
3. **Clean up** the stored references in `unmounted`.

## Changes

- `packages/vuetify/src/directives/touch/index.ts` — store target + options in `mounted`, use stored values in `unmounted`
- `packages/vuetify/src/globals.d.ts` — add `_touchTarget` and `_touchOptions` to the `HTMLElement` interface

Closes #21887