### PR TITLE
fix(VMenu): only emit aria-controls/aria-owns while menu is open (Fixes #23119)

### DIFF
--- a/packages/vuetify/src/components/VMenu/VMenu.tsx
+++ b/packages/vuetify/src/components/VMenu/VMenu.tsx
@@ -168,8 +168,9 @@ export const VMenu = genericComponent<OverlaySlots>()({
       mergeProps({
         'aria-haspopup': 'menu',
         'aria-expanded': String(isActive.value),
-        'aria-controls': id.value,
-        'aria-owns': id.value,
+        ...(isActive.value
+          ? { 'aria-controls': id.value, 'aria-owns': id.value }
+          : {}),
         onKeydown: onActivatorKeydown,
       }, props.activatorProps)
     )

--- a/packages/vuetify/src/composables/menuActivator.ts
+++ b/packages/vuetify/src/composables/menuActivator.ts
@@ -28,7 +28,7 @@ export function useMenuActivator (props: MenuActivatorProps, isOpen: MaybeRefOrG
   const menuId = computed(() => `menu-${uid}`)
 
   const ariaExpanded = toRef(() => toValue(isOpen))
-  const ariaControls = toRef(() => menuId.value)
+  const ariaControls = toRef(() => (toValue(isOpen) ? menuId.value : undefined))
 
   return {
     menuId,


### PR DESCRIPTION
Fixes #23119

## Problem

The W3C validator and axe flag a11y errors on the **closed** state of `VMenu`, `VSelect`, `VAutocomplete` and `VCombobox`: the activator (or the input) references an `aria-controls` / `aria-owns` id (e.g. `menu-42`) that does not exist in the document while the popup is closed.

## Expected behavior

Per the [ARIA combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/):

> Note that `aria-controls` only needs to be set when the popup is visible. However, it is valid to reference an element that is not visible.

Referencing a *hidden* element is valid — referencing an id that is **not in the document** is not. In the [menu button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/), `aria-controls` is optional altogether.

## Fix

- `VMenu.tsx`: `activatorProps` now spreads `aria-controls` / `aria-owns` **only when `isActive.value` is true**
- `composables/menuActivator.ts`: `ariaControls` now resolves to `undefined` while the menu is closed, so the attribute is not rendered on `VSelect` / `VAutocomplete` / `VCombobox` inputs

```js
// before (closed menu)
<input aria-controls="menu-42" />  // menu-42 not in DOM -> axe error

// after (closed menu)
<input />                          // no dangling reference

// after (open menu)
<input aria-controls="menu-42" />  // menu-42 now in DOM
```

## Tests

- Closed `VMenu` / `VSelect` / `VAutocomplete` / `VCombobox`: no `aria-controls` / `aria-owns` attribute in the DOM (validator/axe clean)
- Open state keeps working: attributes appear and reference the actual popup id
