### PR TITLE
fix(VDataTable): key column cells to prevent slot reuse

### DIFF
--- a/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableHeaders.tsx
@@ -388,7 +388,7 @@ export const VDataTableHeaders = genericComponent<VDataTableHeadersSlots>()({
             : headers.value.map((row, y) => (
               <tr>
                 { row.map((column, x) => (
-                  <VDataTableHeaderCell column={ column } x={ x } y={ y } />
+                  <VDataTableHeaderCell key={ column.key ?? x } column={ column } x={ x } y={ y } />
                 ))}
               </tr>
             ))}

--- a/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
+++ b/packages/vuetify/src/components/VDataTable/VDataTableRow.tsx
@@ -148,6 +148,7 @@ export const VDataTableRow = genericComponent<new <T>(
 
           return (
             <VDataTableColumn
+              key={ column.key ?? i }
               align={ column.align }
               indent={ column.indent }
               class={{

--- a/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDataTable/__tests__/VDataTable.spec.browser.tsx
@@ -216,6 +216,27 @@ describe('VDataTable', () => {
     expect(screen.queryAllByCSS('thead .v-selection-control')).toHaveLength(1)
   })
 
+  // https://github.com/vuetifyjs/vuetify/issues/23123
+  it('should keep column cells in place when toggling show-select', async () => {
+    const showSelect = ref(false)
+    render(() => (
+      <VDataTable
+        headers={ DESSERT_HEADERS }
+        items={ DESSERT_ITEMS }
+        showSelect={ showSelect.value }
+      />
+    ))
+
+    const header = screen.getByCSS('thead tr th:first-child')
+    const cell = screen.getByCSS('tbody tr:first-child td:first-child')
+
+    showSelect.value = true
+    await nextTick()
+
+    expect(screen.getByCSS('thead tr th:nth-child(2)')).toBe(header)
+    expect(screen.getByCSS('tbody tr:first-child td:nth-child(2)')).toBe(cell)
+  })
+
   it('with body.append should show correct item count after group is expanded', async () => {
     render(() => (
       <VDataTable


### PR DESCRIPTION
## Description

The cells of a data table row and header row are rendered from `columns.value.map(...)` without a key. Turning `show-select` on prepends one column, so every other cell shifts right by one and Vue's unkeyed diff patches each cell against its left neighbour instead of the cell it belongs to.

Slot content compiled from a template carries a `PROPS` patch flag listing only its own dynamic props, so patching a `header.b2`/`item.b2` node into a `header.b1`/`item.b1` node updates the shared props and leaves the rest behind. In the linked reproduction the first button keeps the second one's `prepend-icon`.

Both cell lists are now keyed by column key, so cells move with their column and are no longer reused across columns.

Fixes #23123

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-btn text="Toggle select" @click="showSelect = !showSelect" />

      <v-data-table
        :headers="headers"
        :items="cars"
        :show-select="showSelect"
        item-value="name"
      >
        <template #item.button1="{ value }">
          <v-btn :text="value" />
        </template>

        <template #item.button2="{ item, value }">
          <v-btn :text="value" :prepend-icon="item.icon" />
        </template>
      </v-data-table>
    </v-container>
  </v-app>
</template>

<script>
  import { ref } from 'vue'

  export default {
    name: 'Playground',
    setup () {
      const showSelect = ref(false)

      const headers = [
        { title: 'Car Model', key: 'name' },
        { title: 'button1', key: 'button1' },
        { title: 'button2', key: 'button2' },
      ]

      const cars = [
        { name: 'Ford Mustang', button1: 'USA', button2: 'Zebra', icon: 'mdi-cog' },
        { name: 'Tesla Model S', button1: 'USA', button2: 'Fox', icon: 'mdi-plus-box-multiple' },
        { name: 'BMW M3', button1: 'Germany', button2: 'Bear', icon: 'mdi-menu-open' },
      ]

      return { showSelect, headers, cars }
    },
  }
</script>
```

Click the toggle. Before this change the button in the `button1` column picks up the icon from `button2`, after it the columns stay independent.