### PR TITLE
fix(VSelect): correct focus resolution in Shadow DOM

### DIFF
--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -40,6 +40,7 @@ import {
   deepEqual,
   ensureValidVNode,
   genericComponent,
+  getActiveElement,
   IN_BROWSER,
   matchesSelector,
   omit,
@@ -406,7 +407,7 @@ export const VSelect = genericComponent<new <
       if (!listRef.value || !isFocused.value) return
 
       // VMenu re-dispatches ArrowUp/Down after open and already moved focus to next/prev
-      if (listRef.value.$el?.contains(document.activeElement)) return
+      if (listRef.value.$el?.contains(getActiveElement())) return
 
       const opts: FocusOptions = { focusVisible: false, preventScroll: props.noAutoScroll }
 


### PR DESCRIPTION
## Description

1. hit Tab to focus input
2. arrow ↓ or ↑ to open the options

Before the fix: focus within the list jumps to 102 and 98 (skips over 101 and 99)

Fixes #23101

## Markup:

```vue
<template>
  <v-app :theme="theme.name.value">
    <v-btn
      icon="mdi-theme-light-dark"
      location="top right"
      position="fixed"
      style="z-index: 2000"
      @click="theme.cycle()"
    />
    <v-container>
      <main class="comparison">
        <section>
          <h2 class="text-subtitle-1 mb-2">Shadow DOM</h2>
          <div class="demo-box">
            <vv-select :theme="theme.name.value" />
          </div>
        </section>
        <section>
          <h2 class="text-subtitle-1 mb-2">regular DOM</h2>
          <div class="demo-box">
            <Demo />
          </div>
        </section>
      </main>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { defineComponent, defineCustomElement, h, onMounted } from 'vue'
  import { VSelect } from '@/components/VSelect'
  import { VThemeProvider } from '@/components/VThemeProvider'
  import { useTheme } from '@/composables/theme'
  import vuetify from './vuetify'

  const Demo = defineComponent(() => () => h(VSelect, {
    items: Array.from({ length: 1000 }, (_, i) => i),
    modelValue: 102,
    label: 'initial focus',
  }))

  const theme = useTheme()

  onMounted(() => {
    theme.change('dark')

    const css = Array.from(document.querySelectorAll('style'))
      .map(el => el.textContent ?? '')
      .join('\n')
      .replace(/:root/g, ':host')
      .replace(/\bhtml\b/g, ':host')
      .replace(/\bbody\b/g, ':host')

    if (customElements.get('vv-select')) return

    const shadowApp = defineComponent({
      props: { theme: String },
      setup: props => () => h(VThemeProvider, { theme: props.theme, withBackground: true }, () => h(Demo)),
    })
    customElements.define('vv-select', defineCustomElement(shadowApp, {
      styles: [css],
      configureApp: app => app.use(vuetify),
    }))
  })
</script>

```