### PR TITLE
fix(VNumberInput): resync display after model is overridden

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -249,7 +249,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       vTextFieldRef.value?.controlRef?.dispatchEvent(new Event('change', { bubbles: true }))
     }
 
-    function toggleUpDown (increment = true) {
+    async function toggleUpDown (increment = true) {
       if (controlsDisabled.value) return
       if (increment ? !canIncrease.value : !canDecrease.value) return
       if (model.value == null) {
@@ -264,6 +264,10 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       } else if (!increment && canDecrease.value) {
         inputText.value = correctPrecision(model.value - props.step, inferredPrecision)
         emitChange()
+      }
+      await nextTick()
+      if (model.value !== toNumber(inputText.value)) {
+        inputText.value = model.value == null ? null : correctPrecision(model.value, inferredPrecision)
       }
     }
 

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -583,4 +583,23 @@ describe('VNumberInput', () => {
       expect(onChange).toHaveBeenCalledTimes(2)
     })
   })
+
+  // https://github.com/vuetifyjs/vuetify/issues/23098
+  it('keeps the display in sync when the emitted value is overridden', async () => {
+    const model = ref(0)
+    render(() => (
+      <VNumberInput
+        modelValue={ model.value }
+        onUpdate:modelValue={ (val: number) => { model.value = Math.max(0, val) } }
+      />
+    ))
+
+    await userEvent.click(screen.getByTestId('decrement'))
+    await expect.element(screen.getByCSS('input')).toHaveValue('0')
+    expect(model.value).toBe(0)
+
+    await userEvent.click(screen.getByTestId('increment'))
+    await expect.element(screen.getByCSS('input')).toHaveValue('1')
+    expect(model.value).toBe(1)
+  })
 })


### PR DESCRIPTION
## Description

The spin buttons set the display text from `model.value + step` and then push that number into the model. When the parent intercepts `update:model-value` and writes back a different value, `model` never changes, so the watcher that refreshes the display never runs and the input keeps showing the rejected number. Stepping the other way then looks like it skips a step.

`toggleUpDown` now compares the model against the text once the update has settled and reformats the text when the two disagree.

Fixes #23098

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-number-input
        :model-value="value"
        @update:model-value="value = Math.max(0, $event)"
      />
      <div>model: {{ value }}</div>
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'

  const value = ref(0)
</script>
```
