### PR TITLE
fix(VTable): stripe expanded data table rows with their parent row

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableRows.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRows.tsx
@@ -13,11 +13,11 @@ import { useLocale } from '@/composables/locale'
 import { MaybeTransition } from '@/composables/transition'
 
 // Utilities
-import { Fragment, mergeProps } from 'vue'
+import { cloneVNode, Fragment, isVNode, mergeProps } from 'vue'
 import { genericComponent, getPrefixedEventHandlers, pick, propsFactory, useRender } from '@/util'
 
 // Types
-import type { Component, PropType, TransitionProps } from 'vue'
+import type { Component, PropType, TransitionProps, VNode, VNodeArrayChildren } from 'vue'
 import type { Group, GroupSummary } from './composables/group'
 import type { CellProps, DataTableItem, DataTableLoading, GroupHeaderSlot, GroupSummarySlot, ItemSlot, RowProps } from './types'
 import type { VDataTableGroupHeaderRowSlots } from './VDataTableGroupHeaderRow'
@@ -32,6 +32,17 @@ export type VDataTableRowsSlots<T> = VDataTableGroupHeaderRowSlots & VDataTableR
   'no-data': never
   'expanded-row': ItemSlot<T>
   expanded: ItemSlot<T>
+}
+
+// rows in the expanded-row slot belong to the item above, so striping skips them
+export function expansionNodes (nodes?: VNodeArrayChildren): VNode[] {
+  return (nodes ?? []).flatMap(node =>
+    Array.isArray(node) ? expansionNodes(node)
+    : !isVNode(node) ? []
+    : node.type === Fragment ? expansionNodes(node.children as VNodeArrayChildren)
+    : typeof node.type === 'symbol' ? []
+    : [cloneVNode(node, { class: 'v-data-table__tr--expansion' })]
+  )
 }
 
 export const makeVDataTableRowsProps = propsFactory({
@@ -200,9 +211,9 @@ export const VDataTableRows = genericComponent<new <T>(
                 )}
 
                 { slots['expanded-row']
-                  ? isExpanded(item) && slots['expanded-row'](slotProps)
+                  ? isExpanded(item) && expansionNodes(slots['expanded-row'](slotProps))
                   : slots.expanded && (
-                    <tr class="v-data-table__tr--expanded">
+                    <tr class="v-data-table__tr--expanded v-data-table__tr--expansion">
                       <td colspan={ columns.value.length }>
                         { props.expandTransition
                           ? (

--- a/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableVirtual.tsx
@@ -2,7 +2,7 @@
 import { makeDataTableProps } from './VDataTable'
 import { VDataTableHeaders } from './VDataTableHeaders'
 import { VDataTableRow } from './VDataTableRow'
-import { VDataTableRows } from './VDataTableRows'
+import { expansionNodes, VDataTableRows } from './VDataTableRows'
 import { VTable } from '@/components/VTable'
 import { VVirtualScrollItem } from '@/components/VVirtualScroll/VVirtualScrollItem'
 
@@ -20,11 +20,11 @@ import { MaybeTransition } from '@/composables/transition'
 import { makeVirtualProps, useVirtual } from '@/composables/virtual'
 
 // Utilities
-import { cloneVNode, computed, Fragment, isVNode, nextTick, shallowRef, toRef, toRefs, watch } from 'vue'
+import { cloneVNode, computed, nextTick, shallowRef, toRef, toRefs, watch } from 'vue'
 import { convertToUnit, genericComponent, omit, pickWithRest, propsFactory, useRender } from '@/util'
 
 // Types
-import type { DeepReadonly, VNode, VNodeArrayChildren } from 'vue'
+import type { DeepReadonly } from 'vue'
 import type { VDataTableSlotProps } from './VDataTable'
 import type { VDataTableHeadersSlots } from './VDataTableHeaders'
 import type { VDataTableRowsSlots } from './VDataTableRows'
@@ -66,16 +66,6 @@ export const makeVDataTableVirtualProps = propsFactory({
 }, 'VDataTableVirtual')
 
 type ItemType<T> = T extends readonly (infer U)[] ? U : never
-
-function elementNodes (nodes?: VNodeArrayChildren): VNode[] {
-  return (nodes ?? []).flatMap(node =>
-    Array.isArray(node) ? elementNodes(node)
-    : !isVNode(node) ? []
-    : node.type === Fragment ? elementNodes(node.children as VNodeArrayChildren)
-    : typeof node.type === 'symbol' ? []
-    : [node]
-  )
-}
 
 export const VDataTableVirtual = genericComponent<new <T extends readonly any[], V>(
   props: {
@@ -320,7 +310,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
                             const index = itemSlotProps.internalItem.virtualIndex ?? itemSlotProps.internalItem.index
                             const itemExpanded = isExpanded(itemSlotProps.internalItem)
                             const expandedRows = props.showExpand && itemExpanded && slots['expanded-row']
-                              ? elementNodes(slots['expanded-row'](itemSlot))
+                              ? expansionNodes(slots['expanded-row'](itemSlot))
                               : []
 
                             // rows that stay never resize, so a shrunk slot reports nothing
@@ -366,7 +356,7 @@ export const VDataTableVirtual = genericComponent<new <T extends readonly any[],
                                         onUpdate:height={ height => setExpandedHeight(index, 0, height) }
                                       >
                                         { ({ itemRef }) => (
-                                          <tr class="v-data-table__tr--expanded" ref={ itemRef }>
+                                          <tr class="v-data-table__tr--expanded v-data-table__tr--expansion" ref={ itemRef }>
                                             <td colspan={ columns.value.length }>
                                               { props.expandTransition
                                                 ? (

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
@@ -1,5 +1,6 @@
 // Components
 import { VDataTable } from '../VDataTable'
+import { VDataTableRow } from '../VDataTableRow'
 
 // Utilities
 import { render, screen, showcase, userEvent } from '@test'
@@ -254,6 +255,43 @@ describe('VDataTable', () => {
       .map(row => getComputedStyle(row).backgroundImage !== 'none')
 
     expect(striped).toEqual([true, true, false, false, true, true, false, false])
+  })
+
+  it('should keep rows from the expanded-row slot out of the stripe count', () => {
+    const child = {
+      type: 'item' as const,
+      key: 'child',
+      index: 0,
+      value: 'child',
+      raw: { name: 'Child' },
+      columns: { name: 'Child' },
+      selectable: false,
+    }
+
+    render(() => (
+      <VDataTable
+        items={ DESSERT_ITEMS }
+        headers={ DESSERT_HEADERS }
+        itemsPerPage={ 4 }
+        itemValue="name"
+        expanded={['Frozen Yogurt']}
+        striped="odd"
+      >
+        {{
+          'expanded-row': ({ columns }) => (
+            <>
+              <VDataTableRow item={ child } />
+              <tr><td colspan={ columns.length }>append</td></tr>
+            </>
+          ),
+        }}
+      </VDataTable>
+    ))
+
+    const striped = screen.getAllByCSS('tbody > tr')
+      .map(row => getComputedStyle(row).backgroundImage !== 'none')
+
+    expect(striped).toEqual([true, false, false, false, true, false])
   })
 
   describe('sort', () => {

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
@@ -237,6 +237,25 @@ describe('VDataTable', () => {
     expect(screen.getByCSS('#body-append')).toHaveTextContent(DESSERT_ITEMS.length)
   })
 
+  // https://github.com/vuetifyjs/vuetify/issues/23091
+  it('should stripe expanded rows the same as the row they belong to', () => {
+    render(() => (
+      <VDataTable
+        items={ DESSERT_ITEMS }
+        headers={ DESSERT_HEADERS }
+        itemsPerPage={ 4 }
+        striped="odd"
+      >
+        {{ expanded: () => <div>expanded</div> }}
+      </VDataTable>
+    ))
+
+    const striped = screen.getAllByCSS('tbody > tr')
+      .map(row => getComputedStyle(row).backgroundImage !== 'none')
+
+    expect(striped).toEqual([true, true, false, false, true, true, false, false])
+  })
+
   describe('sort', () => {
     it('should sort by sortBy', async () => {
       render(() => (

--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -3,6 +3,9 @@
 @use './variables' as *
 @use './mixins' as *
 
+// Rows that belong to the item above them; a stripe only extends onto a lone one
+$expansion-row: '.v-data-table__tr--expansion'
+
 @include tools.layer('components')
   // Theme
   .v-table
@@ -71,16 +74,16 @@
       > .v-table__wrapper
         > table
           > tbody
-            > tr:nth-child(even of :not(.v-data-table__tr--expanded)),
-            > tr:nth-child(even of :not(.v-data-table__tr--expanded)) + .v-data-table__tr--expanded
+            > tr:nth-child(even of :not(#{$expansion-row})),
+            > tr:nth-child(even of :not(#{$expansion-row})) + #{$expansion-row}:not(:has(+ #{$expansion-row}))
               background-image: linear-gradient(0deg, $table-stripe-color, $table-stripe-color)
 
     &.v-table--striped-odd
       > .v-table__wrapper
         > table
           > tbody
-            > tr:nth-child(odd of :not(.v-data-table__tr--expanded)),
-            > tr:nth-child(odd of :not(.v-data-table__tr--expanded)) + .v-data-table__tr--expanded
+            > tr:nth-child(odd of :not(#{$expansion-row})),
+            > tr:nth-child(odd of :not(#{$expansion-row})) + #{$expansion-row}:not(:has(+ #{$expansion-row}))
               background-image: linear-gradient(0deg, $table-stripe-color, $table-stripe-color)
 
     &.v-table--fixed-header

--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -71,14 +71,16 @@
       > .v-table__wrapper
         > table
           > tbody
-            > tr:nth-child(even)
+            > tr:nth-child(even of :not(.v-data-table__tr--expanded)),
+            > tr:nth-child(even of :not(.v-data-table__tr--expanded)) + .v-data-table__tr--expanded
               background-image: linear-gradient(0deg, $table-stripe-color, $table-stripe-color)
 
     &.v-table--striped-odd
       > .v-table__wrapper
         > table
           > tbody
-            > tr:nth-child(odd)
+            > tr:nth-child(odd of :not(.v-data-table__tr--expanded)),
+            > tr:nth-child(odd of :not(.v-data-table__tr--expanded)) + .v-data-table__tr--expanded
               background-image: linear-gradient(0deg, $table-stripe-color, $table-stripe-color)
 
     &.v-table--fixed-header


### PR DESCRIPTION
## Description

`VDataTable` renders the `expanded` slot as its own `<tr>` right after the row it belongs to, and that `<tr>` is in the DOM even while the row is collapsed. Striping is done with `tr:nth-child(odd/even)`, so each of those extra rows flips the parity: every main row ends up the same color and every expansion row gets the other one, which reads as no striping at all.

The stripe selectors now count with `nth-child(... of :not(.v-data-table__tr--expanded))` and paint an expansion row the same as the row above it. Plain tables are unaffected, since every row there matches the `:not()`.

fixes #23091

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-data-table
        :headers="headers"
        :items="items"
        striped="odd"
        show-expand
      >
        <template #expanded="{ item }">
          <div class="pa-4">{{ item.name }}</div>
        </template>
      </v-data-table>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        headers: [
          { title: 'Dessert', key: 'name' },
          { title: 'Calories', key: 'calories' },
        ],
        items: [
          { name: 'Frozen Yogurt', calories: 159 },
          { name: 'Ice cream sandwich', calories: 237 },
          { name: 'Eclair', calories: 262 },
          { name: 'Cupcake', calories: 305 },
        ],
      }
    },
  }
</script>
```
