### PR TITLE
fix(VBadge): guard against NaN in aria-label when content is absent

### DIFF
--- a/packages/vuetify/src/components/VBadge/VBadge.tsx
+++ b/packages/vuetify/src/components/VBadge/VBadge.tsx
@@ -137,7 +137,7 @@ export const VBadge = genericComponent<VBadgeSlots>()({
                   roundedStyles.value,
                 ]}
                 aria-atomic="true"
-                aria-label={ t(props.label, value) }
+                aria-label={ t(props.label, isNaN(value) ? '' : value) }
                 aria-live="polite"
                 role="status"
                 { ...badgeAttrs }

--- a/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.browser.tsx
+++ b/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.browser.tsx
@@ -58,7 +58,7 @@ describe('VBadge', () => {
     })
 
     it('should not interpolate NaN into the aria label when content is absent', () => {
-      const { wrapper } = render(<VBadge label="Notifications {0}" dot />)
+      const { wrapper } = render(<VBadge label="Notifications {0}" />)
       const label = wrapper.find('.v-badge__badge').attributes('aria-label')
 
       expect(label).not.toContain('NaN')

--- a/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.browser.tsx
+++ b/packages/vuetify/src/components/VBadge/__tests__/VBadge.spec.browser.tsx
@@ -56,6 +56,14 @@ describe('VBadge', () => {
       render(<VBadge label="label-badge">label</VBadge>)
       await expect(screen.findByLabelText('label-badge')).resolves.toBeDefined()
     })
+
+    it('should not interpolate NaN into the aria label when content is absent', () => {
+      const { wrapper } = render(<VBadge label="Notifications {0}" dot />)
+      const label = wrapper.find('.v-badge__badge').attributes('aria-label')
+
+      expect(label).not.toContain('NaN')
+      expect(label).toBe('Notifications ')
+    })
   })
 
   describe('max', () => {


### PR DESCRIPTION
`VBadge`'s `aria-label` renders the literal string "NaN" when a consumer uses the documented `{0}` extension point in `label` but the badge has no `content` prop (e.g. before async content resolves, or a conditionally-omitted count).

Screen reader users hear "Notifications NaN" instead of the intended count.

## Root cause
`value = Number(props.content)` at `VBadge.tsx:87` evaluates to `NaN` when `content` is undefined. The `content` variable on the next line does guard with `isNaN(value)` for display purposes, but that guard isn't applied on the accessibility path — `value` is passed unguarded into `t(props.label, value)` at line 140, and the locale adapter's `replace()` (`packages/vuetify/src/locale/adapters/vuetify.ts:17-21`) stringifies parameters unconditionally (`String(NaN)` → `"NaN"`).

## Reproduction
```vue
<v-badge label="Notifications {0}">
  <v-btn>Inbox</v-btn>
</v-badge>
```
Confirmed live via play.vuetifyjs.com before filing this PR: renders `aria-label="Notifications NaN"`.

`value` and the `aria-label` interpolation are computed unconditionally in `useRender`, independent of `dot` — the bug reproduces the same with or without it. Also directly reachable through `VAvatar`'s public API: `<v-avatar :badge="{ label: 'Notifications {0}' }">` with no badge slot hits this exact path today.

## Fix
```tsx
aria-label={ t(props.label, isNaN(value) ? '' : value) }
```

## Test
Added a regression test in `VBadge.spec.browser.tsx`: without the fix it fails with `expected 'Notifications NaN' not to contain 'NaN'`; with the fix, all 5 tests in that describe block pass.

## Verification
- `pnpm --project browser --run VBadge`: 1 new test passing (5 total in the `label` describe block)
- `tsgo` type-check: exit 0
- `eslint --max-warnings 0`: exit 0