### PR TITLE
fix(VChip, VTab): render inner wrappers as phrasing content

### DIFF
--- a/packages/vuetify/src/components/VChip/VChip.tsx
+++ b/packages/vuetify/src/components/VChip/VChip.tsx
@@ -241,7 +241,7 @@ export const VChip = genericComponent<VChipSlots>()({
 
           { hasFilter && (
             <VExpandXTransition key="filter">
-              <div
+              <span
                 class="v-chip__filter"
                 v-show={ group.isSelected.value }
               >
@@ -260,12 +260,12 @@ export const VChip = genericComponent<VChipSlots>()({
                     v-slots:default={ slots.filter }
                   />
                 )}
-              </div>
+              </span>
             </VExpandXTransition>
           )}
 
           { hasPrepend && (
-            <div key="prepend" class="v-chip__prepend">
+            <span key="prepend" class="v-chip__prepend">
               { !slots.prepend ? (
                 <>
                   { props.prependIcon && (
@@ -301,10 +301,10 @@ export const VChip = genericComponent<VChipSlots>()({
                   v-slots:default={ slots.prepend }
                 />
               )}
-            </div>
+            </span>
           )}
 
-          <div class="v-chip__content" data-no-activator="">
+          <span class="v-chip__content" data-no-activator="">
             { slots.default?.({
               isSelected: group?.isSelected.value,
               selectedClass: group?.selectedClass.value,
@@ -313,10 +313,10 @@ export const VChip = genericComponent<VChipSlots>()({
               value: group?.value.value,
               disabled: props.disabled,
             }) ?? toDisplayString(props.text)}
-          </div>
+          </span>
 
           { hasAppend && (
-            <div key="append" class="v-chip__append">
+            <span key="append" class="v-chip__append">
               { !slots.append ? (
                 <>
                   { props.appendIcon && (
@@ -352,7 +352,7 @@ export const VChip = genericComponent<VChipSlots>()({
                   v-slots:default={ slots.append }
                 />
               )}
-            </div>
+            </span>
           )}
 
           { hasClose && (

--- a/packages/vuetify/src/components/VChip/__tests__/VChip.spec.browser.tsx
+++ b/packages/vuetify/src/components/VChip/__tests__/VChip.spec.browser.tsx
@@ -1,5 +1,8 @@
 import { VChip } from '../VChip'
 
+// Components
+import { VChipGroup } from '@/components/VChipGroup'
+
 // Utilities
 import { render, screen, userEvent } from '@test'
 import { nextTick, shallowRef } from 'vue'
@@ -45,5 +48,26 @@ describe('VChip', () => {
     closeLabel.value = undefined
     await nextTick()
     expect(button).toHaveAttribute('aria-label', 'Close')
+  })
+
+  it('should only render phrasing content inside its span root', () => {
+    const { container } = render(() => (
+      <VChipGroup>
+        <VChip
+          appendIcon="$next"
+          filter
+          prependIcon="$prev"
+          text="Chip"
+        />
+      </VChipGroup>
+    ))
+
+    const chip = container.querySelector('.v-chip')!
+
+    expect(chip.tagName).toBe('SPAN')
+    expect(chip.querySelector('.v-chip__filter')).not.toBeNull()
+    expect(chip.querySelector('.v-chip__prepend')).not.toBeNull()
+    expect(chip.querySelector('.v-chip__append')).not.toBeNull()
+    expect(chip.querySelectorAll('div')).toHaveLength(0)
   })
 })

--- a/packages/vuetify/src/components/VTabs/VTab.tsx
+++ b/packages/vuetify/src/components/VTabs/VTab.tsx
@@ -165,7 +165,7 @@ export const VTab = genericComponent<VBtnSlots>()({
                 { slots.default?.() ?? props.text }
 
                 { !props.hideSlider && (
-                  <div
+                  <span
                     ref={ sliderEl }
                     class={[
                       'v-tab__slider',

--- a/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.browser.tsx
@@ -106,5 +106,19 @@ describe('VTabs', () => {
     expect(model.value).toBe('B')
   })
 
+  it('should only render phrasing content inside the button content span', () => {
+    const { container } = render(() => (
+      <VTabs>
+        <VTab value="A">A</VTab>
+      </VTabs>
+    ))
+
+    const content = container.querySelector('.v-tab .v-btn__content')!
+
+    expect(content.tagName).toBe('SPAN')
+    expect(content.querySelector('.v-tab__slider')).not.toBeNull()
+    expect(content.querySelectorAll('div')).toHaveLength(0)
+  })
+
   showcase({ stories })
 })


### PR DESCRIPTION
## Description

fixes #23103

Two components render non-phrasing content inside a `span`, producing the same W3C error:

> Element “div” not allowed as child of element “span” in this context.

**`VChip`** defaults its root `tag` to `span`, so everything it renders inside must be phrasing content. Four wrappers were hardcoded as `div` — `v-chip__filter`, `v-chip__prepend`, `v-chip__content` and `v-chip__append` — so every chip was invalid on its own, anywhere on the page. Unlike the same class of defect on `VBadge` (#23093), there is no `tag` default to debate here, since the root is already a `span`.

All four are now `span`, which is what the sibling `v-chip__overlay` and `v-chip__underlay` wrappers already were.

**`VTab`** renders its underline as a hardcoded `div.v-tab__slider` inside `VBtn`'s default slot, which `VBtn` wraps in a `span.v-btn__content` — so every tab emits a `div` inside a `span` too. It is now a `span`. Repro: https://vtfy.link/vtab-slider-invalid-nesting

**No visual change in either case.** `VChip.sass` declares `display: inline-flex` explicitly on `.v-chip__content` and on the `.v-chip__filter`/`.v-chip__prepend`/`.v-chip__append` group, and `.v-tab__slider` is `position: absolute`, which blockifies the box whatever the tag name. `v-chip__filter` is the only wrapper inside a `VExpandXTransition`; its `display` is declared the same way, and the added test covers it. The chip's close button is untouched — it is a `button` element, already valid phrasing content.

None of these elements is reachable from userland (`tag` only controls the root, and for `VTab` the root of the underlying `VBtn`), so there was no workaround short of patching the package.

Added a test per component: the chip root is a `span` whose subtree contains no `div`, with filter, prepend and append all rendered; and the tab's `v-btn__content` contains the slider and no `div`.

Happy to split this back into two PRs if you'd rather keep them separate.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-chip prepend-icon="mdi-tag" text="Plain chip" />
      <v-chip append-icon="mdi-close" text="With append" />
      <v-chip-group filter>
        <v-chip text="Filterable" />
      </v-chip-group>

      <v-tabs v-model="tab">
        <v-tab value="one" text="One" />
        <v-tab value="two" text="Two" />
      </v-tabs>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        tab: 'one',
      }
    },
  }
</script>
```

Run the rendered page through https://validator.w3.org/nu — one `div`-inside-`span` error per chip and per tab before, none after.
