### PR TITLE
fix(VVirtualScroll): preserve height measurements when items array changes

### DIFF
--- a/packages/vuetify/src/composables/virtual.ts
+++ b/packages/vuetify/src/composables/virtual.ts
@@ -291,9 +291,25 @@ export function useVirtual <T> (props: VirtualProps, items: Ref<readonly T[]>) {
     })
   })
 
-  watch(items, () => {
-    sizes = Array.from({ length: items.value.length })
-    offsets = Array.from({ length: items.value.length })
+  watch(items, (newItems, oldItems) => {
+    const newLength = newItems?.length ?? 0
+    const oldLength = oldItems?.length ?? 0
+    const oldSizes = sizes.slice()
+
+    sizes = Array.from({ length: newLength })
+    offsets = Array.from({ length: newLength })
+
+    // Preserve existing height measurements for items at the same index
+    // so scroll position doesn't jump when items array is reassigned
+    if (oldLength > 0 && newLength > 0) {
+      const minLength = Math.min(oldLength, newLength)
+      for (let i = 0; i < minLength; i++) {
+        if (oldSizes[i]) {
+          sizes[i] = oldSizes[i]
+        }
+      }
+    }
+
     updateOffsets.immediate()
     calculateVisibleItems()
   }, { deep: 1 })


### PR DESCRIPTION
## Description

When using `v-virtual-scroll` with `item-height="null"` (dynamic height), the `sizes` array was completely reset whenever the `items` array was reassigned, causing all previously measured heights to be lost. This caused the scroll position to jump unexpectedly when:

1. Expanding/collapsing rows in a subgrid
2. Updating data that causes the items array to be reassigned
3. Any change that triggers items reactivity

## Root Cause

In `packages/vuetify/src/composables/virtual.ts`, the `watch(items, ...)` handler at line 294 was resetting both `sizes` and `offsets` arrays to empty arrays of the new length, discarding all previously measured heights.

## Fix

Instead of creating empty arrays, the fix preserves existing height measurements for items at the same index:

- Save the old `sizes` array before resetting
- After creating new arrays of the correct length, restore heights for items at matching indices
- Items at new indices (beyond the old length) remain unmeasured (will use estimated heights)
- Items at removed indices (beyond the new length) are simply dropped

This way, scroll position remains stable when the items array changes but contains similar items.

## Related Issue

Fixes #22590