### PR TITLE
fix(VVirtualScroll): preserve measured heights when items change to prevent scroll jump

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -291,9 +291,26 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
     })
   })
 
-  watch(items, () => {
-    sizes = Array.from({ length: items.value.length })
-    offsets = Array.from({ length: items.value.length })
+  watch(items, (newItems, oldItems) => {
+    const newLength = newItems?.length ?? 0
+    const oldLength = oldItems?.length ?? 0
+    const oldSizes = sizes.slice()
+
+    sizes = Array.from({ length: newLength })
+    offsets = Array.from({ length: newLength })
+
+    // Preserve existing height measurements for items that remain
+    // at the same index, so scroll position doesn't jump when items
+    // are added or removed from the list.
+    if (oldLength > 0 && newLength > 0) {
+      const minLength = Math.min(oldLength, newLength)
+      for (let i = 0; i < minLength; i++) {
+        if (oldSizes[i]) {
+          sizes[i] = oldSizes[i]
+        }
+      }
+    }
+
     updateOffsets.immediate()
     calculateVisibleItems()
   }, { deep: 1 })


### PR DESCRIPTION
## Description

When the `items` array changes (e.g. an item is removed via `splice`), the `VVirtualScroll` component completely resets its `sizes` and `offsets` arrays. This causes all previously measured heights to be lost, and offsets are recalculated using the default 16px estimate — which is far from actual measured heights — causing a visible scroll position jump.

## Root Cause

In `packages/vuetify/src/composables/virtual.ts`, the `watch(items, ...)` handler:

```typescript
watch(items, () => {
    sizes = Array.from({ length: items.value.length })  // All null!
    offsets = Array.from({ length: items.value.length }) // All 0!
    updateOffsets.immediate()
    calculateVisibleItems()
}, { deep: 1 })
```

Every item change discards all measured heights, forcing `getSize()` to fall back to the default `itemHeight` (16px). If actual items are 50px tall, `offsets[500]` drops from 25000 to 8000, causing `paddingTop` and the scroll position to jump.

## Fix

Preserve existing height measurements for items that remain at the same index after the items array changes:

```typescript
watch(items, (newItems, oldItems) => {
    const oldSizes = sizes.slice()
    sizes = Array.from({ length: newLength })
    offsets = Array.from({ length: newLength })

    // Preserve existing height measurements for items that remain
    // at the same index
    const minLength = Math.min(oldLength, newLength)
    for (let i = 0; i < minLength; i++) {
      if (oldSizes[i]) {
        sizes[i] = oldSizes[i]
      }
    }

    updateOffsets.immediate()
    calculateVisibleItems()
}, { deep: 1 })
```

This keeps offsets largely accurate when items are added or removed, preventing the scroll position from jumping.

Closes #22610