### PR TITLE
fix(VSelect, VAutocomplete, VCombobox): default modelValue to undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ __screenshots__/
 
 # Superpowers specs/plans
 /docs/
+dist

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -76,7 +76,7 @@ export const makeVAutocompleteProps = propsFactory({
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps(),
   ...omit(makeVTextFieldProps({
-    modelValue: null,
+    modelValue: undefined,
     role: 'combobox',
   }), ['validationValue', 'dirty']),
 }, 'VAutocomplete')

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -81,7 +81,7 @@ export const makeVComboboxProps = propsFactory({
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps({ hideNoData: true, returnObject: true }),
   ...omit(makeVTextFieldProps({
-    modelValue: null,
+    modelValue: undefined,
     role: 'combobox',
   }), ['validationValue', 'dirty']),
 }, 'VCombobox')

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -103,7 +103,7 @@ export const makeVSelectProps = propsFactory({
   ...makeFilterProps({ filterKeys: ['title'] }),
   ...makeSelectProps(),
   ...omit(makeVTextFieldProps({
-    modelValue: null,
+    modelValue: undefined,
     role: 'combobox',
   }), ['validationValue', 'dirty']),
   ...makeTransitionProps({ transition: { component: VDialogTransition as Component } }),


### PR DESCRIPTION
## Description

When `VSelect`, `VAutocomplete`, or `VCombobox` is used without explicitly passing `v-model`, the default `modelValue` was `null`. This caused a null-valued option in the items list to be unintentionally pre-selected, because `useProxiedModel` treats `null` as a valid value (not undefined), so it falls back to the default `null` rather than the empty array.

### Root Cause

In all three components, the `modelValue` prop default was set to `null`:

```ts
modelValue: null,
```

`useProxiedModel` checks `props[prop] !== undefined` to decide whether to use the external value or the default. Since `null !== undefined` is `true`, the internal value became `null` instead of the expected empty array `[]`.

### Fix

Changed the default from `null` to `undefined`. When no `v-model` is provided:
- `props.modelValue` is `undefined`
- `useProxiedModel` falls back to the `defaultValue` (empty array `[]`)
- No null-valued option is pre-selected

When `v-model="null"` is explicitly passed, the behavior is unchanged — the option with `value: null` is still correctly selected.

### Related Issues

- #22126 (this issue)
- #16442 (fixed by #16547 — related null handling)
- #16023 (related prop handling)

Fixes #22126