### PR TITLE
fix(VDivider): stop emitting the implicit separator role on hr

### DIFF
--- a/packages/vuetify/src/components/VDivider/VDivider.tsx
+++ b/packages/vuetify/src/components/VDivider/VDivider.tsx
@@ -74,6 +74,9 @@ export const VDivider = genericComponent()({
     })
 
     useRender(() => {
+      const role = attrs.role as string | undefined
+      const hasSlot = !!slots.default
+
       const divider = (
         <hr
           class={[
@@ -95,15 +98,15 @@ export const VDivider = genericComponent()({
             props.style,
           ]}
           aria-orientation={
-            !attrs.role || attrs.role === 'separator'
+            !hasSlot && !role
               ? props.vertical ? 'vertical' : 'horizontal'
               : undefined
           }
-          role={ attrs.role as string | undefined }
+          role={ !hasSlot ? role : undefined }
         />
       )
 
-      if (!slots.default) return divider
+      if (!hasSlot) return divider
 
       return (
         <div

--- a/packages/vuetify/src/components/VDivider/VDivider.tsx
+++ b/packages/vuetify/src/components/VDivider/VDivider.tsx
@@ -99,7 +99,7 @@ export const VDivider = genericComponent()({
               ? props.vertical ? 'vertical' : 'horizontal'
               : undefined
           }
-          role={ `${attrs.role || 'separator'}` }
+          role={ attrs.role as string | undefined }
         />
       )
 

--- a/packages/vuetify/src/components/VDivider/__tests__/VDivider.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDivider/__tests__/VDivider.spec.browser.tsx
@@ -228,4 +228,31 @@ describe('VDivider', () => {
       }
     })
   })
+
+  describe('role', () => {
+    it('relies on the implicit separator role of hr', () => {
+      render(() => <VDivider />)
+
+      const divider = screen.getByCSS('.v-divider')
+
+      expect(divider.tagName).toBe('HR')
+      expect(divider).not.toHaveAttribute('role')
+      expect(divider).toHaveAttribute('aria-orientation', 'horizontal')
+    })
+
+    it('sets aria-orientation to vertical when vertical', () => {
+      render(() => <VDivider vertical />)
+
+      expect(screen.getByCSS('.v-divider')).toHaveAttribute('aria-orientation', 'vertical')
+    })
+
+    it('honours an explicit role and drops aria-orientation with it', () => {
+      render(() => <VDivider role="presentation" />)
+
+      const divider = screen.getByCSS('.v-divider')
+
+      expect(divider).toHaveAttribute('role', 'presentation')
+      expect(divider).not.toHaveAttribute('aria-orientation')
+    })
+  })
 })


### PR DESCRIPTION
## Description

fixes #23104

`VDivider` always renders an `hr`, and `hr` already maps to the `separator` role in [ARIA in HTML](https://www.w3.org/TR/html-aria/#el-hr), so hardcoding `role="separator"` is redundant. The W3C validator reports it once per divider:

> The “separator” role is unnecessary for element “hr”.

It is a warning rather than an error, so nothing is invalid — but it is noise in every accessibility report, six of them on one page of our own portal.

`role` is now emitted only when the caller supplies one, so the [documented behaviour](https://vuetifyjs.com/en/components/dividers/#accessibility) is unchanged on both halves:

- *"assigned the WAI-ARIA role of separator by default"* — still true, now delivered by the implicit role, with the same computed role in the accessibility tree.
- *"add `role='presentation'` to override"* — still honoured, and still drops `aria-orientation`, which the existing guard already handled.

This was raised in #18229 and closed as *not planned* by the stale bot, on a comment that the separator role is the documented default. It is — and it stays the default here; only the redundant attribute goes away.

Worth noting so the two are not confused: `VDateRangePicker` renders `role="separator"` on a `div`, where it is required and correct. This PR does not touch it. I also checked that nothing in `packages/vuetify/src` or `packages/docs/src` selects on `[role=separator]` or asserts the attribute.

Added tests for the three cases: default (no `role` attribute, `aria-orientation="horizontal"`), `vertical`, and an explicit `role="presentation"` (honoured, `aria-orientation` dropped).

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <p>above</p>
      <v-divider />
      <p>between</p>
      <v-divider role="presentation" />
      <p>below</p>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```

Run the rendered page through https://validator.w3.org/nu — one "unnecessary role" warning per divider before, none after. The second divider keeps `role="presentation"`.
