### PR TITLE
fix(VChip): prevent slide group scroll when clicking chip close button

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -360,6 +360,7 @@ export const VChip = genericComponent<VChipSlots>()({
               key="close"
               class="v-chip__close"
               type="button"
+              data-no-activator=""
               data-testid="close-chip"
               { ...closeProps.value }
             >

--- a/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
+++ b/packages/vuetify/src/components/VSlideGroup/VSlideGroup.tsx
@@ -223,6 +223,14 @@ export const VSlideGroup = genericComponent<new <T>(
 
       if (!isOverflowing.value || !contentRef.el) return
 
+      // Skip scroll if the focused element is inside a "no-activator" element
+      // (e.g. chip close button, button content, etc.)
+      let target = e.target as HTMLElement | null
+      while (target && target !== contentRef.el) {
+        if (target.hasAttribute('data-no-activator')) return
+        target = target.parentElement
+      }
+
       // Focused element is likely to be the root of an item, so a
       // breadth-first search will probably find it in the first iteration
       for (const el of e.composedPath()) {


### PR DESCRIPTION
## Description

When a closable chip inside a VSlideGroup overflows (doesn't fully fit in the visible area), clicking the close button causes the slide group to scroll to the chip instead of closing it.

### Root Cause

The close button's click triggers a `focusin` event on the slide group, which scrolls to the focused chip element via the `onFocusin` handler. This scroll happens before the click handler can close the chip.

### Fix

1. **VChip**: Added `data-no-activator` attribute to the close button, consistent with other Vuetify components (VBtn, VListItem, VField, etc.)
2. **VSlideGroup**: Modified `onFocusin` to check if the focused element (or any ancestor up to the content container) has `data-no-activator`, and skip the scroll-to logic if so

### Test Plan

1. Create a VSlideGroup with max-width and closable VChips with long text
2. Click the close button on a chip that overflows
3. Verify the chip closes instead of the slide group scrolling

Fixes #21806