### PR TITLE
fix(VTable): clip sticky header to container border-radius (Fixes #21394)

### DIFF
--- a/packages/vuetify/src/components/VTable/VTable.sass
+++ b/packages/vuetify/src/components/VTable/VTable.sass
@@ -109,6 +109,7 @@
     max-width: 100%
     display: flex
     flex-direction: column
+    overflow: hidden
 
     > .v-table__wrapper
       > table


### PR DESCRIPTION
## Description

When a table has `border-radius` (e.g. inside a card) and `fixed-header` is enabled, the sticky `thead` header renders with a solid background that covers the container's rounded top corners, breaking the visual border-radius.

### Root cause

The `.v-table__wrapper` has `overflow: auto` and `border-radius: inherit`, but the sticky `thead` inside it is positioned at `top: 0` with `z-index: 2`. The header cells have `background: $table-background` which paints over the wrapper's rounded corners.

### Fix

Added `overflow: hidden` to `.v-table` (the flex container), which clips the sticky header to the table's `border-radius`. This is a standard CSS pattern for rounded corners on scrollable containers with sticky headers.

Fixes #21394