### PR TITLE
feat(inputs): add open-on-focus to inputs with VMenu

### DIFF
--- a/packages/api-generator/src/locale/en/Select.json
+++ b/packages/api-generator/src/locale/en/Select.json
@@ -11,6 +11,7 @@
     "multiple": "Changes select to multiple. Accepts array for value.",
     "noAutoScroll": "Prevents the select menu to scroll to the selected item automatically.",
     "openOnClear": "Open's the menu whenever the clear icon is clicked.",
+    "openOnFocus": "Open the menu when the input receives focus.",
     "openText": "Text set to the inputs **aria-label** and **title** when input menu is open."
   },
   "slots": {

--- a/packages/api-generator/src/locale/en/VColorInput.json
+++ b/packages/api-generator/src/locale/en/VColorInput.json
@@ -3,6 +3,7 @@
   "props": {
     "hidePip": "Hide pip icon",
     "colorPip": "Synchronize pip color with current value",
+    "openOnFocus": "Open the color picker menu when the input receives focus.",
     "pipIcon": "The icon used for pip",
     "pipLocation": "Move pip icon to a different slot",
     "pipVariant": "Variant of the pip control"

--- a/packages/api-generator/src/locale/en/VDateInput.json
+++ b/packages/api-generator/src/locale/en/VDateInput.json
@@ -5,6 +5,7 @@
     "displayFormat": "The format of the date that is displayed in the input. Can use any format [here](/features/dates/#format-options) or a custom function.",
     "inputFormat": "Format for manual date input. Use yyyy, mm, dd with separators '.', '-', '/' (e.g. 'yyyy-mm-dd', 'dd/mm/yyyy').",
     "location": "Specifies the date picker's location. Can combine by using a space separated string.",
+    "openOnFocus": "Open the date picker menu when the input receives focus.",
     "updateOn": "Specifies when the text input should update the model value. If empty, the text field will go into read-only state."
   }
 }

--- a/packages/docs/src/data/new-in.json
+++ b/packages/docs/src/data/new-in.json
@@ -19,7 +19,8 @@
       "closeOnInputClick": "4.2.0",
       "form": "4.2.0",
       "listProps": "3.5.0",
-      "menuElevation": "4.0.0"
+      "menuElevation": "4.0.0",
+      "openOnFocus": "4.2.0"
     },
     "slots": {
       "menu-header": "3.12.0",
@@ -110,6 +111,11 @@
       "scrollToActive": "3.10.6"
     }
   },
+  "VColorInput": {
+    "props": {
+      "openOnFocus": "4.2.0"
+    }
+  },
   "VColorPicker": {
     "props": {
       "hideEyeDropper": "3.10.0",
@@ -127,6 +133,7 @@
       "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0",
+      "openOnFocus": "4.2.0",
       "trimValues": "4.2.0"
     },
     "slots": {
@@ -145,6 +152,11 @@
   "VConfirmEdit": {
     "props": {
       "hideActions": "3.8.0"
+    }
+  },
+  "VDateInput": {
+    "props": {
+      "openOnFocus": "4.2.0"
     }
   },
   "VDatePicker": {
@@ -460,7 +472,8 @@
       "form": "4.2.0",
       "listProps": "3.5.0",
       "menuElevation": "4.0.0",
-      "noAutoScroll": "3.9.0"
+      "noAutoScroll": "3.9.0",
+      "openOnFocus": "4.2.0"
     },
     "slots": {
       "menu-header": "3.12.0",

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -296,6 +296,7 @@ export const VAutocomplete = genericComponent<new <
           break
         case 'Tab':
           selectHighlighted()
+          menu.value = false
           break
         default:
           onSelectionKeydown(e)

--- a/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/VAutocomplete.tsx
@@ -205,7 +205,7 @@ export const VAutocomplete = genericComponent<new <
       (props.hideNoData && !displayItems.value.length) ||
       form.isReadonly.value || form.isDisabled.value
     ))
-    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled })
+    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled, isFocused })
 
     const { menuId, ariaExpanded, ariaControls } = useMenuActivator(props, menu)
 

--- a/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
+++ b/packages/vuetify/src/components/VAutocomplete/__tests__/VAutocomplete.spec.browser.tsx
@@ -46,6 +46,27 @@ const stories = Object.fromEntries(Object.entries({
 )]))
 
 describe('VAutocomplete', () => {
+  it.each([
+    ['{Tab}', 'after'],
+    ['{Shift>}{Tab}{/Shift}', 'before'],
+  ])('should leave the field with a single %s while the menu is open', async (keys, target) => {
+    const menu = ref(false)
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VAutocomplete items={ items } openOnFocus v-model:menu={ menu.value } />
+        <button data-testid="after">after</button>
+      </>
+    ))
+
+    screen.getByCSS('.v-autocomplete input[type="text"]').focus()
+    await expect.poll(() => menu.value).toBe(true)
+
+    await userEvent.keyboard(keys)
+    await expect.poll(() => menu.value).toBe(false)
+    await expect.poll(() => document.activeElement).toBe(screen.getByTestId(target))
+  })
+
   it('should clear focused state after interacting with content and moving to sibling field', async () => {
     const menuA = ref(false)
     const menuB = ref(false)

--- a/packages/vuetify/src/components/VColorInput/VColorInput.tsx
+++ b/packages/vuetify/src/components/VColorInput/VColorInput.tsx
@@ -10,10 +10,11 @@ import { makeVTextFieldProps, VTextField } from '@/components/VTextField/VTextFi
 
 // Composables
 import { makeFocusProps } from '@/composables/focus'
+import { closeWhenFocusLeaves, useOpenOnFocus } from '@/composables/openOnFocus'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
-import { computed, shallowRef } from 'vue'
+import { computed, ref, shallowRef } from 'vue'
 import { genericComponent, omit, propsFactory, useRender } from '@/util'
 
 // Types
@@ -38,6 +39,7 @@ export const makeVColorInputProps = propsFactory({
   hidePip: Boolean,
   colorPip: Boolean,
   menuProps: Object as PropType<VMenu['$props']>,
+  openOnFocus: Boolean,
   pipIcon: {
     type: String,
     default: '$color',
@@ -76,11 +78,15 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
   setup (props, { slots }) {
     const model = useProxiedModel(props, 'modelValue')
     const menu = shallowRef(false)
+    const vMenuRef = ref<VMenu>()
+    const vTextFieldRef = ref<VTextField>()
     const isFocused = shallowRef(props.focused)
 
     const isInteractive = computed(() => !props.disabled && !props.readonly)
 
     const display = computed(() => model.value || null)
+
+    useOpenOnFocus(menu, isFocused, () => props.openOnFocus && isInteractive.value)
 
     function onKeydown (e: KeyboardEvent) {
       if (e.key !== 'Enter') return
@@ -101,6 +107,10 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
       e.stopPropagation()
 
       menu.value = true
+    }
+
+    function onBlur () {
+      closeWhenFocusLeaves(menu, vTextFieldRef.value?.$el, vMenuRef.value?.contentEl)
     }
 
     function onSave () {
@@ -145,6 +155,7 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
 
       return (
         <VTextField
+          ref={ vTextFieldRef }
           { ...textFieldProps }
           class={[
             'v-color-input',
@@ -157,6 +168,7 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
           onClick:control={ !props.disabled ? onClick : undefined }
           onClick:prependInner={ !props.disabled ? onClick : undefined }
           onUpdate:focused={ event => isFocused.value = event }
+          onBlur={ onBlur }
           onClick:appendInner={ !props.disabled ? onClick : undefined }
           onUpdate:modelValue={ val => {
             model.value = val
@@ -168,6 +180,7 @@ export const VColorInput = genericComponent<VColorInputSlots>()({
             default: () => (
               <>
                 <VMenu
+                  ref={ vMenuRef }
                   v-model={ menu.value }
                   activator="parent"
                   minWidth="0"

--- a/packages/vuetify/src/components/VColorInput/__tests__/VColorInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VColorInput/__tests__/VColorInput.spec.browser.tsx
@@ -2,9 +2,59 @@
 import { VColorInput } from '../VColorInput'
 
 // Utilities
-import { render, userEvent } from '@test'
+import { render, screen, userEvent } from '@test'
+
+const openPickers = () => [...document.querySelectorAll<HTMLElement>('.v-color-picker')].filter(el => el.checkVisibility())
 
 describe('VColorInput', () => {
+  it('should close the picker when tabbing out of the field', async () => {
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VColorInput />
+        <button data-testid="after">after</button>
+      </>
+    ))
+
+    const input = screen.getByCSS('.v-color-input input[type="text"]')
+
+    await userEvent.click(input)
+    await expect.poll(openPickers).toHaveLength(1)
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+    await expect.poll(openPickers).toHaveLength(0)
+    expect(document.activeElement).toBe(screen.getByTestId('before'))
+
+    await userEvent.click(input)
+    await expect.poll(openPickers).toHaveLength(1)
+
+    await userEvent.keyboard('{Tab}')
+    await expect.poll(openPickers).toHaveLength(0)
+    expect(document.activeElement).toBe(screen.getByTestId('after'))
+  })
+
+  it('should keep only the focused field open when both use open-on-focus', async () => {
+    render(() => (
+      <>
+        <VColorInput label="A" openOnFocus />
+        <VColorInput label="B" openOnFocus />
+      </>
+    ))
+
+    const inputs = screen.getAllByCSS('.v-color-input input[type="text"]')
+
+    inputs[0].focus()
+    await expect.poll(openPickers).toHaveLength(1)
+
+    await userEvent.keyboard('{Tab}')
+    await expect.poll(() => document.activeElement).toBe(inputs[1])
+    await expect.poll(openPickers).toHaveLength(1)
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+    await expect.poll(() => document.activeElement).toBe(inputs[0])
+    await expect.poll(openPickers).toHaveLength(1)
+  })
+
   it('should not fire @update:focus twice when clicking bottom of input', async () => {
     const onFocus = vi.fn()
     const { element } = render(() => (

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -228,7 +228,7 @@ export const VCombobox = genericComponent<new <
       (props.hideNoData && !displayItems.value.length) ||
       form.isReadonly.value || form.isDisabled.value
     ))
-    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled })
+    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled, isFocused })
 
     const { menuId, ariaExpanded, ariaControls } = useMenuActivator(props, menu)
 

--- a/packages/vuetify/src/components/VCombobox/VCombobox.tsx
+++ b/packages/vuetify/src/components/VCombobox/VCombobox.tsx
@@ -360,6 +360,7 @@ export const VCombobox = genericComponent<new <
           break
         case 'Tab':
           selectHighlighted()
+          menu.value = false
           break
         default:
           onSelectionKeydown(e)

--- a/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
+++ b/packages/vuetify/src/components/VCombobox/__tests__/VCombobox.spec.browser.tsx
@@ -45,6 +45,27 @@ const stories = Object.fromEntries(Object.entries({
 )]))
 
 describe('VCombobox', () => {
+  it.each([
+    ['{Tab}', 'after'],
+    ['{Shift>}{Tab}{/Shift}', 'before'],
+  ])('should leave the field with a single %s while the menu is open', async (keys, target) => {
+    const menu = ref(false)
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VCombobox items={ items } openOnFocus v-model:menu={ menu.value } />
+        <button data-testid="after">after</button>
+      </>
+    ))
+
+    screen.getByCSS('.v-combobox input[type="text"]').focus()
+    await expect.poll(() => menu.value).toBe(true)
+
+    await userEvent.keyboard(keys)
+    await expect.poll(() => menu.value).toBe(false)
+    await expect.poll(() => document.activeElement).toBe(screen.getByTestId(target))
+  })
+
   describe('closableChips', () => {
     it('should close only first chip', async () => {
       const items = [

--- a/packages/vuetify/src/components/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/components/VDateInput/VDateInput.tsx
@@ -13,6 +13,7 @@ import { makeDisplayProps, useDisplay } from '@/composables/display'
 import { makeFocusProps } from '@/composables/focus'
 import { forwardRefs } from '@/composables/forwardRefs'
 import { useLocale } from '@/composables/locale'
+import { closeWhenFocusLeaves, useOpenOnFocus } from '@/composables/openOnFocus'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
@@ -50,6 +51,7 @@ export const makeVDateInputProps = propsFactory({
   },
   menu: Boolean,
   menuProps: Object as PropType<VMenu['$props']>,
+  openOnFocus: Boolean,
   updateOn: {
     type: Array as PropType<('blur' | 'enter')[]>,
     default: () => ['blur', 'enter'],
@@ -130,7 +132,10 @@ export const VDateInput = genericComponent<new <
     const isEditingInput = shallowRef(false)
     const isFocused = shallowRef(props.focused)
     const vTextFieldRef = ref<VTextField>()
+    const vMenuRef = ref<VMenu>()
     const disabledActions = ref<typeof VConfirmEdit['props']['disabled']>(['save'])
+
+    useOpenOnFocus(menu, isFocused, () => props.openOnFocus && !props.disabled)
 
     function format (date: unknown) {
       if (isFunction(props.displayFormat)) {
@@ -241,6 +246,8 @@ export const VDateInput = genericComponent<new <
         menu.value = false
         isEditingInput.value = false
       }
+
+      closeWhenFocusLeaves(menu, vTextFieldRef.value?.$el, vMenuRef.value?.contentEl)
     }
 
     function onUserInput ({ value }: HTMLInputElement) {
@@ -310,6 +317,7 @@ export const VDateInput = genericComponent<new <
             default: () => (
               <>
                 <VMenu
+                  ref={ vMenuRef }
                   v-model={ menu.value }
                   activator="parent"
                   minWidth="0"

--- a/packages/vuetify/src/components/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -6,6 +6,60 @@ import { render, screen, userEvent } from '@test'
 import { ref } from 'vue'
 
 describe('VDateInput', () => {
+  it('should close the picker when tabbing out of the field', async () => {
+    const menu = ref(false)
+    render(() => (
+      <>
+        <button data-testid="before">before</button>
+        <VDateInput v-model:menu={ menu.value } />
+        <button data-testid="after">after</button>
+      </>
+    ))
+
+    const input = screen.getByCSS('.v-date-input input[type="text"]')
+
+    await userEvent.click(input)
+    await expect.poll(() => menu.value).toBe(true)
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+    await expect.poll(() => menu.value).toBe(false)
+    expect(document.activeElement).toBe(screen.getByTestId('before'))
+
+    await userEvent.click(input)
+    await expect.poll(() => menu.value).toBe(true)
+
+    await userEvent.keyboard('{Tab}')
+    await expect.poll(() => menu.value).toBe(false)
+    expect(document.activeElement).toBe(screen.getByTestId('after'))
+  })
+
+  it('should keep only the focused field open when both use open-on-focus', async () => {
+    const menuA = ref(false)
+    const menuB = ref(false)
+    render(() => (
+      <>
+        <VDateInput label="A" openOnFocus v-model:menu={ menuA.value } />
+        <VDateInput label="B" openOnFocus v-model:menu={ menuB.value } />
+      </>
+    ))
+
+    const inputs = screen.getAllByCSS('.v-date-input input[type="text"]')
+
+    inputs[0].focus()
+    await expect.poll(() => menuA.value).toBe(true)
+    await expect.poll(() => menuB.value).toBe(false)
+
+    await userEvent.keyboard('{Tab}')
+    await expect.poll(() => document.activeElement).toBe(inputs[1])
+    await expect.poll(() => menuA.value).toBe(false)
+    await expect.poll(() => menuB.value).toBe(true)
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}')
+    await expect.poll(() => document.activeElement).toBe(inputs[0])
+    await expect.poll(() => menuA.value).toBe(true)
+    await expect.poll(() => menuB.value).toBe(false)
+  })
+
   it('should not fire @update:focus twice when clicking bottom of input', async () => {
     const onFocus = vi.fn()
     const { element } = render(() => (

--- a/packages/vuetify/src/components/VSelect/VSelect.tsx
+++ b/packages/vuetify/src/components/VSelect/VSelect.tsx
@@ -94,6 +94,7 @@ export const makeSelectProps = propsFactory({
     default: '$vuetify.noDataText',
   },
   openOnClear: Boolean,
+  openOnFocus: Boolean,
   itemColor: String,
   noAutoScroll: Boolean,
 
@@ -209,7 +210,7 @@ export const VSelect = genericComponent<new <
       (props.hideNoData && !displayItems.value.length) ||
       form.isReadonly.value || form.isDisabled.value
     ))
-    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled })
+    const { menu, closeOnSelect } = useSelectionMenu(props, { vMenuRef, menuDisabled, isFocused })
 
     const { menuId, ariaExpanded, ariaControls } = useMenuActivator(props, menu)
 
@@ -418,10 +419,24 @@ export const VSelect = genericComponent<new <
         if (closeMenu) nextTick(() => closeOnSelect())
       }
     }
+    let mousedownInsideContentAt = 0
+    function onMousedownContent () {
+      mousedownInsideContentAt = performance.now()
+    }
+
     function onBlur (e: FocusEvent) {
       const target = e.target as Element
       if (!vTextFieldRef.value?.$el.contains(target)) {
         menu.value = false
+      }
+
+      // Clicking dead space in the menu parks focus on body, we still count as focused
+      const next = e.relatedTarget as Node | null
+      if (
+        vMenuRef.value?.contentEl?.contains(next) ||
+        (!next && performance.now() - mousedownInsideContentAt < 10)
+      ) {
+        isFocused.value = true
       }
     }
     function getSelectedIndex () {
@@ -596,6 +611,7 @@ export const VSelect = genericComponent<new <
                     onFocusin={ onFocusin }
                     onFocusout={ onFocusout }
                     onKeydown={ onMenuKeydown }
+                    onMousedown={ onMousedownContent }
                   >
                     { slots['menu-header'] && (
                       <header ref={ headerRef }>

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -48,6 +48,87 @@ const stories = Object.fromEntries(Object.entries({
 )]))
 
 describe('VSelect', () => {
+  describe('open-on-focus', () => {
+    it('should open the menu when the input is focused', async () => {
+      render(() => (
+        <>
+          <button data-testid="before">before</button>
+          <VSelect items={ items } openOnFocus />
+        </>
+      ))
+
+      screen.getByTestId('before').focus()
+      await userEvent.keyboard('{Tab}')
+
+      await expect.poll(() => screen.queryAllByRole('option')).not.toStrictEqual([])
+    })
+
+    it('should open again after the menu was closed by an outside click', async () => {
+      const menu = ref(false)
+      render(() => (
+        <>
+          <button data-testid="outside">outside</button>
+          <VSelect items={ items } openOnFocus v-model:menu={ menu.value } />
+        </>
+      ))
+
+      const input = screen.getByCSS('.v-select input[type="text"]')
+      input.focus()
+      await expect.poll(() => menu.value).toBe(true)
+
+      await userEvent.click(screen.getByTestId('outside'))
+      await expect.poll(() => menu.value).toBe(false)
+
+      input.focus()
+      await expect.poll(() => menu.value).toBe(true)
+    })
+
+    it('should not reopen after Escape when a click landed on dead space in the menu', async () => {
+      const menu = ref(false)
+      render(() => (
+        <>
+          <button data-testid="before">before</button>
+          <VSelect items={ items } openOnFocus v-model:menu={ menu.value }>
+            {{
+              'menu-header': () => <div data-testid="dead-space" style="padding: 16px">Header</div>,
+            }}
+          </VSelect>
+        </>
+      ))
+
+      screen.getByTestId('before').focus()
+      await userEvent.keyboard('{Tab}')
+      await expect.poll(() => menu.value).toBe(true)
+
+      await userEvent.click(screen.getByTestId('dead-space'))
+      await userEvent.keyboard('{Escape}')
+      await wait(300)
+
+      expect(menu.value).toBe(false)
+    })
+  })
+
+  it('should stay focused when a click lands on dead space in the menu', async () => {
+    const { element } = render(() => (
+      <VSelect items={ items }>
+        {{
+          'menu-header': () => <div data-testid="dead-space" style="padding: 16px">Header</div>,
+        }}
+      </VSelect>
+    ))
+
+    await userEvent.click(element)
+    await screen.findByRole('listbox')
+
+    await userEvent.click(screen.getByTestId('dead-space'))
+    await wait(60)
+
+    expect(element).toHaveClass('v-input--focused')
+
+    await userEvent.click(screen.getAllByRole('option')[0])
+    await expect.poll(() => document.activeElement).toBe(screen.getByCSS('.v-select input[type="text"]'))
+  })
+
   it('should toggle menu with dropdown icon', async () => {
     const { element } = render(() => (
       <VSelect items={['Item #1', 'Item #2']} />

--- a/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
+++ b/packages/vuetify/src/components/VSelect/__tests__/VSelect.spec.browser.tsx
@@ -83,6 +83,27 @@ describe('VSelect', () => {
       await expect.poll(() => menu.value).toBe(true)
     })
 
+    it.each([
+      ['{Tab}', 'after'],
+      ['{Shift>}{Tab}{/Shift}', 'before'],
+    ])('should leave the field with a single %s while the menu is open', async (keys, target) => {
+      const menu = ref(false)
+      render(() => (
+        <>
+          <button data-testid="before">before</button>
+          <VSelect items={ items } openOnFocus v-model:menu={ menu.value } />
+          <button data-testid="after">after</button>
+        </>
+      ))
+
+      screen.getByCSS('.v-select input[type="text"]').focus()
+      await expect.poll(() => menu.value).toBe(true)
+
+      await userEvent.keyboard(keys)
+      await expect.poll(() => menu.value).toBe(false)
+      await expect.poll(() => document.activeElement).toBe(screen.getByTestId(target))
+    })
+
     it('should not reopen after Escape when a click landed on dead space in the menu', async () => {
       const menu = ref(false)
       render(() => (

--- a/packages/vuetify/src/components/VSelect/useSelectionMenu.ts
+++ b/packages/vuetify/src/components/VSelect/useSelectionMenu.ts
@@ -1,4 +1,5 @@
 // Composables
+import { useOpenOnFocus } from '@/composables/openOnFocus'
 import { useProxiedModel } from '@/composables/proxiedModel'
 
 // Utilities
@@ -13,6 +14,7 @@ export interface SelectionMenuProps {
   'onUpdate:menu': ((value: boolean) => void) | undefined
   menuProps: VMenu['$props'] | undefined
   multiple: boolean
+  openOnFocus: boolean
 }
 
 export function useSelectionMenu (
@@ -20,6 +22,7 @@ export function useSelectionMenu (
   options: {
     vMenuRef: Ref<VMenu | undefined>
     menuDisabled: MaybeRefOrGetter<boolean>
+    isFocused: Ref<boolean>
   },
 ) {
   const _menu = useProxiedModel(props, 'menu')
@@ -32,6 +35,8 @@ export function useSelectionMenu (
       _menu.value = v
     },
   })
+
+  useOpenOnFocus(menu, options.isFocused, () => props.openOnFocus)
 
   function closeOnSelect () {
     if (props.multiple || props.menuProps?.closeOnContentClick === false) return

--- a/packages/vuetify/src/composables/openOnFocus.ts
+++ b/packages/vuetify/src/composables/openOnFocus.ts
@@ -1,0 +1,42 @@
+// Utilities
+import { nextTick, toValue, watch } from 'vue'
+import { getActiveElement } from '@/util'
+
+// Types
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+/** Close once focus has landed somewhere outside the field and its menu. */
+export function closeWhenFocusLeaves (menu: Ref<boolean>, ...els: (Element | null | undefined)[]) {
+  requestAnimationFrame(() => {
+    const active = getActiveElement()
+    // Body means focus is still in flight, e.g. arrow keys moving it into the menu
+    if (!active || active === document.body) return
+
+    if (!els.some(el => el?.contains(active))) {
+      menu.value = false
+    }
+  })
+}
+
+export function useOpenOnFocus (
+  menu: Ref<boolean>,
+  isFocused: Ref<boolean>,
+  enabled: MaybeRefOrGetter<boolean>,
+) {
+  let returningFocus = false
+
+  watch(menu, val => {
+    if (val) return
+
+    returningFocus = true
+    nextTick(() => returningFocus = false)
+  })
+
+  watch(isFocused, val => {
+    if (!val || returningFocus) {
+      returningFocus = false
+    } else if (toValue(enabled)) {
+      menu.value = true
+    }
+  })
+}


### PR DESCRIPTION
resolves #22934

```vue
<template>
  <v-app theme="dark">
    <v-container max-width="800">
      <v-select
        :items="[1,2,3]"
        item-title="value"
        item-value="id"
        label="Select with menu-header/menu-footer"
        chips
        closable-chips
        multiple
        open-on-focus
      >
        <template #menu-header="{ search }">
          <div class="pa-2 border-b">
            <v-text-field
              v-model="search.value"
              append-inner-icon="$close"
              density="compact"
              placeholder="Search..."
              prepend-inner-icon="mdi-magnify"
              hide-details
            />
          </div>
        </template>
        <template #menu-footer>
          <div class="d-flex justify-space-between pa-2 border-t">
            <v-btn text="Clear" variant="text" />
            <v-btn text="Done" variant="tonal" />
          </div>
        </template>
      </v-select>
      <v-combobox :items="[1,2]" open-on-focus />
      <v-autocomplete :items="[1,2]" open-on-focus />
      <v-date-input open-on-focus />
      <v-color-input open-on-focus show-swatches />
      <v-btn text="dummy" />
    </v-container>
  </v-app>
</template>
```
