### PR TITLE
fix(VFileUpload): avoid empty fragment breaking SSR

### DIFF
--- a/packages/vuetify/src/components/VFileUpload/VFileUploadList.tsx
+++ b/packages/vuetify/src/components/VFileUpload/VFileUploadList.tsx
@@ -5,7 +5,7 @@ import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvi
 import { makeVListProps, VList } from '@/components/VList/VList'
 
 // Utilities
-import { inject } from 'vue'
+import { Fragment, h, inject } from 'vue'
 import { getFileKey } from './fileKey'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
@@ -49,7 +49,8 @@ export const VFileUploadList = genericComponent<VFileUploadListSlots>()({
       const readonly = context?.readonly.value ?? false
       const listProps = VList.filterProps(props)
 
-      if (!slots.default && !files.length) return (<></>)
+      // `<></>` compiles to a fragment with null children, which SSR can't render
+      if (!slots.default && !files.length) return h(Fragment, [])
 
       return (
         <VList

--- a/packages/vuetify/src/components/VFileUpload/__tests__/VFileUploadList.spec.tsx
+++ b/packages/vuetify/src/components/VFileUpload/__tests__/VFileUploadList.spec.tsx
@@ -1,0 +1,25 @@
+// Components
+import { VFileUploadList } from '../VFileUploadList'
+
+// Utilities
+import { renderToString } from '@vue/server-renderer'
+import { createSSRApp } from 'vue'
+import { createVuetify } from '@/framework'
+
+describe('VFileUploadList', () => {
+  it('should render on the server without any files', async () => {
+    const app = createSSRApp({ render: () => <VFileUploadList /> })
+
+    app.use(createVuetify())
+
+    await expect(renderToString(app)).resolves.toBe('<!--[--><!--]-->')
+  })
+
+  it('should render on the server with files', async () => {
+    const app = createSSRApp({ render: () => <VFileUploadList files={[new File([''], 'foo.txt')]} /> })
+
+    app.use(createVuetify())
+
+    await expect(renderToString(app)).resolves.toContain('v-file-upload-list')
+  })
+})


### PR DESCRIPTION
## Description

With no files and no default slot, `VFileUploadList` returns `<></>`, which is what a default `v-file-upload` renders before anything has been picked. That JSX shorthand compiles to a fragment vnode with `children: null`. The client renderer falls back to an empty array in that case, but `@vue/server-renderer` hands the null straight to `renderVNodeChildren`, so `renderToString` throws `Cannot read properties of null (reading 'length')` and any SSR page containing the component 500s.

Giving the fragment an empty array of children keeps the same output and lets it render on the server.

`VOtpField` has the same construct, but every index it is rendered with always maps to an existing slot, so server rendering never reaches it. I left that one alone.

fixes #23086

## Markup:

There is nothing to see in the playground since this only happens while server rendering, so I added a unit test that renders the component with `renderToString` instead.
