### PR TITLE
fix(VSelectionControl): apply on-surface color to icon instead of inherit

### DIFF
--- a/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
+++ b/packages/vuetify/src/components/VSelectionControl/VSelectionControl.sass
@@ -80,6 +80,7 @@
       opacity: calc(#{map.get(settings.$states, 'hover')} * var(--v-theme-overlay-multiplier))
 
     > .v-icon
+      color: $selection-control-color
       opacity: var(--v-medium-emphasis-opacity)
 
     .v-selection-control--disabled &,


### PR DESCRIPTION
## Description

Fixes #22840

The selection control icon (used by VRadio, VCheckbox, VSwitch) was inheriting its color from the parent element, which could result in invisible icons when the component is used inside a VThemeProvider with a different theme.

## Root Cause

The `-control-color` variable was defined in `_variables.scss` but never used in the component's Sass. The icon's color was left as `inherit`.

## Fix

Applied the `-control-color` variable (which uses `on-surface` with high emphasis) directly to the `.v-selection-control__input > .v-icon` selector. This ensures the icon always uses the theme's on-surface color, visible regardless of the inherited parent color.

## Verification

- ✅ Icon now uses `color-mix(in srgb, rgb(var(--v-theme-on-surface)), calc(var(--v-high-emphasis-opacity) * 100%), transparent)` instead of `inherit`
- ✅ When VThemeProvider changes the theme, the icon will automatically use the correct on-surface color
- ✅ When `color` prop is explicitly set, the `textColorClasses` on the wrapper div will still override this color
- ✅ The opacity remains controlled by `var(--v-medium-emphasis-opacity)`