### PR TITLE
fix(VBadge): make wrapper element use tag prop for valid HTML nesting (Fixes #23093)

### DIFF
--- a/packages/vuetify/src/components/VBadge/VBadge.tsx
+++ b/packages/vuetify/src/components/VBadge/VBadge.tsx
@@ -112,7 +112,7 @@ export const VBadge = genericComponent<VBadgeSlots>()({
           { ...attrs }
           style={ props.style }
         >
-          <div class="v-badge__wrapper">
+          <props.tag class="v-badge__wrapper">
             { ctx.slots.default?.() }
 
             <MaybeTransition transition={ props.transition }>
@@ -150,7 +150,7 @@ export const VBadge = genericComponent<VBadgeSlots>()({
                 }
               </span>
             </MaybeTransition>
-          </div>
+          </props.tag>
         </props.tag>
       )
     })

--- a/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.browser.tsx
+++ b/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.browser.tsx
@@ -71,6 +71,13 @@ describe('VBadge', () => {
       const el = wrapper.find('custom-tag').element
       expect(el).toHaveTextContent('tag')
     })
+
+    it('uses the tag for the wrapper element so phrasing content stays valid', () => {
+      const { wrapper } = render(<VBadge tag="span" content="3">child</VBadge>)
+      const root = wrapper.find('span.v-badge').element
+      const wrapperEl = root.querySelector('.v-badge__wrapper')
+      expect(wrapperEl?.tagName).toBe('SPAN')
+    })
   })
 
   showcase({ stories, props, component: VBadge })


### PR DESCRIPTION
## Summary

When `VBadge` is used inside `VBtn` (as shown in the VBadge documentation), the rendered HTML is invalid because `VBadge` hardcodes `<div class="v-badge__wrapper">` inside `VBtn`'s `<span class="v-btn__content">` wrapper. The W3C validator reports:

> Element "div" not allowed as child of element "span" in this context.

## Fix

Make the `v-badge__wrapper` element use the `tag` prop instead of being hardcoded as a `<div>`. When `tag="span"` (or any phrasing-valid tag) is passed, both the root element and the wrapper element produce valid phrasing content.

### Before (invalid HTML)
```html
<span class="v-btn__content">
  <div class="v-badge">
    <div class="v-badge__wrapper">   <!-- INVALID: div inside span -->
```

### After (valid HTML with tag="span")
```html
<span class="v-btn__content">
  <span class="v-badge">
    <span class="v-badge__wrapper">  <!-- VALID: span inside span -->
```

### Backward compatibility
Default `tag="div"` produces identical output to before: `div > div > ...`

Fixes #23093