### PR TITLE
fix(VNumberInput): snap to min/max when using buttons and value is out of range

### DIFF
--- a/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
+++ b/packages/vuetify/src/components/VNumberInput/VNumberInput.tsx
@@ -196,15 +196,23 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       return numberFromText !== clamp(numberFromText, props.min, props.max)
     })
 
+    function stepResult (increment: boolean) {
+      const current = toNumber(inputText.value)
+      const stepped = current + (increment ? props.step : -props.step)
+      return { current, stepped, next: clamp(stepped, props.min, props.max) }
+    }
+
     const canIncrease = computed(() => {
       if (controlsDisabled.value) return false
       if (model.value == null) return true
-      return model.value + props.step <= props.max
+      const { current, next } = stepResult(true)
+      return next !== current
     })
     const canDecrease = computed(() => {
       if (controlsDisabled.value) return false
       if (model.value == null) return true
-      return model.value - props.step >= props.min
+      const { current, next } = stepResult(false)
+      return next !== current
     })
 
     const controlVariant = computed(() => {
@@ -257,14 +265,12 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
         emitChange()
         return
       }
-      const inferredPrecision = Math.max(inferPrecision(toNumber(inputText.value)), inferPrecision(props.step))
-      if (increment && canIncrease.value) {
-        inputText.value = correctPrecision(model.value + props.step, inferredPrecision)
-        emitChange()
-      } else if (!increment && canDecrease.value) {
-        inputText.value = correctPrecision(model.value - props.step, inferredPrecision)
-        emitChange()
-      }
+      const { current, stepped, next } = stepResult(increment)
+
+      inputText.value = next === stepped
+        ? correctPrecision(next, Math.max(inferPrecision(current), inferPrecision(props.step)))
+        : correctPrecision(next)
+      emitChange()
     }
 
     function onBeforeinput (e: InputEvent) {
@@ -309,7 +315,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       nextTick(() => inputText.value = result.text)
     }
 
-    async function onKeydown (e: KeyboardEvent) {
+    function onKeydown (e: KeyboardEvent) {
       if (
         ['Enter', 'ArrowLeft', 'ArrowRight', 'Backspace', 'Delete', 'Tab'].includes(e.key) ||
         e.ctrlKey
@@ -318,14 +324,7 @@ export const VNumberInput = genericComponent<VNumberInputSlots>()({
       if (['ArrowDown', 'ArrowUp'].includes(e.key)) {
         e.preventDefault()
         e.stopPropagation()
-        clampModel()
-        // _model is controlled, so need to wait until props['modelValue'] is updated
-        await nextTick()
-        if (e.key === 'ArrowDown') {
-          toggleUpDown(false)
-        } else {
-          toggleUpDown()
-        }
+        toggleUpDown(e.key === 'ArrowUp')
       }
     }
 

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -266,8 +266,33 @@ describe('VNumberInput', () => {
       await userEvent.click(screen.getByCSS('input'))
       await userEvent.keyboard('{arrowDown}')
 
+      await expect.element(screen.getByCSS('input')).toHaveValue('15')
+      expect(model.value).toBe(15)
+
+      await userEvent.keyboard('{arrowDown}')
+
       await expect.element(screen.getByCSS('input')).toHaveValue('14')
       expect(model.value).toBe(14)
+    })
+
+    it('should snap to the limit when value is out of range by more than one step', async () => {
+      const model = ref(100)
+      render(() =>
+        <VNumberInput min={ 0 } max={ 10 } v-model={ model.value } />
+      )
+
+      await userEvent.click(screen.getByTestId('decrement'))
+      expect(model.value).toBe(10)
+
+      await userEvent.click(screen.getByTestId('decrement'))
+      expect(model.value).toBe(9)
+
+      model.value = -100
+      await userEvent.click(screen.getByTestId('increment'))
+      expect(model.value).toBe(0)
+
+      await userEvent.click(screen.getByTestId('increment'))
+      expect(model.value).toBe(1)
     })
 
     it('should auto-correct when incrementing against the limit', async () => {

--- a/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VNumberInput/__tests__/VNumberInput.spec.browser.tsx
@@ -360,6 +360,21 @@ describe('VNumberInput', () => {
       expect(model.value).toBe(0)
     })
 
+    // 0.2 + 0.1 > 0.3 in IEEE-754; must still allow stepping to max
+    it('should reach max when step has floating-point error', async () => {
+      const model = ref(0)
+      render(() => <VNumberInput step={ 0.1 } max={ 0.3 } v-model={ model.value } precision={ null } />)
+
+      await userEvent.keyboard('{Tab}{ArrowUp}')
+      expect(model.value).toBe(0.1)
+
+      await userEvent.keyboard('{ArrowUp}')
+      expect(model.value).toBe(0.2)
+
+      await userEvent.keyboard('{ArrowUp}')
+      expect(model.value).toBe(0.3)
+    })
+
     it('shows custom decimal separator when incrementing', async () => {
       const model = ref(0)
       render(() => (


### PR DESCRIPTION
fixes #23098

also fixes when step `0.1` and max `0.3`, the value was stuck on `0.2`

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-card class="mx-auto pa-6 my-4" style="max-width: 900px">
        <v-row>
          <v-col cols="4">
            <v-number-input v-model="model.min" label="Min" />
          </v-col>
          <v-col cols="4">
            <v-number-input
              v-model="model.value"
              label="Value"
              :min="model.min"
              :max="model.max"
            />
          </v-col>
          <v-col cols="4">
            <v-number-input v-model="model.max" label="Max" />
          </v-col>
        </v-row>
        <br />
        <v-btn @click="model.value = 15" text="Simulate server (set 15)" />
        <v-btn @click="model.value = 5" text="Simulate server (set 5)" />
      </v-card>
    </v-container>
  </v-app>
</template>

<script setup lang="ts">
  import { reactive } from 'vue'

  const model = reactive({ min: 0, value: 12, max: 10 })
</script>
```
