### PR TITLE
fix(VSlider): set min-height using dyanmic css custom prop

### DIFF
--- a/packages/vuetify/src/components/VSlider/VSlider.sass
+++ b/packages/vuetify/src/components/VSlider/VSlider.sass
@@ -30,6 +30,7 @@
     justify-content: center
     align-items: center
     cursor: pointer
+    min-height: var(--v-input-control-height)
 
     .v-input--disabled &
       opacity: var(--v-disabled-opacity)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

## Description
<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
fixes #22674 

The VSlider doesn't set height based on the density prop. Solving this was as easy as using the CSS props that VInput sets dynamically.
## Markup:
<!--
Information on how to set up your local development environment can be found here:
https://vuetifyjs.com/getting-started/contributing/#setting-up-your-environment
Remove this section for documentation or test-only changes.
-->

<!-- Paste your FULL packages/vuetify/dev/Playground.vue here --->
```vue
<script setup>
  import { ref } from 'vue'

  const density = ref('default')
  const value = ref(35)
  const switchVal = ref(true)
  const checkboxVal = ref(true)

  const densities = ['default', 'comfortable', 'compact']
</script>

<template>
  <v-app>
    <v-container class="pa-6" style="max-width: 960px">
      <h1 class="text-h5 mb-1">VSlider · density</h1>
      <p class="text-body-2 text-medium-emphasis mb-4">
        Compare VSlider against other input components at the same density.
      </p>

      <v-card class="mb-6 pa-4" variant="outlined">
        <div class="d-flex align-center justify-space-between">
          <div class="text-subtitle-2">Global density</div>
          <v-btn-toggle
            v-model="density"
            color="primary"
            density="comfortable"
            variant="outlined"
            divided
            mandatory
          >
            <v-btn v-for="d in densities" :key="d" :value="d">{{ d }}</v-btn>
          </v-btn-toggle>
        </div>
      </v-card>

      <v-card class="mb-6 pa-4" variant="outlined">
        <div class="text-subtitle-2 mb-3">VSlider beside other inputs</div>

        <div class="d-flex align-start ga-3">
          <v-slider
            v-model="value"
            :density="density"
            color="primary"
            label="Value (slider)"
            thumb-label
          />

          <v-text-field
            v-model.number="value"
            :density="density"
            label="Value (text field)"
            max="100"
            min="0"
            type="number"
            variant="outlined"
          />

          <v-switch
            v-model="switchVal"
            :density="density"
            color="primary"
            label="Switch"
            hide-details
          />

          <v-checkbox
            v-model="checkboxVal"
            :density="density"
            color="primary"
            label="Checkbox"
            hide-details
          />
        </div>
      </v-card>
    </v-container>
  </v-app>
</template>
```
