### PR TITLE
fix(VProgressLinear): round the correct bar end when reversed

### DIFF
--- a/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
+++ b/packages/vuetify/src/components/VProgressLinear/VProgressLinear.sass
@@ -206,9 +206,13 @@ $bar-transition: width $progress-linear-transition, left $progress-linear-transi
     .v-progress-linear__stream + .v-progress-linear__background
       @include tools.rounded($progress-linear-border-radius)
 
-    .v-progress-linear__determinate
-      border-start-start-radius: 0
-      border-end-start-radius: 0
+    &:not(.v-progress-linear--reverse) .v-progress-linear__determinate
+      border-top-left-radius: 0
+      border-bottom-left-radius: 0
+
+    &.v-progress-linear--reverse .v-progress-linear__determinate
+      border-top-right-radius: 0
+      border-bottom-right-radius: 0
 
   // Keyframes
   @keyframes indeterminate-ltr

--- a/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.browser.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.browser.tsx
@@ -50,5 +50,13 @@ describe('VProgressLinear', () => {
     expect(screen.getByCSS('.v-progress-linear__determinate').clientWidth).toBe(50)
   })
 
+  it('rounds the end of the bar that is not anchored when reversed', () => {
+    render(() => <VProgressLinear modelValue="25" roundedBar reverse />)
+
+    const styles = getComputedStyle(screen.getByCSS('.v-progress-linear__determinate'))
+    expect(styles.borderTopRightRadius).toBe('0px')
+    expect(styles.borderTopLeftRadius).not.toBe('0px')
+  })
+
   showcase({ stories })
 })

--- a/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.browser.tsx
+++ b/packages/vuetify/src/components/VProgressLinear/__tests__/VProgressLinear.spec.browser.tsx
@@ -50,12 +50,24 @@ describe('VProgressLinear', () => {
     expect(screen.getByCSS('.v-progress-linear__determinate').clientWidth).toBe(50)
   })
 
-  it('rounds the end of the bar that is not anchored when reversed', () => {
+  it('should not round the anchored end of the bar when reversed', async () => {
     render(() => <VProgressLinear modelValue="25" roundedBar reverse />)
 
-    const styles = getComputedStyle(screen.getByCSS('.v-progress-linear__determinate'))
-    expect(styles.borderTopRightRadius).toBe('0px')
-    expect(styles.borderTopLeftRadius).not.toBe('0px')
+    const bar = screen.getByCSS('.v-progress-linear__determinate')
+    await expect.element(bar).toHaveStyle({ borderTopRightRadius: '0px', borderBottomRightRadius: '0px' })
+    await expect.element(bar).not.toHaveStyle({ borderTopLeftRadius: '0px' })
+  })
+
+  it('should not round the anchored end of the bar when reversed in rtl', async () => {
+    render(() => (
+      <VLocaleProvider rtl>
+        <VProgressLinear modelValue="25" roundedBar reverse />
+      </VLocaleProvider>
+    ))
+
+    const bar = screen.getByCSS('.v-progress-linear__determinate')
+    await expect.element(bar).toHaveStyle({ borderTopLeftRadius: '0px', borderBottomLeftRadius: '0px' })
+    await expect.element(bar).not.toHaveStyle({ borderTopRightRadius: '0px' })
   })
 
   showcase({ stories })


### PR DESCRIPTION
## Description

With `rounded-bar`, the determinate bar squares off its logical start corners so it sits flush against the edge it grows from. That edge is picked by the `--reverse` modifier, which is already direction-aware (`isRtl !== reverse`), so the logical properties apply the RTL flip a second time and the wrong end gets squared whenever only one of RTL or `reverse` is set. Switching those two rules to physical corners, split across `--reverse`, keeps the flat end on the anchored side in all four combinations.

Fixes #23143

## Markup:
```vue
<template>
  <v-app>
    <v-container>
      <v-progress-linear model-value="25" height="20" color="primary" rounded-bar reverse />
    </v-container>
  </v-app>
</template>

<script>
  export default {
    name: 'Playground',
    setup () {
      return {
        //
      }
    },
  }
</script>
```
