### PR TITLE
fix(VToolbar): parse string height/extensionHeight values

### DIFF
--- a/packages/vuetify/src/components/VToolbar/VToolbar.tsx
+++ b/packages/vuetify/src/components/VToolbar/VToolbar.tsx
@@ -94,15 +94,15 @@ export const VToolbar = genericComponent<VToolbarSlots>()({
 
     const isExtended = shallowRef(props.extended === null ? !!(slots.extension?.()) : props.extended)
     const contentHeight = computed(() => parseInt((
-      Number(props.height) +
-      (props.density === 'prominent' ? Number(props.height) : 0) -
+      parseFloat(props.height as any) +
+      (props.density === 'prominent' ? parseFloat(props.height as any) : 0) -
       (props.density === 'comfortable' ? 8 : 0) -
       (props.density === 'compact' ? 16 : 0)
     ), 10))
     const extensionHeight = computed(() => isExtended.value
       ? parseInt((
-        Number(props.extensionHeight) +
-        (props.density === 'prominent' ? Number(props.extensionHeight) : 0) -
+        parseFloat(props.extensionHeight as any) +
+        (props.density === 'prominent' ? parseFloat(props.extensionHeight as any) : 0) -
         (props.density === 'comfortable' ? 4 : 0) -
         (props.density === 'compact' ? 8 : 0)
       ), 10)


### PR DESCRIPTION
## Description

When using string values like `100px` for the `height` or `extensionHeight` props, `Number()` returns `NaN` which causes incorrect layout calculations, hiding the top of the navigation drawer content under the AppBar extension.

`parseFloat` correctly extracts the numeric portion from strings with units (`parseFloat('100px') === 100`), while `Number('100px')` returns `NaN`.

## Reproduction

```vue
<v-app-bar :extension-height=100px>
  <template #extension> Extension </template>
</v-app-bar>
```

## Fix

Replace `Number(props.height)` and `Number(props.extensionHeight)` with `parseFloat(props.height as any)` and `parseFloat(props.extensionHeight as any)` in the VToolbar component.

Fixes #22007