### PR TITLE
fix(VOverlay): cache aria-owns lookups

### DIFF
--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -467,6 +467,59 @@ describe('VMenu', () => {
       await expect.poll(() => screen.queryByTestId('l1')).toBeNull()
     })
 
+    it('does not query aria-owns once for every mounted overlay on mousedown', async () => {
+      render(() => (
+        <div>
+          <VBtn data-testid="opener">
+            Open
+            <VMenu activator="parent" closeOnContentClick={ false }>
+              <VList>
+                <VListItem link>Item</VListItem>
+              </VList>
+            </VMenu>
+          </VBtn>
+          <div data-testid="outside" style="position: fixed; bottom: 0; right: 0; width: 120px; height: 120px;">out</div>
+        </div>
+      ))
+
+      const fixtures: Element[] = []
+      for (let i = 0; i < 8; i++) {
+        const owner = document.createElement('button')
+        const overlay = document.createElement('div')
+        const content = document.createElement('div')
+
+        overlay.id = `stale-overlay-${i}`
+        overlay.className = 'v-overlay'
+        content.className = 'v-overlay__content'
+        owner.setAttribute('aria-owns', overlay.id)
+        overlay.append(content)
+        document.body.append(owner, overlay)
+        fixtures.push(owner, overlay)
+      }
+
+      const querySelector = vi.spyOn(document, 'querySelector')
+
+      try {
+        await userEvent.click(screen.getByTestId('opener'))
+        await expect.poll(() => screen.queryByText('Item')).toBeVisible()
+
+        const outside = screen.getByTestId('outside')
+        outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+        outside.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+        outside.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+        const ariaOwnsQueries = querySelector.mock.calls.filter(call => {
+          const selector = call[0]
+          return typeof selector === 'string' && selector.startsWith('[aria-owns~=')
+        })
+
+        expect(ariaOwnsQueries).toHaveLength(0)
+      } finally {
+        querySelector.mockRestore()
+        for (const fixture of fixtures) fixture.remove()
+      }
+    })
+
     it('should close the parent menu when clicking outside an autocomplete child', async () => {
       render(() => (
         <div>

--- a/packages/vuetify/src/components/VOverlay/VOverlay.tsx
+++ b/packages/vuetify/src/components/VOverlay/VOverlay.tsx
@@ -217,7 +217,21 @@ export const VOverlay = genericComponent<OverlaySlots>()({
 
     let openedWithActivatorFocus = false
 
-    function ownsFocus (activeElement: Element | null): boolean {
+    function getAriaOwners (): Map<string, Element> {
+      const owners = new Map<string, Element>()
+
+      for (const el of document.querySelectorAll('[aria-owns]')) {
+        const ids = el.getAttribute('aria-owns')?.trim().split(/\s+/) ?? []
+
+        for (const id of ids) {
+          if (id) owners.set(id, el)
+        }
+      }
+
+      return owners
+    }
+
+    function ownsFocus (activeElement: Element | null, ariaOwners?: Map<string, Element>): boolean {
       let current = activeElement
       const visited = new Set<Element>()
       while (current) {
@@ -226,7 +240,7 @@ export const VOverlay = genericComponent<OverlaySlots>()({
         if (el === contentEl.value) return true
         visited.add(el)
         const ownerId = el.closest('.v-overlay')?.id
-        current = ownerId ? document.querySelector(`[aria-owns~="${CSS.escape(ownerId)}"]`) : null
+        current = ownerId ? ariaOwners?.get(ownerId) ?? document.querySelector(`[aria-owns~="${CSS.escape(ownerId)}"]`) : null
       }
       return false
     }
@@ -410,11 +424,13 @@ export const VOverlay = genericComponent<OverlaySlots>()({
                     closeConditional,
                     include: () => {
                       if (!isActive.value) return []
+                      const ariaOwners = getAriaOwners()
+
                       return [
                         activatorEl.value,
                         // Submenu clicks count as "inside"; clicks in ancestor overlays (e.g. a host dialog) don't.
                         ...Array.from(document.querySelectorAll('.v-overlay__content'))
-                          .filter(ownsFocus) as HTMLElement[],
+                          .filter(el => ownsFocus(el, ariaOwners)) as HTMLElement[],
                       ]
                     },
                   }}


### PR DESCRIPTION
## Description
Fixes #23056

`VOverlay` now builds the `aria-owns` lookup table once while collecting click-outside include elements, instead of running a document-wide selector for each mounted overlay content node on every mousedown. This keeps submenu/activator ownership behavior intact while avoiding the repeated selector work reported in the issue.

Added browser coverage that mounts unrelated overlay owners and asserts the outside mousedown path does not issue per-overlay `[aria-owns~=...]` queries.

## Markup:

```vue
N/A — covered by VMenu browser regression test.
```
