### PR TITLE
feat(VTab): add `slider-variant` prop for MD3

### DIFF
--- a/packages/api-generator/src/locale/en/VTab.json
+++ b/packages/api-generator/src/locale/en/VTab.json
@@ -6,6 +6,7 @@
     "inset": "Changes the slider to take full height. Automatically propagated from VTabs.",
     "fixed": "Forces component to take up all available space up to their maximum width (300px), and centers it.",
     "sliderColor": "Applies specified color to the slider when active on that component - supports utility colors (for example `success` or `purple`) or css color (`#033` or `rgba(255, 0, 0, 0.5)`). Find a list of built-in classes on the [colors page](/styles/colors#material-colors).",
+    "sliderVariant": "Shape of the active tab slider. `primary` follows the Material Design 3 primary tab — a thicker slider with rounded leading corners, sized to the tab content instead of the whole tab. Ignored when `inset` is set.",
     "sliderTransition": "Changes slider transition to one of the predefined animation presets.",
     "sliderTransitionDuration": "Applies custom slider transition duration. Default duration depends on transition type (fade: 400, grow: 350, shift: 225).",
     "stacked": "Displays the tab as a flex-column."

--- a/packages/api-generator/src/locale/en/VTabs.json
+++ b/packages/api-generator/src/locale/en/VTabs.json
@@ -18,6 +18,7 @@
     "nextIcon": "Right pagination icon.",
     "showArrows": "Show pagination arrows if the tab items overflow their container. For mobile devices, arrows will only display when using this prop.",
     "sliderColor": "Changes the background color of an auto-generated `v-tabs-slider`.",
+    "sliderVariant": "Shape of the active tab slider. `primary` follows the Material Design 3 primary tab — a thicker slider with rounded leading corners, sized to the tab content instead of the whole tab. Ignored when `inset` is set.",
     "sliderTransition": "Changes slider transition to one of the predefined animation presets.",
     "sliderTransitionDuration": "Applies custom slider transition duration. Default duration depends on transition type (fade: 400, grow: 350, shift: 225).",
     "stacked": "Apply the stacked prop to all children v-tab components."

--- a/packages/vuetify/src/blueprints/md3.ts
+++ b/packages/vuetify/src/blueprints/md3.ts
@@ -94,8 +94,12 @@ export const md3: Blueprint = {
     VSwitch: {
       indentDetails: true,
     },
+    VTab: {
+      rounded: 0,
+    },
     VTabs: {
       color: 'primary',
+      sliderVariant: 'primary',
     },
     VTextarea: {
       variant: 'outlined',

--- a/packages/vuetify/src/components/VTabs/VTab.sass
+++ b/packages/vuetify/src/components/VTabs/VTab.sass
@@ -18,7 +18,7 @@
   .v-tab__slider
     position: absolute
     bottom: 0
-    left: 0
+    inset-inline-start: 0
     height: $tab-slider-size
     width: 100%
     background: currentColor
@@ -32,6 +32,41 @@
       top: 0
       height: 100%
       width: $tab-slider-size
+
+  .v-tab--slider-primary
+    > .v-btn__content
+      align-self: stretch
+      position: relative
+
+    .v-tab__slider
+      height: $tab-slider-primary-size
+      border-start-start-radius: $tab-slider-primary-radius
+      border-start-end-radius: $tab-slider-primary-radius
+
+    &.v-btn--stacked
+      > .v-btn__content
+        align-self: auto
+        flex-grow: 1
+
+      > .v-btn__prepend
+        align-items: end
+        flex-grow: 1
+
+      &:has(> .v-btn__prepend) > .v-btn__content
+        justify-content: start
+
+    .v-slide-group--vertical &
+      > .v-btn__content
+        align-self: auto
+        position: static
+
+      .v-tab__slider
+        margin-block: auto
+        height: 1lh
+        width: $tab-slider-primary-size
+        border-start-start-radius: 0
+        border-start-end-radius: $tab-slider-primary-radius
+        border-end-end-radius: $tab-slider-primary-radius
 
 @include tools.layer('trumps')
   @media (forced-colors: active)

--- a/packages/vuetify/src/components/VTabs/VTab.tsx
+++ b/packages/vuetify/src/components/VTabs/VTab.tsx
@@ -21,6 +21,10 @@ export const makeVTabProps = propsFactory({
   fixed: Boolean,
 
   sliderColor: String,
+  sliderVariant: {
+    type: String as PropType<'primary' | 'secondary'>,
+    default: 'secondary',
+  },
   sliderTransition: String as PropType<'shift' | 'grow' | 'fade'>,
   sliderTransitionDuration: [String, Number],
   hideSlider: Boolean,
@@ -140,6 +144,7 @@ export const VTab = genericComponent<VBtnSlots>()({
           ref={ rootEl }
           class={[
             'v-tab',
+            props.sliderVariant === 'primary' && !props.inset && 'v-tab--slider-primary',
             props.class,
             isSelected.value && props.inset ? insetColorClasses.value : [],
           ]}

--- a/packages/vuetify/src/components/VTabs/VTabs.tsx
+++ b/packages/vuetify/src/components/VTabs/VTabs.tsx
@@ -76,7 +76,7 @@ export const makeVTabsProps = propsFactory({
   insetRadius: [String, Number],
   sliderColor: String,
 
-  ...pick(makeVTabProps(), ['spaced', 'sliderTransition', 'sliderTransitionDuration']),
+  ...pick(makeVTabProps(), ['spaced', 'sliderTransition', 'sliderTransitionDuration', 'sliderVariant']),
   ...makeVSlideGroupProps({
     mandatory: 'force' as const,
     selectedClass: 'v-tab-item--selected',
@@ -116,6 +116,7 @@ export const VTabs = genericComponent<new <TModel, T = TabItem>(
         fixed: toRef(props, 'fixedTabs'),
         inset: toRef(props, 'inset'),
         sliderColor: toRef(props, 'sliderColor'),
+        sliderVariant: toRef(props, 'sliderVariant'),
         sliderTransition: toRef(props, 'sliderTransition'),
         sliderTransitionDuration: toRef(props, 'sliderTransitionDuration'),
         hideSlider: toRef(props, 'hideSlider'),

--- a/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.browser.tsx
+++ b/packages/vuetify/src/components/VTabs/__tests__/VTabs.spec.browser.tsx
@@ -16,6 +16,8 @@ const stories = {
   'With items': <VTabs items={ FAKE_ITEMS } />,
   'Without slider': <VTabs items={ FAKE_ITEMS } hideSlider />,
   Vertical: <VTabs items={ FAKE_ITEMS } direction="vertical" />,
+  'Primary slider': <VTabs items={ FAKE_ITEMS } sliderVariant="primary" />,
+  'Primary slider vertical': <VTabs items={ FAKE_ITEMS } sliderVariant="primary" direction="vertical" />,
 }
 
 describe('VTabs', () => {
@@ -104,6 +106,26 @@ describe('VTabs', () => {
     expect(model.value).toBe('B')
     show.value = true
     expect(model.value).toBe('B')
+  })
+
+  it.each([
+    ['horizontal', false, 'width', 'height', 'bottom'],
+    ['horizontal', true, 'width', 'height', 'bottom'],
+    ['vertical', false, 'height', 'width', 'left'],
+  ] as const)('should fit the primary slider to the %s tab content (stacked: %s)', async (direction, stacked, along, across, edge) => {
+    render(() => (
+      <VTabs modelValue="A" sliderVariant="primary" direction={ direction } stacked={ stacked }>
+        <VTab value="A" prependIcon="$vuetify">A</VTab>
+      </VTabs>
+    ))
+
+    await nextTick()
+    const tab = screen.getAllByCSS('.v-tab')[0].getBoundingClientRect()
+    const slider = screen.getAllByCSS('.v-tab__slider')[0].getBoundingClientRect()
+
+    expect(slider[along]).toBeLessThan(tab[along])
+    expect(slider[across]).toBe(3)
+    expect(slider[edge]).toBe(tab[edge])
   })
 
   showcase({ stories })

--- a/packages/vuetify/src/components/VTabs/_variables.scss
+++ b/packages/vuetify/src/components/VTabs/_variables.scss
@@ -13,6 +13,8 @@ $tab-border-radius: 0 !default;
 $tab-max-width: 360px !default;
 $tab-min-width: 90px !default;
 $tab-slider-size: 2px !default;
+$tab-slider-primary-size: 3px !default;
+$tab-slider-primary-radius: 3px !default;
 
 $tab-inset-radius: settings.$border-radius-root !default;
 $tab-inset-padding: 4px !default;


### PR DESCRIPTION
- add `slider-variant: primary | secondary`
- update `md3` blueprint

closes #23168

## Markup:

```vue
<template>
  <v-app theme="dark">
    <v-container>
      <div class="d-flex align-center">
        <v-btn :color="color" class="me-6 text-white">Button</v-btn>

        <v-tabs :color="color">
          <v-tab>Tab One</v-tab>
          <v-tab>Tab Two</v-tab>
          <v-tab>Tab Three</v-tab>
        </v-tabs>
      </div>

      <br>

      <v-banner
        :color="color"
        text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Commodi, ratione debitis quis est labore voluptatibus! Eaque cupiditate minima, at placeat totam, magni doloremque veniam neque porro libero rerum unde voluptatem!"
      >
        <template #prepend>
          <!-- rounded added due to bug -->
          <v-avatar
            class="text-white"
            icon="$vuetify"
            rounded="circle"
          />
        </template>
      </v-banner>

      <br>

      <v-text-field
        :color="color"
        label="Text field"
        model-value="Material Design 3"
      />
    </v-container>
  </v-app>
</template>

<script setup>
  const color = '#674fa3'
</script>
```
