### PR TITLE
fix(VWindow): prevent swipe navigation when scrolling a child element

### DIFF
--- a/packages/vuetify/src/components/VWindow/VWindow.tsx
+++ b/packages/vuetify/src/components/VWindow/VWindow.tsx
@@ -239,18 +239,47 @@ export const VWindow = genericComponent<new <T>(
       return arrows
     })
 
+    const touchScrollableParent = shallowRef<HTMLElement | null>(null)
+    const touchScrollLeft = shallowRef(0)
+    const touchScrollTop = shallowRef(0)
+
     const touchOptions = computed(() => {
       if (props.touch === false) return props.touch
 
       const options: TouchHandlers = {
         left: () => {
+          // Skip window navigation if a scrollable child was scrolled horizontally
+          if (touchScrollableParent.value && props.direction === 'horizontal') {
+            const delta = Math.abs(touchScrollableParent.value.scrollLeft - touchScrollLeft.value)
+            if (delta > 0) return
+          }
           isRtlReverse.value ? prev() : next()
         },
         right: () => {
+          // Skip window navigation if a scrollable child was scrolled horizontally
+          if (touchScrollableParent.value && props.direction === 'horizontal') {
+            const delta = Math.abs(touchScrollableParent.value.scrollLeft - touchScrollLeft.value)
+            if (delta > 0) return
+          }
           isRtlReverse.value ? next() : prev()
         },
         start: ({ originalEvent }) => {
           originalEvent.stopPropagation()
+
+          // Check if the touch target is inside a scrollable child element
+          if (IN_BROWSER) {
+            const target = originalEvent.target as HTMLElement | null
+            if (target) {
+              const scrollable = getScrollParent(target, false)
+              if (scrollable && scrollable !== document.scrollingElement) {
+                touchScrollableParent.value = scrollable
+                touchScrollLeft.value = scrollable.scrollLeft
+                touchScrollTop.value = scrollable.scrollTop
+              } else {
+                touchScrollableParent.value = null
+              }
+            }
+          }
         },
       }
 


### PR DESCRIPTION
## Description

When a VWindow contains a horizontally scrollable child element (such as a VBtnToggle or VSlideGroup), swiping to scroll the child also triggers the VWindow's swipe gesture, causing an unintended window navigation.

### Reproduction

1. Create a VWindow with a VBtnToggle inside (or any horizontally scrollable element)
2. On mobile, swipe horizontally on the scrollable child
3. The VWindow navigates to the next/previous item instead of scrolling the child

### Fix

This fix detects whether the touch gesture started inside a scrollable child element. If the child element was scrolled during the gesture, the VWindow swipe is suppressed, allowing the child to handle the scroll naturally.

### References

- Fixes #21888
- Related: #18447 (previous VWindow scroll fix)

## Testing

- On desktop: VWindow navigation via arrows and swipe still works as expected
- On mobile: scrolling a horizontally scrollable child inside a VWindow no longer triggers window navigation
- The fix only applies when the touch target is inside a scrollable element that actually scrolls