### PR TITLE
fix(defaults): let user defaults override hardcoded subcomponent props

### DIFF
--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -66,7 +66,7 @@ This is used internally by some components already:
 - `<v-list>` has `bg-color="transparent"` when nested within a `<v-navigation-drawer>`
 - Lists, chip groups, expansion panels, tabs, and forms all use this system to propagate certain props to their children, for example `<v-tabs disabled>` will set the default value of `disabled` to `true` for all `<v-tab>` components inside it.
 
-Where a component styles a child of its own, nested defaults win over the built-in value. This only works through the nested key — ambient `VBtn` or `VChip` defaults leave these children alone:
+Some components include predefined size and/or variant for internal controls they render, to shield them from global and unscoped defaults. Set those through the nested key:
 
 ```js { resource="src/plugins/vuetify.js" }
 createVuetify({
@@ -79,15 +79,16 @@ createVuetify({
     VFileUploadDropzone: { VBtn: { variant: 'outlined' } },
     VFileUploadItem: { VBtn: { variant: 'outlined' } },
     VSpeedDial: { VBtn: { size: 'default' } },
+    VCarousel: { VBtn: { size: 'small' } }, // delimiters
+    VNumberInput: { VBtn: { variant: 'tonal' } }, // increment and decrement
   },
 })
 ```
 
-A few internal buttons are addressed by a role name instead, and take no `VBtn` defaults at all:
+Buttons addressed by a role name are separate — they read that key and ignore `VBtn`:
 
 - `VPaginationBtn` — `<v-pagination>` and the `<v-data-table>` footer
-- `VNumberInputBtn` — `<v-number-input>` increment and decrement
-- `VCarouselBtn` — `<v-carousel>` delimiters
+- `VStepperActionsPrevBtn`, `VStepperActionsNextBtn` — either stepper action button on its own
 
 A prop written directly in the template still wins over any of this.
 

--- a/packages/docs/src/pages/en/features/global-configuration.md
+++ b/packages/docs/src/pages/en/features/global-configuration.md
@@ -66,6 +66,31 @@ This is used internally by some components already:
 - `<v-list>` has `bg-color="transparent"` when nested within a `<v-navigation-drawer>`
 - Lists, chip groups, expansion panels, tabs, and forms all use this system to propagate certain props to their children, for example `<v-tabs disabled>` will set the default value of `disabled` to `true` for all `<v-tab>` components inside it.
 
+Where a component styles a child of its own, nested defaults win over the built-in value. This only works through the nested key — ambient `VBtn` or `VChip` defaults leave these children alone:
+
+```js { resource="src/plugins/vuetify.js" }
+createVuetify({
+  defaults: {
+    VSelect: { VChip: { size: 'large' } }, // also VAutocomplete, VCombobox, VFileInput
+    VStepperActions: { VBtn: { variant: 'outlined' } },
+    VConfirmEdit: { VBtn: { variant: 'outlined' } },
+    VDataTableFooter: { VSelect: { variant: 'solo-filled' } },
+    VDataTableHeaders: { VSelect: { variant: 'solo-filled' } }, // mobile sort
+    VFileUploadDropzone: { VBtn: { variant: 'outlined' } },
+    VFileUploadItem: { VBtn: { variant: 'outlined' } },
+    VSpeedDial: { VBtn: { size: 'default' } },
+  },
+})
+```
+
+A few internal buttons are addressed by a role name instead, and take no `VBtn` defaults at all:
+
+- `VPaginationBtn` — `<v-pagination>` and the `<v-data-table>` footer
+- `VNumberInputBtn` — `<v-number-input>` increment and decrement
+- `VCarouselBtn` — `<v-carousel>` delimiters
+
+A prop written directly in the template still wins over any of this.
+
 [v-defaults-provider](/components/defaults-providers/) can be used to set defaults for components within a specific scope.
 
 ## Defaults for menu and dialog content

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -809,11 +809,10 @@ export const VAutocomplete = genericComponent<new <
                         !slots.chip ? (
                           <VChip
                             key="chip"
-                            size="small"
+                            closable={ closableChips.value }
+                            size={ chipDefaults.value?.size ?? 'small' }
                             text={ item.title }
                             disabled={ item.props.disabled }
-                            { ...chipDefaults.value }
-                            closable={ closableChips.value }
                             { ...slotProps }
                           />
                         ) : (
@@ -821,10 +820,9 @@ export const VAutocomplete = genericComponent<new <
                             key="chip-defaults"
                             defaults={{
                               VChip: {
-                                size: 'small',
-                                text: item.title,
-                                ...chipDefaults.value,
                                 closable: closableChips.value,
+                                size: chipDefaults.value?.size ?? 'small',
+                                text: item.title,
                               },
                             }}
                           >

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -22,6 +22,7 @@ import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
 import { useSelectionMenu } from '../VSelect/useSelectionMenu'
 import { useTextColor } from '@/composables/color'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
 import { useForm } from '@/composables/form'
@@ -179,6 +180,7 @@ export const VAutocomplete = genericComponent<new <
     })
 
     const closableChips = toRef(() => props.closableChips && !form.isReadonly.value && !form.isDisabled.value)
+    const chipDefaults = injectNestedDefaults<VChip['$props']>('VChip')
     const hasChips = computed(() => !!(props.chips || slots.chip))
     const hasSelectionSlot = computed(() => hasChips.value || !!slots.selection)
 
@@ -807,10 +809,11 @@ export const VAutocomplete = genericComponent<new <
                         !slots.chip ? (
                           <VChip
                             key="chip"
-                            closable={ closableChips.value }
                             size="small"
                             text={ item.title }
                             disabled={ item.props.disabled }
+                            { ...chipDefaults.value }
+                            closable={ closableChips.value }
                             { ...slotProps }
                           />
                         ) : (
@@ -818,9 +821,10 @@ export const VAutocomplete = genericComponent<new <
                             key="chip-defaults"
                             defaults={{
                               VChip: {
-                                closable: closableChips.value,
                                 size: 'small',
                                 text: item.title,
+                                ...chipDefaults.value,
+                                closable: closableChips.value,
                               },
                             }}
                           >

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -8,7 +8,7 @@ import { VProgressLinear } from '@/components/VProgressLinear'
 import { makeVWindowProps, VWindow } from '@/components/VWindow/VWindow'
 
 // Composables
-import { injectComponentDefaults } from '@/composables/defaults'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { IconValue } from '@/composables/icons'
 import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
@@ -81,7 +81,7 @@ export const VCarousel = genericComponent<new <T>(
     const model = useProxiedModel(props, 'modelValue')
     const { t } = useLocale()
     const windowRef = ref<VWindow>()
-    const delimiterDefaults = injectComponentDefaults<VBtn['$props']>('VCarouselBtn')
+    const delimiterDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
 
     let slideTimeout = -1
     watch(model, restartTimeout)
@@ -129,12 +129,6 @@ export const VCarousel = genericComponent<new <T>(
 
     useRender(() => {
       const windowProps = VWindow.filterProps(props)
-      const delimiterBtnDefaults = {
-        color: props.color,
-        icon: props.delimiterIcon,
-        size: 'x-small',
-        variant: 'text',
-      }
 
       return (
         <VWindow
@@ -169,8 +163,12 @@ export const VCarousel = genericComponent<new <T>(
                     { group.items.value.length > 0 && (
                       <VDefaultsProvider
                         defaults={{
-                          VBtn: delimiterBtnDefaults,
-                          VCarouselBtn: { ...delimiterBtnDefaults, ...delimiterDefaults.value },
+                          VBtn: {
+                            color: props.color,
+                            icon: props.delimiterIcon,
+                            size: delimiterDefaults.value?.size ?? 'x-small',
+                            variant: delimiterDefaults.value?.variant ?? 'text',
+                          },
                         }}
                         scoped
                       >
@@ -188,7 +186,7 @@ export const VCarousel = genericComponent<new <T>(
 
                           return slots.item
                             ? slots.item({ props, item })
-                            : (<VBtn _as="VCarouselBtn" { ...item } { ...props } />)
+                            : (<VBtn { ...item } { ...props } />)
                         })}
                       </VDefaultsProvider>
                     )}

--- a/packages/vuetify/src/components/VCarousel/VCarousel.tsx
+++ b/packages/vuetify/src/components/VCarousel/VCarousel.tsx
@@ -8,6 +8,7 @@ import { VProgressLinear } from '@/components/VProgressLinear'
 import { makeVWindowProps, VWindow } from '@/components/VWindow/VWindow'
 
 // Composables
+import { injectComponentDefaults } from '@/composables/defaults'
 import { IconValue } from '@/composables/icons'
 import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
@@ -80,6 +81,7 @@ export const VCarousel = genericComponent<new <T>(
     const model = useProxiedModel(props, 'modelValue')
     const { t } = useLocale()
     const windowRef = ref<VWindow>()
+    const delimiterDefaults = injectComponentDefaults<VBtn['$props']>('VCarouselBtn')
 
     let slideTimeout = -1
     watch(model, restartTimeout)
@@ -127,6 +129,12 @@ export const VCarousel = genericComponent<new <T>(
 
     useRender(() => {
       const windowProps = VWindow.filterProps(props)
+      const delimiterBtnDefaults = {
+        color: props.color,
+        icon: props.delimiterIcon,
+        size: 'x-small',
+        variant: 'text',
+      }
 
       return (
         <VWindow
@@ -161,12 +169,8 @@ export const VCarousel = genericComponent<new <T>(
                     { group.items.value.length > 0 && (
                       <VDefaultsProvider
                         defaults={{
-                          VBtn: {
-                            color: props.color,
-                            icon: props.delimiterIcon,
-                            size: 'x-small',
-                            variant: 'text',
-                          },
+                          VBtn: delimiterBtnDefaults,
+                          VCarouselBtn: { ...delimiterBtnDefaults, ...delimiterDefaults.value },
                         }}
                         scoped
                       >
@@ -184,7 +188,7 @@ export const VCarousel = genericComponent<new <T>(
 
                           return slots.item
                             ? slots.item({ props, item })
-                            : (<VBtn { ...item } { ...props } />)
+                            : (<VBtn _as="VCarouselBtn" { ...item } { ...props } />)
                         })}
                       </VDefaultsProvider>
                     )}

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -23,6 +23,7 @@ import { useFocusRepair } from '../VSelect/useFocusRepair'
 import { useScrolling } from '../VSelect/useScrolling'
 import { useSelectionMenu } from '../VSelect/useSelectionMenu'
 import { useTextColor } from '@/composables/color'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useFocusGroups } from '@/composables/focusGroups'
 import { useForm } from '@/composables/form'
@@ -169,6 +170,7 @@ export const VCombobox = genericComponent<new <
     const form = useForm(props)
 
     const closableChips = toRef(() => props.closableChips && !form.isReadonly.value && !form.isDisabled.value)
+    const chipDefaults = injectNestedDefaults<VChip['$props']>('VChip')
     const hasChips = computed(() => !!(props.chips || slots.chip))
     const hasSelectionSlot = computed(() => hasChips.value || !!slots.selection)
 
@@ -881,10 +883,11 @@ export const VCombobox = genericComponent<new <
                         !slots.chip ? (
                           <VChip
                             key="chip"
-                            closable={ closableChips.value }
                             size="small"
                             text={ item.title }
                             disabled={ item.props.disabled }
+                            { ...chipDefaults.value }
+                            closable={ closableChips.value }
                             { ...slotProps }
                           />
                         ) : (
@@ -892,9 +895,10 @@ export const VCombobox = genericComponent<new <
                             key="chip-defaults"
                             defaults={{
                               VChip: {
-                                closable: closableChips.value,
                                 size: 'small',
                                 text: item.title,
+                                ...chipDefaults.value,
+                                closable: closableChips.value,
                               },
                             }}
                           >

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -883,11 +883,10 @@ export const VCombobox = genericComponent<new <
                         !slots.chip ? (
                           <VChip
                             key="chip"
-                            size="small"
+                            closable={ closableChips.value }
+                            size={ chipDefaults.value?.size ?? 'small' }
                             text={ item.title }
                             disabled={ item.props.disabled }
-                            { ...chipDefaults.value }
-                            closable={ closableChips.value }
                             { ...slotProps }
                           />
                         ) : (
@@ -895,10 +894,9 @@ export const VCombobox = genericComponent<new <
                             key="chip-defaults"
                             defaults={{
                               VChip: {
-                                size: 'small',
-                                text: item.title,
-                                ...chipDefaults.value,
                                 closable: closableChips.value,
+                                size: chipDefaults.value?.size ?? 'small',
+                                text: item.title,
                               },
                             }}
                           >

--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -103,20 +103,18 @@ export const VConfirmEdit = genericComponent<new <T> (
       return (
         <>
           <VBtn
-            variant="text"
-            color={ props.color }
-            { ...btnDefaults.value }
             disabled={ isCancelDisabled.value }
+            variant={ btnDefaults.value?.variant ?? 'text' }
+            color={ props.color }
             onClick={ cancel }
             text={ t(props.cancelText) }
             { ...actionsProps }
           />
 
           <VBtn
-            variant="text"
-            color={ props.color }
-            { ...btnDefaults.value }
             disabled={ isSaveDisabled.value }
+            variant={ btnDefaults.value?.variant ?? 'text' }
+            color={ props.color }
             onClick={ save }
             text={ t(props.okText) }
             { ...actionsProps }

--- a/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/VConfirmEdit.tsx
@@ -2,6 +2,7 @@
 import { VBtn } from '@/components/VBtn'
 
 // Composables
+import { injectNestedDefaults } from '@/composables/defaults'
 import { useLocale } from '@/composables/locale'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
@@ -60,6 +61,7 @@ export const VConfirmEdit = genericComponent<new <T> (
   },
 
   setup (props, { emit, slots }) {
+    const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
     const model = useProxiedModel(props, 'modelValue')
     const internalModel = ref()
     watchEffect(() => {
@@ -101,18 +103,20 @@ export const VConfirmEdit = genericComponent<new <T> (
       return (
         <>
           <VBtn
-            disabled={ isCancelDisabled.value }
             variant="text"
             color={ props.color }
+            { ...btnDefaults.value }
+            disabled={ isCancelDisabled.value }
             onClick={ cancel }
             text={ t(props.cancelText) }
             { ...actionsProps }
           />
 
           <VBtn
-            disabled={ isSaveDisabled.value }
             variant="text"
             color={ props.color }
+            { ...btnDefaults.value }
+            disabled={ isSaveDisabled.value }
             onClick={ save }
             text={ t(props.okText) }
             { ...actionsProps }

--- a/packages/vuetify/src/components/VConfirmEdit/__tests__/VConfirmEdit.spec.browser.tsx
+++ b/packages/vuetify/src/components/VConfirmEdit/__tests__/VConfirmEdit.spec.browser.tsx
@@ -1,5 +1,6 @@
 // Components
 import { VConfirmEdit } from '../'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 
 // Utilities
 import { render, screen, userEvent } from '@test'
@@ -46,6 +47,18 @@ describe('VConfirmEdit', () => {
 
     await userEvent.click(screen.getByText('OK'))
     expect(externalModel.value).toEqual(['foo', 'bar'])
+  })
+
+  it('should let VConfirmEdit > VBtn defaults override action variant', () => {
+    render(() => (
+      <VDefaultsProvider defaults={{ VConfirmEdit: { VBtn: { variant: 'tonal' } } }}>
+        <VConfirmEdit />
+      </VDefaultsProvider>
+    ))
+
+    for (const btn of screen.getAllByCSS('.v-btn')) {
+      expect(btn).toHaveClass('v-btn--variant-tonal')
+    }
   })
 
   describe('hides actions if used from the slot', () => {

--- a/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableFooter.tsx
@@ -7,6 +7,7 @@ import { VSelect } from '@/components/VSelect'
 
 // Composables
 import { usePagination } from './composables/paginate'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { IconValue } from '@/composables/icons'
 import { useLocale } from '@/composables/locale'
 
@@ -84,6 +85,7 @@ export const VDataTableFooter = genericComponent<{ prepend: never }>()({
 
   setup (props, { slots }) {
     const { t } = useLocale()
+    const selectDefaults = injectNestedDefaults<VSelect['$props']>('VSelect')
     const { page, pageCount, startIndex, stopIndex, itemsLength, itemsPerPage, setItemsPerPage } = usePagination()
 
     const itemsPerPageOptions = computed(() => (
@@ -120,7 +122,7 @@ export const VDataTableFooter = genericComponent<{ prepend: never }>()({
               modelValue={ itemsPerPage.value }
               onUpdate:modelValue={ v => setItemsPerPage(Number(v)) }
               density="compact"
-              variant="outlined"
+              variant={ selectDefaults.value?.variant ?? 'outlined' }
               aria-label={ t(props.itemsPerPageText) }
               hideDetails
             />

--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -11,6 +11,7 @@ import { useLoadingConfig } from './composables/loading'
 import { useSelection } from './composables/select'
 import { useSort } from './composables/sort'
 import { useBackgroundColor } from '@/composables/color'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { makeDensityProps } from '@/composables/density'
 import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { IconValue } from '@/composables/icons'
@@ -105,6 +106,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
     const { someSelected, allSelected, selectAll, showSelectAll } = useSelection()
     const { columns, headers } = useHeaders()
     const { loaderClasses } = useLoader(props)
+    const selectDefaults = injectNestedDefaults<VSelect['$props']>('VSelect')
 
     function getFixedStyles (column: InternalDataTableHeader, y: number): CSSProperties | undefined {
       if (!(props.sticky || props.fixedHeader) && !column.fixed) return undefined
@@ -301,7 +303,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
             items={ sortableColumns.value }
             label={ t('$vuetify.dataTable.sortBy') }
             multiple={ props.multiSort }
-            variant="underlined"
+            variant={ selectDefaults.value?.variant ?? 'underlined' }
             returnObject
             onClick:clear={ () => sortBy.value = [] }
           >

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
@@ -1,5 +1,6 @@
 // Components
 import { VDataTable } from '../VDataTable'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 
 // Utilities
 import { render, screen, showcase, userEvent } from '@test'
@@ -110,6 +111,24 @@ describe('VDataTable', () => {
     expect(updatePage).toHaveBeenCalledTimes(2)
     expect(updatePage).toHaveBeenNthCalledWith(1, 2)
     expect(updatePage).toHaveBeenNthCalledWith(2, 1)
+  })
+
+  it('should let nested VSelect defaults override variant of sort and items-per-page selects', async () => {
+    render(() => (
+      <VDefaultsProvider defaults={{
+        VDataTableHeaders: { VSelect: { variant: 'solo' } },
+        VDataTableFooter: { VSelect: { variant: 'solo' } },
+      }}
+      >
+        <VDataTable headers={ DESSERT_HEADERS } items={ DESSERT_ITEMS } mobile />
+      </VDefaultsProvider>
+    ))
+
+    const fields = screen.getAllByCSS('.v-select .v-field')
+    expect(fields).toHaveLength(2)
+    for (const field of fields) {
+      expect(field).toHaveClass('v-field--variant-solo')
+    }
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/16999

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -9,6 +9,7 @@ import { makeVFieldProps } from '@/components/VField/VField'
 import { makeVInputProps, VInput } from '@/components/VInput/VInput'
 
 // Composables
+import { injectNestedDefaults } from '@/composables/defaults'
 import { useFileDrop } from '@/composables/fileDrop'
 import { makeFileFilterProps, useFileFilter } from '@/composables/fileFilter'
 import { useFocus } from '@/composables/focus'
@@ -114,6 +115,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
       val => (!props.multiple && Array.isArray(val)) ? val[0] : val,
     )
     const { isFocused, focus, blur } = useFocus(props)
+    const chipDefaults = injectNestedDefaults<VChip['$props']>('VChip')
     const base = computed(() => !isBoolean(props.showSize) ? props.showSize : undefined)
     const totalBytes = computed(() => (model.value ?? []).reduce((bytes, { size = 0 }) => bytes + size, 0))
     const totalBytesReadable = computed(() => humanReadableFileSize(totalBytes.value, base.value))
@@ -381,6 +383,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                                 <VChip
                                   key={ text }
                                   size="small"
+                                  { ...chipDefaults.value }
                                   text={ text }
                                 />
                               ))

--- a/packages/vuetify/src/components/VFileInput/VFileInput.tsx
+++ b/packages/vuetify/src/components/VFileInput/VFileInput.tsx
@@ -382,8 +382,7 @@ export const VFileInput = genericComponent<VFileInputSlots>()({
                               : props.chips ? fileNames.value.map(text => (
                                 <VChip
                                   key={ text }
-                                  size="small"
-                                  { ...chipDefaults.value }
+                                  size={ chipDefaults.value?.size ?? 'small' }
                                   text={ text }
                                 />
                               ))

--- a/packages/vuetify/src/components/VFileUpload/VFileUploadDropzone.tsx
+++ b/packages/vuetify/src/components/VFileUpload/VFileUploadDropzone.tsx
@@ -119,6 +119,9 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
   setup (props, { emit, slots }) {
     const { t } = useLocale()
     const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
+    const insetBrowseVariant = toRef(() => btnDefaults.value?.variant ?? 'text')
+    const browseSize = toRef(() => btnDefaults.value?.size ?? 'large')
+    const browseVariant = toRef(() => btnDefaults.value?.variant ?? 'tonal')
     const { densityClasses } = useDensity(props)
     const { handleDrop, hasFilesOrFolders, isDraggingFiles } = useFileDrop()
     const context = inject(VFileUploadKey, null)
@@ -309,7 +312,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                   <VBtn
                     readonly={ !interactive }
                     text={ t(props.browseText) }
-                    variant={ btnDefaults.value?.variant ?? 'text' }
+                    variant={ insetBrowseVariant.value }
                     onClick={ onClickBrowse }
                   />
                 ) : (
@@ -318,7 +321,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                       VBtn: {
                         readonly: !interactive,
                         text: t(props.browseText),
-                        variant: btnDefaults.value?.variant ?? 'text',
+                        variant: insetBrowseVariant.value,
                       },
                     }}
                   >
@@ -371,9 +374,9 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                       { !slots.browse ? (
                         <VBtn
                           readonly={ !interactive }
-                          size={ btnDefaults.value?.size ?? 'large' }
+                          size={ browseSize.value }
                           text={ t(props.browseText) }
-                          variant={ btnDefaults.value?.variant ?? 'tonal' }
+                          variant={ browseVariant.value }
                           onClick={ onClickBrowse }
                         />
                       ) : (
@@ -381,9 +384,9 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                           defaults={{
                             VBtn: {
                               readonly: !interactive,
-                              size: btnDefaults.value?.size ?? 'large',
+                              size: browseSize.value,
                               text: t(props.browseText),
-                              variant: btnDefaults.value?.variant ?? 'tonal',
+                              variant: browseVariant.value,
                             },
                           }}
                         >

--- a/packages/vuetify/src/components/VFileUpload/VFileUploadDropzone.tsx
+++ b/packages/vuetify/src/components/VFileUpload/VFileUploadDropzone.tsx
@@ -8,6 +8,7 @@ import { VOverlay } from '@/components/VOverlay/VOverlay'
 import { makeVSheetProps, VSheet } from '@/components/VSheet/VSheet'
 
 // Composables
+import { injectNestedDefaults } from '@/composables/defaults'
 import { makeDelayProps } from '@/composables/delay'
 import { makeDensityProps, useDensity } from '@/composables/density'
 import { useFileDrop } from '@/composables/fileDrop'
@@ -117,6 +118,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
 
   setup (props, { emit, slots }) {
     const { t } = useLocale()
+    const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
     const { densityClasses } = useDensity(props)
     const { handleDrop, hasFilesOrFolders, isDraggingFiles } = useFileDrop()
     const context = inject(VFileUploadKey, null)
@@ -308,6 +310,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                     readonly={ !interactive }
                     text={ t(props.browseText) }
                     variant="text"
+                    { ...btnDefaults.value }
                     onClick={ onClickBrowse }
                   />
                 ) : (
@@ -317,6 +320,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                         readonly: !interactive,
                         text: t(props.browseText),
                         variant: 'text',
+                        ...btnDefaults.value,
                       },
                     }}
                   >
@@ -372,6 +376,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                           size="large"
                           text={ t(props.browseText) }
                           variant="tonal"
+                          { ...btnDefaults.value }
                           onClick={ onClickBrowse }
                         />
                       ) : (
@@ -382,6 +387,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                               size: 'large',
                               text: t(props.browseText),
                               variant: 'tonal',
+                              ...btnDefaults.value,
                             },
                           }}
                         >

--- a/packages/vuetify/src/components/VFileUpload/VFileUploadDropzone.tsx
+++ b/packages/vuetify/src/components/VFileUpload/VFileUploadDropzone.tsx
@@ -309,8 +309,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                   <VBtn
                     readonly={ !interactive }
                     text={ t(props.browseText) }
-                    variant="text"
-                    { ...btnDefaults.value }
+                    variant={ btnDefaults.value?.variant ?? 'text' }
                     onClick={ onClickBrowse }
                   />
                 ) : (
@@ -319,8 +318,7 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                       VBtn: {
                         readonly: !interactive,
                         text: t(props.browseText),
-                        variant: 'text',
-                        ...btnDefaults.value,
+                        variant: btnDefaults.value?.variant ?? 'text',
                       },
                     }}
                   >
@@ -373,10 +371,9 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                       { !slots.browse ? (
                         <VBtn
                           readonly={ !interactive }
-                          size="large"
+                          size={ btnDefaults.value?.size ?? 'large' }
                           text={ t(props.browseText) }
-                          variant="tonal"
-                          { ...btnDefaults.value }
+                          variant={ btnDefaults.value?.variant ?? 'tonal' }
                           onClick={ onClickBrowse }
                         />
                       ) : (
@@ -384,10 +381,9 @@ export const VFileUploadDropzone = genericComponent<VFileUploadDropzoneSlots>()(
                           defaults={{
                             VBtn: {
                               readonly: !interactive,
-                              size: 'large',
+                              size: btnDefaults.value?.size ?? 'large',
                               text: t(props.browseText),
-                              variant: 'tonal',
-                              ...btnDefaults.value,
+                              variant: btnDefaults.value?.variant ?? 'tonal',
                             },
                           }}
                         >

--- a/packages/vuetify/src/components/VFileUpload/VFileUploadItem.tsx
+++ b/packages/vuetify/src/components/VFileUpload/VFileUploadItem.tsx
@@ -4,6 +4,9 @@ import { VBtn } from '@/components/VBtn/VBtn'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvider'
 import { makeVListItemProps, VListItem } from '@/components/VList/VListItem'
 
+// Composables
+import { injectNestedDefaults } from '@/composables/defaults'
+
 // Utilities
 import { computed, ref, watchEffect } from 'vue'
 import { genericComponent, humanReadableFileSize, isBoolean, propsFactory, useRender } from '@/util'
@@ -49,6 +52,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
   },
 
   setup (props, { emit, slots }) {
+    const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
     const preview = ref()
     const base = computed(() => !isBoolean(props.showSize) ? props.showSize : undefined)
 
@@ -111,6 +115,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
                         icon="$clear"
                         density="comfortable"
                         variant="text"
+                        { ...btnDefaults.value }
                         onClick={ onClickRemove }
                       />
                     ) : (
@@ -120,6 +125,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
                             icon: '$clear',
                             density: 'comfortable',
                             variant: 'text',
+                            ...btnDefaults.value,
                           },
                         }}
                       >

--- a/packages/vuetify/src/components/VFileUpload/VFileUploadItem.tsx
+++ b/packages/vuetify/src/components/VFileUpload/VFileUploadItem.tsx
@@ -114,8 +114,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
                       <VBtn
                         icon="$clear"
                         density="comfortable"
-                        variant="text"
-                        { ...btnDefaults.value }
+                        variant={ btnDefaults.value?.variant ?? 'text' }
                         onClick={ onClickRemove }
                       />
                     ) : (
@@ -124,8 +123,7 @@ export const VFileUploadItem = genericComponent<VFileUploadItemSlots>()({
                           VBtn: {
                             icon: '$clear',
                             density: 'comfortable',
-                            variant: 'text',
-                            ...btnDefaults.value,
+                            variant: btnDefaults.value?.variant ?? 'text',
                           },
                         }}
                       >

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -11,6 +11,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 import { formatNumber } from './format'
 import { useHold } from './hold'
 import { processGroupedInput, processPlainInput } from './typing'
+import { injectComponentDefaults } from '@/composables/defaults'
 import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useLocale } from '@/composables/locale'
@@ -96,6 +97,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
   setup (props, { slots }) {
     const vTextFieldRef = ref<VTextField>()
+    const controlDefaults = injectComponentDefaults<VBtn['$props']>('VNumberInputBtn')
 
     const { holdStart, holdStop } = useHold({ toggleUpDown })
     const form = useForm(props)
@@ -397,6 +399,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       function incrementControlNode () {
         return !slots.increment ? (
           <VBtn
+            _as="VNumberInputBtn"
             aria-hidden="true"
             data-testid="increment"
             disabled={ !canIncrease.value }
@@ -408,7 +411,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             onPointerup={ onControlMouseup }
             onPointercancel={ onControlMouseup }
             size={ controlNodeSize.value }
-            variant="text"
+            variant={ controlDefaults.value?.variant ?? 'text' }
             tabindex="-1"
           />
         ) : (
@@ -432,6 +435,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       function decrementControlNode () {
         return !slots.decrement ? (
           <VBtn
+            _as="VNumberInputBtn"
             aria-hidden="true"
             data-testid="decrement"
             disabled={ !canDecrease.value }
@@ -443,7 +447,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
             onPointerup={ onControlMouseup }
             onPointercancel={ onControlMouseup }
             size={ controlNodeSize.value }
-            variant="text"
+            variant={ controlDefaults.value?.variant ?? 'text' }
             tabindex="-1"
           />
         ) : (

--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -11,7 +11,7 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 import { formatNumber } from './format'
 import { useHold } from './hold'
 import { processGroupedInput, processPlainInput } from './typing'
-import { injectComponentDefaults } from '@/composables/defaults'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useLocale } from '@/composables/locale'
@@ -97,7 +97,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
 
   setup (props, { slots }) {
     const vTextFieldRef = ref<VTextField>()
-    const controlDefaults = injectComponentDefaults<VBtn['$props']>('VNumberInputBtn')
+    const controlDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
 
     const { holdStart, holdStop } = useHold({ toggleUpDown })
     const form = useForm(props)
@@ -399,7 +399,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       function incrementControlNode () {
         return !slots.increment ? (
           <VBtn
-            _as="VNumberInputBtn"
             aria-hidden="true"
             data-testid="increment"
             disabled={ !canIncrease.value }
@@ -423,7 +422,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
                 height: controlNodeDefaultHeight.value,
                 size: controlNodeSize.value,
                 icon: incrementIcon.value,
-                variant: 'text',
+                variant: controlDefaults.value?.variant ?? 'text',
               },
             }}
           >
@@ -435,7 +434,6 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       function decrementControlNode () {
         return !slots.decrement ? (
           <VBtn
-            _as="VNumberInputBtn"
             aria-hidden="true"
             data-testid="decrement"
             disabled={ !canDecrease.value }
@@ -459,7 +457,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
                 height: controlNodeDefaultHeight.value,
                 size: controlNodeSize.value,
                 icon: decrementIcon.value,
-                variant: 'text',
+                variant: controlDefaults.value?.variant ?? 'text',
               },
             }}
           >

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -1,5 +1,6 @@
 // Components
 import { VNumberInput } from '../VNumberInput'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VForm } from '@/components/VForm'
 import { VLocaleProvider } from '@/components/VLocaleProvider'
 
@@ -21,6 +22,19 @@ describe('VNumberInput', () => {
     await userEvent.click(element)
     await userEvent.keyboard(typing)
     expect(screen.getByCSS('input')).toHaveValue(expected)
+  })
+
+  it.each([
+    ['VNumberInputBtn defaults should style the controls', { VNumberInputBtn: { variant: 'tonal' } }, 'v-btn--variant-tonal'],
+    ['ambient VBtn defaults should not reach the controls', { VBtn: { variant: 'tonal' } }, 'v-btn--variant-text'],
+  ])('%s', async (_, defaults, expected) => {
+    render(() => (
+      <VDefaultsProvider defaults={ defaults }>
+        <VNumberInput />
+      </VDefaultsProvider>
+    ))
+
+    expect(screen.getByTestId('increment')).toHaveClass(expected)
   })
 
   describe('grouped input', () => {

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -25,8 +25,8 @@ describe('VNumberInput', () => {
   })
 
   it.each([
-    ['VNumberInputBtn defaults should style the controls', { VNumberInputBtn: { variant: 'tonal' } }, 'v-btn--variant-tonal'],
-    ['ambient VBtn defaults should not reach the controls', { VBtn: { variant: 'tonal' } }, 'v-btn--variant-text'],
+    ['VNumberInput > VBtn defaults should style the controls', { VNumberInput: { VBtn: { variant: 'tonal' } } }, 'v-btn--variant-tonal'],
+    ['unscoped VBtn defaults should not apply', { VBtn: { variant: 'tonal' } }, 'v-btn--variant-text'],
   ])('%s', async (_, defaults, expected) => {
     render(() => (
       <VDefaultsProvider defaults={ defaults }>

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -771,11 +771,10 @@ export const VSelect = genericComponent<new <
                         !slots.chip ? (
                           <VChip
                             key="chip"
-                            size="small"
+                            closable={ closableChips.value }
+                            size={ chipDefaults.value?.size ?? 'small' }
                             text={ item.title }
                             disabled={ item.props.disabled }
-                            { ...chipDefaults.value }
-                            closable={ closableChips.value }
                             { ...slotProps }
                           />
                         ) : (
@@ -783,10 +782,9 @@ export const VSelect = genericComponent<new <
                             key="chip-defaults"
                             defaults={{
                               VChip: {
-                                size: 'small',
-                                text: item.title,
-                                ...chipDefaults.value,
                                 closable: closableChips.value,
+                                size: chipDefaults.value?.size ?? 'small',
+                                text: item.title,
                               },
                             }}
                           >

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -22,6 +22,7 @@ import { useFocusRepair } from './useFocusRepair'
 import { useScrolling } from './useScrolling'
 import { useSelectionMenu } from './useSelectionMenu'
 import { useFocusGroups } from '../../composables/focusGroups'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { makeFilterProps, useFilter } from '@/composables/filter'
 import { useForm } from '@/composables/form'
 import { forwardRefs } from '@/composables/forwardRefs'
@@ -191,6 +192,7 @@ export const VSelect = genericComponent<new <
     const selectedValues = computed(() => model.value.map(selection => selection.value))
     const isFocused = shallowRef(false)
     const closableChips = toRef(() => props.closableChips && !form.isReadonly.value && !form.isDisabled.value)
+    const chipDefaults = injectNestedDefaults<VChip['$props']>('VChip')
     const { InputIcon } = useInputIcon(props)
 
     let keyboardLookupPrefix = ''
@@ -769,10 +771,11 @@ export const VSelect = genericComponent<new <
                         !slots.chip ? (
                           <VChip
                             key="chip"
-                            closable={ closableChips.value }
                             size="small"
                             text={ item.title }
                             disabled={ item.props.disabled }
+                            { ...chipDefaults.value }
+                            closable={ closableChips.value }
                             { ...slotProps }
                           />
                         ) : (
@@ -780,9 +783,10 @@ export const VSelect = genericComponent<new <
                             key="chip-defaults"
                             defaults={{
                               VChip: {
-                                closable: closableChips.value,
                                 size: 'small',
                                 text: item.title,
+                                ...chipDefaults.value,
+                                closable: closableChips.value,
                               },
                             }}
                           >

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -1,5 +1,6 @@
 // Components
 import { VSelect } from '../VSelect'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
 import { VDialog } from '@/components/VDialog'
 import { VForm } from '@/components/VForm'
 import { VListItem } from '@/components/VList'
@@ -220,6 +221,19 @@ describe('VSelect', () => {
       </VSelect>
     ))
     expect(screen.getAllByCSS('.v-list-item').at(-1)).toHaveTextContent('Foo')
+  })
+
+  it.each([
+    ['VSelect > VChip defaults should override chip size', { VSelect: { VChip: { size: 'large' } } }, 'v-chip--size-large'],
+    ['ambient VChip defaults should not reach selection chips', { VChip: { size: 'large' } }, 'v-chip--size-small'],
+  ])('%s', async (_, defaults, expected) => {
+    render(() => (
+      <VDefaultsProvider defaults={ defaults }>
+        <VSelect items={ items } modelValue={['California']} chips multiple />
+      </VDefaultsProvider>
+    ))
+
+    expect(screen.getByCSS('.v-chip')).toHaveClass(expected)
   })
 
   it('should close only first chip', async () => {

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -225,7 +225,7 @@ describe('VSelect', () => {
 
   it.each([
     ['VSelect > VChip defaults should override chip size', { VSelect: { VChip: { size: 'large' } } }, 'v-chip--size-large'],
-    ['ambient VChip defaults should not reach selection chips', { VChip: { size: 'large' } }, 'v-chip--size-small'],
+    ['unscoped VChip defaults should not apply', { VChip: { size: 'large' } }, 'v-chip--size-small'],
   ])('%s', async (_, defaults, expected) => {
     render(() => (
       <VDefaultsProvider defaults={ defaults }>

--- a/packages/vuetify/src/components/VSpeedDial/VSpeedDial.tsx
+++ b/packages/vuetify/src/components/VSpeedDial/VSpeedDial.tsx
@@ -81,8 +81,7 @@ export const VSpeedDial = genericComponent<OverlaySlots>()({
               <VDefaultsProvider
                 defaults={{
                   VBtn: {
-                    size: 'small',
-                    ...btnDefaults.value,
+                    size: btnDefaults.value?.size ?? 'small',
                   },
                 }}
               >

--- a/packages/vuetify/src/components/VSpeedDial/VSpeedDial.tsx
+++ b/packages/vuetify/src/components/VSpeedDial/VSpeedDial.tsx
@@ -7,6 +7,7 @@ import { makeVMenuProps, VMenu } from '@/components/VMenu/VMenu'
 
 // Composables
 import { makeComponentProps } from '@/composables/component'
+import { injectNestedDefaults } from '@/composables/defaults'
 import { useProxiedModel } from '@/composables/proxiedModel'
 import { MaybeTransition } from '@/composables/transition'
 
@@ -15,6 +16,7 @@ import { computed, ref } from 'vue'
 import { genericComponent, propsFactory, useRender } from '@/util'
 
 // Types
+import type { VBtn } from '@/components/VBtn'
 import type { OverlaySlots } from '@/components/VOverlay/VOverlay'
 import type { Anchor } from '@/util'
 
@@ -41,6 +43,7 @@ export const VSpeedDial = genericComponent<OverlaySlots>()({
 
   setup (props, { slots }) {
     const model = useProxiedModel(props, 'modelValue')
+    const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
 
     const menuRef = ref<VMenu>()
 
@@ -79,6 +82,7 @@ export const VSpeedDial = genericComponent<OverlaySlots>()({
                 defaults={{
                   VBtn: {
                     size: 'small',
+                    ...btnDefaults.value,
                   },
                 }}
               >

--- a/packages/vuetify/src/components/VStepper/VStepperActions.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperActions.tsx
@@ -3,6 +3,7 @@ import { VBtn } from '@/components/VBtn/VBtn'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvider'
 
 // Composables
+import { injectNestedDefaults } from '@/composables/defaults'
 import { useLocale } from '@/composables/locale'
 
 // Utilities
@@ -48,6 +49,8 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
 
   setup (props, { emit, slots }) {
     const { t } = useLocale()
+    const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
+
     function onClickPrev () {
       emit('click:prev')
     }
@@ -69,9 +72,10 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
           <VDefaultsProvider
             defaults={{
               VBtn: {
+                variant: 'text',
+                ...btnDefaults.value,
                 disabled: ['prev', true].includes(props.disabled),
                 text: t(props.prevText),
-                variant: 'text',
               },
             }}
           >
@@ -84,9 +88,10 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
             defaults={{
               VBtn: {
                 color: props.color,
+                variant: 'tonal',
+                ...btnDefaults.value,
                 disabled: ['next', true].includes(props.disabled),
                 text: t(props.nextText),
-                variant: 'tonal',
               },
             }}
           >

--- a/packages/vuetify/src/components/VStepper/VStepperActions.tsx
+++ b/packages/vuetify/src/components/VStepper/VStepperActions.tsx
@@ -3,7 +3,7 @@ import { VBtn } from '@/components/VBtn/VBtn'
 import { VDefaultsProvider } from '@/components/VDefaultsProvider/VDefaultsProvider'
 
 // Composables
-import { injectNestedDefaults } from '@/composables/defaults'
+import { injectComponentDefaults, injectNestedDefaults } from '@/composables/defaults'
 import { useLocale } from '@/composables/locale'
 
 // Utilities
@@ -50,6 +50,8 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
   setup (props, { emit, slots }) {
     const { t } = useLocale()
     const btnDefaults = injectNestedDefaults<VBtn['$props']>('VBtn')
+    const prevDefaults = injectComponentDefaults<VBtn['$props']>('VStepperActionsPrevBtn')
+    const nextDefaults = injectComponentDefaults<VBtn['$props']>('VStepperActionsNextBtn')
 
     function onClickPrev () {
       emit('click:prev')
@@ -66,37 +68,39 @@ export const VStepperActions = genericComponent<VStepperActionsSlots>()({
       const nextSlotProps = {
         onClick: onClickNext,
       }
+      const prevProps = {
+        disabled: ['prev', true].includes(props.disabled),
+        text: t(props.prevText),
+        variant: prevDefaults.value?.variant ?? btnDefaults.value?.variant ?? 'text',
+      }
+      const nextProps = {
+        color: props.color,
+        disabled: ['next', true].includes(props.disabled),
+        text: t(props.nextText),
+        variant: nextDefaults.value?.variant ?? btnDefaults.value?.variant ?? 'tonal',
+      }
 
       return (
         <div class="v-stepper-actions">
           <VDefaultsProvider
             defaults={{
-              VBtn: {
-                variant: 'text',
-                ...btnDefaults.value,
-                disabled: ['prev', true].includes(props.disabled),
-                text: t(props.prevText),
-              },
+              VBtn: prevProps,
+              VStepperActionsPrevBtn: { ...btnDefaults.value, ...prevDefaults.value, ...prevProps },
             }}
           >
             { slots.prev?.({ props: prevSlotProps }) ?? (
-              <VBtn { ...prevSlotProps } />
+              <VBtn _as="VStepperActionsPrevBtn" { ...prevSlotProps } />
             )}
           </VDefaultsProvider>
 
           <VDefaultsProvider
             defaults={{
-              VBtn: {
-                color: props.color,
-                variant: 'tonal',
-                ...btnDefaults.value,
-                disabled: ['next', true].includes(props.disabled),
-                text: t(props.nextText),
-              },
+              VBtn: nextProps,
+              VStepperActionsNextBtn: { ...btnDefaults.value, ...nextDefaults.value, ...nextProps },
             }}
           >
             { slots.next?.({ props: nextSlotProps }) ?? (
-              <VBtn { ...nextSlotProps } />
+              <VBtn _as="VStepperActionsNextBtn" { ...nextSlotProps } />
             )}
           </VDefaultsProvider>
         </div>

--- a/packages/vuetify/src/components/VStepper/__tests__/VStepperActions.spec.browser.tsx
+++ b/packages/vuetify/src/components/VStepper/__tests__/VStepperActions.spec.browser.tsx
@@ -18,6 +18,21 @@ describe('VStepperActions', () => {
     }
   })
 
+  it.each([
+    ['prev', { VStepperActionsPrevBtn: { variant: 'outlined' } }, ['v-btn--variant-outlined', 'v-btn--variant-tonal']],
+    ['next', { VStepperActionsNextBtn: { variant: 'outlined' } }, ['v-btn--variant-text', 'v-btn--variant-outlined']],
+  ])('should let %s button be targeted on its own', async (_, defaults, [prevClass, nextClass]) => {
+    render(() => (
+      <VDefaultsProvider defaults={ defaults }>
+        <VStepperActions />
+      </VDefaultsProvider>
+    ))
+
+    const [prev, next] = screen.getAllByCSS('.v-btn')
+    expect(prev).toHaveClass(prevClass)
+    expect(next).toHaveClass(nextClass)
+  })
+
   it('should keep built-in variants when only ambient VBtn defaults are set', async () => {
     render(() => (
       <VDefaultsProvider defaults={{ VBtn: { variant: 'elevated' } }}>

--- a/packages/vuetify/src/components/VStepper/__tests__/VStepperActions.spec.browser.tsx
+++ b/packages/vuetify/src/components/VStepper/__tests__/VStepperActions.spec.browser.tsx
@@ -1,0 +1,40 @@
+// Components
+import { VStepperActions } from '../VStepperActions'
+import { VDefaultsProvider } from '@/components/VDefaultsProvider'
+
+// Utilities
+import { render, screen } from '@test'
+
+describe('VStepperActions', () => {
+  it('should let VStepperActions > VBtn defaults override button variant', async () => {
+    render(() => (
+      <VDefaultsProvider defaults={{ VStepperActions: { VBtn: { variant: 'elevated' } } }}>
+        <VStepperActions />
+      </VDefaultsProvider>
+    ))
+
+    for (const btn of screen.getAllByCSS('.v-btn')) {
+      expect(btn).toHaveClass('v-btn--variant-elevated')
+    }
+  })
+
+  it('should keep built-in variants when only ambient VBtn defaults are set', async () => {
+    render(() => (
+      <VDefaultsProvider defaults={{ VBtn: { variant: 'elevated' } }}>
+        <VStepperActions />
+      </VDefaultsProvider>
+    ))
+
+    const [prev, next] = screen.getAllByCSS('.v-btn')
+    expect(prev).toHaveClass('v-btn--variant-text')
+    expect(next).toHaveClass('v-btn--variant-tonal')
+  })
+
+  it('should default to text and tonal variants', async () => {
+    render(() => <VStepperActions />)
+
+    const [prev, next] = screen.getAllByCSS('.v-btn')
+    expect(prev).toHaveClass('v-btn--variant-text')
+    expect(next).toHaveClass('v-btn--variant-tonal')
+  })
+})

--- a/packages/vuetify/src/composables/defaults.ts
+++ b/packages/vuetify/src/composables/defaults.ts
@@ -1,5 +1,5 @@
 // Utilities
-import { computed, inject, provide, ref, shallowRef, unref, watchEffect } from 'vue'
+import { computed, inject, provide, ref, shallowRef, toRef, unref, watchEffect } from 'vue'
 import { isString } from '@/util'
 import { getCurrentInstance } from '@/util/getCurrentInstance'
 import { mergeDeep, toKebabCase } from '@/util/helpers'
@@ -91,6 +91,20 @@ export function provideDefaults (
   provide(DefaultsSymbol, newDefaults)
 
   return newDefaults
+}
+
+export function injectComponentDefaults<T = Record<string, unknown>> (name: string) {
+  const vm = getCurrentInstance('injectComponentDefaults')
+
+  return toRef(() => injectSelf(DefaultsSymbol, vm)?.value?.[name] as Partial<T> | undefined)
+}
+
+export function injectNestedDefaults<T = Record<string, unknown>> (name: string) {
+  const vm = getCurrentInstance('injectNestedDefaults')
+  const defaults = injectDefaults()
+  const self = (vm.props._as ?? vm.type.name) as string
+
+  return toRef(() => defaults.value?.[self]?.[name] as Partial<T> | undefined)
 }
 
 function propIsDefined (vnode: VNode, prop: string) {


### PR DESCRIPTION
Components that style their own children hardcoded the values as direct props or in an inner `VDefaultsProvider`. Neither can be overridden: a direct prop beats every default, and an inner provider always wins over an outer one.

Nested defaults now win over the built-in value. Ambient `VBtn` / `VChip` / `VSelect` defaults stay shielded — the same behaviour `<v-card-actions>` has today — so existing apps look unchanged.

**Note**: `VStepperActionsPrevBtn`, `VStepperActionsNextBtn` join the existing `VPaginationBtn`

---

## Composables

- `injectNestedDefaults(name)` — the owner's own entry from the parent chain, `defaults[VSelect][VChip]`.
- `injectComponentDefaults(name)` — a name from the resolved chain, for `_as` roles.

Both are generic: `injectNestedDefaults<VChip['$props']>('VChip')`.

## Nested keys now honored

| Component                                     | Key       | Was                                   |
|-----------------------------------------------|-----------|---------------------------------------|
| VSelect, VAutocomplete, VCombobox, VFileInput | `VChip`   | `size="small"`                        |
| VStepperActions                               | `VBtn`    | `variant: 'text'` / `'tonal'`         |
| VConfirmEdit                                  | `VBtn`    | `variant="text"`                      |
| VDataTableFooter, VDataTableHeaders           | `VSelect` | `variant="outlined"` / `"underlined"` |
| VFileUploadDropzone, VFileUploadItem          | `VBtn`    | `variant`, `size`, `density`          |
| VSpeedDial                                    | `VBtn`    | `size: 'small'`                       |

---

fixes #21279
fixes #21420
fixes #21490

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-navigation-drawer location="right" width="380" permanent>
      <v-textarea
        v-model="json"
        :rules="[isValidJson]"
        class="defaults-editor"
        hide-details="auto"
        spellcheck="false"
        variant="plain"
        no-resize
      />
    </v-navigation-drawer>

    <v-main>
      <v-container style="max-width: 900px">
        <div class="d-flex flex-column ga-6">
          <v-select v-model="selected" :items="items" label="Chip size" chips multiple />
          <v-number-input v-model="qty" label="Spin buttons" />

          <v-stepper :items="['Step 1', 'Step 2', 'Step 3']">
            <template #item.1>
              <v-card title="Step One" flat>...</v-card>
            </template>

            <template #item.2>
              <v-card title="Step Two" flat>...</v-card>
            </template>

            <template #item.3>
              <v-card title="Step Three" flat>...</v-card>
            </template>
          </v-stepper>

          <div class="d-flex align-start ga-6">
            <v-card
              class="mx-auto"
              title="Confirm you are a robot"
              width="320"
            >
              <template #text>
                Something, something..
              </template>

              <template #actions>
                <v-btn text="Cancel" />
                <v-btn color="red" text="Delete the database" />
              </template>
            </v-card>

            <v-confirm-edit v-model="model">
              <template #default="{ model: proxyModel, actions }">
                <v-card
                  class="mx-auto"
                  title="Update Field"
                  width="320"
                >
                  <template #text>
                    <v-text-field
                      v-model="proxyModel.value"
                      messages="Modify my value"
                    />
                  </template>

                  <template #actions>
                    <v-spacer />

                    <component :is="actions" />
                  </template>
                </v-card>
              </template>
            </v-confirm-edit>
          </div>

          <v-data-table :items="rows" mobile />
        </div>
      </v-container>
    </v-main>
  </v-app>
</template>

<script setup lang="ts">
  import { ref, watch } from 'vue'
  import { injectDefaults } from '@/composables/defaults'
  import { mergeDeep } from '@/util'

  const model = ref('Egg plant')
  const items = ['Apple', 'Banana', 'Cherry']
  const rows = items.map((name, i) => ({ name, qty: i + 1 }))
  const selected = ref(['Apple', 'Banana'])
  const qty = ref(1)

  const root = injectDefaults()
  const base = root.value ?? {}
  const json = ref(JSON.stringify({
    VSelect: { VChip: { size: 'large' } },
    VStepperActions: { VBtn: { variant: 'outlined' } },
    VConfirmEdit: { VBtn: { variant: 'outlined' } },
    VDataTableFooter: { VSelect: { variant: 'solo-filled' } },
    VDataTableHeaders: { VSelect: { variant: 'solo-filled' } },
    VNumberInputBtn: { variant: 'tonal' },
  }, null, 2))

  function parse (value: string) {
    try {
      return JSON.parse(value)
    } catch (e) {
      return e as Error
    }
  }

  function isValidJson (value: string) {
    const parsed = parse(value)
    return parsed instanceof Error ? parsed.message : true
  }

  watch(json, value => {
    const parsed = parse(value)
    if (!(parsed instanceof Error)) {
      root.value = mergeDeep(base, parsed)
    }
  }, { immediate: true })
</script>

<style scoped>
  .defaults-editor,
  .defaults-editor :deep(.v-input__control),
  .defaults-editor :deep(.v-field),
  .defaults-editor :deep(textarea) {
    height: 100%;
  }

  .defaults-editor :deep(textarea) {
    padding: 12px;
    font-family: monospace;
    font-size: 13px;
    tab-size: 2;
  }
</style>
```
