### PR TITLE
fix(VDateInput): keep custom placeholder while focused

### DIFF
--- a/packages/vuetify/src/components/VDateInput/VDateInput.tsx
+++ b/packages/vuetify/src/components/VDateInput/VDateInput.tsx
@@ -342,7 +342,7 @@ export const VDateInput = genericComponent<new <
           style={ props.style }
           modelValue={ text.value }
           inputmode={ inputmode.value }
-          placeholder={ isFocused.value ? undefined : placeholder.value }
+          placeholder={ isFocused.value && !props.placeholder ? undefined : placeholder.value }
           readonly={ isReadonly.value }
           onKeydown={ isInteractive.value ? onKeydown : undefined }
           onBeforeinput={ isInteractive.value ? onBeforeinput : undefined }
@@ -358,7 +358,7 @@ export const VDateInput = genericComponent<new <
             ...slots,
             default: () => (
               <>
-                { isFocused.value && !isReadonly.value && (
+                { isFocused.value && !isReadonly.value && !props.placeholder && (
                   <div class="v-date-input__format-hint" aria-hidden="true">
                     <span style={{ order: isRtl.value ? 1 : 0 }}>{ text.value }</span>
                     { formatHint.value }

--- a/packages/vuetify/src/components/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -693,15 +693,6 @@ describe('VDateInput', () => {
       expect(screen.queryByCSS('.v-date-input__format-hint')).toBeNull()
     })
 
-    it('should still show the format mask hint while typing when no custom placeholder is set', async () => {
-      const { element } = render(() => <VDateInput />)
-
-      await userEvent.click(element)
-      await userEvent.keyboard('12')
-
-      expect(screen.getByCSS('.v-date-input__format-hint')).toHaveTextContent('12/dd/yyyy')
-    })
-
     it.each<{ props: VDateInput['$props'], keys: string, expected: string }>([
       { props: {}, keys: '1225', expected: '12/25/yyyy' },
       { props: { multiple: 'range' }, keys: '1225202501', expected: '12/25/2025 - 01/dd/yyyy' },

--- a/packages/vuetify/src/components/VDateInput/__tests__/VDateInput.spec.browser.tsx
+++ b/packages/vuetify/src/components/VDateInput/__tests__/VDateInput.spec.browser.tsx
@@ -684,6 +684,24 @@ describe('VDateInput', () => {
       expect(screen.getByCSS('input')).toHaveAttribute('placeholder', expected)
     })
 
+    it('should keep a custom placeholder on focus instead of switching to the format mask', async () => {
+      const { element } = render(() => <VDateInput placeholder="MM/DD/YYYY" />)
+
+      await userEvent.click(element)
+
+      expect(screen.getByCSS('input')).toHaveAttribute('placeholder', 'MM/DD/YYYY')
+      expect(screen.queryByCSS('.v-date-input__format-hint')).toBeNull()
+    })
+
+    it('should still show the format mask hint while typing when no custom placeholder is set', async () => {
+      const { element } = render(() => <VDateInput />)
+
+      await userEvent.click(element)
+      await userEvent.keyboard('12')
+
+      expect(screen.getByCSS('.v-date-input__format-hint')).toHaveTextContent('12/dd/yyyy')
+    })
+
     it.each<{ props: VDateInput['$props'], keys: string, expected: string }>([
       { props: {}, keys: '1225', expected: '12/25/yyyy' },
       { props: { multiple: 'range' }, keys: '1225202501', expected: '12/25/2025 - 01/dd/yyyy' },


### PR DESCRIPTION
## Description

`VDateInput` always cleared the input's `placeholder` attribute on focus and showed the locale-format mask overlay (`.v-date-input__format-hint`) instead, even when the consumer had set a custom `placeholder`. That overlay always renders the inferred format (e.g. `mm/dd/yyyy`), so a custom placeholder like `TT.MM.JJJJ` got replaced by the format mask as soon as the field was clicked or typed into.

The format mask overlay and the focused-blank-placeholder behavior now only kick in when no custom `placeholder` prop is set, so a user-supplied placeholder stays visible in every focus state, while the guided masked-input hint still works as before for the default (no custom placeholder) case.

Fixes #23163

## Markup:

```vue
<template>
  <v-app>
    <v-container>
      <v-date-input placeholder="MM/DD/YYYY" />
    </v-container>
  </v-app>
</template>

<script setup>
  import { ref } from 'vue'
</script>
```
