### PR TITLE
fix(VMenu/VSelect/etc.): only set aria-controls while open

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -168,8 +168,8 @@ export const VMenu = genericComponent<OverlaySlots>()({
       mergeProps({
         'aria-haspopup': 'menu',
         'aria-expanded': String(isActive.value),
-        'aria-controls': id.value,
-        'aria-owns': id.value,
+        'aria-controls': isActive.value ? id.value : undefined,
+        'aria-owns': isActive.value ? id.value : undefined,
         onKeydown: onActivatorKeydown,
       }, props.activatorProps)
     )

--- a/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
+++ b/packages/vuetify/src/components/VMenu/__tests__/VMenu.spec.browser.tsx
@@ -340,6 +340,38 @@ describe('VMenu', () => {
     expect(model.value).toBe(false)
   })
 
+  it('should only reference the menu id on the activator while it is open', async () => {
+    render(() => (
+      <VMenu>
+        {{
+          activator: ({ props }: any) => <VBtn { ...props } data-testid="btn">Open</VBtn>,
+          default: () => (
+            <VSheet class="pa-3" data-testid="menu-content">
+              <p>Content</p>
+            </VSheet>
+          ),
+        }}
+      </VMenu>
+    ))
+
+    const btn = screen.getByTestId('btn')
+    expect(btn).not.toHaveAttribute('aria-controls')
+    expect(btn).not.toHaveAttribute('aria-owns')
+
+    await userEvent.click(btn)
+    await expect.poll(() => screen.queryByTestId('menu-content')).toBeVisible()
+
+    const id = btn.getAttribute('aria-controls')
+    expect(btn).toHaveAttribute('aria-owns', id)
+    expect(document.getElementById(id!)).not.toBeNull()
+
+    await userEvent.keyboard('{Escape}')
+    await expect.poll(() => screen.queryByTestId('menu-content')).toBeNull()
+
+    expect(btn).not.toHaveAttribute('aria-controls')
+    expect(btn).not.toHaveAttribute('aria-owns')
+  })
+
   describe('cascade close', () => {
     beforeEach(() => commands.setReduceMotionDisabled())
 

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -739,17 +739,19 @@ describe('VSelect', () => {
 
     const inputField = getByRole('combobox', { expanded: false })
     expect(inputField).toHaveAttribute('aria-expanded', 'false')
-    expect(inputField.getAttribute('aria-controls')).toMatch(/^menu-v-\d+/)
+    expect(inputField).not.toHaveAttribute('aria-controls')
 
     await userEvent.click(inputField, { force: true })
     await commands.waitStable('.v-list')
 
     expect(inputField).toHaveAttribute('aria-expanded', 'true')
+    expect(inputField.getAttribute('aria-controls')).toMatch(/^menu-v-\d+/)
 
     await commands.waitStable('.v-list')
     await userEvent.click(screen.getAllByRole('option')[0])
 
     expect(inputField).toHaveAttribute('aria-expanded', 'false')
+    expect(inputField).not.toHaveAttribute('aria-controls')
   })
 
   // https://github.com/vuetifyjs/vuetify/issues/22052

--- a/packages/vuetify/src/composables/menuActivator.ts
+++ b/packages/vuetify/src/composables/menuActivator.ts
@@ -28,7 +28,7 @@ export function useMenuActivator (props: MenuActivatorProps, isOpen: MaybeRefOrG
   const menuId = computed(() => `menu-${uid}`)
 
   const ariaExpanded = toRef(() => toValue(isOpen))
-  const ariaControls = toRef(() => menuId.value)
+  const ariaControls = toRef(() => toValue(isOpen) ? menuId.value : undefined)
 
   return {
     menuId,


### PR DESCRIPTION
## Description

`VMenu` puts `aria-controls` and `aria-owns` on its activator, and `useMenuActivator` puts `aria-controls` on the input of `VSelect`, `VAutocomplete` and `VCombobox`. Both reference the overlay id, but the element carrying that id only exists while the overlay has content: `useLazy` mounts it on first open and drops it again on close. So before the first open, and after every close, those attributes point at an id that is not in the document, and the W3C validator flags it as an error, once per attribute per closed menu.

They are now emitted only while the menu is open. The APG combobox pattern only asks for `aria-controls` while the popup is visible, and in the menu button pattern it is optional.

The existing `VSelect` test that asserted `aria-controls` on a closed select now asserts it after opening instead.

Fixes #23119

## Markup:

```vue
<template>
  <v-app>
    <v-main>
      <v-container>
        <v-select :items="['a', 'b']" label="Sort by" />

        <v-menu>
          <template #activator="{ props }">
            <v-btn v-bind="props" text="Open" />
          </template>
          <v-list :items="['a']" />
        </v-menu>
      </v-container>
    </v-main>
  </v-app>
</template>
```

Inspect the select input and the button before opening anything. On `master` both carry an id reference that resolves to nothing, with this change neither does until the menu opens.
