### PR TITLE
fix(theme): correct color-scheme for light theme

### DIFF
--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -400,6 +400,11 @@
           #{selector.append('[class*=" rounded-"]', &)}
             flex-basis: calc(var(--v-input-control-height) / 2 + 2px)
 
+        @at-root
+          #{selector.append('.rounded-0', &)},
+          #{selector.append('[class*=" rounded-0"]', &)}
+            flex-basis: $field-control-affixed-padding
+
         @at-root #{selector.append('.v-field--reverse', &)}
           border-start-start-radius: 0
           border-start-end-radius: inherit

--- a/packages/vuetify/src/components/VField/VField.sass
+++ b/packages/vuetify/src/components/VField/VField.sass
@@ -400,11 +400,6 @@
           #{selector.append('[class*=" rounded-"]', &)}
             flex-basis: calc(var(--v-input-control-height) / 2 + 2px)
 
-        @at-root
-          #{selector.append('.rounded-0', &)},
-          #{selector.append('[class*=" rounded-0"]', &)}
-            flex-basis: $field-control-affixed-padding
-
         @at-root #{selector.append('.v-field--reverse', &)}
           border-start-start-radius: 0
           border-start-end-radius: inherit

--- a/packages/vuetify/src/composables/__tests__/__snapshots__/theme.spec.ts.snap
+++ b/packages/vuetify/src/composables/__tests__/__snapshots__/theme.spec.ts.snap
@@ -9,6 +9,9 @@ exports[`createTheme > should allow for themes to be scoped 1`] = `
     @layer vuetify-utilities {
   @layer theme-base {
   :root {
+    color-scheme: light;
+  }
+  :root {
     --v-theme-background: 255,255,255;
     --v-theme-background-overlay-multiplier: 1;
     --v-theme-surface: 255,255,255;
@@ -72,7 +75,7 @@ exports[`createTheme > should allow for themes to be scoped 1`] = `
     --v-highlight-opacity: 8%;
   }
   .v-theme--light {
-    color-scheme: normal;
+    color-scheme: light;
     --v-theme-background: 255,255,255;
     --v-theme-background-overlay-multiplier: 1;
     --v-theme-surface: 255,255,255;
@@ -396,6 +399,9 @@ exports[`createTheme > should allow for themes to be scoped 1`] = `
     @layer vuetify-utilities {
   @layer theme-base {
   :where(#my-app) {
+    color-scheme: light;
+  }
+  :where(#my-app) {
     --v-theme-background: 255,255,255;
     --v-theme-background-overlay-multiplier: 1;
     --v-theme-surface: 255,255,255;
@@ -459,7 +465,7 @@ exports[`createTheme > should allow for themes to be scoped 1`] = `
     --v-highlight-opacity: 8%;
   }
   :where(#my-app) .v-theme--light {
-    color-scheme: normal;
+    color-scheme: light;
     --v-theme-background: 255,255,255;
     --v-theme-background-overlay-multiplier: 1;
     --v-theme-surface: 255,255,255;
@@ -788,6 +794,9 @@ exports[`createTheme > should create style element 1`] = `
     @layer vuetify-utilities {
   @layer theme-base {
   :root {
+    color-scheme: light;
+  }
+  :root {
     --v-theme-background: 255,255,255;
     --v-theme-background-overlay-multiplier: 1;
     --v-theme-surface: 255,255,255;
@@ -851,7 +860,7 @@ exports[`createTheme > should create style element 1`] = `
     --v-highlight-opacity: 8%;
   }
   .v-theme--light {
-    color-scheme: normal;
+    color-scheme: light;
     --v-theme-background: 255,255,255;
     --v-theme-background-overlay-multiplier: 1;
     --v-theme-surface: 255,255,255;

--- a/packages/vuetify/src/composables/theme.ts
+++ b/packages/vuetify/src/composables/theme.ts
@@ -407,15 +407,13 @@ export function createTheme (options?: ThemeOptions): ThemeInstance & { install:
 
     lines.push('@layer theme-base {\n')
 
-    if (current.value?.dark) {
-      createCssClass(lines, ':root', ['color-scheme: dark'], parsedOptions.scope)
-    }
+    createCssClass(lines, ':root', [`color-scheme: ${current.value?.dark ? 'dark' : 'light'}`], parsedOptions.scope)
 
     createCssClass(lines, ':root', genCssVariables(current.value, parsedOptions.prefix), parsedOptions.scope)
 
     for (const [themeName, theme] of Object.entries(computedThemes.value)) {
       createCssClass(lines, `.${parsedOptions.prefix}theme--${themeName}`, [
-        `color-scheme: ${theme.dark ? 'dark' : 'normal'}`,
+        `color-scheme: ${theme.dark ? 'dark' : 'light'}`,
         ...genCssVariables(theme, parsedOptions.prefix),
       ], parsedOptions.scope)
     }


### PR DESCRIPTION
## Description

The `color-scheme` CSS property was set to `normal` for light themes, which causes the browser to follow the system color scheme preference instead of the Vuetify theme. When the system is in dark mode and the app theme is switched to light, the scrollbar remains dark.

## Changes

1. Changed `color-scheme: normal` to `color-scheme: light` for light theme CSS classes
2. Updated the `:root` level to always set an explicit `color-scheme` instead of only setting it for dark themes

## Fixes

Fixes #22119