### PR TITLE
fix(VOverlay): use clientWidth when visualViewport is zoomed

### DIFF
--- a/packages/vuetify/src/util/box.ts
+++ b/packages/vuetify/src/util/box.ts
@@ -70,11 +70,16 @@ export function getElementBox (el: HTMLElement) {
       })
     } else {
       const pageScale = document.body.currentCSSZoom ?? 1
+      const isZoomed = visualViewport.scale > 1 || IS_WEBKIT
       return new Box({
-        x: visualViewport.scale > 1 || IS_WEBKIT ? 0 : visualViewport.offsetLeft,
-        y: visualViewport.scale > 1 || IS_WEBKIT ? 0 : visualViewport.offsetTop,
-        width: visualViewport.width * visualViewport.scale / pageScale,
-        height: visualViewport.height * visualViewport.scale / pageScale,
+        x: isZoomed ? 0 : visualViewport.offsetLeft,
+        y: isZoomed ? 0 : visualViewport.offsetTop,
+        width: isZoomed
+          ? document.documentElement.clientWidth
+          : visualViewport.width * visualViewport.scale / pageScale,
+        height: isZoomed
+          ? document.documentElement.clientHeight
+          : visualViewport.height * visualViewport.scale / pageScale,
       })
     }
   } else {


### PR DESCRIPTION
Fixes #22124

## Problem
When using VOverlay on Android Chrome in desktop view mode with pinch zoom, the `getElementBox` function for `document.documentElement` could produce incorrect layout viewport dimensions. The `visualViewport.width * visualViewport.scale` calculation was unreliable for determining the actual layout viewport size when zoomed, causing the overlay to be positioned incorrectly and triggering unnecessary overflow recalculations.

## Root Cause
The `getElementBox` function in `packages/vuetify/src/util/box.ts` used `visualViewport.width * visualViewport.scale / pageScale` for the viewport dimensions regardless of whether the page was zoomed. When `visualViewport.scale > 1` (pinch zoomed) or on WebKit browsers, the calculation could produce values that didn't match the actual layout viewport, making the overlay appear too small and in the wrong position.

## Fix
When `visualViewport.scale > 1` or `IS_WEBKIT` is true, use `document.documentElement.clientWidth` and `clientHeight` directly instead of the visualViewport-derived calculation. These properties always return the correct layout viewport dimensions regardless of zoom level or browser type.