### PR TITLE
docs: stable anchor scrolling and TOC active states

### DIFF
--- a/packages/docs/src/components/app/Toc.vue
+++ b/packages/docs/src/components/app/Toc.vue
@@ -122,7 +122,7 @@
 </template>
 
 <script setup lang="ts">
-  const { toc: tocDrawer, scrolling } = storeToRefs(useAppStore())
+  const { toc: tocDrawer } = storeToRefs(useAppStore())
 
   const route = useRoute()
   const router = useRouter()
@@ -145,7 +145,6 @@
   }, { rootMargin: '-10% 0px -75%' })
 
   async function observeToc () {
-    scrolling.value = false
     activeStack.length = 0
     activeItem.value = ''
     observer.disconnect()
@@ -165,11 +164,10 @@
   })
 
   let internalScrolling = false
-  let timeout = -1
+
   watch(activeItem, async val => {
     if (!val || internalScrolling) return
 
-    scrolling.value = true
     const query = route.query
 
     if (val === frontmatter.value?.toc?.[0]?.to.slice(1) && route.hash) {
@@ -180,20 +178,37 @@
         await router.replace({ path: route.path, hash: toc.to, query })
       }
     }
-    clearTimeout(timeout)
-    timeout = window.setTimeout(() => {
-      scrolling.value = false
-    }, 200)
   })
 
   async function onClick (hash: string) {
-    if (route.hash === hash) return
-
     internalScrolling = true
     await router.replace({ path: route.path, hash })
-    setTimeout(() => {
+
+    // avoid CSS selector issues by only allowing ID selectors
+    const el = document.getElementById(hash.slice(1))
+    if (el) {
+      // If the user does not want animations, or the jump is greater than 500 pixels, instant.
+      const isReduced =
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+        Math.abs(el.getBoundingClientRect().top) > 500
+
+      // Listener to release internalScrolling just at the end of the animation
+      let fallbackTimeout: ReturnType<typeof setTimeout>
+      const onScrollEnd = () => {
+        internalScrolling = false
+        clearTimeout(fallbackTimeout)
+        document.removeEventListener('scrollend', onScrollEnd)
+      }
+      document.addEventListener('scrollend', onScrollEnd)
+
+      // Security fallback of 1000ms for older browsers or instant jumps
+      fallbackTimeout = setTimeout(onScrollEnd, 1000)
+
+      el.scrollIntoView({ behavior: isReduced ? 'instant' : 'smooth' })
+    } else {
+      // release the internalScrolling flag if the element is not found, to avoid locking the state
       internalScrolling = false
-    }, 1000)
+    }
   }
 
   const sponsorStore = useSponsorsStore()

--- a/packages/docs/src/main.scss
+++ b/packages/docs/src/main.scss
@@ -1,1 +1,6 @@
 @layer vuetify-core, base, vuetify-components, vuetify-overrides, vuetify-utilities, vuetify-final;
+
+/* sections for toc */
+main.v-main section section[id] {
+  scroll-margin-top: var(--v-layout-top);
+}

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -81,10 +81,32 @@ const waitForElementStable = (selector: string, maxWaitMs = 3000): Promise<boole
     const startTime = performance.now()
     let lastTop: number | null = null
     let stableFrames = 0
+    let userAborted = false
+
+    // Listen for user events to abort the automatic scroll
+    const abortEvents = ['wheel', 'touchmove', 'keydown']
+    const onUserInteraction = () => {
+      userAborted = true
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      cleanup()
+      // Return false to cancel the scrollIntoView
+      resolve(false)
+    }
+
+    const cleanup = () => {
+      abortEvents.forEach(e => window.removeEventListener(e, onUserInteraction, { capture: true }))
+    }
+
+    // Register the listeners (once: true so they clean up automatically when triggered)
+    abortEvents.forEach(e => window.addEventListener(e, onUserInteraction, { capture: true, once: true, passive: true }))
 
     const checkFrame = (currentTime: number) => {
+      // If the user moved, stop the loop immediately
+      if (userAborted) return
+
       // abort if we exceed 3 seconds (bounded)
       if (currentTime - startTime > maxWaitMs) {
+        cleanup()
         return resolve(false)
       }
 
@@ -97,6 +119,7 @@ const waitForElementStable = (selector: string, maxWaitMs = 3000): Promise<boole
           stableFrames++
           // If it has been stable for 3 consecutive frames, consider it "position stable"
           if (stableFrames >= 3) {
+            cleanup()
             return resolve(true)
           }
         } else {

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -171,6 +171,11 @@ const router = createRouter({
 
     // 2: Initial load
     if (from === START_LOCATION) {
+      // Respect browser reload convention: restore saved position if available
+      if (savedPosition) {
+        return savedPosition
+      }
+
       if (to.hash) {
         // We do the rAF poll limited to 3s
         const isStable = await waitForElementStable(to.hash, 3000)
@@ -182,40 +187,35 @@ const router = createRouter({
             // manual scroll with "instant" (without behavior: smooth) because the user just entered the page
             // vue-router's scrollBehavior uses scrollTo that does no respect scroll-margin-top CSS rule
             el.scrollIntoView({ behavior: 'instant' })
-            return false
           }
         }
+        // If unstable or aborted by user interaction, do not yank to top; stay put
+        return false
       }
       return { top: 0 }
     }
 
     // 3: Standard navigation crossing pages
-    let wait = 0
     if (to.path !== from.path && to.hash) {
-      wait = 500
-    }
+      // We use the rAF poll instead of a blind 500ms timeout
+      const isStable = await waitForElementStable(to.hash, 3000)
 
-    if (wait > 0) {
-      await (new Promise(resolve => setTimeout(resolve, wait)))
-    }
+      if (isStable) {
+        // avoid CSS selector issues by only allowing ID selectors
+        const el = document.getElementById(to.hash.slice(1))
+        if (el) {
+          // manual scroll with "instant/smooth"
+          // vue-router's scrollBehavior uses scrollTo that does no respect scroll-margin-top CSS rule
+          const isReduced =
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+            Math.abs(el.getBoundingClientRect().top) > 500
 
-    if (to.hash) {
-      // avoid CSS selector issues by only allowing ID selectors
-      const el = document.getElementById(to.hash.slice(1))
-      // manual scroll with "instant/smooth"
-      // vue-router's scrollBehavior uses scrollTo that does no respect scroll-margin-top CSS rule
-      if (el) {
-        // 3.1: Keep 'smooth' ONLY for explicit clicks (onClick) in the TOC
-        // If the user does not want animations, or the jump is greater than 500 pixels, instant.
-        const isReduced =
-          window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
-          Math.abs(el.getBoundingClientRect().top) > 500
-
-        el.scrollIntoView({ behavior: isReduced ? 'instant' : 'smooth' })
-        return false
+          el.scrollIntoView({ behavior: isReduced ? 'instant' : 'smooth' })
+        }
       }
 
-      return { el: to.hash }
+      // Fallback if the element is not found or the user aborted; do not jump to top
+      return false
     } else if (savedPosition) {
       return savedPosition
     } else {

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -6,14 +6,13 @@ import 'prism-theme-vars/base.css'
 import * as Swetrix from 'swetrix'
 import * as Sentry from '@sentry/vue'
 import { createApp } from 'vue'
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, START_LOCATION } from 'vue-router'
 import { createHead } from '@unhead/vue/client'
 import { installVuetify } from '@/plugins/vuetify'
 import { installPinia, pinia } from '@/plugins/pinia'
 import { installGlobalComponents } from '@/plugins/global-components'
 import { installOne } from '@/plugins/one'
 import { installI18n } from '@/plugins/i18n'
-import { useAppStore } from '@/stores/app'
 import { useLocaleStore } from '@/stores/locale'
 import { installPwa } from '@/plugins/pwa'
 import { useUserStore } from '@vuetify/one'
@@ -41,7 +40,6 @@ import { IN_BROWSER } from '@/utils/globals'
 
 const routes = setupLayouts(generatedRoutes)
 
-const appStore = useAppStore(pinia)
 const localeStore = useLocaleStore(pinia)
 const userStore = useUserStore(pinia)
 
@@ -78,6 +76,44 @@ if (IN_BROWSER) {
   })
 }
 
+const waitForElementStable = (selector: string, maxWaitMs = 3000): Promise<boolean> => {
+  return new Promise<boolean>(resolve => {
+    const startTime = performance.now()
+    let lastTop: number | null = null
+    let stableFrames = 0
+
+    const checkFrame = (currentTime: number) => {
+      // abort if we exceed 3 seconds (bounded)
+      if (currentTime - startTime > maxWaitMs) {
+        return resolve(false)
+      }
+
+      // avoid CSS selector issues by only allowing ID selectors
+      const el = document.getElementById(selector.slice(1))
+      if (el) {
+        const currentTop = el.getBoundingClientRect().top
+        // Check if the Y position is identical to the previous frame
+        if (lastTop === currentTop) {
+          stableFrames++
+          // If it has been stable for 3 consecutive frames, consider it "position stable"
+          if (stableFrames >= 3) {
+            return resolve(true)
+          }
+        } else {
+          // If it has moved, reset the counter
+          stableFrames = 0
+          lastTop = currentTop
+        }
+      }
+
+      // next frame
+      requestAnimationFrame(checkFrame)
+    }
+
+    requestAnimationFrame(checkFrame)
+  })
+}
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -107,31 +143,61 @@ const router = createRouter({
     },
   ],
   async scrollBehavior (to, from, savedPosition) {
-    if (appStore.scrolling) return
+    // 1: Table of Contents (TOC) rewrites should never scroll: Toc.vue will scroll.
+    if (to.path === from.path && to.hash !== from.hash) return false
 
-    let main = IN_BROWSER && document.querySelector('main')
-    // For default & hash navigation
+    // 2: Initial load
+    if (from === START_LOCATION) {
+      if (to.hash) {
+        // We do the rAF poll limited to 3s
+        const isStable = await waitForElementStable(to.hash, 3000)
+
+        if (isStable) {
+          // avoid CSS selector issues by only allowing ID selectors
+          const el = document.getElementById(to.hash.slice(1))
+          if (el) {
+            // manual scroll with "instant" (without behavior: smooth) because the user just entered the page
+            // vue-router's scrollBehavior uses scrollTo that does no respect scroll-margin-top CSS rule
+            el.scrollIntoView({ behavior: 'instant' })
+            return false
+          }
+        }
+      }
+      return { top: 0 }
+    }
+
+    // 3: Standard navigation crossing pages
     let wait = 0
-
-    if (!main) {
-      // For initial page load
-      wait = 1500
-      main = document.querySelector('main')
-    } else if (to.path !== from.path && to.hash) {
-      // For cross page navigation
+    if (to.path !== from.path && to.hash) {
       wait = 500
     }
 
-    await (new Promise(resolve => setTimeout(resolve, wait)))
+    if (wait > 0) {
+      await (new Promise(resolve => setTimeout(resolve, wait)))
+    }
 
     if (to.hash) {
-      return {
-        el: to.hash,
-        behavior: main ? 'smooth' : undefined,
-        top: main ? parseInt(getComputedStyle(main).getPropertyValue('--v-layout-top')) : 0,
+      // avoid CSS selector issues by only allowing ID selectors
+      const el = document.getElementById(to.hash.slice(1))
+      // manual scroll with "instant/smooth"
+      // vue-router's scrollBehavior uses scrollTo that does no respect scroll-margin-top CSS rule
+      if (el) {
+        // 3.1: Keep 'smooth' ONLY for explicit clicks (onClick) in the TOC
+        // If the user does not want animations, or the jump is greater than 500 pixels, instant.
+        const isReduced =
+          window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+          Math.abs(el.getBoundingClientRect().top) > 500
+
+        el.scrollIntoView({ behavior: isReduced ? 'instant' : 'smooth' })
+        return false
       }
-    } else if (savedPosition) return savedPosition
-    else return { top: 0 }
+
+      return { el: to.hash }
+    } else if (savedPosition) {
+      return savedPosition
+    } else {
+      return { top: 0 }
+    }
   },
 })
 

--- a/packages/docs/src/stores/app.ts
+++ b/packages/docs/src/stores/app.ts
@@ -14,7 +14,6 @@ type RootState = {
   scrolling: boolean
   items: NavItem[]
   pages: string[]
-  settings: boolean
   categories: Record<string, Category>
 }
 
@@ -33,7 +32,6 @@ export const useAppStore = defineStore('app', {
     apiSearch: '',
     drawer: null,
     toc: null,
-    scrolling: false,
     items: Array.from(data),
     pages: getPages(data as NavItem[]),
     settings: false,

--- a/packages/docs/src/stores/app.ts
+++ b/packages/docs/src/stores/app.ts
@@ -11,9 +11,9 @@ type RootState = {
   apiSearch: string
   drawer: boolean | null
   toc: boolean | null
-  scrolling: boolean
   items: NavItem[]
   pages: string[]
+  settings: boolean
   categories: Record<string, Category>
 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->

This PR completely overhauls the hash navigation, TOC scrolling UX, and layout offset handling in the documentation to fix race conditions, janky long-distance scrolls, and CSS offset overrides.

**Key changes include:**

- **Native CSS Offsets:** Replaced manual JS layout math (`getComputedStyle`) with native `scroll-margin-top: var(--v-layout-top)` on heading anchors (`main.v-main section section[id]`).
- **Stable Initial Load:** Replaced the arbitrary 1.5s timeout for `START_LOCATION` with a bounded `requestAnimationFrame` polling (`waitForElementStable`) that waits for DOM position stability (capped at 3s) before jumping to the anchor.
- **TOC Scrolling UX (`Toc.vue`):** 
  - Dropped the redundant `scrolling` flag from the global store.
  - Replaced arbitrary timeouts with native `scrollend` event listeners (with a fallback) for releasing the internal scroll lock exactly when the animation finishes.
  - Added smart scroll behavior: fallbacks to `instant` scroll behavior for long distances (> 500px) or when `prefers-reduced-motion: reduce` is enabled.
  - Removed early return guards in TOC `onClick` to allow manual re-triggering of the active anchor.
- **Router Scroll Behavior (`main.ts`):**  
  - Bypassed `vue-router`'s native `scrollTo` (which inherently ignores CSS `scroll-margin-top`) by manually calling `el.scrollIntoView()` and returning `false` for hash navigations, allowing the CSS rule to do its job. Included a fallback to native router behavior if the element is not found.
  - During the initial load's rAF poll (which waits up to 3s for DOM stability on heavy API pages), a user might start scrolling manually. If the auto-scroll triggers after they've moved, it yanks them back to the anchor, creating a jarring UX. We add one-time, passive capture listeners for `wheel`, `touchmove`, and `keydown` during the polling phase. If any user input is detected, the automatic `scrollIntoView` is immediately aborted to respect the user's manual navigation.
  - **Reload & Abort Safety:** Ensured browser reload conventions by checking `savedPosition` first on initial load, and returning `false` instead of `{ top: 0 }` on aborts or timeouts so the user is never unexpectedly yanked back to the top of the page.

## Motivation and Context

The previous implementation relied on arbitrary timeouts and JS-calculated offsets which led to race conditions, missed anchors on slow initial loads (especially noticeable with eager API-table rendering), and jarring smooth scrolls over massive distances (e.g., in the `v-date-input` API page). 

By delegating the layout offset to CSS, utilizing native DOM events, and implementing bounded polling, the scrolling experience is now stable, accessible, and much more performant.

## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue

```
