### PR TITLE
fix(VOverlay): restore CSS zoom viewport correction

### DIFF
--- a/packages/vuetify/src/components/VOverlay/__tests__/VOverlay.spec.browser.tsx
+++ b/packages/vuetify/src/components/VOverlay/__tests__/VOverlay.spec.browser.tsx
@@ -10,6 +10,44 @@ import { commands, isClickable, render, screen, userEvent } from '@test'
 import { ref } from 'vue'
 
 describe('VOverlay', () => {
+  it.each([
+    ['html', 0.8],
+    ['html', 1],
+    ['html', 1.25],
+    ['body', 0.8],
+    ['body', 1],
+    ['body', 1.25],
+  ] as const)('should stay attached near viewport edges with %s zoom %s', async (target, zoom) => {
+    const element = target === 'html' ? document.documentElement : document.body
+    const originalZoom = element.style.zoom
+    element.style.zoom = String(zoom)
+
+    try {
+      render(() => (
+        <VOverlay locationStrategy="connected" location="top end" origin="bottom end" transition={ false }>
+          {{
+            activator: ({ props }) => (
+              <button { ...props } data-testid="activator" style="position: fixed; right: 32px; bottom: 32px; width: 48px; height: 48px;">
+                Open
+              </button>
+            ),
+            default: () => <div style="width: 160px; height: 100px;">Content</div>,
+          }}
+        </VOverlay>
+      ))
+
+      await userEvent.click(screen.getByTestId('activator'))
+      await commands.waitStable('.v-overlay__content')
+
+      const activator = screen.getByTestId('activator').getBoundingClientRect()
+      const content = screen.getByCSS('.v-overlay__content').getBoundingClientRect()
+      expect(Math.abs(content.right - activator.right)).toBeLessThan(2)
+      expect(Math.abs(content.bottom - activator.top)).toBeLessThan(2)
+    } finally {
+      element.style.zoom = originalZoom
+    }
+  })
+
   it('without activator', async () => {
     const model = ref(false)
     render(() => (

--- a/packages/vuetify/src/util/__tests__/box.spec.ts
+++ b/packages/vuetify/src/util/__tests__/box.spec.ts
@@ -1,0 +1,56 @@
+// Utilities
+import { getElementBox } from '../box'
+
+describe('getElementBox', () => {
+  const zoomDescriptor = Object.getOwnPropertyDescriptor(document.body, 'currentCSSZoom')
+  let restoreDimensions: () => void
+
+  beforeEach(() => {
+    const width = vi.spyOn(document.documentElement, 'clientWidth', 'get').mockReturnValue(1200)
+    const height = vi.spyOn(document.documentElement, 'clientHeight', 'get').mockReturnValue(800)
+    restoreDimensions = () => {
+      width.mockRestore()
+      height.mockRestore()
+    }
+    vi.stubGlobal('visualViewport', {
+      width: 600,
+      height: 400,
+      scale: 1,
+      offsetLeft: 0,
+      offsetTop: 0,
+    })
+  })
+
+  afterEach(() => {
+    restoreDimensions()
+    vi.unstubAllGlobals()
+    if (zoomDescriptor) {
+      Object.defineProperty(document.body, 'currentCSSZoom', zoomDescriptor)
+    } else {
+      Reflect.deleteProperty(document.body, 'currentCSSZoom')
+    }
+  })
+
+  it.each([
+    [0.8, 1500, 1000],
+    [1, 1200, 800],
+    [1.25, 960, 640],
+    [undefined, 1200, 800],
+  ])('should normalize viewport dimensions at CSS zoom %s', (zoom, width, height) => {
+    Object.defineProperty(document.body, 'currentCSSZoom', { configurable: true, value: zoom })
+
+    expect(getElementBox(document.documentElement)).toEqual({ x: 0, y: 0, width, height })
+  })
+
+  it('should retain layout viewport dimensions during pinch zoom', () => {
+    vi.stubGlobal('visualViewport', {
+      width: 600,
+      height: 400,
+      scale: 2,
+      offsetLeft: 100,
+      offsetTop: 50,
+    })
+
+    expect(getElementBox(document.documentElement)).toEqual({ x: 0, y: 0, width: 1200, height: 800 })
+  })
+})

--- a/packages/vuetify/src/util/box.ts
+++ b/packages/vuetify/src/util/box.ts
@@ -75,11 +75,12 @@ export function getElementBox (el: HTMLElement) {
         height: document.documentElement.clientHeight,
       })
     } else {
+      const pageScale = document.body.currentCSSZoom ?? 1
       return new Box({
         x: visualViewport.scale > 1 || IS_WEBKIT ? 0 : visualViewport.offsetLeft,
         y: visualViewport.scale > 1 || IS_WEBKIT ? 0 : visualViewport.offsetTop,
-        width: document.documentElement.clientWidth,
-        height: document.documentElement.clientHeight,
+        width: document.documentElement.clientWidth / pageScale,
+        height: document.documentElement.clientHeight / pageScale,
       })
     }
   } else {


### PR DESCRIPTION
## Description

Restore CSS zoom normalization of the viewport used by connected overlays.
With `zoom: 0.8` on `html` or `body`, a menu near the right edge is shifted
left because the viewport and activator boxes use different coordinate scales.

Divide the layout viewport dimensions by `document.body.currentCSSZoom ?? 1`,
matching the existing normalization in `Box` and `getTargetBox`. Keep
`clientWidth`/`clientHeight` from the Android desktop-view fix (#22124), and
preserve the existing pinch-zoom and WebKit offset handling (#22923).
Without CSS zoom, the calculation is unchanged.

The correction was removed in 8849b6b15 (v4), also backported as 19b10db77
(v3). The original report compared v3.12.11 with v3.13.3; the same problem
is reproduced on v4.2.0 in Vuetify Play and on current master in Chromium.
Please consider backporting this fix to v3 as well.

Related CSS zoom reports: #20719 and #22326. Related coordinate normalization
work: #22774.

## Reproduction

[Vuetify Play, v4.2.0](https://play.vuetifyjs.com/#eNqlVl1v2zYU/Suc+iAFsCmvTdHOiLMMRYZ9dNiwFHuJ80BL17ZaitRIyq0X5L/vkKJk2WmLAA2gWLz38p7D+yXe3idV3WjjprVo+HurVTJP7peKsWVU2GUyZ0HiZbuW/HqZbJ1r7DzPi1JhW0my2hmuyOWqqfMrmOWmVa6qaVrq+uoFf8nPn+dlZd1YzsnW05XRHy0ZeFkmkxFODuGOzNSQKsmQeSruybYj7BPdV/Fdtd4/ATNaXp3z53zWoUTRVIqV9RDBtff8sFQPySSRlfpgT4Jd2BDo257AN2EGZ97TXQdoTZH/1DQcRkC8sIWpGscsuba59GZdptk90+oPjfRQyR7Y2uiapdiSLpU3GnRZdsYWl31NlLpoa1KO9y/XksLaur0k/p+GlwVLZ/w1/CAEZ0t1kXcMgI2Fo7qRwlFgcrGbiqYj1S+mK2GiYCyauspJunxzc8M8xpwB4SI/VY/22UYUZFg+loFoO6wh6bmwZ6Jw1U44bRbL5J41RjcW6UtGxsHByimG/5UqYResYPNWqE0rNmQ9H1iMEfKj4w5+JHJ46tvLphXsx3IGuHVgJSMKqxS7Ta/VBvbbdMLS30QjFFny779rQ0Kld105HP7mH2g/8vFIHaL3RYNDDP2JTth7wSiuo5wc0loLkC6ksNaHTUxfjyL7Z0OKDSFkwjG3JeZ0w0y12TrO3mHpAZjd6laWzDqxh5kTxRaF67S3752tWue04gcqHrmrtI4X3o9yErvFm3Fn0S1DbxSIpCO00UlvDAaxBQc175vyYOR398rYkAclZKElQ78VWlnHQBDNMyBneNA/kHLo19WGkzHa/CJUKVHaC0a+Mf1WjdYLuoywodvSWsoio0FW+5bO0md4TyGMpw80uuMbqvWObnwvvxObDDZ/gX9liQsps1upRfmzhouzCfPvv3rw7OwuAKxbhS7Sih07YZgfYXh0Z3SQLA5j5N+WzP6GJBVoPjDrBxuSio9GGCp2S+Q8XUyuNcu+g4czYLjWhEGFJW8EZvwwijr8N9tKlpk3xlQ84ueZB3bBM8u2htaRY+eWKfrI4sGzzBDiu6MJlO9BczwNuyP5AT8+U5fAyCZLvbqjz4Ip+Ek/I0eHGyk9GWj9z0gqyvJ6B29v0XqkCJHyh0DLR3Jj949tQ2kE43CAk0m+0uWeoyLwlcy8g6D3g/tx1Hzuh3zGWB1HM0v7T9katpZvtN5IEk2Fz5Suc3yqflyLupL7xd96pZ2efz+bTV7gOcfzEs8rPD/MZj5gj/FDvT2VwOfvDHVZBWpXr/gnTwe978hUQpZkq42qPAKvMQ6giyRim8TS/Oyc+OdkGBxGwVLRp2Da1Uo/Nfo2jxuzcKBQ9MP1q6S1aKXD/PNClBHGYRqvLHkekoSVT1TyMEm6ew+ohltCMlkLaen4LtDLIodkcj+8zuO2h7v/ASoAYio=)

Open **Languages** at the top right in Chromium. The menu should remain
attached to the button, but opens to its left. A wider preview makes the
displacement more obvious. Change the CSS zoom to `1` for comparison.

## Validation

- Added unit coverage for viewport dimensions at CSS zoom 0.8, 1, 1.25,
  an unavailable `currentCSSZoom`, and pinch zoom with differing visual
  and layout viewport dimensions.
- Added Chromium regression coverage for connected overlays near the right
  and bottom viewport edges, at zoom 0.8, 1, and 1.25 on both `html` and `body`.
- Before the fix, the zoom-0.8 and zoom-1.25 unit cases fail, and both Chromium
  zoom-0.8 cases show approximately 240px horizontal displacement at a
  1280px viewport. All added tests pass after the fix.
- Utility unit suite: 101 passed, 29 skipped, 3 todo.
- VOverlay and VMenu Chromium suites: 45 passed.
- ESLint on all changed source/test files and Vuetify's
  `tsconfig.checks.json` type check pass.
- Verified the markup below in the local development Playground.

Android desktop view and iOS keyboard behavior have not been tested on
physical devices; their existing dimension source and offset logic are retained.

## Markup:

```vue
<script setup>
  import { onMounted } from 'vue'

  onMounted(() => {
    document.documentElement.style.zoom = '0.8'
  })
</script>

<template>
  <v-app>
    <v-app-bar>
      <v-app-bar-title>CSS zoom: 0.8</v-app-bar-title>
      <v-spacer />
      <v-menu>
        <template #activator="{ props }">
          <v-btn v-bind="props">Languages</v-btn>
        </template>
        <v-list>
          <v-list-item
            v-for="language in ['English', 'Japanese', 'Korean']"
            :key="language"
            :title="language"
          />
        </v-list>
      </v-menu>
    </v-app-bar>
    <v-main class="pa-8">
      Open Languages at the top right. The menu should stay attached to the button.
    </v-main>
  </v-app>
</template>
```

