### PR TITLE
fix(VProgressLinear): animate left/right directly instead of @property to fix Firefox indeterminate animation throttle

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
@@ -98,6 +98,9 @@
     animation-name: indeterminate-ltr
 
     .long, .short
+      animation-duration: inherit
+      animation-iteration-count: inherit
+      animation-play-state: inherit
       bottom: 0
       height: inherit
       position: absolute
@@ -105,12 +108,14 @@
       width: auto
 
     .long
-      left: var(--v-progress-indeterminate-long-left)
-      right: var(--v-progress-indeterminate-long-right)
+      animation-name: indeterminate-ltr-long
+      left: -90%
+      right: 107%
 
     .short
-      left: var(--v-progress-indeterminate-short-left)
-      right: var(--v-progress-indeterminate-short-right)
+      animation-name: indeterminate-ltr-short
+      left: -200%
+      right: 107%
 
     > .v-progress-linear__background
       height: 100%
@@ -153,6 +158,16 @@
 
     .v-progress-linear__indeterminate
       animation-name: indeterminate-rtl
+
+      .long
+        animation-name: indeterminate-rtl-long
+        left: 107%
+        right: -90%
+
+      .short
+        animation-name: indeterminate-rtl-short
+        left: 107%
+        right: -200%
 
       > .v-progress-linear__background
         &:nth-child(1)
@@ -234,6 +249,25 @@
       --v-progress-indeterminate-short-left: 107%
       --v-progress-indeterminate-short-right: -8%
 
+  @keyframes indeterminate-ltr-long
+    0%
+      left: -90%
+      right: 107%
+    100%
+      left: 107%
+      right: -35%
+
+  @keyframes indeterminate-ltr-short
+    0%
+      left: -200%
+      right: 107%
+    60%
+      left: 107%
+      right: -8%
+    100%
+      left: 107%
+      right: -8%
+
   @keyframes indeterminate-rtl
     0%
       --v-progress-indeterminate-long-left: 107%
@@ -250,6 +284,25 @@
       --v-progress-indeterminate-long-right: 107%
       --v-progress-indeterminate-short-left: -8%
       --v-progress-indeterminate-short-right: 107%
+
+  @keyframes indeterminate-rtl-long
+    0%
+      left: 107%
+      right: -90%
+    100%
+      left: -35%
+      right: 107%
+
+  @keyframes indeterminate-rtl-short
+    0%
+      left: 107%
+      right: -200%
+    60%
+      left: -8%
+      right: 107%
+    100%
+      left: -8%
+      right: 107%
 
   @keyframes stream
     to


### PR DESCRIPTION
## Problem

In Firefox, the indeterminate animation of VProgressLinear pauses when the mouse is not moving. The issue is that Firefox throttles `@property`-registered custom property animations when there is no user interaction, stopping the indeterminate progress bar animation from playing.

## Root Cause

The current implementation uses `@property`-registered custom properties (`--v-progress-indeterminate-long-left`, etc.) animated via `@keyframes`, with `.long` and `.short` elements reading these values via `left: var(...)`. Firefox has a known issue where registered custom property animations are throttled (paused) when the page is idle — the animation only runs when the user is actively interacting with the page.

## Fix

Instead of relying on `@property` custom property interpolation for the `.long` and `.short` indicator bars, animate `left` and `right` directly on these elements using dedicated `@keyframes`:

- `indeterminate-ltr-long` / `indeterminate-ltr-short` for the default LTR direction
- `indeterminate-rtl-long` / `indeterminate-rtl-short` for the reverse RTL direction

This bypasses the Firefox `@property` throttling entirely because `left` and `right` are standard CSS properties that browsers handle on the compositor thread without user-interaction gating.

The `@property` declarations and the original `indeterminate-ltr`/`indeterminate-rtl` keyframes are preserved for the `variant="split"` background chunk elements, which still need custom property interpolation for their gap-based width calculations.

## Key changes

- `.long` and `.short` now use `animation-name: indeterminate-ltr-long` / `indeterminate-ltr-short` instead of reading animated custom properties
- `.long` and `.short` use `animation-play-state: inherit` so they pause/resume with the parent `--active` class
- `.long` and `.short` have explicit initial `left`/`right` values matching the 0% keyframe positions
- Added 4 new `@keyframes` rules: `indeterminate-ltr-long`, `indeterminate-ltr-short`, `indeterminate-rtl-long`, `indeterminate-rtl-short`
- The same fix applied to the RTL/reverse variant

## Fixes

Fixes #23125