### PR TITLE
fix(useLink): prevent flash for every `to` component on page refresh

### DIFF
--- a/packages/vuetify/src/composables/router.tsx
+++ b/packages/vuetify/src/composables/router.tsx
@@ -85,6 +85,13 @@ export function useLink (props: LinkProps & LinkListeners, attrs: SetupContext['
   const route = useRoute()
   const isActive = computed(() => {
     if (!link.value) return false
+    // router still resolving initial navigation, according to posva:
+    // - START_LOCATION has an empty matched array and its name is undefined (unlike 404 Not Page Found)
+    // - if the router is still resolving the initial boot, we bypass the active check and return false to
+    //   prevent the flashing overlay on page refresh
+    if (route.value && route.value.matched.length === 0 && route.value.name == null) {
+      return link.value.isExactActive?.value ?? false
+    }
     if (!props.exact) return link.value.isActive?.value ?? false
     if (!route.value) return link.value.isExactActive?.value ?? false
 

--- a/packages/vuetify/src/composables/router.tsx
+++ b/packages/vuetify/src/composables/router.tsx
@@ -87,8 +87,8 @@ export function useLink (props: LinkProps & LinkListeners, attrs: SetupContext['
     if (!link.value) return false
     // router still resolving initial navigation, according to posva:
     // - START_LOCATION has an empty matched array and its name is undefined (unlike 404 Not Page Found)
-    // - if the router is still resolving the initial boot, we bypass the active check and return false to
-    //   prevent the flashing overlay on page refresh
+    // - if the router is still resolving the initial boot, we bypass the active check and returns
+    //   isExactActive ?? false to prevent the flashing overlay on page refresh
     if (route.value && route.value.matched.length === 0 && route.value.name == null) {
       return link.value.isExactActive?.value ?? false
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
This PR includes a fix to avoid flashing on components using `to` via `vue-router` with nuxt.

It is hard to reproduce the issue, since I use UnoCSS + unocss-preset-vuetify with layers without colors and utilities (disabled at scss); and the playground using vite-ssr/vue, will await for router ready event.

https://discord.com/channels/1513968811047522396/1514028532454658148/1539309759931359236

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
