### PR TITLE
fix(VList): properly trigger reactivity when updating disabled state

### DIFF
--- a/packages/vuetify/src/composables/nested/nested.ts
+++ b/packages/vuetify/src/composables/nested/nested.ts
@@ -383,17 +383,13 @@ export const useNested = (
         itemsUpdatePropagation()
       },
       updateDisabled: (id, isDisabled) => {
+        const newDisabled = new Set(disabled.value)
         if (isDisabled) {
-          disabled.value.add(id)
+          newDisabled.add(id)
         } else {
-          disabled.value.delete(id)
+          newDisabled.delete(id)
         }
-        // classic selection requires refresh to re-evaluate on/off/indeterminate but
-        // currently it is only run for selection interactions, so it will set new disabled
-        // to "off" and the visual state becomes out of sync
-        // -- selected.value = new Map(selected.value)
-        // it is not clear if the framework should un-select when disabled changed to true
-        // more discussion is needed
+        disabled.value = newDisabled
       },
       open: (id, value, event) => {
         vm.emit('click:open', { id, value, path: getPath(id), event })


### PR DESCRIPTION
## Description

When using the classic select strategy, list items that are initially disabled are added to the `disabled` Set. When later re-enabled via `updateDisabled()`, the item was removed from the Set using `Set.delete()`, but since `disabled` is a `shallowRef`, mutating the Set in place does not trigger Vue's reactivity system. This means any component or select strategy relying on the `disabled` set doesn't see the change, and the item remains non-interactive.

## Root Cause

In `packages/vuetify/src/composables/nested/nested.ts`, the `updateDisabled` function:

```typescript
updateDisabled: (id, isDisabled) => {
    if (isDisabled) {
      disabled.value.add(id)  // Mutates the Set in place — no reactivity trigger
    } else {
      disabled.value.delete(id)  // Same issue
    }
}
```

`disabled` is a `shallowRef(new Set())`. Using `.add()`/`.delete()` on the Set mutates it in place, but `shallowRef` only triggers when the reference (`disabled.value`) changes, not when the internal state of the Set changes.

## Fix

Create a new Set on every update, so the `shallowRef` reference changes and triggers reactivity:

```typescript
updateDisabled: (id, isDisabled) => {
    const newDisabled = new Set(disabled.value)
    if (isDisabled) newDisabled.add(id)
    else newDisabled.delete(id)
    disabled.value = newDisabled  // New reference → triggers reactivity
}
```

Closes #21883