### PR TITLE
fix(VMessages): prevent overlapping validation messages during rapid input

### DIFF
--- a/packages/vuetify/src/components/VMessages/VMessages.tsx
+++ b/packages/vuetify/src/components/VMessages/VMessages.tsx
@@ -37,6 +37,7 @@ export const makeVMessagesProps = propsFactory({
     transition: {
       component: VSlideYTransition as Component,
       leaveAbsolute: true,
+      hideOnLeave: true,
       group: true,
     },
   }),


### PR DESCRIPTION
## Description

Fixes #22165

When validation messages change rapidly during user input (e.g., repeatedly adding/deleting characters), the old and new messages visually overlap because the leaving message animates out (0.3s slide-y transition) while the new message simultaneously animates in.

## Root Cause

VMessages uses `VSlideYTransition` with `leaveAbsolute: true` and `group: true`. When messages change, the old message still takes 0.3s to animate out while the new message enters. During this window, both messages are visible, causing a visual overlap.

## Fix

Added `hideOnLeave: true` to the VMessages transition config. This immediately hides the leaving message with `display: none` when it starts transitioning out, preventing the visual overlap. The entering message still animates in with the slide-y transition.

## Testing

- [ ] Open a VTextField with validation rules
- [ ] Type "invalid" to trigger validation errors
- [ ] Rapidly add/delete characters
- [ ] Error messages should not overlap