### PR TITLE
fix(VBtn): do not render the value attribute on a link

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.tsx
+++ b/packages/vuetify/src/components/VBtn/VBtn.tsx
@@ -230,7 +230,7 @@ export const VBtn = genericComponent<VBtnSlots>()({
           disabled={ (isDisabled.value && Tag !== 'a') || undefined }
           tabindex={ props.loading || props.readonly ? -1 : undefined }
           onClick={ onClick }
-          value={ valueAttr.value }
+          value={ Tag !== 'a' ? valueAttr.value : undefined }
         >
           { genOverlays(true, 'v-btn') }
 

--- a/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.browser.tsx
+++ b/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.browser.tsx
@@ -206,14 +206,6 @@ describe('VBtn', () => {
       const { wrapper } = render(<VBtn></VBtn>)
       expect(wrapper.element).not.toHaveValue()
     })
-
-    it('should not render the value attribute on a link', async () => {
-      const { wrapper } = render(() => (
-        <VBtn href="#anchor" value="foo"></VBtn>
-      ))
-      expect(wrapper.element.tagName).toBe('A')
-      expect(wrapper.element).not.toHaveAttribute('value')
-    })
   })
 
   describe('Reactivity', () => {

--- a/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.browser.tsx
+++ b/packages/vuetify/src/components/VBtn/__tests__/VBtn.spec.browser.tsx
@@ -206,6 +206,14 @@ describe('VBtn', () => {
       const { wrapper } = render(<VBtn></VBtn>)
       expect(wrapper.element).not.toHaveValue()
     })
+
+    it('should not render the value attribute on a link', async () => {
+      const { wrapper } = render(() => (
+        <VBtn href="#anchor" value="foo"></VBtn>
+      ))
+      expect(wrapper.element.tagName).toBe('A')
+      expect(wrapper.element).not.toHaveAttribute('value')
+    })
   })
 
   describe('Reactivity', () => {


### PR DESCRIPTION
## Description

fixes #23121

`VBtn` mirrors its group value into a `value` attribute on whatever tag it renders. With `to`/`href` that tag is an `a`, where `value` is not a valid attribute:

> Attribute “value” not allowed on element “a” at this point.

The attribute is now emitted only when the rendered tag is not `a`, mirroring the neighbouring `disabled` binding (`isDisabled.value && Tag !== 'a'`).

Selection is unaffected: `useGroupItem` reads `props.value`, never the DOM attribute. The existing `value` tests all render a `button` and keep asserting the attribute as before; the added test covers the link case.

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn-toggle v-model="selected">
        <v-btn href="#one" :value="1" text="One" />
        <v-btn href="#two" :value="2" text="Two" />
      </v-btn-toggle>
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        selected: 1,
      }
    },
  }
</script>
```

Run the rendered page through https://validator.w3.org/nu — one `value`-on-`a` error per link button before, none after.
