### PR TITLE
fix(VTextField): prevent double role="combobox" on VSelect

### DIFF
--- a/packages/vuetify/src/components/VTextField/VTextField.tsx
+++ b/packages/vuetify/src/components/VTextField/VTextField.tsx
@@ -216,7 +216,6 @@ export const VTextField = genericComponent<VTextFieldSlots>()({
                 onMousedown={ onControlMousedown }
                 onClick={ onControlClick }
                 onClick:clear={ (e: MouseEvent) => onClear(e, reset) }
-                role={ props.role }
                 { ...omit(fieldProps, ['onClick:clear']) }
                 id={ id.value }
                 labelId={ `${id.value}-label` }


### PR DESCRIPTION
## Description

Remove the `role` prop from the `VField` root element in `VTextField`. The `role` attribute should only be set on the `<input>` element, not on the outer `VField` wrapper.

## Problem

When `VSelect` sets `role: 'combobox'` (via `makeVTextFieldProps`), the `VTextField` applies this role to **both** the `VField` root div and the `<input>` element. This results in two nested `role="combobox"` elements:

```html
<div class="v-field" role="combobox">        <!-- invalid — no aria-expanded in SSR -->
  <input role="combobox" aria-expanded="false" aria-controls="menu-…">
</div>
```

Per the [ARIA 1.2 combobox pattern](https://www.w3.org/TR/wai-aria-1.2/#combobox), the `combobox` role belongs on the text input, not on a wrapper. The nested `combobox` is semantically invalid and causes W3C validator warnings during SSR.

## Fix

Remove `role={ props.role }` from the `<VField>` component in `VTextField.tsx`. The `role` prop is still applied to the `<input>` element (line 251), which is the correct placement.

Fixes #23105
