### PR TITLE
fix(VField): correct outline label position for tile variant

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -400,6 +400,11 @@
           #{selector.append('[class*=" rounded-"]', &)}
             flex-basis: calc(var(--v-input-control-height) / 2 + 2px)
 
+        @at-root
+          #{selector.append('.rounded-0', &)},
+          #{selector.append('[class*=" rounded-0"]', &)}
+            flex-basis: $field-control-affixed-padding
+
         @at-root #{selector.append('.v-field--reverse', &)}
           border-start-start-radius: 0
           border-start-end-radius: inherit


### PR DESCRIPTION
## Description

Fixes #22269

The `[class^="rounded-"]` CSS selector was also matching the `rounded-0` class (applied by the `tile` prop), which caused the outline `__start` element to get a wider `flex-basis` intended for rounded corners.

## Root Cause

In `VField.sass`, the outline `__start` element has these rules:

1. Default: `flex: 0 0 $field-control-affixed-padding` (12px)
2. Override for rounded: `flex-basis: calc(var(--v-input-control-height) / 2 + 2px)` (≈30px)

The override selector `[class^="rounded-"]` matches `rounded-0` (tile), causing the `__start` to be 30px wide when it should be 12px. This shifts the notch and label to the right.

## Fix

Added an explicit override for `.rounded-0` to restore the correct `$field-control-affixed-padding` (12px) `flex-basis`, so the label properly aligns with the outline border on tiled fields.

## Reproduction

```vue
<template>
  <v-app>
    <v-container>
      <v-text-field
        model-value="Hi!"
        label="Label"
        variant="outlined"
        hide-details
        tile
      />
      <v-text-field
        model-value="Hi!"
        label="Label"
        variant="outlined"
        hide-details
      />
    </v-container>
  </v-app>
</template>
```

The first field (tiled) has the label slightly misaligned (too far right). After the fix, both fields have correctly aligned labels.