### PR TITLE
fix(VForm): focus first invalid field on submit error for screen reader support

### DIFF
--- a/packages/vuetify/src/components/VForm/VForm.tsx
+++ b/packages/vuetify/src/components/VForm/VForm.tsx
@@ -43,6 +43,21 @@ export const VForm = genericComponent<VFormSlots>()({
     const form = createForm(props)
     const formRef = ref<HTMLFormElement>()
 
+    function focusFirstError (id: number | string) {
+      const field = form.items.value.find(item => item.id === id)
+      if (!field?.vm?.vnode?.el) return
+
+      const el = field.vm.vnode.el as HTMLElement
+      const input = el.querySelector?.(
+        'input, textarea, [tabindex]:not([tabindex="-1"]):not([disabled])'
+      )
+      if (input) {
+        (input as HTMLElement).focus()
+      } else {
+        el.focus()
+      }
+    }
+
     function onReset (e: Event) {
       e.preventDefault()
       form.reset()
@@ -59,9 +74,12 @@ export const VForm = genericComponent<VFormSlots>()({
       emit('submit', e)
 
       if (!e.defaultPrevented) {
-        ready.then(({ valid }) => {
+        ready.then(({ valid, errors }) => {
           if (valid) {
             formRef.value?.submit()
+          } else if (errors.length > 0) {
+            // Focus the first invalid field so screen readers announce the error
+            focusFirstError(errors[0].id)
           }
         })
       }


### PR DESCRIPTION
## Description

When a form is submitted with invalid fields, screen readers do not announce the error messages because the focus does not change to the invalid fields. This is a significant accessibility issue — users relying on assistive technology are not notified that validation has failed.

## Fix

After form validation fails, set focus to the first invalid field's input element. This triggers the screen reader to announce the field's error message, providing immediate feedback to the user.

### Changes

In `packages/vuetify/src/components/VForm/VForm.tsx`:

1. Added a new `focusFirstError` function that:
   - Finds the first invalid field by its ID
   - Gets its DOM element via the component instance (`vm.vnode.el`)
   - Focuses the first focusable input element inside it (input, textarea, or tabbable element)
   - Falls back to focusing the component's root element if no input is found

2. Called `focusFirstError` in the `onSubmit` handler after validation fails but before the default submit is prevented.

### Accessibility impact

With this fix, when a user submits a form with invalid fields:
- The first invalid field receives focus
- Screen readers (VoiceOver, NVDA, JAWS) announce the field's error message
- Keyboard focus is moved to the error, allowing the user to correct it immediately

Closes #21920