### PR TITLE
fix(VTreeviewItem): only attach click when interactive

### DIFF
--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -57,21 +57,15 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
       (vListItemRef.value?.root.activatable.value) &&
       vListItemRef.value?.isGroupActivator
     )
-    const vListItemRefIsClickable = computed(() => (
-      vListItemRef.value?.link.isClickable.value ||
-      (props.value != null && !!vListItemRef.value?.list)
-    ))
-    const isClickable = computed(() =>
+    const isActivatable = computed(() =>
       !props.disabled &&
       props.link !== false &&
-      (props.link || vListItemRefIsClickable.value || isActivatableGroupActivator.value)
+      isActivatableGroupActivator.value
     )
     const isFiltered = computed(() => visibleIds.value && !visibleIds.value.has(toRaw(vListItemRef.value?.id)))
 
     function activateGroupActivator (e: MouseEvent | KeyboardEvent) {
-      if (isClickable.value && isActivatableGroupActivator.value) {
-        vListItemRef.value?.activate(!vListItemRef.value?.isActivated, e)
-      }
+      vListItemRef.value?.activate(!vListItemRef.value?.isActivated, e)
     }
 
     function onClickAction (e: PointerEvent) {
@@ -103,7 +97,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
           ]}
           role="treeitem"
           ripple={ false }
-          onClick={ isClickable.value ? activateGroupActivator : undefined }
+          onClick={ isActivatable.value ? activateGroupActivator : undefined }
         >
           {{
             ...slots,

--- a/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
+++ b/packages/vuetify/src/components/VTreeview/VTreeviewItem.tsx
@@ -103,7 +103,7 @@ export const VTreeviewItem = genericComponent<VTreeviewItemSlots>()({
           ]}
           role="treeitem"
           ripple={ false }
-          onClick={ activateGroupActivator }
+          onClick={ isClickable.value ? activateGroupActivator : undefined }
         >
           {{
             ...slots,


### PR DESCRIPTION
## Description

`VTreeviewItem` passed `onClick` down to its inner `VListItem` on every render. That kept #23028's gate (`isClickable.value || props.onClick || props.onClickOnce`) permanently true, so every row still got a real click listener, including rows that do nothing when clicked. Screen readers announce those rows as clickable, which is what #22854 reported.

The handler being passed, `activateGroupActivator`, already returns early unless the item is clickable, so passing it in the other cases had no effect anyway. It now goes down only when the item is clickable.

Fixes #23117

## Markup:

```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-list border>
          <v-treeview-item title="plain, no listener" />
          <v-treeview-item title="disabled, no listener" value="a" disabled />
          <v-treeview-item title="with value, listener" value="b" />
        </v-list>
      </v-container>
    </v-main>
  </v-app>
</template>
```

Inspect the rendered `.v-list-item` rows. Before this change all three carry a click listener, after it only the last one does.