### PR TITLE
fix(VMenu): custom overlays and tooltips should not prevent closing

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -190,7 +190,6 @@ export const VMenu = genericComponent<OverlaySlots>()({
           v-model={ isActive.value }
           absolute
           activatorProps={ activatorProps.value }
-          _disableLocalTop
           location={ props.location ?? (props.submenu ? 'end' : 'bottom') }
           onClick:outside={ onClickOutside }
           onKeydown={ onKeydown }

--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -190,6 +190,7 @@ export const VMenu = genericComponent<OverlaySlots>()({
           v-model={ isActive.value }
           absolute
           activatorProps={ activatorProps.value }
+          _disableLocalTop
           location={ props.location ?? (props.submenu ? 'end' : 'bottom') }
           onClick:outside={ onClickOutside }
           onKeydown={ onKeydown }

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -6,6 +6,7 @@ import { VList, VListItem, VListItemTitle } from '@/components/VList'
 import { VSheet } from '@/components/VSheet'
 import { VTextarea } from '@/components/VTextarea'
 import { VTextField } from '@/components/VTextField'
+import { VTooltip } from '@/components/VTooltip'
 
 // Utilities
 import { commands, render, screen, userEvent, wait } from '@test'
@@ -538,6 +539,62 @@ describe('VMenu', () => {
       // Top menu stays open, the previously open branch collapses.
       expect(screen.queryByTestId('l1-1')).toBeVisible()
       expect(screen.queryByTestId('l3-1')).toBeNull()
+    })
+
+    // A non-menu overlay child (tooltip, plain overlay) doesn't participate in the
+    // menu close cascade, so an outside click used to leave the menu open.
+    it('should close the menu on outside click while a tooltip child is open', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="opener">
+            Open
+            <VMenu activator="parent" closeOnContentClick={ false }>
+              <VSheet class="pa-4" data-testid="menu-content">
+                <VBtn data-testid="tip-btn">
+                  Tip
+                  <VTooltip activator="parent" openOnHover={ false } openOnClick>Tooltip</VTooltip>
+                </VBtn>
+                <VBtn data-testid="other">Other</VBtn>
+              </VSheet>
+            </VMenu>
+          </VBtn>
+          <div data-testid="outside" style="position: fixed; bottom: 0; right: 0; width: 120px; height: 120px;">out</div>
+        </div>
+      ))
+
+      await userEvent.click(screen.getByTestId('opener'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeVisible()
+      await userEvent.click(screen.getByTestId('tip-btn'))
+      await expect.poll(() => screen.queryByText('Tooltip')).toBeVisible()
+
+      await userEvent.click(screen.getByTestId('outside'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeNull()
+    })
+
+    it('should keep the menu open when clicking inside it while a tooltip child is open', async () => {
+      render(() => (
+        <VBtn data-testid="opener">
+          Open
+          <VMenu activator="parent" closeOnContentClick={ false }>
+            <VSheet class="pa-4" data-testid="menu-content">
+              <VBtn data-testid="tip-btn">
+                Tip
+                <VTooltip activator="parent" openOnHover={ false } openOnClick>Tooltip</VTooltip>
+              </VBtn>
+              <VBtn data-testid="other">Other</VBtn>
+            </VSheet>
+          </VMenu>
+        </VBtn>
+      ))
+
+      await userEvent.click(screen.getByTestId('opener'))
+      await expect.poll(() => screen.queryByTestId('menu-content')).toBeVisible()
+      await userEvent.click(screen.getByTestId('tip-btn'))
+      await expect.poll(() => screen.queryByText('Tooltip')).toBeVisible()
+
+      await userEvent.click(screen.getByTestId('other'))
+      await wait(300)
+      expect(screen.queryByTestId('menu-content')).toBeVisible()
     })
   })
 })

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -130,7 +130,6 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
   props: {
     _disableGlobalStack: Boolean,
-    _disableLocalTop: Boolean,
 
     ...omit(makeVOverlayProps(), ['disableInitialFocus']),
   },
@@ -217,7 +216,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional (e: Event) {
-      return isActive.value && (props._disableLocalTop || localTop.value) && (
+      return isActive.value && localTop.value && (
         // If using scrim, only close if clicking on it rather than anything opened on top
         !props.scrim || e.target === scrimEl.value || (e instanceof MouseEvent && e.shadowTarget === scrimEl.value)
       )

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -1,6 +1,9 @@
 // Styles
 import './VOverlay.sass'
 
+// Components
+import { VMenuSymbol } from '@/components/VMenu/shared'
+
 // Composables
 import { getStaticLocationClasses, makeLocationStrategyProps, useLocationStrategies } from './locationStrategies'
 import { makeScrollStrategyProps, useScrollStrategies } from './scrollStrategies'
@@ -27,6 +30,7 @@ import vClickOutside from '@/directives/click-outside'
 // Utilities
 import {
   computed,
+  inject,
   mergeProps,
   onBeforeUnmount,
   ref,
@@ -200,11 +204,16 @@ export const VOverlay = genericComponent<OverlaySlots>()({
       updateLocation,
     })
 
+    const menuParent = inject(VMenuSymbol, null)
+    const isMenu = vm.parent?.type?.name === 'VMenu'
+
     function onClickOutside (e: MouseEvent) {
       emit('click:outside', e)
 
       if (!props.persistent) isActive.value = false
       else animateClick()
+
+      if (!isMenu) menuParent?.closeParents(e)
     }
 
     function closeConditional (e: Event) {

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -126,6 +126,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
   props: {
     _disableGlobalStack: Boolean,
+    _disableLocalTop: Boolean,
 
     ...omit(makeVOverlayProps(), ['disableInitialFocus']),
   },
@@ -207,7 +208,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
     }
 
     function closeConditional (e: Event) {
-      return isActive.value && localTop.value && (
+      return isActive.value && (props._disableLocalTop || localTop.value) && (
         // If using scrim, only close if clicking on it rather than anything opened on top
         !props.scrim || e.target === scrimEl.value || (e instanceof MouseEvent && e.shadowTarget === scrimEl.value)
       )


### PR DESCRIPTION
## Description

Fixes #22425

When a VOverlay or VTooltip is placed inside a VMenu's content, clicking outside the menu (or on the inner overlay) fails to close the menu. The inner overlay registers as a stack child of the VMenu's overlay, causing the VMenu's `localTop`-based `closeConditional` to prevent closing.

## Root Cause

The VMenu uses VOverlay internally, which tracks a stack of active children via `useStack`. When a plain VOverlay or VTooltip is active inside the VMenu, the VMenu's overlay is not the local top, so its click-outside handler refuses to close — even though the click is outside all overlays.

## Fix

When a non-menu VOverlay (or VTooltip) detects a click outside, it now also calls the parent VMenu's `closeParents` method, ensuring the VMenu closes properly.

## Testing

- Added browser test: clicking outside closes the menu while a tooltip child is open
- Added browser test: clicking inside the menu keeps it open while a tooltip child is open

Co-authored-by: J-Sek <J-Sek@users.noreply.github.com>