### PR TITLE
fix(VPagination): flex bug #23145

### DIFF
--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -161,7 +161,8 @@ export const VPagination = genericComponent<VPaginationSlots>()({
 
       const { target, contentRect } = entries[0]
 
-      const firstItem = target.querySelector('.v-pagination__list > *') as HTMLElement
+      const buttons = target.querySelectorAll('.v-pagination__list > *')
+      const firstItem = buttons[0] as HTMLElement
 
       if (!firstItem) return
 
@@ -169,6 +170,8 @@ export const VPagination = genericComponent<VPaginationSlots>()({
       const itemWidth =
         firstItem.offsetWidth +
         parseFloat(getComputedStyle(firstItem).marginRight) * 2
+      const usedWidth = itemWidth * buttons.length
+      if (usedWidth <= totalWidth + 1 && totalWidth - usedWidth < itemWidth) return
 
       maxButtons.value = getMax(totalWidth, itemWidth)
     })

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -170,8 +170,16 @@ export const VPagination = genericComponent<VPaginationSlots>()({
       const itemWidth =
         firstItem.offsetWidth +
         parseFloat(getComputedStyle(firstItem).marginRight) * 2
-      const usedWidth = itemWidth * buttons.length
-      if (usedWidth <= totalWidth + 1 && totalWidth - usedWidth < itemWidth) return
+      // Assumes every button is as wide as the first one, which is a nav control
+      // (first/prev), not a page item. Custom slots can break that and skew the total.
+      const slack = totalWidth - itemWidth * buttons.length
+
+      // A shrink-to-fit container (flex item, inline-block, table cell) is only ever
+      // as wide as the buttons already inside it, so measuring it feeds the button
+      // count back into itself and oscillates forever. Such a container reports no
+      // overflow and no room to spare, so leave the estimate alone; only react to a
+      // container that is genuinely too small, or has room for another button.
+      if (slack >= -1 && slack < itemWidth) return
 
       maxButtons.value = getMax(totalWidth, itemWidth)
     })

--- a/packages/vuetify/src/components/VPagination/VPagination.tsx
+++ b/packages/vuetify/src/components/VPagination/VPagination.tsx
@@ -170,15 +170,9 @@ export const VPagination = genericComponent<VPaginationSlots>()({
       const itemWidth =
         firstItem.offsetWidth +
         parseFloat(getComputedStyle(firstItem).marginRight) * 2
-      // Assumes every button is as wide as the first one, which is a nav control
-      // (first/prev), not a page item. Custom slots can break that and skew the total.
       const slack = totalWidth - itemWidth * buttons.length
 
-      // A shrink-to-fit container (flex item, inline-block, table cell) is only ever
-      // as wide as the buttons already inside it, so measuring it feeds the button
-      // count back into itself and oscillates forever. Such a container reports no
-      // overflow and no room to spare, so leave the estimate alone; only react to a
-      // container that is genuinely too small, or has room for another button.
+      // only react to a container that is genuinely too small, or has room for another button.
       if (slack >= -1 && slack < itemWidth) return
 
       maxButtons.value = getMax(totalWidth, itemWidth)

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
@@ -37,7 +37,18 @@ describe('VPagination', () => {
     expect(screen.getAllByCSS('.v-pagination__item .v-btn').at(1)).toHaveTextContent('2')
   })
 
-  it('should keep the range stable in a shrink-to-fit container', async () => {
+  // Samples the rendered range once per frame. A resize-observer feedback loop
+  // redelivers every frame, so an oscillation shows up as transitions in the tail.
+  async function sampleFrames (frames: number) {
+    const samples: string[] = []
+    for (let i = 0; i < frames; i++) {
+      await new Promise(resolve => requestAnimationFrame(resolve))
+      samples.push(screen.getByCSS('.v-pagination__list').textContent ?? '')
+    }
+    return samples
+  }
+
+  it('should not oscillate the range in a shrink-to-fit container', async () => {
     render(() => (
       <div class="d-flex">
         <VPagination length="5" modelValue={ 3 } />
@@ -46,15 +57,30 @@ describe('VPagination', () => {
 
     await waitIdle() // resize-observer loop has to settle
 
-    // a shrink-to-fit container is as wide as the buttons it holds, so measuring it
+    const samples = await sampleFrames(20)
+    const transitions = samples.filter((s, i) => i > 0 && s !== samples[i - 1])
+
     // used to alternate between the full range and `1 ... 3 ... 5` on every frame
-    expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(5)
-    expect(screen.getByCSS('.v-pagination__list')).toHaveTextContent('12345')
+    expect(transitions).toHaveLength(0)
+    expect(samples.at(-1)).toBe('12345')
+  })
 
-    await waitIdle()
+  it('should still measure a container that is too small', async () => {
+    render(() => (
+      <div style="width: 300px">
+        <VPagination length="100" modelValue={ 1 } />
+      </div>
+    ))
 
-    expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(5)
-    expect(screen.getByCSS('.v-pagination__list')).toHaveTextContent('12345')
+    await waitIdle() // resize-observer loop has to settle
+
+    // the shrink-to-fit early return must not disable measurement altogether
+    expect(screen.getAllByCSS('.v-pagination__item').length).toBeLessThan(8)
+    expect(screen.getByCSS('.v-pagination__list')).toHaveTextContent('100')
+
+    const samples = await sampleFrames(20)
+
+    expect(samples.filter((s, i) => i > 0 && s !== samples[i - 1])).toHaveLength(0)
   })
 
   it('should still honor an explicit total-visible when length is less than 3', () => {

--- a/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
+++ b/packages/vuetify/src/components/VPagination/__tests__/VPagination.spec.browser.tsx
@@ -37,6 +37,26 @@ describe('VPagination', () => {
     expect(screen.getAllByCSS('.v-pagination__item .v-btn').at(1)).toHaveTextContent('2')
   })
 
+  it('should keep the range stable in a shrink-to-fit container', async () => {
+    render(() => (
+      <div class="d-flex">
+        <VPagination length="5" modelValue={ 3 } />
+      </div>
+    ))
+
+    await waitIdle() // resize-observer loop has to settle
+
+    // a shrink-to-fit container is as wide as the buttons it holds, so measuring it
+    // used to alternate between the full range and `1 ... 3 ... 5` on every frame
+    expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(5)
+    expect(screen.getByCSS('.v-pagination__list')).toHaveTextContent('12345')
+
+    await waitIdle()
+
+    expect(screen.getAllByCSS('.v-pagination__item')).toHaveLength(5)
+    expect(screen.getByCSS('.v-pagination__list')).toHaveTextContent('12345')
+  })
+
   it('should still honor an explicit total-visible when length is less than 3', () => {
     render(() => (
       <div class="d-flex">


### PR DESCRIPTION
## Description
fixes #23145 
## Markup:

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<template>
  <div class="text-center">
    <div class="d-flex w-50">
      <v-pagination v-model="page" :length="3" rounded="circle" />
    </div>
  </div>
</template>

<script setup>
  import { ref } from 'vue'

  const page = ref(1)
</script>

```
