### PR TITLE
fix(VTextField): remove redundant aria-labelledby from input

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -249,7 +249,6 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                         type={ props.type }
                         onFocus={ focus }
                         onBlur={ blur }
-                        aria-labelledby={ `${id.value}-label` }
                         { ...slotProps }
                         { ...inputAttrs }
                       />


### PR DESCRIPTION
## Description

Fixes #21914

The input element had an `aria-labelledby` attribute referencing the main label by id. When the field is active, the main label has `aria-hidden="true"` while the floating label already provides the accessible name via the native `<label for>` association.

This dual association caused screen readers, especially Safari VoiceOver, to read the label text multiple times — up to 5× for a single text field.

## Root Cause

In `VField.tsx`, two label elements are rendered:
1. **Floating label** (visible when active) — has `for={id}` 
2. **Main label** (visible when inactive) — has `id={id}-label`

The `aria-labelledby=\{id}-label\` on the input always references the main label. When the field is active, the main label is `aria-hidden="true"`, making the `aria-labelledby` reference redundant — the native `<label for>` association already provides the correct accessible name.

## Fix

Removed the `aria-labelledby` attribute from the `<input>` element in `VTextField.tsx`. The native `<label for>` association on the label that is currently visible (floating when active, main when inactive) handles the accessible name correctly.

## Testing

- ✅ Vuetify build passes
- ✅ All 9 VTextField unit tests pass
- ✅ No visual changes