### PR TITLE
fix(VDateInput): add combobox aria attributes to input element (Fixes #22977)

### DIFF
--- a/packages/vuetify/src/components/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/components/VDateInput/VDateInput.tsx
@@ -13,6 +13,7 @@ import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeFocusProps } from '@/composables/focus'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useLocale } from '@/composables/locale'
+import { useMenuActivator } from '@/composables/menuActivator'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
@@ -66,6 +67,7 @@ export const makeVDateInputProps = propsFactory({
   }),
   ...makeVTextFieldProps({
     prependIcon: '$calendar',
+    role: 'combobox',
   }),
   ...omit(makeVDatePickerProps({
     hideHeader: true,
@@ -127,6 +129,10 @@ export const VDateInput = genericComponent<new <
     )
 
     const menu = useProxiedModel(props, 'menu')
+    const { menuId, ariaExpanded, ariaControls } = useMenuActivator(
+      { closeText: '$vuetify.close', openText: '$vuetify.open' },
+      menu,
+    )
     const isEditingInput = shallowRef(false)
     const isFocused = shallowRef(props.focused)
     const vTextFieldRef = ref<VTextField>()
@@ -304,12 +310,16 @@ export const VDateInput = genericComponent<new <
           onClick:control={ onClick }
           onUpdate:modelValue={ onUpdateDisplayModel }
           onUpdate:focused={ event => isFocused.value = event }
+          aria-haspopup="dialog"
+          aria-expanded={ ariaExpanded.value }
+          aria-controls={ ariaControls.value }
         >
           {{
             ...slots,
             default: () => (
               <>
                 <VMenu
+                  id={ menuId.value }
                   v-model={ menu.value }
                   activator="parent"
                   minWidth="0"


### PR DESCRIPTION
## Description

Fixes #22977

`VDateInput` renders its input element via `VTextField`, which only sets `role` but not the required combobox ARIA attributes. When the input is used as an activator for the date-picker dialog, assistive technology cannot determine whether the popup is expanded or what it controls.

### Changes

- Set `role="combobox"` as the default for `VDateInput`'s text field (mirrors `VSelect`)
- Add `aria-haspopup="dialog"`, `aria-expanded` and `aria-controls` to the input element, driven by the `VMenu` state via `useMenuActivator`
- Give the `VMenu` the matching `menu-*` id so `aria-controls` points at the real popup

### Before

The input element has `role` but no `aria-expanded` / `aria-controls`, which is flagged by aXe and violates the combobox accessibility pattern:

```
<input role="combobox" aria-labelledby="...">  <!-- no expanded/controls -->
```

### After

```
<input role="combobox" aria-expanded="false" aria-controls="menu-123" aria-haspopup="dialog">
```

## Test plan

- Render `<v-date-input>` and inspect the input element: `role="combobox"` with `aria-expanded`, `aria-controls` and `aria-haspopup` present
- Open the menu: `aria-expanded` flips to `true` and `aria-controls` matches the menu id
- Run axe-core on the docs playground page — no more "aria-expanded not allowed" or missing combobox attributes violation